### PR TITLE
fix(google): google provider codeExecution tool no longer treated as a client tool

### DIFF
--- a/.changeset/loud-dolls-sparkle.md
+++ b/.changeset/loud-dolls-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Fixes the 'AI_NoOutputGeneratedError' for the Google provider when using 'codeExecution' with structured output. Provider tool calls are no longer mapping to finishReasons meant for client side tool calls.

--- a/examples/ai-core/src/generate-text/google-code-execution-output-object.ts
+++ b/examples/ai-core/src/generate-text/google-code-execution-output-object.ts
@@ -1,0 +1,26 @@
+import { google } from '@ai-sdk/google';
+import { generateText, Output } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const result = await generateText({
+    model: google('gemini-3-flash-preview'),
+    tools: {
+      code_execution: google.tools.codeExecution({}),
+    },
+    output: Output.object({
+      schema: z.object({
+        answer: z.number(),
+        explanation: z.string(),
+      }),
+    }),
+    prompt:
+      'Calculate the sum of the first 50 prime numbers. Make sure to use the python tool. Show your work.',
+  });
+
+  console.log(JSON.stringify(result.output, null, 2));
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/google-code-execution.ts
+++ b/examples/ai-core/src/generate-text/google-code-execution.ts
@@ -1,0 +1,20 @@
+import { google } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: google('gemini-3-flash-preview'),
+    tools: {
+      code_execution: google.tools.codeExecution({}),
+    },
+    prompt:
+      'Calculate the sum of the first 50 prime numbers. ' +
+      'Make sure to use the python tool. Show your work.',
+  });
+
+  console.log(result.text);
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/google-code-execution.ts
+++ b/examples/ai-core/src/generate-text/google-code-execution.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 
 async function main() {
   const result = await generateText({
-    model: google('gemini-3-flash-preview'),
+    model: google('gemini-2.5-flash'),
     tools: {
       code_execution: google.tools.codeExecution({}),
     },

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -166,11 +166,11 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
             responseFormat?.type === 'json' ? 'application/json' : undefined,
           responseSchema:
             responseFormat?.type === 'json' &&
-            responseFormat.schema != null &&
-            // Google GenAI does not support all OpenAPI Schema features,
-            // so this is needed as an escape hatch:
-            // TODO convert into provider option
-            (googleOptions?.structuredOutputs ?? true)
+              responseFormat.schema != null &&
+              // Google GenAI does not support all OpenAPI Schema features,
+              // so this is needed as an escape hatch:
+              // TODO convert into provider option
+              (googleOptions?.structuredOutputs ?? true)
               ? convertJSONSchemaToOpenAPISchema(responseFormat.schema)
               : undefined,
           ...(googleOptions?.audioTimestamp && {
@@ -193,9 +193,9 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
         tools: googleTools,
         toolConfig: googleOptions?.retrievalConfig
           ? {
-              ...googleToolConfig,
-              retrievalConfig: googleOptions.retrievalConfig,
-            }
+            ...googleToolConfig,
+            retrievalConfig: googleOptions.retrievalConfig,
+          }
           : googleToolConfig,
         cachedContent: googleOptions?.cachedContent,
         labels: googleOptions?.labels,
@@ -274,10 +274,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
           text: part.text,
           providerMetadata: part.thoughtSignature
             ? {
-                [providerOptionsName]: {
-                  thoughtSignature: part.thoughtSignature,
-                },
-              }
+              [providerOptionsName]: {
+                thoughtSignature: part.thoughtSignature,
+              },
+            }
             : undefined,
         });
       } else if ('functionCall' in part) {
@@ -288,10 +288,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
           input: JSON.stringify(part.functionCall.args),
           providerMetadata: part.thoughtSignature
             ? {
-                [providerOptionsName]: {
-                  thoughtSignature: part.thoughtSignature,
-                },
-              }
+              [providerOptionsName]: {
+                thoughtSignature: part.thoughtSignature,
+              },
+            }
             : undefined,
         });
       } else if ('inlineData' in part) {
@@ -301,10 +301,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
           mediaType: part.inlineData.mimeType,
           providerMetadata: part.thoughtSignature
             ? {
-                [providerOptionsName]: {
-                  thoughtSignature: part.thoughtSignature,
-                },
-              }
+              [providerOptionsName]: {
+                thoughtSignature: part.thoughtSignature,
+              },
+            }
             : undefined,
         });
       }
