### PR TITLE
feat(ai): per-chunk timeouts for streamText

### DIFF
--- a/.changeset/orange-laws-give.md
+++ b/.changeset/orange-laws-give.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): per-step timeouts for streamText

--- a/.changeset/orange-laws-give.md
+++ b/.changeset/orange-laws-give.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-feat(ai): per-step timeouts for streamText
+feat(ai): per-chunk timeouts for streamText

--- a/content/docs/03-ai-sdk-core/25-settings.mdx
+++ b/content/docs/03-ai-sdk-core/25-settings.mdx
@@ -111,10 +111,11 @@ An optional timeout in milliseconds. The call will be aborted if it takes longer
 
 This is a convenience parameter that creates an abort signal internally. It can be used alongside `abortSignal` - if both are provided, the call will abort when either condition is met.
 
-You can specify the timeout either as a number (milliseconds) or as an object with `totalMs` and/or `stepMs` properties:
+You can specify the timeout either as a number (milliseconds) or as an object with `totalMs`, `stepMs`, and/or `chunkMs` properties:
 
 - `totalMs`: The total timeout for the entire call including all steps.
 - `stepMs`: The timeout for each individual step (LLM call). This is useful for multi-step generations where you want to limit the time spent on each step independently.
+- `chunkMs`: The timeout between stream chunks (streaming only). The call will abort if no new chunk is received within this duration. This is useful for detecting stalled streams.
 
 #### Example: 5 second timeout (number format)
 
