### PR TITLE
fix(anthropic): ignore vertex <> anthropic proxy events

### DIFF
--- a/.changeset/tidy-schools-lay.md
+++ b/.changeset/tidy-schools-lay.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+ignore vertex_events from vertex-anthropic proxies to unsuspecting anthropic clients

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -1051,6 +1051,20 @@ export const anthropicMessagesChunkSchema = lazySchema(() =>
       z.object({
         type: z.literal('ping'),
       }),
+      // Vertex AI proxies inject vertex_event SSE events with usage info - ignore them
+      z.object({
+        type: z.literal('vertex_event'),
+        usage: z
+          .looseObject({
+            input_tokens: z.number().optional(),
+            output_tokens: z.number().optional(),
+            cache_creation_input_tokens: z.number().nullish(),
+            cache_read_input_tokens: z.number().nullish(),
+            web_search_requests: z.unknown().nullish(),
+            cache_creation: z.unknown().nullish(),
+          })
+          .optional(),
+      }),
     ]),
   ),
 );

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -1095,6 +1095,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
               return; // ignored
             }
 
+            case 'vertex_event': {
+              return; // ignored - Vertex AI proxy usage event
+            }
+
             case 'content_block_start': {
               const part = value.content_block;
               const contentBlockType = part.type;


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->
Naively address #11309 

## Summary

Ignores `vertex_event` SSE events from LLM proxies that present Anthropic API, but use Vertex-Anthropic upstream

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

I created a minimal repro Deno project and substituted `ai-sdk` with my local branch in `deno.json`

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
