### PR TITLE
fix(xai): map server-side tool types to toolName when part.name is empty

### DIFF
--- a/.changeset/fix-xai-toolname-mapping.md
+++ b/.changeset/fix-xai-toolname-mapping.md
@@ -1,0 +1,9 @@
+---
+"@ai-sdk/xai": patch
+---
+
+fix: map server-side tool types to correct toolName when part.name is empty
+
+When xAI returns web_search_call, x_search_call, code_execution_call, or other server-side tool events, the part.name field may be empty or undefined. Previously, this caused AI_NoSuchToolError because the toolName was set to an empty string.
+
+This fix checks part.type in addition to part.name to correctly map the tool call back to the user-provided tool name from the tools object.

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -202,12 +202,28 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
         part.type === 'custom_tool_call'
       ) {
         let toolName = part.name ?? '';
-        if (webSearchSubTools.includes(part.name ?? '')) {
+        // Map tool name based on part.type when part.name is empty/undefined
+        // xAI server-side tools may not include name in the response
+        if (
+          part.type === 'web_search_call' ||
+          webSearchSubTools.includes(part.name ?? '')
+        ) {
           toolName = webSearchToolName ?? 'web_search';
-        } else if (xSearchSubTools.includes(part.name ?? '')) {
+        } else if (
+          part.type === 'x_search_call' ||
+          xSearchSubTools.includes(part.name ?? '')
+        ) {
           toolName = xSearchToolName ?? 'x_search';
-        } else if (part.name === 'code_execution') {
+        } else if (
+          part.type === 'code_execution_call' ||
+          part.type === 'code_interpreter_call' ||
+          part.name === 'code_execution'
+        ) {
           toolName = codeExecutionToolName ?? 'code_execution';
+        } else if (part.type === 'view_image_call') {
+          toolName = 'view_image';
+        } else if (part.type === 'view_x_video_call') {
+          toolName = 'view_x_video';
         }
 
         // custom_tool_call uses 'input' field, others use 'arguments'
@@ -498,12 +514,28 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
                   ];
 
                   let toolName = part.name ?? '';
-                  if (webSearchSubTools.includes(part.name ?? '')) {
+                  // Map tool name based on part.type when part.name is empty/undefined
+                  // xAI server-side tools may not include name in the response
+                  if (
+                    part.type === 'web_search_call' ||
+                    webSearchSubTools.includes(part.name ?? '')
+                  ) {
                     toolName = webSearchToolName ?? 'web_search';
-                  } else if (xSearchSubTools.includes(part.name ?? '')) {
+                  } else if (
+                    part.type === 'x_search_call' ||
+                    xSearchSubTools.includes(part.name ?? '')
+                  ) {
                     toolName = xSearchToolName ?? 'x_search';
-                  } else if (part.name === 'code_execution') {
+                  } else if (
+                    part.type === 'code_execution_call' ||
+                    part.type === 'code_interpreter_call' ||
+                    part.name === 'code_execution'
+                  ) {
                     toolName = codeExecutionToolName ?? 'code_execution';
+                  } else if (part.type === 'view_image_call') {
+                    toolName = 'view_image';
+                  } else if (part.type === 'view_x_video_call') {
+                    toolName = 'view_x_video';
                   }
 
                   // custom_tool_call uses 'input' field, others use 'arguments'


### PR DESCRIPTION
## Problem

When using `xai.tools.webSearch()` with `xai.responses()` and `streamText`, tool-call events are emitted with empty `toolName`, causing `AI_NoSuchToolError`.

Example of the error:
```json
{
  "type": "tool-call",
  "toolCallId": "ws_24e5ff31-0c00-48c9-c980-671b70dd254e_call_48407951",
  "toolName": "",
  "invalid": true,
  "error": {
    "name": "AI_NoSuchToolError",
    "toolName": "",
    "availableTools": ["web_search"]
  }
}
```

## Root Cause

In `xai-responses-language-model.ts`, the code maps `part.name` to the user's tool name, but only checks if `part.name` matches specific sub-tool names like `web_search`, `browse_page`, etc.

When xAI returns `web_search_call` events, `part.name` may be `undefined` or empty, so the mapping fails and `toolName` remains an empty string.

## Solution

Check `part.type` in addition to `part.name` to correctly identify server-side tools:
- `web_search_call` → `webSearchToolName`
- `x_search_call` → `xSearchToolName`
- `code_execution_call` / `code_interpreter_call` → `codeExecutionToolName`
- `view_image_call` → `view_image`
- `view_x_video_call` → `view_x_video`

## Changes

- Fixed tool name mapping in both `doGenerate` and `doStream` methods
- Added 5 test cases to verify correct mapping when `part.name` is empty

## Testing

- All 120 existing tests pass
- Added new tests for empty `part.name` scenarios
- Verified fix with real xAI API calls using `streamText` with `xai.tools.webSearch()`

Fixes #11263