### PR TITLE
refactor(openai-compatible): use provider name for providerOptions key with backwards compatibility

### DIFF
--- a/.changeset/moody-geese-dream.md
+++ b/.changeset/moody-geese-dream.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Standardize provider options handling to use provider name as key with backwards compatibility for legacy 'openaiCompatible' key

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -298,6 +298,8 @@ const { text } = await generateText({
 
 The request body sent to the provider will include the `customOption` field with the value `magic-value`. This gives you an easy way to add provider-specific options to requests without having to modify the provider or AI SDK code.
 
+Provider-specific options are also supported on individual messages and message content.
+
 ## Custom Metadata Extraction
 
 The OpenAI Compatible provider supports extracting provider-specific metadata from API responses through metadata extractors.

--- a/packages/openai-compatible/src/chat/get-provider-metadata.test.ts
+++ b/packages/openai-compatible/src/chat/get-provider-metadata.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { getProviderMetadata } from './get-provider-metadata';
+
+describe('getProviderMetadata', () => {
+  describe('provider-specific metadata', () => {
+    it('should extract provider-specific metadata when available', () => {
+      const result = getProviderMetadata(
+        {
+          providerOptions: {
+            openai: {
+              user: 'test-user',
+              customOption: 'value',
+            },
+          },
+        },
+        'openai',
+      );
+
+      expect(result).toEqual({
+        user: 'test-user',
+        customOption: 'value',
+      });
+    });
+
+    it('should return empty object when no metadata exists', () => {
+      const result = getProviderMetadata({}, 'openai');
+
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object when providerOptions is undefined', () => {
+      const result = getProviderMetadata(
+        { providerOptions: undefined },
+        'openai',
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object when provider name does not match', () => {
+      const result = getProviderMetadata(
+        {
+          providerOptions: {
+            anthropic: {
+              user: 'test-user',
+            },
+          },
+        },
+        'openai',
+      );
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('backwards compatibility with openaiCompatible', () => {
+    it('should fall back to openaiCompatible when provider-specific metadata is not available', () => {
+      const result = getProviderMetadata(
+        {
+          providerOptions: {
+            openaiCompatible: {
+              user: 'legacy-user',
+              cacheControl: { type: 'ephemeral' },
+            },
+          },
+        },
+        'openai',
+      );
+
+      expect(result).toEqual({
+        user: 'legacy-user',
+        cacheControl: { type: 'ephemeral' },
+      });
+    });
+
+    it('should prioritize provider-specific metadata over openaiCompatible', () => {
+      const result = getProviderMetadata(
+        {
+          providerOptions: {
+            openai: {
+              user: 'new-user',
+            },
+            openaiCompatible: {
+              user: 'legacy-user',
+              otherOption: 'value',
+            },
+          },
+        },
+        'openai',
+      );
+
+      expect(result).toEqual({
+        user: 'new-user',
+        otherOption: 'value',
+      });
+    });
+
+    it('should merge provider-specific and openaiCompatible metadata', () => {
+      const result = getProviderMetadata(
+        {
+          providerOptions: {
+            openai: {
+              newOption: 'new-value',
+              sharedOption: 'provider-value',
+            },
+            openaiCompatible: {
+              legacyOption: 'legacy-value',
+              sharedOption: 'legacy-value',
+            },
+          },
+        },
+        'openai',
+      );
+
+      expect(result).toEqual({
+        newOption: 'new-value',
+        legacyOption: 'legacy-value',
+        sharedOption: 'provider-value',
+      });
+    });
+  });
+
+  describe('complex metadata structures', () => {
+    it('should handle nested objects', () => {
+      const result = getProviderMetadata(
+        {
+          providerOptions: {
+            openai: {
+              nested: {
+                deep: {
+                  value: 'test',
+                },
+              },
+            },
+          },
+        },
+        'openai',
+      );
+
+      expect(result).toEqual({
+        nested: {
+          deep: {
+            value: 'test',
+          },
+        },
+      });
+    });
+
+    it('should handle arrays in metadata', () => {
+      const result = getProviderMetadata(
+        {
+          providerOptions: {
+            openai: {
+              tags: ['tag1', 'tag2'],
+            },
+          },
+        },
+        'openai',
+      );
+
+      expect(result).toEqual({
+        tags: ['tag1', 'tag2'],
+      });
+    });
+  });
+});

--- a/packages/openai-compatible/src/chat/get-provider-metadata.ts
+++ b/packages/openai-compatible/src/chat/get-provider-metadata.ts
@@ -1,0 +1,47 @@
+import { SharedV3ProviderMetadata } from '@ai-sdk/provider';
+
+/**
+ * Extracts provider-specific metadata from providerOptions.
+ *
+ * This function first checks for metadata under the specific provider name,
+ * and falls back to the legacy 'openaiCompatible' key for backwards compatibility.
+ *
+ * @param item - An object that may contain providerOptions
+ * @param providerName - The name of the provider (e.g., 'openai', 'anthropic', 'test-provider')
+ * @returns The merged metadata object
+ *
+ * @example
+ * // New approach (provider-specific)
+ * getProviderMetadata({ providerOptions: { openai: { user: 'test' } } }, 'openai')
+ * // Returns: { user: 'test' }
+ *
+ * @example
+ * // Legacy approach (backwards compatible)
+ * getProviderMetadata({ providerOptions: { openaiCompatible: { user: 'test' } } }, 'openai')
+ * // Returns: { user: 'test' }
+ *
+ * @example
+ * // Provider-specific takes precedence over legacy
+ * getProviderMetadata({
+ *   providerOptions: {
+ *     openai: { user: 'new' },
+ *     openaiCompatible: { user: 'old', extra: 'data' }
+ *   }
+ * }, 'openai')
+ * // Returns: { user: 'new', extra: 'data' }
+ */
+export function getProviderMetadata(
+  item: {
+    providerOptions?: SharedV3ProviderMetadata;
+  },
+  providerName: string,
+): Record<string, unknown> {
+  const legacyMetadata = item?.providerOptions?.openaiCompatible ?? {};
+  const providerMetadata = item?.providerOptions?.[providerName] ?? {};
+
+  // Provider-specific metadata takes precedence over legacy metadata
+  return {
+    ...legacyMetadata,
+    ...providerMetadata,
+  };
+}

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -215,7 +215,10 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
         verbosity: compatibleOptions.textVerbosity,
 
         // messages:
-        messages: convertToOpenAICompatibleChatMessages(prompt),
+        messages: convertToOpenAICompatibleChatMessages(
+          prompt,
+          this.providerOptionsName,
+        ),
 
         // tools:
         tools: openaiTools,


### PR DESCRIPTION
## Summary

Standardizes provider options handling in the `openai-compatible` package to use the actual provider name (e.g., `'openai'`, `'anthropic'`, `'test-provider'`) as the key in `providerOptions`, while maintaining full backwards compatibility with the legacy `'openaiCompatible'` key.

This addresses the inconsistency raised by @lgrammel in https://github.com/vercel/ai/pull/11505#discussion_r2675788599

## Motivation

The codebase had inconsistent behavior:
- `convert-to-openai-compatible-chat-messages.ts` always used the hardcoded `'openaiCompatible'` key
- `openai-compatible-chat-language-model.ts` used `providerOptionsName` (the actual provider name)
- This inconsistency needed to be resolved before adding tool-level provider options in #11505

## Backwards Compatibility

- [X] All existing code using `providerOptions: { openaiCompatible: { ... } }` continues to work
- [X] Provider-specific options take precedence when both are present
- [X] Default `providerName` is `'openaiCompatible'` (matching legacy behavior)

## Related

- Prerequisite for #11505 (tool-level provider options)
- Once merged, #11505 will use the same `getProviderMetadata` helper for tools