### PR TITLE
Update default to ai gateway

### DIFF
--- a/examples/ai-core/src/e2e/gateway.test.ts
+++ b/examples/ai-core/src/e2e/gateway.test.ts
@@ -9,7 +9,7 @@ const createChatModel = (modelId: string) =>
   createLanguageModelWithCapabilities(provider.languageModel(modelId));
 
 createFeatureTestSuite({
-  name: 'Gateway',
+  name: 'AI Gateway',
   models: {
     languageModels: [createChatModel('xai/grok-3-beta')],
   },


### PR DESCRIPTION
## Background

This change addresses a user request to update instances of "Gateway" to "AI Gateway" for branding consistency. While the primary request for the documentation UI (code selector tabs) is handled in the `vercel/front` repository, an internal test suite in this repository also used "Gateway" and has been updated for alignment.

## Summary

Updated the `createFeatureTestSuite` name from `'Gateway'` to `'AI Gateway'` in `examples/ai-core/src/e2e/gateway.test.ts` to ensure consistent branding.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

The main documentation UI change (updating "Gateway" to "AI Gateway" in code selector tabs) needs to be implemented in the `vercel/front` repository, as it controls the rendering of these elements.

---
[Slack Thread](https://vercel.slack.com/archives/C099VQB75TP/p1767998322767859?thread_ts=1767998322.767859&cid=C099VQB75TP)

<a href="https://cursor.com/background-agent?bcId=bc-29e8f25c-d52e-464e-9d7e-84a8388033a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29e8f25c-d52e-464e-9d7e-84a8388033a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

