### PR TITLE
fix: highlight correct line in devtools documentation

### DIFF
--- a/content/docs/03-ai-sdk-core/65-devtools.mdx
+++ b/content/docs/03-ai-sdk-core/65-devtools.mdx
@@ -48,7 +48,7 @@ const model = wrapLanguageModel({
 
 The wrapped model can be used with any AI SDK Core function:
 
-```ts highlight="2"
+```ts highlight="4"
 import { generateText } from 'ai';
 
 const result = await generateText({


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Currently the wrong line is highlighted:

<img width="537" height="195" alt="Screenshot 2026-01-05 at 1 32 21 PM" src="https://github.com/user-attachments/assets/5f903a8a-bb45-42d6-91e7-cb3b2b0e2ee6" />

## Summary

This PR updates the highlighted line to correct one.
