### PR TITLE
Update 65-devtools.mdx

### DIFF
--- a/content/docs/03-ai-sdk-core/65-devtools.mdx
+++ b/content/docs/03-ai-sdk-core/65-devtools.mdx
@@ -37,13 +37,13 @@ pnpm add @ai-sdk/devtools
 Wrap your language model with the DevTools middleware using [`wrapLanguageModel`](/docs/ai-sdk-core/middleware):
 
 ```ts
-import { wrapLanguageModel } from 'ai';
+import { wrapLanguageModel, gateway } from 'ai';
 import { devToolsMiddleware } from '@ai-sdk/devtools';
 __PROVIDER_IMPORT__;
 
 const model = wrapLanguageModel({
-  model: __MODEL__,
-  middleware: devToolsMiddleware,
+  model: gateway(__MODEL__),
+  middleware: devToolsMiddleware(),
 });
 ```
 

--- a/content/docs/03-ai-sdk-core/65-devtools.mdx
+++ b/content/docs/03-ai-sdk-core/65-devtools.mdx
@@ -39,10 +39,9 @@ Wrap your language model with the DevTools middleware using [`wrapLanguageModel`
 ```ts
 import { wrapLanguageModel, gateway } from 'ai';
 import { devToolsMiddleware } from '@ai-sdk/devtools';
-__PROVIDER_IMPORT__;
 
 const model = wrapLanguageModel({
-  model: gateway(__MODEL__),
+  model: gateway('anthropic/claude-sonnet-4.5'),
   middleware: devToolsMiddleware(),
 });
 ```


### PR DESCRIPTION
While working in Typescript, if you don't wrap the model name in gateway(), Typescript throws an error: type 'string' is not is not assignable to type 'LanguageModelV3'. Additionally, devToolsMiddleware() is a function that needs to be called.

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

## Summary

<!-- What did you change? -->

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
