### PR TITLE
devtools don't work with Bun: Avoid using `NODE_ENV` in devtools server code

### DIFF
--- a/.changeset/yellow-chicken-refuse.md
+++ b/.changeset/yellow-chicken-refuse.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/devtools': patch
+---
+
+Avoid using `NODE_ENV` in devtools lib code to make devtools bin work with `bunx --bun devtools command for users that have `NODE_ENV` set to development in a .env file

--- a/packages/devtools/src/viewer/server.ts
+++ b/packages/devtools/src/viewer/server.ts
@@ -37,8 +37,7 @@ const broadcastToClients = (event: string, data: Record<string, unknown>) => {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Determine if we're running from source (tsx) or built (dist)
-const isDevMode =
-  __dirname.includes('/src/') || process.env.NODE_ENV === 'development';
+const isDevMode = __dirname.includes('/src/');
 const projectRoot = isDevMode
   ? path.resolve(__dirname, '../..')
   : path.resolve(__dirname, '../..');
@@ -237,9 +236,7 @@ app.get('*', async c => {
 });
 
 export const startViewer = (port = 4983) => {
-  const isDev =
-    process.env.NODE_ENV === 'development' ||
-    process.argv[1]?.includes('/src/');
+  const isDev = process.argv[1]?.includes('/src/');
 
   const server = serve(
     {


### PR DESCRIPTION
when running the `devtools` bin with bun using `bunx --bun devtools` in user's codebase, the lib doesn't work properly and runs in dev mode for the user if they have a `.env` file with the value `NODE_ENV` set to `development` because bun auto loads the user's vars from the `.env` file. I don't think its wise to use environment variables in libraries' code because users' environments can affect the runtime behaviour, especially so for popular runtime variables such as `NODE_ENV`.

I also noticed that the `devToolsMiddleware` function also uses `NODE_ENV` to throw an error if the user using this in production. i think the same reasoning against env vars in libraries' code applies again, but its less harmful here.

I checked that this fix works but pointing to the local build for the devtools code from my own project where i encountered the code and made sure that `bunx --bun devtools` works (not in dev mode) even if i have a .env file with `NODE_ENV` set to `development`.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)