### PR TITLE
feat(mcp): make MCP Client stable in v6

### DIFF
--- a/.changeset/bright-masks-listen.md
+++ b/.changeset/bright-masks-listen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+feat(mcp): make MCPClient stable

--- a/content/cookbook/01-next/73-mcp-tools.mdx
+++ b/content/cookbook/01-next/73-mcp-tools.mdx
@@ -17,10 +17,8 @@ If you prefer to use the official transports (optional), install the official Ty
 <Snippet text="pnpm install @modelcontextprotocol/sdk" />
 
 ```ts filename="app/api/completion/route.ts"
-import {
-  experimental_createMCPClient as createMCPClient,
-  streamText,
-} from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
+import { streamText } from 'ai';
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 import { openai } from '@ai-sdk/openai';
 // Optional: Official transports if you prefer them

--- a/content/cookbook/05-node/54-mcp-tools.mdx
+++ b/content/cookbook/05-node/54-mcp-tools.mdx
@@ -13,11 +13,8 @@ If you prefer to use the official transports (optional), install the official Mo
 <Snippet text="pnpm install @modelcontextprotocol/sdk" />
 
 ```ts
-import {
-  experimental_createMCPClient as createMCPClient,
-  generateText,
-  stepCountIs,
-} from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
+import { generateText, stepCountIs } from 'ai';
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 import { openai } from '@ai-sdk/openai';
 // Optional: Official transports if you prefer them

