### PR TITLE
fix(langchain): re-enable support for streamEvents in toUIMessageStream

### DIFF
--- a/.changeset/ten-bees-worry.md
+++ b/.changeset/ten-bees-worry.md
@@ -1,5 +1,4 @@
 ---
-'@example/next-langchain': patch
 '@ai-sdk/langchain': patch
 ---
 

--- a/.changeset/ten-bees-worry.md
+++ b/.changeset/ten-bees-worry.md
@@ -3,4 +3,4 @@
 '@ai-sdk/langchain': patch
 ---
 
-feat(langchain): add streamEvents support to toUIMessageStream
+fix(langchain): re-enable support for streamEvents in toUIMessageStream

--- a/.changeset/ten-bees-worry.md
+++ b/.changeset/ten-bees-worry.md
@@ -1,0 +1,6 @@
+---
+'@example/next-langchain': patch
+'@ai-sdk/langchain': patch
+---
+
+feat(langchain): add streamEvents support to toUIMessageStream

--- a/content/providers/04-adapters/01-langchain.mdx
+++ b/content/providers/04-adapters/01-langchain.mdx
@@ -36,6 +36,7 @@ enabling you to use LangChain models and LangGraph agents with AI SDK UI compone
 
 - Convert AI SDK `UIMessage` to LangChain `BaseMessage` format using `toBaseMessages`
 - Transform LangChain/LangGraph streams to AI SDK `UIMessageStream` using `toUIMessageStream`
+- Support for `streamEvents()` output for granular event streaming and observability
 - `LangSmithDeploymentTransport` for connecting directly to a deployed LangGraph graph
 - Full support for text, tool calls, tool results, and multimodal content
 - Custom data streaming with typed events (`data-{type}`)
@@ -205,6 +206,47 @@ export async function POST(req: Request) {
   });
 }
 ```
+
+## Example: Streaming with streamEvents
+
+LangChain's [`streamEvents()`](https://docs.langchain.com/oss/javascript/langchain/streaming) method provides granular, semantic events with metadata. This is useful for debugging, observability, and migrating existing LCEL applications:
+
+```tsx filename="app/api/stream-events/route.ts"
+import { toBaseMessages, toUIMessageStream } from '@ai-sdk/langchain';
+import { ChatOpenAI } from '@langchain/openai';
+import { createUIMessageStreamResponse, UIMessage } from 'ai';
+
+export const maxDuration = 30;
+
+const model = new ChatOpenAI({
+  model: 'gpt-4o-mini',
+  temperature: 0,
+});
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+
+  const langchainMessages = await toBaseMessages(messages);
+
+  // Use streamEvents() for granular event streaming
+  // Produces events like on_chat_model_stream, on_tool_start, on_tool_end
+  const streamEvents = model.streamEvents(langchainMessages, {
+    version: 'v2',
+  });
+
+  // The adapter automatically detects and handles streamEvents format
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream(streamEvents),
+  });
+}
+```
+
+<Note>
+**When to use `streamEvents()` vs `graph.stream()`:**
+
+- **`streamEvents()`**: Best for debugging, observability, filtering by event type, agents created with `createAgent`, and migrating existing LCEL applications that rely on callbacks
+- **`graph.stream()` with `streamMode`**: Best for LangGraph applications where you need structured state updates via `values`, `messages`, or `custom` modes
+  </Note>
 
 ## Example: Custom Data Streaming
 
@@ -428,7 +470,7 @@ const langchainMessages = convertModelMessages(modelMessages);
 
 ### `toUIMessageStream(stream)`
 
-Converts a LangChain/LangGraph stream to an AI SDK `UIMessageStream`. Automatically detects the stream type and handles both direct model streams and LangGraph streams.
+Converts a LangChain/LangGraph stream to an AI SDK `UIMessageStream`. Automatically detects the stream type and handles direct model streams, LangGraph streams, and `streamEvents()` output.
 
 ```ts
 import { toUIMessageStream } from '@ai-sdk/langchain';
