### PR TITLE
feat(provider/bedrock): expose stop_sequence in provider metadata 

### DIFF
--- a/.changeset/bedrock-stop-sequence.md
+++ b/.changeset/bedrock-stop-sequence.md
@@ -3,3 +3,9 @@
 ---
 
 feat(provider/amazon-bedrock): expose stop_sequence in provider metadata
+
+The Bedrock provider now exposes the specific stop sequence that triggered generation to halt via `providerMetadata.bedrock.stopSequence`. This is implemented by:
+
+- Requesting `/stop_sequence` via `additionalModelResponseFieldPaths` in the API call
+- Parsing the value from `additionalModelResponseFields.stop_sequence` in both generate and stream responses
+- Exposing it as `stopSequence` in the provider metadata (returns `null` when no stop sequence was matched)

--- a/.changeset/bedrock-stop-sequence.md
+++ b/.changeset/bedrock-stop-sequence.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+feat(provider/amazon-bedrock): expose stop_sequence in provider metadata

--- a/.changeset/wild-toes-lay.md
+++ b/.changeset/wild-toes-lay.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+'@example/ai-core': patch
+---
+
+Add stop sequence support for amazon bedrock provider

--- a/examples/ai-core/src/generate-text/bedrock-stop-sequence.ts
+++ b/examples/ai-core/src/generate-text/bedrock-stop-sequence.ts
@@ -13,10 +13,7 @@ async function main() {
   console.log();
   console.log('Token usage:', result.usage);
   console.log('Finish reason:', result.finishReason);
-  console.log(
-    'Stop sequence:',
-    result.providerMetadata?.bedrock?.stopSequence,
-  );
+  console.log('Stop sequence:', result.providerMetadata?.bedrock?.stopSequence);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/generate-text/bedrock-stop-sequence.ts
+++ b/examples/ai-core/src/generate-text/bedrock-stop-sequence.ts
@@ -1,0 +1,22 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: bedrock('anthropic.claude-3-5-sonnet-20240620-v1:0'),
+    prompt: 'Write a short story and end it with the word END.',
+    stopSequences: ['END'],
+  });
+
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+  console.log(
+    'Stop sequence:',
+    result.providerMetadata?.bedrock?.stopSequence,
+  );
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/bedrock-stop-sequence.ts
+++ b/examples/ai-core/src/stream-text/bedrock-stop-sequence.ts
@@ -1,0 +1,25 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: bedrock('anthropic.claude-3-5-sonnet-20240620-v1:0'),
+    prompt: 'Write a short story and end it with the word END.',
+    stopSequences: ['END'],
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log(
+    'Stop sequence:',
+    (await result.providerMetadata)?.bedrock?.stopSequence,
+  );
+}
+
+main().catch(console.error);

--- a/packages/amazon-bedrock/src/bedrock-api-types.ts
+++ b/packages/amazon-bedrock/src/bedrock-api-types.ts
@@ -12,6 +12,7 @@ export interface BedrockConverseInput {
     stopSequences?: string[];
   };
   additionalModelRequestFields?: Record<string, unknown>;
+  additionalModelResponseFieldPaths?: string[];
   guardrailConfig?:
     | BedrockGuardrailConfiguration
     | BedrockGuardrailStreamConfiguration

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -872,6 +872,7 @@ describe('doStream', () => {
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
       messages: [{ role: 'user', content: [{ text: 'Hello' }] }],
       system: [{ text: 'System Prompt' }],
+      additionalModelResponseFieldPaths: ['/stop_sequence'],
     });
   });
 
