### PR TITLE
example: add shared type definition example

### DIFF
--- a/examples/ai-core/src/types/tool-set-shared.ts
+++ b/examples/ai-core/src/types/tool-set-shared.ts
@@ -1,0 +1,41 @@
+import { InferUITools, tool, Tool, UIMessage } from 'ai';
+import { z } from 'zod';
+
+type WeatherTool = Tool<
+  {
+    location: string;
+  },
+  {
+    temperature: number;
+    condition: string;
+  }
+>;
+
+type MyToolSet = {
+  weather: WeatherTool;
+};
+
+export type MyUITools = InferUITools<MyToolSet>;
+
+export type MyUIMessage = UIMessage<never, never, MyUITools>;
+
+const myUIMessage: MyUIMessage = undefined!;
+
+myUIMessage.parts.forEach(part => {
+  if (part.type === 'tool-weather') {
+    if (part.state === 'input-available') {
+      part.input.location;
+    }
+  }
+});
+
+export const serverWeatherTool = tool({
+  description: 'Get the weather in a location',
+  inputSchema: z.object({ location: z.string() }),
+  execute({ location }: { location: string }) {
+    return {
+      condition: 'sunny',
+      temperature: 72,
+    };
+  },
+}) satisfies WeatherTool;


### PR DESCRIPTION
## Background

There was no example on how to put tool types in a shared package.

## Summary

Add example outline.

## Future Work

- create cookbook example

## Related Issues

Fixes #11268 