### PR TITLE
feat(openai-compatible): add sendReasoning support for reasoning content in messages

### DIFF
--- a/.changeset/shy-cups-roll.md
+++ b/.changeset/shy-cups-roll.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+support multi-turn interval-thinking in tool-call

--- a/.changeset/shy-cups-roll.md
+++ b/.changeset/shy-cups-roll.md
@@ -2,4 +2,4 @@
 '@ai-sdk/openai-compatible': patch
 ---
 
-support multi-turn interval-thinking in tool-call
+support multi-turn reasoning in tool-call

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -344,7 +344,7 @@ import { generateText } from 'ai';
 const provider = createOpenAICompatible({
   name: 'provider-name',
   apiKey: process.env.PROVIDER_API_KEY,
-  baseURL: 'https://api.provider.com/v1'
+  baseURL: 'https://api.provider.com/v1',
 });
 
 const { text } = await generateText({

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -289,7 +289,7 @@ const provider = createOpenAICompatible({
   baseURL: 'https://api.provider.com/v1',
   providerOptions: {
     'provider-name': {
-      sendReasoning: true
+      sendReasoning: true,
     },
   },
 });

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -287,7 +287,11 @@ const provider = createOpenAICompatible({
   name: 'provider-name',
   apiKey: process.env.PROVIDER_API_KEY,
   baseURL: 'https://api.provider.com/v1',
-  sendReasoning: true, // Enable reasoning content in requests
+  providerOptions: {
+    'provider-name': {
+      sendReasoning: true
+    },
+  },
 });
 
 const { text } = await generateText({

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -274,6 +274,36 @@ const { images } = await generateImage({
   URL-based images and convert them to the appropriate format.
 </Note>
 
+## Reasoning Content
+
+Some OpenAI-compatible providers support reasoning/thinking modes that allow models to express their internal reasoning process during multi-turn conversations and tool calls.
+The OpenAI Compatible provider supports sending reasoning content through the `sendReasoning` option:
+
+```ts highlight="8"
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText } from 'ai';
+
+const provider = createOpenAICompatible({
+  name: 'provider-name',
+  apiKey: process.env.PROVIDER_API_KEY,
+  baseURL: 'https://api.provider.com/v1',
+  sendReasoning: true, // Enable reasoning content in requests
+});
+
+const { text } = await generateText({
+  model: provider('model-id'),
+  prompt: 'Solve this math problem: 2 + 2',
+});
+```
+
+When `sendReasoning` is enabled, the provider will include reasoning content in the `reasoning_content` field of assistant messages sent to the model. This allows models that support reasoning to show their thought process.
+
+<Note>
+  This feature defaults to `false` and should only be enabled when using a
+  provider that explicitly supports reasoning content. Enabling it with
+  providers that don't support reasoning may cause API errors.
+</Note>
+
 ## Provider-specific options
 
 The OpenAI Compatible provider supports adding provider-specific options to the request body. These are specified with the `providerOptions` field in the request body.

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -274,40 +274,6 @@ const { images } = await generateImage({
   URL-based images and convert them to the appropriate format.
 </Note>
 
-## Reasoning Content
-
-Some OpenAI-compatible providers support reasoning/thinking modes that allow models to express their internal reasoning process during multi-turn conversations and tool calls.
-The OpenAI Compatible provider supports sending reasoning content through the `sendReasoning` option:
-
-```ts highlight="8"
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-import { generateText } from 'ai';
-
-const provider = createOpenAICompatible({
-  name: 'provider-name',
-  apiKey: process.env.PROVIDER_API_KEY,
-  baseURL: 'https://api.provider.com/v1',
-  providerOptions: {
-    'provider-name': {
-      sendReasoning: true,
-    },
-  },
-});
-
-const { text } = await generateText({
-  model: provider('model-id'),
-  prompt: 'Solve this math problem: 2 + 2',
-});
-```
-
-When `sendReasoning` is enabled, the provider will include reasoning content in the `reasoning_content` field of assistant messages sent to the model. This allows models that support reasoning to show their thought process.
-
-<Note>
-  This feature defaults to `false` and should only be enabled when using a
-  provider that explicitly supports reasoning content. Enabling it with
-  providers that don't support reasoning may cause API errors.
-</Note>
-
 ## Provider-specific options
 
 The OpenAI Compatible provider supports adding provider-specific options to the request body. These are specified with the `providerOptions` field in the request body.
@@ -360,7 +326,11 @@ const { text } = await generateText({
 
 When `sendReasoning` is enabled, the provider will include reasoning content in the `reasoning_content` field of assistant messages sent to the model. This allows models that support reasoning to show their thought process.
 
-**Note:** This feature defaults to `false` and should only be enabled when using a provider that explicitly supports reasoning content. Enabling it with providers that don't support reasoning may cause API errors.
+<Note>
+  This feature defaults to `false` and should only be enabled when using a
+  provider that explicitly supports reasoning content. Enabling it with
+  providers that don't support reasoning may cause API errors.
+</Note>
 
 ## Custom Metadata Extraction
 

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -332,6 +332,36 @@ const { text } = await generateText({
 
 The request body sent to the provider will include the `customOption` field with the value `magic-value`. This gives you an easy way to add provider-specific options to requests without having to modify the provider or AI SDK code.
 
+## Reasoning Content
+
+Some OpenAI-compatible providers support reasoning/thinking modes that allow models to express their internal reasoning process during multi-turn conversations and tool calls.
+The OpenAI Compatible provider supports sending reasoning content through the `sendReasoning` option:
+
+```ts highlight="8"
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText } from 'ai';
+
+const provider = createOpenAICompatible({
+  name: 'provider-name',
+  apiKey: process.env.PROVIDER_API_KEY,
+  baseURL: 'https://api.provider.com/v1'
+});
+
+const { text } = await generateText({
+  model: provider('model-id'),
+  prompt: 'Solve this math problem: 2 + 2',
+  providerOptions: {
+    'provider-name': {
+      sendReasoning: true,
+    },
+  },
+});
+```
+
+When `sendReasoning` is enabled, the provider will include reasoning content in the `reasoning_content` field of assistant messages sent to the model. This allows models that support reasoning to show their thought process.
+
+**Note:** This feature defaults to `false` and should only be enabled when using a provider that explicitly supports reasoning content. Enabling it with providers that don't support reasoning may cause API errors.
+
 ## Custom Metadata Extraction
 
 The OpenAI Compatible provider supports extracting provider-specific metadata from API responses through metadata extractors.

--- a/examples/ai-core/src/stream-text/openai-compatible-send-reasoning.ts
+++ b/examples/ai-core/src/stream-text/openai-compatible-send-reasoning.ts
@@ -1,0 +1,76 @@
+import 'dotenv/config';
+import {
+  createOpenAICompatible,
+  OpenAICompatibleProviderOptions,
+} from '@ai-sdk/openai-compatible';
+import { streamText } from 'ai';
+import { weatherTool } from '../tools/weather-tool';
+
+async function main() {
+  const deepseek = createOpenAICompatible({
+    baseURL: 'https://api.deepseek.com/v1',
+    name: 'deepseek',
+    headers: {
+      Authorization: `Bearer ${process.env.DEEPSEEK_API_KEY}`,
+    },
+    fetch: async (url, options) => {
+      const body = JSON.parse(options!.body! as string);
+      console.log('Request messages:', JSON.stringify(body.messages, null, 2));
+      console.log();
+      return await fetch(url, options);
+    },
+  });
+
+  const model = deepseek.chatModel('deepseek-reasoner');
+
+  console.log('Turn 1: Initial tool call with reasoning\n');
+
+  const result1 = streamText({
+    model,
+    prompt: 'What is the weather in San Francisco?',
+    tools: { weather: weatherTool },
+    providerOptions: {
+      deepseek: {
+        sendReasoning: true,
+      } satisfies OpenAICompatibleProviderOptions,
+    },
+  });
+
+  for await (const part of result1.fullStream) {
+    if (part.type === 'reasoning-delta') {
+      process.stdout.write('\x1b[34m' + part.text + '\x1b[0m'); // blue
+    } else if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+
+  const messages1 = (await result1.response).messages;
+  console.log('\n\n');
+
+  // Turn 2: Follow-up question WITH sendReasoning: true
+  console.log('Turn 2: Follow-up with sendReasoning: true\n');
+
+  const result2 = streamText({
+    model,
+    messages: [
+      ...messages1,
+      { role: 'user', content: 'Should I bring an umbrella?' },
+    ],
+    tools: { weather: weatherTool },
+    providerOptions: {
+      deepseek: {
+        sendReasoning: true,
+      } satisfies OpenAICompatibleProviderOptions,
+    },
+  });
+
+  for await (const part of result2.fullStream) {
+    if (part.type === 'reasoning-delta') {
+      process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
+    } else if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -3,30 +3,34 @@ import { describe, it, expect } from 'vitest';
 
 describe('user messages', () => {
   it('should convert messages with only a text part to a string content', async () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'Hello' }],
-      },
-    ] });
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+    });
 
     expect(result).toEqual([{ role: 'user', content: 'Hello' }]);
   });
 
   it('should convert messages with image parts', async () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'user',
-        content: [
-          { type: 'text', text: 'Hello' },
-          {
-            type: 'file',
-            data: Buffer.from([0, 1, 2, 3]).toString('base64'),
-            mediaType: 'image/png',
-          },
-        ],
-      },
-    ] });
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hello' },
+            {
+              type: 'file',
+              data: Buffer.from([0, 1, 2, 3]).toString('base64'),
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -43,19 +47,21 @@ describe('user messages', () => {
   });
 
   it('should convert messages with image parts from Uint8Array', async () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'user',
-        content: [
-          { type: 'text', text: 'Hi' },
-          {
-            type: 'file',
-            data: new Uint8Array([0, 1, 2, 3]),
-            mediaType: 'image/png',
-          },
-        ],
-      },
-    ] });
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hi' },
+            {
+              type: 'file',
+              data: new Uint8Array([0, 1, 2, 3]),
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -72,18 +78,20 @@ describe('user messages', () => {
   });
 
   it('should handle URL-based images', async () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'file',
-            data: new URL('https://example.com/image.jpg'),
-            mediaType: 'image/*',
-          },
-        ],
-      },
-    ] });
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: new URL('https://example.com/image.jpg'),
+              mediaType: 'image/*',
+            },
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -101,30 +109,32 @@ describe('user messages', () => {
 
 describe('tool calls', () => {
   it('should stringify arguments to tool calls', () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'assistant',
-        content: [
-          {
-            type: 'tool-call',
-            input: { foo: 'bar123' },
-            toolCallId: 'quux',
-            toolName: 'thwomp',
-          },
-        ],
-      },
-      {
-        role: 'tool',
-        content: [
-          {
-            type: 'tool-result',
-            toolCallId: 'quux',
-            toolName: 'thwomp',
-            output: { type: 'json', value: { oof: '321rab' } },
-          },
-        ],
-      },
-    ] });
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              input: { foo: 'bar123' },
+              toolCallId: 'quux',
+              toolName: 'thwomp',
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'quux',
+              toolName: 'thwomp',
+              output: { type: 'json', value: { oof: '321rab' } },
+            },
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -150,30 +160,32 @@ describe('tool calls', () => {
   });
 
   it('should handle text output type in tool results', () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'assistant',
-        content: [
-          {
-            type: 'tool-call',
-            input: { query: 'weather' },
-            toolCallId: 'call-1',
-            toolName: 'getWeather',
-          },
-        ],
-      },
-      {
-        role: 'tool',
-        content: [
-          {
-            type: 'tool-result',
-            toolCallId: 'call-1',
-            toolName: 'getWeather',
-            output: { type: 'text', value: 'It is sunny today' },
-          },
-        ],
-      },
-    ] });
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              input: { query: 'weather' },
+              toolCallId: 'call-1',
+              toolName: 'getWeather',
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'getWeather',
+              output: { type: 'text', value: 'It is sunny today' },
+            },
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -201,17 +213,19 @@ describe('tool calls', () => {
 
 describe('provider-specific metadata merging', () => {
   it('should merge system message metadata', async () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'system',
-        content: 'You are a helpful assistant.',
-        providerOptions: {
-          openaiCompatible: {
-            cacheControl: { type: 'ephemeral' },
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'system',
+          content: 'You are a helpful assistant.',
+          providerOptions: {
+            openaiCompatible: {
+              cacheControl: { type: 'ephemeral' },
+            },
           },
         },
-      },
-    ] });
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -223,22 +237,24 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should merge user message content metadata', async () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'text',
-            text: 'Hello',
-            providerOptions: {
-              openaiCompatible: {
-                cacheControl: { type: 'ephemeral' },
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Hello',
+              providerOptions: {
+                openaiCompatible: {
+                  cacheControl: { type: 'ephemeral' },
+                },
               },
             },
-          },
-        ],
-      },
-    ] });
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -250,27 +266,29 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should prioritize content-level metadata when merging', async () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'user',
-        providerOptions: {
-          openaiCompatible: {
-            messageLevel: true,
-          },
-        },
-        content: [
-          {
-            type: 'text',
-            text: 'Hello',
-            providerOptions: {
-              openaiCompatible: {
-                contentLevel: true,
-              },
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          providerOptions: {
+            openaiCompatible: {
+              messageLevel: true,
             },
           },
-        ],
-      },
-    ] });
+          content: [
+            {
+              type: 'text',
+              text: 'Hello',
+              providerOptions: {
+                openaiCompatible: {
+                  contentLevel: true,
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -282,24 +300,26 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle tool calls with metadata', async () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'assistant',
-        content: [
-          {
-            type: 'tool-call',
-            toolCallId: 'call1',
-            toolName: 'calculator',
-            input: { x: 1, y: 2 },
-            providerOptions: {
-              openaiCompatible: {
-                cacheControl: { type: 'ephemeral' },
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call1',
+              toolName: 'calculator',
+              input: { x: 1, y: 2 },
+              providerOptions: {
+                openaiCompatible: {
+                  cacheControl: { type: 'ephemeral' },
+                },
               },
             },
-          },
-        ],
-      },
-    ] });
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -322,23 +342,25 @@ describe('provider-specific metadata merging', () => {
 
   it('should handle image content with metadata', async () => {
     const imageUrl = new URL('https://example.com/image.jpg');
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'file',
-            data: imageUrl,
-            mediaType: 'image/*',
-            providerOptions: {
-              openaiCompatible: {
-                cacheControl: { type: 'ephemeral' },
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: imageUrl,
+              mediaType: 'image/*',
+              providerOptions: {
+                openaiCompatible: {
+                  cacheControl: { type: 'ephemeral' },
+                },
               },
             },
-          },
-        ],
-      },
-    ] });
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -355,17 +377,19 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should omit non-openaiCompatible metadata', async () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'system',
-        content: 'Hello',
-        providerOptions: {
-          someOtherProvider: {
-            shouldBeIgnored: true,
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'system',
+          content: 'Hello',
+          providerOptions: {
+            someOtherProvider: {
+              shouldBeIgnored: true,
+            },
           },
         },
-      },
-    ] });
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -376,32 +400,34 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle a user message with multiple content parts (text + image)', () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'text',
-            text: 'Hello from part 1',
-            providerOptions: {
-              openaiCompatible: { sentiment: 'positive' },
-              leftoverKey: { foo: 'some leftover data' },
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Hello from part 1',
+              providerOptions: {
+                openaiCompatible: { sentiment: 'positive' },
+                leftoverKey: { foo: 'some leftover data' },
+              },
             },