@@ -1030,7 +1031,7 @@ describe('doStream', () => {
         JSON.stringify({
           messageStop: {
             stopReason: 'stop_sequence',
-            stopSequence: 'STOP',
+            additionalModelResponseFields: { stop_sequence: 'STOP' },
           },
         }) + '\n',
       ],
@@ -1048,6 +1049,11 @@ describe('doStream', () => {
         [
           {
             "finishReason": "stop",
+            "providerMetadata": {
+              "bedrock": {
+                "stopSequence": "STOP",
+              },
+            },
             "type": "finish",
             "usage": {
               "inputTokens": {
@@ -2639,6 +2645,7 @@ describe('doGenerate', () => {
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
       messages: [{ role: 'user', content: [{ text: 'Hello' }] }],
       system: [{ text: 'System Prompt' }],
+      additionalModelResponseFieldPaths: ['/stop_sequence'],
     });
   });
 
@@ -2709,7 +2716,7 @@ describe('doGenerate', () => {
           },
         },
         stopReason: 'stop_sequence',
-        stopSequence: 'STOP',
+        additionalModelResponseFields: { stop_sequence: 'STOP' },
         usage: {
           inputTokens: 4,
           outputTokens: 30,
@@ -2726,7 +2733,7 @@ describe('doGenerate', () => {
     expect(result.providerMetadata).toMatchInlineSnapshot(`
       {
         "bedrock": {
-          "stopSequence": null,
+          "stopSequence": "STOP",
         },
       }
     `);

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -1048,11 +1048,6 @@ describe('doStream', () => {
         [
           {
             "finishReason": "stop",
-            "providerMetadata": {
-              "bedrock": {
-                "stopSequence": "STOP",
-              },
-            },
             "type": "finish",
             "usage": {
               "inputTokens": {
@@ -1748,6 +1743,7 @@ describe('doStream', () => {
           "providerMetadata": {
             "bedrock": {
               "isJsonResponseFromTool": true,
+              "stopSequence": null,
             },
           },
           "type": "finish",
@@ -1830,6 +1826,7 @@ describe('doStream', () => {
           "providerMetadata": {
             "bedrock": {
               "isJsonResponseFromTool": true,
+              "stopSequence": null,
             },
           },
           "type": "finish",
@@ -1913,6 +1910,7 @@ describe('doStream', () => {
           "providerMetadata": {
             "bedrock": {
               "isJsonResponseFromTool": true,
+              "stopSequence": null,
             },
           },
           "type": "finish",
@@ -2012,6 +2010,7 @@ describe('doStream', () => {
           "providerMetadata": {
             "bedrock": {
               "isJsonResponseFromTool": true,
+              "stopSequence": null,
             },
           },
           "type": "finish",
@@ -2127,6 +2126,7 @@ describe('doStream', () => {
           "providerMetadata": {
             "bedrock": {
               "isJsonResponseFromTool": true,
+              "stopSequence": null,
             },
           },
           "type": "finish",
@@ -2269,6 +2269,7 @@ describe('doStream', () => {
           "providerMetadata": {
             "bedrock": {
               "isJsonResponseFromTool": true,
+              "stopSequence": null,
             },
           },
           "type": "finish",
@@ -2725,7 +2726,7 @@ describe('doGenerate', () => {
     expect(result.providerMetadata).toMatchInlineSnapshot(`
       {
         "bedrock": {
-          "stopSequence": "STOP",
+          "stopSequence": null,
         },
       }
     `);
@@ -3209,6 +3210,7 @@ describe('doGenerate', () => {
     expect(response.providerMetadata).toMatchInlineSnapshot(`
       {
         "bedrock": {
+          "stopSequence": null,
           "usage": {
             "cacheWriteInputTokens": 3,
           },

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -562,8 +562,8 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
                 isJsonResponseFromTool,
               );
               stopSequence =
-                value.messageStop.additionalModelResponseFields?.stop_sequence ??
-                null;
+                value.messageStop.additionalModelResponseFields
+                  ?.stop_sequence ?? null;
             }
 
             if (value.metadata) {
@@ -883,9 +883,8 @@ const BedrockResponseSchema = z.object({
     }),
   }),
   stopReason: BedrockStopReasonSchema,
-  additionalModelResponseFields: BedrockAdditionalModelResponseFieldsSchema
-    .passthrough()
-    .nullish(),
+  additionalModelResponseFields:
+    BedrockAdditionalModelResponseFieldsSchema.passthrough().nullish(),
   trace: z.unknown().nullish(),
   usage: z.object({
     inputTokens: z.number(),
@@ -939,9 +938,8 @@ const BedrockStreamSchema = z.object({
   internalServerException: z.record(z.string(), z.unknown()).nullish(),
   messageStop: z
     .object({
-      additionalModelResponseFields: BedrockAdditionalModelResponseFieldsSchema
-        .passthrough()
-        .nullish(),
+      additionalModelResponseFields:
+        BedrockAdditionalModelResponseFieldsSchema.passthrough().nullish(),
       stopReason: BedrockStopReasonSchema,
     })
     .nullish(),

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -834,9 +834,11 @@ const BedrockStopReasonSchema = z.union([
   z.string(),
 ]);
 
-const BedrockAdditionalModelResponseFieldsSchema = z.object({
-  stop_sequence: z.string().optional(),
-});
+const BedrockAdditionalModelResponseFieldsSchema = z
+  .object({
+    stop_sequence: z.string().optional(),
+  })
+  .catchall(z.unknown());
 
 const BedrockToolUseSchema = z.object({
   toolUseId: z.string(),
@@ -884,7 +886,7 @@ const BedrockResponseSchema = z.object({
   }),
   stopReason: BedrockStopReasonSchema,
   additionalModelResponseFields:
-    BedrockAdditionalModelResponseFieldsSchema.passthrough().nullish(),
+    BedrockAdditionalModelResponseFieldsSchema.nullish(),
   trace: z.unknown().nullish(),
   usage: z.object({
     inputTokens: z.number(),
@@ -939,7 +941,7 @@ const BedrockStreamSchema = z.object({
   messageStop: z
     .object({
       additionalModelResponseFields:
-        BedrockAdditionalModelResponseFieldsSchema.passthrough().nullish(),
+        BedrockAdditionalModelResponseFieldsSchema.nullish(),
       stopReason: BedrockStopReasonSchema,
     })
     .nullish(),

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -314,6 +314,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
         messages,
         additionalModelRequestFields:
           bedrockOptions.additionalModelRequestFields,
+        additionalModelResponseFieldPaths: ['/stop_sequence'],
         ...(Object.keys(inferenceConfig).length > 0 && {
           inferenceConfig,
         }),


### PR DESCRIPTION
## background

the bedrock converse api can return which specific stop sequence triggered generation to halt, but only when explicitly requested via `additionalModelResponseFieldPaths`. the stop sequence value is returned in `additionalModelResponseFields.stop_sequence`. the ai sdk was not requesting or exposing this field.

## summary

- request `/stop_sequence` via `additionalModelResponseFieldPaths` in api calls
- parse `stop_sequence` from `additionalModelResponseFields` in responses
- expose `stopSequence` in `providerMetadata.bedrock` for both generate and stream
- added proper typing for `additionalModelResponseFields` with `stop_sequence` field
- included tests for both generate and stream scenarios
- added example files demonstrating stop sequence capture

## implementation details

unlike the direct anthropic api which returns `stop_sequence` as a top-level response field, the bedrock converse api requires:
1. requesting it via `additionalModelResponseFieldPaths: ["/stop_sequence"]` in the request
2. extracting it from `additionalModelResponseFields.stop_sequence` in the response

## verification

tested with both generateText and streamText using `stopSequences: ['END']`. confirmed `providerMetadata.bedrock.stopSequence` correctly returns "END" when triggered
