### PR TITLE
chore(specification): rename EmbeddingModelCallOptions

### DIFF
--- a/.changeset/orange-fans-own.md
+++ b/.changeset/orange-fans-own.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider': patch
+'ai': patch
+---
+
+chore(specification): rename EmbeddingModelCallOptions

--- a/packages/ai/src/middleware/default-embedding-settings-middleware.test.ts
+++ b/packages/ai/src/middleware/default-embedding-settings-middleware.test.ts
@@ -1,9 +1,9 @@
-import { EmbeddingModelCallOptions } from '@ai-sdk/provider';
+import { EmbeddingModelV3CallOptions } from '@ai-sdk/provider';
 import { defaultEmbeddingSettingsMiddleware } from './default-embedding-settings-middleware';
 import { MockEmbeddingModelV3 } from '../test/mock-embedding-model-v3';
 import { describe, it, expect } from 'vitest';
 
-const params: EmbeddingModelCallOptions = {
+const params: EmbeddingModelV3CallOptions = {
   values: ['hello world'],
 };
 

--- a/packages/ai/src/middleware/default-embedding-settings-middleware.ts
+++ b/packages/ai/src/middleware/default-embedding-settings-middleware.ts
@@ -1,4 +1,4 @@
-import { EmbeddingModelCallOptions } from '@ai-sdk/provider';
+import { EmbeddingModelV3CallOptions } from '@ai-sdk/provider';
 import { EmbeddingModelMiddleware } from '../types';
 import { mergeObjects } from '../util/merge-objects';
 
@@ -9,14 +9,14 @@ export function defaultEmbeddingSettingsMiddleware({
   settings,
 }: {
   settings: Partial<{
-    headers?: EmbeddingModelCallOptions['headers'];
-    providerOptions?: EmbeddingModelCallOptions['providerOptions'];
+    headers?: EmbeddingModelV3CallOptions['headers'];
+    providerOptions?: EmbeddingModelV3CallOptions['providerOptions'];
   }>;
 }): EmbeddingModelMiddleware {
   return {
     specificationVersion: 'v3',
     transformParams: async ({ params }) => {
-      return mergeObjects(settings, params) as EmbeddingModelCallOptions;
+      return mergeObjects(settings, params) as EmbeddingModelV3CallOptions;
     },
   };
 }

--- a/packages/ai/src/middleware/wrap-embedding-model.test.ts
+++ b/packages/ai/src/middleware/wrap-embedding-model.test.ts
@@ -1,5 +1,5 @@
 import {
-  EmbeddingModelCallOptions,
+  EmbeddingModelV3CallOptions,
   EmbeddingModelV3Middleware,
 } from '@ai-sdk/provider';
 import { wrapEmbeddingModel } from '../middleware/wrap-embedding-model';
@@ -169,7 +169,7 @@ describe('wrapEmbeddingModel', () => {
       },
     });
 
