### PR TITLE
feat(openai-compat): add thoughtSignature handling for google models

### DIFF
--- a/.changeset/chilled-pigs-repair.md
+++ b/.changeset/chilled-pigs-repair.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+feat(openai-compat): add thoughtSignature handling for google models

--- a/examples/ai-core/src/generate-text/openai-compatible-google-thought-signatures.ts
+++ b/examples/ai-core/src/generate-text/openai-compatible-google-thought-signatures.ts
@@ -1,0 +1,166 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText, tool, ModelMessage, stepCountIs } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  const googleOpenAI = createOpenAICompatible({
+    baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+    name: 'google',
+    headers: {
+      Authorization: `Bearer ${process.env.GOOGLE_GENERATIVE_AI_API_KEY}`,
+    },
+  });
+
+  const model = googleOpenAI.chatModel('gemini-3-pro-preview');
+
+  const tools = {
+    check_flight: tool({
+      description: 'Gets the current status of a flight',
+      inputSchema: z.object({
+        flight: z.string().describe('The flight number to check'),
+      }),
+      execute: async ({ flight }) => {
+        return {
+          flight,
+          status: 'delayed',
+          departure_time: '12 PM',
+        };
+      },
+    }),
+    book_taxi: tool({
+      description: 'Book a taxi for a specific time',
+      inputSchema: z.object({
+        time: z.string().describe('Time to book the taxi'),
+      }),
+      execute: async ({ time }) => {
+        return {
+          booking_status: 'success',
+          pickup_time: time,
+        };
+      },
+    }),
+  };
+
+  const result1 = await generateText({
+    model,
+    tools,
+    prompt:
+      'Check flight status for AA100 and book a taxi 2 hours before if delayed.',
+    stopWhen: stepCountIs(5),
+    onStepFinish: ({ toolCalls, toolResults }) => {
+      if (toolCalls) {
+        toolCalls.forEach(call => {
+          const sig = call.providerMetadata?.google?.thoughtSignature;
+          console.log(
+            `    Tool call ${call.toolName}: ${
+              sig && typeof sig === 'string'
+                ? 'Signature: ' + sig.substring(0, 50) + '...'
+                : 'No signature'
+            }`,
+          );
+        });
+      }
+
+      if (toolResults) {
+        toolResults.forEach(result => {
+          const sig = result.providerMetadata?.google?.thoughtSignature;
+          console.log(
+            `    Tool result ${result.toolName}: ${
+              sig && typeof sig === 'string'
+                ? 'Signature preserved'
+                : 'No signature'
+            }`,
+          );
+        });
+      }
+    },
+  });
+
+  console.log('\nFinal response:');
+  console.log(result1.text);
+
+  result1.response.messages.forEach((msg, i) => {
+    if (msg.role === 'assistant' && typeof msg.content !== 'string') {
+      console.log(`Message ${i} (assistant):`);
+      msg.content.forEach(part => {
+        if (part.type === 'tool-call') {
+          const sig = part.providerOptions?.google?.thoughtSignature;
+          console.log(
+            `  ${part.toolName}: ${sig ? 'Has signature' : 'No signature'}`,
+          );
+        }
+      });
+    }
+  });
+
+  console.log('\n\n=== Turn 2: Follow-up question ===\n');
+
+  const messagesForTurn2: ModelMessage[] = [
+    {
+      role: 'user',
+      content:
+        'Check flight status for AA100 and book a taxi 2 hours before if delayed.',
+    },
+    ...result1.response.messages,
+    {
+      role: 'user',
+      content: 'Summarize what you did.',
+    },
+  ];
+
+  try {
+    const result2 = await generateText({
+      model,
+      messages: messagesForTurn2,
+      tools,
+      stopWhen: stepCountIs(1),
+    });
+
+    console.log('Turn 2 response:');
+    console.log(result2.text);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+
+  console.log('\n\n=== Parallel Function Calling Test ===\n');
+
+  const parallelResult = await generateText({
+    model,
+    tools: {
+      get_weather: tool({
+        description: 'Get weather for a location',
+        inputSchema: z.object({
+          location: z.string(),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temp: location === 'Paris' ? '15C' : '12C',
+        }),
+      }),
+    },
+    prompt: 'Check the weather in Paris and London.',
+    stopWhen: stepCountIs(2),
+    onStepFinish: ({ toolCalls }) => {
+      if (toolCalls && toolCalls.length > 1) {
+        console.log('Parallel tool calls:');
+        toolCalls.forEach((call, i) => {
+          const sig = call.providerMetadata?.google?.thoughtSignature;
+          console.log(
+            `  [${i}] ${call.toolName}(${JSON.stringify(call.input)}): ${
+              sig
+                ? 'Has signature (expected only on first for Gemini 3)'
+                : i === 0
+                  ? 'Missing on first call'
+                  : 'No signature (correct for parallel)'
+            }`,
+          );
+        });
+      }
+    },
+  });
+
+  console.log('\nParallel test response:');
+  console.log(parallelResult.text);
+});

