### PR TITLE
fix(ai): skip tool input validation when output-error has undefined input

### DIFF
--- a/.changeset/fix-safe-validate-ui-messages-undefined-input.md
+++ b/.changeset/fix-safe-validate-ui-messages-undefined-input.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+fix(ai): skip tool input validation in `safeValidateUIMessages` when `output-error` state has undefined input
+
+Fixes #11392

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -1000,7 +1000,7 @@ describe('validateUIMessages', () => {
       `);
     });
 
-    it('should validate tool input when state is output-error', async () => {
+    it('should validate tool input when state is output-error and there is input', async () => {
       const messages = await validateUIMessages<TestMessage>({
         messages: [
           {
@@ -1035,6 +1035,50 @@ describe('validateUIMessages', () => {
                   "foo": "bar",
                 },
                 "providerExecuted": true,
+                "state": "output-error",
+                "toolCallId": "1",
+                "type": "tool-foo",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
+    it('should skip tool input validation when state is output-error and there is no input', async () => {
+      const messages = await validateUIMessages<TestMessage>({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-foo',
+                toolCallId: '1',
+                state: 'output-error',
+                input: undefined,
+                errorText: 'Tool input validation failed',
+                providerExecuted: false,
+              },
+            ],
+          },
+        ],
+        tools: {
+          foo: testTool,
+        },
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<TestMessage>>();
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "errorText": "Tool input validation failed",
+                "input": undefined,
+                "providerExecuted": false,
                 "state": "output-error",
                 "toolCallId": "1",
                 "type": "tool-foo",

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -402,7 +402,7 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
           if (
             toolPart.state === 'input-available' ||
             toolPart.state === 'output-available' ||
-            toolPart.state === 'output-error'
+            (toolPart.state === 'output-error' && toolPart.input !== undefined)
           ) {
             await validateTypes({
               value: toolPart.input,


### PR DESCRIPTION
## Background

if tool call input is invalid, ai sdk avoids setting `input` field and sets `rawInput` field instead, problem is, the validation logic still checks for `input` and expects it to be defined, even though it is intentionally not defined when the tool input is invalid. this renders methods like `pipeAgentUIStreamToResponse` which uses `createAgentUIStream` unusable when the AI incorrectly sends invalid input because internally it uses `validateUIMessages` which will always fail because `input` field isn't set (copied from #11390 )

## Summary

Only validate when input is available since there are two possible states for output-error the error happened before inputSchemas was validated or after. Right now code always validates as it was after

## Manual Verification

Ran the test, and I'm fixing an issue from a live application, also the issue provides a minimal reproduction.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11392
Similar to #11390 