### PR TITLE
feat(ai): introduce timeout configuration object

### DIFF
--- a/.changeset/fast-taxis-talk.md
+++ b/.changeset/fast-taxis-talk.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): introduce timeout configuration object

--- a/content/docs/03-ai-sdk-core/25-settings.mdx
+++ b/content/docs/03-ai-sdk-core/25-settings.mdx
@@ -111,13 +111,25 @@ An optional timeout in milliseconds. The call will be aborted if it takes longer
 
 This is a convenience parameter that creates an abort signal internally. It can be used alongside `abortSignal` - if both are provided, the call will abort when either condition is met.
 
-#### Example: 5 second timeout
+You can specify the timeout either as a number (milliseconds) or as an object with a `totalMs` property.
+
+#### Example: 5 second timeout (number format)
 
 ```ts
 const result = await generateText({
   model: __MODEL__,
   prompt: 'Invent a new holiday and describe its traditions.',
   timeout: 5000, // 5 seconds
+});
+```
+
+#### Example: 5 second timeout (object format)
+
+```ts
+const result = await generateText({
+  model: __MODEL__,
+  prompt: 'Invent a new holiday and describe its traditions.',
+  timeout: { totalMs: 5000 }, // 5 seconds
 });
 ```
 

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -437,10 +437,10 @@ To see `generateText` in action, check out [these examples](#examples).
     },
     {
       name: 'timeout',
-      type: 'number',
+      type: 'number | { totalMs?: number }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with a totalMs property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
     },
     {
       name: 'headers',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -438,10 +438,10 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'timeout',
-      type: 'number',
+      type: 'number | { totalMs?: number }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with a totalMs property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
     },
     {
       name: 'headers',

--- a/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
@@ -58,10 +58,11 @@ export type AgentCallParameters<CALL_OPTIONS> = ([CALL_OPTIONS] extends [never]
      */
     abortSignal?: AbortSignal;
     /**
-     * Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout.
+     * Timeout in milliseconds. Can be specified as a number or as an object with a totalMs property.
+     * The call will be aborted if it takes longer than the specified timeout.
      * Can be used alongside abortSignal.
      */
-    timeout?: number;
+    timeout?: number | { totalMs?: number };
   };
 
 /**
@@ -134,7 +135,7 @@ Both `generate()` and `stream()` accept an `AgentCallParameters<CALL_OPTIONS>` o
 - `messages` (optional): An array of `ModelMessage` objects (mutually exclusive with `prompt`)
 - `options` (optional): Additional call options when `CALL_OPTIONS` is not `never`
 - `abortSignal` (optional): An `AbortSignal` to cancel the operation
-- `timeout` (optional): A timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside `abortSignal`.
+- `timeout` (optional): A timeout in milliseconds. Can be specified as a number or as an object with a `totalMs` property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside `abortSignal`.
 
 ## Example: Custom Agent Implementation
 

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -243,10 +243,10 @@ const result = await agent.generate({
     },
     {
       name: 'timeout',
-      type: 'number',
+      type: 'number | { totalMs?: number }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with a totalMs property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
     },
   ]}
 />
@@ -290,10 +290,10 @@ for await (const chunk of stream.textStream) {
     },
     {
       name: 'timeout',
-      type: 'number',
+      type: 'number | { totalMs?: number }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with a totalMs property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
     },
     {
       name: 'experimental_transform',

--- a/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
@@ -67,10 +67,10 @@ export async function* streamAgent(
     },
     {
       name: 'timeout',
-      type: 'number',
+      type: 'number | { totalMs?: number }',
       isRequired: false,
       description:
-        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with a totalMs property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
     },
     {
       name: 'options',

--- a/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
@@ -68,10 +68,10 @@ export async function POST(request: Request) {
     },
     {
       name: 'timeout',
-      type: 'number',
+      type: 'number | { totalMs?: number }',
       isRequired: false,
       description:
-        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with a totalMs property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
     },
     {
       name: 'options',

--- a/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
@@ -69,10 +69,10 @@ export async function handler(req, res) {
     },
     {
       name: 'timeout',
-      type: 'number',
+      type: 'number | { totalMs?: number }',
       isRequired: false,
       description:
-        'Timeout in milliseconds. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with a totalMs property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside abortSignal.',
     },
     {
       name: 'options',

--- a/examples/ai-core/src/generate-text/openai-timeout-object.ts
+++ b/examples/ai-core/src/generate-text/openai-timeout-object.ts
@@ -6,7 +6,7 @@ run(async () => {
   const { text, usage } = await generateText({
     model: openai('gpt-3.5-turbo'),
     prompt: 'Invent a new holiday and describe its traditions.',
-    timeout: 1000, // 1 second timeout
+    timeout: { totalMs: 1000 }, // 1 second timeout using object format
   });
 
   console.log(text);

--- a/examples/ai-core/src/stream-text/openai-timeout-object.ts
+++ b/examples/ai-core/src/stream-text/openai-timeout-object.ts
@@ -1,0 +1,19 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import { printFullStream } from '../lib/print-full-stream';
+import { run } from '../lib/run';
+import { print } from '../lib/print';
+
+run(async () => {
+  const result = streamText({
+    model: openai('gpt-3.5-turbo'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+    timeout: { totalMs: 1000 }, // 1 second timeout using object format
+  });
+
+  printFullStream({ result });
+
+  print('Usage:', await result.usage);
+  print('Finish reason:', await result.finishReason);
+});
+

--- a/examples/ai-core/src/stream-text/openai-timeout-object.ts
+++ b/examples/ai-core/src/stream-text/openai-timeout-object.ts
@@ -16,4 +16,3 @@ run(async () => {
   print('Usage:', await result.usage);
   print('Finish reason:', await result.finishReason);
 });
-

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -4,6 +4,7 @@ import { Output } from '../generate-text/output';
 import { StreamTextTransform } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolSet } from '../generate-text/tool-set';
+import { TimeoutConfiguration } from '../prompt/call-settings';
 
 /**
  * Parameters for calling an agent.
@@ -49,9 +50,9 @@ export type AgentCallParameters<CALL_OPTIONS> = ([CALL_OPTIONS] extends [never]
     abortSignal?: AbortSignal;
 
     /**
-     * Timeout in milliseconds.
+     * Timeout in milliseconds. Can be specified as a number or as an object with `totalMs`.
      */
-    timeout?: number;
+    timeout?: TimeoutConfiguration;
   };
 
 /**

--- a/packages/ai/src/agent/create-agent-ui-stream-response.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.ts
@@ -1,6 +1,7 @@
 import { StreamTextTransform, UIMessageStreamOptions } from '../generate-text';
 import { Output } from '../generate-text/output';
 import { ToolSet } from '../generate-text/tool-set';
+import { TimeoutConfiguration } from '../prompt/call-settings';
 import { createUIMessageStreamResponse } from '../ui-message-stream';
 import { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-stream-response-init';
 import { InferUITools, UIMessage } from '../ui/ui-messages';
@@ -30,7 +31,7 @@ export async function createAgentUIStreamResponse<
   agent: Agent<CALL_OPTIONS, TOOLS, OUTPUT>;
   uiMessages: unknown[];
   abortSignal?: AbortSignal;
-  timeout?: number;
+  timeout?: TimeoutConfiguration;
   options?: CALL_OPTIONS;
   experimental_transform?:
     | StreamTextTransform<TOOLS>

--- a/packages/ai/src/agent/create-agent-ui-stream.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.ts
@@ -1,6 +1,7 @@
 import { StreamTextTransform, UIMessageStreamOptions } from '../generate-text';
 import { Output } from '../generate-text/output';
 import { ToolSet } from '../generate-text/tool-set';
+import { TimeoutConfiguration } from '../prompt/call-settings';
 import { InferUIMessageChunk } from '../ui-message-stream';
 import { convertToModelMessages } from '../ui/convert-to-model-messages';
 import { InferUITools, UIMessage } from '../ui/ui-messages';
@@ -37,7 +38,7 @@ export async function createAgentUIStream<
   agent: Agent<CALL_OPTIONS, TOOLS, OUTPUT>;
   uiMessages: unknown[];
   abortSignal?: AbortSignal;
-  timeout?: number;
+  timeout?: TimeoutConfiguration;
   options?: CALL_OPTIONS;
   experimental_transform?:
     | StreamTextTransform<TOOLS>

--- a/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
+++ b/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
@@ -2,6 +2,7 @@ import { ServerResponse } from 'node:http';
 import { StreamTextTransform, UIMessageStreamOptions } from '../generate-text';
 import { Output } from '../generate-text/output';
 import { ToolSet } from '../generate-text/tool-set';
+import { TimeoutConfiguration } from '../prompt/call-settings';
 import { pipeUIMessageStreamToResponse } from '../ui-message-stream';
 import { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-stream-response-init';
 import { InferUITools, UIMessage } from '../ui/ui-messages';
@@ -31,7 +32,7 @@ export async function pipeAgentUIStreamToResponse<
   agent: Agent<CALL_OPTIONS, TOOLS, OUTPUT>;
   uiMessages: unknown[];
   abortSignal?: AbortSignal;
-  timeout?: number;
+  timeout?: TimeoutConfiguration;
   options?: CALL_OPTIONS;
   experimental_transform?:
     | StreamTextTransform<TOOLS>

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -3928,7 +3928,7 @@ describe('generateText', () => {
                       },
                       {
                         type: 'text',
-                        text: "**Game Over!** \n\nPlayer 1 dominated this game with a decisive 3-0 victory! Looking at the rolls:\n- **Round 1**: Both rolled 6 (Draw)\n- **Round 2**: Player 1 (5) beat Player 2 (4)\n- **Round 3**: Player 1 (6) beat Player 2 (4)\n- **Round 4**: Player 1 (6) beat Player 2 (3)\n\nBased on these results, it appears **Player 1 is likely the one with the loaded die** - they rolled 6 three times out of four rolls (including the draw), and consistently rolled high numbers (5, 6, 6, 6). Player 2's rolls were more varied and lower (6, 4, 4, 3), which looks more like a fair die distribution.\n\nThe loaded die gave Player 1 a significant advantage, allowing them to win the game without Player 2 scoring a single round!",
+                        text: "**Game Over!**\n\nPlayer 1 dominated this game with a decisive 3-0 victory! Looking at the rolls:\n- **Round 1**: Both rolled 6 (Draw)\n- **Round 2**: Player 1 (5) beat Player 2 (4)\n- **Round 3**: Player 1 (6) beat Player 2 (4)\n- **Round 4**: Player 1 (6) beat Player 2 (3)\n\nBased on these results, it appears **Player 1 is likely the one with the loaded die** - they rolled 6 three times out of four rolls (including the draw), and consistently rolled high numbers (5, 6, 6, 6). Player 2's rolls were more varied and lower (6, 4, 4, 3), which looks more like a fair die distribution.\n\nThe loaded die gave Player 1 a significant advantage, allowing them to win the game without Player 2 scoring a single round!",
                       },
                     ],
                     finishReason: { unified: 'stop', raw: 'stop' },

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -16,7 +16,7 @@ import { NoOutputGeneratedError } from '../error';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
 import { ModelMessage } from '../prompt';
-import { CallSettings } from '../prompt/call-settings';
+import { CallSettings, getTotalTimeoutMs } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { createToolModelOutput } from '../prompt/create-tool-model-output';
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
@@ -308,9 +308,10 @@ A function that attempts to repair a tool call that failed to parse.
   const model = resolveLanguageModel(modelArg);
   const stopConditions = asArray(stopWhen);
 
+  const totalTimeoutMs = getTotalTimeoutMs(timeout);
   const mergedAbortSignal = mergeAbortSignals(
     abortSignal,
-    timeout != null ? AbortSignal.timeout(timeout) : undefined,
+    totalTimeoutMs != null ? AbortSignal.timeout(totalTimeoutMs) : undefined,
   );
 
   const { maxRetries, retry } = prepareRetries({

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -10108,6 +10108,103 @@ describe('streamText', () => {
 
       expect(receivedAbortSignal).toBeUndefined();
     });
+
+    it('should support timeout object with totalMs', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+
+      const result = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: { totalMs: 5000 },
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      expect(receivedAbortSignal).toBeDefined();
+    });
+
+    it('should merge timeout object with abort signal', async () => {
+      const abortController = new AbortController();
+      let receivedAbortSignal: AbortSignal | undefined;
+
+      const result = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: { totalMs: 5000 },
+        abortSignal: abortController.signal,
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      // The merged signal should be different from the original
+      expect(receivedAbortSignal).toBeDefined();
+      expect(receivedAbortSignal).not.toBe(abortController.signal);
+    });
+
+    it('should pass undefined when timeout object has no totalMs', async () => {
+      let receivedAbortSignal: AbortSignal | undefined = 'not-set' as any;
+
+      const result = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: {},
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      expect(receivedAbortSignal).toBeUndefined();
+    });
   });
 
   describe('telemetry', () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -17,7 +17,7 @@ import { ServerResponse } from 'node:http';
 import { NoOutputGeneratedError } from '../error';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
-import { CallSettings } from '../prompt/call-settings';
+import { CallSettings, getTotalTimeoutMs } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { createToolModelOutput } from '../prompt/create-tool-model-output';
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
@@ -432,6 +432,7 @@ Internal. For test use only. May change without notice.
       currentDate?: () => Date;
     };
   }): StreamTextResult<TOOLS, OUTPUT> {
+  const totalTimeoutMs = getTotalTimeoutMs(timeout);
   return new DefaultStreamTextResult<TOOLS, OUTPUT>({
     model: resolveLanguageModel(model),
     telemetry,
@@ -440,7 +441,7 @@ Internal. For test use only. May change without notice.
     maxRetries,
     abortSignal: mergeAbortSignals(
       abortSignal,
-      timeout != null ? AbortSignal.timeout(timeout) : undefined,
+      totalTimeoutMs != null ? AbortSignal.timeout(totalTimeoutMs) : undefined,
     ),
     system,
     prompt,

--- a/packages/ai/src/prompt/call-settings.ts
+++ b/packages/ai/src/prompt/call-settings.ts
@@ -1,3 +1,28 @@
+/**
+Timeout configuration for API calls. Can be specified as:
+- A number representing milliseconds
+- An object with `totalMs` property for the total timeout in milliseconds
+ */
+export type TimeoutConfiguration = number | { totalMs?: number };
+
+/**
+Extracts the total timeout value in milliseconds from a TimeoutConfiguration.
+
+@param timeout - The timeout configuration.
+@returns The total timeout in milliseconds, or undefined if no timeout is configured.
+ */
+export function getTotalTimeoutMs(
+  timeout: TimeoutConfiguration | undefined,
+): number | undefined {
+  if (timeout == null) {
+    return undefined;
+  }
+  if (typeof timeout === 'number') {
+    return timeout;
+  }
+  return timeout.totalMs;
+}
+
 export type CallSettings = {
   /**
 Maximum number of tokens to generate.
@@ -75,8 +100,10 @@ Abort signal.
   /**
 Timeout in milliseconds. The call will be aborted if it takes longer
 than the specified timeout. Can be used alongside abortSignal.
+
+Can be specified as a number (milliseconds) or as an object with `totalMs`.
    */
-  timeout?: number;
+  timeout?: TimeoutConfiguration;
 
   /**
 Additional HTTP headers to be sent with the request.

--- a/packages/ai/src/prompt/index.ts
+++ b/packages/ai/src/prompt/index.ts
@@ -1,4 +1,5 @@
-export type { CallSettings } from './call-settings';
+export type { CallSettings, TimeoutConfiguration } from './call-settings';
+export { getTotalTimeoutMs } from './call-settings';
 export {
   assistantModelMessageSchema,
   modelMessageSchema,

--- a/packages/ai/src/telemetry/get-base-telemetry-attributes.ts
+++ b/packages/ai/src/telemetry/get-base-telemetry-attributes.ts
@@ -1,5 +1,5 @@
-import { Attributes } from '@opentelemetry/api';
-import { CallSettings } from '../prompt/call-settings';
+import { Attributes, AttributeValue } from '@opentelemetry/api';
+import { CallSettings, getTotalTimeoutMs } from '../prompt/call-settings';
 import { TelemetrySettings } from './telemetry-settings';
 
 export function getBaseTelemetryAttributes({
@@ -19,7 +19,17 @@ export function getBaseTelemetryAttributes({
 
     // settings:
     ...Object.entries(settings).reduce((attributes, [key, value]) => {
-      attributes[`ai.settings.${key}`] = value;
+      // Handle timeout specially since it can be a number or object
+      if (key === 'timeout') {
+        const totalTimeoutMs = getTotalTimeoutMs(
+          value as Parameters<typeof getTotalTimeoutMs>[0],
+        );
+        if (totalTimeoutMs != null) {
+          attributes[`ai.settings.${key}`] = totalTimeoutMs;
+        }
+      } else {
+        attributes[`ai.settings.${key}`] = value as AttributeValue;
+      }
       return attributes;
     }, {} as Attributes),
 


### PR DESCRIPTION
## Background

A timeout option was introduced in #11571 . It is planned to add specific per-step and per-chunk timeouts. To prepare for this, a timeout options object needs to be introduced.

## Summary

Introduce timeout configuration object with `totalMs` property.

## Manual Verification

- [x] run `examples/ai-core/src/generate-text/openai-timeout-object.ts`
- [x] run `examples/ai-core/src/stream-text/openai-timeout-object.ts`

## Future Work

* add per step timeouts #11575
* add per chunk timeouts #11576

## Related Issues

Builds on #11571 