### PR TITLE
docs: update link to ai gateway

### DIFF
--- a/content/docs/02-getting-started/00-choosing-a-provider.mdx
+++ b/content/docs/02-getting-started/00-choosing-a-provider.mdx
@@ -23,7 +23,7 @@ The [Vercel AI Gateway](/providers/ai-sdk-providers/ai-gateway) is the fastest w
 
 <div className="max-w-[40%] mx-auto">
   <ButtonLink
-    href="https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%2Fapi-keys%3Futm_source%3Dgateway-models-page%26model%3Dcreate-key&title=Get+Started+with+Vercel+AI+Gateway"
+    href="https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%2Fapi-keys%3Futm_source%3Dgateway-models-page%26showCreateKeyModal%3Dtrue&title=Get+Started+with+Vercel+AI+Gateway"
     shape="rounded"
     size="large"
     type="default"

--- a/content/docs/02-getting-started/00-choosing-a-provider.mdx
+++ b/content/docs/02-getting-started/00-choosing-a-provider.mdx
@@ -23,7 +23,7 @@ The [Vercel AI Gateway](/providers/ai-sdk-providers/ai-gateway) is the fastest w
 
 <div className="max-w-[40%] mx-auto">
   <ButtonLink
-    href="https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%3Futm_source%3Dgateway-models-page&title=Get+Started+with+Vercel+AI+Gateway"
+    href="https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%2Fapi-keys%3Futm_source%3Dgateway-models-page%26model%3Dcreate-key&title=Get+Started+with+Vercel+AI+Gateway"
     shape="rounded"
     size="large"
     type="default"


### PR DESCRIPTION
## Background

This pull request updates the link to get an api key for using the AI Gateway as a provider.

## Summary

Updated the link to include `?modal=create-key` param and subpath `/api-keys`.
