### PR TITLE
docs: mention bash-tool in ready-to-use-tools section of docs

### DIFF
--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -128,6 +128,7 @@ These packages provide pre-built tools you can install and use immediately:
 - **[JigsawStack](http://www.jigsawstack.com/docs/integration/vercel)** - Over 30+ small custom fine-tuned models available for specific uses.
 - **[AI Tools Registry](https://ai-tools-registry.vercel.app)** - A Shadcn-compatible tool definitions and components registry for the AI SDK.
 - **[Toolhouse](https://docs.toolhouse.ai/toolhouse/toolhouse-sdk/using-vercel-ai)** - AI function-calling in 3 lines of code for over 25 different actions.
+- **[bash-tool](https://www.npmjs.com/package/bash-tool)** - Provides `bash`, `readFile`, and `writeFile` tools for AI agents. It's powered by [just-bash](https://github.com/vercel-labs/just-bash), a TypeScript implementation of bash with its own parser, interpreter, and reimplemented commands. Supports [@vercel/sandbox](https://vercel.com/docs/vercel-sandbox) for full VM isolation.
 
 ### MCP Tools
 

--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -128,7 +128,7 @@ These packages provide pre-built tools you can install and use immediately:
 - **[JigsawStack](http://www.jigsawstack.com/docs/integration/vercel)** - Over 30+ small custom fine-tuned models available for specific uses.
 - **[AI Tools Registry](https://ai-tools-registry.vercel.app)** - A Shadcn-compatible tool definitions and components registry for the AI SDK.
 - **[Toolhouse](https://docs.toolhouse.ai/toolhouse/toolhouse-sdk/using-vercel-ai)** - AI function-calling in 3 lines of code for over 25 different actions.
-- **[bash-tool](https://www.npmjs.com/package/bash-tool)** - Provides `bash`, `readFile`, and `writeFile` tools for AI agents. It's powered by [just-bash](https://github.com/vercel-labs/just-bash), a TypeScript implementation of bash with its own parser, interpreter, and reimplemented commands. Supports [@vercel/sandbox](https://vercel.com/docs/vercel-sandbox) for full VM isolation.
+- **[bash-tool](https://www.npmjs.com/package/bash-tool)** - Provides `bash`, `readFile`, and `writeFile` tools for AI agents. Supports [@vercel/sandbox](https://vercel.com/docs/vercel-sandbox) for full VM isolation.
 
 ### MCP Tools
 

--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -419,4 +419,36 @@ console.log(text);`,
     websiteUrl: 'https://airweave.ai',
     npmUrl: 'https://www.npmjs.com/package/@airweave/vercel-ai-sdk',
   },
+  {
+    slug: 'bash-tool',
+    name: 'bash-tool',
+    description:
+      'Provides bash, readFile, and writeFile tools for AI agents. Powered by just-bash, a bash interpreter written entirely in TypeScript with its own parser, interpreter, and reimplemented commands—no shell process required. Supports @vercel/sandbox for full VM isolation.',
+    packageName: 'bash-tool',
+    tags: ['bash', 'file-system', 'sandbox', 'code-execution'],
+    installCommand: {
+      pnpm: 'pnpm install bash-tool',
+      npm: 'npm install bash-tool',
+      yarn: 'yarn add bash-tool',
+      bun: 'bun add bash-tool',
+    },
+    codeExample: `import { generateText, stepCountIs } from 'ai';
+import { createBashTool } from 'bash-tool';
+
+const { tools } = await createBashTool({
+  files: { 'src/index.ts': "export const hello = 'world';" },
+});
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4',
+  prompt: 'List the files in src/ and show me the contents of index.ts',
+  tools,
+  stopWhen: stepCountIs(5),
+});
+
+console.log(text);`,
+    docsUrl: 'https://github.com/vercel/bash-tool',
+    websiteUrl: 'https://github.com/vercel/bash-tool',
+    npmUrl: 'https://www.npmjs.com/package/bash-tool',
+  },
 ];

--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -423,7 +423,7 @@ console.log(text);`,
     slug: 'bash-tool',
     name: 'bash-tool',
     description:
-      'Provides bash, readFile, and writeFile tools for AI agents. Powered by just-bash, a bash interpreter written entirely in TypeScript with its own parser, interpreter, and reimplemented commands—no shell process required. Supports @vercel/sandbox for full VM isolation.',
+      'Provides bash, readFile, and writeFile tools for AI agents. Supports @vercel/sandbox for full VM isolation.',
     packageName: 'bash-tool',
     tags: ['bash', 'file-system', 'sandbox', 'code-execution'],
     installCommand: {


### PR DESCRIPTION
This pull request adds a new pre-built tool to the documentation, expanding the list of available AI agent tools.

New tool addition:

* Added `bash-tool` to the list of pre-built tools, highlighting its features such as providing `bash`, `readFile`, and `writeFile` tools, TypeScript implementation, and support for VM isolation via `@vercel/sandbox`.


and to https://ai-sdk.dev/tools-registry