### PR TITLE
feat (provider/xai): include cached input token metrics in responses api usage

### DIFF
--- a/.changeset/tame-files-give.md
+++ b/.changeset/tame-files-give.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat (provider/xai): include cached input token metrics in responses api usage

--- a/packages/xai/src/responses/__snapshots__/xai-responses-language-model.test.ts.snap
+++ b/packages/xai/src/responses/__snapshots__/xai-responses-language-model.test.ts.snap
@@ -3764,6 +3764,7 @@ Sonora's style emerged from indigenous Yaqui and Mayo tribes, who used desert fo
     "finishReason": "stop",
     "type": "finish",
     "usage": {
+      "cachedInputTokens": 192,
       "inputTokens": 216,
       "outputTokens": 863,
       "reasoningTokens": 237,
@@ -7062,6 +7063,7 @@ Sonoran's style is practical for its hot, dry climate—dishes are quick to prep
     "finishReason": "stop",
     "type": "finish",
     "usage": {
+      "cachedInputTokens": 192,
       "inputTokens": 216,
       "outputTokens": 831,
       "reasoningTokens": 253,
@@ -10477,6 +10479,7 @@ Sonoran cuisine reflects Indigenous roots from tribes like the Tohono O'odham an
     "finishReason": "stop",
     "type": "finish",
     "usage": {
+      "cachedInputTokens": 192,
       "inputTokens": 216,
       "outputTokens": 923,
       "reasoningTokens": 323,
@@ -11917,6 +11920,7 @@ Note: "XAI" can also refer to "Explainable AI," a field in machine learning that
     "finishReason": "stop",
     "type": "finish",
     "usage": {
+      "cachedInputTokens": 1578,
       "inputTokens": 1875,
       "outputTokens": 695,
       "reasoningTokens": 397,

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -279,6 +279,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV2 {
         outputTokens: response.usage.output_tokens,
         totalTokens: response.usage.total_tokens,
         reasoningTokens: response.usage.output_tokens_details?.reasoning_tokens,
+        cachedInputTokens: response.usage.input_tokens_details?.cached_tokens,
       },
       request: { body },
       response: {
@@ -459,6 +460,8 @@ export class XaiResponsesLanguageModel implements LanguageModelV2 {
 
               if (response.usage) {
                 usage.inputTokens = response.usage.input_tokens;
+                usage.cachedInputTokens =
+                  response.usage.input_tokens_details?.cached_tokens;
                 usage.outputTokens = response.usage.output_tokens;
                 usage.totalTokens = response.usage.total_tokens;
                 usage.reasoningTokens =


### PR DESCRIPTION
## Background

Developers need insight into cached input token usage. The x.ai responses api implementation is not currently including the metrics in usage data.

## Summary

Extract cached input token usage from the x.ai response and propagate it in the AI SDK usage record.

## Manual Verification

Ran the existing x.ai example scripts with grok-4.1-fast-reasoning and observed cached input token presence in usage.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
