### PR TITLE
feat(ai): add timeout option to generateText, streamText, and Agent

### DIFF
--- a/.changeset/swift-files-kneel.md
+++ b/.changeset/swift-files-kneel.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add timeout option to generateText, streamText, and Agent

--- a/content/docs/03-ai-sdk-core/25-settings.mdx
+++ b/content/docs/03-ai-sdk-core/25-settings.mdx
@@ -93,15 +93,31 @@ Maximum number of retries. Set to 0 to disable retries. Default: `2`.
 An optional abort signal that can be used to cancel the call.
 
 The abort signal can e.g. be forwarded from a user interface to cancel the call,
-or to define a timeout.
+or to define a timeout using `AbortSignal.timeout`.
 
-#### Example: Timeout
+#### Example: AbortSignal.timeout
 
 ```ts
 const result = await generateText({
   model: __MODEL__,
   prompt: 'Invent a new holiday and describe its traditions.',
   abortSignal: AbortSignal.timeout(5000), // 5 seconds
+});
+```
+
+### `timeout`
+
+An optional timeout in milliseconds. The call will be aborted if it takes longer than the specified duration.
+
+This is a convenience parameter that creates an abort signal internally. It can be used alongside `abortSignal` - if both are provided, the call will abort when either condition is met.
+
+#### Example: 5 second timeout
+
+```ts
+const result = await generateText({
+  model: __MODEL__,
+  prompt: 'Invent a new holiday and describe its traditions.',
+  timeout: 5000, // 5 seconds
 });
 ```
 

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -436,6 +436,13 @@ To see `generateText` in action, check out [these examples](#examples).
         'An optional abort signal that can be used to cancel the call.',
     },
     {
+      name: 'timeout',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+    },
+    {
       name: 'headers',
       type: 'Record<string, string>',
       isOptional: true,

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -437,6 +437,13 @@ To see `streamText` in action, check out [these examples](#examples).
         'An optional abort signal that can be used to cancel the call.',
     },
     {
+      name: 'timeout',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+    },
+    {
       name: 'headers',
       type: 'Record<string, string>',
       isOptional: true,

--- a/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
@@ -57,6 +57,11 @@ export type AgentCallParameters<CALL_OPTIONS> = ([CALL_OPTIONS] extends [never]
      * Abort signal.
      */
     abortSignal?: AbortSignal;
+    /**
+     * Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout.
+     * Can be used alongside abortSignal.
+     */
+    timeout?: number;
   };
 
 /**
@@ -129,6 +134,7 @@ Both `generate()` and `stream()` accept an `AgentCallParameters<CALL_OPTIONS>` o
 - `messages` (optional): An array of `ModelMessage` objects (mutually exclusive with `prompt`)
 - `options` (optional): Additional call options when `CALL_OPTIONS` is not `never`
 - `abortSignal` (optional): An `AbortSignal` to cancel the operation
+- `timeout` (optional): A timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside `abortSignal`.
 
 ## Example: Custom Agent Implementation
 

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -247,6 +247,13 @@ const result = await agent.generate({
       description:
         'An optional abort signal that can be used to cancel the call.',
     },
+    {
+      name: 'timeout',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+    },
   ]}
 />
 
@@ -286,6 +293,13 @@ for await (const chunk of stream.textStream) {
       isOptional: true,
       description:
         'An optional abort signal that can be used to cancel the call.',
+    },
+    {
+      name: 'timeout',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
     },
     {
       name: 'experimental_transform',

--- a/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
@@ -66,6 +66,13 @@ export async function* streamAgent(
         'Optional abort signal to cancel the stream early (for example, if the client disconnects).',
     },
     {
+      name: 'timeout',
+      type: 'number',
+      isRequired: false,
+      description:
+        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+    },
+    {
       name: 'options',
       type: 'CALL_OPTIONS',
       isRequired: false,

--- a/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
@@ -67,6 +67,13 @@ export async function POST(request: Request) {
         'Optional abort signal to cancel streaming, e.g., on client disconnect. This should be an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) instance.',
     },
     {
+      name: 'timeout',
+      type: 'number',
+      isRequired: false,
+      description:
+        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+    },
+    {
       name: 'options',
       type: 'CALL_OPTIONS',
       isRequired: false,

--- a/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
@@ -68,6 +68,13 @@ export async function handler(req, res) {
         'Optional abort signal to cancel streaming (e.g., on client disconnect). Supply an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal), for example from an `AbortController`.',
     },
     {
+      name: 'timeout',
+      type: 'number',
+      isRequired: false,
+      description:
+        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+    },
+    {
       name: 'options',
       type: 'CALL_OPTIONS',
       isRequired: false,

--- a/examples/ai-core/src/generate-text/openai-timeout.ts
+++ b/examples/ai-core/src/generate-text/openai-timeout.ts
@@ -6,7 +6,7 @@ async function main() {
   const { text, usage } = await generateText({
     model: openai('gpt-3.5-turbo'),
     prompt: 'Invent a new holiday and describe its traditions.',
-    abortSignal: AbortSignal.timeout(1000),
+    timeout: 1000, // 1 second timeout
   });
 
   console.log(text);

--- a/examples/ai-core/src/stream-text/openai-timeout.ts
+++ b/examples/ai-core/src/stream-text/openai-timeout.ts
@@ -1,0 +1,19 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import { printFullStream } from '../lib/print-full-stream';
+import { run } from '../lib/run';
+import { print } from '../lib/print';
+
+run(async () => {
+  const result = streamText({
+    model: openai('gpt-3.5-turbo'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+    timeout: 1000, // 1 second timeout
+  });
+
+  printFullStream({ result });
+
+  print('Usage:', await result.usage);
+  print('Finish reason:', await result.finishReason);
+});
+

--- a/examples/ai-core/src/stream-text/openai-timeout.ts
+++ b/examples/ai-core/src/stream-text/openai-timeout.ts
@@ -16,4 +16,3 @@ run(async () => {
   print('Usage:', await result.usage);
   print('Finish reason:', await result.finishReason);
 });
-

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -47,6 +47,11 @@ export type AgentCallParameters<CALL_OPTIONS> = ([CALL_OPTIONS] extends [never]
      * Abort signal.
      */
     abortSignal?: AbortSignal;
+
+    /**
+     * Timeout in milliseconds.
+     */
+    timeout?: number;
   };
 
 /**

--- a/packages/ai/src/agent/create-agent-ui-stream-response.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.ts
@@ -30,6 +30,7 @@ export async function createAgentUIStreamResponse<
   agent: Agent<CALL_OPTIONS, TOOLS, OUTPUT>;
   uiMessages: unknown[];
   abortSignal?: AbortSignal;
+  timeout?: number;
   options?: CALL_OPTIONS;
   experimental_transform?:
     | StreamTextTransform<TOOLS>

--- a/packages/ai/src/agent/create-agent-ui-stream.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.ts
@@ -14,6 +14,7 @@ import { Agent } from './agent';
  * @param agent - The agent to run.
  * @param uiMessages - The input UI messages.
  * @param abortSignal - The abort signal. Optional.
+ * @param timeout - Timeout in milliseconds. Optional.
  * @param options - The options for the agent.
  * @param experimental_transform - The stream transformations. Optional.
  *
@@ -29,12 +30,14 @@ export async function createAgentUIStream<
   uiMessages,
   options,
   abortSignal,
+  timeout,
   experimental_transform,
   ...uiMessageStreamOptions
 }: {
   agent: Agent<CALL_OPTIONS, TOOLS, OUTPUT>;
   uiMessages: unknown[];
   abortSignal?: AbortSignal;
+  timeout?: number;
   options?: CALL_OPTIONS;
   experimental_transform?:
     | StreamTextTransform<TOOLS>
@@ -61,6 +64,7 @@ export async function createAgentUIStream<
     prompt: modelMessages,
     options: options as CALL_OPTIONS,
     abortSignal,
+    timeout,
     experimental_transform,
   });
 

--- a/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
+++ b/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
@@ -31,6 +31,7 @@ export async function pipeAgentUIStreamToResponse<
   agent: Agent<CALL_OPTIONS, TOOLS, OUTPUT>;
   uiMessages: unknown[];
   abortSignal?: AbortSignal;
+  timeout?: number;
   options?: CALL_OPTIONS;
   experimental_transform?:
     | StreamTextTransform<TOOLS>

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -77,6 +77,18 @@ describe('ToolLoopAgent', () => {
       expect(doGenerateOptions?.abortSignal).toBe(abortController.signal);
     });
 
+    it('should pass timeout to generateText', async () => {
+      const agent = new ToolLoopAgent({ model: mockModel });
+
+      await agent.generate({
+        prompt: 'Hello, world!',
+        timeout: 5000,
+      });
+
+      // timeout is merged into abortSignal, so we check that an abort signal was created
+      expect(doGenerateOptions?.abortSignal).toBeDefined();
+    });
+
     it('should pass experimental_download to generateText', async () => {
       const downloadFunction = vi
         .fn()
@@ -336,6 +348,22 @@ describe('ToolLoopAgent', () => {
       await result.consumeStream();
 
       expect(doStreamOptions?.abortSignal).toBe(abortController.signal);
+    });
+
+    it('should pass timeout to streamText', async () => {
+      const agent = new ToolLoopAgent({
+        model: mockModel,
+      });
+
+      const result = await agent.stream({
+        prompt: 'Hello, world!',
+        timeout: 5000,
+      });
+
+      await result.consumeStream();
+
+      // timeout is merged into abortSignal, so we check that an abort signal was created
+      expect(doStreamOptions?.abortSignal).toBeDefined();
     });
 
     it('should pass string instructions', async () => {

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -81,6 +81,7 @@ export class ToolLoopAgent<
    */
   async generate({
     abortSignal,
+    timeout,
     ...options
   }: AgentCallParameters<CALL_OPTIONS>): Promise<
     GenerateTextResult<TOOLS, OUTPUT>
@@ -88,6 +89,7 @@ export class ToolLoopAgent<
     return generateText({
       ...(await this.prepareCall(options)),
       abortSignal,
+      timeout,
     });
   }
 
