### PR TITLE
fix(provider/anthropic): handling of errors in anthropic web fetch tool

### DIFF
--- a/.changeset/loud-stingrays-explain.md
+++ b/.changeset/loud-stingrays-explain.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Fix handling of error in web fetch tool in anthropic

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -285,22 +285,26 @@ export interface AnthropicBashCodeExecutionToolResultContent {
 export interface AnthropicWebFetchToolResultContent {
   type: 'web_fetch_tool_result';
   tool_use_id: string;
-  content: {
-    type: 'web_fetch_result';
-    url: string;
-    retrieved_at: string | null;
-    content: {
-      type: 'document';
-      title: string | null;
-      citations?: { enabled: boolean };
-      source:
-        | { type: 'base64'; media_type: 'application/pdf'; data: string }
-        | { type: 'text'; media_type: 'text/plain'; data: string };
-    };
-  };
+  content:
+    | {
+        type: 'web_fetch_result';
+        url: string;
+        retrieved_at: string | null;
+        content: {
+          type: 'document';
+          title: string | null;
+          citations?: { enabled: boolean };
+          source:
+            | { type: 'base64'; media_type: 'application/pdf'; data: string }
+            | { type: 'text'; media_type: 'text/plain'; data: string };
+        };
+      }
+    | {
+        type: 'web_fetch_tool_result_error';
+        error_code: string;
+      };
   cache_control: AnthropicCacheControl | undefined;
 }
-
 export interface AnthropicMcpToolUseContent {
   type: 'mcp_tool_use';
   id: string;

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -1232,6 +1232,78 @@ describe('assistant messages', () => {
     expect(warnings).toMatchInlineSnapshot(`[]`);
   });
 
+  it('should convert anthropic web_fetch tool call with error result', async () => {
+    const warnings: SharedV3Warning[] = [];
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              input: {
+                url: 'https://httpbin.org/status/500',
+              },
+              providerExecuted: true,
+              toolCallId: 'srvtoolu_016yTvwN6L1sDdjdPUzPbZRV',
+              toolName: 'web_fetch',
+              type: 'tool-call',
+            },
+            {
+              output: {
+                type: 'error-json',
+                value: JSON.stringify({
+                  type: 'web_fetch_tool_result_error',
+                  errorCode: 'url_not_accessible',
+                }),
+              },
+              toolCallId: 'srvtoolu_016yTvwN6L1sDdjdPUzPbZRV',
+              toolName: 'web_fetch',
+              type: 'tool-result',
+            },
+          ],
+        },
+      ],
+      sendReasoning: false,
+      warnings,
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "betas": Set {},
+        "prompt": {
+          "messages": [
+            {
+              "content": [
+                {
+                  "cache_control": undefined,
+                  "id": "srvtoolu_016yTvwN6L1sDdjdPUzPbZRV",
+                  "input": {
+                    "url": "https://httpbin.org/status/500",
+                  },
+                  "name": "web_fetch",
+                  "type": "server_tool_use",
+                },
+                {
+                  "cache_control": undefined,
+                  "content": {
+                    "error_code": "url_not_accessible",
+                    "type": "web_fetch_tool_result_error",
+                  },
+                  "tool_use_id": "srvtoolu_016yTvwN6L1sDdjdPUzPbZRV",
+                  "type": "web_fetch_tool_result",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          "system": undefined,
+        },
+      }
+    `);
+    expect(warnings).toMatchInlineSnapshot(`[]`);
+  });
+
   describe('code_execution 20250522', () => {
     it('should convert anthropic code_execution tool call and result parts', async () => {
       const warnings: SharedV3Warning[] = [];

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -787,6 +787,22 @@ export async function convertToAnthropicMessagesPrompt({
                 if (providerToolName === 'web_fetch') {
                   const output = part.output;
 
+                  if (output.type === 'error-json') {
+                    const errorValue = JSON.parse(output.value as string);
+
+                    anthropicContent.push({
+                      type: 'web_fetch_tool_result',
+                      tool_use_id: part.toolCallId,
+                      content: {
+                        type: 'web_fetch_tool_result_error',
+                        error_code: errorValue.errorCode,
+                      },
+                      cache_control: cacheControl,
+                    });
+
+                    break;
+                  }
+
                   if (output.type !== 'json') {
                     warnings.push({
                       type: 'other',
@@ -816,7 +832,10 @@ export async function convertToAnthropicMessagesPrompt({
                           type: webFetchOutput.content.source.type,
                           media_type: webFetchOutput.content.source.mediaType,
                           data: webFetchOutput.content.source.data,
-                        } as AnthropicWebFetchToolResultContent['content']['content']['source'],
+                        } as Extract<
+                          AnthropicWebFetchToolResultContent['content'],
+                          { type: 'web_fetch_result' }
+                        >['content']['source'],
                       },
                     },
                     cache_control: cacheControl,


### PR DESCRIPTION

## Background

1. Set up an Anthropic agent with web fetch enabled
2. Send a message like "fetch this webpage for me https://httpbin.org/status/500"
3. That will return an error message in the correct format
4. Then send another message which should reserialize the error message, but it just skips that error result entirely when serializing
5. Anthropic returns an error like:  
`{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.3.web_fetch_tool_result.content.RequestWebFetchToolResultError.type: Input should be 'web_fetch_tool_result_error'"},"request_id":"req_011CWLLTWJ2Zpxv36m6vzu6B"}`


## Summary

We were not correctly serializing web fetch errors in the anthropic response message fixed that.

## Manual Verification
Ran example in `next-openai/chat-anthropic-web-fetch`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)


## Related Issues
Fixes #9929 
