### PR TITLE
fix(provider/mistral): Update refrence_ids type to be union of string and numbers

### DIFF
--- a/.changeset/swift-snakes-nail.md
+++ b/.changeset/swift-snakes-nail.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': patch
+---
+
+Update refrence_ids type to be union of number and string

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -502,7 +502,7 @@ const mistralContentSchema = z
         }),
         z.object({
           type: z.literal('reference'),
-          reference_ids: z.array(z.number()),
+          reference_ids: z.array(z.union([z.string(), z.number()])),
         }),
         z.object({
           type: z.literal('thinking'),


### PR DESCRIPTION


## Background
Mistral outputs strings as reference_ids frequently, but we defined the schema for it to be numbers, which result in schema validation errors

## Summary

Update the refrence_ids type to be union of string and number

## Manual Verification
Added a unit test with mix of numbers and string ref_ids

## Checklist


- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)


## Related Issues
Fixes #11384 
