### PR TITLE
feat (provider/xai): fix chat usage output token computation

### DIFF
--- a/.changeset/healthy-grapes-obey.md
+++ b/.changeset/healthy-grapes-obey.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat (provider/xai): fix chat usage output token computation

--- a/packages/xai/src/convert-xai-chat-usage.test.ts
+++ b/packages/xai/src/convert-xai-chat-usage.test.ts
@@ -1,0 +1,181 @@
+import { convertXaiChatUsage } from './convert-xai-chat-usage';
+import { describe, it, expect } from 'vitest';
+
+describe('convertXaiChatUsage', () => {
+  it('should convert basic usage without reasoning tokens', () => {
+    const result = convertXaiChatUsage({
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      total_tokens: 150,
+    });
+
+    expect(result).toEqual({
+      inputTokens: {
+        total: 100,
+        noCache: 100,
+        cacheRead: 0,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 50,
+        text: 50,
+        reasoning: 0,
+      },
+      raw: {
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        total_tokens: 150,
+      },
+    });
+  });
+
+  it('should convert usage with reasoning tokens', () => {
+    const result = convertXaiChatUsage({
+      prompt_tokens: 168,
+      completion_tokens: 342,
+      total_tokens: 1038,
+      completion_tokens_details: {
+        reasoning_tokens: 528,
+      },
+    });
+
+    expect(result).toEqual({
+      inputTokens: {
+        total: 168,
+        noCache: 168,
+        cacheRead: 0,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 870, // 342 + 528
+        text: 342,
+        reasoning: 528,
+      },
+      raw: {
+        prompt_tokens: 168,
+        completion_tokens: 342,
+        total_tokens: 1038,
+        completion_tokens_details: {
+          reasoning_tokens: 528,
+        },
+      },
+    });
+  });
+
+  it('should handle reasoning tokens greater than completion tokens', () => {
+    const result = convertXaiChatUsage({
+      prompt_tokens: 168,
+      completion_tokens: 342,
+      total_tokens: 1038,
+      completion_tokens_details: {
+        reasoning_tokens: 528,
+      },
+    });
+
+    expect(result.outputTokens.text).toBe(342);
+    expect(result.outputTokens.text).toBeGreaterThanOrEqual(0);
+    expect(result.outputTokens.total).toBe(870);
+  });
+
+  it('should convert usage with cached input tokens', () => {
+    const result = convertXaiChatUsage({
+      prompt_tokens: 168,
+      completion_tokens: 578,
+      total_tokens: 1204,
+      prompt_tokens_details: {
+        text_tokens: 168,
+        audio_tokens: 0,
+        image_tokens: 0,
+        cached_tokens: 146,
+      },
+      completion_tokens_details: {
+        reasoning_tokens: 458,
+      },
+    });
+
+    expect(result).toEqual({
+      inputTokens: {
+        total: 168,
+        noCache: 22, // 168 - 146
+        cacheRead: 146,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 1036, // 578 + 458
+        text: 578,
+        reasoning: 458,
+      },
+      raw: {
+        prompt_tokens: 168,
+        completion_tokens: 578,
+        total_tokens: 1204,
+        prompt_tokens_details: {
+          text_tokens: 168,
+          audio_tokens: 0,
+          image_tokens: 0,
+          cached_tokens: 146,
+        },
+        completion_tokens_details: {
+          reasoning_tokens: 458,
+        },
+      },
+    });
+  });
+
+  it('should handle null/undefined token details gracefully', () => {
+    const result = convertXaiChatUsage({
+      prompt_tokens: 100,
+      completion_tokens: 200,
+      total_tokens: 300,
+      prompt_tokens_details: null,
+      completion_tokens_details: null,
+    });
+
+    expect(result.inputTokens.cacheRead).toBe(0);
+    expect(result.inputTokens.noCache).toBe(100);
+    expect(result.outputTokens.reasoning).toBe(0);
+    expect(result.outputTokens.text).toBe(200);
+    expect(result.outputTokens.total).toBe(200);
+  });
+
+  it('should handle zero reasoning tokens', () => {
+    const result = convertXaiChatUsage({
+      prompt_tokens: 50,
+      completion_tokens: 100,
+      total_tokens: 150,
+      completion_tokens_details: {
+        reasoning_tokens: 0,
+      },
+    });
+
+    expect(result.outputTokens).toEqual({
+      total: 100,
+      text: 100,
+      reasoning: 0,
+    });
+  });
+
+  it('should preserve raw usage data', () => {
+    const rawUsage = {
+      prompt_tokens: 168,
+      completion_tokens: 342,
+      total_tokens: 1038,
+      prompt_tokens_details: {
+        text_tokens: 168,
+        audio_tokens: 0,
+        image_tokens: 0,
+        cached_tokens: 167,
+      },
+      completion_tokens_details: {
+        reasoning_tokens: 528,
+        audio_tokens: 0,
+        accepted_prediction_tokens: 0,
+        rejected_prediction_tokens: 0,
+      },
+    };
+
+    const result = convertXaiChatUsage(rawUsage);
+
+    expect(result.raw).toEqual(rawUsage);
+  });
+});

--- a/packages/xai/src/convert-xai-chat-usage.ts
+++ b/packages/xai/src/convert-xai-chat-usage.ts
@@ -14,8 +14,8 @@ export function convertXaiChatUsage(usage: XaiChatUsage): LanguageModelV3Usage {
       cacheWrite: undefined,
     },
     outputTokens: {
-      total: usage.completion_tokens,
-      text: usage.completion_tokens - reasoningTokens,
+      total: usage.completion_tokens + reasoningTokens,
+      text: usage.completion_tokens,
       reasoning: reasoningTokens,
     },
     raw: usage,

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -1390,8 +1390,8 @@ describe('XaiChatLanguageModel', () => {
           },
           "outputTokens": {
             "reasoning": 10,
-            "text": 10,
-            "total": 20,
+            "text": 20,
+            "total": 30,
           },
           "raw": {
             "completion_tokens": 20,
@@ -1490,8 +1490,8 @@ describe('XaiChatLanguageModel', () => {
               },
               "outputTokens": {
                 "reasoning": 10,
-                "text": 10,
-                "total": 20,
+                "text": 20,
+                "total": 30,
               },
               "raw": {
                 "completion_tokens": 20,
@@ -1598,8 +1598,8 @@ describe('XaiChatLanguageModel', () => {
               },
               "outputTokens": {
                 "reasoning": 10,
-                "text": 10,
-                "total": 20,
+                "text": 20,
+                "total": 30,
               },
               "raw": {
                 "completion_tokens": 20,


### PR DESCRIPTION
## Background

The logic to compute output tokens is incorrect for the [x.ai](http://x.ai) chat completion API. This can produce incorrect numbers for total and text token counts. When reasoning token count exceeds text token count, it can produce a negative text token count.

## Summary

In the chat api [x.ai](http://x.ai) does not include reasoning token counts in the completion token counts. Compare to AI SDK v5 [logic](https://github.com/vercel/ai/blob/release-v5.0/packages/xai/src/xai-chat-language-model.ts#L382).

## Manual Verification

Ran `stream-text/xai.ts` with several models including `grok-code-fast-1`, `grok-4` and `grok-4-1-fast-reasoning` and reviewed token counts for correctness.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)