### PR TITLE
feat(ai): add --latest model version resolution support

### DIFF
--- a/.changeset/heavy-ravens-flow.md
+++ b/.changeset/heavy-ravens-flow.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Add --latest model version resolution support

--- a/examples/ai-core/src/registry/example-latest-usage.ts
+++ b/examples/ai-core/src/registry/example-latest-usage.ts
@@ -1,0 +1,52 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { openai } from '@ai-sdk/openai';
+import { createProviderRegistry } from 'ai';
+import { generateText } from 'ai';
+
+// Setup registry with multiple providers
+const registry = createProviderRegistry({
+  anthropic,
+  openai,
+});
+
+async function exampleWithLatest() {
+  // Using --latest suffix automatically resolves to claude-sonnet-4-5
+  const result = await generateText({
+    model: registry.languageModel('anthropic:claude-sonnet--latest'),
+    prompt: 'What is the meaning of life?',
+  });
+
+  console.log(result.text);
+}
+
+async function exampleWithMultipleProviders() {
+  // Test with different providers using --latest
+  
+  // Anthropic - resolves to claude-opus-4-1
+  const anthropicResult = await generateText({
+    model: registry.languageModel('anthropic:claude-opus--latest'),
+    prompt: 'Write a haiku about coding',
+  });
+
+  // OpenAI - resolves to gpt-4.5
+  const openaiResult = await generateText({
+    model: registry.languageModel('openai:gpt--latest'),
+    prompt: 'Write a haiku about AI',
+  });
+
+  console.log('Anthropic:', anthropicResult.text);
+  console.log('OpenAI:', openaiResult.text);
+}
+
+async function exampleWithoutLatest() {
+  // Traditional usage still works - specify exact version
+  const result = await generateText({
+    model: registry.languageModel('anthropic:claude-sonnet-4-5'),
+    prompt: 'Hello!',
+  });
+
+  console.log(result.text);
+}
+
+// Run examples
+exampleWithLatest();

--- a/packages/ai/src/registry/latest-versions.test.ts
+++ b/packages/ai/src/registry/latest-versions.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLatestVersion } from './latest-versions';
+
+describe('resolveLatestVersion', () => {
+  it('should resolve --latest suffix to actual version', () => {
+    expect(resolveLatestVersion('anthropic', 'claude-sonnet--latest')).toBe(
+      'claude-sonnet-4-5',
+    );
+    expect(resolveLatestVersion('openai', 'gpt--latest')).toBe('gpt-4.5');
+  });
+
+  it('should return original modelId if no --latest suffix', () => {
+    expect(resolveLatestVersion('anthropic', 'claude-sonnet-4-5')).toBe(
+      'claude-sonnet-4-5',
+    );
+    expect(resolveLatestVersion('openai', 'gpt-4o')).toBe('gpt-4o');
+  });
+
+  it('should return original modelId if provider not in mapping', () => {
+    expect(
+      resolveLatestVersion('unknown-provider', 'some-model--latest'),
+    ).toBe('some-model--latest');
+  });
+
+  it('should return original modelId if base model not in mapping', () => {
+    expect(resolveLatestVersion('anthropic', 'unknown-model--latest')).toBe(
+      'unknown-model--latest',
+    );
+  });
+
+  it('should handle all major providers', () => {
+    // Anthropic
+    expect(resolveLatestVersion('anthropic', 'claude-opus--latest')).toBe(
+      'claude-opus-4-1',
+    );
+    expect(resolveLatestVersion('anthropic', 'claude-haiku--latest')).toBe(
+      'claude-haiku-4-5',
+    );
+
+    // OpenAI
+    expect(resolveLatestVersion('openai', 'gpt-mini--latest')).toBe(
+      'gpt-4.5-mini',
+    );
+
+    // Google
+    expect(resolveLatestVersion('google', 'gemini-flash--latest')).toBe(
+      'gemini-2.0-flash-exp',
+    );
+
+    // Mistral
+    expect(resolveLatestVersion('mistral', 'mistral-large--latest')).toBe(
+      'mistral-large-latest',
+    );
+
+    // DeepSeek
+    expect(resolveLatestVersion('deepseek', 'deepseek-chat--latest')).toBe(
+      'deepseek-chat',
+    );
+
+    // xAI
+    expect(resolveLatestVersion('xai', 'grok--latest')).toBe('grok-2-latest');
+  });
+});