@@ -96,6 +98,7 @@ export class ToolLoopAgent<
    */
   async stream({
     abortSignal,
+    timeout,
     experimental_transform,
     ...options
   }: AgentStreamParameters<CALL_OPTIONS, TOOLS>): Promise<
@@ -104,6 +107,7 @@ export class ToolLoopAgent<
     return streamText({
       ...(await this.prepareCall(options)),
       abortSignal,
+      timeout,
       experimental_transform,
     });
   }

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -4524,7 +4524,7 @@ describe('generateText', () => {
                   },
                   {
                     "providerOptions": undefined,
-                    "text": "**Game Over!**
+                    "text": "**Game Over!** 
 
             Player 1 dominated this game with a decisive 3-0 victory! Looking at the rolls:
             - **Round 1**: Both rolled 6 (Draw)

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -2261,6 +2261,109 @@ describe('generateText', () => {
     });
   });
 
+  describe('options.timeout', () => {
+    it('should forward timeout as abort signal to model', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+
+      await generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: 'Hello, world!' }],
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: 5000,
+      });
+
+      expect(receivedAbortSignal).toBeDefined();
+    });
+
+    it('should merge timeout with abort signal', async () => {
+      const abortController = new AbortController();
+      let receivedAbortSignal: AbortSignal | undefined;
+
+      await generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: 'Hello, world!' }],
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: 5000,
+        abortSignal: abortController.signal,
+      });
+
+      // The merged signal should be different from the original
+      expect(receivedAbortSignal).toBeDefined();
+      expect(receivedAbortSignal).not.toBe(abortController.signal);
+    });
+
+    it('should pass undefined when no timeout or abortSignal provided', async () => {
+      let receivedAbortSignal: AbortSignal | undefined = 'not-set' as any;
+
+      await generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: 'Hello, world!' }],
+            };
+          },
+        }),
+        prompt: 'test-input',
+      });
+
+      expect(receivedAbortSignal).toBeUndefined();
+    });
+
+    it('should forward timeout abort signal to tool execution', async () => {
+      const toolExecuteMock = vi.fn().mockResolvedValue('tool result');
+
+      await generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            content: [
+              {
+                type: 'tool-call',
+                toolCallType: 'function',
+                toolCallId: 'call-1',
+                toolName: 'tool1',
+                input: `{ "value": "value" }`,
+              },
+            ],
+          }),
+        }),
+        tools: {
+          tool1: {
+            inputSchema: z.object({ value: z.string() }),
+            execute: toolExecuteMock,
+          },
+        },
+        prompt: 'test-input',
+        timeout: 5000,
+      });
+
+      expect(toolExecuteMock).toHaveBeenCalledWith(
+        { value: 'value' },
+        {
+          abortSignal: expect.any(AbortSignal),
+          toolCallId: 'call-1',
+          messages: expect.any(Array),
+        },
+      );
+    });
+  });
+
   describe('options.activeTools', () => {
     it('should filter available tools to only the ones in activeTools', async () => {
       let tools:
@@ -4421,7 +4524,7 @@ describe('generateText', () => {
                   },
                   {
                     "providerOptions": undefined,
-                    "text": "**Game Over!** 
+                    "text": "**Game Over!**
 
             Player 1 dominated this game with a decisive 3-0 victory! Looking at the rolls:
             - **Round 1**: Both rolled 6 (Draw)

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -7,7 +7,6 @@ import {
   createIdGenerator,
   getErrorMessage,
   IdGenerator,
-  mergedAbortSignals,
   ProviderOptions,
   ToolApprovalResponse,
   withUserAgentSuffix,
@@ -70,6 +69,7 @@ import { TypedToolError } from './tool-error';
 import { ToolOutput } from './tool-output';
 import { TypedToolResult } from './tool-result';
 import { ToolSet } from './tool-set';
+import { mergeAbortSignals } from '../util/merge-abort-signals';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -308,8 +308,7 @@ A function that attempts to repair a tool call that failed to parse.
   const model = resolveLanguageModel(modelArg);
   const stopConditions = asArray(stopWhen);
 
-  // Merge timeout and abort signal
-  const mergedAbortSignal = mergedAbortSignals(
+  const mergedAbortSignal = mergeAbortSignals(
     abortSignal,
     timeout != null ? AbortSignal.timeout(timeout) : undefined,
   );

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -7,6 +7,7 @@ import {
   createIdGenerator,
   getErrorMessage,
   IdGenerator,
+  mergedAbortSignals,
   ProviderOptions,
   ToolApprovalResponse,
   withUserAgentSuffix,
@@ -149,6 +150,7 @@ If set and supported by the model, calls will generate deterministic results.
 
 @param maxRetries - Maximum number of retries. Set to 0 to disable retries. Default: 2.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
+@param timeout - An optional timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout.
 @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
 
 @param experimental_generateMessageId - Generate a unique ID for each message.
@@ -171,6 +173,7 @@ export async function generateText<
   messages,
   maxRetries: maxRetriesArg,
   abortSignal,
+  timeout,
   headers,
   stopWhen = stepCountIs(1),
   experimental_output,
@@ -304,9 +307,16 @@ A function that attempts to repair a tool call that failed to parse.
   }): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
   const model = resolveLanguageModel(modelArg);
   const stopConditions = asArray(stopWhen);
+
+  // Merge timeout and abort signal
+  const mergedAbortSignal = mergedAbortSignals(
+    abortSignal,
+    timeout != null ? AbortSignal.timeout(timeout) : undefined,
+  );
+
   const { maxRetries, retry } = prepareRetries({
     maxRetries: maxRetriesArg,
-    abortSignal,
+    abortSignal: mergedAbortSignal,
   });
 
   const callSettings = prepareCallSettings(settings);
@@ -375,7 +385,7 @@ A function that attempts to repair a tool call that failed to parse.
             tracer,
             telemetry,
             messages: initialMessages,
-            abortSignal,
+            abortSignal: mergedAbortSignal,
             experimental_context,
           });
 
@@ -556,7 +566,7 @@ A function that attempts to repair a tool call that failed to parse.
                   responseFormat: await output?.responseFormat,
                   prompt: promptMessages,
                   providerOptions: stepProviderOptions,
-                  abortSignal,
+                  abortSignal: mergedAbortSignal,
                   headers: headersWithUserAgent,
                 });
 
@@ -659,7 +669,7 @@ A function that attempts to repair a tool call that failed to parse.
                 input: toolCall.input,
                 toolCallId: toolCall.toolCallId,
                 messages: stepInputMessages,
-                abortSignal,
+                abortSignal: mergedAbortSignal,
                 experimental_context,
               });
             }
