### PR TITLE
fix(langchain): do not re-emit executed tool calls

### DIFF
--- a/.changeset/silly-eagles-judge.md
+++ b/.changeset/silly-eagles-judge.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/langchain': patch
+---
+
+fix(langchain): do not re-emit executed tool calls

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -1328,9 +1328,7 @@ describe('toUIMessageStream', () => {
           id: 'ai-2',
           type: 'ai',
           content: '',
-          tool_calls: [
-            { id: currentToolCall, name: 'tool_c', args: { c: 3 } },
-          ],
+          tool_calls: [{ id: currentToolCall, name: 'tool_c', args: { c: 3 } }],
         },
       ],
     };


### PR DESCRIPTION
## Background

When using `@ai-sdk/langchain` with LangGraph agents that have tools, multi-turn conversations fail with:

```
400 An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: call_xxxxx
```

The root cause is in `toUIMessageStream`'s handling of LangGraph `values` events. When a `values` event contains the full message history (including AIMessages with `tool_calls` from previous turns), the adapter emits `tool-input-start` and `tool-input-available` events for ALL historical tool calls, but does NOT emit corresponding `tool-output-available` events for them.

This creates orphaned tool parts in the UIMessage with state `input-available` (no output). When `toBaseMessages` converts these back for the next request, it creates AIMessages with `tool_calls` but no following ToolMessages, causing the OpenAI API error.

## Summary

Added a two-pass approach when processing `values` events in `processLangGraphEvent`:

1. **First pass**: Collect all tool call IDs that have been responded to by ToolMessages in the message history. These are "completed" historical tool calls.

2. **Second pass**: When processing AIMessages with tool calls, skip emitting events for any tool call that exists in the completed set.

This ensures that:
- Historical tool calls that already have ToolMessage responses are NOT re-emitted
- Only new/current tool calls (those without ToolMessage responses yet) are emitted
- The client's message history remains consistent without orphaned tool parts

## Manual Verification

I double checked this resolution using the provided reproduction case and was able to validate that all is working fine:

<img width="1624" height="1056" alt="Screenshot 2025-12-23 at 5 25 32 PM" src="https://github.com/user-attachments/assets/94f08b19-2cb6-4bb7-8b46-8c3b2a3863d0" />


## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

n/a

## Related Issues

Fixes #11415