### PR TITLE
feat (provider/gateway): add zero data retention provider option

### DIFF
--- a/.changeset/olive-feet-return.md
+++ b/.changeset/olive-feet-return.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): add zero data retention provider option

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -412,6 +412,10 @@ The following gateway provider options are available:
   - Multiple credentials: `byok: { 'vertex': [{ projectId: 'proj-1', privateKey: '...' }, { projectId: 'proj-2', privateKey: '...' }] }`
   - Multiple providers: `byok: { 'anthropic': [{ apiKey: '...' }], 'bedrock': [{ accessKeyId: '...', secretAccessKey: '...' }] }`
 
+- **zeroDataRetention** _boolean_
+
+  Restricts routing requests to providers that have zero data retention policies.
+
 You can combine these options to have fine-grained control over routing and tracking:
 
 ```ts
@@ -453,6 +457,27 @@ const { text } = await generateText({
 // 2. If it fails, try openai/gpt-5-nano
 // 3. If that fails, try gemini-2.0-flash
 // 4. Return the result from the first model that succeeds
+```
+
+#### Zero Data Retention Example
+
+Set `zeroDataRetention` to true to ensure requests are only routed to providers
+that have zero data retention policies. When `zeroDataRetention` is `false` or not
+specified, there is no enforcement of restricting routing.
+
+```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4.5',
+  prompt: 'Analyze this sensitive document...',
+  providerOptions: {
+    gateway: {
+      zeroDataRetention: true,
+    } satisfies GatewayProviderOptions,
+  },
+});
 ```
 
 ### Provider-Specific Options

--- a/examples/ai-core/src/stream-text/gateway-provider-options-zero-data-retention.ts
+++ b/examples/ai-core/src/stream-text/gateway-provider-options-zero-data-retention.ts
@@ -1,0 +1,29 @@
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: 'openai/gpt-oss-120b',
+    prompt: 'Tell me the history of the tenrec in a few sentences.',
+    providerOptions: {
+      gateway: {
+        zeroDataRetention: true,
+      } satisfies GatewayProviderOptions,
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(await result.providerMetadata, null, 2),
+  );
+}
+
+main().catch(console.error);

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -52,6 +52,13 @@ const gatewayProviderOptions = lazySchema(() =>
       byok: z
         .record(z.string(), z.array(z.record(z.string(), z.unknown())))
         .optional(),
+      /**
+       * Whether to filter by only providers that state they have zero data
+       * retention with Vercel AI Gateway. When enabled, only providers that
+       * have agreements with Vercel AI Gateway for zero data retention will be
+       * used.
+       */
+      zeroDataRetention: z.boolean().optional(),
     }),
   ),
 );


### PR DESCRIPTION
## Background

Vercel AI Gateway is adding support to constrain AI queries to only execute on providers with zero data retention policies.

## Summary

Updated version of https://github.com/vercel/ai/pull/10383

## Manual Verification

Ran example script added in this PR locally.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
