### PR TITLE
Fix bedrock ConverseStream undocumented `/delta/stop_sequence`

### DIFF
--- a/.changeset/rotten-steaks-hammer.md
+++ b/.changeset/rotten-steaks-hammer.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Fix bedrock ConverseStream using /delta/stop_sequence

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -1108,6 +1108,54 @@ describe('doStream', () => {
       `);
   });
 
+  it('should correctly parse delta.stop_sequence structure in streaming with additional fields', async () => {
+    setupMockEventStreamHandler();
+    server.urls[streamUrl].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { text: 'Response' },
+          },
+        }) + '\n',
+        JSON.stringify({
+          metadata: {
+            usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          },
+        }) + '\n',
+        JSON.stringify({
+          messageStop: {
+            stopReason: 'stop_sequence',
+            additionalModelResponseFields: {
+              delta: {
+                stop_sequence: 'CUSTOM_END',
+              },
+              // Additional fields that might be present
+              otherField: 'value',
+            },
+          },
+        }) + '\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      stopSequences: ['CUSTOM_END'],
+    });
+
+    const chunks = await convertReadableStreamToArray(stream);
+    const finishChunk = chunks.find(chunk => chunk.type === 'finish');
+
+    expect(finishChunk?.providerMetadata?.bedrock?.stopSequence).toBe(
+      'CUSTOM_END',
+    );
+    expect(finishChunk?.finishReason).toEqual({
+      unified: 'stop',
+      raw: 'stop_sequence',
+    });
+  });
+
   it('should include response headers in rawResponse', async () => {
     setupMockEventStreamHandler();
     server.urls[streamUrl].response = {
@@ -2833,7 +2881,7 @@ describe('doGenerate', () => {
           },
         },
         stopReason: 'tool_use',
-        additionalModelResponseFields: { stop_sequence: null },
+        additionalModelResponseFields: { delta: { stop_sequence: null } },
         usage: {
           inputTokens: 10,
           outputTokens: 20,
@@ -2884,6 +2932,44 @@ describe('doGenerate', () => {
         },
       }
     `);
+  });
+
+  it('should correctly parse delta.stop_sequence structure from additionalModelResponseFields', async () => {
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ text: 'Response text' }],
+          },
+        },
+        stopReason: 'stop_sequence',
+        additionalModelResponseFields: {
+          delta: {
+            stop_sequence: 'CUSTOM_STOP',
+          },
+          // Additional fields that might be present
+          otherField: 'value',
+        },
+        usage: {
+          inputTokens: 10,
+          outputTokens: 20,
+          totalTokens: 30,
+        },
+      },
+    };
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      stopSequences: ['CUSTOM_STOP'],
+    });
+
+    expect(result.providerMetadata?.bedrock.stopSequence).toBe('CUSTOM_STOP');
+    expect(result.finishReason).toEqual({
+      unified: 'stop',
+      raw: 'stop_sequence',
+    });
   });
 
   it('should include response headers in rawResponse', async () => {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -896,7 +896,7 @@ describe('doStream', () => {
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
       messages: [{ role: 'user', content: [{ text: 'Hello' }] }],
       system: [{ text: 'System Prompt' }],
-      additionalModelResponseFieldPaths: ['/stop_sequence'],
+      additionalModelResponseFieldPaths: ['/delta/stop_sequence'],
     });
   });
 
@@ -1058,7 +1058,7 @@ describe('doStream', () => {
         JSON.stringify({
           messageStop: {
             stopReason: 'stop_sequence',
-            additionalModelResponseFields: { stop_sequence: 'STOP' },
+            additionalModelResponseFields: { delta: { stop_sequence: 'STOP' } },
           },
         }) + '\n',
       ],
@@ -2718,7 +2718,7 @@ describe('doGenerate', () => {
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
       messages: [{ role: 'user', content: [{ text: 'Hello' }] }],
       system: [{ text: 'System Prompt' }],
-      additionalModelResponseFieldPaths: ['/stop_sequence'],
+      additionalModelResponseFieldPaths: ['/delta/stop_sequence'],
     });
   });
 
@@ -2789,7 +2789,7 @@ describe('doGenerate', () => {
           },
         },
         stopReason: 'stop_sequence',
-        additionalModelResponseFields: { stop_sequence: 'STOP' },
+        additionalModelResponseFields: { delta: { stop_sequence: 'STOP' } },
         usage: {
           inputTokens: 4,
           outputTokens: 30,

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -311,13 +311,19 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       ...filteredBedrockOptions
     } = providerOptions?.bedrock || {};
 
+    const additionalModelResponseFieldPaths = isAnthropicModel
+      ? ['/delta/stop_sequence']
+      : undefined;
+
     return {
       command: {
         system,
         messages,
         additionalModelRequestFields:
           bedrockOptions.additionalModelRequestFields,
-        additionalModelResponseFieldPaths: ['/stop_sequence'],
+        ...(additionalModelResponseFieldPaths && {
+          additionalModelResponseFieldPaths,
+        }),
         ...(Object.keys(inferenceConfig).length > 0 && {
           inferenceConfig,
         }),
@@ -435,7 +441,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
 
     // provider metadata:
     const stopSequence =
-      response.additionalModelResponseFields?.stop_sequence ?? null;
+      response.additionalModelResponseFields?.delta?.stop_sequence ?? null;
 
     const providerMetadata =
       response.trace || response.usage || isJsonResponseFromTool || stopSequence
@@ -575,7 +581,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
                 raw: value.messageStop.stopReason ?? undefined,
               };
               stopSequence =
-                value.messageStop.additionalModelResponseFields
+                value.messageStop.additionalModelResponseFields?.delta
                   ?.stop_sequence ?? null;
             }
 
@@ -849,7 +855,11 @@ const BedrockStopReasonSchema = z.union([
 
 const BedrockAdditionalModelResponseFieldsSchema = z
   .object({
-    stop_sequence: z.string().nullish(),
+    delta: z
+      .object({
+        stop_sequence: z.string().nullish(),
+      })
+      .nullish(),
   })
   .catchall(z.unknown());
 


### PR DESCRIPTION
## background

PR #11286 attempted to expose the stop sequence from Bedrock's Converse API, but had a bug: it was reading from the wrong response path. The AWS Bedrock API actually returns the stop sequence nested under a `delta` object: `additionalModelResponseFields.delta.stop_sequence`, not directly at `additionalModelResponseFields.stop_sequence`.

## summary

**Fixed stop sequence extraction to read from correct API response path**
- Changed extraction path from `additionalModelResponseFields.stop_sequence` to `additionalModelResponseFields.delta.stop_sequence`
- Updated TypeScript schema to include `delta` wrapper in `BedrockAdditionalModelResponseFieldsSchema`
- Updated tests to match actual AWS Bedrock API response structure
- Verified fix works with both `generateText` and `streamText`

## implementation details

The AWS Bedrock Converse API returns additional model response fields nested under a `delta` object when using `additionalModelResponseFieldPaths: ['/delta/stop_sequence']`. The previous implementation incorrectly assumed the field would be at the top level of `additionalModelResponseFields`.

**Correct structure:**
```typescript
{
  messageStop: {
    stopReason: "stop_sequence",
    additionalModelResponseFields: {
      delta: {
        stop_sequence: "END"  // ← nested under delta
      }
    }
  }
}
```

## verification

Tested with `streamText` using `stopSequences: ['END']`. Confirmed `providerMetadata.bedrock.stopSequence` now correctly returns `"END"` when the stop sequence is triggered (previously returned `undefined`).

---

**Fixes:** #11286