### PR TITLE
fix(provider-utils): add additionalProperty field for standard schema function

### DIFF
--- a/.changeset/tiny-months-wink.md
+++ b/.changeset/tiny-months-wink.md
@@ -2,4 +2,4 @@
 '@ai-sdk/provider-utils': patch
 ---
 
-fix(provider-utils): add additionalProperty field for standard schema function
+fix(provider-utils): add additionalProperties field for standard schema function

--- a/.changeset/tiny-months-wink.md
+++ b/.changeset/tiny-months-wink.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix(provider-utils): add additionalProperty field for standard schema function

--- a/examples/ai-core/src/generate-text/openai-output-object-arktype.ts
+++ b/examples/ai-core/src/generate-text/openai-output-object-arktype.ts
@@ -1,0 +1,24 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, Output } from 'ai';
+import { type } from 'arktype';
+import { print } from '../lib/print';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: openai('gpt-4o-mini'),
+    output: Output.object({
+      schema: type({
+        recipe: {
+          name: 'string',
+          ingredients: type({ name: 'string', amount: 'string' }).array(),
+          steps: 'string[]',
+        },
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+  });
+
+  print('Output:', result.output);
+  print('Request:', result.request.body);
+});

--- a/packages/provider-utils/src/schema.test.ts
+++ b/packages/provider-utils/src/schema.test.ts
@@ -244,6 +244,7 @@ describe('StandardSchema (StandardJSONSchemaV1)', () => {
 
       expect(await schema.jsonSchema).toStrictEqual({
         type: 'object',
+        additionalProperties: false,
         properties: {
           name: { type: 'string' },
           age: { type: 'number' },
@@ -277,9 +278,14 @@ describe('StandardSchema (StandardJSONSchemaV1)', () => {
       } as StandardSchema<{ text: string }>;
 
       const schema = asSchema(standardSchema);
-      await schema.jsonSchema;
+      const jsonSchema = await schema.jsonSchema;
 
       expect(capturedTarget).toBe('draft-07');
+      expect(jsonSchema).toStrictEqual({
+        type: 'object',
+        additionalProperties: false,
+        properties: { text: { type: 'string' } },
+      });
     });
 
     it('should support nested objects', async () => {
@@ -309,9 +315,11 @@ describe('StandardSchema (StandardJSONSchemaV1)', () => {
 
       expect(await schema.jsonSchema).toStrictEqual({
         type: 'object',
+        additionalProperties: false,
         properties: {
           user: {
             type: 'object',
+            additionalProperties: false,
             properties: {
               name: { type: 'string' },
               email: { type: 'string' },
@@ -342,6 +350,7 @@ describe('StandardSchema (StandardJSONSchemaV1)', () => {
 
       expect(await schema.jsonSchema).toStrictEqual({
         type: 'object',
+        additionalProperties: false,
         properties: {
           items: {
             type: 'array',
@@ -485,6 +494,7 @@ describe('StandardSchema (StandardJSONSchemaV1)', () => {
 
       expect(await schema.jsonSchema).toStrictEqual({
         type: 'object',
+        additionalProperties: false,
         properties: { text: { type: 'string' } },
       });
     });

--- a/packages/provider-utils/src/schema.ts
+++ b/packages/provider-utils/src/schema.ts
@@ -148,9 +148,11 @@ function standardSchema<OBJECT>(
 ): Schema<OBJECT> {
   return jsonSchema(
     () =>
-      standardSchema['~standard'].jsonSchema.input({
-        target: 'draft-07',
-      }),
+      addAdditionalPropertiesToJsonSchema(
+        standardSchema['~standard'].jsonSchema.input({
+          target: 'draft-07',
+        }) as JSONSchema7,
+      ),
     {
       validate: async value => {
         const result = await standardSchema['~standard'].validate(value);


### PR DESCRIPTION
## Background

when using structured outputs with arktype schema validation, we weren't applying the `additionalProperties` field to the JSON obejct - which then led to invalid outputs.

we applied it for zod schema but not standard schema.

#11705 

## Summary

wrap the function `standardSchema()` with `addAdditionalPropertiesToJsonSchema()` which ensures `additionalProperties: false` is added recursively to all object types

## Manual Verification

verified by running example `examples/ai-core/src/generate-text/openai-output-object-arktype.ts` which fails before we apply the fix

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11705 
