### PR TITLE
chore: add CLAUDE.md symlink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Background

Claude Code uses `CLAUDE.md` not `AGENTS.md`.

## Summary

Symlink `CLAUDE.md`.