### PR TITLE
docs: fix markdown syntax in langchain page

### DIFF
--- a/content/providers/04-adapters/01-langchain.mdx
+++ b/content/providers/04-adapters/01-langchain.mdx
@@ -243,10 +243,9 @@ export async function POST(req: Request) {
 
 <Note>
 **When to use `streamEvents()` vs `graph.stream()`:**
-
 - **`streamEvents()`**: Best for debugging, observability, filtering by event type, agents created with `createAgent`, and migrating existing LCEL applications that rely on callbacks
 - **`graph.stream()` with `streamMode`**: Best for LangGraph applications where you need structured state updates via `values`, `messages`, or `custom` modes
-  </Note>
+</Note>
 
 ## Example: Custom Data Streaming
 

--- a/content/providers/04-adapters/01-langchain.mdx
+++ b/content/providers/04-adapters/01-langchain.mdx
@@ -242,9 +242,12 @@ export async function POST(req: Request) {
 ```
 
 <Note>
-**When to use `streamEvents()` vs `graph.stream()`:**
-- **`streamEvents()`**: Best for debugging, observability, filtering by event type, agents created with `createAgent`, and migrating existing LCEL applications that rely on callbacks
-- **`graph.stream()` with `streamMode`**: Best for LangGraph applications where you need structured state updates via `values`, `messages`, or `custom` modes
+  **When to use `streamEvents()` vs `graph.stream()`:** - **`streamEvents()`**:
+  Best for debugging, observability, filtering by event type, agents created
+  with `createAgent`, and migrating existing LCEL applications that rely on
+  callbacks - **`graph.stream()` with `streamMode`**: Best for LangGraph
+  applications where you need structured state updates via `values`, `messages`,
+  or `custom` modes
 </Note>
 
 ## Example: Custom Data Streaming

--- a/content/providers/04-adapters/01-langchain.mdx
+++ b/content/providers/04-adapters/01-langchain.mdx
@@ -242,12 +242,9 @@ export async function POST(req: Request) {
 ```
 
 <Note>
-  **When to use `streamEvents()` vs `graph.stream()`:** - **`streamEvents()`**:
-  Best for debugging, observability, filtering by event type, agents created
-  with `createAgent`, and migrating existing LCEL applications that rely on
-  callbacks - **`graph.stream()` with `streamMode`**: Best for LangGraph
-  applications where you need structured state updates via `values`, `messages`,
-  or `custom` modes
+**When to use `streamEvents()` vs `graph.stream()`:**
+- **`streamEvents()`**: Best for debugging, observability, filtering by event type, agents created with `createAgent`, and migrating existing LCEL applications that rely on callbacks
+- **`graph.stream()` with `streamMode`**: Best for LangGraph applications where you need structured state updates via `values`, `messages`, or `custom` modes
 </Note>
 
 ## Example: Custom Data Streaming


### PR DESCRIPTION
This pull request fixes a syntax issue in one of the docs pages that was causing auto-build action from failing.
