### PR TITLE
fix(google): structured output with google provider tools

### DIFF
--- a/.changeset/happy-clouds-check.md
+++ b/.changeset/happy-clouds-check.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(google): parse structured output when using google provider tools

--- a/examples/ai-core/src/generate-text/google-code-execution-tool-object.ts
+++ b/examples/ai-core/src/generate-text/google-code-execution-tool-object.ts
@@ -1,0 +1,22 @@
+import { generateText, Output } from 'ai';
+import { google } from '@ai-sdk/google';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: google('gemini-3-flash-preview'),
+    tools: {
+      code_execution: google.tools.codeExecution({}),
+    },
+    output: Output.object({
+      schema: z.object({
+        answer: z.number(),
+        explanation: z.string(),
+      }),
+    }),
+    prompt: 'Calculate the sum of the first 50 prime numbers. Show your work.',
+  });
+
+  console.log(result.output);
+});

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -1505,6 +1505,184 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should return stop finish reason for code execution (provider-executed tool)', async () => {
+    server.urls[TEST_URL_GEMINI_2_0_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  executableCode: {
+                    language: 'PYTHON',
+                    code: 'print(1+1)',
+                  },
+                },
+                {
+                  codeExecutionResult: {
+                    outcome: 'OUTCOME_OK',
+                    output: '2',
+                  },
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+          },
+        ],
+      },
+    };
+
+    const model = provider.languageModel('gemini-2.0-pro');
+    const { finishReason } = await model.doGenerate({
+      tools: [
+        {
+          type: 'provider',
+          id: 'google.code_execution',
+          name: 'code_execution',
+          args: {},
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    // Provider-executed tools should not trigger 'tool-calls' finish reason
+    // since they don't require SDK iteration
+    expect(finishReason).toMatchInlineSnapshot(`
+      {
+        "raw": "STOP",
+        "unified": "stop",
+      }
+    `);
+  });
+
+  it('should return stop finish reason for code execution with text response (structured output scenario)', async () => {
+    server.urls[TEST_URL_GEMINI_2_0_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  executableCode: {
+                    language: 'PYTHON',
+                    code: 'primes = [2, 3, 5, 7, 11]\nprint(sum(primes))',
+                  },
+                },
+                {
+                  codeExecutionResult: {
+                    outcome: 'OUTCOME_OK',
+                    output: '28',
+                  },
+                },
+                {
+                  text: '{"answer": 28, "explanation": "Sum of first 5 primes"}',
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+          },
+        ],
+      },
+    };
+
+    const model = provider.languageModel('gemini-2.0-pro');
+    const { finishReason, content } = await model.doGenerate({
+      tools: [
+        {
+          type: 'provider',
+          id: 'google.code_execution',
+          name: 'code_execution',
+          args: {},
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    // Should return 'stop' so structured output can be parsed
+    expect(finishReason).toMatchInlineSnapshot(`
+      {
+        "raw": "STOP",
+        "unified": "stop",
+      }
+    `);
+
+    // Verify text content is included
+    const textPart = content.find(part => part.type === 'text');
+    expect(textPart).toBeDefined();
+    expect((textPart as { type: 'text'; text: string }).text).toBe(
+      '{"answer": 28, "explanation": "Sum of first 5 primes"}',
+    );
+  });
+
+  it('should return tool-calls finish reason when code execution is combined with function tools', async () => {
+    server.urls[TEST_URL_GEMINI_2_0_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  executableCode: {
+                    language: 'PYTHON',
+                    code: 'print(1+1)',
+                  },
+                },
+                {
+                  codeExecutionResult: {
+                    outcome: 'OUTCOME_OK',
+                    output: '2',
+                  },
+                },
+                {
+                  functionCall: {
+                    name: 'test-tool',
+                    args: { value: 'test' },
+                  },
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+          },
+        ],
+      },
+    };
+
+    const model = provider.languageModel('gemini-2.0-pro');
+    const { finishReason } = await model.doGenerate({
+      tools: [
+        {
+          type: 'provider',
+          id: 'google.code_execution',
+          name: 'code_execution',
+          args: {},
+        },
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    // Should return 'tool-calls' because there's a client-executed function tool
+    expect(finishReason).toMatchInlineSnapshot(`
+      {
+        "raw": "STOP",
+        "unified": "tool-calls",
+      }
+    `);
+  });
+
   describe('search tool selection', () => {
     const provider = createGoogleGenerativeAI({
       apiKey: 'test-api-key',
@@ -2910,6 +3088,77 @@ describe('doStream', () => {
         },
       ]
     `);
+  });
+
+  it('should return stop finish reason for streamed code execution (provider-executed tool)', async () => {
+    server.urls[TEST_URL_GEMINI_2_0_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    executableCode: {
+                      language: 'PYTHON',
+                      code: 'print("hello")',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    codeExecutionResult: {
+                      outcome: 'OUTCOME_OK',
+                      output: 'hello\n',
+                    },
+                  },
+                  {
+                    text: '{"result": "hello"}',
+                  },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        })}\n\n`,
+      ],
+    };
+
+    const model = provider.languageModel('gemini-2.0-pro');
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'provider',
+          id: 'google.code_execution',
+          name: 'code_execution',
+          args: {},
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+
+    const finishEvent = events.find(e => e.type === 'finish');
+
+    // Provider-executed tools should not trigger 'tool-calls' finish reason
+    // since they don't require SDK iteration - allows structured output to work
+    expect(finishEvent).toMatchObject({
+      type: 'finish',
+      finishReason: {
+        raw: 'STOP',
+        unified: 'stop',
+      },
+    });
   });
 
   describe('search tool selection', () => {

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -324,7 +324,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
       finishReason: {
         unified: mapGoogleGenerativeAIFinishReason({
           finishReason: candidate.finishReason,
-          hasToolCalls: content.some(part => part.type === 'tool-call'),
+          // Only count client-executed tool calls for finish reason determination.
+          hasToolCalls: content.some(
+            part => part.type === 'tool-call' && !part.providerExecuted,
+          ),
         }),
         raw: candidate.finishReason ?? undefined,
       },
@@ -459,8 +462,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                     input: JSON.stringify(part.executableCode),
                     providerExecuted: true,
                   });
-
-                  hasToolCalls = true;
                 } else if (
                   'codeExecutionResult' in part &&
                   part.codeExecutionResult


### PR DESCRIPTION
## Background

#11466 

When using code execution tool with google provider, the SDK was incorrectly mapping the finish reason to 'tool-calls' instead of 'stop'. 

This prevented structured output from being parsed because generateText only parses output when finishReason === 'stop'

## Manual Verification

- verified the solution by running the example `examples/ai-core/src/generate-text/google-code-execution-tool-object.ts` before and after fix

## Summary

filter out provider executed tools when determining if there are tool calls

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #11466