--- a/packages/ai/src/registry/latest-versions.ts
+++ b/packages/ai/src/registry/latest-versions.ts
@@ -1,0 +1,91 @@
+/**
+ * Maps provider and model base names to their latest versions.
+ * This allows using `--latest` suffix to automatically resolve to the newest model version.
+ * 
+ * Usage: 'anthropic:claude-sonnet--latest' -> 'anthropic:claude-sonnet-4-5'
+ */
+export const LATEST_VERSIONS: Record<string, Record<string, string>> = {
+  anthropic: {
+    'claude-opus': 'claude-opus-4-1',
+    'claude-sonnet': 'claude-sonnet-4-5',
+    'claude-haiku': 'claude-haiku-4-5',
+  },
+  openai: {
+    'gpt': 'gpt-4.5',
+    'gpt-mini': 'gpt-4.5-mini',
+    'o1': 'o1',
+    'o1-mini': 'o1-mini',
+    'o3-mini': 'o3-mini',
+  },
+  google: {
+    'gemini-pro': 'gemini-2.0-flash-exp',
+    'gemini-flash': 'gemini-2.0-flash-exp',
+  },
+  'google-vertex': {
+    'gemini-pro': 'gemini-2.0-flash-exp',
+    'gemini-flash': 'gemini-2.0-flash-exp',
+  },
+  cohere: {
+    'command': 'command-r-plus-08-2024',
+    'command-r': 'command-r-08-2024',
+  },
+  mistral: {
+    'mistral-large': 'mistral-large-latest',
+    'mistral-small': 'mistral-small-latest',
+    'mistral-medium': 'mistral-medium-latest',
+  },
+  groq: {
+    'llama': 'llama-3.3-70b-versatile',
+    'mixtral': 'mixtral-8x7b-32768',
+  },
+  deepseek: {
+    'deepseek-chat': 'deepseek-chat',
+    'deepseek-reasoner': 'deepseek-reasoner',
+  },
+  xai: {
+    'grok': 'grok-2-latest',
+  },
+};
+
+/**
+ * Resolves a model ID with --latest suffix to its actual latest version.
+ * 
+ * @param providerId - The provider identifier (e.g., 'anthropic', 'openai')
+ * @param modelId - The model identifier, potentially with --latest suffix
+ * @returns The resolved model ID, or the original if --latest not used
+ * 
+ * @example
+ * resolveLatestVersion('anthropic', 'claude-sonnet--latest') 
+ * // Returns: 'claude-sonnet-4-5'
+ * 
+ * resolveLatestVersion('openai', 'gpt-4o') 
+ * // Returns: 'gpt-4o' (unchanged)
+ */
+export function resolveLatestVersion(
+  providerId: string,
+  modelId: string,
+): string {
+  // Check if the model ID ends with --latest
+  if (!modelId.endsWith('--latest')) {
+    return modelId;
+  }
+
+  // Extract the base model name by removing --latest suffix
+  const baseModel = modelId.slice(0, -('--latest'.length));
+
+  // Look up the latest version for this provider and base model
+  const providerVersions = LATEST_VERSIONS[providerId];
+  if (!providerVersions) {
+    // Provider not in mapping, return original modelId
+    // This allows --latest to pass through to providers that support it natively
+    return modelId;
+  }
+
+  const resolvedVersion = providerVersions[baseModel];
+  if (!resolvedVersion) {
+    // Base model not in mapping, return original modelId
+    return modelId;
+  }
+
+  return resolvedVersion;
+}

--- a/packages/ai/src/registry/provider-registry.ts
+++ b/packages/ai/src/registry/provider-registry.ts
@@ -12,6 +12,7 @@ import { wrapImageModel } from '../middleware/wrap-image-model';
 import { wrapLanguageModel } from '../middleware/wrap-language-model';
 import { ImageModelMiddleware, LanguageModelMiddleware } from '../types';
 import { NoSuchProviderError } from './no-such-provider-error';
+import { resolveLatestVersion } from './latest-versions';
 
 type ExtractLiteralUnion<T> = T extends string
   ? string extends T
@@ -220,8 +221,12 @@ class DefaultProviderRegistry<
     id: `${KEY & string}${SEPARATOR}${string}`,
   ): LanguageModelV3 {
     const [providerId, modelId] = this.splitId(id, 'languageModel');
+    
+    // 🔥 NEW: Resolve --latest suffix to actual model version
+    const resolvedModelId = resolveLatestVersion(providerId, modelId);
+    
     let model = this.getProvider(providerId, 'languageModel').languageModel?.(
-      modelId,
+      resolvedModelId,
     );
 
     if (model == null) {


### PR DESCRIPTION
## Background

When AI providers release new model versions (e.g., Anthropic's `claude-sonnet-4-5` → `claude-sonnet-5-0`), users currently need to update model IDs throughout their entire codebase. This creates maintenance overhead and makes applications brittle to version changes.

## Summary

Added automatic model version resolution using `--latest` suffix (similar to Docker's `:latest` tag). Users can now reference models like `anthropic:claude-sonnet--latest` which automatically resolves to the newest version defined in a centralized mapping file.

**Changes:**
- Added `LATEST_VERSIONS` mapping for major providers (Anthropic, OpenAI, Google, Mistral, DeepSeek, xAI, Cohere, Groq)
- Added `resolveLatestVersion()` function to handle version resolution
- Modified provider registry `languageModel()` method to use version resolution
- Added comprehensive test coverage (5 tests, all passing)
- Added usage example demonstrating the feature

## Manual Verification

1. Built the package successfully (`pnpm build`)
2. Ran all tests - 1651 tests passing including 5 new tests for the feature
3. Created example file showing usage with `--latest` suffix
4. Verified resolution works correctly for multiple providers in tests

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Add `--latest` support for other model types (embedding, image, transcription, speech)
- Consider dynamic version fetching from provider APIs
- Add support for other version strategies (e.g., `--stable`, `--experimental`)
- CLI tool to automatically update `LATEST_VERSIONS` mapping

## Related Issues

N/A - This is a new feature enhancement