@@ -156,6 +157,16 @@ const result = await generateText({
     totalMs: 60000, // 60 seconds total
     stepMs: 10000, // 10 seconds per step
   },
+});
+```
+
+#### Example: Per-chunk timeout for streaming (streamText only)
+
+```ts
+const result = streamText({
+  model: __MODEL__,
+  prompt: 'Invent a new holiday and describe its traditions.',
+  timeout: { chunkMs: 5000 }, // abort if no chunk received for 5 seconds
 });
 ```
 

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -438,10 +438,10 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'timeout',
-      type: 'number | { totalMs?: number; stepMs?: number }',
+      type: 'number | { totalMs?: number; stepMs?: number; chunkMs?: number }',
       isOptional: true,
       description:
-        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs and/or stepMs properties. totalMs sets the total timeout for the entire call. stepMs sets the timeout for each individual step (LLM call), useful for multi-step generations. Can be used alongside abortSignal.',
+        'Timeout in milliseconds. Can be specified as a number or as an object with totalMs, stepMs, and/or chunkMs properties. totalMs sets the total timeout for the entire call. stepMs sets the timeout for each individual step (LLM call), useful for multi-step generations. chunkMs sets the timeout between stream chunks - the call will abort if no new chunk is received within this duration, useful for detecting stalled streams. Can be used alongside abortSignal.',
     },
     {
       name: 'headers',

--- a/examples/ai-core/src/stream-text/openai-timeout-chunk.ts
+++ b/examples/ai-core/src/stream-text/openai-timeout-chunk.ts
@@ -1,0 +1,21 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import { printFullStream } from '../lib/print-full-stream';
+import { run } from '../lib/run';
+import { print } from '../lib/print';
+
+run(async () => {
+  const result = streamText({
+    model: openai('gpt-4o'),
+    prompt: 'Write a short poem about the ocean.',
+    // Per-chunk timeout: abort if no chunk is received for 5 seconds
+    // This is useful for detecting stalled streams where the connection
+    // is open but no data is flowing.
+    timeout: { chunkMs: 5000 },
+  });
+
+  printFullStream({ result });
+
+  print('Usage:', await result.usage);
+  print('Finish reason:', await result.finishReason);
+});

--- a/examples/ai-core/src/stream-text/openai-timeout-chunk.ts
+++ b/examples/ai-core/src/stream-text/openai-timeout-chunk.ts
@@ -6,12 +6,9 @@ import { print } from '../lib/print';
 
 run(async () => {
   const result = streamText({
-    model: openai('gpt-4o'),
+    model: openai('gpt-5'),
     prompt: 'Write a short poem about the ocean.',
-    // Per-chunk timeout: abort if no chunk is received for 5 seconds
-    // This is useful for detecting stalled streams where the connection
-    // is open but no data is flowing.
-    timeout: { chunkMs: 5000 },
+    timeout: { chunkMs: 5 },
   });
 
   printFullStream({ result });

--- a/examples/ai-core/src/stream-text/openai-timeout-chunk.ts
+++ b/examples/ai-core/src/stream-text/openai-timeout-chunk.ts
@@ -6,9 +6,9 @@ import { print } from '../lib/print';
 
 run(async () => {
   const result = streamText({
-    model: openai('gpt-5'),
+    model: openai('gpt-4o'),
     prompt: 'Write a short poem about the ocean.',
-    timeout: { chunkMs: 5 },
+    timeout: { chunkMs: 500 },
   });
 
   printFullStream({ result });

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -10365,6 +10365,155 @@ describe('streamText', () => {
 
       expect(receivedAbortSignal).toBeDefined();
     });
+
+    it('should forward chunkMs as abort signal to model', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+
+      const result = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: { chunkMs: 5000 },
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      expect(receivedAbortSignal).toBeDefined();
+    });
+
+    it('should complete successfully when chunks arrive within chunkMs timeout', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+
+      const result = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello' },
+                { type: 'text-delta', id: '1', delta: ' World' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: { chunkMs: 5000 }, // generous chunk timeout
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      // Stream should complete successfully without abort
+      expect(receivedAbortSignal?.aborted).toBeFalsy();
+    });
+
+    it('should abort when chunk timeout expires', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+      const delayedPromise = new DelayedPromise<void>();
+
+      const result = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: new ReadableStream({
+                async start(controller) {
+                  // Send first chunk immediately
+                  controller.enqueue({ type: 'text-start', id: '1' });
+                  controller.enqueue({
+                    type: 'text-delta',
+                    id: '1',
+                    delta: 'Hello',
+                  });
+
+                  // Wait for the stream to stall (will be resolved after timeout fires)
+                  await delayedPromise.promise;
+
+                  controller.enqueue({ type: 'text-end', id: '1' });
+                  controller.enqueue({
+                    type: 'finish',
+                    finishReason: { unified: 'stop', raw: 'stop' },
+                    usage: testUsage,
+                  });
+                  controller.close();
+                },
+              }),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: { chunkMs: 50 }, // 50ms chunk timeout
+        onError: () => {},
+      });
+
+      // Start consuming the stream (won't complete until delayedPromise resolves)
+      const consumePromise = result.consumeStream();
+
+      // Advance time past the chunk timeout
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Resolve the delayed promise to allow the stream to finish
+      delayedPromise.resolve(undefined);
+
+      await consumePromise;
+
+      // The abort signal should have been triggered due to chunk timeout
+      expect(receivedAbortSignal?.aborted).toBe(true);
+    });
+
+    it('should support chunkMs alongside totalMs and stepMs', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+
+      const result = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: { totalMs: 30000, stepMs: 10000, chunkMs: 5000 },
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      expect(receivedAbortSignal).toBeDefined();
+    });
   });
 
   describe('telemetry', () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1463,7 +1463,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
               new TransformStream<
                 SingleRequestTextStreamPart<TOOLS>,
                 TextStreamPart<TOOLS>
-              >              ({
+              >({
                 async transform(chunk, controller): Promise<void> {
                   if (chunk.type === 'stream-start') {
                     warnings = chunk.warnings;

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -19,6 +19,7 @@ import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
 import {
   CallSettings,
+  getChunkTimeoutMs,
   getStepTimeoutMs,
   getTotalTimeoutMs,
 } from '../prompt/call-settings';
@@ -433,8 +434,11 @@ Internal. For test use only. May change without notice.
   }): StreamTextResult<TOOLS, OUTPUT> {
   const totalTimeoutMs = getTotalTimeoutMs(timeout);
   const stepTimeoutMs = getStepTimeoutMs(timeout);
+  const chunkTimeoutMs = getChunkTimeoutMs(timeout);
   const stepAbortController =
     stepTimeoutMs != null ? new AbortController() : undefined;
+  const chunkAbortController =
+    chunkTimeoutMs != null ? new AbortController() : undefined;
   return new DefaultStreamTextResult<TOOLS, OUTPUT>({
     model: resolveLanguageModel(model),
     telemetry,
@@ -445,9 +449,12 @@ Internal. For test use only. May change without notice.
       abortSignal,
       totalTimeoutMs != null ? AbortSignal.timeout(totalTimeoutMs) : undefined,
       stepAbortController?.signal,
+      chunkAbortController?.signal,
     ),
     stepTimeoutMs,
     stepAbortController,
+    chunkTimeoutMs,
+    chunkAbortController,
     system,
     prompt,
     messages,
@@ -616,6 +623,8 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
     abortSignal,
     stepTimeoutMs,
     stepAbortController,
+    chunkTimeoutMs,
+    chunkAbortController,
     system,
     prompt,
     messages,
@@ -647,6 +656,8 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
     abortSignal: AbortSignal | undefined;
     stepTimeoutMs: number | undefined;
     stepAbortController: AbortController | undefined;
+    chunkTimeoutMs: number | undefined;
+    chunkAbortController: AbortController | undefined;
     system: Prompt['system'];
     prompt: Prompt['prompt'];
     messages: Prompt['messages'];
@@ -1283,6 +1294,29 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
               ? setTimeout(() => stepAbortController!.abort(), stepTimeoutMs)
               : undefined;
 
+          // Set up chunk timeout tracking (will be reset on each chunk)
+          let chunkTimeoutId: ReturnType<typeof setTimeout> | undefined =
+            undefined;
+
+          function resetChunkTimeout() {
+            if (chunkTimeoutMs != null) {
+              if (chunkTimeoutId != null) {
+                clearTimeout(chunkTimeoutId);
+              }
+              chunkTimeoutId = setTimeout(
+                () => chunkAbortController!.abort(),
+                chunkTimeoutMs,
+              );
+            }
+          }
+
+          function clearChunkTimeout() {
+            if (chunkTimeoutId != null) {
+              clearTimeout(chunkTimeoutId);
+              chunkTimeoutId = undefined;
+            }
+          }
+
           stepFinish = new DelayedPromise<void>();
 
           const stepInputMessages = [...initialMessages, ...responseMessages];
@@ -1429,12 +1463,15 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
               new TransformStream<
                 SingleRequestTextStreamPart<TOOLS>,
                 TextStreamPart<TOOLS>
-              >({
+              >              ({
                 async transform(chunk, controller): Promise<void> {
                   if (chunk.type === 'stream-start') {
                     warnings = chunk.warnings;
                     return; // stream start chunks are sent immediately and do not count as first chunk
                   }
+
+                  // Reset chunk timeout on each received chunk
+                  resetChunkTimeout();
 
                   if (stepFirstChunk) {
                     // Telemetry for first chunk:
@@ -1731,10 +1768,11 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                     }
                   }
 
-                  // Clear the step timeout before the next step is started
+                  // Clear the step and chunk timeouts before the next step is started
                   if (stepTimeoutId != null) {
                     clearTimeout(stepTimeoutId);
                   }
+                  clearChunkTimeout();
 
                   if (
                     // Continue if:

--- a/packages/ai/src/prompt/call-settings.ts
+++ b/packages/ai/src/prompt/call-settings.ts
@@ -3,10 +3,11 @@ Timeout configuration for API calls. Can be specified as:
 - A number representing milliseconds
 - An object with `totalMs` property for the total timeout in milliseconds
 - An object with `stepMs` property for the timeout of each step in milliseconds
+- An object with `chunkMs` property for the timeout between stream chunks (streaming only)
  */
 export type TimeoutConfiguration =
   | number
-  | { totalMs?: number; stepMs?: number };
+  | { totalMs?: number; stepMs?: number; chunkMs?: number };
 
 /**
 Extracts the total timeout value in milliseconds from a TimeoutConfiguration.
@@ -39,6 +40,22 @@ export function getStepTimeoutMs(
     return undefined;
   }
   return timeout.stepMs;
+}
+
+/**
+Extracts the chunk timeout value in milliseconds from a TimeoutConfiguration.
+This timeout is for streaming only - it aborts if no new chunk is received within the specified duration.
+
+@param timeout - The timeout configuration.
+@returns The chunk timeout in milliseconds, or undefined if no chunk timeout is configured.
+ */
+export function getChunkTimeoutMs(
+  timeout: TimeoutConfiguration | undefined,
+): number | undefined {
+  if (timeout == null || typeof timeout === 'number') {
+    return undefined;
+  }
+  return timeout.chunkMs;
 }
 
 export type CallSettings = {

--- a/packages/ai/src/prompt/index.ts
+++ b/packages/ai/src/prompt/index.ts
@@ -1,5 +1,4 @@
 export type { CallSettings, TimeoutConfiguration } from './call-settings';
-export { getStepTimeoutMs, getTotalTimeoutMs } from './call-settings';
 export {
   assistantModelMessageSchema,
   modelMessageSchema,


### PR DESCRIPTION
## Background

In some cases streams can hang and you may want to timeout earlier than waiting for the full step or total timeout.

## Summary

Add `chunkMs` option to `TimeoutConfiguration` (streaming only).

## Manual Verification

- [x] run `examples/ai-core/src/stream-text/openai-timeout-chunk.ts`

## Related Issues

Resolves #11576