### PR TITLE
feat (provider/gateway): update route path version and embed format

### DIFF
--- a/.changeset/brave-llamas-sell.md
+++ b/.changeset/brave-llamas-sell.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): update route path version and embed format

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -80,7 +80,7 @@ You can use the following optional settings to customize the AI Gateway provider
 
 - **baseURL** _string_
 
-  Use a different URL prefix for API calls. The default prefix is `https://ai-gateway.vercel.sh/v1/ai`.
+  Use a different URL prefix for API calls. The default prefix is `https://ai-gateway.vercel.sh/v3/ai`.
 
 - **apiKey** _string_
 

--- a/packages/gateway/src/gateway-embedding-model.test.ts
+++ b/packages/gateway/src/gateway-embedding-model.test.ts
@@ -101,17 +101,12 @@ describe('GatewayEmbeddingModel', () => {
       expect(usage).toStrictEqual({ tokens: 42 });
     });
 
-    it('should send single value as string, multiple values as array', async () => {
+    it('should send value as array', async () => {
       prepareJsonResponse();
 
       await createTestModel().doEmbed({ values: testValues });
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        input: testValues,
-      });
-
-      await createTestModel().doEmbed({ values: [testValues[0]] });
-      expect(await server.calls[1].requestBodyJson).toStrictEqual({
-        input: testValues[0],
+        values: testValues,
       });
     });
 
@@ -124,7 +119,7 @@ describe('GatewayEmbeddingModel', () => {
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        input: testValues,
+        values: testValues,
         providerOptions: { openai: { dimensions: 64 } },
       });
     });
@@ -135,7 +130,7 @@ describe('GatewayEmbeddingModel', () => {
       await createTestModel().doEmbed({ values: testValues });
 
       const body = await server.calls[0].requestBodyJson;
-      expect(body).toStrictEqual({ input: testValues });
+      expect(body).toStrictEqual({ values: testValues });
       expect('providerOptions' in body).toBe(false);
     });
 

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -57,7 +57,7 @@ export class GatewayEmbeddingModel implements EmbeddingModelV3 {
           await resolve(this.config.o11yHeaders),
         ),
         body: {
-          input: values.length === 1 ? values[0] : values,
+          values,
           ...(providerOptions ? { providerOptions } : {}),
         },
         successfulResponseHandler: createJsonResponseHandler(

--- a/packages/gateway/src/gateway-provider.test.ts
+++ b/packages/gateway/src/gateway-provider.test.ts
@@ -409,7 +409,7 @@ describe('GatewayProvider', () => {
       // Check that GatewayFetchMetadata was instantiated with the default baseURL
       expect(GatewayFetchMetadata).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseURL: 'https://ai-gateway.vercel.sh/v1/ai',
+          baseURL: 'https://ai-gateway.vercel.sh/v3/ai',
         }),
       );
     });
@@ -432,7 +432,7 @@ describe('GatewayProvider', () => {
 
       const config = getGatewayImageModelInternalConfig(model);
       expect(config.provider).toBe('gateway');
-      expect(config.baseURL).toBe('https://ai-gateway.vercel.sh/v1/ai');
+      expect(config.baseURL).toBe('https://ai-gateway.vercel.sh/v3/ai');
     });
 
     it('should override default baseURL when provided', async () => {
@@ -932,7 +932,7 @@ describe('GatewayProvider', () => {
       expect(credits).toEqual({ balance: '150.50', total_used: '75.25' });
       expect(GatewayFetchMetadata).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseURL: 'https://ai-gateway.vercel.sh/v1/ai',
+          baseURL: 'https://ai-gateway.vercel.sh/v3/ai',
           headers: expect.any(Function),
           fetch: undefined,
         }),
@@ -947,7 +947,7 @@ describe('GatewayProvider', () => {
     });
 
     it('should work with custom baseURL', async () => {
-      const customBaseURL = 'https://custom-gateway.example.com/v1/ai';
+      const customBaseURL = 'https://custom-gateway.example.com/v3/ai';
       const provider = createGatewayProvider({
         apiKey: 'test-key',
         baseURL: customBaseURL,

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -114,7 +114,7 @@ export function createGatewayProvider(
 
   const baseURL =
     withoutTrailingSlash(options.baseURL) ??
-    'https://ai-gateway.vercel.sh/v1/ai';
+    'https://ai-gateway.vercel.sh/v3/ai';
 
   const getHeaders = async () => {
     const auth = await getGatewayAuthToken(options);


### PR DESCRIPTION
## Background

AI Gateway is moving to a separate route for AI SDK v6. The embed call options have also changed since v5.

## Summary

Updated base url for new route path, and embed params to reflect new call options.

## Manual Verification

Ran an embed query manually against local gateway server with new route handlers.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
