### PR TITLE
chore: fix unclosed type in generate text docs

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -837,7 +837,7 @@ To see `generateText` in action, check out [these examples](#examples).
           parameters: [
             {
               name: 'finishReason',
-              type: '"stop" | "length" | "content-filter" | "tool-calls" | "error" | "other",
+              type: '"stop" | "length" | "content-filter" | "tool-calls" | "error" | "other"',
               description:
                 'The reason the model finished generating the text for the step.',
             },
@@ -1122,7 +1122,7 @@ To see `generateText` in action, check out [these examples](#examples).
           parameters: [
             {
               name: 'finishReason',
-              type: '"stop" | "length" | "content-filter" | "tool-calls" | "error" | "other",
+              type: '"stop" | "length" | "content-filter" | "tool-calls" | "error" | "other"',
               description: 'The reason the model finished generating the text.',
             },
             {


### PR DESCRIPTION
Submodule action broken due to unclosed string from #11338.