### PR TITLE
fix(openai-compatible): use looseObject for robustness with non-standard APIs

### DIFF
--- a/.changeset/popular-spiders-happen.md
+++ b/.changeset/popular-spiders-happen.md
@@ -2,4 +2,4 @@
 '@ai-sdk/openai-compatible': patch
 ---
 
-Change some response schemas from z.object to z.looseObject to improve compatibility with non-standard OpenAI-compatible APIs. 
+Change some response schemas from z.object to z.looseObject to improve compatibility with non-standard OpenAI-compatible APIs.

--- a/.changeset/popular-spiders-happen.md
+++ b/.changeset/popular-spiders-happen.md
@@ -2,4 +2,4 @@
 '@ai-sdk/openai-compatible': patch
 ---
 
-Change z.object to z.looseObject for robustness
+Change some response schemas from z.object to z.looseObject to improve compatibility with non-standard OpenAI-compatible APIs. 

--- a/.changeset/popular-spiders-happen.md
+++ b/.changeset/popular-spiders-happen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Change z.object to z.looseObject for robustness

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -651,7 +651,7 @@ const openaiCompatibleTokenUsageSchema = z
 
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-const OpenAICompatibleChatResponseSchema = z.object({
+const OpenAICompatibleChatResponseSchema = z.looseObject({
   id: z.string().nullish(),
   created: z.number().nullish(),
   model: z.string().nullish(),
@@ -680,7 +680,7 @@ const OpenAICompatibleChatResponseSchema = z.object({
   usage: openaiCompatibleTokenUsageSchema,
 });
 
-const chunkBaseSchema = z.object({
+const chunkBaseSchema = z.looseObject({
   id: z.string().nullish(),
   created: z.number().nullish(),
   model: z.string().nullish(),

--- a/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.ts
+++ b/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.ts
@@ -344,7 +344,7 @@ export class OpenAICompatibleCompletionLanguageModel
   }
 }
 
-const usageSchema = z.object({
+const usageSchema = z.looseObject({
   prompt_tokens: z.number(),
   completion_tokens: z.number(),
   total_tokens: z.number(),
@@ -352,12 +352,12 @@ const usageSchema = z.object({
 
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-const openaiCompatibleCompletionResponseSchema = z.object({
+const openaiCompatibleCompletionResponseSchema = z.looseObject({
   id: z.string().nullish(),
   created: z.number().nullish(),
   model: z.string().nullish(),
   choices: z.array(
-    z.object({
+    z.looseObject({
       text: z.string(),
       finish_reason: z.string(),
     }),
@@ -373,12 +373,12 @@ const createOpenAICompatibleCompletionChunkSchema = <
   errorSchema: ERROR_SCHEMA,
 ) =>
   z.union([
-    z.object({
+    z.looseObject({
       id: z.string().nullish(),
       created: z.number().nullish(),
       model: z.string().nullish(),
       choices: z.array(
-        z.object({
+        z.looseObject({
           text: z.string(),
           finish_reason: z.string().nullish(),
           index: z.number(),

--- a/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.ts
+++ b/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.ts
@@ -344,7 +344,7 @@ export class OpenAICompatibleCompletionLanguageModel
   }
 }
 
-const usageSchema = z.looseObject({
+const usageSchema = z.object({
   prompt_tokens: z.number(),
   completion_tokens: z.number(),
   total_tokens: z.number(),
@@ -352,12 +352,12 @@ const usageSchema = z.looseObject({
 
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-const openaiCompatibleCompletionResponseSchema = z.looseObject({
+const openaiCompatibleCompletionResponseSchema = z.object({
   id: z.string().nullish(),
   created: z.number().nullish(),
   model: z.string().nullish(),
   choices: z.array(
-    z.looseObject({
+    z.object({
       text: z.string(),
       finish_reason: z.string(),
     }),
@@ -373,12 +373,12 @@ const createOpenAICompatibleCompletionChunkSchema = <
   errorSchema: ERROR_SCHEMA,
 ) =>
   z.union([
-    z.looseObject({
+    z.object({
       id: z.string().nullish(),
       created: z.number().nullish(),
       model: z.string().nullish(),
       choices: z.array(
-        z.looseObject({
+        z.object({
           text: z.string(),
           finish_reason: z.string().nullish(),
           index: z.number(),


### PR DESCRIPTION
## Background

Some providers that implement OpenAI-compatible APIs don't strictly follow OpenAI's API standards and may include additional fields in their responses. Using strict `z.object` validation can cause these extra fields to fail validation.

For example, Tencent Hunyuan API includes a non-standard `note` field in their responses (see [cherry-studio#12369](https://github.com/CherryHQ/cherry-studio/issues/12369)). While that specific issue was caused by other validation problems, the presence of extra fields demonstrates why flexible schema validation is necessary for OpenAI-compatible APIs.

## Summary

Changed specific Zod schemas in the `@ai-sdk/openai-compatible` package from `z.object` to `z.looseObject`:
- `OpenAICompatibleChatResponseSchema` - handles chat completion responses
- `chunkBaseSchema` - handles streaming chat chunks

This targeted approach allows unknown fields in API responses to be accepted without being processed, while maintaining backward compatibility with standard OpenAI API responses.

## Manual Verification

Tested with:
- Standard OpenAI API responses - behavior unchanged
- Non-standard APIs with extra fields - responses now parse successfully without validation errors

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Related Issues

Related to [cherry-studio#12369](https://github.com/CherryHQ/cherry-studio/issues/12369)