### PR TITLE
docs(README): add example showing direct provider usage

### DIFF
--- a/.changeset/rich-eggs-promise.md
+++ b/.changeset/rich-eggs-promise.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+docs: update README with usage example for @ai-sdk/anthropic

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -33,6 +33,15 @@ You can also connect to providers directly using their SDK packages:
 npm install @ai-sdk/openai @ai-sdk/anthropic @ai-sdk/google
 ```
 
+```ts
+import { anthropic } from '@ai-sdk/anthropic';
+
+const result = await generateText({
+  model: anthropic('claude-opus-4-5-20250414'), // or openai('gpt-5.2'), google('gemini-3-flash'), etc.
+  prompt: 'Hello!',
+});
+```
+
 ## Usage
 
 ### Generating Text


### PR DESCRIPTION
## Background

README currently shows example using AI Gateway, but not using providers directly

## Summary

Add example using provider packages.

## Manual Verification

[Preview](https://github.com/vercel/ai/blob/update-readme-example/packages/ai/README.md)

## Checklist

- [ ] n/a ~~Tests have been added / updated (for bug fixes / features)~~
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
