### PR TITLE
fix(ai): fix LanguageModelV2ProviderTool type

### DIFF
--- a/.changeset/quick-apples-fly.md
+++ b/.changeset/quick-apples-fly.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+fix(ai): fix LanguageModelV2ProviderTool type

--- a/packages/provider/src/language-model/v2/language-model-v2-call-options.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-call-options.ts
@@ -2,7 +2,7 @@ import { JSONSchema7 } from 'json-schema';
 import { SharedV2ProviderOptions } from '../../shared/v2/shared-v2-provider-options';
 import { LanguageModelV2FunctionTool } from './language-model-v2-function-tool';
 import { LanguageModelV2Prompt } from './language-model-v2-prompt';
-import { LanguageModelV2ProvideDefinedTool } from './language-model-v2-provider-defined-tool';
+import { LanguageModelV2ProviderDefinedTool } from './language-model-v2-provider-defined-tool';
 import { LanguageModelV2ToolChoice } from './language-model-v2-tool-choice';
 
 export type LanguageModelV2CallOptions = {
@@ -94,7 +94,7 @@ by the model, calls will generate deterministic results.
 The tools that are available for the model.
   */
   tools?: Array<
-    LanguageModelV2FunctionTool | LanguageModelV2ProvideDefinedTool
+    LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool
   >;
 
   /**

--- a/packages/provider/src/language-model/v2/language-model-v2-call-options.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-call-options.ts
@@ -2,7 +2,7 @@ import { JSONSchema7 } from 'json-schema';
 import { SharedV2ProviderOptions } from '../../shared/v2/shared-v2-provider-options';
 import { LanguageModelV2FunctionTool } from './language-model-v2-function-tool';
 import { LanguageModelV2Prompt } from './language-model-v2-prompt';
-import { LanguageModelV2ProviderTool } from './language-model-v2-provider-defined-tool';
+import { LanguageModelV2ProvideDefinedTool } from './language-model-v2-provider-defined-tool';
 import { LanguageModelV2ToolChoice } from './language-model-v2-tool-choice';
 
 export type LanguageModelV2CallOptions = {
@@ -93,7 +93,9 @@ by the model, calls will generate deterministic results.
   /**
 The tools that are available for the model.
   */
-  tools?: Array<LanguageModelV2FunctionTool | LanguageModelV2ProviderTool>;
+  tools?: Array<
+    LanguageModelV2FunctionTool | LanguageModelV2ProvideDefinedTool
+  >;
 
   /**
 Specifies how the tool should be selected. Defaults to 'auto'.

--- a/packages/provider/src/language-model/v2/language-model-v2-call-warning.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-call-warning.ts
@@ -1,6 +1,6 @@
 import { LanguageModelV2CallOptions } from './language-model-v2-call-options';
 import { LanguageModelV2FunctionTool } from './language-model-v2-function-tool';
-import { LanguageModelV2ProvideDefinedTool } from './language-model-v2-provider-defined-tool';
+import { LanguageModelV2ProviderDefinedTool } from './language-model-v2-provider-defined-tool';
 
 /**
 Warning from the model provider for this call. The call will proceed, but e.g.
@@ -14,7 +14,7 @@ export type LanguageModelV2CallWarning =
     }
   | {
       type: 'unsupported-tool';
-      tool: LanguageModelV2FunctionTool | LanguageModelV2ProvideDefinedTool;
+      tool: LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool;
       details?: string;
     }
   | {

--- a/packages/provider/src/language-model/v2/language-model-v2-call-warning.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-call-warning.ts
@@ -1,6 +1,6 @@
 import { LanguageModelV2CallOptions } from './language-model-v2-call-options';
 import { LanguageModelV2FunctionTool } from './language-model-v2-function-tool';
-import { LanguageModelV2ProviderTool } from './language-model-v2-provider-defined-tool';
+import { LanguageModelV2ProvideDefinedTool } from './language-model-v2-provider-defined-tool';
 
 /**
 Warning from the model provider for this call. The call will proceed, but e.g.
@@ -14,7 +14,7 @@ export type LanguageModelV2CallWarning =
     }
   | {
       type: 'unsupported-tool';
-      tool: LanguageModelV2FunctionTool | LanguageModelV2ProviderTool;
+      tool: LanguageModelV2FunctionTool | LanguageModelV2ProvideDefinedTool;
       details?: string;
     }
   | {

--- a/packages/provider/src/language-model/v2/language-model-v2-provider-defined-tool.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-provider-defined-tool.ts
@@ -1,7 +1,7 @@
 /**
 The configuration of a tool that is defined by the provider.
  */
-export type LanguageModelV2ProvideDefinedTool = {
+export type LanguageModelV2ProviderDefinedTool = {
   /**
 The type of the tool (always 'provider-defined').
    */

--- a/packages/provider/src/language-model/v2/language-model-v2-provider-defined-tool.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-provider-defined-tool.ts
@@ -3,9 +3,9 @@ The configuration of a tool that is defined by the provider.
  */
 export type LanguageModelV2ProviderTool = {
   /**
-The type of the tool (always 'provider').
+The type of the tool (always 'provider-defined').
    */
-  type: 'provider';
+  type: 'provider-defined';
 
   /**
 The ID of the tool. Should follow the format `<provider-name>.<unique-tool-name>`.

--- a/packages/provider/src/language-model/v2/language-model-v2-provider-defined-tool.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-provider-defined-tool.ts
@@ -1,7 +1,7 @@
 /**
 The configuration of a tool that is defined by the provider.
  */
-export type LanguageModelV2ProviderTool = {
+export type LanguageModelV2ProvideDefinedTool = {
   /**
 The type of the tool (always 'provider-defined').
    */


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Compared to `release-v5.0` branch, LanguageModelV2ProviderTool currently has different types
- v2: type = `provider-defined` ([code](https://github.com/vercel/ai/blob/release-v5.0/packages/provider/src/language-model/v2/language-model-v2-provider-defined-tool.ts))
- v3: type = `provider`

## Summary

`LanguageModelV2ProviderTool` to have type = `provider-defined`

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

Compared with ai sdk v5

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)