### PR TITLE
Bugfix/add image propers to generate call

### DIFF
--- a/.changeset/perfect-scissors-chew.md
+++ b/.changeset/perfect-scissors-chew.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': major
+---
+
+adds files and mask to the gateway doGenerate method

--- a/packages/gateway/src/gateway-image-model.test.ts
+++ b/packages/gateway/src/gateway-image-model.test.ts
@@ -157,6 +157,86 @@ describe('GatewayImageModel', () => {
       expect(requestBody).not.toHaveProperty('size');
       expect(requestBody).not.toHaveProperty('aspectRatio');
       expect(requestBody).not.toHaveProperty('seed');
+      expect(requestBody).not.toHaveProperty('files');
+      expect(requestBody).not.toHaveProperty('mask');
+    });
+
+    it('should include files when provided', async () => {
+      prepareJsonResponse();
+
+      const files = [
+        { type: 'base64' as const, data: 'base64-encoded-image-data' },
+      ];
+      await createTestModel().doGenerate({
+        prompt: 'Edit this image',
+        files,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).toEqual({
+        prompt: 'Edit this image',
+        n: 1,
+        files,
+        providerOptions: {},
+      });
+    });
+
+    it('should include mask when provided', async () => {
+      prepareJsonResponse();
+
+      const mask = { type: 'base64' as const, data: 'base64-encoded-mask-data' };
+      await createTestModel().doGenerate({
+        prompt: 'Inpaint this area',
+        files: undefined,
+        mask,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).toEqual({
+        prompt: 'Inpaint this area',
+        n: 1,
+        mask,
+        providerOptions: {},
+      });
+    });
+
+    it('should include both files and mask when provided', async () => {
+      prepareJsonResponse();
+
+      const files = [
+        { type: 'base64' as const, data: 'base64-encoded-image-data' },
+      ];
+      const mask = { type: 'base64' as const, data: 'base64-encoded-mask-data' };
+      await createTestModel().doGenerate({
+        prompt: 'Inpaint this image',
+        files,
+        mask,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).toEqual({
+        prompt: 'Inpaint this image',
+        n: 1,
+        files,
+        mask,
+        providerOptions: {},
+      });
     });
 
     it('should return images array correctly', async () => {

--- a/packages/gateway/src/gateway-image-model.ts
+++ b/packages/gateway/src/gateway-image-model.ts
@@ -38,6 +38,8 @@ export class GatewayImageModel implements ImageModelV3 {
     size,
     aspectRatio,
     seed,
+    files,
+    mask,
     providerOptions,
     headers,
     abortSignal,
@@ -64,6 +66,8 @@ export class GatewayImageModel implements ImageModelV3 {
           ...(size && { size }),
           ...(aspectRatio && { aspectRatio }),
           ...(seed && { seed }),
+          ...(files && { files }),
+          ...(mask && { mask }),
           ...(providerOptions && { providerOptions }),
         },
         successfulResponseHandler: createJsonResponseHandler(


### PR DESCRIPTION

## Background

The gateway image model class was missing images and masks from the actual request, but these are necessary for image editing. 

## Summary

Updated doGenerate method to pass in the required params 


## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
