### PR TITLE
fix(ai): handle undefined usage in asLanguageModelUsage when stream errors early

### DIFF
--- a/.changeset/cool-jokes-trade.md
+++ b/.changeset/cool-jokes-trade.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fixed crash when accessing usage after stream errors

--- a/packages/ai/src/types/usage.ts
+++ b/packages/ai/src/types/usage.ts
@@ -91,25 +91,29 @@ The number of tokens used in the embedding.
 export function asLanguageModelUsage(
   usage: LanguageModelV3Usage,
 ): LanguageModelUsage {
+  if (usage == null) {
+    return createNullLanguageModelUsage();
+  }
+
   return {
-    inputTokens: usage.inputTokens.total,
+    inputTokens: usage.inputTokens?.total,
     inputTokenDetails: {
-      noCacheTokens: usage.inputTokens.noCache,
-      cacheReadTokens: usage.inputTokens.cacheRead,
-      cacheWriteTokens: usage.inputTokens.cacheWrite,
+      noCacheTokens: usage.inputTokens?.noCache,
+      cacheReadTokens: usage.inputTokens?.cacheRead,
+      cacheWriteTokens: usage.inputTokens?.cacheWrite,
     },
-    outputTokens: usage.outputTokens.total,
+    outputTokens: usage.outputTokens?.total,
     outputTokenDetails: {
-      textTokens: usage.outputTokens.text,
-      reasoningTokens: usage.outputTokens.reasoning,
+      textTokens: usage.outputTokens?.text,
+      reasoningTokens: usage.outputTokens?.reasoning,
     },
     totalTokens: addTokenCounts(
-      usage.inputTokens.total,
-      usage.outputTokens.total,
+      usage.inputTokens?.total,
+      usage.outputTokens?.total,
     ),
     raw: usage.raw,
-    reasoningTokens: usage.outputTokens.reasoning,
-    cachedInputTokens: usage.inputTokens.cacheRead,
+    reasoningTokens: usage.outputTokens?.reasoning,
+    cachedInputTokens: usage.inputTokens?.cacheRead,
   };
 }
 


### PR DESCRIPTION
## Background

When using ToolLoopAgent with models that generate text when only tool calls are expected (used Google's gemini-2.5-flash-lite), the stream may error out before completing any steps. This causes a crash when accessing result.usage with the error:
```
TypeError: Cannot read properties of undefined (reading 'total')
```

## Summary

Added null check and optional chaining to asLanguageModelUsage() in `packages/ai/src/types/usage.ts` to handle cases where usage data is undefined due to stream errors.


## Manual Verification

1. Created a ToolLoopAgent with gemini-2.5-flash-lite.
2. Configured toolChoice: 'required' to force tool-only mode.
3. Triggered a scenario where the model generates text instead of calling tools.
4. Attempted to access result.usage after the stream errors.

Now allows for graceful error handling when failing (LanguageModelUsage object with all fields set to undefined).

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [] Tests have been added / updated (for bug fixes / features)
- [] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)