-    const params: EmbeddingModelCallOptions = {
+    const params: EmbeddingModelV3CallOptions = {
       values: [
         'sunny day at the beach',
         'rainy afternoon in the city',
@@ -205,7 +205,7 @@ describe('wrapEmbeddingModel', () => {
       },
     });
 
-    const params: EmbeddingModelCallOptions = {
+    const params: EmbeddingModelV3CallOptions = {
       values: [
         'sunny day at the beach',
         'rainy afternoon in the city',
@@ -252,7 +252,7 @@ describe('wrapEmbeddingModel', () => {
         ],
       });
 
-      const params: EmbeddingModelCallOptions = {
+      const params: EmbeddingModelV3CallOptions = {
         values: [
           'sunny day at the beach',
           'rainy afternoon in the city',
@@ -313,7 +313,7 @@ describe('wrapEmbeddingModel', () => {
         ],
       });
 
-      const params: EmbeddingModelCallOptions = {
+      const params: EmbeddingModelV3CallOptions = {
         values: [
           'sunny day at the beach',
           'rainy afternoon in the city',

--- a/packages/ai/src/middleware/wrap-embedding-model.ts
+++ b/packages/ai/src/middleware/wrap-embedding-model.ts
@@ -1,4 +1,7 @@
-import { EmbeddingModelV3, EmbeddingModelCallOptions } from '@ai-sdk/provider';
+import {
+  EmbeddingModelV3,
+  EmbeddingModelV3CallOptions,
+} from '@ai-sdk/provider';
 import { EmbeddingModelMiddleware } from '../types';
 import { asArray } from '../util/as-array';
 
@@ -53,7 +56,7 @@ const doWrap = ({
   async function doTransform({
     params,
   }: {
-    params: EmbeddingModelCallOptions;
+    params: EmbeddingModelV3CallOptions;
   }) {
     return transformParams ? await transformParams({ params, model }) : params;
   }
@@ -67,7 +70,7 @@ const doWrap = ({
     supportsParallelCalls:
       overrideSupportsParallelCalls?.({ model }) ?? model.supportsParallelCalls,
     async doEmbed(
-      params: EmbeddingModelCallOptions,
+      params: EmbeddingModelV3CallOptions,
     ): Promise<Awaited<ReturnType<EmbeddingModelV3['doEmbed']>>> {
       const transformedParams = await doTransform({ params });
       const doEmbed = async () => model.doEmbed(transformedParams);

--- a/packages/provider/src/embedding-model-middleware/v3/embedding-model-v3-middleware.ts
+++ b/packages/provider/src/embedding-model-middleware/v3/embedding-model-v3-middleware.ts
@@ -1,5 +1,5 @@
 import { EmbeddingModelV3 } from '../../embedding-model/v3/embedding-model-v3';
-import { EmbeddingModelCallOptions } from '../../embedding-model/v3/embedding-model-v3-call-options';
+import { EmbeddingModelV3CallOptions } from '../../embedding-model/v3/embedding-model-v3-call-options';
 
 /**
  * Middleware for EmbeddingModelV3.
@@ -47,9 +47,9 @@ export type EmbeddingModelV3Middleware = {
    * @returns A promise that resolves to the transformed parameters.
    */
   transformParams?: (options: {
-    params: EmbeddingModelCallOptions;
+    params: EmbeddingModelV3CallOptions;
     model: EmbeddingModelV3;
-  }) => PromiseLike<EmbeddingModelCallOptions>;
+  }) => PromiseLike<EmbeddingModelV3CallOptions>;
 
   /**
    * Wraps the embed operation of the embedding model.
@@ -63,7 +63,7 @@ export type EmbeddingModelV3Middleware = {
    */
   wrapEmbed?: (options: {
     doEmbed: () => ReturnType<EmbeddingModelV3['doEmbed']>;
-    params: EmbeddingModelCallOptions;
+    params: EmbeddingModelV3CallOptions;
     model: EmbeddingModelV3;
   }) => Promise<Awaited<ReturnType<EmbeddingModelV3['doEmbed']>>>;
 };

--- a/packages/provider/src/embedding-model/v3/embedding-model-v3-call-options.ts
+++ b/packages/provider/src/embedding-model/v3/embedding-model-v3-call-options.ts
@@ -1,6 +1,6 @@
 import { SharedV3Headers, SharedV3ProviderOptions } from '../../shared';
 
-export type EmbeddingModelCallOptions = {
+export type EmbeddingModelV3CallOptions = {
   /**
  List of text values to generate embeddings for.
  */

--- a/packages/provider/src/embedding-model/v3/embedding-model-v3-result.ts
+++ b/packages/provider/src/embedding-model/v3/embedding-model-v3-result.ts
@@ -1,0 +1,48 @@
+import {
+  SharedV3Headers,
+  SharedV3ProviderMetadata,
+  SharedV3Warning,
+} from '../../shared';
+import { EmbeddingModelV3Embedding } from './embedding-model-v3-embedding';
+
+/**
+ * The result of a embedding model doEmbed call.
+ */
+export type EmbeddingModelV3Result = {
+  /**
+   * Generated embeddings. They are in the same order as the input values.
+   */
+  embeddings: Array<EmbeddingModelV3Embedding>;
+
+  /**
+   * Token usage. We only have input tokens for embeddings.
+   */
+  usage?: { tokens: number };
+
+  /**
+   * Additional provider-specific metadata. They are passed through
+   * from the provider to the AI SDK and enable provider-specific
+   * results that can be fully encapsulated in the provider.
+   */
+  providerMetadata?: SharedV3ProviderMetadata;
+
+  /**
+   * Optional response information for debugging purposes.
+   */
+  response?: {
+    /**
+     * Response headers.
+     */
+    headers?: SharedV3Headers;
+
+    /**
+      The response body.
+      */
+    body?: unknown;
+  };
+
+  /**
+   * Warnings for the call, e.g. unsupported settings.
+   */
+  warnings: Array<SharedV3Warning>;
+};

--- a/packages/provider/src/embedding-model/v3/embedding-model-v3.ts
+++ b/packages/provider/src/embedding-model/v3/embedding-model-v3.ts
@@ -1,10 +1,5 @@
-import {
-  SharedV3Headers,
-  SharedV3ProviderMetadata,
-  SharedV3Warning,
-} from '../../shared';
-import { EmbeddingModelCallOptions } from './embedding-model-v3-call-options';
-import { EmbeddingModelV3Embedding } from './embedding-model-v3-embedding';
+import { EmbeddingModelV3CallOptions } from './embedding-model-v3-call-options';
+import { EmbeddingModelV3Result } from './embedding-model-v3-result';
 
 /**
 Specification for an embedding model that implements the embedding model
@@ -53,42 +48,7 @@ Generates a list of embeddings for the given input text.
 Naming: "do" prefix to prevent accidental direct usage of the method
 by the user.
    */
-  doEmbed(options: EmbeddingModelCallOptions): PromiseLike<{
-    /**
-Generated embeddings. They are in the same order as the input values.
-     */
-    embeddings: Array<EmbeddingModelV3Embedding>;
-
-    /**
-Token usage. We only have input tokens for embeddings.
-    */
-    usage?: { tokens: number };
-
-    /**
-Additional provider-specific metadata. They are passed through
-from the provider to the AI SDK and enable provider-specific
-results that can be fully encapsulated in the provider.
-     */
-    providerMetadata?: SharedV3ProviderMetadata;
-
-    /**
-Optional response information for debugging purposes.
-     */
-    response?: {
-      /**
-Response headers.
-       */
-      headers?: SharedV3Headers;
-
-      /**
-      The response body.
-      */
-      body?: unknown;
-    };
-
-    /**
-Warnings for the call, e.g. unsupported settings.
-     */
-    warnings: Array<SharedV3Warning>;
-  }>;
+  doEmbed(
+    options: EmbeddingModelV3CallOptions,
+  ): PromiseLike<EmbeddingModelV3Result>;
 };

--- a/packages/provider/src/embedding-model/v3/index.ts
+++ b/packages/provider/src/embedding-model/v3/index.ts
@@ -1,3 +1,4 @@
 export * from './embedding-model-v3';
 export * from './embedding-model-v3-call-options';
 export * from './embedding-model-v3-embedding';
+export * from './embedding-model-v3-result';


### PR DESCRIPTION
## Background

The name `EmbeddingModelCallOptions` does not include `V3`.

## Summary

* Rename `EmbeddingModelCallOptions` to `EmbeddingModelV3CallOptions`
* Extract ``EmbeddingModelV3Result` type