### PR TITLE
fix(provider/google): preserve nested empty object schemas and descriptions in tool parameters

### DIFF
--- a/.changeset/cold-apricots-yell.md
+++ b/.changeset/cold-apricots-yell.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(provider/google): preserve nested empty object schemas and descriptions in tool parameters

--- a/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
@@ -527,7 +527,10 @@ it('should preserve nested empty object schemas to avoid breaking required array
     type: 'object',
     properties: {
       url: { type: 'string', description: 'URL to navigate to' },
-      launchOptions: { type: 'object', description: 'PuppeteerJS LaunchOptions' },
+      launchOptions: {
+        type: 'object',
+        description: 'PuppeteerJS LaunchOptions',
+      },
       allowDangerous: {
         type: 'boolean',
         description: 'Allow dangerous options',

--- a/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
@@ -527,13 +527,33 @@ it('should preserve nested empty object schemas to avoid breaking required array
     type: 'object',
     properties: {
       url: { type: 'string', description: 'URL to navigate to' },
-      launchOptions: { type: 'object' },
+      launchOptions: { type: 'object', description: 'PuppeteerJS LaunchOptions' },
       allowDangerous: {
         type: 'boolean',
         description: 'Allow dangerous options',
       },
     },
     required: ['url', 'launchOptions'],
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
+});
+
+it('should preserve nested empty object schemas without descriptions', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      options: { type: 'object' },
+    },
+    required: ['options'],
+  };
+
+  const expected = {
+    type: 'object',
+    properties: {
+      options: { type: 'object' },
+    },
+    required: ['options'],
   };
 
   expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);

--- a/packages/google/src/convert-json-schema-to-openapi-schema.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.ts
@@ -17,6 +17,9 @@ export function convertJSONSchemaToOpenAPISchema(
       return undefined;
     }
 
+    if (typeof jsonSchema === 'object' && jsonSchema.description) {
+      return { type: 'object', description: jsonSchema.description };
+    }
     return { type: 'object' };
   }
 


### PR DESCRIPTION
forward of #11319