### PR TITLE
fix (provider/xai): use correct format for function tools

### DIFF
--- a/.changeset/green-coins-admire.md
+++ b/.changeset/green-coins-admire.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix (provider/xai): use correct format for function tools

--- a/examples/ai-core/src/generate-text/xai-responses-tool-call.ts
+++ b/examples/ai-core/src/generate-text/xai-responses-tool-call.ts
@@ -6,7 +6,7 @@ import { weatherTool } from '../tools/weather-tool';
 
 async function main() {
   const result = await generateText({
-    model: xai('grok-4-1-fast-reasoning'),
+    model: xai.responses('grok-4-1-fast-reasoning'),
     maxOutputTokens: 512,
     tools: {
       weather: weatherTool,

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -82,11 +82,9 @@ export type XaiResponsesTool =
   | { type: 'mcp' }
   | {
       type: 'function';
-      function: {
-        name: string;
-        description?: string;
-        parameters: unknown;
-      };
+      name: string;
+      description?: string;
+      parameters: unknown;
     };
 
 const annotationSchema = z.union([

--- a/packages/xai/src/responses/xai-responses-prepare-tools.test.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.test.ts
@@ -315,20 +315,18 @@ describe('prepareResponsesTools', () => {
       expect(result.tools).toMatchInlineSnapshot(`
         [
           {
-            "function": {
-              "description": "get weather information",
-              "name": "weather",
-              "parameters": {
-                "properties": {
-                  "location": {
-                    "type": "string",
-                  },
+            "description": "get weather information",
+            "name": "weather",
+            "parameters": {
+              "properties": {
+                "location": {
+                  "type": "string",
                 },
-                "required": [
-                  "location",
-                ],
-                "type": "object",
               },
+              "required": [
+                "location",
+              ],
+              "type": "object",
             },
             "type": "function",
           },

--- a/packages/xai/src/responses/xai-responses-prepare-tools.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.ts
@@ -127,11 +127,9 @@ export async function prepareResponsesTools({
     } else {
       xaiTools.push({
         type: 'function',
-        function: {
-          name: tool.name,
-          description: tool.description,
-          parameters: tool.inputSchema,
-        },
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.inputSchema,
       });
     }
   }


### PR DESCRIPTION
## Background

Attempting to use function tools with the `xai` provider `responses` api fails with invalid json parse error on xai server side.

Sample error:
```
Failed to deserialize the JSON body into the target type: tools[0]: missing field `name` at line 1 column 496
```

## Summary

Revised format of function calls to use a flat format matching existing openai responses api implementation.

The official xai docs do not seem to define the format to this level of detail: https://docs.x.ai/docs/api-reference#create-new-response

## Manual Verification

Added example script to explicitly test tool calls with the responses API. Fails before the change and passes after.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
