### PR TITLE
Invoke devToolsMiddleware in model wrapping

### DIFF
--- a/content/docs/03-ai-sdk-core/65-devtools.mdx
+++ b/content/docs/03-ai-sdk-core/65-devtools.mdx
@@ -43,7 +43,7 @@ __PROVIDER_IMPORT__;
 
 const model = wrapLanguageModel({
   model: __MODEL__,
-  middleware: devToolsMiddleware,
+  middleware: devToolsMiddleware(),
 });
 ```
 


### PR DESCRIPTION
Background

  The DevTools documentation shows devToolsMiddleware passed directly to wrapLanguageModel, but devToolsMiddleware is a factory function that must be invoked.

  Summary

  Fix documentation to call devToolsMiddleware() instead of passing it as a reference.

  const model = wrapLanguageModel({
    model: __MODEL__,
  -  middleware: devToolsMiddleware,
  +  middleware: devToolsMiddleware(),
  });

  Checklist
  - Documentation has been added / updated
  - I have reviewed this pull request (self-review)