### PR TITLE
feat (provider/google-vertex): add support for maas models

### DIFF
--- a/.changeset/unlucky-cats-grow.md
+++ b/.changeset/unlucky-cats-grow.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+feat (provider/google-vertex): add support for maas models

--- a/examples/ai-functions/src/generate-text/google-vertex-maas-deepseek.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-maas-deepseek.ts
@@ -1,10 +1,10 @@
 import { run } from '../lib/run';
-import { vertex } from '@ai-sdk/google-vertex';
+import { vertexMaas } from '@ai-sdk/google-vertex/maas';
 import { generateText } from 'ai';
 
 run(async () => {
   const result = await generateText({
-    model: vertex('qwen3-next-80b-a3b-instruct-maas'),
+    model: vertexMaas('deepseek-ai/deepseek-v3.2-maas'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/generate-text/google-vertex-maas-kimi.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-maas-kimi.ts
@@ -1,10 +1,10 @@
 import { run } from '../lib/run';
-import { vertex } from '@ai-sdk/google-vertex';
+import { vertexMaas } from '@ai-sdk/google-vertex/maas';
 import { generateText } from 'ai';
 
 run(async () => {
   const result = await generateText({
-    model: vertex('qwen3-next-80b-a3b-instruct-maas'),
+    model: vertexMaas('moonshotai/kimi-k2-instruct-0905-maas'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/generate-text/google-vertex-maas-qwen.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-maas-qwen.ts
@@ -1,10 +1,10 @@
 import { run } from '../lib/run';
-import { vertex } from '@ai-sdk/google-vertex';
+import { vertexMaas } from '@ai-sdk/google-vertex/maas';
 import { generateText } from 'ai';
 
 run(async () => {
   const result = await generateText({
-    model: vertex('qwen3-next-80b-a3b-instruct-maas'),
+    model: vertexMaas('qwen/qwen3-next-80b-a3b-instruct-maas'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/generate-text/google-vertex-maas-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-maas-tool-call.ts
@@ -9,8 +9,12 @@ run(async () => {
     tools: {
       weather: tool({
         description: 'Get the weather in a location (fahrenheit)',
-        parameters: z.object({
+        inputSchema: z.object({
           location: z.string().describe('The location to get the weather for'),
+        }),
+        outputSchema: z.object({
+          location: z.string(),
+          temperature: z.number(),
         }),
         execute: async ({ location }) => ({
           location,

--- a/examples/ai-functions/src/generate-text/google-vertex-maas-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-maas-tool-call.ts
@@ -1,0 +1,31 @@
+import { run } from '../lib/run';
+import { vertexMaas } from '@ai-sdk/google-vertex/maas';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+run(async () => {
+  const result = await generateText({
+    model: vertexMaas('qwen/qwen3-next-80b-a3b-instruct-maas'),
+    tools: {
+      weather: tool({
+        description: 'Get the weather in a location (fahrenheit)',
+        parameters: z.object({
+          location: z.string().describe('The location to get the weather for'),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temperature: 72 + Math.floor(Math.random() * 21) - 10,
+        }),
+      }),
+    },
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Tool calls:', result.toolCalls);
+  console.log('Tool results:', result.toolResults);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/google-vertex-maas-deepseek.ts
+++ b/examples/ai-functions/src/stream-text/google-vertex-maas-deepseek.ts
@@ -1,0 +1,19 @@
+import { run } from '../lib/run';
+import { vertexMaas } from '@ai-sdk/google-vertex/maas';
+import { streamText } from 'ai';
+
+run(async () => {
+  const result = streamText({
+    model: vertexMaas('deepseek-ai/deepseek-v3.2-maas'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/google-vertex-maas-kimi.ts
+++ b/examples/ai-functions/src/stream-text/google-vertex-maas-kimi.ts
@@ -1,0 +1,19 @@
+import { run } from '../lib/run';
+import { vertexMaas } from '@ai-sdk/google-vertex/maas';
+import { streamText } from 'ai';
+
+run(async () => {
+  const result = streamText({
+    model: vertexMaas('moonshotai/kimi-k2-instruct-0905-maas'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/google-vertex-maas-qwen.ts
+++ b/examples/ai-functions/src/stream-text/google-vertex-maas-qwen.ts
@@ -1,0 +1,19 @@
+import { run } from '../lib/run';
+import { vertexMaas } from '@ai-sdk/google-vertex/maas';
+import { streamText } from 'ai';
+
+run(async () => {
+  const result = streamText({
+    model: vertexMaas('qwen/qwen3-next-80b-a3b-instruct-maas'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/google-vertex-maas-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/google-vertex-maas-tool-call.ts
@@ -1,0 +1,35 @@
+import { run } from '../lib/run';
+import { vertexMaas } from '@ai-sdk/google-vertex/maas';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+
+run(async () => {
+  const result = streamText({
+    model: vertexMaas('qwen/qwen3-next-80b-a3b-instruct-maas'),
+    tools: {
+      weather: tool({
+        description: 'Get the weather in a location (fahrenheit)',
+        parameters: z.object({
+          location: z.string().describe('The location to get the weather for'),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temperature: 72 + Math.floor(Math.random() * 21) - 10,
+        }),
+      }),
+    },
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log();
+  console.log('Tool calls:', await result.toolCalls);
+  console.log('Tool results:', await result.toolResults);
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/google-vertex-maas-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/google-vertex-maas-tool-call.ts
@@ -9,8 +9,12 @@ run(async () => {
     tools: {
       weather: tool({
         description: 'Get the weather in a location (fahrenheit)',
-        parameters: z.object({
+        inputSchema: z.object({
           location: z.string().describe('The location to get the weather for'),
+        }),
+        outputSchema: z.object({
+          location: z.string(),
+          temperature: z.number(),
         }),
         execute: async ({ location }) => ({
           location,

--- a/packages/google-vertex/.gitignore
+++ b/packages/google-vertex/.gitignore
@@ -1,3 +1,5 @@
 edge/dist
 anthropic/dist
 anthropic/edge/dist
+maas/dist
+maas/edge/dist

--- a/packages/google-vertex/maas/edge.d.ts
+++ b/packages/google-vertex/maas/edge.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/maas/edge/index';

--- a/packages/google-vertex/maas/index.d.ts
+++ b/packages/google-vertex/maas/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/maas/index';

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -12,7 +12,9 @@
     "README.md",
     "edge.d.ts",
     "anthropic/edge.d.ts",
-    "anthropic/index.d.ts"
+    "anthropic/index.d.ts",
+    "maas/edge.d.ts",
+    "maas/index.d.ts"
   ],
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
@@ -48,11 +50,22 @@
       "types": "./dist/anthropic/edge/index.d.ts",
       "import": "./dist/anthropic/edge/index.mjs",
       "require": "./dist/anthropic/edge/index.js"
+    },
+    "./maas": {
+      "types": "./dist/maas/index.d.ts",
+      "import": "./dist/maas/index.mjs",
+      "require": "./dist/maas/index.js"
+    },
+    "./maas/edge": {
+      "types": "./dist/maas/edge/index.d.ts",
+      "import": "./dist/maas/edge/index.mjs",
+      "require": "./dist/maas/edge/index.js"
     }
   },
   "dependencies": {
     "@ai-sdk/anthropic": "workspace:*",
     "@ai-sdk/google": "workspace:*",
+    "@ai-sdk/openai-compatible": "workspace:*",
     "@ai-sdk/provider": "workspace:*",
     "@ai-sdk/provider-utils": "workspace:*",
     "google-auth-library": "^10.5.0"

--- a/packages/google-vertex/src/maas/edge/google-vertex-maas-provider-edge.test.ts
+++ b/packages/google-vertex/src/maas/edge/google-vertex-maas-provider-edge.test.ts
@@ -2,15 +2,14 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   createVertexMaas,
   vertexMaas,
-} from './google-vertex-maas-provider-node';
-import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
+} from './google-vertex-maas-provider-edge';
+import { generateAuthToken } from '../../edge/google-vertex-auth-edge';
 
-// Mock the imported modules
-vi.mock('../google-vertex-auth-google-auth-library', () => ({
+vi.mock('../../edge/google-vertex-auth-edge', () => ({
   generateAuthToken: vi.fn(),
 }));
 
-vi.mock('./google-vertex-maas-provider', () => ({
+vi.mock('../google-vertex-maas-provider', () => ({
   createVertexMaas: vi.fn(options => {
     const provider: any = vi.fn();
     provider.fetch = options.fetch;
@@ -26,7 +25,7 @@ vi.mock('@ai-sdk/provider-utils', () => ({
   }),
 }));
 
-describe('google-vertex-maas-provider-node', () => {
+describe('google-vertex-maas-provider-edge', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -38,7 +37,7 @@ describe('google-vertex-maas-provider-node', () => {
 
     expect(provider).toBeDefined();
     const { createVertexMaas: baseCreateVertexMaas } = vi.mocked(
-      await import('./google-vertex-maas-provider'),
+      await import('../google-vertex-maas-provider'),
     );
     expect(baseCreateVertexMaas).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -77,21 +76,24 @@ describe('google-vertex-maas-provider-node', () => {
     });
   });
 
-  it('should pass googleAuthOptions to generateAuthToken', async () => {
+  it('should pass googleCredentials to generateAuthToken', async () => {
     vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
     const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
     global.fetch = mockFetch;
 
-    const googleAuthOptions = { scopes: ['test-scope'] };
+    const googleCredentials = {
+      clientEmail: 'test@example.com',
+      privateKey: 'test-key',
+    };
     const provider = createVertexMaas({
       project: 'test-project',
-      googleAuthOptions,
+      googleCredentials,
     });
 
     const customFetch = (provider as any).fetch;
     await customFetch('https://example.com/test', {});
 
-    expect(generateAuthToken).toHaveBeenCalledWith(googleAuthOptions);
+    expect(generateAuthToken).toHaveBeenCalledWith(googleCredentials);
   });
 
   it('should merge custom headers with auth header', async () => {
@@ -207,7 +209,7 @@ describe('google-vertex-maas-provider-node', () => {
     });
 
     const { createVertexMaas: baseCreateVertexMaas } = vi.mocked(
-      await import('./google-vertex-maas-provider'),
+      await import('../google-vertex-maas-provider'),
     );
     expect(baseCreateVertexMaas).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/google-vertex/src/maas/edge/google-vertex-maas-provider-edge.ts
+++ b/packages/google-vertex/src/maas/edge/google-vertex-maas-provider-edge.ts
@@ -1,0 +1,66 @@
+import { FetchFunction, resolve } from '@ai-sdk/provider-utils';
+import {
+  generateAuthToken,
+  GoogleCredentials,
+} from '../../edge/google-vertex-auth-edge';
+import {
+  createVertexMaas as createVertexMaasOriginal,
+  GoogleVertexMaasProvider,
+  GoogleVertexMaasProviderSettings as GoogleVertexMaasProviderSettingsOriginal,
+} from '../google-vertex-maas-provider';
+
+export type { GoogleVertexMaasProvider };
+
+export interface GoogleVertexMaasProviderSettings
+  extends GoogleVertexMaasProviderSettingsOriginal {
+  /**
+   * Optional. The Google credentials for the Google Cloud service account. If
+   * not provided, the Google Vertex provider will use environment variables to
+   * load the credentials.
+   */
+  googleCredentials?: GoogleCredentials;
+}
+
+/**
+ * Create a Google Vertex AI MaaS (Model as a Service) provider instance for Edge runtimes.
+ * Uses the OpenAI-compatible Chat Completions API for partner and open models.
+ * Automatically handles Google Cloud authentication.
+ *
+ * @see https://cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models
+ */
+export function createVertexMaas(
+  options: GoogleVertexMaasProviderSettings = {},
+): GoogleVertexMaasProvider {
+  // Create a custom fetch wrapper that adds auth headers
+  const customFetch: FetchFunction = async (url, init) => {
+    const token = await generateAuthToken(options.googleCredentials);
+    const resolvedHeaders = await resolve(options.headers);
+    const authHeaders = {
+      ...resolvedHeaders,
+      Authorization: `Bearer ${token}`,
+    };
+
+    // Merge auth headers with existing headers from init
+    const fetchInit = {
+      ...init,
+      headers: {
+        ...init?.headers,
+        ...authHeaders,
+      },
+    };
+
+    // Call the original fetch or user's custom fetch
+    return (options.fetch ?? fetch)(url, fetchInit);
+  };
+
+  return createVertexMaasOriginal({
+    ...options,
+    fetch: customFetch,
+    headers: undefined, // Don't pass headers, we handle them in fetch
+  });
+}
+
+/**
+ * Default Google Vertex AI MaaS provider instance for Edge runtimes.
+ */
+export const vertexMaas = createVertexMaas();

--- a/packages/google-vertex/src/maas/edge/index.ts
+++ b/packages/google-vertex/src/maas/edge/index.ts
@@ -1,0 +1,9 @@
+export {
+  createVertexMaas,
+  vertexMaas,
+} from './google-vertex-maas-provider-edge';
+export type {
+  GoogleVertexMaasProvider,
+  GoogleVertexMaasProviderSettings,
+} from './google-vertex-maas-provider-edge';
+export type { GoogleVertexMaasModelId } from '../google-vertex-maas-options';

--- a/packages/google-vertex/src/maas/google-vertex-maas-options.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-options.ts
@@ -1,26 +1,15 @@
-/**
- * Google Vertex AI MaaS (Model as a Service) model IDs.
- * These models use the OpenAI-compatible Chat Completions API.
- * @see https://cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models
- */
+// https://cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models
 export type GoogleVertexMaasModelId =
-  // DeepSeek models
   | 'deepseek-ai/deepseek-r1-0528-maas'
   | 'deepseek-ai/deepseek-v3.1-maas'
   | 'deepseek-ai/deepseek-v3.2-maas'
-  // GPT-OSS models
   | 'openai/gpt-oss-120b-maas'
   | 'openai/gpt-oss-20b-maas'
-  // Llama models
   | 'meta/llama-4-maverick-17b-128e-instruct-maas'
   | 'meta/llama-4-scout-17b-16e-instruct-maas'
-  // MiniMax models
   | 'minimax/minimax-m2-maas'
-  // Qwen models
   | 'qwen/qwen3-coder-480b-a35b-instruct-maas'
   | 'qwen/qwen3-next-80b-a3b-instruct-maas'
   | 'qwen/qwen3-next-80b-a3b-thinking-maas'
-  // Kimi models (MoonshotAI)
   | 'moonshotai/kimi-k2-instruct-0905-maas'
-  // Allow arbitrary model strings
   | (string & {});

--- a/packages/google-vertex/src/maas/google-vertex-maas-options.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-options.ts
@@ -1,0 +1,26 @@
+/**
+ * Google Vertex AI MaaS (Model as a Service) model IDs.
+ * These models use the OpenAI-compatible Chat Completions API.
+ * @see https://cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models
+ */
+export type GoogleVertexMaasModelId =
+  // DeepSeek models
+  | 'deepseek-ai/deepseek-r1-0528-maas'
+  | 'deepseek-ai/deepseek-v3.1-maas'
+  | 'deepseek-ai/deepseek-v3.2-maas'
+  // GPT-OSS models
+  | 'openai/gpt-oss-120b-maas'
+  | 'openai/gpt-oss-20b-maas'
+  // Llama models
+  | 'meta/llama-4-maverick-17b-128e-instruct-maas'
+  | 'meta/llama-4-scout-17b-16e-instruct-maas'
+  // MiniMax models
+  | 'minimax/minimax-m2-maas'
+  // Qwen models
+  | 'qwen/qwen3-coder-480b-a35b-instruct-maas'
+  | 'qwen/qwen3-next-80b-a3b-instruct-maas'
+  | 'qwen/qwen3-next-80b-a3b-thinking-maas'
+  // Kimi models (MoonshotAI)
+  | 'moonshotai/kimi-k2-instruct-0905-maas'
+  // Allow arbitrary model strings
+  | (string & {});

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider-node.test.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider-node.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  createVertexMaas,
+  vertexMaas,
+} from './google-vertex-maas-provider-node';
+import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
+
+// Mock the imported modules
+vi.mock('../google-vertex-auth-google-auth-library', () => ({
+  generateAuthToken: vi.fn(),
+}));
+
+vi.mock('./google-vertex-maas-provider', () => ({
+  createVertexMaas: vi.fn((options) => {
+    // Return a mock provider that captures the fetch function
+    const provider: any = vi.fn();
+    provider.fetch = options.fetch;
+    provider.headers = options.headers;
+    return provider;
+  }),
+}));
+
+vi.mock('@ai-sdk/provider-utils', () => ({
+  resolve: vi.fn().mockImplementation(async (value) => {
+    if (typeof value === 'function') return value();
+    return value;
+  }),
+}));
+
+describe('google-vertex-maas-provider-node', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create provider with auth wrapper', async () => {
+    const provider = createVertexMaas({
+      project: 'test-project',
+    });
+
+    expect(provider).toBeDefined();
+    const { createVertexMaas: baseCreateVertexMaas } = vi.mocked(
+      await import('./google-vertex-maas-provider'),
+    );
+    expect(baseCreateVertexMaas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: 'test-project',
+        fetch: expect.any(Function),
+        headers: undefined,
+      }),
+    );
+  });
+
+  it('should generate auth token and add to request headers', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const provider = createVertexMaas({
+      project: 'test-project',
+    });
+
+    // Get the custom fetch function from the provider
+    const customFetch = (provider as any).fetch;
+    expect(customFetch).toBeDefined();
+
+    // Call the custom fetch
+    await customFetch('https://example.com/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    // Verify auth token was generated
+    expect(generateAuthToken).toHaveBeenCalledWith(undefined);
+
+    // Verify fetch was called with auth header
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/test', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer mock-auth-token',
+      },
+    });
+  });
+
+  it('should pass googleAuthOptions to generateAuthToken', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const googleAuthOptions = { scopes: ['test-scope'] };
+    const provider = createVertexMaas({
+      project: 'test-project',
+      googleAuthOptions,
+    });
+
+    const customFetch = (provider as any).fetch;
+    await customFetch('https://example.com/test', {});
+
+    expect(generateAuthToken).toHaveBeenCalledWith(googleAuthOptions);
+  });
+
+  it('should merge custom headers with auth header', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const customHeaders = { 'X-Custom': 'header-value' };
+    const provider = createVertexMaas({
+      project: 'test-project',
+      headers: customHeaders,
+    });
+
+    const customFetch = (provider as any).fetch;
+    await customFetch('https://example.com/test', {
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/test', {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Custom': 'header-value',
+        Authorization: 'Bearer mock-auth-token',
+      },
+    });
+  });
+
+  it('should use custom fetch when provided', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const customFetch = vi.fn().mockResolvedValue(new Response('{}'));
+
+    const provider = createVertexMaas({
+      project: 'test-project',
+      fetch: customFetch,
+    });
+
+    const authFetch = (provider as any).fetch;
+    await authFetch('https://example.com/test', {});
+
+    // Verify custom fetch was called instead of global fetch
+    expect(customFetch).toHaveBeenCalledWith(
+      'https://example.com/test',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer mock-auth-token',
+        }),
+      }),
+    );
+  });
+
+  it('should handle async custom headers', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const asyncHeaders = Promise.resolve({ 'X-Async': 'async-value' });
+    const provider = createVertexMaas({
+      project: 'test-project',
+      headers: asyncHeaders,
+    });
+
+    const customFetch = (provider as any).fetch;
+    await customFetch('https://example.com/test', {});
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com/test',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Async': 'async-value',
+          Authorization: 'Bearer mock-auth-token',
+        }),
+      }),
+    );
+  });
+
+  it('should preserve headers from init parameter', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const provider = createVertexMaas({
+      project: 'test-project',
+    });
+
+    const customFetch = (provider as any).fetch;
+    await customFetch('https://example.com/test', {
+      headers: {
+        'User-Agent': 'test-agent',
+        'X-Request-ID': 'test-id',
+      },
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com/test',
+      expect.objectContaining({
+        headers: {
+          'User-Agent': 'test-agent',
+          'X-Request-ID': 'test-id',
+          Authorization: 'Bearer mock-auth-token',
+        },
+      }),
+    );
+  });
+
+  it('should export default vertexMaas instance', () => {
+    expect(vertexMaas).toBeDefined();
+    expect(typeof vertexMaas).toBe('function');
+  });
+
+  it('should set headers to undefined in base provider call', async () => {
+    createVertexMaas({
+      project: 'test-project',
+      headers: { 'X-Custom': 'value' },
+    });
+
+    const { createVertexMaas: baseCreateVertexMaas } = vi.mocked(
+      await import('./google-vertex-maas-provider'),
+    );
+    expect(baseCreateVertexMaas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: undefined, // Headers handled in fetch wrapper
+      }),
+    );
+  });
+});

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider-node.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider-node.ts
@@ -1,0 +1,65 @@
+import { FetchFunction, resolve } from '@ai-sdk/provider-utils';
+import { GoogleAuthOptions } from 'google-auth-library';
+import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
+import {
+  createVertexMaas as createVertexMaasOriginal,
+  GoogleVertexMaasProvider,
+  GoogleVertexMaasProviderSettings as GoogleVertexMaasProviderSettingsOriginal,
+} from './google-vertex-maas-provider';
+
+export type { GoogleVertexMaasProvider };
+
+export interface GoogleVertexMaasProviderSettings
+  extends GoogleVertexMaasProviderSettingsOriginal {
+  /**
+   * Optional. The Authentication options provided by google-auth-library.
+   * Complete list of authentication options is documented in the
+   * GoogleAuthOptions interface:
+   * https://github.com/googleapis/google-auth-library-nodejs/blob/main/src/auth/googleauth.ts.
+   */
+  googleAuthOptions?: GoogleAuthOptions;
+}
+
+/**
+ * Create a Google Vertex AI MaaS (Model as a Service) provider instance for Node.js.
+ * Uses the OpenAI-compatible Chat Completions API for partner and open models.
+ * Automatically handles Google Cloud authentication.
+ *
+ * @see https://cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models
+ */
+export function createVertexMaas(
+  options: GoogleVertexMaasProviderSettings = {},
+): GoogleVertexMaasProvider {
+  // Create a custom fetch wrapper that adds auth headers
+  const customFetch: FetchFunction = async (url, init) => {
+    const token = await generateAuthToken(options.googleAuthOptions);
+    const resolvedHeaders = await resolve(options.headers);
+    const authHeaders = {
+      ...resolvedHeaders,
+      Authorization: `Bearer ${token}`,
+    };
+
+    // Merge auth headers with existing headers from init
+    const fetchInit = {
+      ...init,
+      headers: {
+        ...init?.headers,
+        ...authHeaders,
+      },
+    };
+
+    // Call the original fetch or user's custom fetch
+    return (options.fetch ?? fetch)(url, fetchInit);
+  };
+
+  return createVertexMaasOriginal({
+    ...options,
+    fetch: customFetch,
+    headers: undefined, // Don't pass headers, we handle them in fetch
+  });
+}
+
+/**
+ * Default Google Vertex AI MaaS provider instance for Node.js.
+ */
+export const vertexMaas = createVertexMaas();

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
@@ -87,15 +87,13 @@ describe('google-vertex-maas-provider', () => {
     );
   });
 
-  it('should not pass headers to openai-compatible provider (handled in fetch wrapper)', () => {
+  it('should not pass headers to openai-compatible provider', () => {
     const customHeaders = { 'X-Custom': 'header-value' };
     createVertexMaas({
       project: 'test-project',
       headers: customHeaders,
     });
 
-    // Headers are not passed to createOpenAICompatible because they are
-    // handled by the auth fetch wrapper in Node.js/Edge implementations
     expect(createOpenAICompatible).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'vertex.maas',
@@ -103,7 +101,6 @@ describe('google-vertex-maas-provider', () => {
         fetch: undefined,
       }),
     );
-    // Verify headers are NOT in the call
     expect(createOpenAICompatible).not.toHaveBeenCalledWith(
       expect.objectContaining({
         headers: expect.anything(),

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createVertexMaas } from './google-vertex-maas-provider';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+
+// Mock the imported modules
+vi.mock('@ai-sdk/openai-compatible', () => ({
+  createOpenAICompatible: vi.fn(),
+}));
+
+vi.mock('@ai-sdk/provider-utils', () => ({
+  loadSetting: vi.fn().mockImplementation(({ settingValue }) => {
+    if (settingValue === undefined) {
+      throw new Error('Setting is missing');
+    }
+    return settingValue;
+  }),
+  loadOptionalSetting: vi
+    .fn()
+    .mockImplementation(({ settingValue }) => settingValue),
+  withoutTrailingSlash: vi.fn().mockImplementation(url => {
+    if (!url) return '';
+    return url?.endsWith('/') ? url.slice(0, -1) : url;
+  }),
+}));
+
+describe('google-vertex-maas-provider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create a provider with correct base URL for global location', () => {
+    createVertexMaas({
+      project: 'test-project',
+      location: 'global',
+    });
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'vertex.maas',
+        baseURL:
+          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi',
+      }),
+    );
+  });
+
+  it('should create a provider with correct base URL for regional location', () => {
+    createVertexMaas({
+      project: 'test-project',
+      location: 'us-central1',
+    });
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'vertex.maas',
+        baseURL:
+          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi',
+      }),
+    );
+  });
+
+  it('should default to global location when not specified', () => {
+    createVertexMaas({
+      project: 'test-project',
+    });
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'vertex.maas',
+        baseURL:
+          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi',
+      }),
+    );
+  });
+
+  it('should use custom baseURL when provided', () => {
+    const customBaseURL = 'https://custom-endpoint.example.com';
+    createVertexMaas({
+      project: 'test-project',
+      baseURL: customBaseURL,
+    });
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'vertex.maas',
+        baseURL: customBaseURL,
+      }),
+    );
+  });
+
+  it('should not pass headers to openai-compatible provider (handled in fetch wrapper)', () => {
+    const customHeaders = { 'X-Custom': 'header-value' };
+    createVertexMaas({
+      project: 'test-project',
+      headers: customHeaders,
+    });
+
+    // Headers are not passed to createOpenAICompatible because they are
+    // handled by the auth fetch wrapper in Node.js/Edge implementations
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'vertex.maas',
+        baseURL: expect.any(String),
+        fetch: undefined,
+      }),
+    );
+    // Verify headers are NOT in the call
+    expect(createOpenAICompatible).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.anything(),
+      }),
+    );
+  });
+
+  it('should pass custom fetch to openai-compatible provider', () => {
+    const customFetch = vi.fn();
+    createVertexMaas({
+      project: 'test-project',
+      fetch: customFetch,
+    });
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetch: customFetch,
+      }),
+    );
+  });
+
+  it('should construct correct URL with trailing slash removed from baseURL', () => {
+    createVertexMaas({
+      project: 'test-project',
+      baseURL: 'https://custom-endpoint.example.com/',
+    });
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'https://custom-endpoint.example.com',
+      }),
+    );
+  });
+
+  it('should construct correct URL when baseURL is empty string', () => {
+    createVertexMaas({
+      project: 'test-project',
+      location: 'us-central1',
+      baseURL: '',
+    });
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL:
+          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi',
+      }),
+    );
+  });
+
+  it('should return a provider from createOpenAICompatible', () => {
+    const mockProvider = vi.fn();
+    vi.mocked(createOpenAICompatible).mockReturnValue(mockProvider as any);
+
+    const result = createVertexMaas({
+      project: 'test-project',
+    });
+
+    expect(result).toBe(mockProvider);
+  });
+});

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
@@ -1,0 +1,95 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import type { OpenAICompatibleProvider } from '@ai-sdk/openai-compatible';
+import {
+  FetchFunction,
+  loadOptionalSetting,
+  loadSetting,
+  Resolvable,
+  withoutTrailingSlash,
+} from '@ai-sdk/provider-utils';
+import type { GoogleVertexMaasModelId } from './google-vertex-maas-options';
+
+export interface GoogleVertexMaasProvider
+  extends OpenAICompatibleProvider<
+    GoogleVertexMaasModelId,
+    string,
+    string,
+    string
+  > {}
+
+export interface GoogleVertexMaasProviderSettings {
+  /**
+   * Google Cloud project ID. Defaults to the value of the `GOOGLE_VERTEX_PROJECT` environment variable.
+   */
+  project?: string;
+
+  /**
+   * Google Cloud location/region. Defaults to the value of the `GOOGLE_VERTEX_LOCATION` environment variable.
+   * Use 'global' for the global endpoint.
+   */
+  location?: string;
+
+  /**
+   * Base URL for the API calls. If not provided, will be constructed from project and location.
+   */
+  baseURL?: string;
+
+  /**
+   * Headers to use for requests. Can be:
+   * - A headers object
+   * - A Promise that resolves to a headers object
+   * - A function that returns a headers object
+   * - A function that returns a Promise of a headers object
+   */
+  headers?: Resolvable<Record<string, string | undefined>>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept requests,
+   * or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+}
+
+/**
+ * Create a Google Vertex AI MaaS (Model as a Service) provider instance.
+ * Uses the OpenAI-compatible Chat Completions API for partner and open models.
+ *
+ * @see https://cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models
+ */
+export function createVertexMaas(
+  options: GoogleVertexMaasProviderSettings = {},
+): GoogleVertexMaasProvider {
+  // Lazy-load settings to support loading from environment variables at runtime
+  const loadLocation = () =>
+    loadOptionalSetting({
+      settingValue: options.location,
+      environmentVariableName: 'GOOGLE_VERTEX_LOCATION',
+    });
+
+  const loadProject = () =>
+    loadSetting({
+      settingValue: options.project,
+      settingName: 'project',
+      environmentVariableName: 'GOOGLE_VERTEX_PROJECT',
+      description: 'Google Vertex project',
+    });
+
+  // Construct base URL: https://aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/openapi
+  const constructBaseURL = () => {
+    const projectId = loadProject();
+    const location = loadLocation() ?? 'global';
+
+    return `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/${location}/endpoints/openapi`;
+  };
+
+  const baseURL =
+    withoutTrailingSlash(options.baseURL ?? '') || constructBaseURL();
+
+  return createOpenAICompatible({
+    name: 'vertex.maas',
+    baseURL,
+    // Note: headers are not passed here as they are handled by the auth wrapper
+    // in the Node.js/Edge-specific implementations via the fetch function
+    fetch: options.fetch,
+  });
+}

--- a/packages/google-vertex/src/maas/index.ts
+++ b/packages/google-vertex/src/maas/index.ts
@@ -1,0 +1,9 @@
+export {
+  createVertexMaas,
+  vertexMaas,
+} from './google-vertex-maas-provider-node';
+export type {
+  GoogleVertexMaasProvider,
+  GoogleVertexMaasProviderSettings,
+} from './google-vertex-maas-provider-node';
+export type { GoogleVertexMaasModelId } from './google-vertex-maas-options';

--- a/packages/google-vertex/tsconfig.json
+++ b/packages/google-vertex/tsconfig.json
@@ -12,7 +12,9 @@
     "tsup.config.ts",
     "edge.d.ts",
     "anthropic/edge.d.ts",
-    "anthropic/index.d.ts"
+    "anthropic/index.d.ts",
+    "maas/edge.d.ts",
+    "maas/index.d.ts"
   ],
   "references": [
     {
@@ -20,6 +22,9 @@
     },
     {
       "path": "../google"
+    },
+    {
+      "path": "../openai-compatible"
     },
     {
       "path": "../provider"

--- a/packages/google-vertex/tsup.config.ts
+++ b/packages/google-vertex/tsup.config.ts
@@ -53,4 +53,30 @@ export default defineConfig([
     },
     outDir: 'dist/anthropic/edge',
   },
+  {
+    entry: ['src/maas/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+    outDir: 'dist/maas',
+  },
+  {
+    entry: ['src/maas/edge/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+    outDir: 'dist/maas/edge',
+  },
 ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2164,6 +2164,9 @@ importers:
       '@ai-sdk/google':
         specifier: workspace:*
         version: link:../google
+      '@ai-sdk/openai-compatible':
+        specifier: workspace:*
+        version: link:../openai-compatible
       '@ai-sdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -19429,7 +19432,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.3(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.3(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.101.2))(webpack@5.101.2)
+      '@angular-devkit/build-webpack': 0.2003.3(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.101.2))(webpack@5.101.2(esbuild@0.25.9))
       '@angular-devkit/core': 20.3.3(chokidar@4.0.3)
       '@angular/build': 20.3.3(@angular/compiler-cli@20.3.2(@angular/compiler@20.3.2)(typescript@5.8.3))(@angular/compiler@20.3.2)(@angular/core@20.3.2(@angular/compiler@20.3.2)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.2(@angular/common@20.3.2(@angular/core@20.3.2(@angular/compiler@20.3.2)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.2(@angular/compiler@20.3.2)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.30.2)(postcss@8.5.6)(tailwindcss@4.1.18)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@2.1.4(@edge-runtime/vm@5.0.0)(@types/node@22.7.4)(jsdom@26.0.0)(less@4.4.0)(lightningcss@1.30.2)(msw@2.7.0(@types/node@22.7.4)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.2(@angular/compiler@20.3.2)(typescript@5.8.3)
@@ -19443,13 +19446,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.3(@angular/compiler-cli@20.3.2(@angular/compiler@20.3.2)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.101.2)
+      '@ngtools/webpack': 20.3.3(@angular/compiler-cli@20.3.2(@angular/compiler@20.3.2)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.101.2(esbuild@0.25.9))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.101.2)
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.101.2(esbuild@0.25.9))
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.101.2)
-      css-loader: 7.1.2(webpack@5.101.2)
+      copy-webpack-plugin: 13.0.1(webpack@5.101.2(esbuild@0.25.9))
+      css-loader: 7.1.2(webpack@5.101.2(esbuild@0.25.9))
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19457,22 +19460,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.101.2)
-      license-webpack-plugin: 4.0.2(webpack@5.101.2)
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.101.2(esbuild@0.25.9))
+      license-webpack-plugin: 4.0.2(webpack@5.101.2(esbuild@0.25.9))
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.101.2)
+      mini-css-extract-plugin: 2.9.4(webpack@5.101.2(esbuild@0.25.9))
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.101.2)
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.101.2(esbuild@0.25.9))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.101.2)
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.101.2(esbuild@0.25.9))
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.101.2)
+      source-map-loader: 5.0.0(webpack@5.101.2(esbuild@0.25.9))
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19482,7 +19485,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.101.2)
       webpack-dev-server: 5.2.2(webpack@5.101.2)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.101.2)
+      webpack-subresource-integrity: 5.1.0(webpack@5.101.2(esbuild@0.25.9))
     optionalDependencies:
       '@angular/core': 20.3.2(@angular/compiler@20.3.2)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.2(@angular/common@20.3.2(@angular/core@20.3.2(@angular/compiler@20.3.2)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.2(@angular/compiler@20.3.2)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19512,7 +19515,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.3(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.101.2))(webpack@5.101.2)':
+  '@angular-devkit/build-webpack@0.2003.3(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.101.2))(webpack@5.101.2(esbuild@0.25.9))':
     dependencies:
       '@angular-devkit/architect': 0.2003.3(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24642,7 +24645,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.3(@angular/compiler-cli@20.3.2(@angular/compiler@20.3.2)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.101.2)':
+  '@ngtools/webpack@20.3.3(@angular/compiler-cli@20.3.2(@angular/compiler@20.3.2)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.101.2(esbuild@0.25.9))':
     dependencies:
       '@angular/compiler-cli': 20.3.2(@angular/compiler@20.3.2)(typescript@5.8.3)
       typescript: 5.8.3
@@ -29583,7 +29586,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.101.2):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30330,7 +30333,7 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
-  copy-webpack-plugin@13.0.1(webpack@5.101.2):
+  copy-webpack-plugin@13.0.1(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30432,7 +30435,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.101.2):
+  css-loader@7.1.2(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -34452,7 +34455,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.101.2):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -34479,7 +34482,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-webpack-plugin@4.0.2(webpack@5.101.2):
+  license-webpack-plugin@4.0.2(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -35343,7 +35346,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.101.2):
+  mini-css-extract-plugin@2.9.4(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36787,7 +36790,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.101.2):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.6
@@ -37774,7 +37777,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.101.2):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -38129,7 +38132,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.101.2):
+  source-map-loader@5.0.0(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -40420,7 +40423,7 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.101.2):
+  webpack-subresource-integrity@5.1.0(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.101.2(esbuild@0.25.9)


### PR DESCRIPTION
## Background

Google Vertex AI offers Model as a Service (MaaS) capabilities that allow access to partner and open models through an OpenAI-compatible API. This integration enables AI SDK users to leverage these models in their applications.

## Summary

Added support for Google Vertex AI MaaS (Model as a Service) models in the AI SDK. This implementation:

- Created a new `@ai-sdk/google-vertex/maas` package that provides access to partner models like DeepSeek, Qwen, and Kimi
- Implemented both Node.js and Edge runtime support
- Added automatic Google Cloud authentication handling
- Integrated with the OpenAI-compatible API interface
- Added example files demonstrating text generation and streaming with various MaaS models
- Included support for tool calling functionality

## Manual Verification

Tested the implementation with various MaaS models including DeepSeek, Qwen, and Kimi. Verified both text generation and streaming functionality work correctly. Also confirmed tool calling works with compatible models.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)