### PR TITLE
fix(openai-compatible): use consistent camelCase for providerOptions key

### DIFF
--- a/.changeset/consistent-provider-options-key.md
+++ b/.changeset/consistent-provider-options-key.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Use consistent camelCase `openaiCompatible` key for providerOptions. The kebab-case `openai-compatible` key is now deprecated but still supported with a console warning.

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -434,6 +434,25 @@ describe('doGenerate', () => {
     await provider('grok-beta').doGenerate({
       prompt: TEST_PROMPT,
       providerOptions: {
+        openaiCompatible: {
+          user: 'test-user-id',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'grok-beta',
+      messages: [{ role: 'user', content: 'Hello' }],
+      user: 'test-user-id',
+    });
+  });
+
+  it('should pass settings with deprecated openai-compatible key and emit warning', async () => {
+    prepareJsonResponse();
+
+    const result = await provider('grok-beta').doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
         'openai-compatible': {
           user: 'test-user-id',
         },
@@ -444,6 +463,11 @@ describe('doGenerate', () => {
       model: 'grok-beta',
       messages: [{ role: 'user', content: 'Hello' }],
       user: 'test-user-id',
+    });
+
+    expect(result.warnings).toContainEqual({
+      type: 'other',
+      message: `The 'openai-compatible' key in providerOptions is deprecated. Use 'openaiCompatible' instead.`,
     });
   });
 

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -128,10 +128,24 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
   }: LanguageModelV3CallOptions) {
     const warnings: SharedV3Warning[] = [];
 
-    // Parse provider options
+    // Parse provider options - check for deprecated 'openai-compatible' key
+    const deprecatedOptions = await parseProviderOptions({
+      provider: 'openai-compatible',
+      providerOptions,
+      schema: openaiCompatibleProviderOptions,
+    });
+
+    if (deprecatedOptions != null) {
+      warnings.push({
+        type: 'other',
+        message: `The 'openai-compatible' key in providerOptions is deprecated. Use 'openaiCompatible' instead.`,
+      });
+    }
+
     const compatibleOptions = Object.assign(
+      deprecatedOptions ?? {},
       (await parseProviderOptions({
-        provider: 'openai-compatible',
+        provider: 'openaiCompatible',
         providerOptions,
         schema: openaiCompatibleProviderOptions,
       })) ?? {},

--- a/packages/openai-compatible/src/embedding/openai-compatible-embedding-model.test.ts
+++ b/packages/openai-compatible/src/embedding/openai-compatible-embedding-model.test.ts
@@ -101,7 +101,7 @@ describe('doEmbed', () => {
     await provider.embeddingModel('text-embedding-3-large').doEmbed({
       values: testValues,
       providerOptions: {
-        'openai-compatible': {
+        openaiCompatible: {
           dimensions: 64,
         },
       },
@@ -112,6 +112,33 @@ describe('doEmbed', () => {
       input: testValues,
       encoding_format: 'float',
       dimensions: 64,
+    });
+  });
+
+  it('should pass settings with deprecated openai-compatible key and emit warning', async () => {
+    prepareJsonResponse();
+
+    const result = await provider
+      .embeddingModel('text-embedding-3-large')
+      .doEmbed({
+        values: testValues,
+        providerOptions: {
+          'openai-compatible': {
+            dimensions: 64,
+          },
+        },
+      });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'text-embedding-3-large',
+      input: testValues,
+      encoding_format: 'float',
+      dimensions: 64,
+    });
+
+    expect(result.warnings).toContainEqual({
+      type: 'other',
+      message: `The 'openai-compatible' key in providerOptions is deprecated. Use 'openaiCompatible' instead.`,
     });
   });
 


### PR DESCRIPTION
## Background

There's an inconsistency in the `@ai-sdk/openai-compatible` package regarding the key used for provider options:

- **Top-level `providerOptions`** used kebab-case: `'openai-compatible'`
- **Per-message `providerOptions`** used camelCase: `openaiCompatible`

## Summary

- Use `openaiCompatible` (camelCase) as the primary providerOptions key for consistency with per-message providerOptions
- The `openai-compatible` (kebab-case) key is deprecated but still supported with a console warning
- Updated existing tests to use camelCase
- Added deprecation tests that verify the old key still works and emits a warning

## Manual Verification

_tbd_

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] _tbd_ I have reviewed this pull request (self-review)

## Related Issues

Fixes #11840