### PR TITLE
fix(ai): pass providerMetadata in smooth stream

### DIFF
--- a/.changeset/chilly-oranges-act.md
+++ b/.changeset/chilly-oranges-act.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): pass providerMetadata in smooth stream to preserve thinking tag

--- a/packages/ai/src/generate-text/smooth-stream.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test.ts
@@ -1509,6 +1509,78 @@ describe('smoothStream', () => {
     });
   });
 
+  describe('providerMetadata preservation', () => {
+    it('should preserve providerMetadata on reasoning-delta chunks (signature for Anthropic thinking)', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'reasoning-start', id: '1' },
+        { text: 'I am', type: 'reasoning-delta', id: '1' },
+        { text: ' thinking...', type: 'reasoning-delta', id: '1' },
+        // Signature comes as an empty delta with providerMetadata
+        {
+          text: '',
+          type: 'reasoning-delta',
+          id: '1',
+          providerMetadata: {
+            anthropic: { signature: 'sig_abc123' },
+          },
+        },
+        { type: 'reasoning-end', id: '1' },
+        { type: 'text-start', id: '2' },
+        { text: 'Hello!', type: 'text-delta', id: '2' },
+        { type: 'text-end', id: '2' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      // Find the last reasoning-delta chunk (flushed before reasoning-end)
+      // It should contain the providerMetadata with the signature
+      const reasoningDeltas = events.filter(
+        (e: any) => e.type === 'reasoning-delta',
+      );
+      const lastReasoningDelta = reasoningDeltas[reasoningDeltas.length - 1];
+
+      expect(lastReasoningDelta).toHaveProperty('providerMetadata');
+      expect(lastReasoningDelta.providerMetadata).toEqual({
+        anthropic: { signature: 'sig_abc123' },
+      });
+    });
+
+    it('should preserve providerMetadata on reasoning-start for redacted thinking', async () => {
+      // Redacted thinking blocks have providerMetadata on reasoning-start
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        {
+          type: 'reasoning-start',
+          id: '1',
+          providerMetadata: {
+            anthropic: { redactedData: 'redacted-thinking-data' },
+          },
+        },
+        { type: 'reasoning-end', id: '1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      // reasoning-start should pass through unchanged with providerMetadata
+      const reasoningStart = events.find(
+        (e: any) => e.type === 'reasoning-start',
+      );
+      expect(reasoningStart).toHaveProperty('providerMetadata');
+      expect(reasoningStart.providerMetadata).toEqual({
+        anthropic: { redactedData: 'redacted-thinking-data' },
+      });
+    });
+  });
+
   describe('Intl.Segmenter chunking', () => {
     it('should segment English text using Intl.Segmenter', async () => {
       const segmenter = new Intl.Segmenter('en', { granularity: 'word' });

--- a/packages/ai/src/generate-text/smooth-stream.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test.ts
@@ -1515,7 +1515,7 @@ describe('smoothStream', () => {
         { type: 'reasoning-start', id: '1' },
         { text: 'I am', type: 'reasoning-delta', id: '1' },
         { text: ' thinking...', type: 'reasoning-delta', id: '1' },
-        // Signature comes as an empty delta with providerMetadata
+        // signature as an empty delta with providerMetadata
         {
           text: '',
           type: 'reasoning-delta',
@@ -1537,8 +1537,7 @@ describe('smoothStream', () => {
 
       await consumeStream(stream);
 
-      // Find the last reasoning-delta chunk (flushed before reasoning-end)
-      // It should contain the providerMetadata with the signature
+      // Find the last reasoning-delta chunk
       const reasoningDeltas = events.filter(
         (e: any) => e.type === 'reasoning-delta',
       );
@@ -1551,7 +1550,6 @@ describe('smoothStream', () => {
     });
 
     it('should preserve providerMetadata on reasoning-start for redacted thinking', async () => {
-      // Redacted thinking blocks have providerMetadata on reasoning-start
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         {
           type: 'reasoning-start',


### PR DESCRIPTION
## Background

when using anthropic's extended thinking with tool calls, we drop the thinking blocks from previous turns.

#11602 

based on the reproduction provided, the issue turned out to be in smoothStream, where smoothStream was stripping providerMetadata from reasoning-delta chunks. this signature is required when sending thinking blocks back to the API in subsequent turns

## Summary

pass `providerMetadata` through smoothStream

## Manual Verification

the reproduction code [given here](https://gist.github.com/p3droml/503c5d4888182a75222377109bfdd291) was run before and after the fix, and was resolved

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11602 and #11689