### PR TITLE
docs: fix inputSchema Zod schema reference

### DIFF
--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -24,7 +24,7 @@ and [`streamText`](/docs/reference/ai-sdk-core/stream-text) by passing one or mo
 A tool consists of three properties:
 
 - **`description`**: An optional description of the tool that can influence when the tool is picked.
-- **`inputSchema`**: A [Zod schema](/docs/foundations/tools#schema-specification-and-validation-with-zod) or a [JSON schema](/docs/reference/ai-sdk-core/json-schema) that defines the input required for the tool to run. The schema is consumed by the LLM, and also used to validate the LLM tool calls.
+- **`inputSchema`**: A [Zod schema](/docs/reference/ai-sdk-core/zod-schema) or a [JSON schema](/docs/reference/ai-sdk-core/json-schema) that defines the input required for the tool to run. The schema is consumed by the LLM, and also used to validate the LLM tool calls.
 - **`execute`**: An optional async function that is called with the arguments from the tool call.
 
 <Note>


### PR DESCRIPTION
## Background

The existing `inputSchema` documentation linked to an outdated Zod schema reference. The Zod documentation has since been reorganized, and the previous link no longer points to the canonical Zod schema guide for the AI SDK.

## Summary

Updated the `inputSchema` documentation to reference the correct Zod schema documentation under `/docs/reference/ai-sdk-core/zod-schema`, ensuring consistency with the current AI SDK docs structure and preventing broken or misleading links.

## Manual Verification

N/A (documentation-only change)

## Checklist

- [ ] Tests added or updated
- [ ] Code changes reviewed
- [x] Documentation updated
- [ ] Breaking change
