### PR TITLE
fix(ai): implement elementStream for streamText with Output.array()

### DIFF
--- a/.changeset/smooth-cherries-bathe.md
+++ b/.changeset/smooth-cherries-bathe.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Add `elementStream` to `streamText` for streaming individual array elements when using `output: Output.array()`.

--- a/examples/ai-core/src/stream-text/openai-output-array-element-stream.ts
+++ b/examples/ai-core/src/stream-text/openai-output-array-element-stream.ts
@@ -1,0 +1,34 @@
+import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { Output, stepCountIs, streamText } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+import { weatherTool } from '../tools/weather-tool';
+
+run(async () => {
+  const result = streamText({
+    model: openai('gpt-4o-mini'),
+    providerOptions: {
+      openai: {
+        strictJsonSchema: true,
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+    tools: {
+      weather: weatherTool,
+    },
+    stopWhen: stepCountIs(5),
+    output: Output.array({
+      element: z.object({
+        location: z.string(),
+        temperature: z.number(),
+        condition: z.string(),
+      }),
+    }),
+    prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
+  });
+
+  // elementStream streams individual completed elements one at a time,
+  // unlike partialOutputStream which streams the entire partial array
+  for await (const element of result.elementStream) {
+    console.log('New element:', element);
+  }
+});

--- a/packages/ai/src/generate-text/output-utils.ts
+++ b/packages/ai/src/generate-text/output-utils.ts
@@ -11,3 +11,9 @@ export type InferCompleteOutput<OUTPUT extends Output> =
  */
 export type InferPartialOutput<OUTPUT extends Output> =
   OUTPUT extends Output<any, infer PARTIAL_OUTPUT> ? PARTIAL_OUTPUT : never;
+
+/**
+ * Infers the element type from an array output specification.
+ */
+export type InferElementOutput<OUTPUT extends Output> =
+  OUTPUT extends Output<Array<infer ELEMENT>, any> ? ELEMENT : never;

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -18,7 +18,11 @@ import { ErrorHandler } from '../util/error-handler';
 import { ContentPart } from './content-part';
 import { GeneratedFile } from './generated-file';
 import { Output } from './output';
-import { InferCompleteOutput, InferPartialOutput } from './output-utils';
+import {
+  InferCompleteOutput,
+  InferElementOutput,
+  InferPartialOutput,
+} from './output-utils';
 import { ReasoningOutput } from './reasoning-output';
 import { ResponseMessage } from './response-message';
 import { StepResult } from './step-result';
@@ -296,6 +300,12 @@ enables provider-specific results that can be fully encapsulated in the provider
    * A stream of partial parsed outputs. It uses the `output` specification.
    */
   readonly partialOutputStream: AsyncIterableStream<InferPartialOutput<OUTPUT>>;
+
+  /**
+   * A stream of individual array elements as they complete.
+   * Only available when using `output: Output.array()`.
+   */
+  readonly elementStream: AsyncIterableStream<InferElementOutput<OUTPUT>>;
 
   /**
    * The complete parsed output. It uses the `output` specification.

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -148,4 +148,53 @@ describe('streamText types', () => {
       >();
     });
   });
+
+  describe('elementStream', () => {
+    it('should infer element type for array output', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.array({ element: z.object({ value: z.string() }) }),
+      });
+
+      expectTypeOf<typeof result.elementStream>().toEqualTypeOf<
+        AsyncIterableStream<{ value: string }>
+      >();
+    });
+
+    it('should infer never for text output', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.text(),
+      });
+
+      expectTypeOf<typeof result.elementStream>().toEqualTypeOf<
+        AsyncIterableStream<never>
+      >();
+    });
+
+    it('should infer never for object output', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.object({ schema: z.object({ value: z.string() }) }),
+      });
+
+      expectTypeOf<typeof result.elementStream>().toEqualTypeOf<
+        AsyncIterableStream<never>
+      >();
+    });
+
+    it('should infer never for default output', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+      });
+
+      expectTypeOf<typeof result.elementStream>().toEqualTypeOf<
+        AsyncIterableStream<never>
+      >();
+    });
+  });
 });

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -13260,6 +13260,23 @@ describe('streamText', () => {
           `);
         });
 
+        it('should stream individual elements in elementStream', async () => {
+          expect(await convertAsyncIterableToArray(result!.elementStream))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "content": "element 1",
+              },
+              {
+                "content": "element 2",
+              },
+              {
+                "content": "element 3",
+              },
+            ]
+          `);
+        });
+
         it('should resolve output promise with the correct content', async () => {
           expect(await result!.output).toStrictEqual([
             { content: 'element 1' },
@@ -13323,6 +13340,20 @@ describe('streamText', () => {
                   "content": "element 2",
                 },
               ],
+            ]
+          `);
+        });
+
+        it('should stream individual elements in elementStream', async () => {
+          expect(await convertAsyncIterableToArray(result!.elementStream))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "content": "element 1",
+              },
+              {
+                "content": "element 2",
+              },
             ]
           `);
         });


### PR DESCRIPTION
## Background

The [AI SDK v6 documentation](https://ai-sdk.dev/docs/ai-sdk-core/generating-structured-data#outputarray) states that `elementStream` is available when using `streamText` with `Output.array()`:

> With streamText, you can also iterate over the generated array elements using elementStream

However, this method was not implemented, causing errors when trying to use.

## Summary

Implements `elementStream` for `streamText` when using `output: Output.array()`. 

The implementation mirrors the approach from the deprecated `streamObject` function's `elementStream`.

**Changes:**
- Added `InferElementOutput` type helper to `output-utils.ts`
- Added `elementStream` property to `StreamTextResult` interface
- Implemented `elementStream` getter in `DefaultStreamTextResult` class

## Manual Verification

- Ran the example and test files to ensure everything works as expected. The individual elements stream in one at a time.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes https://github.com/vercel/ai/issues/11421
