### PR TITLE
feat: support tool-level provider options in OpenAI-compatible provider

### DIFF
--- a/.changeset/wild-snakes-smile.md
+++ b/.changeset/wild-snakes-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Support tool-level provider options in OpenAI-compatible provider. Tools can now include custom provider metadata through the `providerOptions` field, which gets properly merged into the prepared tools for API requests.

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -276,7 +276,9 @@ const { images } = await generateImage({
 
 ## Provider-specific options
 
-The OpenAI Compatible provider supports adding provider-specific options to the request body. These are specified with the `providerOptions` field in the request body.
+The OpenAI Compatible provider supports adding provider-specific options to the request, message, and tool levels. These are specified with the `providerOptions` field.
+
+### Request-level options
 
 For example, if you create a provider instance with the name `provider-name`, you can add a `custom-option` field to the request body like this:
 
@@ -297,6 +299,61 @@ const { text } = await generateText({
 ```
 
 The request body sent to the provider will include the `customOption` field with the value `magic-value`. This gives you an easy way to add provider-specific options to requests without having to modify the provider or AI SDK code.
+
+### Message and content-level options
+
+You can also add provider-specific options to individual messages and message content by using the `openaiCompatible` key:
+
+```ts
+const { text } = await generateText({
+  model: provider('model-id'),
+  system: 'You are a helpful assistant.',
+  messages: [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'Hello!',
+          providerOptions: {
+            openaiCompatible: {
+              cacheControl: { type: 'ephemeral' },
+            },
+          },
+        },
+      ],
+    },
+  ],
+});
+```
+
+These options are merged into the message in the request sent to the provider.
+
+### Tool-level options
+
+Tools can include provider-specific options by using the `openaiCompatible` key in the `providerOptions` field:
+
+```ts
+const { text } = await generateText({
+  model: provider('model-id'),
+  tools: [
+    {
+      type: 'function',
+      name: 'getCacheableData',
+      description: 'Fetch data that can be cached',
+      inputSchema: { type: 'object', properties: {} },
+      providerOptions: {
+        openaiCompatible: {
+          cacheControl: { type: 'ephemeral' },
+        },
+      },
+    },
+  ],
+  prompt: 'Use the tool to fetch data',
+});
+```
+
+Tool-level options are merged into the tool definition in the request sent to the provider. This is particularly useful when using provider features like prompt caching.
 
 ## Custom Metadata Extraction
 

--- a/packages/openai-compatible/src/chat/openai-compatible-prepare-tools.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-prepare-tools.test.ts
@@ -333,4 +333,197 @@ describe('prepareTools', () => {
       `);
     });
   });
+
+  describe('tool-level provider options', () => {
+    it('should merge tool metadata from providerOptions', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            providerOptions: {
+              openaiCompatible: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "cacheControl": {
+                "type": "ephemeral",
+              },
+              "function": {
+                "description": "A test function",
+                "name": "testFunction",
+                "parameters": {
+                  "properties": {},
+                  "type": "object",
+                },
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('should not include metadata when providerOptions is undefined', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result.tools?.[0]).toEqual({
+        type: 'function',
+        function: {
+          name: 'testFunction',
+          description: 'A test function',
+          parameters: { type: 'object', properties: {} },
+        },
+      });
+    });
+
+    it('should preserve tool metadata with strict mode', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+            providerOptions: {
+              openaiCompatible: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result.tools?.[0]).toEqual({
+        type: 'function',
+        function: {
+          name: 'testFunction',
+          description: 'A test function',
+          parameters: { type: 'object', properties: {} },
+          strict: true,
+        },
+        cacheControl: { type: 'ephemeral' },
+      });
+    });
+
+    it('should handle multiple tools with different metadata', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'tool1',
+            description: 'Tool 1',
+            inputSchema: { type: 'object', properties: {} },
+            providerOptions: {
+              openaiCompatible: {
+                option1: 'value1',
+              },
+            },
+          },
+          {
+            type: 'function',
+            name: 'tool2',
+            description: 'Tool 2',
+            inputSchema: { type: 'object', properties: {} },
+            providerOptions: {
+              openaiCompatible: {
+                option2: 'value2',
+              },
+            },
+          },
+          {
+            type: 'function',
+            name: 'tool3',
+            description: 'Tool 3',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result.tools).toHaveLength(3);
+      expect(result.tools?.[0]).toEqual({
+        type: 'function',
+        function: {
+          name: 'tool1',
+          description: 'Tool 1',
+          parameters: { type: 'object', properties: {} },
+        },
+        option1: 'value1',
+      });
+      expect(result.tools?.[1]).toEqual({
+        type: 'function',
+        function: {
+          name: 'tool2',
+          description: 'Tool 2',
+          parameters: { type: 'object', properties: {} },
+        },
+        option2: 'value2',
+      });
+      expect(result.tools?.[2]).toEqual({
+        type: 'function',
+        function: {
+          name: 'tool3',
+          description: 'Tool 3',
+          parameters: { type: 'object', properties: {} },
+        },
+      });
+    });
+
+    it('should handle complex nested metadata in providerOptions', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            providerOptions: {
+              openaiCompatible: {
+                cacheControl: { type: 'ephemeral' },
+                customField: { nested: { key: 'value' } },
+              },
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result.tools?.[0]).toEqual({
+        type: 'function',
+        function: {
+          name: 'testFunction',
+          description: 'A test function',
+          parameters: { type: 'object', properties: {} },
+        },
+        cacheControl: { type: 'ephemeral' },
+        customField: { nested: { key: 'value' } },
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

This PR adds support for tool-level provider options in the OpenAI-compatible provider. Tools can now include custom provider metadata through the `providerOptions` field, which gets properly merged into the prepared tools for API requests.

### Changes Made

- **Extended `prepareTools` function** to extract and merge tool-level metadata from `providerOptions.openaiCompatible`
- **Updated type definitions** to allow tools to include arbitrary metadata fields from provider options