### PR TITLE
fix(amazon-bedrock): normalize tool call IDs for Mistral models

### DIFF
--- a/.changeset/fix-bedrock-mistral-tool-ids.md
+++ b/.changeset/fix-bedrock-mistral-tool-ids.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): normalize tool call IDs for Mistral models
+
+Mistral models on Bedrock require tool call IDs to match exactly 9 alphanumeric characters. This fix normalizes Bedrock-generated tool call IDs when using Mistral models to prevent validation errors during multi-turn tool calling.

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -39,6 +39,7 @@ import { prepareTools } from './bedrock-prepare-tools';
 import { BedrockUsage, convertBedrockUsage } from './convert-bedrock-usage';
 import { convertToBedrockChatMessages } from './convert-to-bedrock-chat-messages';
 import { mapBedrockFinishReason } from './map-bedrock-finish-reason';
+import { isMistralModel, normalizeToolCallId } from './normalize-tool-call-id';
 
 type BedrockChatConfig = {
   baseUrl: () => string;
@@ -312,8 +313,11 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       }
     }
 
-    const { system, messages } =
-      await convertToBedrockChatMessages(filteredPrompt);
+    const isMistral = isMistralModel(this.modelId);
+    const { system, messages } = await convertToBedrockChatMessages(
+      filteredPrompt,
+      isMistral,
+    );
 
     // Filter out reasoningConfig from providerOptions.bedrock to prevent sending it to Bedrock API
     const {
@@ -440,9 +444,12 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
             text: JSON.stringify(part.toolUse.input),
           });
         } else {
+          const isMistral = isMistralModel(this.modelId);
+          const rawToolCallId =
+            part.toolUse?.toolUseId ?? this.config.generateId();
           content.push({
             type: 'tool-call' as const,
-            toolCallId: part.toolUse?.toolUseId ?? this.config.generateId(),
+            toolCallId: normalizeToolCallId(rawToolCallId, isMistral),
             toolName: part.toolUse?.name ?? `tool-${this.config.generateId()}`,
             input: JSON.stringify(part.toolUse?.input ?? {}),
           });
@@ -499,6 +506,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       warnings,
       usesJsonResponseTool,
     } = await this.getArgs(options);
