### PR TITLE
fix(amazon-bedrock): map reasoningConfig to reasoning_effort

### DIFF
--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -2656,11 +2656,11 @@ describe('doGenerate', () => {
     stopReason?: string;
     trace?: typeof mockTrace;
     reasoningContent?:
-      | BedrockReasoningContentBlock
-      | BedrockRedactedReasoningContentBlock
-      | Array<
-          BedrockReasoningContentBlock | BedrockRedactedReasoningContentBlock
-        >;
+    | BedrockReasoningContentBlock
+    | BedrockRedactedReasoningContentBlock
+    | Array<
+      BedrockReasoningContentBlock | BedrockRedactedReasoningContentBlock
+    >;
   }) {
     server.urls[generateUrl].response = {
       type: 'json-value',
@@ -3584,14 +3584,19 @@ describe('doGenerate', () => {
     });
 
     const requestBody = await server.calls[0].requestBodyJson;
+    // Verify snake_case keys are used in the request (reasoning_effort, max_reasoning_effort)
     expect(requestBody).toMatchObject({
       additionalModelRequestFields: {
-        reasoningConfig: {
+        reasoning_effort: {
           type: 'enabled',
-          maxReasoningEffort: 'medium',
+          max_reasoning_effort: 'medium',
         },
       },
     });
+    // Verify camelCase key (reasoningConfig) is NOT present in final request
+    expect(
+      requestBody.additionalModelRequestFields?.reasoningConfig,
+    ).toBeUndefined();
     expect(requestBody.additionalModelRequestFields?.thinking).toBeUndefined();
   });
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -218,11 +218,11 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
     if (maxReasoningEffort != null && !isAnthropicModel) {
       bedrockOptions.additionalModelRequestFields = {
         ...bedrockOptions.additionalModelRequestFields,
-        reasoningConfig: {
+        reasoning_effort: {
           ...(bedrockOptions.reasoningConfig?.type != null && {
             type: bedrockOptions.reasoningConfig.type,
           }),
-          maxReasoningEffort,
+          max_reasoning_effort: maxReasoningEffort,
         },
       };
     } else if (maxReasoningEffort != null && isAnthropicModel) {


### PR DESCRIPTION
## Background

The Amazon Bedrock provider currently sends `reasoningConfig` / `maxReasoningEffort` (camelCase) in the request payload when configuring reasoning effort for non-Anthropic models (e.g. Nova). However, the AWS Bedrock API expects these fields in snake_case (`reasoning_effort` / `max_reasoning_effort`).  
This mismatch can lead to request validation errors or the configuration being ignored at runtime.

## Summary

This PR fixes the internal request mapping in the Amazon Bedrock provider so that:
- The public SDK API remains unchanged (`reasoningConfig`, `maxReasoningEffort`)
- The outgoing Bedrock request payload correctly uses `reasoning_effort` and `max_reasoning_effort`
- The fix is scoped only to non-Anthropic Bedrock models

## Manual Verification

Manually verified by:
- Inspecting the constructed Bedrock request payload to confirm `reasoning_effort.max_reasoning_effort` is sent
- Confirming `reasoningConfig` does not appear anywhere in the final request body
- Ensuring no other providers or request fields are affected

Automated provider-level tests were updated to cover this behavior.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #11467 
