### PR TITLE
fix: protocol docs

### DIFF
--- a/content/docs/04-ai-sdk-ui/50-stream-protocol.mdx
+++ b/content/docs/04-ai-sdk-ui/50-stream-protocol.mdx
@@ -300,7 +300,7 @@ data: {"type":"tool-input-start","toolCallId":"call_fJdQDqnXeGxTmr4E3YPSR7Ar","t
 
 ### Tool Input Delta Part
 
-Incremental chunks of tool input as it's being generated.
+Incremental chunks of tool input as it's being generated. The `inputTextDelta` is a fragment of the JSON-stringified input object.
 
 Format: Server-Sent Event with JSON object
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

## Summary

Clarifies that `inputTextDelta` is a fragment of the JSON-stringified input object in the Tool Input Delta Part section.
Added clarification to the `inputTextDelta` field description in the stream protocol documentation

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