@@ -324,7 +324,9 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
       finishReason: {
         unified: mapGoogleGenerativeAIFinishReason({
           finishReason: candidate.finishReason,
-          hasToolCalls: content.some(part => part.type === 'tool-call'),
+          hasClientToolCalls: content.some(
+            part => part.type === 'tool-call' && !part.providerExecuted,
+          ),
         }),
         raw: candidate.finishReason ?? undefined,
       },
@@ -378,7 +380,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
     let providerMetadata: SharedV3ProviderMetadata | undefined = undefined;
 
     const generateId = this.config.generateId;
-    let hasToolCalls = false;
+    let hasClientToolCalls = false;
 
     // Track active blocks to group consecutive parts of same type
     let currentTextBlockId: string | null = null;
@@ -460,7 +462,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                     providerExecuted: true,
                   });
 
-                  hasToolCalls = true;
+
                 } else if (
                   'codeExecutionResult' in part &&
                   part.codeExecutionResult
@@ -504,10 +506,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                         id: currentReasoningBlockId,
                         providerMetadata: part.thoughtSignature
                           ? {
-                              [providerOptionsName]: {
-                                thoughtSignature: part.thoughtSignature,
-                              },
-                            }
+                            [providerOptionsName]: {
+                              thoughtSignature: part.thoughtSignature,
+                            },
+                          }
                           : undefined,
                       });
                     }
@@ -518,10 +520,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                       delta: part.text,
                       providerMetadata: part.thoughtSignature
                         ? {
-                            [providerOptionsName]: {
-                              thoughtSignature: part.thoughtSignature,
-                            },
-                          }
+                          [providerOptionsName]: {
+                            thoughtSignature: part.thoughtSignature,
+                          },
+                        }
                         : undefined,
                     });
                   } else {
@@ -542,10 +544,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                         id: currentTextBlockId,
                         providerMetadata: part.thoughtSignature
                           ? {
-                              [providerOptionsName]: {
-                                thoughtSignature: part.thoughtSignature,
-                              },
-                            }
+                            [providerOptionsName]: {
+                              thoughtSignature: part.thoughtSignature,
+                            },
+                          }
                           : undefined,
                       });
                     }
@@ -556,10 +558,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                       delta: part.text,
                       providerMetadata: part.thoughtSignature
                         ? {
-                            [providerOptionsName]: {
-                              thoughtSignature: part.thoughtSignature,
-                            },
-                          }
+                          [providerOptionsName]: {
+                            thoughtSignature: part.thoughtSignature,
+                          },
+                        }
                         : undefined,
                     });
                   }
@@ -609,7 +611,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                     providerMetadata: toolCall.providerMetadata,
                   });
 
-                  hasToolCalls = true;
+                  hasClientToolCalls = true;
                 }
               }
             }
@@ -618,7 +620,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
               finishReason = {
                 unified: mapGoogleGenerativeAIFinishReason({
                   finishReason: candidate.finishReason,
-                  hasToolCalls,
+                  hasClientToolCalls,
                 }),
                 raw: candidate.finishReason,
               };
