### PR TITLE
feat(ai): add per-step timeout support for streamText

### DIFF
--- a/.changeset/cyan-ladybugs-argue.md
+++ b/.changeset/cyan-ladybugs-argue.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+add per-step timeout feature for streamText

--- a/examples/ai-core/src/stream-text/openai-step-timeout.ts
+++ b/examples/ai-core/src/stream-text/openai-step-timeout.ts
@@ -1,0 +1,40 @@
+import { openai } from '@ai-sdk/openai';
+import { stepCountIs, streamText, tool } from 'ai';
+import { printFullStream } from '../lib/print-full-stream';
+import { run } from '../lib/run';
+import { print } from '../lib/print';
+import { z } from 'zod';
+
+run(async () => {
+  const result = streamText({
+    model: openai('gpt-3.5-turbo'),
+    prompt: 'Get the weather for Paris, London, and Tokyo, then summarize.',
+    tools: {
+      getWeather: tool({
+        description: 'Get the weather in a location',
+        inputSchema: z.object({
+          location: z.string().describe('The location to get the weather for'),
+        }),
+        execute: async ({ location }) => {
+          if (location === 'London')
+            await new Promise(r => setTimeout(r, 5000));
+          return {
+            location,
+            temperature: 72 + Math.floor(Math.random() * 21) - 10,
+            condition: 'sunny',
+          };
+        },
+      }),
+    },
+    stopWhen: stepCountIs(5),
+    timeout: {
+      totalMs: 30000,
+      stepMs: 3000,
+    },
+  });
+
+  printFullStream({ result });
+
+  print('Usage:', await result.usage);
+  print('Finish reason', await result.finishReason);
+});

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1281,13 +1281,6 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
 
           stepFinish = new DelayedPromise<void>();
 
-          const stepAbortSignal = mergeAbortSignals(
-            abortSignal,
-            stepTimeoutMs != null
-              ? AbortSignal.timeout(stepTimeoutMs)
-              : undefined,
-          );
-
           const stepInputMessages = [...initialMessages, ...responseMessages];
 
           const prepareStepResult = await prepareStep?.({
@@ -1325,6 +1318,14 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
             providerOptions,
             prepareStepResult?.providerOptions,
           );
+
+          const stepAbortSignal = mergeAbortSignals(
+            abortSignal,
+            stepTimeoutMs != null
+              ? AbortSignal.timeout(stepTimeoutMs)
+              : undefined,
+          );
+
           const {
             result: { stream, response, request },
             doStreamSpan,

--- a/packages/ai/src/prompt/call-settings.ts
+++ b/packages/ai/src/prompt/call-settings.ts
@@ -1,7 +1,9 @@
 /**
 Timeout configuration for API calls. Can be specified as:
 - A number representing milliseconds
-- An object with `totalMs` property for the total timeout in milliseconds
+- An object with timeout properties:
+  - `totalMs`: Total timeout for the entire operation in millisecond
+  - `stepMs`: Timeout for each individual step in millisecond
  */
 export type TimeoutConfiguration =
   | number

--- a/packages/ai/src/prompt/call-settings.ts
+++ b/packages/ai/src/prompt/call-settings.ts
@@ -3,7 +3,9 @@ Timeout configuration for API calls. Can be specified as:
 - A number representing milliseconds
 - An object with `totalMs` property for the total timeout in milliseconds
  */
-export type TimeoutConfiguration = number | { totalMs?: number };
+export type TimeoutConfiguration =
+  | number
+  | { totalMs?: number; stepMs?: number };
 
 /**
 Extracts the total timeout value in milliseconds from a TimeoutConfiguration.
@@ -21,6 +23,21 @@ export function getTotalTimeoutMs(
     return timeout;
   }
   return timeout.totalMs;
+}
+
+/**
+Extracts the step timeout value in milliseconds from a TimeoutConfiguration.
+
+@param timeout - The timeout configuration
+@returns The per-step timeout in millisecond, or undefined if no timeout is configured.
+ */
+export function getStepTimeoutMs(
+  timeout: TimeoutConfiguration | undefined,
+): number | undefined {
+  if (timeout == null || typeof timeout === 'number') {
+    return undefined;
+  }
+  return timeout.stepMs;
 }
 
 export type CallSettings = {

--- a/packages/ai/src/prompt/index.ts
+++ b/packages/ai/src/prompt/index.ts
@@ -1,5 +1,5 @@
 export type { CallSettings, TimeoutConfiguration } from './call-settings';
-export { getTotalTimeoutMs } from './call-settings';
+export { getTotalTimeoutMs, getStepTimeoutMs } from './call-settings';
 export {
   assistantModelMessageSchema,
   modelMessageSchema,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Ref: #11575 

## Summary

<!-- What did you change? -->
Added support for per-step timeout in streamText timeout object , this allows to set timeout for each individual step in a multistep flow

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->
- added `examples/ai-core/src/stream-text/openai-timeout.ts`, it correctly aborts when the step fetching weather for 'London' takes more than specified step timeout

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)