+    const isMistral = isMistralModel(this.modelId);
     const url = `${this.getUrl(this.modelId)}/converse-stream`;
 
     const { value: response, responseHeaders } = await postJsonToApi({
@@ -773,9 +781,13 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
               const isJsonResponseTool =
                 usesJsonResponseTool && toolUse.name === 'json';
 
+              const normalizedToolCallId = normalizeToolCallId(
+                toolUse.toolUseId!,
+                isMistral,
+              );
               contentBlocks[blockIndex] = {
                 type: 'tool-call',
-                toolCallId: toolUse.toolUseId!,
+                toolCallId: normalizedToolCallId,
                 toolName: toolUse.name!,
                 jsonText: '',
                 isJsonResponseTool,
@@ -785,7 +797,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
               if (!isJsonResponseTool) {
                 controller.enqueue({
                   type: 'tool-input-start',
-                  id: toolUse.toolUseId!,
+                  id: normalizedToolCallId,
                   toolName: toolUse.name!,
                 });
               }

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -22,6 +22,7 @@ import {
 } from './bedrock-api-types';
 import { bedrockReasoningMetadataSchema } from './bedrock-chat-language-model';
 import { bedrockFilePartProviderOptions } from './bedrock-chat-options';
+import { normalizeToolCallId } from './normalize-tool-call-id';
 
 function getCachePoint(
   providerMetadata: SharedV3ProviderMetadata | undefined,
@@ -43,6 +44,7 @@ async function shouldEnableCitations(
 
 export async function convertToBedrockChatMessages(
   prompt: LanguageModelV3Prompt,
+  isMistral: boolean = false,
 ): Promise<{
   system: BedrockSystemMessages;
   messages: BedrockMessages;
@@ -204,7 +206,7 @@ export async function convertToBedrockChatMessages(
 
                 bedrockContent.push({
                   toolResult: {
-                    toolUseId: part.toolCallId,
+                    toolUseId: normalizeToolCallId(part.toolCallId, isMistral),
                     content: toolResultContent,
                   },
                 });
@@ -305,7 +307,7 @@ export async function convertToBedrockChatMessages(
               case 'tool-call': {
                 bedrockContent.push({
                   toolUse: {
-                    toolUseId: part.toolCallId,
+                    toolUseId: normalizeToolCallId(part.toolCallId, isMistral),
                     name: part.toolName,
                     input: part.input as JSONObject,
                   },

--- a/packages/amazon-bedrock/src/normalize-tool-call-id.test.ts
+++ b/packages/amazon-bedrock/src/normalize-tool-call-id.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { isMistralModel, normalizeToolCallId } from './normalize-tool-call-id';
+
+describe('isMistralModel', () => {
+  it('should return true for mistral models', () => {
+    expect(isMistralModel('mistral.mistral-7b-instruct-v0:2')).toBe(true);
+    expect(isMistralModel('mistral.mixtral-8x7b-instruct-v0:1')).toBe(true);
+    expect(isMistralModel('mistral.mistral-large-2402-v1:0')).toBe(true);
+    expect(isMistralModel('mistral.mistral-small-2402-v1:0')).toBe(true);
+    expect(isMistralModel('mistral.mistral-large-2407-v1:0')).toBe(true);
+    expect(isMistralModel('mistral.ministral-3-14b-instruct')).toBe(true);
+    expect(isMistralModel('mistral.ministral-3-8b-instruct')).toBe(true);
+  });
+
+  it('should return true for region-prefixed mistral models', () => {
+    expect(isMistralModel('us.mistral.pixtral-large-2502-v1:0')).toBe(true);
+    expect(isMistralModel('eu.mistral.mistral-large-2407-v1:0')).toBe(true);
+  });
+
+  it('should return false for non-mistral models', () => {
+    expect(isMistralModel('anthropic.claude-3-5-sonnet-20241022-v2:0')).toBe(
+      false,
+    );
+    expect(isMistralModel('amazon.nova-pro-v1:0')).toBe(false);
+    expect(isMistralModel('openai.gpt-4o')).toBe(false);
+    expect(isMistralModel('meta.llama3-70b-instruct-v1:0')).toBe(false);
+  });
+});
+
+describe('normalizeToolCallId', () => {
+  it('should return the original ID when not a Mistral model', () => {
+    const originalId = 'tooluse_bpe71yCfRu2b5i-nKGDr5g';
+    expect(normalizeToolCallId(originalId, false)).toBe(originalId);
+  });
+
+  it('should extract first 9 alphanumeric characters for Mistral models', () => {
+    // Bedrock format: tooluse_bpe71yCfRu2b5i-nKGDr5g
+    // After removing non-alphanumeric: toolusebpe71yCfRu2b5inKGDr5g
+    // First 9 chars: toolusebp
+    expect(normalizeToolCallId('tooluse_bpe71yCfRu2b5i-nKGDr5g', true)).toBe(
+      'toolusebp',
+    );
+  });
+
+  it('should handle IDs with various special characters', () => {
+    expect(normalizeToolCallId('tool-use_123ABC456', true)).toBe('tooluse12');
+    expect(normalizeToolCallId('___abc123DEF___', true)).toBe('abc123DEF');
+  });
+
+  it('should handle IDs that are already alphanumeric', () => {
+    expect(normalizeToolCallId('abcdefghi', true)).toBe('abcdefghi');
+    expect(normalizeToolCallId('abc123XYZ', true)).toBe('abc123XYZ');
+  });
+
+  it('should handle short IDs', () => {
+    expect(normalizeToolCallId('abc', true)).toBe('abc');
+    expect(normalizeToolCallId('12345', true)).toBe('12345');
+  });
+
+  it('should handle IDs with only special characters', () => {
+    expect(normalizeToolCallId('___---___', true)).toBe('');
+  });
+
+  it('should produce valid Mistral tool call IDs (9 alphanumeric chars)', () => {
+    const normalizedId = normalizeToolCallId(
+      'tooluse_bpe71yCfRu2b5i-nKGDr5g',
+      true,
+    );
+    // Verify the ID matches Mistral's requirements: ^[a-zA-Z0-9]{1,9}$
+    expect(normalizedId).toMatch(/^[a-zA-Z0-9]{1,9}$/);
+  });
+});

--- a/packages/amazon-bedrock/src/normalize-tool-call-id.ts
+++ b/packages/amazon-bedrock/src/normalize-tool-call-id.ts
@@ -1,0 +1,36 @@
+/**
+ * Checks if the given model ID is a Mistral model.
+ * Mistral models on Bedrock are prefixed with 'mistral.' or region-prefixed like 'us.mistral.'.
+ */
+export function isMistralModel(modelId: string): boolean {
+  return modelId.includes('mistral.');
+}
+
+/**
+ * Normalizes a tool call ID for Mistral models.
+ *
+ * Mistral models require tool call IDs to match the regex `^[a-zA-Z0-9]{9}$`:
+ * - Exactly 9 characters
+ * - Alphanumeric only (no underscores, hyphens, or other characters)
+ *
+ * Bedrock generates tool call IDs in formats like `tooluse_bpe71yCfRu2b5i-nKGDr5g`,
+ * which are incompatible with Mistral's requirements.
+ *
+ * This function extracts the first 9 alphanumeric characters from the ID.
+ *
+ * @param toolCallId - The original tool call ID from Bedrock
+ * @param isMistral - Whether the model is a Mistral model
+ * @returns The normalized tool call ID (9 alphanumeric chars) if Mistral, otherwise the original ID
+ */
+export function normalizeToolCallId(
+  toolCallId: string,
+  isMistral: boolean,
+): string {
+  if (!isMistral) {
+    return toolCallId;
+  }
+
+  // Extract only alphanumeric characters and take first 9
+  const alphanumericChars = toolCallId.replace(/[^a-zA-Z0-9]/g, '');
+  return alphanumericChars.slice(0, 9);
+}


### PR DESCRIPTION
## Background

Mistral models on Bedrock require tool call IDs to match exactly 9 alphanumeric characters (regex `^[a-zA-Z0-9]{9}$`). However, Bedrock generates tool call IDs in formats like `tooluse_bpe71yCfRu2b5i-nKGDr5g` which are incompatible with Mistral validation. This causes tool calling to fail on the second turn when sending the tool result back.

## Summary

- Added `isMistralModel()` helper to detect Mistral models (prefixed with `mistral.` or region-prefixed like `us.mistral.`)
- Added `normalizeToolCallId()` to extract first 9 alphanumeric characters from IDs
- Applied normalization when receiving tool calls from Mistral models in `doGenerate` and `doStream`
- Applied normalization when sending tool results to Mistral models in `convertToBedrockChatMessages`
- Maintained original behavior for non-Mistral models

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11802