### PR TITLE
docs(ai): Update Unified Provider Architecture section in README

### DIFF
--- a/.changeset/friendly-clouds-glow.md
+++ b/.changeset/friendly-clouds-glow.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Updated Unified Provider Architecture section in README to describe AI Gateway as the default.

--- a/.changeset/friendly-clouds-glow.md
+++ b/.changeset/friendly-clouds-glow.md
@@ -1,5 +1,5 @@
 ---
-"ai": patch
+'ai': patch
 ---
 
 Updated Unified Provider Architecture section in README to describe AI Gateway as the default.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -18,11 +18,20 @@ npm install ai
 
 The AI SDK provides a [unified API](https://ai-sdk.dev/docs/foundations/providers-and-models) to interact with model providers like [OpenAI](https://ai-sdk.dev/providers/ai-sdk-providers/openai), [Anthropic](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic), [Google](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai), and [more](https://ai-sdk.dev/providers/ai-sdk-providers).
 
+By default, the AI SDK uses the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) to give you access to all major providers out of the box. Just pass a model string for any supported model:
+
+```ts
+const result = await generateText({
+  model: 'anthropic/claude-opus-4.5', // or 'openai/gpt-5.2', 'google/gemini-3-flash', etc.
+  prompt: 'Hello!',
+});
+```
+
+You can also connect to providers directly using their SDK packages:
+
 ```shell
 npm install @ai-sdk/openai @ai-sdk/anthropic @ai-sdk/google
 ```
-
-Alternatively you can use the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway).
 
 ## Usage
 


### PR DESCRIPTION
## Background

This section didn't make it clear that the Vercel AI Gateway is the default.

## Summary

Updated the readme to show how to use the AI Gateway with model strings and re-worded the Unified Provider Architecture section to make this clear.

## Manual Verification

N/A - Docs only change

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
