### PR TITLE
fix(anthropic): add application/pdf type regex matching

### DIFF
--- a/.changeset/chilled-experts-joke.md
+++ b/.changeset/chilled-experts-joke.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): add application/json type regex matching

--- a/packages/anthropic/src/anthropic-provider.test.ts
+++ b/packages/anthropic/src/anthropic-provider.test.ts
@@ -139,7 +139,9 @@ describe('anthropic provider - supportedUrls', () => {
     const supportedUrls = await model.supportedUrls;
 
     expect(supportedUrls['image/*']).toBeDefined();
-    expect(supportedUrls['image/*']![0]!.test('https://example.com/image.png')).toBe(true);
+    expect(
+      supportedUrls['image/*']![0]!.test('https://example.com/image.png'),
+    ).toBe(true);
   });
 
   it('should support application/pdf URLs', async () => {
@@ -151,6 +153,10 @@ describe('anthropic provider - supportedUrls', () => {
     const supportedUrls = await model.supportedUrls;
 
     expect(supportedUrls['application/pdf']).toBeDefined();
-    expect(supportedUrls['application/pdf']![0]!.test('https://arxiv.org/pdf/2401.00001')).toBe(true);
+    expect(
+      supportedUrls['application/pdf']![0]!.test(
+        'https://arxiv.org/pdf/2401.00001',
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/anthropic/src/anthropic-provider.test.ts
+++ b/packages/anthropic/src/anthropic-provider.test.ts
@@ -128,3 +128,29 @@ describe('anthropic provider - custom provider name', () => {
     expect(model.provider).toBe('anthropic.messages');
   });
 });
+
+describe('anthropic provider - supportedUrls', () => {
+  it('should support image/* URLs', async () => {
+    const provider = createAnthropic({
+      apiKey: 'test-api-key',
+    });
+
+    const model = provider('claude-3-haiku-20240307');
+    const supportedUrls = await model.supportedUrls;
+
+    expect(supportedUrls['image/*']).toBeDefined();
+    expect(supportedUrls['image/*']![0]!.test('https://example.com/image.png')).toBe(true);
+  });
+
+  it('should support application/pdf URLs', async () => {
+    const provider = createAnthropic({
+      apiKey: 'test-api-key',
+    });
+
+    const model = provider('claude-3-haiku-20240307');
+    const supportedUrls = await model.supportedUrls;
+
+    expect(supportedUrls['application/pdf']).toBeDefined();
+    expect(supportedUrls['application/pdf']![0]!.test('https://arxiv.org/pdf/2401.00001')).toBe(true);
+  });
+});

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -114,6 +114,7 @@ export function createAnthropic(
       generateId: options.generateId ?? generateId,
       supportedUrls: () => ({
         'image/*': [/^https?:\/\/.*$/],
+        'application/pdf': [/^https?:\/\/.*$/],
       }),
     });
 


### PR DESCRIPTION
## Background

Reported in #11685, the `supportedUrls` config was missing regex matching for application/pdf type, which in turn led to the SDK downloading the PDF's first.

This wasn't needed for anthropic provider since it directly supported reading pdfs from URL.

But before this fix, if the connection while downloading the pdf was a little flaky, it would lead to a socket timeout error.

## Summary

add the regex url pattern for `application/pdf` type

## Manual Verification

manual verification was a little erratic since running the repro code given by the user only sometimes gave the error. 
but there was still a feature gap

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11685 