@@ -440,7 +482,7 @@ return createUIMessageStreamResponse({
   stream: toUIMessageStream(modelStream),
 });
 
-// Also works with LangGraph streams
+// Works with LangGraph streams
 const graphStream = await graph.stream(
   { messages },
   { streamMode: ['values', 'messages'] },
@@ -448,11 +490,17 @@ const graphStream = await graph.stream(
 return createUIMessageStreamResponse({
   stream: toUIMessageStream(graphStream),
 });
+
+// Works with streamEvents() output
+const streamEvents = model.streamEvents(messages, { version: 'v2' });
+return createUIMessageStreamResponse({
+  stream: toUIMessageStream(streamEvents),
+});
 ```
 
 **Parameters:**
 
-- `stream`: `AsyncIterable<AIMessageChunk> | ReadableStream` - LangChain or LangGraph stream
+- `stream`: `AsyncIterable<AIMessageChunk> | ReadableStream` - LangChain model stream, LangGraph stream, or `streamEvents()` output
 
 **Returns:** `ReadableStream<UIMessageChunk>`
 

--- a/examples/next-langchain/README.md
+++ b/examples/next-langchain/README.md
@@ -243,30 +243,30 @@ The `@ai-sdk/langchain` adapter supports both `graph.stream()` and `streamEvents
 
 ### When to use `graph.stream()` with `streamMode`
 
-| Use Case | Why |
-| -------- | --- |
-| **LangGraph workflows** | Optimized for state-based graphs with `values`, `messages`, `updates` modes |
-| **Tool execution tracking** | Clean tool call lifecycle with `messages` mode |
-| **Custom data streaming** | Use `custom` mode with `config.writer()` for typed events |
-| **State snapshots** | Get full state after each step with `values` mode |
-| **Production apps** | Simpler integration with AI SDK's `toUIMessageStream` |
+| Use Case                    | Why                                                                         |
+| --------------------------- | --------------------------------------------------------------------------- |
+| **LangGraph workflows**     | Optimized for state-based graphs with `values`, `messages`, `updates` modes |
+| **Tool execution tracking** | Clean tool call lifecycle with `messages` mode                              |
+| **Custom data streaming**   | Use `custom` mode with `config.writer()` for typed events                   |
+| **State snapshots**         | Get full state after each step with `values` mode                           |
+| **Production apps**         | Simpler integration with AI SDK's `toUIMessageStream`                       |
 
 ```typescript
 const stream = await graph.stream(
   { messages },
-  { streamMode: ['values', 'messages'] }
+  { streamMode: ['values', 'messages'] },
 );
 ```
 
 ### When to use `streamEvents()`
 
-| Use Case | Why |
-| -------- | --- |
-| **Debugging/observability** | Get detailed events for every component in the chain |
+| Use Case                    | Why                                                                     |
+| --------------------------- | ----------------------------------------------------------------------- |
+| **Debugging/observability** | Get detailed events for every component in the chain                    |
 | **Filtering by event type** | Filter for specific events like `on_chat_model_stream`, `on_tool_start` |
-| **Run metadata access** | Access run IDs, names, tags for each component |
-| **LCEL migration** | When migrating apps that rely on callback-based streaming |
-| **Simple model streaming** | Direct model streaming without LangGraph complexity |
+| **Run metadata access**     | Access run IDs, names, tags for each component                          |
+| **LCEL migration**          | When migrating apps that rely on callback-based streaming               |
+| **Simple model streaming**  | Direct model streaming without LangGraph complexity                     |
 
 ```typescript
 const streamEvents = model.streamEvents(messages, {
@@ -276,14 +276,14 @@ const streamEvents = model.streamEvents(messages, {
 
 ### Event Types in streamEvents()
 
-| Event | Description |
-| ----- | ----------- |
-| `on_chat_model_start` | Model invocation started |
-| `on_chat_model_stream` | Token chunk received |
-| `on_chat_model_end` | Model completed with full message |
-| `on_tool_start` | Tool execution started |
-| `on_tool_end` | Tool execution completed |
-| `on_chain_start/end` | Chain/graph lifecycle events |
+| Event                  | Description                       |
+| ---------------------- | --------------------------------- |
+| `on_chat_model_start`  | Model invocation started          |
+| `on_chat_model_stream` | Token chunk received              |
+| `on_chat_model_end`    | Model completed with full message |
+| `on_tool_start`        | Tool execution started            |
+| `on_tool_end`          | Tool execution completed          |
+| `on_chain_start/end`   | Chain/graph lifecycle events      |
 
 For most LangGraph applications, `graph.stream()` with appropriate `streamMode` options is recommended. Use `streamEvents()` when you need the additional granularity for debugging or when working with pure LangChain (non-LangGraph) applications.
 

--- a/examples/next-langchain/app/api/stream-events/route.ts
+++ b/examples/next-langchain/app/api/stream-events/route.ts
@@ -1,0 +1,92 @@
+import { toBaseMessages, toUIMessageStream } from '@ai-sdk/langchain';
+import { ChatOpenAI } from '@langchain/openai';
+import { createUIMessageStreamResponse, UIMessage } from 'ai';
+import { NextResponse } from 'next/server';
+
+/**
+ * Allow streaming responses up to 30 seconds
+ */
+export const maxDuration = 30;
+
+/**
+ * The model to use for streaming
+ */
+const model = new ChatOpenAI({
+  model: 'gpt-4o-mini',
+  temperature: 0,
+});
+
+/**
+ * streamEvents API Example
+ *
+ * This example demonstrates using LangChain's `streamEvents()` method with
+ * the AI SDK adapter. `streamEvents()` provides granular, semantic events
+ * that are useful for:
+ *
+ * - **Filtering by event type**: Easily filter for specific events like
+ *   `on_chat_model_stream`, `on_tool_start`, `on_chain_end`
+ *
+ * - **Debugging and observability**: Get detailed events about what's
+ *   happening inside chains, agents, and tools
+ *
+ * - **Migrating LCEL apps**: When migrating large LangChain Expression
+ *   Language (LCEL) applications that rely on callbacks
+ *
+ * - **Custom metadata access**: Access run IDs, names, and other metadata
+ *   for each component in the chain
+ *
+ * Compare this to `graph.stream()` which is optimized for LangGraph and
+ * provides structured state updates via `streamMode` options.
+ *
+ * @see https://docs.langchain.com/oss/javascript/langchain/streaming
+ */
+export async function POST(req: Request) {
+  try {
+    const {
+      messages,
+    }: {
+      /**
+       * The messages to send to the model
+       */
+      messages: UIMessage[];
+    } = await req.json();
+
+    /**
+     * Convert AI SDK UIMessages to LangChain messages
+     */
+    const langchainMessages = await toBaseMessages(messages);
+
+    /**
+     * Use streamEvents() to get semantic events with metadata.
+     * This produces events like:
+     * - { event: "on_chat_model_start", data: { input: ... } }
+     * - { event: "on_chat_model_stream", data: { chunk: AIMessageChunk } }
+     * - { event: "on_chat_model_end", data: { output: AIMessage } }
+     *
+     * The adapter automatically detects and handles this format.
+     * Note: Type assertion needed due to LangChain type version mismatch
+     */
+    const streamEvents = model.streamEvents(langchainMessages, {
+      version: 'v2',
+    });
+
+    /**
+     * Convert the streamEvents stream to UI message stream.
+     * The adapter auto-detects the event format and processes:
+     * - on_chat_model_stream -> text-delta events
+     * - on_tool_start -> tool-input-start events
+     * - on_tool_end -> tool-output-available events
+     *
+     * Note: streamEvents returns an AsyncIterable, which toUIMessageStream
+     * handles natively through its async iterator support.
+     */
+    return createUIMessageStreamResponse({
+      stream: toUIMessageStream(streamEvents),
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'An unknown error occurred';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/examples/next-langchain/app/api/stream-events/route.ts
+++ b/examples/next-langchain/app/api/stream-events/route.ts
@@ -89,4 +89,3 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }
-

--- a/examples/next-langchain/app/constants.ts
+++ b/examples/next-langchain/app/constants.ts
@@ -6,6 +6,7 @@ import {
   Shield,
   Sparkles,
   Activity,
+  Radio,
   LucideIcon,
 } from 'lucide-react';
 
@@ -35,6 +36,12 @@ export const navItems: NavItem[] = [
     label: 'LangGraph',
     description: 'StateGraph with streaming',
     icon: Cpu,
+  },
+  {
+    href: '/stream-events',
+    label: 'streamEvents',
+    description: 'Semantic event streaming',
+    icon: Radio,
   },
   {
     href: '/createAgent',

--- a/examples/next-langchain/app/stream-events/page.tsx
+++ b/examples/next-langchain/app/stream-events/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import { useMemo } from 'react';
+import { ChatContainer } from '../../components/chat-container';
+import { type CustomDataMessage } from '../types';
+
+export default function StreamEventsChat() {
+  const transport = useMemo(
+    () => new DefaultChatTransport({ api: '/api/stream-events' }),
+    [],
+  );
+
+  const { messages, sendMessage, status, error } = useChat<CustomDataMessage>({
+    transport,
+  });
+
+  return (
+    <ChatContainer
+      title="streamEvents Example"
+      description={
+        <>
+          Uses LangChain&apos;s <code>streamEvents()</code> method for granular
+          semantic events. Ideal for debugging, observability, and migrating
+          LCEL apps. Compare with LangGraph&apos;s <code>stream()</code> for
+          state-based workflows.
+        </>
+      }
+      messages={messages}
+      onSend={text => sendMessage({ text })}
+      status={status}
+      error={error}
+      placeholder="Ask anything..."
+      suggestions={[
+        'Tell me a short story',
+        'Explain streaming in LangChain',
+        'What is the weather like today?',
+      ]}
+    />
+  );
+}
+

--- a/examples/next-langchain/app/stream-events/page.tsx
+++ b/examples/next-langchain/app/stream-events/page.tsx
@@ -40,4 +40,3 @@ export default function StreamEventsChat() {
     />
   );
 }
-

--- a/packages/langchain/src/adapter.ts
+++ b/packages/langchain/src/adapter.ts
@@ -152,8 +152,7 @@ function processStreamEventsEvent(
        * Handle model start - capture message metadata if available
        * run_id is at event level in v2, but check data for backwards compatibility
        */
-      const runId =
-        event.run_id || (event.data.run_id as string | undefined);
+      const runId = event.run_id || (event.data.run_id as string | undefined);
       if (runId) {
         state.messageId = runId;
       }
@@ -182,7 +181,10 @@ function processStreamEventsEvent(
           if (!state.reasoningStarted) {
             // Track the ID used for reasoning-start to ensure reasoning-end uses the same ID
             state.reasoningMessageId = state.messageId;
-            controller.enqueue({ type: 'reasoning-start', id: state.messageId });
+            controller.enqueue({
+              type: 'reasoning-start',
+              id: state.messageId,
+            });
             state.reasoningStarted = true;
             state.started = true;
           }
@@ -247,8 +249,7 @@ function processStreamEventsEvent(
        * Handle tool call start
        * run_id and name are at event level in v2, check data for backwards compatibility
        */
-      const runId =
-        event.run_id || (event.data.run_id as string | undefined);
+      const runId = event.run_id || (event.data.run_id as string | undefined);
       const name = event.name || (event.data.name as string | undefined);
 
       if (runId && name) {
@@ -267,8 +268,7 @@ function processStreamEventsEvent(
        * Handle tool call end
        * run_id is at event level in v2, check data for backwards compatibility
        */
-      const runId =
-        event.run_id || (event.data.run_id as string | undefined);
+      const runId = event.run_id || (event.data.run_id as string | undefined);
       const output = event.data.output;
 
       if (runId) {

--- a/packages/langchain/src/adapter.ts
+++ b/packages/langchain/src/adapter.ts
@@ -16,6 +16,7 @@ import {
   processModelChunk,
   processLangGraphEvent,
   isToolResultPart,
+  extractReasoningFromContentBlocks,
 } from './utils';
 import { type LangGraphEventState } from './types';
 import { type StreamCallbacks } from './stream-callbacks';
@@ -90,13 +91,207 @@ export function convertModelMessages(
 }
 
 /**
+ * Type guard to check if a value is a streamEvents event object.
+ * streamEvents produces objects with `event` and `data` properties.
+ *
+ * @param value - The value to check.
+ * @returns True if the value is a streamEvents event object.
+ */
+function isStreamEventsEvent(
+  value: unknown,
+): value is { event: string; data: Record<string, unknown> } {
+  if (value == null || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  // Check for event property being a string
+  if (!('event' in obj) || typeof obj.event !== 'string') return false;
+  // Check for data property being an object (but allow null/undefined)
+  if (!('data' in obj)) return false;
+  // data can be null in some events, treat as empty object
+  return obj.data === null || typeof obj.data === 'object';
+}
+
+/**
+ * Processes a streamEvents event and emits UI message chunks.
+ *
+ * @param event - The streamEvents event to process.
+ * @param state - The state for tracking stream progress.
+ * @param controller - The controller to emit UI message chunks.
+ */
+function processStreamEventsEvent(
+  event: {
+    event: string;
+    data: Record<string, unknown> | null;
+    run_id?: string;
+    name?: string;
+  },
+  state: {
+    started: boolean;
+    messageId: string;
+    reasoningStarted: boolean;
+    textStarted: boolean;
+    textMessageId: string | null;
+    reasoningMessageId: string | null;
+  },
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+): void {
+  /**
+   * Capture run_id from event level if available (streamEvents v2 format)
+   */
+  if (event.run_id && !state.started) {
+    state.messageId = event.run_id;
+  }
+
+  /**
+   * Skip events with null/undefined data
+   */
+  if (!event.data) return;
+
+  switch (event.event) {
+    case 'on_chat_model_start': {
+      /**
+       * Handle model start - capture message metadata if available
+       * run_id is at event level in v2, but check data for backwards compatibility
+       */
+      const runId =
+        event.run_id || (event.data.run_id as string | undefined);
+      if (runId) {
+        state.messageId = runId;
+      }
+      break;
+    }
+
+    case 'on_chat_model_stream': {
+      /**
+       * Handle streaming token chunks
+       */
+      const chunk = event.data.chunk;
+      if (chunk && typeof chunk === 'object') {
+        /**
+         * Get message ID from chunk if available
+         */
+        const chunkId = (chunk as { id?: string }).id;
+        if (chunkId) {
+          state.messageId = chunkId;
+        }
+
+        /**
+         * Handle reasoning content from contentBlocks
+         */
+        const reasoning = extractReasoningFromContentBlocks(chunk);
+        if (reasoning) {
+          if (!state.reasoningStarted) {
+            // Track the ID used for reasoning-start to ensure reasoning-end uses the same ID
+            state.reasoningMessageId = state.messageId;
+            controller.enqueue({ type: 'reasoning-start', id: state.messageId });
+            state.reasoningStarted = true;
+            state.started = true;
+          }
+          controller.enqueue({
+            type: 'reasoning-delta',
+            delta: reasoning,
+            id: state.reasoningMessageId ?? state.messageId,
+          });
+        }
+
+        /**
+         * Extract text content from chunk
+         */
+        const content = (chunk as { content?: unknown }).content;
+        const text =
+          typeof content === 'string'
+            ? content
+            : Array.isArray(content)
+              ? content
+                  .filter(
+                    (c): c is { type: 'text'; text: string } =>
+                      typeof c === 'object' &&
+                      c !== null &&
+                      'type' in c &&
+                      c.type === 'text',
+                  )
+                  .map(c => c.text)
+                  .join('')
+              : '';
+
+        if (text) {
+          /**
+           * If reasoning was streamed before text, close reasoning first
+           */
+          if (state.reasoningStarted && !state.textStarted) {
+            controller.enqueue({
+              type: 'reasoning-end',
+              id: state.reasoningMessageId ?? state.messageId,
+            });
+            state.reasoningStarted = false;
+          }
+
+          if (!state.textStarted) {
+            // Track the ID used for text-start to ensure text-end uses the same ID
+            state.textMessageId = state.messageId;
+            controller.enqueue({ type: 'text-start', id: state.messageId });
+            state.textStarted = true;
+            state.started = true;
+          }
+          controller.enqueue({
+            type: 'text-delta',
+            delta: text,
+            id: state.textMessageId ?? state.messageId,
+          });
+        }
+      }
+      break;
+    }
+
+    case 'on_tool_start': {
+      /**
+       * Handle tool call start
+       * run_id and name are at event level in v2, check data for backwards compatibility
+       */
+      const runId =
+        event.run_id || (event.data.run_id as string | undefined);
+      const name = event.name || (event.data.name as string | undefined);
+
+      if (runId && name) {
+        controller.enqueue({
+          type: 'tool-input-start',
+          toolCallId: runId,
+          toolName: name,
+          dynamic: true,
+        });
+      }
+      break;
+    }
+
+    case 'on_tool_end': {
+      /**
+       * Handle tool call end
+       * run_id is at event level in v2, check data for backwards compatibility
+       */
+      const runId =
+        event.run_id || (event.data.run_id as string | undefined);
+      const output = event.data.output;
+
+      if (runId) {
+        controller.enqueue({
+          type: 'tool-output-available',
+          toolCallId: runId,
+          output,
+        });
+      }
+      break;
+    }
+  }
+}
+
+/**
  * Converts a LangChain stream to an AI SDK UIMessageStream.
  *
- * This function automatically detects the stream type and handles both:
+ * This function automatically detects the stream type and handles:
  * - Direct model streams (AsyncIterable from `model.stream()`)
  * - LangGraph streams (ReadableStream with `streamMode: ['values', 'messages']`)
+ * - streamEvents streams (from `agent.streamEvents()` or `model.streamEvents()`)
  *
- * @param stream - A stream from LangChain model.stream() or LangGraph graph.stream().
+ * @param stream - A stream from LangChain model.stream(), graph.stream(), or streamEvents().
  * @param callbacks - Optional callbacks for stream lifecycle events.
  * @returns A ReadableStream of UIMessageChunk objects.
  *
@@ -117,6 +312,15 @@ export function convertModelMessages(
  * return createUIMessageStreamResponse({
  *   stream: toUIMessageStream(graphStream),
  * });
+ *
+ * // With streamEvents
+ * const streamEvents = agent.streamEvents(
+ *   { messages },
+ *   { version: "v2" }
+ * );
+ * return createUIMessageStreamResponse({
+ *   stream: toUIMessageStream(streamEvents),
+ * });
  * ```
  */
 export function toUIMessageStream(
@@ -136,6 +340,10 @@ export function toUIMessageStream(
     messageId: 'langchain-msg-1',
     reasoningStarted: false,
     textStarted: false,
+    /** Track the ID used for text-start to ensure text-end uses the same ID */
+    textMessageId: null as string | null,
+    /** Track the ID used for reasoning-start to ensure reasoning-end uses the same ID */
+    reasoningMessageId: null as string | null,
   };
 
   /**
@@ -162,7 +370,7 @@ export function toUIMessageStream(
   /**
    * Track detected stream type: null = not yet detected
    */
-  let streamType: 'model' | 'langgraph' | null = null;
+  let streamType: 'model' | 'langgraph' | 'streamEvents' | null = null;
 
   /**
    * Get async iterator from the stream (works for both AsyncIterable and ReadableStream)
@@ -229,6 +437,8 @@ export function toUIMessageStream(
           if (streamType === null) {
             if (Array.isArray(value)) {
               streamType = 'langgraph';
+            } else if (isStreamEventsEvent(value)) {
+              streamType = 'streamEvents';
             } else {
               streamType = 'model';
             }
@@ -240,6 +450,17 @@ export function toUIMessageStream(
           if (streamType === 'model') {
             processModelChunk(
               value as AIMessageChunk,
+              modelState,
+              wrappedController,
+            );
+          } else if (streamType === 'streamEvents') {
+            processStreamEventsEvent(
+              value as {
+                event: string;
+                data: Record<string, unknown> | null;
+                run_id?: string;
+                name?: string;
+              },
               modelState,
               wrappedController,
             );
@@ -255,15 +476,21 @@ export function toUIMessageStream(
         /**
          * Finalize based on stream type
          */
-        if (streamType === 'model') {
+        if (streamType === 'model' || streamType === 'streamEvents') {
           if (modelState.reasoningStarted) {
             controller.enqueue({
               type: 'reasoning-end',
-              id: modelState.messageId,
+              id: modelState.reasoningMessageId ?? modelState.messageId,
             });
           }
           if (modelState.textStarted) {
-            controller.enqueue({ type: 'text-end', id: modelState.messageId });
+            /**
+             * Use the same ID that was used for text-start
+             */
+            controller.enqueue({
+              type: 'text-end',
+              id: modelState.textMessageId ?? modelState.messageId,
+            });
           }
           controller.enqueue({ type: 'finish' });
         }


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Updating the LangChain integration package in https://github.com/vercel/ai/pull/11238 didn't consider users that use `streamEvents` capabilities, causing breaking changes.

## Summary

This PR restores and improves support for LangChain's `streamEvents()` method in `toUIMessageStream`:

### Core Changes (`packages/langchain/src/adapter.ts`)
- Added `isStreamEventsEvent` type guard to detect the `streamEvents` format (`{ event: string; data: Record<string, unknown> }`)
- Added `processStreamEventsEvent` function to handle:
  - `on_chat_model_start` - captures message ID from `run_id`
  - `on_chat_model_stream` - emits `text-delta` and `reasoning-delta` events
  - `on_tool_start` - emits `tool-input-start` events
  - `on_tool_end` - emits `tool-output-available` events
- Track `textMessageId` and `reasoningMessageId` separately to ensure consistent IDs between `*-start` and `*-end` events (fixes "Cannot set properties of undefined" UI error)
- Support `run_id` at event level (streamEvents v2 format) in addition to `data.run_id`

### Tests (`packages/langchain/src/adapter.test.ts`)
- Added 4 new test cases covering:
  - Basic text streaming with streamEvents
  - Tool call handling (on_tool_start/on_tool_end)
  - Reasoning content extraction
  - Array content format

### Documentation
- Updated `packages/langchain/README.md` with streamEvents usage example and API reference
- Added guidance on when to use `streamEvents()` vs `graph.stream()` in `examples/next-langchain/README.md`

### Example
- Added `examples/next-langchain/app/api/stream-events/route.ts` - API route demonstrating streamEvents usage
- Added `examples/next-langchain/app/stream-events/page.tsx` - Client-side page for the example

## Manual Verification

1. Built the `@ai-sdk/langchain` package with `pnpm build`
2. Ran the `next-langchain` example with `pnpm dev`
3. Navigated to the streamEvents example page
4. Sent messages and verified:
   - Text streams correctly without errors
   - Messages display properly in the UI

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11425