### PR TITLE
feat(ai): support Intl.Segmenter in smoothStream

### DIFF
--- a/.changeset/sour-goats-whisper.md
+++ b/.changeset/sour-goats-whisper.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): support Intl.Segmenter in smoothStream

--- a/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
@@ -42,10 +42,10 @@ const result = streamText({
     },
     {
       name: 'chunking',
-      type: '"word" | "line" | RegExp | (buffer: string) => string | undefined | null',
+      type: '"word" | "line" | RegExp | Intl.Segmenter | (buffer: string) => string | undefined | null',
       isOptional: true,
       description:
-        'Controls how text and reasoning content is chunked for streaming. Use "word" to stream word by word (default), "line" to stream line by line, or provide a custom callback or RegExp pattern for custom chunking.',
+        'Controls how text and reasoning content is chunked for streaming. Use "word" to stream word by word (default), "line" to stream line by line, an Intl.Segmenter for locale-aware word segmentation (recommended for CJK languages), or provide a custom callback or RegExp pattern for custom chunking.',
     },
   ]}
 />
@@ -54,12 +54,60 @@ const result = streamText({
 
 The word based chunking **does not work well** with the following languages that do not delimit words with spaces:
 
-For these languages we recommend using a custom regex, like the following:
+- Chinese
+- Japanese
+- Korean
+- Vietnamese
+- Thai
+
+#### Using Intl.Segmenter (recommended)
+
+For these languages, we recommend using `Intl.Segmenter` for proper locale-aware word segmentation.
+This is the preferred approach as it provides accurate word boundaries for CJK and other languages.
+
+<Note>
+  `Intl.Segmenter` is available in Node.js 16+ and all modern browsers (Chrome
+  87+, Firefox 125+, Safari 14.1+).
+</Note>
+
+```tsx filename="Japanese example with Intl.Segmenter"
+import { smoothStream, streamText } from 'ai';
+__PROVIDER_IMPORT__;
+
+const segmenter = new Intl.Segmenter('ja', { granularity: 'word' });
+
+const result = streamText({
+  model: __MODEL__,
+  prompt: 'Your prompt here',
+  experimental_transform: smoothStream({
+    chunking: segmenter,
+  }),
+});
+```
+
+```tsx filename="Chinese example with Intl.Segmenter"
+import { smoothStream, streamText } from 'ai';
+__PROVIDER_IMPORT__;
+
+const segmenter = new Intl.Segmenter('zh', { granularity: 'word' });
+
+const result = streamText({
+  model: __MODEL__,
+  prompt: 'Your prompt here',
+  experimental_transform: smoothStream({
+    chunking: segmenter,
+  }),
+});
+```
+
+#### Using RegExp (fallback for older runtimes)
+
+If you need to support older runtimes without `Intl.Segmenter`, you can use a custom regex:
 
 - Chinese - `/[\u4E00-\u9FFF]|\S+\s+/`
 - Japanese - `/[\u3040-\u309F\u30A0-\u30FF]|\S+\s+/`
 
-```tsx filename="Japanese example"
+```tsx filename="Japanese example with RegExp"
 import { smoothStream, streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -72,7 +120,7 @@ const result = streamText({
 });
 ```
 
-```tsx filename="Chinese example"
+```tsx filename="Chinese example with RegExp"
 import { smoothStream, streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
@@ -84,12 +132,6 @@ const result = streamText({
   }),
 });
 ```
-
-For these languages you could pass your own language aware chunking function:
-
-- Vietnamese
-- Thai
-- Javanese (Aksara Jawa)
 
 #### Regex based chunking
 

--- a/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
@@ -100,39 +100,6 @@ const result = streamText({
 });
 ```
 
-#### Using RegExp (fallback for older runtimes)
-
-If you need to support older runtimes without `Intl.Segmenter`, you can use a custom regex:
-
-- Chinese - `/[\u4E00-\u9FFF]|\S+\s+/`
-- Japanese - `/[\u3040-\u309F\u30A0-\u30FF]|\S+\s+/`
-
-```tsx filename="Japanese example with RegExp"
-import { smoothStream, streamText } from 'ai';
-__PROVIDER_IMPORT__;
-
-const result = streamText({
-  model: __MODEL__,
-  prompt: 'Your prompt here',
-  experimental_transform: smoothStream({
-    chunking: /[\u3040-\u309F\u30A0-\u30FF]|\S+\s+/,
-  }),
-});
-```
-
-```tsx filename="Chinese example with RegExp"
-import { smoothStream, streamText } from 'ai';
-__PROVIDER_IMPORT__;
-
-const result = streamText({
-  model: __MODEL__,
-  prompt: 'Your prompt here',
-  experimental_transform: smoothStream({
-    chunking: /[\u4E00-\u9FFF]|\S+\s+/,
-  }),
-});
-```
-
 #### Regex based chunking
 
 To use regex based chunking, pass a `RegExp` to the `chunking` option.

--- a/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
@@ -3,9 +3,6 @@ import { MockLanguageModelV3 } from 'ai/test';
 import { run } from '../lib/run';
 
 run(async () => {
-  // Use Intl.Segmenter for proper Chinese word segmentation
-  const segmenter = new Intl.Segmenter('zh', { granularity: 'word' });
-
   const result = streamText({
     model: new MockLanguageModelV3({
       doStream: async () => ({
@@ -44,7 +41,7 @@ run(async () => {
 
     prompt: 'Say hello in Chinese!',
     experimental_transform: smoothStream({
-      chunking: segmenter,
+      chunking: new Intl.Segmenter('zh', { granularity: 'word' }),
     }),
   });
 

--- a/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
@@ -39,7 +39,6 @@ run(async () => {
         }),
       }),
     }),
-
     prompt: 'Say hello in Chinese!',
     experimental_transform: smoothStream({
       chunking: new Intl.Segmenter('zh', { granularity: 'word' }),

--- a/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
@@ -9,11 +9,12 @@ run(async () => {
         stream: simulateReadableStream({
           chunks: [
             { type: 'text-start', id: '0' },
-            { type: 'text-delta', id: '0', delta: '今天天气很好，' },
-            { type: 'text-delta', id: '0', delta: '我们一起去公园散步吧。' },
-            { type: 'text-delta', id: '0', delta: '春天的花朵非常美丽，' },
-            { type: 'text-delta', id: '0', delta: '阳光温暖而舒适。' },
-            { type: 'text-delta', id: '0', delta: '这是一个完美的周末。' },
+            {
+              type: 'text-delta',
+              id: '0',
+              delta:
+                '今天天气很好，我们一起去公园散步吧。春天的花朵非常美丽，阳光温暖而舒适。这是一个完美的周末。',
+            },
             { type: 'text-end', id: '0' },
             {
               type: 'finish',

--- a/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
@@ -3,6 +3,9 @@ import { MockLanguageModelV3 } from 'ai/test';
 import { run } from '../lib/run';
 
 run(async () => {
+  // Use Intl.Segmenter for proper Chinese word segmentation
+  const segmenter = new Intl.Segmenter('zh', { granularity: 'word' });
+
   const result = streamText({
     model: new MockLanguageModelV3({
       doStream: async () => ({
@@ -41,7 +44,7 @@ run(async () => {
 
     prompt: 'Say hello in Chinese!',
     experimental_transform: smoothStream({
-      chunking: /[\u4E00-\u9FFF]|\S+\s+/,
+      chunking: segmenter,
     }),
   });
 

--- a/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
@@ -35,13 +35,13 @@ run(async () => {
               },
             },
           ],
-          chunkDelayInMs: 400,
         }),
       }),
     }),
     prompt: 'Say hello in Chinese!',
     experimental_transform: smoothStream({
       chunking: new Intl.Segmenter('zh', { granularity: 'word' }),
+      delayInMs: 100,
     }),
   });
 

--- a/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
@@ -9,11 +9,11 @@ run(async () => {
         stream: simulateReadableStream({
           chunks: [
             { type: 'text-start', id: '0' },
-            { type: 'text-delta', id: '0', delta: '你好你好你好你好你好' },
-            { type: 'text-delta', id: '0', delta: '你好你好你好你好你好' },
-            { type: 'text-delta', id: '0', delta: '你好你好你好你好你好' },
-            { type: 'text-delta', id: '0', delta: '你好你好你好你好你好' },
-            { type: 'text-delta', id: '0', delta: '你好你好你好你好你好' },
+            { type: 'text-delta', id: '0', delta: '今天天气很好，' },
+            { type: 'text-delta', id: '0', delta: '我们一起去公园散步吧。' },
+            { type: 'text-delta', id: '0', delta: '春天的花朵非常美丽，' },
+            { type: 'text-delta', id: '0', delta: '阳光温暖而舒适。' },
+            { type: 'text-delta', id: '0', delta: '这是一个完美的周末。' },
             { type: 'text-end', id: '0' },
             {
               type: 'finish',

--- a/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
@@ -3,6 +3,9 @@ import { MockLanguageModelV3 } from 'ai/test';
 import { run } from '../lib/run';
 
 run(async () => {
+  // Use Intl.Segmenter for proper Japanese word segmentation
+  const segmenter = new Intl.Segmenter('ja', { granularity: 'word' });
+
   const result = streamText({
     model: new MockLanguageModelV3({
       doStream: async () => ({
@@ -40,7 +43,7 @@ run(async () => {
 
     prompt: 'Say hello in Japanese!',
     experimental_transform: smoothStream({
-      chunking: /[\u3040-\u309F\u30A0-\u30FF]|\S+\s+/,
+      chunking: segmenter,
     }),
   });
 

--- a/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
@@ -9,17 +9,11 @@ run(async () => {
         stream: simulateReadableStream({
           chunks: [
             { type: 'text-start', id: '0' },
-            { type: 'text-delta', id: '0', delta: '東京は日本の首都です。' },
-            { type: 'text-delta', id: '0', delta: '人口は約1400万人で、' },
             {
               type: 'text-delta',
               id: '0',
-              delta: '世界最大の都市圏の一つです。',
-            },
-            {
-              type: 'text-delta',
-              id: '0',
-              delta: '美しい桜の季節には多くの観光客が訪れます。',
+              delta:
+                '東京は日本の首都です。人口は約1400万人で、世界最大の都市圏の一つです。美しい桜の季節には多くの観光客が訪れます。',
             },
             { type: 'text-end', id: '0' },
             {

--- a/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
@@ -39,7 +39,6 @@ run(async () => {
         }),
       }),
     }),
-
     prompt: 'Say hello in Japanese!',
     experimental_transform: smoothStream({
       chunking: new Intl.Segmenter('ja', { granularity: 'word' }),

--- a/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
@@ -35,13 +35,13 @@ run(async () => {
               },
             },
           ],
-          chunkDelayInMs: 400,
         }),
       }),
     }),
     prompt: 'Say hello in Japanese!',
     experimental_transform: smoothStream({
       chunking: new Intl.Segmenter('ja', { granularity: 'word' }),
+      delayInMs: 100,
     }),
   });
 

--- a/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
@@ -9,10 +9,18 @@ run(async () => {
         stream: simulateReadableStream({
           chunks: [
             { type: 'text-start', id: '0' },
-            { type: 'text-delta', id: '0', delta: 'こんにちは' },
-            { type: 'text-delta', id: '0', delta: 'こんにちは' },
-            { type: 'text-delta', id: '0', delta: 'こんにちは' },
-            { type: 'text-delta', id: '0', delta: 'こんにちは' },
+            { type: 'text-delta', id: '0', delta: '東京は日本の首都です。' },
+            { type: 'text-delta', id: '0', delta: '人口は約1400万人で、' },
+            {
+              type: 'text-delta',
+              id: '0',
+              delta: '世界最大の都市圏の一つです。',
+            },
+            {
+              type: 'text-delta',
+              id: '0',
+              delta: '美しい桜の季節には多くの観光客が訪れます。',
+            },
             { type: 'text-end', id: '0' },
             {
               type: 'finish',

--- a/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
@@ -3,9 +3,6 @@ import { MockLanguageModelV3 } from 'ai/test';
 import { run } from '../lib/run';
 
 run(async () => {
-  // Use Intl.Segmenter for proper Japanese word segmentation
-  const segmenter = new Intl.Segmenter('ja', { granularity: 'word' });
-
   const result = streamText({
     model: new MockLanguageModelV3({
       doStream: async () => ({
@@ -43,7 +40,7 @@ run(async () => {
 
     prompt: 'Say hello in Japanese!',
     experimental_transform: smoothStream({
-      chunking: segmenter,
+      chunking: new Intl.Segmenter('ja', { granularity: 'word' }),
     }),
   });
 

--- a/packages/ai/src/generate-text/smooth-stream.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test.ts
@@ -1777,5 +1777,255 @@ describe('smoothStream', () => {
         ]
       `);
     });
