### PR TITLE
feat(mcp): enhance tool output handling and schema definitions

### DIFF
--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -14,7 +14,13 @@ const ToolMetaSchema = z.optional(z.record(z.string(), z.unknown()));
 export type ToolMeta = z.infer<typeof ToolMetaSchema>;
 
 export type ToolSchemas =
-  | Record<string, { inputSchema: FlexibleSchema<JSONObject | unknown> }>
+  | Record<
+      string,
+      {
+        inputSchema: FlexibleSchema<JSONObject | unknown>;
+        outputSchema?: FlexibleSchema<JSONObject | unknown>;
+      }
+    >
   | 'automatic'
   | undefined;
 
@@ -128,6 +134,10 @@ const ToolSchema = z
         properties: z.optional(z.object({}).loose()),
       })
       .loose(),
+    outputSchema: z.optional(z.object({
+      type: z.literal('object'),
+      properties: z.optional(z.object({}).loose()),
+    }).loose()),
     annotations: z.optional(
       z
         .object({


### PR DESCRIPTION
## Background

I need **tighter MCP ↔ LLM integration** so tool call results can be better consumed without overflowing the context window. This enables downstream behaviors like **reading specific properties**, filtering, and validating/parsing results based on a tool’s declared output shape.

## Summary

- Normalized MCP `tools/call` results into **LLM-friendly `ToolResultOutput`**:
  - If the MCP server returns **structured output** (`toolResult` or `structuredContent`), we return it as **JSON model output** so the LLM (and app code) can work directly with properties.
  - If the MCP server marks the result as an error (`isError`), we return **error text** extracted from text content for better surfaced failures.
  - Otherwise we pass through the regular MCP `content` array.
- Added support for **`outputSchema`** on MCP tool definitions and plumbed it through when building AI SDK tools, so consumers can **parse/validate tool outputs** using the declared schema.

## Manual Verification

- Fetched tools from the mock MCP server and verified the generated AI SDK tool includes the server-provided schemas (including `outputSchema` when present).
- Executed a tool and verified the client produces a **structured JSON model output** when the MCP response contains structured results (and returns error text when `isError` is set).

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

- Add docs/examples showing recommended patterns for consuming structured tool output (property access/filtering) and using `outputSchema` to parse results.

## Related Issues
