### PR TITLE
feat: add `prepareSendMessagesRequest` to direct transport

### DIFF
--- a/.changeset/tall-apes-end.md
+++ b/.changeset/tall-apes-end.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Customize messages for transport with `new DirectChatTransport({ agent, prepareSendMessagesRequest: (...) => ... })`.

--- a/content/docs/07-reference/02-ai-sdk-ui/50-direct-chat-transport.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/50-direct-chat-transport.mdx
@@ -57,6 +57,62 @@ export default function Chat() {
         'Options to pass to the agent when calling it. These are agent-specific options defined when creating the agent.',
     },
     {
+      name: 'prepareSendMessagesRequest',
+      type: 'DirectPrepareSendMessagesRequest',
+      isOptional: true,
+      description:
+        'A function to customize the request before calling the agent. Can modify messages or agent options based on context.',
+      properties: [
+        {
+          type: 'DirectPrepareSendMessagesRequest',
+          parameters: [
+            {
+              name: 'options',
+              type: 'DirectPrepareSendMessagesRequestOptions',
+              description: 'Options for preparing the request',
+              properties: [
+                {
+                  type: 'DirectPrepareSendMessagesRequestOptions',
+                  parameters: [
+                    {
+                      name: 'id',
+                      type: 'string',
+                      description: 'The chat ID',
+                    },
+                    {
+                      name: 'messages',
+                      type: 'UIMessage[]',
+                      description: 'Current messages in the chat',
+                    },
+                    {
+                      name: 'requestMetadata',
+                      type: 'unknown',
+                      description: 'The request metadata',
+                    },
+                    {
+                      name: 'agentOptions',
+                      type: 'CALL_OPTIONS | undefined',
+                      description: 'The current agent options',
+                    },
+                    {
+                      name: 'trigger',
+                      type: "'submit-message' | 'regenerate-message'",
+                      description: 'The trigger for the request',
+                    },
+                    {
+                      name: 'messageId',
+                      type: 'string | undefined',
+                      description: 'The message ID if applicable',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
       name: 'originalMessages',
       type: 'UIMessage[]',
       isOptional: true,
@@ -175,7 +231,7 @@ const stream = await transport.sendMessages({
       name: 'metadata',
       type: 'unknown',
       isOptional: true,
-      description: 'Custom metadata (ignored by DirectChatTransport).',
+      description: 'Custom metadata passed to `prepareSendMessagesRequest` as `requestMetadata`.',
     },
   ]}
 />
@@ -329,5 +385,45 @@ export default function Chat() {
       ))}
     </div>
   );
+}
+```
+
+### With Request Preparation
+
+Use `prepareSendMessagesRequest` to customize messages or agent options before each request:
+
+```tsx
+import { useChat } from '@ai-sdk/react';
+import { DirectChatTransport, ToolLoopAgent } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const agent = new ToolLoopAgent<{ userId: string }>({
+  model: openai('gpt-4o'),
+  prepareCall: ({ options, ...rest }) => ({
+    ...rest,
+    providerOptions: {
+      openai: { user: options.userId },
+    },
+  }),
+});
+
+export default function Chat({ userId }: { userId: string }) {
+  const { messages, sendMessage } = useChat({
+    transport: new DirectChatTransport({
+      agent,
+      prepareSendMessagesRequest: ({ messages, trigger }) => {
+        // Only send the last 10 messages to reduce context
+        const recentMessages = messages.slice(-10);
+
+        // Dynamically set agent options based on context
+        return {
+          messages: recentMessages,
+          agentOptions: { userId },
+        };
+      },
+    }),
+  });
+
+  // ... render chat UI
 }
 ```

--- a/packages/ai/src/ui/direct-chat-transport.ts
+++ b/packages/ai/src/ui/direct-chat-transport.ts
@@ -154,7 +154,7 @@ export class DirectChatTransport<
     const streamOptions = {
       prompt: modelMessages,
       abortSignal,
-      ...(finalAgentOptions && { options: finalAgentOptions }),
+      ...(finalAgentOptions !== undefined ? { options: finalAgentOptions } : {}),
     };
 
     const result = await this.agent.stream(streamOptions);

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -21,6 +21,7 @@ export { DefaultChatTransport } from './default-chat-transport';
 export {
   DirectChatTransport,
   type DirectChatTransportOptions,
+  type DirectPrepareSendMessagesRequest,
 } from './direct-chat-transport';
 export {
   HttpChatTransport,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Allows us to customize what messages are sent to model analogous to `DefaultChatTransport`.

## Summary

Added `prepareSendMessagesRequest` to `DirectChatTransport`.

## Manual Verification

Added tests in `packages/ai/src/ui/direct-chat-transport.test.ts`.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
