### PR TITLE
chore (provider/gateway): bump specification version header to reflect v3

### DIFF
--- a/.changeset/grumpy-spoons-tan.md
+++ b/.changeset/grumpy-spoons-tan.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+chore (provider/gateway): bump specification version header to reflect v3

--- a/packages/gateway/src/gateway-embedding-model.test.ts
+++ b/packages/gateway/src/gateway-embedding-model.test.ts
@@ -67,7 +67,7 @@ describe('GatewayEmbeddingModel', () => {
       expect(headers).toMatchObject({
         authorization: 'Bearer test-token',
         'custom-header': 'test-value',
-        'ai-embedding-model-specification-version': '2',
+        'ai-embedding-model-specification-version': '3',
         'ai-model-id': 'openai/text-embedding-3-small',
       });
     });

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -90,7 +90,7 @@ export class GatewayEmbeddingModel implements EmbeddingModelV3 {
 
   private getModelConfigHeaders() {
     return {
-      'ai-embedding-model-specification-version': '2',
+      'ai-embedding-model-specification-version': '3',
       'ai-model-id': this.modelId,
     };
   }

--- a/packages/gateway/src/gateway-image-model.test.ts
+++ b/packages/gateway/src/gateway-image-model.test.ts
@@ -100,7 +100,7 @@ describe('GatewayImageModel', () => {
       const headers = server.calls[0].requestHeaders;
       expect(headers).toMatchObject({
         authorization: 'Bearer test-token',
-        'ai-image-model-specification-version': '2',
+        'ai-image-model-specification-version': '3',
         'ai-model-id': TEST_MODEL_ID,
       });
     });
@@ -364,7 +364,7 @@ describe('GatewayImageModel', () => {
       expect(headers).toMatchObject({
         authorization: 'Bearer test-token',
         'x-custom-header': 'custom-value',
-        'ai-image-model-specification-version': '2',
+        'ai-image-model-specification-version': '3',
         'ai-model-id': TEST_MODEL_ID,
       });
     });

--- a/packages/gateway/src/gateway-image-model.ts
+++ b/packages/gateway/src/gateway-image-model.ts
@@ -99,7 +99,7 @@ export class GatewayImageModel implements ImageModelV3 {
 
   private getModelConfigHeaders() {
     return {
-      'ai-image-model-specification-version': '2',
+      'ai-image-model-specification-version': '3',
       'ai-model-id': this.modelId,
     };
   }

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -91,7 +91,7 @@ describe('GatewayLanguageModel', () => {
       expect(headers).toMatchObject({
         authorization: 'Bearer test-token',
         'custom-header': 'test-value',
-        'ai-language-model-specification-version': '2',
+        'ai-language-model-specification-version': '3',
         'ai-language-model-id': 'test-model',
         'ai-language-model-streaming': 'false',
       });
@@ -635,7 +635,7 @@ describe('GatewayLanguageModel', () => {
 
       const headers = server.calls[0].requestHeaders;
       expect(headers).toMatchObject({
-        'ai-language-model-specification-version': '2',
+        'ai-language-model-specification-version': '3',
         'ai-language-model-id': 'test-model',
         'ai-language-model-streaming': 'true',
       });

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -204,7 +204,7 @@ export class GatewayLanguageModel implements LanguageModelV3 {
 
   private getModelConfigHeaders(modelId: string, streaming: boolean) {
     return {
-      'ai-language-model-specification-version': '2',
+      'ai-language-model-specification-version': '3',
       'ai-language-model-id': modelId,
       'ai-language-model-streaming': String(streaming),
     };


### PR DESCRIPTION
## Background

AI SDK v6 moves to specification v3. The `ai-language-model-specification-version` value in headers sent to the gateway server is intended to reflect the specification version.

## Summary

Updated to pass `3` to reflect v6 current specification version.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