+
+    it('should segment longer Japanese sentence with mixed content', async () => {
+      const segmenter = new Intl.Segmenter('ja', { granularity: 'word' });
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'text-start', id: '1' },
+        {
+          text: '東京は日本の首都です。人口は約1400万人で、世界最大の都市圏の一つです。美しい桜の季節には多くの観光客が訪れます。',
+          type: 'text-delta',
+          id: '1',
+        },
+        { type: 'text-end', id: '1' },
+      ]).pipeThrough(
+        smoothStream({
+          chunking: segmenter,
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "type": "text-start",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "東京",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "は",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "日本",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "の",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "首都",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "です",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "。",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "人口",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "は",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "約",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "1400",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "万人",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "で",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "、",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "世界",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "最大",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "の",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "都市",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "圏",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "の",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "一つ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "です",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "。",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "美しい",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "桜の",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "季節",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "に",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "は",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "多く",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "の",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "観光",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "客",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "が",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "訪れ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "ます",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "。",
+            "type": "text-delta",
+          },
+          {
+            "id": "1",
+            "type": "text-end",
+          },
+        ]
+      `);
+    });
   });
 });


### PR DESCRIPTION
## Background

Smooth streaming words depends on understanding the language that is being streamed. `Intl.Segmenter` supports splitting text from different languages into segments.

## Summary

Add `Intl.Segmenter` support to `smoothStream.chunking`.