@@ -716,7 +726,7 @@ A function that attempts to repair a tool call that failed to parse.
                 tracer,
                 telemetry,
                 messages: stepInputMessages,
-                abortSignal,
+                abortSignal: mergedAbortSignal,
                 experimental_context,
               })),
             );

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -10012,6 +10012,98 @@ describe('streamText', () => {
     });
   });
 
+  describe('options.timeout', () => {
+    it('should forward timeout as abort signal to model', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+
+      const result = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'text-delta', textDelta: 'Hello' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: 5000,
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      expect(receivedAbortSignal).toBeDefined();
+    });
+
+    it('should merge timeout with abort signal', async () => {
+      const abortController = new AbortController();
+      let receivedAbortSignal: AbortSignal | undefined;
+
+      const result = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'text-delta', textDelta: 'Hello' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: 5000,
+        abortSignal: abortController.signal,
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      // The merged signal should be different from the original
+      expect(receivedAbortSignal).toBeDefined();
+      expect(receivedAbortSignal).not.toBe(abortController.signal);
+    });
+
+    it('should pass undefined when no timeout or abortSignal provided', async () => {
+      let receivedAbortSignal: AbortSignal | undefined = 'not-set' as any;
+
+      const result = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'text-delta', textDelta: 'Hello' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      expect(receivedAbortSignal).toBeUndefined();
+    });
+  });
+
   describe('telemetry', () => {
     let tracer: MockTracer;
 

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -10022,7 +10022,9 @@ describe('streamText', () => {
             receivedAbortSignal = abortSignal;
             return {
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: 'Hello' },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello' },
+                { type: 'text-end', id: '1' },
                 {
                   type: 'finish',
                   finishReason: { unified: 'stop', raw: 'stop' },
@@ -10052,7 +10054,9 @@ describe('streamText', () => {
             receivedAbortSignal = abortSignal;
             return {
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: 'Hello' },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello' },
+                { type: 'text-end', id: '1' },
                 {
                   type: 'finish',
                   finishReason: { unified: 'stop', raw: 'stop' },
@@ -10084,7 +10088,9 @@ describe('streamText', () => {
             receivedAbortSignal = abortSignal;
             return {
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: 'Hello' },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello' },
+                { type: 'text-end', id: '1' },
                 {
                   type: 'finish',
                   finishReason: { unified: 'stop', raw: 'stop' },

--- a/packages/ai/src/prompt/call-settings.ts
+++ b/packages/ai/src/prompt/call-settings.ts
@@ -73,6 +73,12 @@ Abort signal.
   abortSignal?: AbortSignal;
 
   /**
+Timeout in milliseconds. The call will be aborted if it takes longer
+than the specified timeout. Can be used alongside abortSignal.
+   */
+  timeout?: number;
+
+  /**
 Additional HTTP headers to be sent with the request.
 Only applicable for HTTP-based providers.
    */

--- a/packages/ai/src/util/merge-abort-signals.test.ts
+++ b/packages/ai/src/util/merge-abort-signals.test.ts
@@ -1,36 +1,36 @@
 import { describe, expect, it } from 'vitest';
-import { mergedAbortSignals } from './merged-abort-signals';
+import { mergeAbortSignals } from './merge-abort-signals';
 
-describe('mergedAbortSignals', () => {
+describe('mergeAbortSignals', () => {
   it('should return a signal that is initially not aborted', () => {
     const controller1 = new AbortController();
     const controller2 = new AbortController();
 
-    const merged = mergedAbortSignals(controller1.signal, controller2.signal);
+    const merged = mergeAbortSignals(controller1.signal, controller2.signal);
 
-    expect(merged.aborted).toBe(false);
+    expect(merged!.aborted).toBe(false);
   });
 
   it('should abort when the first signal aborts', () => {
     const controller1 = new AbortController();
     const controller2 = new AbortController();
 
-    const merged = mergedAbortSignals(controller1.signal, controller2.signal);
+    const merged = mergeAbortSignals(controller1.signal, controller2.signal);
 
     controller1.abort();
 
-    expect(merged.aborted).toBe(true);
+    expect(merged!.aborted).toBe(true);
   });
 
   it('should abort when the second signal aborts', () => {
     const controller1 = new AbortController();
     const controller2 = new AbortController();
 
-    const merged = mergedAbortSignals(controller1.signal, controller2.signal);
+    const merged = mergeAbortSignals(controller1.signal, controller2.signal);
 
     controller2.abort();
 
-    expect(merged.aborted).toBe(true);
+    expect(merged!.aborted).toBe(true);
   });
 
   it('should preserve the abort reason from the triggering signal', () => {
@@ -38,21 +38,21 @@ describe('mergedAbortSignals', () => {
     const controller2 = new AbortController();
     const reason = new Error('custom abort reason');
 
-    const merged = mergedAbortSignals(controller1.signal, controller2.signal);
+    const merged = mergeAbortSignals(controller1.signal, controller2.signal);
 
     controller1.abort(reason);
 
-    expect(merged.reason).toBe(reason);
+    expect(merged!.reason).toBe(reason);
   });
 
   it('should preserve string abort reason', () => {
     const controller1 = new AbortController();
 
-    const merged = mergedAbortSignals(controller1.signal);
+    const merged = mergeAbortSignals(controller1.signal);
 
     controller1.abort('string reason');
 
-    expect(merged.reason).toBe('string reason');
+    expect(merged!.reason).toBe('string reason');
   });
 
   it('should handle already-aborted signals', () => {
@@ -60,10 +60,10 @@ describe('mergedAbortSignals', () => {
     const reason = new Error('already aborted');
     controller1.abort(reason);
 
-    const merged = mergedAbortSignals(controller1.signal);
+    const merged = mergeAbortSignals(controller1.signal);
 
-    expect(merged.aborted).toBe(true);
-    expect(merged.reason).toBe(reason);
+    expect(merged!.aborted).toBe(true);
+    expect(merged!.reason).toBe(reason);
   });
 
   it('should use the first already-aborted signal reason when multiple are aborted', () => {
@@ -75,20 +75,20 @@ describe('mergedAbortSignals', () => {
     controller1.abort(reason1);
     controller2.abort(reason2);
 
-    const merged = mergedAbortSignals(controller1.signal, controller2.signal);
+    const merged = mergeAbortSignals(controller1.signal, controller2.signal);
 
-    expect(merged.aborted).toBe(true);
-    expect(merged.reason).toBe(reason1);
+    expect(merged!.aborted).toBe(true);
+    expect(merged!.reason).toBe(reason1);
   });
 
   it('should return undefined when no signals provided', () => {
-    const merged = mergedAbortSignals();
+    const merged = mergeAbortSignals();
 
     expect(merged).toBeUndefined();
   });
 
   it('should return undefined when only null/undefined signals provided', () => {
-    const merged = mergedAbortSignals(null, undefined, null);
+    const merged = mergeAbortSignals(null, undefined, null);
 
     expect(merged).toBeUndefined();
   });
@@ -97,7 +97,7 @@ describe('mergedAbortSignals', () => {
     const controller = new AbortController();
     const reason = new Error('abort reason');
 
-    const merged = mergedAbortSignals(null, controller.signal, undefined);
+    const merged = mergeAbortSignals(null, controller.signal, undefined);
 
     expect(merged).not.toBeUndefined();
     expect(merged!.aborted).toBe(false);
@@ -111,7 +111,7 @@ describe('mergedAbortSignals', () => {
   it('should return the signal directly when only one valid signal provided', () => {
     const controller = new AbortController();
 
-    const merged = mergedAbortSignals(null, controller.signal, undefined);
+    const merged = mergeAbortSignals(null, controller.signal, undefined);
 
     expect(merged).toBe(controller.signal);
   });
@@ -122,19 +122,19 @@ describe('mergedAbortSignals', () => {
     const reason1 = new Error('first reason');
     const reason2 = new Error('second reason');
 
-    const merged = mergedAbortSignals(controller1.signal, controller2.signal);
+    const merged = mergeAbortSignals(controller1.signal, controller2.signal);
 
     // Both abort, but the first one's listener was registered first
     controller1.abort(reason1);
     controller2.abort(reason2);
 
-    expect(merged.reason).toBe(reason1);
+    expect(merged!.reason).toBe(reason1);
   });
 
   it('should return the original signal when only one signal provided', () => {
     const controller = new AbortController();
 
-    const merged = mergedAbortSignals(controller.signal);
+    const merged = mergeAbortSignals(controller.signal);
 
     expect(merged).toBe(controller.signal);
   });
@@ -143,13 +143,13 @@ describe('mergedAbortSignals', () => {
     const controllers = Array.from({ length: 10 }, () => new AbortController());
     const reason = new Error('signal 5 reason');
 
-    const merged = mergedAbortSignals(...controllers.map(c => c.signal));
+    const merged = mergeAbortSignals(...controllers.map(c => c.signal));
 
-    expect(merged.aborted).toBe(false);
+    expect(merged!.aborted).toBe(false);
 
     controllers[5].abort(reason);
 
-    expect(merged.aborted).toBe(true);
-    expect(merged.reason).toBe(reason);
+    expect(merged!.aborted).toBe(true);
+    expect(merged!.reason).toBe(reason);
   });
 });

--- a/packages/ai/src/util/merge-abort-signals.ts
+++ b/packages/ai/src/util/merge-abort-signals.ts
@@ -7,7 +7,7 @@
  * @returns An AbortSignal that aborts when any of the input signals abort,
  *          or undefined if no valid signals are provided.
  */
-export function mergedAbortSignals(
+export function mergeAbortSignals(
   ...signals: (AbortSignal | null | undefined)[]
 ): AbortSignal | undefined {
   const validSignals = signals.filter(

--- a/packages/provider-utils/src/merged-abort-signals.test.ts
+++ b/packages/provider-utils/src/merged-abort-signals.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { mergedAbortSignals } from './merged-abort-signals';
+
+describe('mergedAbortSignals', () => {
+  it('should return a signal that is initially not aborted', () => {
+    const controller1 = new AbortController();
+    const controller2 = new AbortController();
+
+    const merged = mergedAbortSignals(controller1.signal, controller2.signal);
+
+    expect(merged.aborted).toBe(false);
+  });
+
+  it('should abort when the first signal aborts', () => {
+    const controller1 = new AbortController();
+    const controller2 = new AbortController();
+
+    const merged = mergedAbortSignals(controller1.signal, controller2.signal);
+
+    controller1.abort();
+
+    expect(merged.aborted).toBe(true);
+  });
+
+  it('should abort when the second signal aborts', () => {
+    const controller1 = new AbortController();
+    const controller2 = new AbortController();
+
+    const merged = mergedAbortSignals(controller1.signal, controller2.signal);
+
+    controller2.abort();
+
+    expect(merged.aborted).toBe(true);
+  });
+
+  it('should preserve the abort reason from the triggering signal', () => {
+    const controller1 = new AbortController();
+    const controller2 = new AbortController();
+    const reason = new Error('custom abort reason');
+
+    const merged = mergedAbortSignals(controller1.signal, controller2.signal);
+
+    controller1.abort(reason);
+
+    expect(merged.reason).toBe(reason);
+  });
+
+  it('should preserve string abort reason', () => {
+    const controller1 = new AbortController();
+
+    const merged = mergedAbortSignals(controller1.signal);
+
+    controller1.abort('string reason');
+
+    expect(merged.reason).toBe('string reason');
+  });
+
+  it('should handle already-aborted signals', () => {
+    const controller1 = new AbortController();
+    const reason = new Error('already aborted');
+    controller1.abort(reason);
+
+    const merged = mergedAbortSignals(controller1.signal);
+
+    expect(merged.aborted).toBe(true);
+    expect(merged.reason).toBe(reason);
+  });
+
+  it('should use the first already-aborted signal reason when multiple are aborted', () => {
+    const controller1 = new AbortController();
+    const controller2 = new AbortController();
+    const reason1 = new Error('first reason');
+    const reason2 = new Error('second reason');
+
+    controller1.abort(reason1);
+    controller2.abort(reason2);
+
+    const merged = mergedAbortSignals(controller1.signal, controller2.signal);
+
+    expect(merged.aborted).toBe(true);
+    expect(merged.reason).toBe(reason1);
+  });
+
+  it('should handle empty input (no signals)', () => {
+    const merged = mergedAbortSignals();
+
+    expect(merged.aborted).toBe(false);
+  });
+
+  it('should use the first aborting signal reason when multiple abort simultaneously', () => {
+    const controller1 = new AbortController();
+    const controller2 = new AbortController();
+    const reason1 = new Error('first reason');
+    const reason2 = new Error('second reason');
+
+    const merged = mergedAbortSignals(controller1.signal, controller2.signal);
+
+    // Both abort, but the first one's listener was registered first
+    controller1.abort(reason1);
+    controller2.abort(reason2);
+
+    expect(merged.reason).toBe(reason1);
+  });
+
+  it('should work with a single signal', () => {
+    const controller = new AbortController();
+    const reason = new Error('single signal reason');
+
+    const merged = mergedAbortSignals(controller.signal);
+
+    expect(merged.aborted).toBe(false);
+
+    controller.abort(reason);
+
+    expect(merged.aborted).toBe(true);
+    expect(merged.reason).toBe(reason);
+  });
+
+  it('should work with many signals', () => {
+    const controllers = Array.from({ length: 10 }, () => new AbortController());
+    const reason = new Error('signal 5 reason');
+
+    const merged = mergedAbortSignals(...controllers.map(c => c.signal));
+
+    expect(merged.aborted).toBe(false);
+
+    controllers[5].abort(reason);
+
+    expect(merged.aborted).toBe(true);
+    expect(merged.reason).toBe(reason);
+  });
+});

--- a/packages/provider-utils/src/merged-abort-signals.ts
+++ b/packages/provider-utils/src/merged-abort-signals.ts
@@ -3,13 +3,28 @@
  * The returned signal will abort when any of the input signals abort,
  * with the same reason as the first signal to abort.
  *
- * @param signals - The AbortSignals to merge.
- * @returns An AbortSignal that aborts when any of the input signals abort.
+ * @param signals - The AbortSignals to merge. Null and undefined values are filtered out.
+ * @returns An AbortSignal that aborts when any of the input signals abort,
+ *          or undefined if no valid signals are provided.
  */
-export function mergedAbortSignals(...signals: AbortSignal[]): AbortSignal {
+export function mergedAbortSignals(
+  ...signals: (AbortSignal | null | undefined)[]
+): AbortSignal | undefined {
+  const validSignals = signals.filter(
+    (signal): signal is AbortSignal => signal != null,
+  );
+
+  if (validSignals.length === 0) {
+    return undefined;
+  }
+
+  if (validSignals.length === 1) {
+    return validSignals[0];
+  }
+
   const controller = new AbortController();
 
-  for (const signal of signals) {
+  for (const signal of validSignals) {
     if (signal.aborted) {
       controller.abort(signal.reason);
       return controller.signal;

--- a/packages/provider-utils/src/merged-abort-signals.ts
+++ b/packages/provider-utils/src/merged-abort-signals.ts
@@ -1,0 +1,28 @@
+/**
+ * Merges multiple AbortSignals into a single AbortSignal.
+ * The returned signal will abort when any of the input signals abort,
+ * with the same reason as the first signal to abort.
+ *
+ * @param signals - The AbortSignals to merge.
+ * @returns An AbortSignal that aborts when any of the input signals abort.
+ */
+export function mergedAbortSignals(...signals: AbortSignal[]): AbortSignal {
+  const controller = new AbortController();
+
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      return controller.signal;
+    }
+
+    signal.addEventListener(
+      'abort',
+      () => {
+        controller.abort(signal.reason);
+      },
+      { once: true },
+    );
+  }
+
+  return controller.signal;
+}


### PR DESCRIPTION
## Background

Currently you can use `AbortSignal.timeout` to abort a `generateText` or `streamText` call after a certain amount of time has passed. However, more fine-grained controls such as per-step and per-chunk timeouts are desirable.

As a first step, I introduce a basic `timeout` option with a millisecond timeout number.

## Summary

* add `timeout` option to `generateText`
* add `timeout` option to `streamText`
* add `timeout` option to `Agent.stream` and `Agent.generate` and related helpers

## Manual Verification

- [x] run `examples/ai-core/src/generate-text/openai-timeout.ts`
- [x] run `examples/ai-core/src/stream-text/openai-timeout.ts`

## Tasks

- [x] merge abort signals
- [x] add timeout option to generateText
- [x] add timeout option to streamText
- [x] add timeout option to Agent and ToolLoopAgent
- [x] rename (mergeAbortSignals)
- [x] add timeout option to agent ui stream helpers
- [x] changeset

## Future Work

- introduce per-step timeouts #11575
- introduce per-chunk timeouts #11576
- fix: streamText should throw timeout when timeout occurs (throws NoOutputGeneratedError) #11577

## Related Issues

Resolves #3169