### PR TITLE
fix (docs): unescaped character in gemini cli docs

### DIFF
--- a/content/providers/03-community-providers/100-gemini-cli.mdx
+++ b/content/providers/03-community-providers/100-gemini-cli.mdx
@@ -79,7 +79,7 @@ Authentication options:
 
 - **authType** _'oauth' | 'oauth-personal' | 'api-key' | 'gemini-api-key' | 'vertex-ai' | 'google-auth-library'_ - Optional. Defaults to `'oauth-personal'`.
 - **apiKey** _string_ - Required for `'api-key'` / `'gemini-api-key'`.
-- **vertexAI** _{ projectId, location }_ - Required for `'vertex-ai'`.
+- **vertexAI** _\{ projectId, location \}_ - Required for `'vertex-ai'`.
 - **googleAuth** _GoogleAuth_ - Required for `'google-auth-library'`.
 - **cacheDir** _string_ - Optional directory for OAuth credentials cache.
 - **proxy** _string_ - HTTP/HTTPS proxy URL.


### PR DESCRIPTION
Submodule action broken due to unescaped curly brackets. Introduced in #11498.