### PR TITLE
docs: add standalone page for unauthenticated AI Gateway

### DIFF
--- a/content/unauthenticated-ai-gateway/index.mdx
+++ b/content/unauthenticated-ai-gateway/index.mdx
@@ -1,0 +1,494 @@
+---
+title: AI Gateway
+description: Learn how to use the AI Gateway provider with the AI SDK.
+---
+
+# AI Gateway Provider
+
+The [AI Gateway](https://vercel.com/docs/ai-gateway) provider connects you to models from multiple AI providers through a single interface. Instead of integrating with each provider separately, you can access OpenAI, Anthropic, Google, Meta, xAI, and other providers and their models.
+
+## Features
+
+- Access models from multiple providers without having to install additional provider modules/dependencies
+- Use the same code structure across different AI providers
+- Switch between models and providers easily
+- Automatic authentication when deployed on Vercel
+- View pricing information across providers
+- Observability for AI model usage through the Vercel dashboard
+
+## Setup
+
+The Vercel AI Gateway provider is part of the AI SDK.
+
+## Basic Usage
+
+For most use cases, you can use the AI Gateway directly with a model string:
+
+```ts
+// use plain model string with global provider
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'openai/gpt-5',
+  prompt: 'Hello world',
+});
+```
+
+```ts
+// use provider instance (requires version 5.0.36 or later)
+import { generateText, gateway } from 'ai';
+
+const { text } = await generateText({
+  model: gateway('openai/gpt-5'),
+  prompt: 'Hello world',
+});
+```
+
+The AI SDK automatically uses the AI Gateway when you pass a model string in the `creator/model-name` format.
+
+## Provider Instance
+
+<Note>
+  The `gateway` provider instance is available from the `ai` package in version
+  5.0.36 and later.
+</Note>
+
+You can also import the default provider instance `gateway` from `ai`:
+
+```ts
+import { gateway } from 'ai';
+```
+
+You may want to create a custom provider instance when you need to:
+
+- Set custom configuration options (API key, base URL, headers)
+- Use the provider in a [provider registry](/docs/ai-sdk-core/provider-management)
+- Wrap the provider with [middleware](/docs/ai-sdk-core/middleware)
+- Use different settings for different parts of your application
+
+To create a custom provider instance, import `createGateway` from `ai`:
+
+```ts
+import { createGateway } from 'ai';
+
+const gateway = createGateway({
+  apiKey: process.env.AI_GATEWAY_API_KEY ?? '',
+});
+```
+
+You can use the following optional settings to customize the AI Gateway provider instance:
+
+- **baseURL** _string_
+
+  Use a different URL prefix for API calls. The default prefix is `https://ai-gateway.vercel.sh/v1/ai`.
+
+- **apiKey** _string_
+
+  API key that is being sent using the `Authorization` header. It defaults to
+  the `AI_GATEWAY_API_KEY` environment variable.
+
+- **headers** _Record&lt;string,string&gt;_
+
+  Custom headers to include in the requests.
+
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+  Defaults to the global `fetch` function.
+  You can use it as a middleware to intercept requests,
+  or to provide a custom fetch implementation for e.g. testing.
+
+- **metadataCacheRefreshMillis** _number_
+
+  How frequently to refresh the metadata cache in milliseconds. Defaults to 5 minutes (300,000ms).
+
+## Authentication
+
+The Gateway provider supports two authentication methods:
+
+### API Key Authentication
+
+Set your API key via environment variable:
+
+```bash
+AI_GATEWAY_API_KEY=your_api_key_here
+```
+
+Or pass it directly to the provider:
+
+```ts
+import { createGateway } from 'ai';
+
+const gateway = createGateway({
+  apiKey: 'your_api_key_here',
+});
+```
+
+### OIDC Authentication (Vercel Deployments)
+
+When deployed to Vercel, the AI Gateway provider supports authenticating using [OIDC (OpenID Connect)
+tokens](https://vercel.com/docs/oidc) without API Keys.
+
+#### How OIDC Authentication Works
+
+1. **In Production/Preview Deployments**:
+
+   - OIDC authentication is automatically handled
+   - No manual configuration needed
+   - Tokens are automatically obtained and refreshed
+
+2. **In Local Development**:
+   - First, install and authenticate with the [Vercel CLI](https://vercel.com/docs/cli)
+   - Run `vercel env pull` to download your project's OIDC token locally
+   - For automatic token management:
+     - Use `vercel dev` to start your development server - this will handle token refreshing automatically
+   - For manual token management:
+     - If not using `vercel dev`, note that OIDC tokens expire after 12 hours
+     - You'll need to run `vercel env pull` again to refresh the token before it expires
+
+<Note>
+  If an API Key is present (either passed directly or via environment), it will
+  always be used, even if invalid.
+</Note>
+
+Read more about using OIDC tokens in the [Vercel AI Gateway docs](https://vercel.com/docs/ai-gateway#using-the-ai-gateway-with-a-vercel-oidc-token).
+
+## Bring Your Own Key (BYOK)
+
+You can connect your own provider credentials to use with Vercel AI Gateway. This lets you use your existing provider accounts and access private resources.
+
+To set up BYOK, add your provider credentials in your Vercel team's AI Gateway settings. Once configured, AI Gateway automatically uses your credentials. No code changes are needed.
+
+Learn more in the [BYOK documentation](https://vercel.com/docs/ai-gateway/byok).
+
+## Language Models
+
+You can create language models using a provider instance. The first argument is the model ID in the format `creator/model-name`:
+
+```ts
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'openai/gpt-5',
+  prompt: 'Explain quantum computing in simple terms',
+});
+```
+
+AI Gateway language models can also be used in the `streamText`, `generateObject`, and `streamObject` functions (see [AI SDK Core](/docs/ai-sdk-core)).
+
+## Available Models
+
+The AI Gateway supports models from OpenAI, Anthropic, Google, Meta, xAI, Mistral, DeepSeek, Amazon Bedrock, Cohere, Perplexity, Alibaba, and other providers.
+
+For the complete list of available models, see the [AI Gateway documentation](https://vercel.com/docs/ai-gateway).
+
+## Dynamic Model Discovery
+
+You can discover available models programmatically:
+
+```ts
+import { gateway, generateText } from 'ai';
+
+const availableModels = await gateway.getAvailableModels();
+
+// List all available models
+availableModels.models.forEach(model => {
+  console.log(`${model.id}: ${model.name}`);
+  if (model.description) {
+    console.log(`  Description: ${model.description}`);
+  }
+  if (model.pricing) {
+    console.log(`  Input: $${model.pricing.input}/token`);
+    console.log(`  Output: $${model.pricing.output}/token`);
+    if (model.pricing.cachedInputTokens) {
+      console.log(
+        `  Cached input (read): $${model.pricing.cachedInputTokens}/token`,
+      );
+    }
+    if (model.pricing.cacheCreationInputTokens) {
+      console.log(
+        `  Cache creation (write): $${model.pricing.cacheCreationInputTokens}/token`,
+      );
+    }
+  }
+});
+
+// Use any discovered model with plain string
+const { text } = await generateText({
+  model: availableModels.models[0].id, // e.g., 'openai/gpt-4o'
+  prompt: 'Hello world',
+});
+```
+
+## Credit Usage
+
+You can check your team's current credit balance and usage:
+
+```ts
+import { gateway } from 'ai';
+
+const credits = await gateway.getCredits();
+
+console.log(`Team balance: ${credits.balance} credits`);
+console.log(`Team total used: ${credits.total_used} credits`);
+```
+
+The `getCredits()` method returns your team's credit information based on the authenticated API key or OIDC token:
+
+- **balance** _number_ - Your team's current available credit balance
+- **total_used** _number_ - Total credits consumed by your team
+
+## Examples
+
+### Basic Text Generation
+
+```ts
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4',
+  prompt: 'Write a haiku about programming',
+});
+
+console.log(text);
+```
+
+### Streaming
+
+```ts
+import { streamText } from 'ai';
+
+const { textStream } = await streamText({
+  model: 'openai/gpt-5',
+  prompt: 'Explain the benefits of serverless architecture',
+});
+
+for await (const textPart of textStream) {
+  process.stdout.write(textPart);
+}
+```
+
+### Tool Usage
+
+```ts
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+const { text } = await generateText({
+  model: 'xai/grok-4',
+  prompt: 'What is the weather like in San Francisco?',
+  tools: {
+    getWeather: tool({
+      description: 'Get the current weather for a location',
+      parameters: z.object({
+        location: z.string().describe('The location to get weather for'),
+      }),
+      execute: async ({ location }) => {
+        // Your weather API call here
+        return `It's sunny in ${location}`;
+      },
+    }),
+  },
+});
+```
+
+### Provider-Executed Tools
+
+Some providers offer tools that are executed by the provider itself, such as [OpenAI's web search tool](/providers/ai-sdk-providers/openai#web-search-tool). To use these tools through AI Gateway, import the provider to access the tool definitions:
+
+```ts
+import { generateText, stepCountIs } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const result = await generateText({
+  model: 'openai/gpt-5-mini',
+  prompt: 'What is the Vercel AI Gateway?',
+  stopWhen: stepCountIs(10),
+  tools: {
+    web_search: openai.tools.webSearch({}),
+  },
+});
+
+console.dir(result.text);
+```
+
+<Note>
+  Some provider-executed tools require account-specific configuration (such as
+  Claude Agent Skills) and may not work through AI Gateway. To use these tools,
+  you must bring your own key (BYOK) directly to the provider.
+</Note>
+
+### Usage Tracking with User and Tags
+
+Track usage per end-user and categorize requests with tags:
+
+```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'openai/gpt-5',
+  prompt: 'Summarize this document...',
+  providerOptions: {
+    gateway: {
+      user: 'user-abc-123', // Track usage for this specific end-user
+      tags: ['document-summary', 'premium-feature'], // Categorize for reporting
+    } satisfies GatewayProviderOptions,
+  },
+});
+```
+
+This allows you to:
+
+- View usage and costs broken down by end-user in your analytics
+- Filter and analyze spending by feature or use case using tags
+- Track which users or features are driving the most AI usage
+
+## Provider Options
+
+The AI Gateway provider accepts provider options that control routing behavior and provider-specific configurations.
+
+### Gateway Provider Options
+
+You can use the `gateway` key in `providerOptions` to control how AI Gateway routes requests:
+
+```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4',
+  prompt: 'Explain quantum computing',
+  providerOptions: {
+    gateway: {
+      order: ['vertex', 'anthropic'], // Try Vertex AI first, then Anthropic
+      only: ['vertex', 'anthropic'], // Only use these providers
+    } satisfies GatewayProviderOptions,
+  },
+});
+```
+
+The following gateway provider options are available:
+
+- **order** _string[]_
+
+  Specifies the sequence of providers to attempt when routing requests. The gateway will try providers in the order specified. If a provider fails or is unavailable, it will move to the next provider in the list.
+
+  Example: `order: ['bedrock', 'anthropic']` will attempt Amazon Bedrock first, then fall back to Anthropic.
+
+- **only** _string[]_
+
+  Restricts routing to only the specified providers. When set, the gateway will never route to providers not in this list, even if they would otherwise be available.
+
+  Example: `only: ['anthropic', 'vertex']` will only allow routing to Anthropic or Vertex AI.
+
+- **models** _string[]_
+
+  Specifies fallback models to use when the primary model fails or is unavailable. The gateway will try the primary model first (specified in the `model` parameter), then try each model in this array in order until one succeeds.
+
+  Example: `models: ['openai/gpt-5-nano', 'gemini-2.0-flash']` will try the fallback models in order if the primary model fails.
+
+- **user** _string_
+
+  Optional identifier for the end user on whose behalf the request is being made. This is used for spend tracking and attribution purposes, allowing you to track usage per end-user in your application.
+
+  Example: `user: 'user-123'` will associate this request with end-user ID "user-123" in usage reports.
+
+- **tags** _string[]_
+
+  Optional array of tags for categorizing and filtering usage in reports. Useful for tracking spend by feature, prompt version, or any other dimension relevant to your application.
+
+  Example: `tags: ['chat', 'v2']` will tag this request with "chat" and "v2" for filtering in usage analytics.
+
+- **byok** _Record&lt;string, Array&lt;Record&lt;string, unknown&gt;&gt;&gt;_
+
+  Request-scoped BYOK (Bring Your Own Key) credentials to use for this request. When provided, any cached BYOK credentials configured in the gateway system are not considered. Requests may still fall back to use system credentials if the provided credentials fail.
+
+  Each provider can have multiple credentials (tried in order). The structure is a record where keys are provider slugs and values are arrays of credential objects.
+
+  Examples:
+
+  - Single provider: `byok: { 'anthropic': [{ apiKey: 'sk-ant-...' }] }`
+  - Multiple credentials: `byok: { 'vertex': [{ projectId: 'proj-1', privateKey: '...' }, { projectId: 'proj-2', privateKey: '...' }] }`
+  - Multiple providers: `byok: { 'anthropic': [{ apiKey: '...' }], 'bedrock': [{ accessKeyId: '...', secretAccessKey: '...' }] }`
+
+You can combine these options to have fine-grained control over routing and tracking:
+
+```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4',
+  prompt: 'Write a haiku about programming',
+  providerOptions: {
+    gateway: {
+      order: ['vertex'], // Prefer Vertex AI
+      only: ['anthropic', 'vertex'], // Only allow these providers
+    } satisfies GatewayProviderOptions,
+  },
+});
+```
+
+#### Model Fallbacks Example
+
+The `models` option enables automatic fallback to alternative models when the primary model fails:
+
+```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'openai/gpt-4o', // Primary model
+  prompt: 'Write a TypeScript haiku',
+  providerOptions: {
+    gateway: {
+      models: ['openai/gpt-5-nano', 'gemini-2.0-flash'], // Fallback models
+    } satisfies GatewayProviderOptions,
+  },
+});
+
+// This will:
+// 1. Try openai/gpt-4o first
+// 2. If it fails, try openai/gpt-5-nano
+// 3. If that fails, try gemini-2.0-flash
+// 4. Return the result from the first model that succeeds
+```
+
+### Provider-Specific Options
+
+When using provider-specific options through AI Gateway, use the actual provider name (e.g. `anthropic`, `openai`, not `gateway`) as the key:
+
+```ts
+import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4',
+  prompt: 'Explain quantum computing',
+  providerOptions: {
+    gateway: {
+      order: ['vertex', 'anthropic'],
+    } satisfies GatewayProviderOptions,
+    anthropic: {
+      thinking: { type: 'enabled', budgetTokens: 12000 },
+    } satisfies AnthropicProviderOptions,
+  },
+});
+```
+
+This works with any provider supported by AI Gateway. Each provider has its own set of options - see the individual [provider documentation pages](/providers/ai-sdk-providers) for details on provider-specific options.
+
+### Available Providers
+
+AI Gateway supports routing to 20+ providers.
+
+For a complete list of available providers and their slugs, see the [AI Gateway documentation](https://vercel.com/docs/ai-gateway/provider-options#available-providers).
+
+## Model Capabilities
+
+Model capabilities depend on the specific provider and model you're using. For detailed capability information, see:
+
+- [AI Gateway provider options](https://vercel.com/docs/ai-gateway/provider-options#available-providers) for an overview of available providers
+- Individual [AI SDK provider pages](/providers/ai-sdk-providers) for specific model capabilities and features


### PR DESCRIPTION
## Summary

- Create a dedicated page at `/unauthenticated-ai-gateway` for users who encounter authentication errors with the AI Gateway
- This page contains the full AI Gateway provider documentation to help users understand authentication options

## Background

Currently, the URL `https://ai-sdk.dev/unauthenticated-ai-gateway` (referenced in error messages) redirects to a section within the choosing-a-provider page. This PR creates a standalone page so users landing here from error messages get a dedicated experience.

## Test plan

- [ ] Verify the new page renders correctly at `/unauthenticated-ai-gateway`
- [ ] Update redirect configuration to serve this page instead of redirecting