### PR TITLE
feat(anthropic): add a more flexible util for extracting container details from prev. steps.

### DIFF
--- a/.changeset/anthropic-container-expiry.md
+++ b/.changeset/anthropic-container-expiry.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Add `extractAnthropicContainerReuseDetails` function to retrieve container ID and expiry time from previous steps. This allows users to check container expiration before deciding to reuse it in programmatic tool calling workflows.

--- a/packages/anthropic/src/forward-anthropic-container-id-from-last-step.ts
+++ b/packages/anthropic/src/forward-anthropic-container-id-from-last-step.ts
@@ -2,6 +2,55 @@ import { JSONObject } from '@ai-sdk/provider';
 import { AnthropicMessageMetadata } from './anthropic-message-metadata';
 
 /**
+ * Container information from a previous step.
+ */
+export interface AnthropicContainerReuseDetails {
+  /**
+   * Identifier for the container.
+   */
+  id: string;
+
+  /**
+   * The time at which the container will expire (RFC3339 timestamp).
+   */
+  expiresAt: string;
+}
+
+/**
+ * Extracts details relevant for reusing anthropic's containerized environment.
+ *
+ * Searches backwards through steps to find details about most recently
+ * used container environment.
+ *
+ * @returns The container id and expiresAt if found, undefined otherwise.
+ */
+export function extractAnthropicContainerReuseDetails({
+  steps,
+}: {
+  steps: Array<{
+    providerMetadata?: Record<string, JSONObject>;
+  }>;
+}): AnthropicContainerReuseDetails | undefined {
+  // Search backwards through steps to find the most recent container
+  for (let i = steps.length - 1; i >= 0; i--) {
+    const container = (
+      steps[i].providerMetadata?.anthropic as unknown as
+        | AnthropicMessageMetadata
+        | undefined
+    )?.container;
+
+    if (container) {
+      return {
+        id: container.id,
+        expiresAt: container.expiresAt,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+/**
  * Sets the Anthropic container ID in the provider options based on
  * any previous step's provider metadata.
  *
@@ -18,7 +67,7 @@ export function forwardAnthropicContainerIdFromLastStep({
   // Search backwards through steps to find the most recent container ID
   for (let i = steps.length - 1; i >= 0; i--) {
     const containerId = (
-      steps[i].providerMetadata?.anthropic as
+      steps[i].providerMetadata?.anthropic as unknown as
         | AnthropicMessageMetadata
         | undefined
     )?.container?.id;

--- a/packages/anthropic/src/index.ts
+++ b/packages/anthropic/src/index.ts
@@ -6,5 +6,9 @@ export type {
   AnthropicProvider,
   AnthropicProviderSettings,
 } from './anthropic-provider';
-export { forwardAnthropicContainerIdFromLastStep } from './forward-anthropic-container-id-from-last-step';
+export {
+  forwardAnthropicContainerIdFromLastStep,
+  extractAnthropicContainerReuseDetails,
+} from './forward-anthropic-container-id-from-last-step';
+export type { AnthropicContainerReuseDetails } from './forward-anthropic-container-id-from-last-step';
 export { VERSION } from './version';


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

When using Anthropic's code execution tool or programmatic tool calling, anthropic provides `containerId` in response metadata, which can be used to maintain state across requests. The SDK currently provides `forwardAnthropicContainerIdFromLastStep` to forward container IDs between steps, but this function has few limitations:

1. **Rigid design**: The function returns a pre-structured `providerOptions` object, making it **difficult to use outside** of the `prepareStep` callback or combine with other provider options.

2. **No expiration awareness**: Anthropic purges container after `expires_at` timestamp. The existing function forwards the container ID without a check. Passing expired `container.id` results in `container_expired` errors on subsequent `code_execution` tool calls ([error reference](https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool#errors)). If `now` has passed `expires_at`, the caller shouldn't pass `container.id`, anthropic would just spawn a new container and attach the `id` in response metadata, since it would result in a futile error.

3. **Manual workarounds required**: To restore a container ID across streams or check expiration, users must:
   - Deconstruct the `providerOptions` object returned by `forwardAnthropicContainerIdFromLastStep` to extract the container ID
   - Manually search backwards through steps to find the `expiresAt` timestamp
   - This significantly reduces the utility of the existing function

## Summary

Adds a new function `extractAnthropicContainerReuseDetails` that searches backwards through steps and returns both the container `id` and `expiresAt` timestamp. This provides users with the information needed to make informed decisions about container reuse.

**New exports from `@ai-sdk/anthropic`:**
- `extractAnthropicContainerReuseDetails({ steps })` - Returns `{ id, expiresAt }` or `undefined`
- `AnthropicContainerInfo` type - Interface for the returned container details

**Example usage:**

```typescript
// Cache container-id for reuse across stream sessions, enabling continued appends to created files in the container env.

import {
  extractAnthropicContainerReuseDetails,
  forwardAnthropicContainerIdFromLastStep,
} from '@ai-sdk/anthropic';

     result.steps.then(async (steps) => {
        const containerDetails = extractAnthropicContainerReuseDetails({ steps });
        
        if (containerDetails !== undefined) {
          const latestContainerId = containerDetails.id;
          const expiresAt = containerDetails.expiresAt;
          const now = new Date();
          await redisClient?.set(`container:${fooId}`, latestContainerId, {
            EX: (expiresAt.getTime() - now.getTime())/1000 
          });
        }
      });
   // During next stream
   const redisClient = await getRedis();
   const prevContainerId = await redisClient?.get(`container:${fooId}`);
   .......
   return streamText({
    model: anthropic(modelId),
    providerOptions: {
      anthropic: {
        thinking: { type: "enabled", budgetTokens: 10240 },
        container: {
          skills: ...,
          ...(prevContainerId ? { id: prevContainerId } : {}),
        },
      } satisfies AnthropicProviderOptions,
    },
    .....
```
This approach gives users full flexibility over:
- Whether to reuse a container based on expiration
- How to structure their providerOptions response
- Container ID restoration across streams without deconstruction

## Manual Verification

Verified TypeScript compilation passes with `npx tsc --noEmit`.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)


Related to Anthropic's container lifecycle documentation:
https://platform.claude.com/docs/en/agents-and-tools/tool-use/programmatic-tool-calling#container-lifecycle
https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool#reusing-containers