@@ -693,18 +695,18 @@ function getToolCallsFromParts({
   return functionCallParts == null || functionCallParts.length === 0
     ? undefined
     : functionCallParts.map(part => ({
-        type: 'tool-call' as const,
-        toolCallId: generateId(),
-        toolName: part.functionCall.name,
-        args: JSON.stringify(part.functionCall.args),
-        providerMetadata: part.thoughtSignature
-          ? {
-              [providerOptionsName]: {
-                thoughtSignature: part.thoughtSignature,
-              },
-            }
-          : undefined,
-      }));
+      type: 'tool-call' as const,
+      toolCallId: generateId(),
+      toolName: part.functionCall.name,
+      args: JSON.stringify(part.functionCall.args),
+      providerMetadata: part.thoughtSignature
+        ? {
+          [providerOptionsName]: {
+            thoughtSignature: part.thoughtSignature,
+          },
+        }
+        : undefined,
+    }));
 }
 
 function extractSources({

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -166,11 +166,11 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
             responseFormat?.type === 'json' ? 'application/json' : undefined,
           responseSchema:
             responseFormat?.type === 'json' &&
-              responseFormat.schema != null &&
-              // Google GenAI does not support all OpenAPI Schema features,
-              // so this is needed as an escape hatch:
-              // TODO convert into provider option
-              (googleOptions?.structuredOutputs ?? true)
+            responseFormat.schema != null &&
+            // Google GenAI does not support all OpenAPI Schema features,
+            // so this is needed as an escape hatch:
+            // TODO convert into provider option
+            (googleOptions?.structuredOutputs ?? true)
               ? convertJSONSchemaToOpenAPISchema(responseFormat.schema)
               : undefined,
           ...(googleOptions?.audioTimestamp && {
@@ -193,9 +193,9 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
         tools: googleTools,
         toolConfig: googleOptions?.retrievalConfig
           ? {
-            ...googleToolConfig,
-            retrievalConfig: googleOptions.retrievalConfig,
-          }
+              ...googleToolConfig,
+              retrievalConfig: googleOptions.retrievalConfig,
+            }
           : googleToolConfig,
         cachedContent: googleOptions?.cachedContent,
         labels: googleOptions?.labels,
@@ -274,10 +274,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
           text: part.text,
           providerMetadata: part.thoughtSignature
             ? {
-              [providerOptionsName]: {
-                thoughtSignature: part.thoughtSignature,
-              },
-            }
+                [providerOptionsName]: {
+                  thoughtSignature: part.thoughtSignature,
+                },
+              }
             : undefined,
         });
       } else if ('functionCall' in part) {
@@ -288,10 +288,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
           input: JSON.stringify(part.functionCall.args),
           providerMetadata: part.thoughtSignature
             ? {
-              [providerOptionsName]: {
-                thoughtSignature: part.thoughtSignature,
-              },
-            }
+                [providerOptionsName]: {
+                  thoughtSignature: part.thoughtSignature,
+                },
+              }
             : undefined,
         });
       } else if ('inlineData' in part) {
@@ -301,10 +301,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
           mediaType: part.inlineData.mimeType,
           providerMetadata: part.thoughtSignature
             ? {
-              [providerOptionsName]: {
-                thoughtSignature: part.thoughtSignature,
-              },
-            }
+                [providerOptionsName]: {
+                  thoughtSignature: part.thoughtSignature,
+                },
+              }
             : undefined,
         });
       }
@@ -461,8 +461,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                     input: JSON.stringify(part.executableCode),
                     providerExecuted: true,
                   });
-
-
                 } else if (
                   'codeExecutionResult' in part &&
                   part.codeExecutionResult
@@ -506,10 +504,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                         id: currentReasoningBlockId,
                         providerMetadata: part.thoughtSignature
                           ? {
-                            [providerOptionsName]: {
-                              thoughtSignature: part.thoughtSignature,
-                            },
-                          }
+                              [providerOptionsName]: {
+                                thoughtSignature: part.thoughtSignature,
+                              },
+                            }
                           : undefined,
                       });
                     }
@@ -520,10 +518,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                       delta: part.text,
                       providerMetadata: part.thoughtSignature
                         ? {
-                          [providerOptionsName]: {
-                            thoughtSignature: part.thoughtSignature,
-                          },
-                        }
+                            [providerOptionsName]: {
+                              thoughtSignature: part.thoughtSignature,
+                            },
+                          }
                         : undefined,
                     });
                   } else {
@@ -544,10 +542,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                         id: currentTextBlockId,
                         providerMetadata: part.thoughtSignature
                           ? {
-                            [providerOptionsName]: {
-                              thoughtSignature: part.thoughtSignature,
-                            },
-                          }
+                              [providerOptionsName]: {
+                                thoughtSignature: part.thoughtSignature,
+                              },
+                            }
                           : undefined,
                       });
                     }
@@ -558,10 +556,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                       delta: part.text,
                       providerMetadata: part.thoughtSignature
                         ? {
-                          [providerOptionsName]: {
-                            thoughtSignature: part.thoughtSignature,
-                          },
-                        }
+                            [providerOptionsName]: {
+                              thoughtSignature: part.thoughtSignature,
+                            },
+                          }
                         : undefined,
                     });
                   }
