### PR TITLE
fix(amazon-bedrock): handle `stop_sequence: null`

### DIFF
--- a/.changeset/tasty-crabs-scream.md
+++ b/.changeset/tasty-crabs-scream.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+handle `stop_sequence: null`

--- a/examples/ai-core/src/generate-text/bedrock-stop-sequence.ts
+++ b/examples/ai-core/src/generate-text/bedrock-stop-sequence.ts
@@ -1,12 +1,21 @@
-import { bedrock } from '@ai-sdk/amazon-bedrock';
 import { generateText } from 'ai';
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { z } from 'zod';
 import 'dotenv/config';
 
 async function main() {
   const result = await generateText({
-    model: bedrock('anthropic.claude-3-5-sonnet-20240620-v1:0'),
-    prompt: 'Write a short story and end it with the word END.',
-    stopSequences: ['END'],
+    model: bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    prompt: 'Find me 3 accounts',
+    tools: {
+      querySalesforce: {
+        description: 'Query Salesforce',
+        inputSchema: z.object({ query: z.string() }),
+        execute: async ({ query }) => {
+          return `Results for query: ${query}`;
+        },
+      },
+    },
   });
 
   console.log(result.text);
@@ -16,4 +25,6 @@ async function main() {
   console.log('Stop sequence:', result.providerMetadata?.bedrock?.stopSequence);
 }
 
-main().catch(console.error);
+main().catch(error => {
+  console.error('Error generating text:', error);
+});

--- a/examples/ai-core/src/generate-text/bedrock-stop-sequence.ts
+++ b/examples/ai-core/src/generate-text/bedrock-stop-sequence.ts
@@ -1,21 +1,12 @@
-import { generateText } from 'ai';
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { z } from 'zod';
+import { generateText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
   const result = await generateText({
-    model: bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
-    prompt: 'Find me 3 accounts',
-    tools: {
-      querySalesforce: {
-        description: 'Query Salesforce',
-        inputSchema: z.object({ query: z.string() }),
-        execute: async ({ query }) => {
-          return `Results for query: ${query}`;
-        },
-      },
-    },
+    model: bedrock('anthropic.claude-3-5-sonnet-20240620-v1:0'),
+    prompt: 'Write a short story and end it with the word END.',
+    stopSequences: ['END'],
   });
 
   console.log(result.text);
@@ -25,6 +16,4 @@ async function main() {
   console.log('Stop sequence:', result.providerMetadata?.bedrock?.stopSequence);
 }
 
-main().catch(error => {
-  console.error('Error generating text:', error);
-});
+main().catch(console.error);

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -849,7 +849,7 @@ const BedrockStopReasonSchema = z.union([
 
 const BedrockAdditionalModelResponseFieldsSchema = z
   .object({
-    stop_sequence: z.string().optional(),
+    stop_sequence: z.string().nullish(),
   })
   .catchall(z.unknown());
 


### PR DESCRIPTION
## Background

When the model responds with stopReason: "tool_use", Bedrock returns stop_sequence: null. This results in an error due to a response schema for `stop_sequence` introduced in https://github.com/vercel/ai/pull/11286

## Summary

```diff
-    stop_sequence: z.string().optional(),
+    stop_sequence: z.string().nullish(),
```

## Manual Verification

```ts
import { generateText } from 'ai';
import { bedrock } from '@ai-sdk/amazon-bedrock';
import { z } from 'zod';
import 'dotenv/config';

async function main() {
  const result = await generateText({
    model: bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
    prompt: 'Find me 3 accounts',
    tools: {
      querySalesforce: {
        description: 'Query Salesforce',
        inputSchema: z.object({ query: z.string() }),
        execute: async ({ query }) => {
          return `Results for query: ${query}`;
        },
      },
    },
  });

  console.log(result.text);
  console.log();
  console.log('Token usage:', result.usage);
  console.log('Finish reason:', result.finishReason);
  console.log('Stop sequence:', result.providerMetadata?.bedrock?.stopSequence);
}

main().catch(console.error);
```

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Closes #11371