### PR TITLE
fix(ai): exclude duplicative messages from tool call responses when using openai conversations

### DIFF
--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -2341,6 +2341,10 @@ describe('generateText', () => {
         tools: {
           serverTool: {
             type: 'provider',
+            id: 'test.server_tool',
+            inputSchema: z.object({}),
+            outputSchema: z.object({ result: z.string() }),
+            args: {},
             supportsDeferredResults: true,
           },
         },

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -75,11 +75,6 @@ const originalGenerateId = createIdGenerator({
   size: 24,
 });
 
-/**
- * Extracts the OpenAI conversation ID from provider options if present.
- * When conversation mode is active, the SDK sends incremental messages
- * during tool loops instead of the full message history.
- */
 function getOpenAIConversationId(providerOptions: unknown): string | undefined {
   const convo = (providerOptions as any)?.openai?.conversation;
   return typeof convo === 'string' && convo.length > 0 ? convo : undefined;
@@ -461,15 +456,11 @@ A function that attempts to repair a tool call that failed to parse.
 
         const callSettings = prepareCallSettings(settings);
 
-        // OpenAI conversation mode: track incremental messages for tool loops.
-        // When conversation is enabled, OpenAI persists the conversation server-side,
-        // so we only send new client-originated items (tool results) on subsequent
+        // OpenAI conversation mode: send only new tool results on subsequent
         // loop iterations instead of the full message history.
-        const openAIConversationId = getOpenAIConversationId(providerOptions);
-        const useOpenAIConversationDeltaPrompt = openAIConversationId != null;
-        // Start as undefined to indicate first call should send full messages
-        let deltaStepInputMessages: Array<ResponseMessage> | undefined =
-          undefined;
+        const useOpenAIConversationDeltaPrompt =
+          getOpenAIConversationId(providerOptions) != null;
+        let deltaStepInputMessages: Array<ResponseMessage> | undefined;
 
         let currentModelResponse: Awaited<
           ReturnType<LanguageModelV3['doGenerate']>
@@ -501,21 +492,14 @@ A function that attempts to repair a tool call that failed to parse.
             prepareStepResult?.model ?? model,
           );
 
-          // In OpenAI conversation mode, on the first call we send the full prompt.
-          // On subsequent calls (tool loop iterations), we send only new
-          // client-originated messages (tool results) since OpenAI persists
-          // the conversation server-side.
-          // Note: We also check length > 0 because if there are pending deferred
-          // tool calls but no new client tool results, we need to fall back to
-          // full messages rather than sending an empty array.
+          // In conversation mode, send only delta (tool results) on subsequent calls:
           const messagesForPrompt =
             useOpenAIConversationDeltaPrompt &&
             deltaStepInputMessages != null &&
             deltaStepInputMessages.length > 0
-              ? deltaStepInputMessages // Subsequent calls: send only delta (tool results)
-              : (prepareStepResult?.messages ?? stepInputMessages); // First call, empty delta, or non-conversation: send full
+              ? deltaStepInputMessages
+              : (prepareStepResult?.messages ?? stepInputMessages);
 
-          // Clear delta after determining what to send (will be populated with tool results)
           if (useOpenAIConversationDeltaPrompt) {
             deltaStepInputMessages = [];
           }
@@ -806,8 +790,6 @@ A function that attempts to repair a tool call that failed to parse.
           });
           responseMessages.push(...stepResponseMessages);
 
-          // In OpenAI conversation mode, only send tool result messages on subsequent
-          // iterations (not assistant messages, which OpenAI already has server-side)
           if (useOpenAIConversationDeltaPrompt) {
             deltaStepInputMessages ??= [];
             deltaStepInputMessages.push(

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -9989,7 +9989,10 @@ describe('streamText', () => {
                     },
                     {
                       type: 'finish',
-                      finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                      finishReason: {
+                        unified: 'tool-calls',
+                        raw: 'tool_calls',
+                      },
                       usage: testUsage,
                     },
                   ]),
@@ -10083,7 +10086,10 @@ describe('streamText', () => {
                     },
                     {
                       type: 'finish',
-                      finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                      finishReason: {
+                        unified: 'tool-calls',
+                        raw: 'tool_calls',
+                      },
                       usage: testUsage,
                     },
                   ]),
@@ -10117,6 +10123,10 @@ describe('streamText', () => {
         tools: {
           serverTool: {
             type: 'provider',
+            id: 'test.server_tool',
+            inputSchema: z.object({}),
+            outputSchema: z.object({ result: z.string() }),
+            args: {},
             supportsDeferredResults: true,
           },
         },
@@ -10189,7 +10199,10 @@ describe('streamText', () => {
                     },
                     {
                       type: 'finish',
-                      finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                      finishReason: {
+                        unified: 'tool-calls',
+                        raw: 'tool_calls',
+                      },
                       usage: testUsage,
                     },
                   ]),


### PR DESCRIPTION
## Background

When using OpenAI's conversation mode (`providerOptions.openai.conversation`), the provider persists conversation history server-side. The AI SDK's tool loop was re-sending all prior messages (including assistant items the model had already produced) on subsequent iterations, causing duplicate item errors and misaligned tool outputs.

## Summary

This change implements delta prompting for OpenAI conversation mode in both `generateText` and `streamText`:

* On the first model call, send the full prompt
* On subsequent loop iterations, send only new client-originated items (tool results)
* Fall back to full messages when the delta is empty (e.g., when a provider-executed tool has deferred results but no client tool results exist yet)

Added `getOpenAIConversationId` helper to detect when conversation mode is active. The helper returns `undefined` for empty strings to avoid accidental activation.

## Manual Verification

Using the Responses API with a tool that auto-executes. Without this fix, the second call would fail with a duplicate item error from OpenAI. Running this script from packages/ai will throw an error on main but works with this change.

```typescript
import { generateText, stepCountIs } from './src/index.js';
import { createOpenAI } from '../openai/src/index.js';
import { tool } from '../provider-utils/src/index.js';
import { z } from 'zod/v4';

const OPENAI_API_KEY = 'sk-svcacct-...';
const openai = createOpenAI({ apiKey: OPENAI_API_KEY });

async function main() {
  const result = await generateText({
    model: openai.responses('gpt-4o-mini'),
    prompt: 'Get the secret from the tool call and tell me what it is',
    stopWhen: stepCountIs(40),
    tools: {
      secret: tool({
        description: 'Returns the secret for any input string',
        inputSchema: z.object({
          input: z.string(),
        }),
        execute: async ({ input }) => {
          return `purple monkey dishwasher`;
        },
      }),
    },
    providerOptions: {
      openai: { conversation: 'conv_...' },
    },
  });

  console.log(result.text);
}

main();
```

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)