### PR TITLE
fix(core): validateUIMessages throws on output-error tool parts with undefined input

### DIFF
--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -150,7 +150,8 @@ const uiMessagesSchema = lazySchema(() =>
                   toolName: z.string(),
                   toolCallId: z.string(),
                   state: z.literal('output-error'),
-                  input: z.unknown(),
+                  input: z.unknown().optional(),
+                  rawInput: z.unknown().optional(),
                   providerExecuted: z.boolean().optional(),
                   output: z.never().optional(),
                   errorText: z.string(),
@@ -253,7 +254,8 @@ const uiMessagesSchema = lazySchema(() =>
                   toolCallId: z.string(),
                   state: z.literal('output-error'),
                   providerExecuted: z.boolean().optional(),
-                  input: z.unknown(),
+                  input: z.unknown().optional(),
+                  rawInput: z.unknown().optional(),
                   output: z.never().optional(),
                   errorText: z.string(),
                   callProviderMetadata: providerMetadataSchema.optional(),
@@ -404,6 +406,9 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
             toolPart.state === 'output-available' ||
             toolPart.state === 'output-error'
           ) {
+            if ('rawInput' in toolPart || toolPart.input === undefined) {
+              continue;
+            }
             await validateTypes({
               value: toolPart.input,
               schema: tool.inputSchema,


### PR DESCRIPTION
if tool call input is invalid, ai sdk avoids setting `input` field and sets `rawInput` field instead, problem is, the validation logic still checks for `input` and expects it to be defined, even though it is intentionally not defined when the tool input is invalid. this renders methods like `pipeAgentUIStreamToResponse` which uses `createAgentUIStream` unusable when the AI incorrectly sends invalid input because internally it uses `validateUIMessages` which will always fail because `input` field isn't set.