### PR TITLE
fix(bedrock): map reasoningConfig to reasoning_effort for openai models

### DIFF
--- a/.changeset/metal-baboons-provide.md
+++ b/.changeset/metal-baboons-provide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(bedrock): map reasoningConfig to reasoning_effort for openai models

--- a/examples/ai-core/src/generate-text/bedrock-openai-reasoning.ts
+++ b/examples/ai-core/src/generate-text/bedrock-openai-reasoning.ts
@@ -1,0 +1,18 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: bedrock('openai.gpt-oss-120b-1:0'),
+    prompt: 'What is 2 + 2 equal to?',
+    providerOptions: {
+      bedrock: {
+        reasoningConfig: { type: 'enabled', maxReasoningEffort: 'medium' },
+      },
+    },
+  });
+
+  console.log(result.reasoningText);
+  console.log(result.text);
+});

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -87,6 +87,11 @@ const novaGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
   novaModelId,
 )}/converse`;
 
+const openaiModelId = 'openai.gpt-oss-120b-1:0';
+const openaiGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
+  openaiModelId,
+)}/converse`;
+
 const server = createTestServer({
   [generateUrl]: {},
   [streamUrl]: {
@@ -98,6 +103,7 @@ const server = createTestServer({
   // Configure the server for the Anthropic model from the start
   [anthropicGenerateUrl]: {},
   [novaGenerateUrl]: {},
+  [openaiGenerateUrl]: {},
 });
 
 function prepareJsonFixtureResponse(filename: string) {
@@ -145,6 +151,13 @@ const model = new BedrockChatLanguageModel(modelId, {
 });
 
 const novaModel = new BedrockChatLanguageModel(novaModelId, {
+  baseUrl: () => baseUrl,
+  headers: {},
+  fetch: fakeFetchWithAuth,
+  generateId: () => 'test-id',
+});
+
+const openaiModel = new BedrockChatLanguageModel(openaiModelId, {
   baseUrl: () => baseUrl,
   headers: {},
   fetch: fakeFetchWithAuth,
@@ -3592,6 +3605,41 @@ describe('doGenerate', () => {
         },
       },
     });
+    expect(requestBody.additionalModelRequestFields?.thinking).toBeUndefined();
+  });
+
+  it('maps maxReasoningEffort to reasoning_effort for OpenAI models (generate)', async () => {
+    server.urls[openaiGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: { content: [{ text: 'Hello' }], role: 'assistant' },
+        },
+        stopReason: 'stop_sequence',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      },
+    };
+
+    await openaiModel.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        bedrock: {
+          reasoningConfig: {
+            maxReasoningEffort: 'medium',
+          },
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody).toMatchObject({
+      additionalModelRequestFields: {
+        reasoning_effort: 'medium',
+      },
+    });
+    expect(
+      requestBody.additionalModelRequestFields?.reasoningConfig,
+    ).toBeUndefined();
     expect(requestBody.additionalModelRequestFields?.thinking).toBeUndefined();
   });
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -215,16 +215,27 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
 
     const maxReasoningEffort =
       bedrockOptions.reasoningConfig?.maxReasoningEffort;
+    const isOpenAIModel = this.modelId.startsWith('openai.');
+
     if (maxReasoningEffort != null && !isAnthropicModel) {
-      bedrockOptions.additionalModelRequestFields = {
-        ...bedrockOptions.additionalModelRequestFields,
-        reasoningConfig: {
-          ...(bedrockOptions.reasoningConfig?.type != null && {
-            type: bedrockOptions.reasoningConfig.type,
-          }),
-          maxReasoningEffort,
-        },
-      };
+      if (isOpenAIModel) {
+        // OpenAI models on Bedrock expect `reasoning_effort` as a flat value
+        bedrockOptions.additionalModelRequestFields = {
+          ...bedrockOptions.additionalModelRequestFields,
+          reasoning_effort: maxReasoningEffort,
+        };
+      } else {
+        // other models (such as Nova 2) use reasoningConfig format
+        bedrockOptions.additionalModelRequestFields = {
+          ...bedrockOptions.additionalModelRequestFields,
+          reasoningConfig: {
+            ...(bedrockOptions.reasoningConfig?.type != null && {
+              type: bedrockOptions.reasoningConfig.type,
+            }),
+            maxReasoningEffort,
+          },
+        };
+      }
     } else if (maxReasoningEffort != null && isAnthropicModel) {
       warnings.push({
         type: 'unsupported',


### PR DESCRIPTION
## Background

#11467

Improper mapping of `reasoningConfig` to it's equivalent `reasoning_effort` when using openAI models in bedrock

## Summary

swap in`reasoning_effort` param for when an openai model is used

## Manual Verification

verified by running the cli example in `examples/ai-core/src/generate-text/bedrock-openai-reasoning.ts` which failed before the fix.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11467 
