### PR TITLE
fix(ai): do not cleanup AsyncIterableStream twice

### DIFF
--- a/.changeset/swift-students-fail.md
+++ b/.changeset/swift-students-fail.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): do not cleanup AsyncIterableStream twice

--- a/packages/ai/src/util/async-iterable-stream.test.ts
+++ b/packages/ai/src/util/async-iterable-stream.test.ts
@@ -206,4 +206,36 @@ describe('createAsyncIterableStream()', () => {
 
     expect(collected).toEqual([]);
   });
+
+  it('should not throw when return is called after the stream completed', async () => {
+    const input = ['chunk1', 'chunk2', 'chunk3'];
+    const source = convertArrayToReadableStream(input);
+
+    const asyncIterableStream = createAsyncIterableStream(source);
+
+    const asyncIterator = asyncIterableStream[Symbol.asyncIterator]();
+
+    const output = await (async () => {
+      const output: Array<string> = [];
+
+      while (true) {
+        const value = await asyncIterator.next();
+
+        if (value.done) {
+          break;
+        }
+
+        output.push(value.value);
+      }
+
+      return output;
+    })();
+
+    expect(output).toEqual(input);
+
+    expect(await asyncIterator.return?.()).toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
 });

--- a/packages/ai/src/util/async-iterable-stream.ts
+++ b/packages/ai/src/util/async-iterable-stream.ts
@@ -68,7 +68,7 @@ export function createAsyncIterableStream<T>(
       },
 
       /**
-       * Called on early exit (e.g., break from for-await).
+       * May be called on early exit (e.g., break from for-await) or after completion.
        * Ensures the stream is cancelled and resources are released.
        * @returns A promise resolving to a completed IteratorResult.
        */

--- a/packages/ai/src/util/async-iterable-stream.ts
+++ b/packages/ai/src/util/async-iterable-stream.ts
@@ -33,6 +33,8 @@ export function createAsyncIterableStream<T>(
      * Cleans up the reader by cancelling and releasing the lock.
      */
     async function cleanup(cancelStream: boolean) {
+      if (finished) return;
+
       finished = true;
       try {
         if (cancelStream) {


### PR DESCRIPTION
## Background

Errors are thrown on return when the stream was already cleaned up (see #11715 for details).

## Summary

Not running the clean up if it has already been ran.

## Manual Verification

I manually updated the file in the `node_modules` with the fix I suggested in the PR, and it worked

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11715
