### PR TITLE
fix(mcp): lenient JSON-RPC parsing for http transport

### DIFF
--- a/.changeset/rare-flowers-rush.md
+++ b/.changeset/rare-flowers-rush.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+fix(mcp): lenient JSON-RPC parsing for http transport

--- a/examples/mcp/src/shopify-mcp/client.ts
+++ b/examples/mcp/src/shopify-mcp/client.ts
@@ -1,0 +1,45 @@
+import { openai } from '@ai-sdk/openai';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { streamText } from 'ai';
+import 'dotenv/config';
+import { createMCPClient, MCPClient } from '@ai-sdk/mcp';
+
+async function main() {
+  const transport = new StreamableHTTPClientTransport(
+    new URL('https://cowboy.com/api/mcp'),
+  );
+
+  const mcpClient: MCPClient = await createMCPClient({
+    transport: {
+      type: 'http',
+      url: 'https://cowboy.com/api/mcp',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  });
+
+  try {
+    const tools = await mcpClient.tools();
+
+    const result = streamText({
+      model: openai('gpt-4o-mini'),
+      tools,
+      system: 'You are a helpful chatbot',
+      prompt: 'What tools are available for me to call?',
+      onFinish: async () => {
+        await mcpClient.close();
+      },
+    });
+
+    for await (const chunk of result.textStream) {
+      process.stdout.write(chunk);
+    }
+    console.log();
+  } catch (error) {
+    console.error('Error:', error);
+    await mcpClient.close();
+  }
+}
+
+main();

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -186,6 +186,13 @@ export class HttpMCPTransport implements MCPTransport {
           throw error;
         }
 
+        // Notifications (messages without 'id') don't expect a JSON-RPC response
+        // Some servers return 200 with acknowledgment JSON instead of 202
+        const isNotification = !('id' in message);
+        if (isNotification) {
+          return;
+        }
+
         const contentType = response.headers.get('content-type') || '';
         if (contentType.includes('application/json')) {
           const data = await response.json();


### PR DESCRIPTION
## Background

In AI SDK v6, we introduced MCP Client's inbuilt http transport - which was very strict in how it handled responses that didn't conform to JSON RPC spec.

Some servers would return non JSON-RPC format responses (like {}) for notifications, which led to errors, as seen in #11792 

## Summary

return early for notifications (messages without id) after successful response

## Manual Verification

verified by running `examples/mcp/src/shopify-mcp/client.ts` before and after the fix. 

before -> threw the same error user saw
after -> proper streamed responsed from the model with the correct tools

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11792 
