### PR TITLE
fix(provider/xai): send reasoning-end before text-start in streaming

### DIFF
--- a/.changeset/little-singers-do.md
+++ b/.changeset/little-singers-do.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(provider/xai): send reasoning-end before text-start in streaming

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -1459,6 +1459,10 @@ describe('XaiChatLanguageModel', () => {
             "type": "reasoning-delta",
           },
           {
+            "id": "reasoning-b7f32e89-8d6c-4a1e-9f5b-2c8e7a9d4f6b",
+            "type": "reasoning-end",
+          },
+          {
             "id": "text-b7f32e89-8d6c-4a1e-9f5b-2c8e7a9d4f6b",
             "type": "text-start",
           },
@@ -1466,10 +1470,6 @@ describe('XaiChatLanguageModel', () => {
             "delta": "The answer is 303.",
             "id": "text-b7f32e89-8d6c-4a1e-9f5b-2c8e7a9d4f6b",
             "type": "text-delta",
-          },
-          {
-            "id": "reasoning-b7f32e89-8d6c-4a1e-9f5b-2c8e7a9d4f6b",
-            "type": "reasoning-end",
           },
           {
             "id": "text-b7f32e89-8d6c-4a1e-9f5b-2c8e7a9d4f6b",
@@ -1567,6 +1567,10 @@ describe('XaiChatLanguageModel', () => {
             "type": "reasoning-delta",
           },
           {
+            "id": "reasoning-grok-4-test",
+            "type": "reasoning-end",
+          },
+          {
             "id": "text-grok-4-test",
             "type": "text-start",
           },
@@ -1574,10 +1578,6 @@ describe('XaiChatLanguageModel', () => {
             "delta": "The answer is 42.",
             "id": "text-grok-4-test",
             "type": "text-delta",
-          },
-          {
-            "id": "reasoning-grok-4-test",
-            "type": "reasoning-end",
           },
           {
             "id": "text-grok-4-test",


### PR DESCRIPTION
## Background

xai provider was sending `reasoning-end` and `text-end` events in `flush()` at stream end, rather than when content blocks actually finished. this caused issues for UI rendering that needed to know when reasoning completed before text started, and caused duplicate event errors when using middleware to track reasoning timing

## Summary

- send `reasoning-end` when text or tool calls start, not at stream end
- track ended blocks to prevent duplicate end events

## Verification

tested with live xai api - event order now correctly shows:

```
reasoning-start
[reasoning deltas...]
reasoning-end      ← now sent when text starts
text-start
[text deltas...]
text-end
finish
```

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #7076