### PR TITLE
docs(elevenlabs): update voice argument usage and examples in ElevenLabs provider documentation

### DIFF
--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -75,7 +75,8 @@ The first argument is the model id e.g. `eleven_multilingual_v2`.
 const model = elevenlabs.speech('eleven_multilingual_v2');
 ```
 
-You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying a voice to use for the generated audio.
+The `voice` argument can be set to a voice ID from the [ElevenLabs Voice Library](https://elevenlabs.io/app/voice-library).
+You can find voice IDs by selecting a voice in the library and copying its ID.
 
 ```ts highlight="6"
 import { experimental_generateSpeech as generateSpeech } from 'ai';
@@ -84,7 +85,28 @@ import { elevenlabs } from '@ai-sdk/elevenlabs';
 const result = await generateSpeech({
   model: elevenlabs.speech('eleven_multilingual_v2'),
   text: 'Hello, world!',
-  providerOptions: { elevenlabs: {} },
+  voice: '21m00Tcm4TlvDq8ikWAM', // Rachel voice
+});
+```
+
+You can also pass additional provider-specific options using the `providerOptions` argument:
+
+```ts highlight="7-9"
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { elevenlabs } from '@ai-sdk/elevenlabs';
+
+const result = await generateSpeech({
+  model: elevenlabs.speech('eleven_multilingual_v2'),
+  text: 'Hello, world!',
+  voice: '21m00Tcm4TlvDq8ikWAM',
+  providerOptions: {
+    elevenlabs: {
+      voiceSettings: {
+        stability: 0.5,
+        similarityBoost: 0.75,
+      },
+    },
+  },
 });
 ```
 


### PR DESCRIPTION
The current documentation at [`content/providers/01-ai-sdk-providers/90-elevenlabs.mdx`](content/providers/01-ai-sdk-providers/90-elevenlabs.mdx) shows an example using `generateSpeech` but doesn't demonstrate the `voice` argument. The `voice` parameter is a direct argument to `generateSpeech` (not a provider option) and accepts a voice ID from ElevenLabs.

This pull request modifies the example code block to include the `voice` argument:

```ts
import { experimental_generateSpeech as generateSpeech } from 'ai';
import { elevenlabs } from '@ai-sdk/elevenlabs';

const result = await generateSpeech({
  model: elevenlabs.speech('eleven_multilingual_v2'),
  text: 'Hello, world!',
  voice: '21m00Tcm4TlvDq8ikWAM', // ElevenLabs voice ID
});
```

## FYI

- The default voice ID is `21m00Tcm4TlvDq8ikWAM` (Rachel) per [the provider implementation](https://github.com/vercel/ai/blob/8a6317d6404e600187e5191bba0ef7e8733addd4/packages/elevenlabs/src/elevenlabs-speech-model.ts#L71)
- Voice IDs can be found on the ElevenLabs website in the Voice Library
- The `voice` parameter is optional; when omitted, it uses the default voice

## Future Work

- Rachel is a Legacy voice scheduled for deprecation on February 28, 2026 and will be replaced by the "Janet" voice ([source](https://help.elevenlabs.io/hc/en-us/articles/26928417254801-What-are-Legacy-voices#:~:text=Legacy%20voices%20are%20former%20Default,all%20products%20after%20that%20date.))
- Review documentation for othe providers that use the `generateSpeech` API to make sure they document the `voice` argument