--- a/examples/ai-core/src/stream-text/openai-compatible-google-thought-signatures.ts
+++ b/examples/ai-core/src/stream-text/openai-compatible-google-thought-signatures.ts
@@ -1,0 +1,223 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { streamText, tool, ModelMessage } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  const googleOpenAI = createOpenAICompatible({
+    baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+    name: 'google',
+    headers: {
+      Authorization: `Bearer ${process.env.GOOGLE_GENERATIVE_AI_API_KEY}`,
+    },
+  });
+
+  const model = googleOpenAI.chatModel('gemini-3-pro-preview');
+
+  const turn1 = streamText({
+    model,
+    tools: {
+      check_flight: tool({
+        description: 'Gets the current status of a flight',
+        inputSchema: z.object({
+          flight: z.string().describe('The flight number to check'),
+        }),
+        execute: async ({ flight }) => {
+          return {
+            flight,
+            status: 'delayed',
+            departure_time: '12 PM',
+            delay_minutes: 120,
+          };
+        },
+      }),
+      book_taxi: tool({
+        description: 'Book a taxi for a specific time',
+        inputSchema: z.object({
+          time: z.string().describe('Time to book the taxi'),
+        }),
+        execute: async ({ time }) => {
+          return {
+            booking_status: 'success',
+            pickup_time: time,
+            confirmation: 'TAXI-12345',
+          };
+        },
+      }),
+    },
+    prompt:
+      'Check flight status for AA100 and book a taxi 2 hours before if delayed.',
+    onStepFinish: ({ toolCalls, toolResults }) => {
+      if (toolCalls) {
+        console.log(`\n  Tool calls: ${toolCalls.length}`);
+        toolCalls.forEach(call => {
+          const sig = call.providerMetadata?.google?.thoughtSignature;
+          console.log(
+            `    ${call.toolName}: ${
+              sig && typeof sig === 'string'
+                ? 'Signature: ' +
+                  sig.substring(0, 50) +
+                  '... (length: ' +
+                  sig.length +
+                  ')'
+                : 'No signature (may be parallel call or non-Gemini 3)'
+            }`,
+          );
+        });
+      }
+      if (toolResults) {
+        console.log(`\n  Tool results: ${toolResults.length}`);
+        toolResults.forEach(result => {
+          const sig = result.providerMetadata?.google?.thoughtSignature;
+          console.log(
+            `    ${result.toolName}: ${
+              sig && typeof sig === 'string'
+                ? 'Signature preserved: ' + sig.substring(0, 50) + '...'
+                : 'No signature'
+            }`,
+          );
+        });
+      }
+    },
+  });
+
+  console.log('Turn 1 response:');
+  for await (const chunk of turn1.fullStream) {
+    if (chunk.type === 'text-delta') {
+      process.stdout.write(chunk.text);
+    } else if (chunk.type === 'tool-call') {
+      console.log(`\n  [Stream] Tool call: ${chunk.toolName}`);
+      if (chunk.providerMetadata?.google?.thoughtSignature) {
+        console.log(`Thought signature in stream event FOUND!`);
+      }
+    }
+  }
+
+  const response1 = await turn1.response;
+  console.log('\n\n=== Messages after Turn 1 ===');
+
+  response1.messages.forEach((msg, i) => {
+    if (msg.role === 'assistant' && typeof msg.content !== 'string') {
+      console.log(`Message ${i} (assistant):`);
+      msg.content.forEach(part => {
+        if (part.type === 'tool-call') {
+          const sig = part.providerOptions?.google?.thoughtSignature;
+          console.log(
+            `  tool-call ${part.toolName}: ${
+              sig && typeof sig === 'string'
+                ? 'Signature: ' + sig.substring(0, 40) + '...'
+                : 'No signature'
+            }`,
+          );
+        }
+      });
+    }
+    if (msg.role === 'tool') {
+      console.log(`Message ${i} (tool):`);
+      msg.content.forEach(part => {
+        if (part.type === 'tool-result') {
+          const sig = part.providerOptions?.google?.thoughtSignature;
+          console.log(
+            `  tool-result ${part.toolName}: ${
+              sig && typeof sig === 'string'
+                ? 'Signature: ' + sig.substring(0, 40) + '...'
+                : 'No signature'
+            }`,
+          );
+        }
+      });
+    }
+  });
+
+  console.log('\n\n=== Turn 2: Continue with follow-up question ===\n');
+
+  const messagesForTurn2: ModelMessage[] = [
+    {
+      role: 'user',
+      content:
+        'Check flight status for AA100 and book a taxi 2 hours before if delayed.',
+    },
+    ...response1.messages,
+    {
+      role: 'user',
+      content: 'What was the taxi confirmation number?',
+    },
+  ];
+
+  try {
+    const turn2 = streamText({
+      model,
+      messages: messagesForTurn2,
+      tools: {
+        check_flight: tool({
+          description: 'Gets the current status of a flight',
+          inputSchema: z.object({
+            flight: z.string(),
+          }),
+          execute: async ({ flight }) => ({ flight, status: 'on-time' }),
+        }),
+        book_taxi: tool({
+          description: 'Book a taxi',
+          inputSchema: z.object({
+            time: z.string(),
+          }),
+          execute: async ({ time }) => ({ time, status: 'booked' }),
+        }),
+      },
+    });
+
+    console.log('Turn 2 response:');
+    for await (const chunk of turn2.fullStream) {
+      if (chunk.type === 'text-delta') {
+        process.stdout.write(chunk.text);
+      }
+    }
+  } catch (error) {
+    console.error(error);
+  }
+
+  console.log('\n\n=== Parallel Function Calling Test ===\n');
+
+  const parallelTest = streamText({
+    model,
+    tools: {
+      get_weather: tool({
+        description: 'Get weather for a location',
+        inputSchema: z.object({
+          location: z.string(),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temp: location === 'Paris' ? '15C' : '12C',
+          condition: 'cloudy',
+        }),
+      }),
+    },
+    prompt: 'Check the weather in Paris and London.',
+    onStepFinish: ({ toolCalls }) => {
+      if (toolCalls && toolCalls.length > 1) {
+        console.log('\n  Parallel tool calls detected:');
+        toolCalls.forEach((call, i) => {
+          const sig = call.providerMetadata?.google?.thoughtSignature;
+          const hasSignature = sig && typeof sig === 'string';
+          console.log(
+            `    [${i}] ${call.toolName}(${JSON.stringify(call.input)}): ${
+              hasSignature
+                ? 'Has signature'
+                : i === 0
+                  ? 'Missing (expected on first)'
+                  : 'No signature (expected for parallel)'
+            }`,
+          );
+        });
+      }
+    },
+  });
+
+  console.log('Parallel test response:');
+  for await (const chunk of parallelTest.fullStream) {
+    if (chunk.type === 'text-delta') {
+      process.stdout.write(chunk.text);
+    }
+  }
+});

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -79,6 +79,11 @@ export function convertToOpenAICompatibleChatMessages(
           id: string;
           type: 'function';
           function: { name: string; arguments: string };
+          extra_content?: {
+            google?: {
+              thought_signature?: string;
+            };
+          };
         }> = [];
 
         for (const part of content) {
@@ -89,6 +94,8 @@ export function convertToOpenAICompatibleChatMessages(
               break;
             }
             case 'tool-call': {
+              const thoughtSignature =
+                part.providerOptions?.google?.thoughtSignature;
               toolCalls.push({
                 id: part.toolCallId,
                 type: 'function',
@@ -97,6 +104,16 @@ export function convertToOpenAICompatibleChatMessages(
                   arguments: JSON.stringify(part.input),
                 },
                 ...partMetadata,
+                // Include extra_content for Google Gemini thought signatures
+                ...(thoughtSignature
+                  ? {
+                      extra_content: {
+                        google: {
+                          thought_signature: String(thoughtSignature),
+                        },
+                      },
+                    }
+                  : {}),
               });
               break;
             }

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -94,6 +94,7 @@ export function convertToOpenAICompatibleChatMessages(
               break;
             }
             case 'tool-call': {
+              // TODO: thoughtSignature should be abstracted once we add support for other providers
               const thoughtSignature =
                 part.providerOptions?.google?.thoughtSignature;
               toolCalls.push({

--- a/packages/openai-compatible/src/chat/openai-compatible-api-types.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-api-types.ts
@@ -54,6 +54,15 @@ export interface OpenAICompatibleMessageToolCall extends JsonRecord {
     arguments: string;
     name: string;
   };
+  /**
+   * Additional content for provider-specific features.
+   * Used by Google Gemini for thought signatures via OpenAI compatibility.
+   */
+  extra_content?: {
+    google?: {
+      thought_signature?: string;
+    };
+  };
 }
 
 export interface OpenAICompatibleToolMessage extends JsonRecord {

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -86,6 +86,11 @@ describe('doGenerate', () => {
         name: string;
         arguments: string;
       };
+      extra_content?: {
+        google?: {
+          thought_signature?: string;
+        };
+      };
     }>;
     function_call?: {
       name: string;
@@ -600,6 +605,173 @@ describe('doGenerate', () => {
         },
       ]
     `);
+  });
+
+  describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
+    it('should parse thought signature from extra_content and include in providerMetadata', async () => {
+      prepareJsonResponse({
+        tool_calls: [
+          {
+            id: 'function-call-1',
+            type: 'function',
+            function: {
+              name: 'check_flight',
+              arguments: '{"flight":"AA100"}',
+            },
+            extra_content: {
+              google: {
+                thought_signature: '<Signature A>',
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await model.doGenerate({
+        tools: [
+          {
+            type: 'function',
+            name: 'check_flight',
+            inputSchema: {
+              type: 'object',
+              properties: { flight: { type: 'string' } },
+              required: ['flight'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.content).toMatchInlineSnapshot(`
+        [
+          {
+            "input": "{"flight":"AA100"}",
+            "providerMetadata": {
+              "test-provider": {
+                "thoughtSignature": "<Signature A>",
+              },
+            },
+            "toolCallId": "function-call-1",
+            "toolName": "check_flight",
+            "type": "tool-call",
+          },
+        ]
+      `);
+    });
+
+    it('should handle parallel tool calls with signature only on first call', async () => {
+      prepareJsonResponse({
+        tool_calls: [
+          {
+            id: 'function-call-paris',
+            type: 'function',
+            function: {
+              name: 'get_current_temperature',
+              arguments: '{"location":"Paris"}',
+            },
+            extra_content: {
+              google: {
+                thought_signature: '<Signature A>',
+              },
+            },
+          },
+          {
+            id: 'function-call-london',
+            type: 'function',
+            function: {
+              name: 'get_current_temperature',
+              arguments: '{"location":"London"}',
+            },
+            // No extra_content - parallel calls don't have signatures
+          },
+        ],
+      });
+
+      const result = await model.doGenerate({
+        tools: [
+          {
+            type: 'function',
+            name: 'get_current_temperature',
+            inputSchema: {
+              type: 'object',
+              properties: { location: { type: 'string' } },
+              required: ['location'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.content).toMatchInlineSnapshot(`
+        [
+          {
+            "input": "{"location":"Paris"}",
+            "providerMetadata": {
+              "test-provider": {
+                "thoughtSignature": "<Signature A>",
+              },
+            },
+            "toolCallId": "function-call-paris",
+            "toolName": "get_current_temperature",
+            "type": "tool-call",
+          },
+          {
+            "input": "{"location":"London"}",
+            "toolCallId": "function-call-london",
+            "toolName": "get_current_temperature",
+            "type": "tool-call",
+          },
+        ]
+      `);
+    });
+
+    it('should not include providerMetadata when no thought signature is present', async () => {
+      prepareJsonResponse({
+        tool_calls: [
+          {
+            id: 'call-1',
+            type: 'function',
+            function: {
+              name: 'some_tool',
+              arguments: '{"param":"value"}',
+            },
+            // No extra_content
+          },
+        ],
+      });
+
+      const result = await model.doGenerate({
+        tools: [
+          {
+            type: 'function',
+            name: 'some_tool',
+            inputSchema: {
+              type: 'object',
+              properties: { param: { type: 'string' } },
+              required: ['param'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.content).toMatchInlineSnapshot(`
+        [
+          {
+            "input": "{"param":"value"}",
+            "toolCallId": "call-1",
+            "toolName": "some_tool",
+            "type": "tool-call",
+          },
+        ]
+      `);
+    });
   });
 
   describe('response format', () => {
@@ -1659,6 +1831,144 @@ describe('doStream', () => {
         },
       ]
     `);
+  });
+
+  it('should stream tool call with thought signature from extra_content', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        // First chunk with tool call start and thought signature in extra_content
+        `data: {"id":"chatcmpl-gemini-thought","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"function-call-1","type":"function","function":{"name":"check_flight","arguments":""},` +
+          `"extra_content":{"google":{"thought_signature":"<Signature A>"}}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        // Subsequent chunks with arguments
+        `data: {"id":"chatcmpl-gemini-thought","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"flight\\":"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-gemini-thought","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"AA100\\"}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-gemini-thought","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'check_flight',
+          inputSchema: {
+            type: 'object',
+            properties: { flight: { type: 'string' } },
+            required: ['flight'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const result = await convertReadableStreamToArray(stream);
+
+    // Find the tool-call event and verify it has the thought signature in providerMetadata
+    const toolCallEvent = result.find(
+      (event: { type: string }) => event.type === 'tool-call',
+    );
+    expect(toolCallEvent).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'function-call-1',
+      toolName: 'check_flight',
+      input: '{"flight":"AA100"}',
+      providerMetadata: {
+        'test-provider': {
+          thoughtSignature: '<Signature A>',
+        },
+      },
+    });
+  });
+
+  it('should stream parallel tool calls with signature only on first call', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        // First chunk with two tool calls - only first has thought signature
+        `data: {"id":"chatcmpl-gemini-parallel","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[` +
+          `{"index":0,"id":"call-paris","type":"function","function":{"name":"get_weather","arguments":""},` +
+          `"extra_content":{"google":{"thought_signature":"<Signature A>"}}},` +
+          `{"index":1,"id":"call-london","type":"function","function":{"name":"get_weather","arguments":""}}` +
+          `]},` +
+          `"finish_reason":null}]}\n\n`,
+        // Arguments for first call
+        `data: {"id":"chatcmpl-gemini-parallel","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"location\\":\\"Paris\\"}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        // Arguments for second call
+        `data: {"id":"chatcmpl-gemini-parallel","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\\"location\\":\\"London\\"}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-gemini-parallel","object":"chat.completion.chunk","created":1711357598,"model":"gemini-3-pro",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          inputSchema: {
+            type: 'object',
+            properties: { location: { type: 'string' } },
+            required: ['location'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const result = await convertReadableStreamToArray(stream);
+
+    const toolCallEvents = result.filter(
+      (event: { type: string }) => event.type === 'tool-call',
+    );
+
+    expect(toolCallEvents).toHaveLength(2);
+
+    // First tool call should have thought signature
+    expect(toolCallEvents[0]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'call-paris',
+      toolName: 'get_weather',
+      providerMetadata: {
+        'test-provider': {
+          thoughtSignature: '<Signature A>',
+        },
+      },
+    });
+
+    // Second tool call should NOT have thought signature
+    expect(toolCallEvents[1]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'call-london',
+      toolName: 'get_weather',
+    });
+    expect(
+      (toolCallEvents[1] as { providerMetadata?: unknown }).providerMetadata,
+    ).toBeUndefined();
   });
 
   it('should stream tool call deltas when tool call arguments are passed in the first chunk', async () => {


### PR DESCRIPTION
## Background

feature request #11590 

## Summary

added handling for thought signatures returned by google models by preserving them in the providerMetadata through the message flow

## Manual Verification

Tested for multiturn examples in:
- `example/ai-core/src/generate-text/openai-compatible-google-thought-signatures.ts` 
- `example/ai-core/src/stream-text/openai-compatible-google-thought-signatures.ts`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11590 