-          },
-          {
-            type: 'file',
-            data: Buffer.from([0, 1, 2, 3]).toString('base64'),
-            mediaType: 'image/png',
-            providerOptions: {
-              openaiCompatible: { alt_text: 'A sample image' },
+            {
+              type: 'file',
+              data: Buffer.from([0, 1, 2, 3]).toString('base64'),
+              mediaType: 'image/png',
+              providerOptions: {
+                openaiCompatible: { alt_text: 'A sample image' },
+              },
             },
+          ],
+          providerOptions: {
+            openaiCompatible: { priority: 'high' },
           },
-        ],
-        providerOptions: {
-          openaiCompatible: { priority: 'high' },
         },
-      },
-    ] });
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -426,15 +452,17 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle a user message with multiple text parts (flattening disabled)', () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'user',
-        content: [
-          { type: 'text', text: 'Part 1' },
-          { type: 'text', text: 'Part 2' },
-        ],
-      },
-    ] });
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Part 1' },
+            { type: 'text', text: 'Part 2' },
+          ],
+        },
+      ],
+    });
 
     // Because there are multiple text parts, the converter won't flatten them
     expect(result).toEqual([
@@ -449,30 +477,32 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle an assistant message with text plus multiple tool calls', () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'assistant',
-        content: [
-          { type: 'text', text: 'Checking that now...' },
-          {
-            type: 'tool-call',
-            toolCallId: 'call1',
-            toolName: 'searchTool',
-            input: { query: 'Weather' },
-            providerOptions: {
-              openaiCompatible: { function_call_reason: 'user request' },
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Checking that now...' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call1',
+              toolName: 'searchTool',
+              input: { query: 'Weather' },
+              providerOptions: {
+                openaiCompatible: { function_call_reason: 'user request' },
+              },
             },
-          },
-          { type: 'text', text: 'Almost there...' },
-          {
-            type: 'tool-call',
-            toolCallId: 'call2',
-            toolName: 'mapsTool',
-            input: { location: 'Paris' },
-          },
-        ],
-      },
-    ] });
+            { type: 'text', text: 'Almost there...' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call2',
+              toolName: 'mapsTool',
+              input: { location: 'Paris' },
+            },
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -502,32 +532,34 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle a single tool role message with multiple tool-result parts', () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'tool',
-        providerOptions: {
-          // this just gets omitted as we prioritize content-level metadata
-          openaiCompatible: { responseTier: 'detailed' },
-        },
-        content: [
-          {
-            type: 'tool-result',
-            toolCallId: 'call123',
-            toolName: 'calculator',
-            output: { type: 'json', value: { stepOne: 'data chunk 1' } },
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'tool',
+          providerOptions: {
+            // this just gets omitted as we prioritize content-level metadata
+            openaiCompatible: { responseTier: 'detailed' },
           },
-          {
-            type: 'tool-result',
-            toolCallId: 'call123',
-            toolName: 'calculator',
-            providerOptions: {
-              openaiCompatible: { partial: true },
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call123',
+              toolName: 'calculator',
+              output: { type: 'json', value: { stepOne: 'data chunk 1' } },
             },
-            output: { type: 'json', value: { stepTwo: 'data chunk 2' } },
-          },
-        ],
-      },
-    ] });
+            {
+              type: 'tool-result',
+              toolCallId: 'call123',
+              toolName: 'calculator',
+              providerOptions: {
+                openaiCompatible: { partial: true },
+              },
+              output: { type: 'json', value: { stepTwo: 'data chunk 2' } },
+            },
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -545,33 +577,35 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle multiple content parts with multiple metadata layers', () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'user',
-        providerOptions: {
-          openaiCompatible: { messageLevel: 'global-metadata' },
-          leftoverForMessage: { x: 123 },
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          providerOptions: {
+            openaiCompatible: { messageLevel: 'global-metadata' },
+            leftoverForMessage: { x: 123 },
+          },
+          content: [
+            {
+              type: 'text',
+              text: 'Part A',
+              providerOptions: {
+                openaiCompatible: { textPartLevel: 'localized' },
+                leftoverForText: { info: 'text leftover' },
+              },
+            },
+            {
+              type: 'file',
+              data: Buffer.from([9, 8, 7, 6]).toString('base64'),
+              mediaType: 'image/png',
+              providerOptions: {
+                openaiCompatible: { imagePartLevel: 'image-data' },
+              },
+            },
+          ],
         },
