### PR TITLE
fix(examples): resolve method for improved path handling

### DIFF
--- a/examples/next-openai/lib/apply-patch-file-editor.ts
+++ b/examples/next-openai/lib/apply-patch-file-editor.ts
@@ -105,11 +105,17 @@ export class WorkspaceEditor {
     return await fs.readFile(targetPath, 'utf8');
   }
 
-  private async resolve(relativePath: string): Promise<string> {
-    const resolved = path.resolve(this.root, relativePath);
-    if (!resolved.startsWith(this.root)) {
-      throw new Error(`Operation outside workspace: ${relativePath}`);
-    }
-    return resolved;
+private async resolve(relativePath: string): Promise<string> {
+  const rootPath = path.resolve(this.root);
+  const targetPath = path.resolve(rootPath, relativePath);
+
+  const relative = path.relative(rootPath, targetPath);
+
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Operation outside workspace: ${relativePath}`);
   }
+
+  return targetPath;
+}
+
 }

--- a/examples/next-openai/lib/apply-patch-file-editor.ts
+++ b/examples/next-openai/lib/apply-patch-file-editor.ts
@@ -105,17 +105,16 @@ export class WorkspaceEditor {
     return await fs.readFile(targetPath, 'utf8');
   }
 
-private async resolve(relativePath: string): Promise<string> {
-  const rootPath = path.resolve(this.root);
-  const targetPath = path.resolve(rootPath, relativePath);
+  private async resolve(relativePath: string): Promise<string> {
+    const rootPath = path.resolve(this.root);
+    const targetPath = path.resolve(rootPath, relativePath);
 
-  const relative = path.relative(rootPath, targetPath);
+    const relative = path.relative(rootPath, targetPath);
 
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error(`Operation outside workspace: ${relativePath}`);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error(`Operation outside workspace: ${relativePath}`);
+    }
+
+    return targetPath;
   }
-
-  return targetPath;
-}
-
 }


### PR DESCRIPTION
Your original check is unsafe because it uses a string comparison which is "startsWith" to decide filesystem safety.

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->
Your original check is bad because it uses a string comparison (startsWith) to decide filesystem safety.

## Summary

Changed the function using startsWith to using the relative path for better enhanced security.

## Manual Verification

Verified that creating, updating, and deleting files inside the workspace works as expected.
Verified that attempts to access files outside the workspace are correctly blocked.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x ] I have reviewed this pull request (self-review)


