### PR TITLE
fix(google-vertex): lazy load the env vars for vertexAnthropic

### DIFF
--- a/.changeset/tough-houses-reflect.md
+++ b/.changeset/tough-houses-reflect.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+fix(google-vertex): lazy load the env vars for vertexAnthropic

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -71,23 +71,26 @@ Create a Google Vertex Anthropic provider instance.
 export function createVertexAnthropic(
   options: GoogleVertexAnthropicProviderSettings = {},
 ): GoogleVertexAnthropicProvider {
-  const location = loadOptionalSetting({
-    settingValue: options.location,
-    environmentVariableName: 'GOOGLE_VERTEX_LOCATION',
-  });
-  const project = loadOptionalSetting({
-    settingValue: options.project,
-    environmentVariableName: 'GOOGLE_VERTEX_PROJECT',
-  });
+  const getBaseURL = () => {
+    const location = loadOptionalSetting({
+      settingValue: options.location,
+      environmentVariableName: 'GOOGLE_VERTEX_LOCATION',
+    });
+    const project = loadOptionalSetting({
+      settingValue: options.project,
+      environmentVariableName: 'GOOGLE_VERTEX_PROJECT',
+    });
 
-  const baseURL =
-    withoutTrailingSlash(options.baseURL) ??
-    `https://${location === 'global' ? '' : location + '-'}aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`;
+    return (
+      withoutTrailingSlash(options.baseURL) ??
+      `https://${location === 'global' ? '' : location + '-'}aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`
+    );
+  };
 
   const createChatModel = (modelId: GoogleVertexAnthropicMessagesModelId) =>
     new AnthropicMessagesLanguageModel(modelId, {
       provider: 'vertex.anthropic.messages',
-      baseURL,
+      baseURL: getBaseURL(),
       headers: options.headers ?? {},
       fetch: options.fetch,
 


### PR DESCRIPTION
## Background

#11845 

## Summary

we now wrap the environment variable loading in a function so it's evaluated lazily when a model is actually created.

this is similar to patterns for other providers

## Manual Verification

verified by running static examples `examples/ai-functions/src/generate-text/google-vertex-anthropic-*.ts` (where previously an error was thrown)

## Checklist

- [ ] n/a ~~Tests have been added / updated (for bug fixes / features)~~
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11845  