-        content: [
-          {
-            type: 'text',
-            text: 'Part A',
-            providerOptions: {
-              openaiCompatible: { textPartLevel: 'localized' },
-              leftoverForText: { info: 'text leftover' },
-            },
-          },
-          {
-            type: 'file',
-            data: Buffer.from([9, 8, 7, 6]).toString('base64'),
-            mediaType: 'image/png',
-            providerOptions: {
-              openaiCompatible: { imagePartLevel: 'image-data' },
-            },
-          },
-        ],
-      },
-    ] });
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -596,28 +630,30 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle different tool metadata vs. message-level metadata', () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'assistant',
-        providerOptions: {
-          openaiCompatible: { globalPriority: 'high' },
-        },
-        content: [
-          { type: 'text', text: 'Initiating tool calls...' },
-          {
-            type: 'tool-call',
-            toolCallId: 'callXYZ',
-            toolName: 'awesomeTool',
-            input: { param: 'someValue' },
-            providerOptions: {
-              openaiCompatible: {
-                toolPriority: 'critical',
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          providerOptions: {
+            openaiCompatible: { globalPriority: 'high' },
+          },
+          content: [
+            { type: 'text', text: 'Initiating tool calls...' },
+            {
+              type: 'tool-call',
+              toolCallId: 'callXYZ',
+              toolName: 'awesomeTool',
+              input: { param: 'someValue' },
+              providerOptions: {
+                openaiCompatible: {
+                  toolPriority: 'critical',
+                },
               },
             },
-          },
-        ],
-      },
-    ] });
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {
@@ -640,31 +676,33 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle metadata collisions and overwrites in tool calls', () => {
-    const result = convertToOpenAICompatibleChatMessages({ prompt: [
-      {
-        role: 'assistant',
-        providerOptions: {
-          openaiCompatible: {
-            cacheControl: { type: 'default' },
-            sharedKey: 'assistantLevel',
-          },
-        },
-        content: [
-          {
-            type: 'tool-call',
-            toolCallId: 'collisionToolCall',
-            toolName: 'collider',
-            input: { num: 42 },
-            providerOptions: {
-              openaiCompatible: {
-                cacheControl: { type: 'ephemeral' }, // overwrites top-level
-                sharedKey: 'toolLevel',
-              },
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          providerOptions: {
+            openaiCompatible: {
+              cacheControl: { type: 'default' },
+              sharedKey: 'assistantLevel',
             },
           },
-        ],
-      },
-    ] });
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'collisionToolCall',
+              toolName: 'collider',
+              input: { num: 42 },
+              providerOptions: {
+                openaiCompatible: {
+                  cacheControl: { type: 'ephemeral' }, // overwrites top-level
+                  sharedKey: 'toolLevel',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
 
     expect(result).toEqual([
       {

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -3,18 +3,18 @@ import { describe, it, expect } from 'vitest';
 
 describe('user messages', () => {
   it('should convert messages with only a text part to a string content', async () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'user',
         content: [{ type: 'text', text: 'Hello' }],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([{ role: 'user', content: 'Hello' }]);
   });
 
   it('should convert messages with image parts', async () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'user',
         content: [
@@ -26,7 +26,7 @@ describe('user messages', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -43,7 +43,7 @@ describe('user messages', () => {
   });
 
   it('should convert messages with image parts from Uint8Array', async () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'user',
         content: [
@@ -55,7 +55,7 @@ describe('user messages', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -72,7 +72,7 @@ describe('user messages', () => {
   });
 
   it('should handle URL-based images', async () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'user',
         content: [
@@ -83,7 +83,7 @@ describe('user messages', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -101,7 +101,7 @@ describe('user messages', () => {
 
 describe('tool calls', () => {
   it('should stringify arguments to tool calls', () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'assistant',
         content: [
@@ -124,7 +124,7 @@ describe('tool calls', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -150,7 +150,7 @@ describe('tool calls', () => {
   });
 
   it('should handle text output type in tool results', () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'assistant',
         content: [
@@ -173,7 +173,7 @@ describe('tool calls', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -201,7 +201,7 @@ describe('tool calls', () => {
 
 describe('provider-specific metadata merging', () => {
   it('should merge system message metadata', async () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'system',
         content: 'You are a helpful assistant.',
@@ -211,7 +211,7 @@ describe('provider-specific metadata merging', () => {
           },
         },
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -223,7 +223,7 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should merge user message content metadata', async () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'user',
         content: [
@@ -238,7 +238,7 @@ describe('provider-specific metadata merging', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -250,7 +250,7 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should prioritize content-level metadata when merging', async () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'user',
         providerOptions: {
@@ -270,7 +270,7 @@ describe('provider-specific metadata merging', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -282,7 +282,7 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle tool calls with metadata', async () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'assistant',
         content: [
@@ -299,7 +299,7 @@ describe('provider-specific metadata merging', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -322,7 +322,7 @@ describe('provider-specific metadata merging', () => {
 
   it('should handle image content with metadata', async () => {
     const imageUrl = new URL('https://example.com/image.jpg');
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'user',
         content: [
@@ -338,7 +338,7 @@ describe('provider-specific metadata merging', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -355,7 +355,7 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should omit non-openaiCompatible metadata', async () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'system',
         content: 'Hello',
@@ -365,7 +365,7 @@ describe('provider-specific metadata merging', () => {
           },
         },
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -376,7 +376,7 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle a user message with multiple content parts (text + image)', () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'user',
         content: [
@@ -401,7 +401,7 @@ describe('provider-specific metadata merging', () => {
           openaiCompatible: { priority: 'high' },
         },
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -426,7 +426,7 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle a user message with multiple text parts (flattening disabled)', () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'user',
         content: [
@@ -434,7 +434,7 @@ describe('provider-specific metadata merging', () => {
           { type: 'text', text: 'Part 2' },
         ],
       },
-    ]);
+    ] });
 
     // Because there are multiple text parts, the converter won't flatten them
     expect(result).toEqual([
@@ -449,7 +449,7 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle an assistant message with text plus multiple tool calls', () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'assistant',
         content: [
@@ -472,7 +472,7 @@ describe('provider-specific metadata merging', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -502,7 +502,7 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle a single tool role message with multiple tool-result parts', () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'tool',
         providerOptions: {
@@ -527,7 +527,7 @@ describe('provider-specific metadata merging', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -545,7 +545,7 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle multiple content parts with multiple metadata layers', () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'user',
         providerOptions: {
@@ -571,7 +571,7 @@ describe('provider-specific metadata merging', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -596,7 +596,7 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle different tool metadata vs. message-level metadata', () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'assistant',
         providerOptions: {
@@ -617,7 +617,7 @@ describe('provider-specific metadata merging', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -640,7 +640,7 @@ describe('provider-specific metadata merging', () => {
   });
 
   it('should handle metadata collisions and overwrites in tool calls', () => {
-    const result = convertToOpenAICompatibleChatMessages([
+    const result = convertToOpenAICompatibleChatMessages({ prompt: [
       {
         role: 'assistant',
         providerOptions: {
@@ -664,7 +664,7 @@ describe('provider-specific metadata merging', () => {
           },
         ],
       },
-    ]);
+    ] });
 
     expect(result).toEqual([
       {
@@ -684,6 +684,185 @@ describe('provider-specific metadata merging', () => {
             sharedKey: 'toolLevel',
           },
         ],
+      },
+    ]);
+  });
+});
+
+describe('reasoning content', () => {
+  it('should include reasoning_content when sendReasoning is true', () => {
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Let me think about this.' },
+            { type: 'reasoning', text: 'First, I need to consider...' },
+            { type: 'text', text: 'The answer is 42.' },
+          ],
+        },
+      ],
+      sendReasoning: true,
+    });
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: 'Let me think about this.The answer is 42.',
+        reasoning_content: 'First, I need to consider...',
+      },
+    ]);
+  });
+
+  it('should omit reasoning_content when sendReasoning is false (default)', () => {
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Let me think about this.' },
+            { type: 'reasoning', text: 'First, I need to consider...' },
+            { type: 'text', text: 'The answer is 42.' },
+          ],
+        },
+      ],
+      sendReasoning: false,
+    });
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: 'Let me think about this.The answer is 42.',
+      },
+    ]);
+  });
+
+  it('should omit reasoning_content when sendReasoning is not provided', () => {
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Response text.' },
+            { type: 'reasoning', text: 'Internal reasoning.' },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: 'Response text.',
+      },
+    ]);
+  });
+
+  it('should concatenate multiple reasoning parts when sendReasoning is true', () => {
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'First step: analyze the problem. ' },
+            { type: 'reasoning', text: 'Second step: formulate solution.' },
+            { type: 'text', text: 'Here is the solution.' },
+          ],
+        },
+      ],
+      sendReasoning: true,
+    });
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: 'Here is the solution.',
+        reasoning_content:
+          'First step: analyze the problem. Second step: formulate solution.',
+      },
+    ]);
+  });
+
+  it('should handle reasoning with tool calls when sendReasoning is true', () => {
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'I need to check the weather.' },
+            {
+              type: 'reasoning',
+              text: 'The user asked about weather, so I should use the weather tool.',
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'getWeather',
+              input: { location: 'Paris' },
+            },
+          ],
+        },
+      ],
+      sendReasoning: true,
+    });
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: 'I need to check the weather.',
+        reasoning_content:
+          'The user asked about weather, so I should use the weather tool.',
+        tool_calls: [
+          {
+            id: 'call-1',
+            type: 'function',
+            function: {
+              name: 'getWeather',
+              arguments: JSON.stringify({ location: 'Paris' }),
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should handle assistant message with only reasoning content', () => {
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'Thinking through the problem...' },
+          ],
+        },
+      ],
+      sendReasoning: true,
+    });
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'Thinking through the problem...',
+      },
+    ]);
+  });
+
+  it('should omit reasoning_content field entirely when no reasoning and sendReasoning is true', () => {
+    const result = convertToOpenAICompatibleChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Just a regular response.' }],
+        },
+      ],
+      sendReasoning: true,
+    });
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: 'Just a regular response.',
       },
     ]);
   });

--- a/packages/openai-compatible/src/chat/openai-compatible-api-types.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-api-types.ts
@@ -44,6 +44,7 @@ export interface OpenAICompatibleAssistantMessage
   extends JsonRecord<OpenAICompatibleMessageToolCall> {
   role: 'assistant';
   content?: string | null;
+  reasoning_content?: string | null;
   tool_calls?: Array<OpenAICompatibleMessageToolCall>;
 }
 

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -198,7 +198,10 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
         verbosity: compatibleOptions.textVerbosity,
 
         // messages:
-        messages: convertToOpenAICompatibleChatMessages(prompt),
+        messages: convertToOpenAICompatibleChatMessages({
+          prompt,
+          sendReasoning: compatibleOptions.sendReasoning ?? false,
+        }),
 
         // tools:
         tools: openaiTools,

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-options.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-options.ts
@@ -18,6 +18,12 @@ export const openaiCompatibleProviderOptions = z.object({
    * Controls the verbosity of the generated text. Defaults to `medium`.
    */
   textVerbosity: z.string().optional(),
+
+  /**
+   * Whether to send reasoning content back to the model in multi-turn
+   * tool-calling conversations. Defaults to `false`.
+   */
+  sendReasoning: z.boolean().optional(),
 });
 
 export type OpenAICompatibleProviderOptions = z.infer<


### PR DESCRIPTION
## Background

  More and more LLM providers are now supporting reasoning/thinking mode during multi-turn tool calls, where the model can express its internal reasoning process. Examples include:
  - [Xiaomi MiMo's thinking mode with multi-turn tool calls](https://platform.xiaomimimo.com/#/docs/quick-start/first-api-call?target=make-multi-turn-tool-calls-in-thinking-mode)
  - [Minimax's function calling with reasoning](https://platform.minimax.io/docs/guides/text-m2-function-call)

  The Anthropic provider already supports sending reasoning content through the `sendReasoning` option (implemented in `convert-to-anthropic-messages-prompt.ts`). However, the OpenAI-compatible provider was missing this capability, preventing users from leveraging reasoning features when using OpenAI-compatible models that support this functionality.

  ## Summary

  This PR adds support for sending reasoning content in OpenAI-compatible messages by:

  1. **Updated the conversion function signature** in `convert-to-openai-compatible-chat-messages.ts`:
     - Added `sendReasoning` parameter to the function signature (similar to Anthropic implementation)
     - When `sendReasoning: true`, reasoning content is collected and included in the `reasoning_content` field
     - When `sendReasoning: false` or undefined (default), reasoning content is omitted

  2. **Added comprehensive unit tests** in `convert-to-openai-compatible-chat-messages.test.ts`:
     - Test reasoning content inclusion when `sendReasoning` is true
     - Test reasoning content omission when `sendReasoning` is false or not provided
     - Test concatenation of multiple reasoning parts
     - Test reasoning combined with tool calls
     - Test edge cases (only reasoning content, no reasoning content, etc.)
     - Total: 7 new test cases added, all passing

  3. **Updated the language model integration**:
     - Updated `openai-compatible-chat-language-model.ts` to pass `sendReasoning` option through to the conversion function
     - Added `sendReasoning` option to the chat settings schema

  ## Manual Verification

  Unit tests cover all the functionality comprehensively:
  - ✅ Node environment: 149 tests passed (including 7 new reasoning tests)
  - ✅ Edge environment: 149 tests passed (including 7 new reasoning tests)

  The implementation follows the same patterns used in the Anthropic provider for consistency across the SDK.

  ## Checklist

  - [x] Tests have been added / updated (for bug fixes / features)
  - [x] Documentation has been added / updated (for bug fixes / features)
  - [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
  - [x] I have reviewed this pull request (self-review)

  ## Future Work

  - Add documentation explaining how to use the `sendReasoning` option with OpenAI-compatible providers
  - Consider adding examples showing reasoning mode with tool calls
  - Document which OpenAI-compatible providers support reasoning content

  ## Related Issues

  <!-- Add any related issues here -->