### PR TITLE
feat(groq): add strictJsonSchema for provider

### DIFF
--- a/.changeset/tame-brooms-matter.md
+++ b/.changeset/tame-brooms-matter.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/groq': patch
+---
+
+feat(groq,compat): add strictJsonSchema for providers

--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -136,6 +136,14 @@ The following optional provider options are available for Groq language models:
 
   When enabled, object generation will use the `json_schema` format instead of `json_object` format, providing more reliable structured outputs.
 
+- **strictJsonSchema** _boolean_
+
+  Whether to use strict JSON schema validation. When `true`, the model uses constrained decoding to guarantee schema compliance.
+
+  Defaults to `true`.
+
+  Only used when `structuredOutputs` is enabled and a schema is provided. See [Groq's Structured Outputs documentation](https://console.groq.com/docs/structured-outputs) for details on strict mode limitations.
+
 - **parallelToolCalls** _boolean_
 
   Whether to enable parallel function calling during tool use. Defaults to `true`.

--- a/examples/ai-core/src/agent/groq-generate-output-object.ts
+++ b/examples/ai-core/src/agent/groq-generate-output-object.ts
@@ -9,14 +9,14 @@ run(async () => {
     output: Output.object({
       schema: z.object({
         recipe: z.object({
-        name: z.string(),
-        ingredients: z.array(
-          z.object({
-            name: z.string(),
-            amount: z.string(),
-          }),
-        ),
-        steps: z.array(z.string()),
+          name: z.string(),
+          ingredients: z.array(
+            z.object({
+              name: z.string(),
+              amount: z.string(),
+            }),
+          ),
+          steps: z.array(z.string()),
         }),
       }),
     }),

--- a/examples/ai-core/src/agent/groq-generate-output-object.ts
+++ b/examples/ai-core/src/agent/groq-generate-output-object.ts
@@ -1,0 +1,32 @@
+import { groq, GroqProviderOptions } from '@ai-sdk/groq';
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: groq('moonshotai/kimi-k2-instruct-0905'),
+    output: Output.object({
+      schema: z.object({
+        recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({
+            name: z.string(),
+            amount: z.string(),
+          }),
+        ),
+        steps: z.array(z.string()),
+        }),
+      }),
+    }),
+    providerOptions: {
+      groq: {
+        strictJsonSchema: true,
+      } satisfies GroqProviderOptions,
+    },
+    prompt: 'Generate a lasagna recipe.',
+  });
+
+  console.log(JSON.stringify(result.output, null, 2));
+});

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -514,6 +514,7 @@ describe('doGenerate', () => {
       response_format: {
         type: 'json_schema',
         json_schema: {
+          strict: true,
           name: 'test-name',
           description: 'test description',
           schema: {
@@ -605,6 +606,7 @@ describe('doGenerate', () => {
       response_format: {
         type: 'json_schema',
         json_schema: {
+          strict: true,
           name: 'test-name',
           description: 'test description',
           schema: {
@@ -649,7 +651,55 @@ describe('doGenerate', () => {
       response_format: {
         type: 'json_schema',
         json_schema: {
+          strict: true,
           name: 'response',
+          schema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      },
+    });
+  });
+
+  it('should send strict: false when strictJsonSchema is explicitly disabled', async () => {
+    prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+    const model = provider('gemma2-9b-it');
+
+    await model.doGenerate({
+      providerOptions: {
+        groq: {
+          strictJsonSchema: false,
+        },
+      },
+      responseFormat: {
+        type: 'json',
+        name: 'test-name',
+        description: 'test description',
+        schema: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+          additionalProperties: false,
+          $schema: 'http://json-schema.org/draft-07/schema#',
+        },
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gemma2-9b-it',
+      messages: [{ role: 'user', content: 'Hello' }],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          strict: false,
+          name: 'test-name',
+          description: 'test description',
           schema: {
             type: 'object',
             properties: { value: { type: 'string' } },
@@ -754,6 +804,7 @@ describe('doGenerate', () => {
               ],
               "type": "object",
             },
+            "strict": true,
           },
           "type": "json_schema",
         },

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -84,6 +84,7 @@ export class GroqChatLanguageModel implements LanguageModelV3 {
     });
 
     const structuredOutputs = groqOptions?.structuredOutputs ?? true;
+    const strictJsonSchema = groqOptions?.strictJsonSchema ?? true;
 
     if (topK != null) {
       warnings.push({ type: 'unsupported', feature: 'topK' });
@@ -134,6 +135,7 @@ export class GroqChatLanguageModel implements LanguageModelV3 {
                   type: 'json_schema',
                   json_schema: {
                     schema: responseFormat.schema,
+                    strict: strictJsonSchema,
                     name: responseFormat.name ?? 'response',
                     description: responseFormat.description,
                   },

--- a/packages/groq/src/groq-chat-options.ts
+++ b/packages/groq/src/groq-chat-options.ts
@@ -56,6 +56,15 @@ export const groqProviderOptions = z.object({
   structuredOutputs: z.boolean().optional(),
 
   /**
+   * Whether to use strict JSON schema validation.
+   * When true, the model uses constrained decoding to guarantee schema compliance.
+   * Only used when structured outputs are enabled and a schema is provided.
+   *
+   * @default true
+   */
+  strictJsonSchema: z.boolean().optional(),
+
+  /**
    * Service tier for the request.
    * - 'on_demand': Default tier with consistent performance and fairness
    * - 'flex': Higher throughput tier optimized for workloads that can handle occasional request failures

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -884,6 +884,7 @@ describe('doGenerate', () => {
         response_format: {
           type: 'json_schema',
           json_schema: {
+            strict: true,
             name: 'response',
             schema: {
               type: 'object',
@@ -1027,6 +1028,7 @@ describe('doGenerate', () => {
         response_format: {
           type: 'json_schema',
           json_schema: {
+            strict: true,
             name: 'response',
             schema: {
               type: 'object',
@@ -1072,6 +1074,59 @@ describe('doGenerate', () => {
         response_format: {
           type: 'json_schema',
           json_schema: {
+            strict: true,
+            name: 'test-name',
+            description: 'test description',
+            schema: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        },
+      });
+    });
+
+    it('should send strict: false when strictJsonSchema is explicitly disabled', async () => {
+      prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel('gpt-4o-2024-08-06', {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+        supportsStructuredOutputs: true,
+      });
+
+      await model.doGenerate({
+        responseFormat: {
+          type: 'json',
+          name: 'test-name',
+          description: 'test description',
+          schema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+        providerOptions: {
+          'test-provider': {
+            strictJsonSchema: false,
+          },
+        },
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{ role: 'user', content: 'Hello' }],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            strict: false,
             name: 'test-name',
             description: 'test description',
             schema: {

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -131,6 +131,8 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
       })) ?? {},
     );
 
+    const strictJsonSchema = compatibleOptions?.strictJsonSchema ?? true;
+
     if (topK != null) {
       warnings.push({ type: 'unsupported', feature: 'topK' });
     }
@@ -179,6 +181,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
                   type: 'json_schema',
                   json_schema: {
                     schema: responseFormat.schema,
+                    strict: strictJsonSchema,
                     name: responseFormat.name ?? 'response',
                     description: responseFormat.description,
                   },

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-options.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-options.ts
@@ -18,6 +18,15 @@ export const openaiCompatibleProviderOptions = z.object({
    * Controls the verbosity of the generated text. Defaults to `medium`.
    */
   textVerbosity: z.string().optional(),
+
+  /**
+   * Whether to use strict JSON schema validation.
+   * When true, the model uses constrained decoding to guarantee schema compliance.
+   * Only used when the provider supports structured outputs and a schema is provided.
+   *
+   * @default true
+   */
+  strictJsonSchema: z.boolean().optional(),
 });
 
 export type OpenAICompatibleProviderOptions = z.infer<


### PR DESCRIPTION
## Background

Providers like Groq and and Cerebras (openai-compat) allow `strict: true` for structured outputs. But AI SDK only allows that param to be passed for OpenAI provider

## Summary

Update the schema to allow `strictJsonSchema` flag to be passed

## Manual Verification

added cli example under `examples/ai-core/src/generate-text/groq-generate-output-object.ts`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11230 
