### PR TITLE
feat(ui): add DirectChatTransport

### DIFF
--- a/.changeset/smooth-spoons-invent.md
+++ b/.changeset/smooth-spoons-invent.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ui): add DirectChatTransport

--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -671,6 +671,55 @@ export async function POST(req: Request) {
 
 To learn more about building custom transports, refer to the [Transport API documentation](/docs/ai-sdk-ui/transport).
 
+### Direct Agent Transport
+
+For scenarios where you want to communicate directly with an Agent without going through HTTP, you can use `DirectChatTransport`. This is useful for:
+
+- Server-side rendering scenarios
+- Testing without network
+- Single-process applications
+
+```tsx filename="app/page.tsx"
+import { useChat } from '@ai-sdk/react';
+import { DirectChatTransport, ToolLoopAgent } from 'ai';
+__PROVIDER_IMPORT__;
+
+const agent = new ToolLoopAgent({
+  model: __MODEL__,
+  instructions: 'You are a helpful assistant.',
+});
+
+export default function Chat() {
+  const { messages, sendMessage, status } = useChat({
+    transport: new DirectChatTransport({ agent }),
+  });
+
+  return (
+    <>
+      {messages.map(message => (
+        <div key={message.id}>
+          {message.role === 'user' ? 'User: ' : 'AI: '}
+          {message.parts.map((part, index) =>
+            part.type === 'text' ? <span key={index}>{part.text}</span> : null,
+          )}
+        </div>
+      ))}
+
+      <button
+        onClick={() => sendMessage({ text: 'Hello!' })}
+        disabled={status !== 'ready'}
+      >
+        Send
+      </button>
+    </>
+  );
+}
+```
+
+The `DirectChatTransport` invokes the agent's `stream()` method directly, converting UI messages to model messages and streaming the response back as UI message chunks.
+
+For more details, see the [DirectChatTransport reference](/docs/reference/ai-sdk-ui/direct-chat-transport).
+
 ## Controlling the response stream
 
 With `streamText`, you can control how error messages and usage information are sent back to the client.

--- a/content/docs/04-ai-sdk-ui/21-transport.mdx
+++ b/content/docs/04-ai-sdk-ui/21-transport.mdx
@@ -96,6 +96,66 @@ const { messages, sendMessage } = useChat({
 });
 ```
 
+## Direct Agent Transport
+
+For scenarios where you want to communicate directly with an [Agent](/docs/reference/ai-sdk-core/agent) without going through HTTP, you can use `DirectChatTransport`. This transport invokes the agent's `stream()` method directly in-process.
+
+This is useful for:
+
+- **Server-side rendering**: Run the agent on the server without an API endpoint
+- **Testing**: Test chat functionality without network requests
+- **Single-process applications**: Desktop or CLI apps where client and agent run together
+
+```tsx
+import { useChat } from '@ai-sdk/react';
+import { DirectChatTransport, ToolLoopAgent } from 'ai';
+__PROVIDER_IMPORT__;
+
+const agent = new ToolLoopAgent({
+  model: __MODEL__,
+  instructions: 'You are a helpful assistant.',
+  tools: {
+    weather: weatherTool,
+  },
+});
+
+const { messages, sendMessage } = useChat({
+  transport: new DirectChatTransport({ agent }),
+});
+```
+
+### How It Works
+
+Unlike `DefaultChatTransport` which sends HTTP requests:
+
+1. `DirectChatTransport` validates incoming UI messages
+2. Converts them to model messages using `convertToModelMessages`
+3. Calls the agent's `stream()` method directly
+4. Returns the result as a UI message stream via `toUIMessageStream()`
+
+### Configuration Options
+
+You can pass additional options to customize the stream output:
+
+```tsx
+const transport = new DirectChatTransport({
+  agent,
+  // Pass options to the agent
+  options: { customOption: 'value' },
+  // Configure what's sent to the client
+  sendReasoning: true,
+  sendSources: true,
+});
+```
+
+<Note>
+  `DirectChatTransport` does not support stream reconnection since there is no
+  persistent server-side stream. The `reconnectToStream()` method always returns
+  `null`.
+</Note>
+
+For complete API details, see the [DirectChatTransport reference](/docs/reference/ai-sdk-ui/direct-chat-transport).
+
 ## Building Custom Transports
 
 To understand how to build your own transport, refer to the source code of the default implementation:

--- a/content/docs/07-reference/02-ai-sdk-ui/50-direct-chat-transport.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/50-direct-chat-transport.mdx
@@ -1,0 +1,332 @@
+---
+title: DirectChatTransport
+description: API Reference for the DirectChatTransport class.
+---
+
+# `DirectChatTransport`
+
+A transport that directly communicates with an [Agent](/docs/reference/ai-sdk-core/agent) in-process, without going through HTTP. This is useful for:
+
+- Server-side rendering scenarios
+- Testing without network
+- Single-process applications
+
+Unlike `DefaultChatTransport` which sends HTTP requests to an API endpoint, `DirectChatTransport` invokes the agent's `stream()` method directly and converts the result to a UI message stream.
+
+```tsx
+import { useChat } from '@ai-sdk/react';
+import { DirectChatTransport, ToolLoopAgent } from 'ai';
+__PROVIDER_IMPORT__;
+
+const agent = new ToolLoopAgent({
+  model: __MODEL__,
+  instructions: 'You are a helpful assistant.',
+});
+
+export default function Chat() {
+  const { messages, sendMessage, status } = useChat({
+    transport: new DirectChatTransport({ agent }),
+  });
+
+  // ... render chat UI
+}
+```
+
+## Import
+
+<Snippet text={`import { DirectChatTransport } from "ai"`} prompt={false} />
+
+## Constructor
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'agent',
+      type: 'Agent',
+      isRequired: true,
+      description:
+        'The Agent instance to use for generating responses. The agent will be called with `stream()` for each message.',
+    },
+    {
+      name: 'options',
+      type: 'CALL_OPTIONS',
+      isOptional: true,
+      description:
+        'Options to pass to the agent when calling it. These are agent-specific options defined when creating the agent.',
+    },
+    {
+      name: 'originalMessages',
+      type: 'UIMessage[]',
+      isOptional: true,
+      description:
+        'The original messages. If provided, persistence mode is assumed, and a message ID is provided for the response message.',
+    },
+    {
+      name: 'generateMessageId',
+      type: 'IdGenerator',
+      isOptional: true,
+      description:
+        'Generate a message ID for the response message. If not provided, no message ID will be set for the response message.',
+    },
+    {
+      name: 'messageMetadata',
+      type: '(options: { part: TextStreamPart }) => METADATA | undefined',
+      isOptional: true,
+      description:
+        'Extracts message metadata that will be sent to the client. Called on `start` and `finish` events.',
+    },
+    {
+      name: 'sendReasoning',
+      type: 'boolean',
+      isOptional: true,
+      description: 'Send reasoning parts to the client. Defaults to true.',
+    },
+    {
+      name: 'sendSources',
+      type: 'boolean',
+      isOptional: true,
+      description: 'Send source parts to the client. Defaults to false.',
+    },
+    {
+      name: 'sendFinish',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'Send the finish event to the client. Set to false if you are using additional streamText calls that send additional data. Defaults to true.',
+    },
+    {
+      name: 'sendStart',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'Send the message start event to the client. Set to false if you are using additional streamText calls and the message start event has already been sent. Defaults to true.',
+    },
+    {
+      name: 'onError',
+      type: '(error: unknown) => string',
+      isOptional: true,
+      description:
+        "Process an error, e.g. to log it. Defaults to `() => 'An error occurred.'`. Return the error message to include in the data stream.",
+    },
+  ]}
+/>
+
+## Methods
+
+### `sendMessages()`
+
+Sends messages to the agent and returns a streaming response. This method validates and converts UI messages to model messages, calls the agent's `stream()` method, and returns the result as a UI message stream.
+
+```ts
+const stream = await transport.sendMessages({
+  chatId: 'chat-123',
+  trigger: 'submit-message',
+  messages: [...],
+  abortSignal: controller.signal,
+});
+```
+
+<PropertiesTable
+  content={[
+    {
+      name: 'chatId',
+      type: 'string',
+      description: 'Unique identifier for the chat session.',
+    },
+    {
+      name: 'trigger',
+      type: "'submit-message' | 'regenerate-message'",
+      description:
+        'The type of message submission - either new message or regeneration.',
+    },
+    {
+      name: 'messageId',
+      type: 'string | undefined',
+      description:
+        'ID of the message to regenerate, or undefined for new messages.',
+    },
+    {
+      name: 'messages',
+      type: 'UIMessage[]',
+      description: 'Array of UI messages representing the conversation history.',
+    },
+    {
+      name: 'abortSignal',
+      type: 'AbortSignal | undefined',
+      description: 'Signal to abort the request if needed.',
+    },
+    {
+      name: 'headers',
+      type: 'Record<string, string> | Headers',
+      isOptional: true,
+      description: 'Additional headers (ignored by DirectChatTransport).',
+    },
+    {
+      name: 'body',
+      type: 'object',
+      isOptional: true,
+      description: 'Additional body properties (ignored by DirectChatTransport).',
+    },
+    {
+      name: 'metadata',
+      type: 'unknown',
+      isOptional: true,
+      description: 'Custom metadata (ignored by DirectChatTransport).',
+    },
+  ]}
+/>
+
+#### Returns
+
+Returns a `Promise<ReadableStream<UIMessageChunk>>` - a stream of UI message chunks that can be processed by the chat UI.
+
+### `reconnectToStream()`
+
+Direct transport does not support reconnection since there is no persistent server-side stream to reconnect to.
+
+#### Returns
+
+Always returns `Promise<null>`.
+
+## Examples
+
+### Basic Usage
+
+```tsx
+import { useChat } from '@ai-sdk/react';
+import { DirectChatTransport, ToolLoopAgent } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const agent = new ToolLoopAgent({
+  model: openai('gpt-4o'),
+  instructions: 'You are a helpful assistant.',
+});
+
+export default function Chat() {
+  const { messages, sendMessage, status } = useChat({
+    transport: new DirectChatTransport({ agent }),
+  });
+
+  return (
+    <div>
+      {messages.map(message => (
+        <div key={message.id}>
+          {message.role === 'user' ? 'User: ' : 'AI: '}
+          {message.parts.map((part, index) =>
+            part.type === 'text' ? <span key={index}>{part.text}</span> : null,
+          )}
+        </div>
+      ))}
+      <button onClick={() => sendMessage({ text: 'Hello!' })}>Send</button>
+    </div>
+  );
+}
+```
+
+### With Agent Tools
+
+```tsx
+import { useChat } from '@ai-sdk/react';
+import { DirectChatTransport, ToolLoopAgent, tool } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { z } from 'zod';
+
+const weatherTool = tool({
+  description: 'Get the current weather',
+  parameters: z.object({
+    location: z.string().describe('The city and state'),
+  }),
+  execute: async ({ location }) => {
+    return `The weather in ${location} is sunny and 72°F.`;
+  },
+});
+
+const agent = new ToolLoopAgent({
+  model: openai('gpt-4o'),
+  instructions: 'You are a helpful assistant with access to weather data.',
+  tools: { weather: weatherTool },
+});
+
+export default function Chat() {
+  const { messages, sendMessage } = useChat({
+    transport: new DirectChatTransport({ agent }),
+  });
+
+  // ... render chat UI with tool results
+}
+```
+
+### With Custom Agent Options
+
+```tsx
+import { useChat } from '@ai-sdk/react';
+import { DirectChatTransport, ToolLoopAgent } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const agent = new ToolLoopAgent<{ userId: string }>({
+  model: openai('gpt-4o'),
+  prepareCall: ({ options, ...rest }) => ({
+    ...rest,
+    providerOptions: {
+      openai: { user: options.userId },
+    },
+  }),
+});
+
+export default function Chat({ userId }: { userId: string }) {
+  const { messages, sendMessage } = useChat({
+    transport: new DirectChatTransport({
+      agent,
+      options: { userId },
+    }),
+  });
+
+  // ... render chat UI
+}
+```
+
+### With Reasoning
+
+```tsx
+import { useChat } from '@ai-sdk/react';
+import { DirectChatTransport, ToolLoopAgent } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const agent = new ToolLoopAgent({
+  model: openai('o1-preview'),
+});
+
+export default function Chat() {
+  const { messages, sendMessage } = useChat({
+    transport: new DirectChatTransport({
+      agent,
+      sendReasoning: true,
+    }),
+  });
+
+  return (
+    <div>
+      {messages.map(message => (
+        <div key={message.id}>
+          {message.parts.map((part, index) => {
+            if (part.type === 'text') {
+              return <p key={index}>{part.text}</p>;
+            }
+            if (part.type === 'reasoning') {
+              return (
+                <pre key={index} style={{ opacity: 0.6 }}>
+                  {part.text}
+                </pre>
+              );
+            }
+            return null;
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+

--- a/content/docs/07-reference/02-ai-sdk-ui/50-direct-chat-transport.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/50-direct-chat-transport.mdx
@@ -150,7 +150,8 @@ const stream = await transport.sendMessages({
     {
       name: 'messages',
       type: 'UIMessage[]',
-      description: 'Array of UI messages representing the conversation history.',
+      description:
+        'Array of UI messages representing the conversation history.',
     },
     {
       name: 'abortSignal',
@@ -167,7 +168,8 @@ const stream = await transport.sendMessages({
       name: 'body',
       type: 'object',
       isOptional: true,
-      description: 'Additional body properties (ignored by DirectChatTransport).',
+      description:
+        'Additional body properties (ignored by DirectChatTransport).',
     },
     {
       name: 'metadata',
@@ -329,4 +331,3 @@ export default function Chat() {
   );
 }
 ```
-

--- a/examples/next-openai/app/chat-openai-direct/page.tsx
+++ b/examples/next-openai/app/chat-openai-direct/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { DirectChatTransport, ToolLoopAgent } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+import ChatInput from '@/components/chat-input';
+
+/**
+ * WARNING: This example is for testing/demonstration purposes only.
+ *
+ * DO NOT USE IN PRODUCTION! Exposing your OpenAI API key in client-side code
+ * is a security risk. Anyone can view the key in the browser and use it for
+ * their own purposes, potentially incurring charges on your account.
+ *
+ * For production, use DefaultChatTransport with a server-side API route.
+ *
+ * You might want to use direct calls when there are no API keys, e.g.
+ * when calling on-device, in-browser, or local models.
+ */
+const openai = createOpenAI({
+  apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY,
+});
+
+const agent = new ToolLoopAgent({
+  model: openai('gpt-4o-mini'),
+  instructions: 'You are a helpful assistant.',
+});
+
+export default function Chat() {
+  const { error, status, sendMessage, messages, regenerate, stop } = useChat({
+    transport: new DirectChatTransport({ agent }),
+  });
+
+  return (
+    <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
+      {messages.map(m => (
+        <div key={m.id} className="whitespace-pre-wrap">
+          {m.role === 'user' ? 'User: ' : 'AI: '}
+          {m.parts.map(part => {
+            if (part.type === 'text') {
+              return part.text;
+            }
+          })}
+        </div>
+      ))}
+
+      {(status === 'submitted' || status === 'streaming') && (
+        <div className="mt-4 text-gray-500">
+          {status === 'submitted' && <div>Loading...</div>}
+          <button
+            type="button"
+            className="px-4 py-2 mt-4 text-blue-500 rounded-md border border-blue-500"
+            onClick={stop}
+          >
+            Stop
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-4">
+          <div className="text-red-500">An error occurred.</div>
+          <button
+            type="button"
+            className="px-4 py-2 mt-4 text-blue-500 rounded-md border border-blue-500"
+            onClick={() => regenerate()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <ChatInput status={status} onSubmit={text => sendMessage({ text })} />
+    </div>
+  );
+}

--- a/packages/ai/src/ui/direct-chat-transport.test.ts
+++ b/packages/ai/src/ui/direct-chat-transport.test.ts
@@ -1,0 +1,447 @@
+import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { MockLanguageModelV3 } from '../test/mock-language-model-v3';
+import { ToolLoopAgent } from '../agent/tool-loop-agent';
+import { DirectChatTransport } from './direct-chat-transport';
+
+describe('DirectChatTransport', () => {
+  describe('sendMessages', () => {
+    let mockModel: MockLanguageModelV3;
+
+    beforeEach(() => {
+      mockModel = new MockLanguageModelV3({
+        doStream: async () => {
+          return {
+            stream: convertArrayToReadableStream([
+              {
+                type: 'stream-start',
+                warnings: [],
+              },
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'Hello' },
+              { type: 'text-delta', id: '1', delta: ', ' },
+              { type: 'text-delta', id: '1', delta: 'world!' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: {
+                  inputTokens: {
+                    total: 3,
+                    noCache: 3,
+                    cacheRead: undefined,
+                    cacheWrite: undefined,
+                  },
+                  outputTokens: {
+                    total: 10,
+                    text: 10,
+                    reasoning: undefined,
+                  },
+                },
+              },
+            ]),
+          };
+        },
+      });
+    });
+
+    it('should stream text response from agent', async () => {
+      const agent = new ToolLoopAgent({ model: mockModel });
+      const transport = new DirectChatTransport({ agent });
+
+      const stream = await transport.sendMessages({
+        chatId: 'chat-1',
+        messageId: undefined,
+        trigger: 'submit-message',
+        messages: [
+          {
+            id: 'msg-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Hello!' }],
+          },
+        ],
+        abortSignal: undefined,
+      });
+
+      const chunks: unknown[] = [];
+      const reader = stream.getReader();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+
+      // Check for text streaming chunks
+      const textChunks = chunks.filter(
+        (chunk: any) =>
+          chunk.type === 'text-start' ||
+          chunk.type === 'text-delta' ||
+          chunk.type === 'text-end',
+      );
+
+      expect(textChunks.length).toBeGreaterThan(0);
+
+      // Check we got text deltas with content
+      const textDeltas = chunks.filter(
+        (chunk: any) => chunk.type === 'text-delta',
+      );
+      expect(textDeltas).toMatchObject([
+        { type: 'text-delta', delta: 'Hello' },
+        { type: 'text-delta', delta: ', ' },
+        { type: 'text-delta', delta: 'world!' },
+      ]);
+    });
+
+    it('should pass abortSignal to agent', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+
+      const mockModelWithCapture = new MockLanguageModelV3({
+        doStream: async options => {
+          receivedAbortSignal = options.abortSignal;
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'test' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: {
+                  inputTokens: {
+                    total: 1,
+                    noCache: 1,
+                    cacheRead: undefined,
+                    cacheWrite: undefined,
+                  },
+                  outputTokens: { total: 1, text: 1, reasoning: undefined },
+                },
+              },
+            ]),
+          };
+        },
+      });
+
+      const agent = new ToolLoopAgent({ model: mockModelWithCapture });
+      const transport = new DirectChatTransport({ agent });
+
+      const abortController = new AbortController();
+
+      const stream = await transport.sendMessages({
+        chatId: 'chat-1',
+        messageId: undefined,
+        trigger: 'submit-message',
+        messages: [
+          {
+            id: 'msg-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Hello!' }],
+          },
+        ],
+        abortSignal: abortController.signal,
+      });
+
+      // Consume the stream
+      const reader = stream.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+
+      expect(receivedAbortSignal).toBe(abortController.signal);
+    });
+
+    it('should pass agent options to agent', async () => {
+      let receivedProviderOptions: unknown;
+
+      const mockModelWithCapture = new MockLanguageModelV3({
+        doStream: async options => {
+          receivedProviderOptions = options.providerOptions;
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'test' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: {
+                  inputTokens: {
+                    total: 1,
+                    noCache: 1,
+                    cacheRead: undefined,
+                    cacheWrite: undefined,
+                  },
+                  outputTokens: { total: 1, text: 1, reasoning: undefined },
+                },
+              },
+            ]),
+          };
+        },
+      });
+
+      const agent = new ToolLoopAgent<{ customOption: string }>({
+        model: mockModelWithCapture,
+        prepareCall: ({ options, ...rest }) => ({
+          ...rest,
+          providerOptions: { custom: { value: options.customOption } },
+        }),
+      });
+
+      const transport = new DirectChatTransport({
+        agent,
+        options: { customOption: 'test-value' },
+      });
+
+      const stream = await transport.sendMessages({
+        chatId: 'chat-1',
+        messageId: undefined,
+        trigger: 'submit-message',
+        messages: [
+          {
+            id: 'msg-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Hello!' }],
+          },
+        ],
+        abortSignal: undefined,
+      });
+
+      // Consume the stream
+      const reader = stream.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+
+      expect(receivedProviderOptions).toMatchObject({
+        custom: { value: 'test-value' },
+      });
+    });
+
+    it('should apply UIMessageStreamOptions', async () => {
+      const mockModelWithReasoning = new MockLanguageModelV3({
+        doStream: async () => {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'reasoning-start', id: 'r1' },
+              { type: 'reasoning-delta', id: 'r1', delta: 'thinking...' },
+              { type: 'reasoning-end', id: 'r1' },
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'result' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: {
+                  inputTokens: {
+                    total: 1,
+                    noCache: 1,
+                    cacheRead: undefined,
+                    cacheWrite: undefined,
+                  },
+                  outputTokens: { total: 1, text: 1, reasoning: undefined },
+                },
+              },
+            ]),
+          };
+        },
+      });
+
+      const agent = new ToolLoopAgent({ model: mockModelWithReasoning });
+
+      // Test with sendReasoning: true
+      const transportWithReasoning = new DirectChatTransport({
+        agent,
+        sendReasoning: true,
+      });
+
+      const stream = await transportWithReasoning.sendMessages({
+        chatId: 'chat-1',
+        messageId: undefined,
+        trigger: 'submit-message',
+        messages: [
+          {
+            id: 'msg-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Hello!' }],
+          },
+        ],
+        abortSignal: undefined,
+      });
+
+      const chunks: unknown[] = [];
+      const reader = stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+
+      // With sendReasoning: true, we should see reasoning chunks
+      const reasoningChunks = chunks.filter(
+        (chunk: any) =>
+          chunk.type === 'reasoning-start' ||
+          chunk.type === 'reasoning-delta' ||
+          chunk.type === 'reasoning-end',
+      );
+      expect(reasoningChunks.length).toBeGreaterThan(0);
+    });
+
+    it('should convert UI messages to model messages correctly', async () => {
+      let receivedPrompt: unknown;
+
+      const mockModelWithCapture = new MockLanguageModelV3({
+        doStream: async options => {
+          receivedPrompt = options.prompt;
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'response' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: {
+                  inputTokens: {
+                    total: 1,
+                    noCache: 1,
+                    cacheRead: undefined,
+                    cacheWrite: undefined,
+                  },
+                  outputTokens: { total: 1, text: 1, reasoning: undefined },
+                },
+              },
+            ]),
+          };
+        },
+      });
+
+      const agent = new ToolLoopAgent({ model: mockModelWithCapture });
+      const transport = new DirectChatTransport({ agent });
+
+      const stream = await transport.sendMessages({
+        chatId: 'chat-1',
+        messageId: undefined,
+        trigger: 'submit-message',
+        messages: [
+          {
+            id: 'msg-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'First message' }],
+          },
+          {
+            id: 'msg-2',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Assistant reply' }],
+          },
+          {
+            id: 'msg-3',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Second message' }],
+          },
+        ],
+        abortSignal: undefined,
+      });
+
+      // Consume the stream
+      const reader = stream.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+
+      expect(receivedPrompt).toMatchObject([
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'First message' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Assistant reply' }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Second message' }],
+        },
+      ]);
+    });
+
+    it('should throw error for invalid messages', async () => {
+      const agent = new ToolLoopAgent({ model: mockModel });
+      const transport = new DirectChatTransport({ agent });
+
+      await expect(
+        transport.sendMessages({
+          chatId: 'chat-1',
+          messageId: undefined,
+          trigger: 'submit-message',
+          messages: [
+            {
+              // Missing id - invalid message
+              role: 'user',
+              parts: [{ type: 'text', text: 'Hello!' }],
+            },
+          ] as any,
+          abortSignal: undefined,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('reconnectToStream', () => {
+    it('should return null', async () => {
+      const mockModel = new MockLanguageModelV3({
+        doStream: async () => {
+          return {
+            stream: convertArrayToReadableStream([]),
+          };
+        },
+      });
+
+      const agent = new ToolLoopAgent({ model: mockModel });
+      const transport = new DirectChatTransport({ agent });
+
+      const result = await transport.reconnectToStream({
+        chatId: 'chat-1',
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+});
+

--- a/packages/ai/src/ui/direct-chat-transport.test.ts
+++ b/packages/ai/src/ui/direct-chat-transport.test.ts
@@ -444,4 +444,3 @@ describe('DirectChatTransport', () => {
     });
   });
 });
-

--- a/packages/ai/src/ui/direct-chat-transport.ts
+++ b/packages/ai/src/ui/direct-chat-transport.ts
@@ -77,9 +77,9 @@ export class DirectChatTransport<
   async sendMessages({
     messages,
     abortSignal,
-  }: Parameters<
-    ChatTransport<UI_MESSAGE>['sendMessages']
-  >[0]): Promise<ReadableStream<UIMessageChunk>> {
+  }: Parameters<ChatTransport<UI_MESSAGE>['sendMessages']>[0]): Promise<
+    ReadableStream<UIMessageChunk>
+  > {
     // Validate the incoming UI messages
     const validatedMessages = await validateUIMessages<UI_MESSAGE>({
       messages,
@@ -116,4 +116,3 @@ export class DirectChatTransport<
     return null;
   }
 }
-

--- a/packages/ai/src/ui/direct-chat-transport.ts
+++ b/packages/ai/src/ui/direct-chat-transport.ts
@@ -1,0 +1,119 @@
+import { Output } from '../generate-text/output';
+import { UIMessageStreamOptions } from '../generate-text/stream-text-result';
+import { ToolSet } from '../generate-text/tool-set';
+import { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
+import { Agent } from '../agent/agent';
+import { ChatTransport } from './chat-transport';
+import { convertToModelMessages } from './convert-to-model-messages';
+import { InferUITools, UIMessage } from './ui-messages';
+import { validateUIMessages } from './validate-ui-messages';
+
+/**
+ * Options for the `DirectChatTransport` class.
+ */
+export type DirectChatTransportOptions<
+  CALL_OPTIONS,
+  TOOLS extends ToolSet,
+  OUTPUT extends Output,
+  UI_MESSAGE extends UIMessage<unknown, never, InferUITools<TOOLS>>,
+> = {
+  /**
+   * The agent to use for generating responses.
+   */
+  agent: Agent<CALL_OPTIONS, TOOLS, OUTPUT>;
+
+  /**
+   * Options to pass to the agent when calling it.
+   */
+  options?: CALL_OPTIONS;
+} & Omit<UIMessageStreamOptions<UI_MESSAGE>, 'onFinish'>;
+
+/**
+ * A transport that directly communicates with an Agent in-process,
+ * without going through HTTP. This is useful for:
+ * - Server-side rendering scenarios
+ * - Testing without network
+ * - Single-process applications
+ *
+ * @example
+ * ```tsx
+ * import { useChat } from '@ai-sdk/react';
+ * import { DirectChatTransport } from 'ai';
+ * import { myAgent } from './my-agent';
+ *
+ * const { messages, sendMessage } = useChat({
+ *   transport: new DirectChatTransport({ agent: myAgent }),
+ * });
+ * ```
+ */
+export class DirectChatTransport<
+  CALL_OPTIONS = never,
+  TOOLS extends ToolSet = {},
+  OUTPUT extends Output = never,
+  UI_MESSAGE extends UIMessage<unknown, never, InferUITools<TOOLS>> = UIMessage<
+    unknown,
+    never,
+    InferUITools<TOOLS>
+  >,
+> implements ChatTransport<UI_MESSAGE>
+{
+  private readonly agent: Agent<CALL_OPTIONS, TOOLS, OUTPUT>;
+  private readonly agentOptions: CALL_OPTIONS | undefined;
+  private readonly uiMessageStreamOptions: Omit<
+    UIMessageStreamOptions<UI_MESSAGE>,
+    'onFinish'
+  >;
+
+  constructor({
+    agent,
+    options,
+    ...uiMessageStreamOptions
+  }: DirectChatTransportOptions<CALL_OPTIONS, TOOLS, OUTPUT, UI_MESSAGE>) {
+    this.agent = agent;
+    this.agentOptions = options;
+    this.uiMessageStreamOptions = uiMessageStreamOptions;
+  }
+
+  async sendMessages({
+    messages,
+    abortSignal,
+  }: Parameters<
+    ChatTransport<UI_MESSAGE>['sendMessages']
+  >[0]): Promise<ReadableStream<UIMessageChunk>> {
+    // Validate the incoming UI messages
+    const validatedMessages = await validateUIMessages<UI_MESSAGE>({
+      messages,
+      tools: this.agent.tools,
+    });
+
+    // Convert UI messages to model messages
+    const modelMessages = await convertToModelMessages(validatedMessages, {
+      tools: this.agent.tools,
+    });
+
+    // Stream from the agent
+    const result = await this.agent.stream({
+      prompt: modelMessages,
+      abortSignal,
+      ...(this.agentOptions !== undefined
+        ? { options: this.agentOptions }
+        : {}),
+    } as Parameters<Agent<CALL_OPTIONS, TOOLS, OUTPUT>['stream']>[0]);
+
+    // Return the UI message stream
+    return result.toUIMessageStream(this.uiMessageStreamOptions);
+  }
+
+  /**
+   * Direct transport does not support reconnection since there is no
+   * persistent server-side stream to reconnect to.
+   *
+   * @returns Always returns `null`
+   */
+  async reconnectToStream(
+    _options: Parameters<ChatTransport<UI_MESSAGE>['reconnectToStream']>[0],
+  ): Promise<ReadableStream<UIMessageChunk> | null> {
+    return null;
+  }
+}
+

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -19,6 +19,10 @@ export { convertFileListToFileUIParts } from './convert-file-list-to-file-ui-par
 export { convertToModelMessages } from './convert-to-model-messages';
 export { DefaultChatTransport } from './default-chat-transport';
 export {
+  DirectChatTransport,
+  type DirectChatTransportOptions,
+} from './direct-chat-transport';
+export {
   HttpChatTransport,
   type HttpChatTransportInitOptions,
   type PrepareReconnectToStreamRequest,


### PR DESCRIPTION
## Background

When using on-device, in-browser, or locally hosted models, it can make sense to call the LLM API directly without using an intermediate server.

## Summary

Add `DirectChatTransport` which calls an `Agent` implementation directly.

## Manual Verification

- [x] run `examples/next-openai/app/chat-openai-direct/page.tsx`

## Related Issues

Resolves #5140