### PR TITLE
fix(ai): add v5 subdomain to error link

### DIFF
--- a/.changeset/lazy-dolls-perform.md
+++ b/.changeset/lazy-dolls-perform.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+`https://ai-sdk.dev` -> `https://v5.ai-sdk.dev`

--- a/packages/ai/src/prompt/wrap-gateway-error.ts
+++ b/packages/ai/src/prompt/wrap-gateway-error.ts
@@ -5,7 +5,7 @@ export function wrapGatewayError(error: unknown): unknown {
   if (!GatewayAuthenticationError.isInstance(error)) return error;
 
   const isProductionEnv = process?.env.NODE_ENV === 'production';
-  const moreInfoURL = 'https://ai-sdk.dev/unauthenticated-ai-gateway';
+  const moreInfoURL = 'https://v5.ai-sdk.dev/unauthenticated-ai-gateway';
 
   if (isProductionEnv) {
     return new AISDKError({


### PR DESCRIPTION
backport of https://github.com/vercel/ai/pull/11372