### PR TITLE
feat(fal): add support for multiple image urls as input

### DIFF
--- a/.changeset/fast-pandas-suffer.md
+++ b/.changeset/fast-pandas-suffer.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fal': patch
+---
+
+feat(fal): add support for multiple image urls as input

--- a/examples/ai-core/src/generate-image/fal-flux2-edit.ts
+++ b/examples/ai-core/src/generate-image/fal-flux2-edit.ts
@@ -1,0 +1,23 @@
+import { fal } from '@ai-sdk/fal';
+import { generateImage } from 'ai';
+import { presentImages } from '../lib/present-image';
+import { run } from '../lib/run';
+
+run(async () => {
+  const { images } = await generateImage({
+    model: fal.image('fal-ai/flux-2/edit'),
+    prompt: {
+      text: 'Change his clothes to a tuxedo in the first image, and add the flour packet from the second image to the flour bag in the first image',
+      images: [
+        'https://storage.googleapis.com/falserverless/example_inputs/flux2_dev_edit_input.png',
+        'https://v3.fal.media/files/rabbit/rmgBxhwGYb2d3pl3x9sKf_output.png',
+      ],
+    },
+    providerOptions: {
+      fal: {
+        useMultipleImages: true,
+      },
+    },
+  });
+  await presentImages(images);
+});

--- a/packages/fal/src/fal-image-options.ts
+++ b/packages/fal/src/fal-image-options.ts
@@ -26,9 +26,7 @@ export const falImageProviderOptionsSchema = lazySchema(() =>
           .or(z.number().min(1).max(6))
           .nullish(),
         /**
-         * When true, converts multiple input images to `image_urls` array
-         * instead of `image_url` string. Use this for models like
-         * `fal-ai/flux-2/edit` that support multiple input images.
+         * When true, converts multiple input images to `image_urls` array instead of `image_url` string. 
          */
         useMultipleImages: z.boolean().nullish(),
 

--- a/packages/fal/src/fal-image-options.ts
+++ b/packages/fal/src/fal-image-options.ts
@@ -26,7 +26,7 @@ export const falImageProviderOptionsSchema = lazySchema(() =>
           .or(z.number().min(1).max(6))
           .nullish(),
         /**
-         * When true, converts multiple input images to `image_urls` array instead of `image_url` string. 
+         * When true, converts multiple input images to `image_urls` array instead of `image_url` string.
          */
         useMultipleImages: z.boolean().nullish(),
 

--- a/packages/fal/src/fal-image-options.ts
+++ b/packages/fal/src/fal-image-options.ts
@@ -25,6 +25,12 @@ export const falImageProviderOptionsSchema = lazySchema(() =>
           .enum(['1', '2', '3', '4', '5', '6'])
           .or(z.number().min(1).max(6))
           .nullish(),
+        /**
+         * When true, converts multiple input images to `image_urls` array
+         * instead of `image_url` string. Use this for models like
+         * `fal-ai/flux-2/edit` that support multiple input images.
+         */
+        useMultipleImages: z.boolean().nullish(),
 
         // Deprecated snake_case versions
         image_url: z.string().nullish(),
@@ -74,6 +80,12 @@ export const falImageProviderOptionsSchema = lazySchema(() =>
         if (data.acceleration !== undefined && data.acceleration !== null) {
           result.acceleration = data.acceleration;
         }
+        if (
+          data.useMultipleImages !== undefined &&
+          data.useMultipleImages !== null
+        ) {
+          result.useMultipleImages = data.useMultipleImages;
+        }
 
         for (const [key, value] of Object.entries(data)) {
           if (
@@ -89,6 +101,7 @@ export const falImageProviderOptionsSchema = lazySchema(() =>
               'strength',
               'acceleration',
               'safetyTolerance',
+              'useMultipleImages',
               // snake_case known keys
               'image_url',
               'mask_url',


### PR DESCRIPTION
## Background

Fal.ai's api supported multiple image support for image editing

#11593 

## Summary

instead of using the first file as the primary image, we now have a array that will allow for multiple image url input for fal

## Manual Verification

added `examples/ai-core/src/generate-image/fal-flux2-edit.ts`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11593 