@@ -695,18 +693,18 @@ function getToolCallsFromParts({
   return functionCallParts == null || functionCallParts.length === 0
     ? undefined
     : functionCallParts.map(part => ({
-      type: 'tool-call' as const,
-      toolCallId: generateId(),
-      toolName: part.functionCall.name,
-      args: JSON.stringify(part.functionCall.args),
-      providerMetadata: part.thoughtSignature
-        ? {
-          [providerOptionsName]: {
-            thoughtSignature: part.thoughtSignature,
-          },
-        }
-        : undefined,
-    }));
+        type: 'tool-call' as const,
+        toolCallId: generateId(),
+        toolName: part.functionCall.name,
+        args: JSON.stringify(part.functionCall.args),
+        providerMetadata: part.thoughtSignature
+          ? {
+              [providerOptionsName]: {
+                thoughtSignature: part.thoughtSignature,
+              },
+            }
+          : undefined,
+      }));
 }
 
 function extractSources({

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -445,7 +445,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
               }
             }
 
-            // Process tool call's parts before determining finishReason to ensure hasToolCalls is properly set
+            // Process tool call's parts before determining finishReason to ensure hasClientToolCalls is properly set
             if (content != null) {
               // Process all parts in a single loop to preserve original order
               const parts = content.parts ?? [];

--- a/packages/google/src/map-google-generative-ai-finish-reason.ts
+++ b/packages/google/src/map-google-generative-ai-finish-reason.ts
@@ -2,14 +2,14 @@ import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
 
 export function mapGoogleGenerativeAIFinishReason({
   finishReason,
-  hasToolCalls,
+  hasClientToolCalls,
 }: {
   finishReason: string | null | undefined;
-  hasToolCalls: boolean;
+  hasClientToolCalls: boolean;
 }): LanguageModelV3FinishReason['unified'] {
   switch (finishReason) {
     case 'STOP':
-      return hasToolCalls ? 'tool-calls' : 'stop';
+      return hasClientToolCalls ? 'tool-calls' : 'stop';
     case 'MAX_TOKENS':
       return 'length';
     case 'IMAGE_SAFETY':


### PR DESCRIPTION

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

Provider level tools calls do not need another step. The AI SDK was waiting for another step because it was treating it like a client tool call. So for structured outputs, the SDK was waiting for another step to parse the JSON.

## Summary

<!-- What did you change? -->

1. `hasToolCalls` -> `hasClientToolCalls` because provider tool calls do not need another step but client tools do
2. Only client tool calls (`!part.providerExecuted,`) are added. The Gemini API is not consistent when the provider level tool call adds stuff to `parts`, (other provider tools do not), so this seemed the best way to handle that.
3. Remove explicit setting of ~~`hasToolCalls`~~ (now `hasClientToolCalls`) to `true` during provider level code execution


## Manual Verification
```
import { generateText, Output } from "ai";
import { google } from "@ai-sdk/google";
import { z } from "zod";
import dotenv from "dotenv";
dotenv.config();

async function main() {
  const result = await generateText({
    model: google("gemini-3-flash-preview"),
    tools: {
      code_execution: google.tools.codeExecution({}),
    },
    output: Output.object({
      schema: z.object({
        answer: z.number(),
        explanation: z.string(),
      }),
    }),
    prompt:
      "Calculate the sum of the first 50 prime numbers. Make sure to use the python tool. Show your work.",
  });

  // Check if any step contained a tool call
  const usedCodeExecution = result.steps.some((step) =>
    step.toolCalls.some((tc) => tc.toolName === "code_execution")
  );

  console.log("Did Gemini use Python?", usedCodeExecution);
  console.log(result.output);
}

main();
```
## Before (main):
<img width="525" height="250" alt="image" src="https://github.com/user-attachments/assets/0a57a116-9f41-4fc0-ac96-86b2b6967e45" />

## After (PR branch):
<img width="525" height="250" alt="image" src="https://github.com/user-attachments/assets/4a37a682-a5f3-49ef-b145-81b1e6bbb18e" />


Previously this only coincidentally worked if Gemini decided to complete the task without the code execution tool even though it was included. This is just non deterministic LLM stuff, the point is that it should also work when Gemini _does_ use its provider side code execution tool.
<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)



## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->

Fixes #11466

