### PR TITLE
fix(openai/azure): passing response_format correctly

### DIFF
--- a/.changeset/heavy-tomatoes-know.md
+++ b/.changeset/heavy-tomatoes-know.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai/azure): passing response_format correctly

--- a/packages/openai/src/image/openai-image-model.test.ts
+++ b/packages/openai/src/image/openai-image-model.test.ts
@@ -254,6 +254,34 @@ describe('doGenerate', () => {
     expect(requestBody).not.toHaveProperty('response_format');
   });
 
+  it('should not include response_format for date-suffixed gpt-image model IDs (Azure deployment names)', async () => {
+    prepareJsonResponse();
+
+    // Azure OpenAI allows custom deployment names like 'gpt-image-1.5-2025-12-16'
+    const azureDeploymentModel = provider.image('gpt-image-1.5-2025-12-16');
+    await azureDeploymentModel.doGenerate({
+      prompt,
+      files: undefined,
+      mask: undefined,
+      n: 1,
+      size: '1024x1024',
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {},
+    });
+
+    const requestBody =
+      await server.calls[server.calls.length - 1].requestBodyJson;
+    expect(requestBody).toStrictEqual({
+      model: 'gpt-image-1.5-2025-12-16',
+      prompt,
+      n: 1,
+      size: '1024x1024',
+    });
+
+    expect(requestBody).not.toHaveProperty('response_format');
+  });
+
   it('should handle null revised_prompt responses', async () => {
     server.urls['https://api.openai.com/v1/images/generations'].response = {
       type: 'json-value',

--- a/packages/openai/src/image/openai-image-model.ts
+++ b/packages/openai/src/image/openai-image-model.ts
@@ -160,7 +160,7 @@ export class OpenAIImageModel implements ImageModelV3 {
         n,
         size,
         ...(providerOptions.openai ?? {}),
-        ...(!hasDefaultResponseFormat.has(this.modelId)
+        ...(!hasDefaultResponseFormat(this.modelId)
           ? { response_format: 'b64_json' }
           : {}),
       },

--- a/packages/openai/src/image/openai-image-options.ts
+++ b/packages/openai/src/image/openai-image-options.ts
@@ -15,8 +15,14 @@ export const modelMaxImagesPerCall: Record<OpenAIImageModelId, number> = {
   'gpt-image-1.5': 10,
 };
 
-export const hasDefaultResponseFormat = new Set([
-  'gpt-image-1',
+const defaultResponseFormatPrefixes = [
   'gpt-image-1-mini',
   'gpt-image-1.5',
-]);
+  'gpt-image-1',
+];
+
+export function hasDefaultResponseFormat(modelId: string): boolean {
+  return defaultResponseFormatPrefixes.some(prefix =>
+    modelId.startsWith(prefix),
+  );
+}


### PR DESCRIPTION
## Background

#11519 

For models deployed on Azure, the check for passing the `response_format` was hardcoded. This was incorrect since model ID names in azure can vary based on deployment. 

## Summary

Instead of checking for an exact string match, we check if the model ID string in azure starts with the static set we previously defined.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11519
