### PR TITLE
[feat] adds disallowPromptTraining gateway provider options

### DIFF
--- a/.changeset/young-points-turn.md
+++ b/.changeset/young-points-turn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': major
+---
+
+adds a provider option to enforce non prompt training providers

--- a/.changeset/young-points-turn.md
+++ b/.changeset/young-points-turn.md
@@ -1,5 +1,5 @@
 ---
-'@ai-sdk/gateway': major
+'@ai-sdk/gateway': patch
 ---
 
 adds a provider option to enforce non prompt training providers

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -416,7 +416,7 @@ The following gateway provider options are available:
 
   Restricts routing requests to providers that have zero data retention policies.
 
-- **enforceNonPromptTrainingProviders** _boolean_
+- **disallowPromptTraining** _boolean_
 
   Restricts routing requests to providers that do not use prompts for model training.
 
@@ -484,10 +484,10 @@ const { text } = await generateText({
 });
 ```
 
-#### Enforce Non-Prompt Training Providers Example
+#### Disallow Prompt Training Example
 
-Set `enforceNonPromptTrainingProviders` to true to ensure requests are only routed to providers
-that do not use prompts for model training. When `enforceNonPromptTrainingProviders` is `false` or not
+Set `disallowPromptTraining` to true to ensure requests are only routed to providers
+that do not use prompts for model training. When `disallowPromptTraining` is `false` or not
 specified, there is no enforcement of restricting routing.
 
 ```ts
@@ -499,7 +499,7 @@ const { text } = await generateText({
   prompt: 'Analyze this proprietary business data...',
   providerOptions: {
     gateway: {
-      enforceNonPromptTrainingProviders: true,
+      disallowPromptTraining: true,
     } satisfies GatewayProviderOptions,
   },
 });

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -416,6 +416,10 @@ The following gateway provider options are available:
 
   Restricts routing requests to providers that have zero data retention policies.
 
+- **enforceNonPromptTrainingProviders** _boolean_
+
+  Restricts routing requests to providers that do not use prompts for model training.
+
 You can combine these options to have fine-grained control over routing and tracking:
 
 ```ts
@@ -475,6 +479,27 @@ const { text } = await generateText({
   providerOptions: {
     gateway: {
       zeroDataRetention: true,
+    } satisfies GatewayProviderOptions,
+  },
+});
+```
+
+#### Enforce Non-Prompt Training Providers Example
+
+Set `enforceNonPromptTrainingProviders` to true to ensure requests are only routed to providers
+that do not use prompts for model training. When `enforceNonPromptTrainingProviders` is `false` or not
+specified, there is no enforcement of restricting routing.
+
+```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4.5',
+  prompt: 'Analyze this proprietary business data...',
+  providerOptions: {
+    gateway: {
+      enforceNonPromptTrainingProviders: true,
     } satisfies GatewayProviderOptions,
   },
 });

--- a/examples/ai-core/src/stream-text/gateway-provider-options-disallow-prompt-training.ts
+++ b/examples/ai-core/src/stream-text/gateway-provider-options-disallow-prompt-training.ts
@@ -8,7 +8,7 @@ run(async () => {
     prompt: 'Tell me the history of the tenrec in a few sentences.',
     providerOptions: {
       gateway: {
-        enforceNonPromptTrainingProviders: true,
+        disallowPromptTraining: true,
       } satisfies GatewayProviderOptions,
     },
   });

--- a/examples/ai-core/src/stream-text/gateway-provider-options-enforce-non-prompt-training-providers.ts
+++ b/examples/ai-core/src/stream-text/gateway-provider-options-enforce-non-prompt-training-providers.ts
@@ -1,0 +1,28 @@
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { streamText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: 'openai/gpt-oss-120b',
+    prompt: 'Tell me the history of the tenrec in a few sentences.',
+    providerOptions: {
+      gateway: {
+        enforceNonPromptTrainingProviders: true,
+      } satisfies GatewayProviderOptions,
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(await result.providerMetadata, null, 2),
+  );
+});
+

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -59,6 +59,12 @@ const gatewayProviderOptions = lazySchema(() =>
        * used.
        */
       zeroDataRetention: z.boolean().optional(),
+      /**
+       * Whether to filter by only providers that do not train on prompt data.
+       * When enabled, only providers that have agreements with Vercel AI Gateway
+       * to not use prompts for model training will be used.
+       */
+      enforceNonPromptTrainingProviders: z.boolean().optional(),
     }),
   ),
 );

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -64,7 +64,7 @@ const gatewayProviderOptions = lazySchema(() =>
        * When enabled, only providers that have agreements with Vercel AI Gateway
        * to not use prompts for model training will be used.
        */
-      enforceNonPromptTrainingProviders: z.boolean().optional(),
+      disallowPromptTraining: z.boolean().optional(),
     }),
   ),
 );


### PR DESCRIPTION
## Background

Gateway is adding support for filtering providers by those that don't train on prompts, so we are updating the gateway package to add support. 

## Summary

Added a new field to gateway provider options `disallowPromptTraining`. 

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

