### PR TITLE
fix(provider/google): Fix Google model tool schema error

### DIFF
--- a/.changeset/tall-islands-build.md
+++ b/.changeset/tall-islands-build.md
@@ -2,4 +2,4 @@
 '@ai-sdk/google': patch
 ---
 
-fix(provider/google): Fix Google model tool schema error
+fix(provider/google): preserve nested empty object schemas in tool parameters to fix "property is not defined" validation errors when using required properties with empty object types

--- a/.changeset/tall-islands-build.md
+++ b/.changeset/tall-islands-build.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(provider/google): Fix Google model tool schema error

--- a/examples/ai-core/src/generate-text/google-tool-nested-empty-object.ts
+++ b/examples/ai-core/src/generate-text/google-tool-nested-empty-object.ts
@@ -1,0 +1,30 @@
+import { google } from '@ai-sdk/google';
+import { generateText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const result = await generateText({
+    model: google('gemini-3-flash-preview'),
+    tools: {
+      navigate: tool({
+        description: 'Navigate to a URL',
+        inputSchema: z.object({
+          url: z.string().describe('URL to navigate to'),
+          launchOptions: z
+            .object({})
+            .describe('Browser launch options as key-value pairs'),
+        }),
+      }),
+    },
+    toolChoice: 'required',
+    prompt: 'Navigate to https://example.com with default launch options',
+  });
+
+  console.log('Tool calls:');
+  for (const toolCall of result.toolCalls) {
+    console.log(`  ${toolCall.toolName}:`, toolCall.input);
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/google-tool-nested-empty-object.ts
+++ b/examples/ai-core/src/stream-text/google-tool-nested-empty-object.ts
@@ -1,0 +1,31 @@
+import { google } from '@ai-sdk/google';
+import { streamText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const result = streamText({
+    model: google('gemini-3-flash-preview'),
+    tools: {
+      navigate: tool({
+        description: 'Navigate to a URL',
+        inputSchema: z.object({
+          url: z.string().describe('URL to navigate to'),
+          launchOptions: z
+            .object({})
+            .describe('Browser launch options as key-value pairs'),
+        }),
+      }),
+    },
+    toolChoice: 'required',
+    prompt: 'Navigate to https://example.com with default launch options',
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'tool-call') {
+      console.log('Tool call:', part.toolName, part.input);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
@@ -495,7 +495,7 @@ it('should handle descriptions', () => {
   expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
 });
 
-it('should return undefined for empty object schemas', () => {
+it('should return undefined for empty object schemas at root level', () => {
   const emptyObjectSchemas = [
     { type: 'object' },
     { type: 'object', properties: {} },
@@ -504,6 +504,30 @@ it('should return undefined for empty object schemas', () => {
   emptyObjectSchemas.forEach(schema => {
     expect(convertJSONSchemaToOpenAPISchema(schema)).toBeUndefined();
   });
+});
+
+it('should preserve nested empty object schemas to avoid breaking required array validation', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'URL to navigate to' },
+      launchOptions: { type: 'object', description: 'PuppeteerJS LaunchOptions' },
+      allowDangerous: { type: 'boolean', description: 'Allow dangerous options' },
+    },
+    required: ['url', 'launchOptions'],
+  };
+
+  const expected = {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'URL to navigate to' },
+      launchOptions: { type: 'object' },
+      allowDangerous: { type: 'boolean', description: 'Allow dangerous options' },
+    },
+    required: ['url', 'launchOptions'],
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
 });
 
 it('should handle non-empty object schemas', () => {

--- a/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
@@ -511,8 +511,14 @@ it('should preserve nested empty object schemas to avoid breaking required array
     type: 'object',
     properties: {
       url: { type: 'string', description: 'URL to navigate to' },
-      launchOptions: { type: 'object', description: 'PuppeteerJS LaunchOptions' },
-      allowDangerous: { type: 'boolean', description: 'Allow dangerous options' },
+      launchOptions: {
+        type: 'object',
+        description: 'PuppeteerJS LaunchOptions',
+      },
+      allowDangerous: {
+        type: 'boolean',
+        description: 'Allow dangerous options',
+      },
     },
     required: ['url', 'launchOptions'],
   };
@@ -522,7 +528,10 @@ it('should preserve nested empty object schemas to avoid breaking required array
     properties: {
       url: { type: 'string', description: 'URL to navigate to' },
       launchOptions: { type: 'object' },
-      allowDangerous: { type: 'boolean', description: 'Allow dangerous options' },
+      allowDangerous: {
+        type: 'boolean',
+        description: 'Allow dangerous options',
+      },
     },
     required: ['url', 'launchOptions'],
   };

--- a/packages/google/src/convert-json-schema-to-openapi-schema.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.ts
@@ -7,7 +7,7 @@ export function convertJSONSchemaToOpenAPISchema(
   jsonSchema: JSONSchema7Definition | undefined,
   isRoot = true,
 ): unknown {
-  // parameters need to be undefined if they are empty objects:
+  // Handle empty object schemas: undefined at root, preserved when nested
   if (jsonSchema == null) {
     return undefined;
   }

--- a/packages/google/src/convert-json-schema-to-openapi-schema.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.ts
@@ -92,7 +92,9 @@ export function convertJSONSchemaToOpenAPISchema(
   }
 
   if (allOf) {
-    result.allOf = allOf.map(item => convertJSONSchemaToOpenAPISchema(item, false));
+    result.allOf = allOf.map(item =>
+      convertJSONSchemaToOpenAPISchema(item, false),
+    );
   }
   if (anyOf) {
     // Handle cases where anyOf includes a null type
@@ -107,22 +109,31 @@ export function convertJSONSchemaToOpenAPISchema(
 
       if (nonNullSchemas.length === 1) {
         // If there's only one non-null schema, convert it and make it nullable
-        const converted = convertJSONSchemaToOpenAPISchema(nonNullSchemas[0], false);
+        const converted = convertJSONSchemaToOpenAPISchema(
+          nonNullSchemas[0],
+          false,
+        );
         if (typeof converted === 'object') {
           result.nullable = true;
           Object.assign(result, converted);
         }
       } else {
         // If there are multiple non-null schemas, keep them in anyOf
-        result.anyOf = nonNullSchemas.map(item => convertJSONSchemaToOpenAPISchema(item, false));
+        result.anyOf = nonNullSchemas.map(item =>
+          convertJSONSchemaToOpenAPISchema(item, false),
+        );
         result.nullable = true;
       }
     } else {
-      result.anyOf = anyOf.map(item => convertJSONSchemaToOpenAPISchema(item, false));
+      result.anyOf = anyOf.map(item =>
+        convertJSONSchemaToOpenAPISchema(item, false),
+      );
     }
   }
   if (oneOf) {
-    result.oneOf = oneOf.map(item => convertJSONSchemaToOpenAPISchema(item, false));
+    result.oneOf = oneOf.map(item =>
+      convertJSONSchemaToOpenAPISchema(item, false),
+    );
   }
 
   if (minLength !== undefined) {

--- a/packages/google/src/convert-json-schema-to-openapi-schema.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.ts
@@ -5,10 +5,19 @@ import { JSONSchema7Definition } from '@ai-sdk/provider';
  */
 export function convertJSONSchemaToOpenAPISchema(
   jsonSchema: JSONSchema7Definition | undefined,
+  isRoot = true,
 ): unknown {
   // parameters need to be undefined if they are empty objects:
-  if (jsonSchema == null || isEmptyObjectSchema(jsonSchema)) {
+  if (jsonSchema == null) {
     return undefined;
+  }
+
+  if (isEmptyObjectSchema(jsonSchema)) {
+    if (isRoot) {
+      return undefined;
+    }
+
+    return { type: 'object' };
   }
 
   if (typeof jsonSchema === 'boolean') {
@@ -69,7 +78,7 @@ export function convertJSONSchemaToOpenAPISchema(
   if (properties != null) {
     result.properties = Object.entries(properties).reduce(
       (acc, [key, value]) => {
-        acc[key] = convertJSONSchemaToOpenAPISchema(value);
+        acc[key] = convertJSONSchemaToOpenAPISchema(value, false);
         return acc;
       },
       {} as Record<string, unknown>,
@@ -78,12 +87,12 @@ export function convertJSONSchemaToOpenAPISchema(
 
   if (items) {
     result.items = Array.isArray(items)
-      ? items.map(convertJSONSchemaToOpenAPISchema)
-      : convertJSONSchemaToOpenAPISchema(items);
+      ? items.map(item => convertJSONSchemaToOpenAPISchema(item, false))
+      : convertJSONSchemaToOpenAPISchema(items, false);
   }
 
   if (allOf) {
-    result.allOf = allOf.map(convertJSONSchemaToOpenAPISchema);
+    result.allOf = allOf.map(item => convertJSONSchemaToOpenAPISchema(item, false));
   }
   if (anyOf) {
     // Handle cases where anyOf includes a null type
@@ -98,22 +107,22 @@ export function convertJSONSchemaToOpenAPISchema(
 
       if (nonNullSchemas.length === 1) {
         // If there's only one non-null schema, convert it and make it nullable
-        const converted = convertJSONSchemaToOpenAPISchema(nonNullSchemas[0]);
+        const converted = convertJSONSchemaToOpenAPISchema(nonNullSchemas[0], false);
         if (typeof converted === 'object') {
           result.nullable = true;
           Object.assign(result, converted);
         }
       } else {
         // If there are multiple non-null schemas, keep them in anyOf
-        result.anyOf = nonNullSchemas.map(convertJSONSchemaToOpenAPISchema);
+        result.anyOf = nonNullSchemas.map(item => convertJSONSchemaToOpenAPISchema(item, false));
         result.nullable = true;
       }
     } else {
-      result.anyOf = anyOf.map(convertJSONSchemaToOpenAPISchema);
+      result.anyOf = anyOf.map(item => convertJSONSchemaToOpenAPISchema(item, false));
     }
   }
   if (oneOf) {
-    result.oneOf = oneOf.map(convertJSONSchemaToOpenAPISchema);
+    result.oneOf = oneOf.map(item => convertJSONSchemaToOpenAPISchema(item, false));
   }
 
   if (minLength !== undefined) {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Fixes https://linear.app/vercel/issue/AI-4776/investigate-roo-code-gemini-mcp-tool-schema-error

## Summary

When tool schemas with nested empty object properties were sent (like launchOptions: { type: "object" }) to Gemini through the Gateway, the google package's schema conversion function was treating these empty objects as unnecessary and converting them to undefined, which removed them from the properties object entirely. But the required array still referenced them by name. Gemini's validation then failed with "property is not defined" because it found "launchOptions" in required but couldn't find it in properties.

The fix adds a simple check: only convert empty objects to undefined at the root level (where it's actually useful), but preserve them as { type: "object" } when they're nested properties so they stay in sync with the required array.

## Manual Verification
New test passes

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues
https://linear.app/vercel/issue/AI-4776/investigate-roo-code-gemini-mcp-tool-schema-error