### PR TITLE
docs(openai): update voice argument usage and examples in OpenAI provider documentation

### DIFF
--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1961,7 +1961,7 @@ The first argument is the model id e.g. `tts-1`.
 const model = openai.speech('tts-1');
 ```
 
-You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying a voice to use for the generated audio.
+The `voice` argument can be set to one of OpenAI's available voices: `alloy`, `ash`, `coral`, `echo`, `fable`, `onyx`, `nova`, `sage`, or `shimmer`.
 
 ```ts highlight="6"
 import { experimental_generateSpeech as generateSpeech } from 'ai';
@@ -1970,7 +1970,25 @@ import { openai } from '@ai-sdk/openai';
 const result = await generateSpeech({
   model: openai.speech('tts-1'),
   text: 'Hello, world!',
-  providerOptions: { openai: {} },
+  voice: 'alloy', // OpenAI voice ID
+});
+```
+
+You can also pass additional provider-specific options using the `providerOptions` argument:
+
+```ts highlight="7-9"
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const result = await generateSpeech({
+  model: openai.speech('tts-1'),
+  text: 'Hello, world!',
+  voice: 'alloy',
+  providerOptions: {
+    openai: {
+      speed: 1.2,
+    },
+  },
 });
 ```
 


### PR DESCRIPTION
## Background

The documentation for the OpenAI provider has been updated to clarify the usage of the `voice` argument in the `generateSpeech` function. The examples now demonstrate how to set the `voice` directly, along with additional provider-specific options using the `providerOptions` argument.

## Manual Verification

[Preview](https://github.com/vercel/ai/blob/gr2m/docs-speech-voice-argument/content/providers/01-ai-sdk-providers/03-openai.mdx#speech-models)

I tested locally by altering `examples/ai-core/src/generate-speech/openai.ts`

## Checklist

- [ ] n/a ~~Tests have been added / updated (for bug fixes / features)~~
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] n/a ~~A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)~~
- [x] I have reviewed this pull request (self-review)

## Future Work

- Fal uses speech models but it's not using the `voice` argument
- `lmnt` is also using `generateSpeech()` but I don't currently have an API key to test the integration

## Related Issues

Follow up to https://github.com/vercel/ai/pull/11742