### PR TITLE
fix(provider/xai): handle error responses returned with 200 status

### DIFF
--- a/.changeset/purple-pets-admire.md
+++ b/.changeset/purple-pets-admire.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(provider/xai): handle error responses returned with 200 status

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -1772,4 +1772,34 @@ describe('doStream with raw chunks', () => {
       ]
     `);
   });
+
+  describe('error handling', () => {
+    it('should throw APICallError when xai returns error with 200 status (doGenerate)', async () => {
+      server.urls['https://api.x.ai/v1/chat/completions'].response = {
+        type: 'json-value',
+        body: {
+          code: 'The service is currently unavailable',
+          error: 'Timed out waiting for first token',
+        },
+      };
+
+      await expect(model.doGenerate({ prompt: TEST_PROMPT })).rejects.toThrow(
+        'Timed out waiting for first token',
+      );
+    });
+
+    it('should throw APICallError when xai returns error with 200 status (doStream)', async () => {
+      server.urls['https://api.x.ai/v1/chat/completions'].response = {
+        type: 'json-value',
+        body: {
+          code: 'The service is currently unavailable',
+          error: 'Timed out waiting for first token',
+        },
+      };
+
+      await expect(model.doStream({ prompt: TEST_PROMPT })).rejects.toThrow(
+        'Timed out waiting for first token',
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Background

xai api sometimes returns error responses with http 200 status code instead of proper error status codes. for example, when the service is overloaded:

```json
{"code":"The service is currently unavailable","error":"Timed out waiting for first token"}
```

this caused confusing "Type validation failed" or "Invalid JSON response" errors instead of showing the actual error message to users

## Summary

- detect error responses in both doGenerate and doStream
- throw APICallError with actual error message
- mark as retryable when service is unavailable

## Verification

added test cases for both generate and stream error scenarios. tested against live api

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues
Fixes #10533
