### PR TITLE
chore(ai): add AGENTS.md and CLAUDE.md to npm package

### DIFF
--- a/.changeset/popular-dingos-doubt.md
+++ b/.changeset/popular-dingos-doubt.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore(ai): add AGENTS.md to npm package

--- a/.changeset/popular-dingos-doubt.md
+++ b/.changeset/popular-dingos-doubt.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-chore(ai): add AGENTS.md to npm package
+chore(ai): add AGENTS.md and CLAUDE.md to npm package

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tsconfig.vitest-temp.json
 
 # Generated files
 packages/ai/AGENTS.md
+packages/ai/CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ tsconfig.vitest-temp.json
 *.log
 *.local
 *.tsbuildinfo
+
+# Generated files
+packages/ai/AGENTS.md

--- a/packages/ai/USAGE-AGENTS.md
+++ b/packages/ai/USAGE-AGENTS.md
@@ -1,0 +1,1 @@
+## AI SDK Usage

--- a/packages/ai/USAGE-AGENTS.md
+++ b/packages/ai/USAGE-AGENTS.md
@@ -1,1 +1,57 @@
-## AI SDK Usage
+# AI SDK Usage
+
+## Use Cases
+
+### Generating Text
+
+#### text prompt
+
+```ts
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-5',
+  prompt: 'Invent a new holiday.', // text prompt
+});
+
+const text = result.text; // access generated text
+```
+
+#### Specifying the maximum number of tokens to generate
+
+```ts
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-5',
+  prompt: 'Invent a new holiday.',
+  maxOutputTokens: 100, // maximum number of tokens to generate
+});
+```
+
+### Streaming Text
+
+#### text prompt and text stream
+
+```ts
+import { streamText } from 'ai';
+
+const result = streamText({
+  model: 'openai/gpt-5',
+  prompt: 'Invent a new holiday.', // text prompt
+});
+
+const textStream = result.textStream; // access text stream
+```
+
+#### Specifying the maximum number of tokens to generate
+
+```ts
+import { streamText } from 'ai';
+
+const result = await streamText({
+  model: 'openai/gpt-5',
+  prompt: 'Invent a new holiday.',
+  maxOutputTokens: 100, // maximum number of tokens to generate
+});
+```

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -9,6 +9,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "AGENTS.md",
     "CHANGELOG.md",
     "internal.d.ts",
     "README.md",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -11,6 +11,7 @@
     "dist/**/*",
     "AGENTS.md",
     "CHANGELOG.md",
+    "CLAUDE.md",
     "internal.d.ts",
     "README.md",
     "test.d.ts"

--- a/packages/ai/tsup.config.ts
+++ b/packages/ai/tsup.config.ts
@@ -1,3 +1,4 @@
+import { copyFileSync } from 'node:fs';
 import { defineConfig } from 'tsup';
 
 export default defineConfig([
@@ -15,6 +16,10 @@ export default defineConfig([
         (await import('./package.json', { with: { type: 'json' } })).default
           .version,
       ),
+    },
+    onSuccess: async () => {
+      // Copy USAGE-AGENTS.md to AGENTS.md for inclusion in the published package
+      copyFileSync('USAGE-AGENTS.md', 'AGENTS.md');
     },
   },
   // Internal APIs

--- a/packages/ai/tsup.config.ts
+++ b/packages/ai/tsup.config.ts
@@ -18,8 +18,9 @@ export default defineConfig([
       ),
     },
     onSuccess: async () => {
-      // Copy USAGE-AGENTS.md to AGENTS.md for inclusion in the published package
+      // Copy USAGE-AGENTS.md to AGENTS.md and CLAUDE.md for inclusion in the published package
       copyFileSync('USAGE-AGENTS.md', 'AGENTS.md');
+      copyFileSync('USAGE-AGENTS.md', 'CLAUDE.md');
     },
   },
   // Internal APIs


### PR DESCRIPTION
## Background

AI agents can benefit from an `AGENTS.md` in the npm package that shows how to use the library.

## Summary

Add `USER-AGENTS.ms` with basic patterns for testing the approach.

It is shipped as `AGENTS.md` (for Cursor) and `CLAUDE.md` for Claude code.

## Manual Verification

- [x] snapshot build contains `AGENTS.md` and `CLAUDE.md` https://www.npmjs.com/package/ai/v/0.0.0-0219f568-20260113124214?activeTab=code

## Future Work

* evaluate if this approach helps with `maxOutputTokens` when generating examples with AI agents
* add more patterns to `AGENTS.md`

## Related Issues

Resolves #11759 