### PR TITLE
fix(anthropic/provider): Do not use structured output header with json response tool

### DIFF
--- a/.changeset/orange-dolphins-compete.md
+++ b/.changeset/orange-dolphins-compete.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Not sending structured output beta header for json response tool

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -871,6 +871,35 @@ describe('AnthropicMessagesLanguageModel', () => {
           }
         `);
       });
+
+      it('should NOT include beta header when using json response tool (jsonTool mode)', async () => {
+        prepareJsonFixtureResponse('anthropic-json-tool.1');
+
+        await provider('claude-sonnet-4-5').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            anthropic: {
+              structuredOutputMode: 'jsonTool',
+            } satisfies AnthropicProviderOptions,
+          },
+          responseFormat: {
+            type: 'json',
+            schema: {
+              type: 'object',
+              properties: { name: { type: 'string' } },
+              required: ['name'],
+            },
+          },
+        });
+
+        expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+          {
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+            "x-api-key": "test-api-key",
+          }
+        `);
+      });
     });
 
     it('should extract text response', async () => {

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -526,7 +526,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
             toolChoice: { type: 'required' },
             disableParallelToolUse: true,
             cacheControlValidator,
-            supportsStructuredOutput,
+            supportsStructuredOutput: false,
           }
         : {
             tools: tools ?? [],


### PR DESCRIPTION
## Background

We were sending structured output beta header with json response tool which was performing strict json schema validation causing errors.

## Summary

Do not send beta header for json response tool

## Manual Verification

Ran eg of anthropic tool calls

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)



## Related Issues

Fixes #11850 