--- a/content/cookbook/05-node/57-mcp-elicitation.mdx
+++ b/content/cookbook/05-node/57-mcp-elicitation.mdx
@@ -13,10 +13,7 @@ Elicitation is a mechanism where MCP servers can request additional information 
 This example shows how to set up an MCP client to handle elicitation requests from a server that needs to collect user input.
 
 ```ts
-import {
-  experimental_createMCPClient as createMCPClient,
-  ElicitationRequestSchema,
-} from '@ai-sdk/mcp';
+import { createMCPClient, ElicitationRequestSchema } from '@ai-sdk/mcp';
 import { generateText } from 'ai';
 
 // Create the MCP client with elicitation capability enabled

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -5,10 +5,6 @@ description: Learn how to connect to Model Context Protocol (MCP) servers and us
 
 # Model Context Protocol (MCP)
 
-<Note type="warning">
-  The MCP tools feature is experimental and may change in the future.
-</Note>
-
 The AI SDK supports connecting to [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers to access their tools, resources, and prompts.
 This enables your AI applications to discover and use capabilities across various services through a standardized interface.
 
@@ -34,7 +30,7 @@ Create an MCP client using one of the following transport options:
 For production deployments, we recommend using the HTTP transport. You can configure it directly on the client:
 
 ```typescript
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
 
 const mcpClient = await createMCPClient({
   transport: {
@@ -53,7 +49,7 @@ const mcpClient = await createMCPClient({
 Alternatively, you can use `StreamableHTTPClientTransport` from MCP's official TypeScript SDK:
 
 ```typescript
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 const url = new URL('https://your-server.com/mcp');
@@ -69,7 +65,7 @@ const mcpClient = await createMCPClient({
 SSE provides an alternative HTTP-based transport option. Configure it with a `type` and `url` property. You can also provide an `authProvider` for OAuth:
 
 ```typescript
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
 
 const mcpClient = await createMCPClient({
   transport: {
@@ -94,7 +90,7 @@ const mcpClient = await createMCPClient({
 The Stdio transport can be imported from either the MCP SDK or the AI SDK:
 
 ```typescript
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 // Or use the AI SDK's stdio transport:
 // import { Experimental_StdioMCPTransport as StdioClientTransport } from '@ai-sdk/mcp/mcp-stdio';
@@ -112,7 +108,7 @@ const mcpClient = await createMCPClient({
 You can also bring your own transport by implementing the `MCPTransport` interface for specific requirements not covered by the standard transports.
 
 <Note>
-  The client returned by the `experimental_createMCPClient` function is a
+  The client returned by the `createMCPClient` function is a
   lightweight client intended for use in tool conversion. It currently does not
   support all features of the full MCP client, such as: session
   management, resumable streams, and receiving notifications.
@@ -132,7 +128,7 @@ After initialization, you should close the MCP client based on your usage patter
 When streaming responses, you can close the client when the LLM response has finished. For example, when using `streamText`, you should use the `onFinish` callback:
 
 ```typescript
-const mcpClient = await experimental_createMCPClient({
+const mcpClient = await createMCPClient({
   // ...
 });
 
@@ -154,7 +150,7 @@ When generating responses without streaming, you can use try/finally or cleanup 
 let mcpClient: MCPClient | undefined;
 
 try {
-  mcpClient = await experimental_createMCPClient({
+  mcpClient = await createMCPClient({
     // ...
   });
 } finally {
@@ -269,7 +265,7 @@ Elicitation is a mechanism where MCP servers can request additional information 
 To enable elicitation, you need to advertise the capability when creating the MCP client:
 
 ```typescript
-const mcpClient = await experimental_createMCPClient({
+const mcpClient = await createMCPClient({
   transport: {
     type: 'sse',
     url: 'https://your-server.com/sse',

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -231,12 +231,16 @@ const templates = await mcpClient.listResourceTemplates();
 
 ## Using MCP Prompts
 
+<Note type="warning">
+  MCP Prompts is an experimental feature and may change in the future.
+</Note>
+
 According to the MCP specification, prompts are user-controlled templates that servers expose for clients to list and retrieve with optional arguments.
 
 ### Listing Prompts
 
 ```typescript
-const prompts = await mcpClient.listPrompts();
+const prompts = await mcpClient.experimental_listPrompts();
 ```
 
 ### Getting a Prompt
@@ -244,7 +248,7 @@ const prompts = await mcpClient.listPrompts();
 Retrieve prompt messages, optionally passing arguments defined by the server:
 
 ```typescript
-const prompt = await mcpClient.getPrompt({
+const prompt = await mcpClient.experimental_getPrompt({
   name: 'code_review',
   arguments: { code: 'function add(a, b) { return a + b; }' },
 });

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -243,12 +243,13 @@ Returns a Promise that resolves to an `MCPClient` with the following methods:
       ],
     },
     {
-      name: 'listPrompts',
+      name: 'experimental_listPrompts',
       type: `async (options?: {
         params?: PaginatedRequest['params'];
         options?: RequestOptions;
       }) => Promise<ListPromptsResult>`,
-      description: 'Lists available prompts from the MCP server.',
+      description:
+        'Lists available prompts from the MCP server. This method is experimental and may change in the future.',
       properties: [
         {
           type: 'options',
@@ -271,13 +272,14 @@ Returns a Promise that resolves to an `MCPClient` with the following methods:
       ],
     },
     {
-      name: 'getPrompt',
+      name: 'experimental_getPrompt',
       type: `async (args: {
         name: string;
         arguments?: Record<string, unknown>;
         options?: RequestOptions;
       }) => Promise<GetPromptResult>`,
-      description: 'Retrieves a prompt by name, optionally passing arguments.',
+      description:
+        'Retrieves a prompt by name, optionally passing arguments. This method is experimental and may change in the future.',
       properties: [
         {
           type: 'args',

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -1,9 +1,9 @@
 ---
-title: experimental_createMCPClient
+title: createMCPClient
 description: Create a client for connecting to MCP servers
 ---
 
-# `experimental_createMCPClient()`
+# `createMCPClient()`
 
 Creates a lightweight Model Context Protocol (MCP) client that connects to an MCP server. The client provides:
 
@@ -14,12 +14,10 @@ Creates a lightweight Model Context Protocol (MCP) client that connects to an MC
 
 It currently does not support accepting notifications from an MCP server, and custom configuration of the client.
 
-This feature is experimental and may change or be removed in the future.
-
 ## Import
 
 <Snippet
-  text={`import { experimental_createMCPClient } from "@ai-sdk/mcp"`}
+  text={`import { createMCPClient } from "@ai-sdk/mcp"`}
   prompt={false}
 />
 
@@ -346,10 +344,8 @@ Returns a Promise that resolves to an `MCPClient` with the following methods:
 ## Example
 
 ```typescript
-import {
-  experimental_createMCPClient as createMCPClient,
-  generateText,
-} from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
+import { generateText } from 'ai';
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 
 let client;

--- a/content/docs/07-reference/01-ai-sdk-core/index.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/index.mdx
@@ -75,7 +75,7 @@ It also contains the following helper functions:
       href: '/docs/reference/ai-sdk-core/tool',
     },
     {
-      title: 'experimental_createMCPClient()',
+      title: 'createMCPClient()',
       description: 'Creates a client for connecting to MCP servers.',
       href: '/docs/reference/ai-sdk-core/create-mcp-client',
     },

--- a/examples/mcp/src/elicitation-multi-step/client.ts
+++ b/examples/mcp/src/elicitation-multi-step/client.ts
@@ -1,7 +1,4 @@
-import {
-  experimental_createMCPClient as createMCPClient,
-  ElicitationRequestSchema,
-} from '@ai-sdk/mcp';
+import { createMCPClient, ElicitationRequestSchema } from '@ai-sdk/mcp';
 import { openai } from '@ai-sdk/openai';
 import { generateText, stepCountIs } from 'ai';
 import { createInterface } from 'node:readline/promises';

--- a/examples/mcp/src/elicitation/client.ts
+++ b/examples/mcp/src/elicitation/client.ts
@@ -1,7 +1,4 @@
-import {
-  experimental_createMCPClient as createMCPClient,
-  ElicitationRequestSchema,
-} from '@ai-sdk/mcp';
+import { createMCPClient, ElicitationRequestSchema } from '@ai-sdk/mcp';
 import { openai } from '@ai-sdk/openai';
 import { generateText, stepCountIs } from 'ai';
 import { createInterface } from 'node:readline/promises';

--- a/examples/mcp/src/http/client.ts
+++ b/examples/mcp/src/http/client.ts
@@ -2,10 +2,7 @@ import { openai } from '@ai-sdk/openai';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
-import {
-  experimental_createMCPClient as createMCPClient,
-  experimental_MCPClient as MCPClient,
-} from '@ai-sdk/mcp';
+import { createMCPClient, MCPClient } from '@ai-sdk/mcp';
 
 async function main() {
   const transport = new StreamableHTTPClientTransport(

--- a/examples/mcp/src/mcp-prompts/client.ts
+++ b/examples/mcp/src/mcp-prompts/client.ts
@@ -1,4 +1,4 @@
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
 
 async function main() {
   const mcpClient = await createMCPClient({

--- a/examples/mcp/src/mcp-prompts/client.ts
+++ b/examples/mcp/src/mcp-prompts/client.ts
@@ -9,10 +9,10 @@ async function main() {
   });
 
   try {
-    const prompts = await mcpClient.listPrompts();
+    const prompts = await mcpClient.experimental_listPrompts();
     console.log('PROMPTS:', JSON.stringify(prompts, null, 2));
 
-    const prompt = await mcpClient.getPrompt({
+    const prompt = await mcpClient.experimental_getPrompt({
       name: 'code_review',
       arguments: {
         code: 'function add(a, b) { return a + b; }\n',

--- a/examples/mcp/src/mcp-resources/client.ts
+++ b/examples/mcp/src/mcp-resources/client.ts
@@ -1,4 +1,4 @@
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
 import { openai } from '@ai-sdk/openai';
 import { generateText, stepCountIs } from 'ai';
 

--- a/examples/mcp/src/mcp-with-auth/client.ts
+++ b/examples/mcp/src/mcp-with-auth/client.ts
@@ -13,10 +13,7 @@ import type {
 } from 'ai';
 */
 
-import {
-  experimental_createMCPClient as createMCPClient,
-  auth,
-} from '@ai-sdk/mcp';
+import { createMCPClient, auth } from '@ai-sdk/mcp';
 import 'dotenv/config';
 import type {
   OAuthClientProvider,

--- a/examples/mcp/src/sse/client.ts
+++ b/examples/mcp/src/sse/client.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { generateText, stepCountIs } from 'ai';
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
 
 import 'dotenv/config';
 

--- a/examples/mcp/src/stdio/client.ts
+++ b/examples/mcp/src/stdio/client.ts
@@ -1,7 +1,7 @@
 import { openai } from '@ai-sdk/openai';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { generateText, stepCountIs } from 'ai';
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
 import 'dotenv/config';
 import { z } from 'zod';
 

--- a/examples/mcp/src/tool-meta/client.ts
+++ b/examples/mcp/src/tool-meta/client.ts
@@ -1,4 +1,4 @@
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 async function main() {

--- a/examples/next-openai/app/api/mcp-elicitation/route.ts
+++ b/examples/next-openai/app/api/mcp-elicitation/route.ts
@@ -6,10 +6,7 @@ import {
   convertToModelMessages,
   stepCountIs,
 } from 'ai';
-import {
-  experimental_createMCPClient as createMCPClient,
-  ElicitationRequestSchema,
-} from '@ai-sdk/mcp';
+import { createMCPClient, ElicitationRequestSchema } from '@ai-sdk/mcp';
 import { MCPElicitationUIMessage } from './types';
 import { createPendingElicitation } from './elicitation-store';
 

--- a/examples/next-openai/app/api/mcp-with-auth/route.ts
+++ b/examples/next-openai/app/api/mcp-with-auth/route.ts
@@ -7,7 +7,7 @@ import {
   createUIMessageStreamResponse,
 } from 'ai';
 import {
-  experimental_createMCPClient as createMCPClient,
+  createMCPClient,
   auth,
   type OAuthClientInformation,
   type OAuthClientMetadata,

--- a/examples/next-openai/app/api/mcp-zapier/route.ts
+++ b/examples/next-openai/app/api/mcp-zapier/route.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { convertToModelMessages, stepCountIs, streamText } from 'ai';
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
 
 export const maxDuration = 30;
 

--- a/examples/next-openai/app/mcp/chat/route.ts
+++ b/examples/next-openai/app/mcp/chat/route.ts
@@ -1,7 +1,7 @@
 import { openai } from '@ai-sdk/openai';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { convertToModelMessages, stepCountIs, streamText } from 'ai';
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
 
 export async function POST(req: Request) {
   const requestUrl = new URL(req.url);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -5,16 +5,18 @@ export type {
   JSONRPCRequest,
   JSONRPCResponse,
 } from './tool/json-rpc-message';
+
+// Stable exports
 export {
-  createMCPClient as experimental_createMCPClient,
-  type MCPClientConfig as experimental_MCPClientConfig,
-  type MCPClient as experimental_MCPClient,
+  createMCPClient,
+  type MCPClientConfig,
+  type MCPClient,
 } from './tool/mcp-client';
 export { ElicitationRequestSchema, ElicitResultSchema } from './tool/types';
 export type {
   ElicitationRequest,
   ElicitResult,
-  ClientCapabilities as experimental_MCPClientCapabilities,
+  ClientCapabilities as MCPClientCapabilities,
 } from './tool/types';
 export { auth, UnauthorizedError } from './tool/oauth';
 export type { OAuthClientProvider } from './tool/oauth';
@@ -24,3 +26,23 @@ export type {
   OAuthTokens,
 } from './tool/oauth-types';
 export type { MCPTransport } from './tool/mcp-transport';
+
+/**
+ * @deprecated Use `createMCPClient` instead. Will be removed in a future version.
+ */
+export { createMCPClient as experimental_createMCPClient } from './tool/mcp-client';
+
+/**
+ * @deprecated Use `MCPClientConfig` instead. Will be removed in a future version.
+ */
+export type { MCPClientConfig as experimental_MCPClientConfig } from './tool/mcp-client';
+
+/**
+ * @deprecated Use `MCPClient` instead. Will be removed in a future version.
+ */
+export type { MCPClient as experimental_MCPClient } from './tool/mcp-client';
+
+/**
+ * @deprecated Use `MCPClientCapabilities` instead. Will be removed in a future version.
+ */
+export type { ClientCapabilities as experimental_MCPClientCapabilities } from './tool/types';

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -190,7 +190,7 @@ describe('MCPClient', () => {
       transport: { type: 'sse', url: 'https://example.com/sse' },
     });
 
-    const prompts = await client.listPrompts();
+    const prompts = await client.experimental_listPrompts();
 
     expectTypeOf(prompts).toEqualTypeOf<ListPromptsResult>();
 
@@ -217,7 +217,7 @@ describe('MCPClient', () => {
       transport: { type: 'sse', url: 'https://example.com/sse' },
     });
 
-    const prompt = await client.getPrompt({
+    const prompt = await client.experimental_getPrompt({
       name: 'code_review',
       arguments: { code: 'print(42)' },
     });
@@ -253,8 +253,8 @@ describe('MCPClient', () => {
       transport: { type: 'sse', url: 'https://example.com/sse' },
     });
 
-    await expect(client.listPrompts()).rejects.toThrow(MCPClientError);
-    await expect(client.getPrompt({ name: 'code_review' })).rejects.toThrow(
+    await expect(client.experimental_listPrompts()).rejects.toThrow(MCPClientError);
+    await expect(client.experimental_getPrompt({ name: 'code_review' })).rejects.toThrow(
       MCPClientError,
     );
   });

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -253,10 +253,12 @@ describe('MCPClient', () => {
       transport: { type: 'sse', url: 'https://example.com/sse' },
     });
 
-    await expect(client.experimental_listPrompts()).rejects.toThrow(MCPClientError);
-    await expect(client.experimental_getPrompt({ name: 'code_review' })).rejects.toThrow(
+    await expect(client.experimental_listPrompts()).rejects.toThrow(
       MCPClientError,
     );
+    await expect(
+      client.experimental_getPrompt({ name: 'code_review' }),
+    ).rejects.toThrow(MCPClientError);
   });
 
   it('should return typed AI SDK compatible tool set when schemas are provided', async () => {

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -100,12 +100,12 @@ export interface MCPClient {
     options?: RequestOptions;
   }): Promise<ListResourceTemplatesResult>;
 
-  listPrompts(options?: {
+  experimental_listPrompts(options?: {
     params?: PaginatedRequest['params'];
     options?: RequestOptions;
   }): Promise<ListPromptsResult>;
 
-  getPrompt(args: {
+  experimental_getPrompt(args: {
     name: string;
     arguments?: Record<string, unknown>;
     options?: RequestOptions;
@@ -575,7 +575,7 @@ class DefaultMCPClient implements MCPClient {
     return this.listResourceTemplatesInternal({ options });
   }
 
-  listPrompts({
+  experimental_listPrompts({
     params,
     options,
   }: {
@@ -585,7 +585,7 @@ class DefaultMCPClient implements MCPClient {
     return this.listPromptsInternal({ params, options });
   }
 
-  getPrompt({
+  experimental_getPrompt({
     name,
     arguments: args,
     options,


### PR DESCRIPTION
## Background

Makig MCP Client stable for v6

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
