### PR TITLE
feat(ai): expose token usage in useChat onFinish callback with forward compatibility fix

### DIFF
--- a/.changeset/thick-trees-train.md
+++ b/.changeset/thick-trees-train.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-Add usage information to onFinish callback in useChat
+Add usage information to onFinish callback in useChat and fix forward compatibility by using z.object instead of z.strictObject in UI message chunks

--- a/.changeset/thick-trees-train.md
+++ b/.changeset/thick-trees-train.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Add usage information to onFinish callback in useChat

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -282,6 +282,13 @@ Allows you to easily create a conversational user interface for your chatbot app
               description:
                 'The reason why the model finished generating the response. Undefined if the finish reason was not provided by the model.',
             },
+            {
+              name: 'usage',
+              type: 'LanguageModelUsage',
+              isOptional: true,
+              description:
+                'Token usage information for the response, including inputTokens, outputTokens, and totalTokens.',
+            },
           ],
         },
       ],

--- a/packages/ai/src/agent/create-agent-ui-stream-response.test.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.test.ts
@@ -245,7 +245,7 @@ describe('createAgentUIStreamResponse', () => {
           "data: {"type":"finish-step"}
 
         ",
-          "data: {"type":"finish","finishReason":"stop"}
+          "data: {"type":"finish","finishReason":"stop","usage":{"inputTokens":10,"inputTokenDetails":{"noCacheTokens":10},"outputTokens":10,"outputTokenDetails":{"textTokens":10},"totalTokens":20}}
 
         ",
           "data: [DONE]

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -655,7 +655,7 @@ exports[`streamText > result.pipeUIMessageStreamToResponse > should mask error m
   "data: {"type":"finish-step"}
 
 ",
-  "data: {"type":"finish","finishReason":"error"}
+  "data: {"type":"finish","finishReason":"error","usage":{"inputTokenDetails":{},"outputTokenDetails":{}}}
 
 ",
   "data: [DONE]
@@ -678,7 +678,7 @@ exports[`streamText > result.pipeUIMessageStreamToResponse > should support cust
   "data: {"type":"finish-step"}
 
 ",
-  "data: {"type":"finish","finishReason":"error"}
+  "data: {"type":"finish","finishReason":"error","usage":{"inputTokenDetails":{},"outputTokenDetails":{}}}
 
 ",
   "data: [DONE]
@@ -803,6 +803,22 @@ exports[`streamText > result.toUIMessageStream > should mask error messages by d
   {
     "finishReason": "error",
     "type": "finish",
+    "usage": {
+      "cachedInputTokens": undefined,
+      "inputTokenDetails": {
+        "cacheReadTokens": undefined,
+        "cacheWriteTokens": undefined,
+        "noCacheTokens": undefined,
+      },
+      "inputTokens": undefined,
+      "outputTokenDetails": {
+        "reasoningTokens": undefined,
+        "textTokens": undefined,
+      },
+      "outputTokens": undefined,
+      "reasoningTokens": undefined,
+      "totalTokens": undefined,
+    },
   },
 ]
 `;
@@ -849,6 +865,22 @@ exports[`streamText > result.toUIMessageStream > should send tool call, tool cal
   {
     "finishReason": "stop",
     "type": "finish",
+    "usage": {
+      "cachedInputTokens": undefined,
+      "inputTokenDetails": {
+        "cacheReadTokens": undefined,
+        "cacheWriteTokens": undefined,
+        "noCacheTokens": 3,
+      },
+      "inputTokens": 3,
+      "outputTokenDetails": {
+        "reasoningTokens": undefined,
+        "textTokens": 10,
+      },
+      "outputTokens": 10,
+      "reasoningTokens": undefined,
+      "totalTokens": 13,
+    },
   },
 ]
 `;
@@ -871,6 +903,22 @@ exports[`streamText > result.toUIMessageStream > should support custom error mes
   {
     "finishReason": "error",
     "type": "finish",
+    "usage": {
+      "cachedInputTokens": undefined,
+      "inputTokenDetails": {
+        "cacheReadTokens": undefined,
+        "cacheWriteTokens": undefined,
+        "noCacheTokens": undefined,
+      },
+      "inputTokens": undefined,
+      "outputTokenDetails": {
+        "reasoningTokens": undefined,
+        "textTokens": undefined,
+      },
+      "outputTokens": undefined,
+      "reasoningTokens": undefined,
+      "totalTokens": undefined,
+    },
   },
 ]
 `;
@@ -889,7 +937,7 @@ exports[`streamText > result.toUIMessageStreamResponse > should mask error messa
   "data: {"type":"finish-step"}
 
 ",
-  "data: {"type":"finish","finishReason":"error"}
+  "data: {"type":"finish","finishReason":"error","usage":{"inputTokenDetails":{},"outputTokenDetails":{}}}
 
 ",
   "data: [DONE]
@@ -912,7 +960,7 @@ exports[`streamText > result.toUIMessageStreamResponse > should support custom e
   "data: {"type":"finish-step"}
 
 ",
-  "data: {"type":"finish","finishReason":"error"}
+  "data: {"type":"finish","finishReason":"error","usage":{"inputTokenDetails":{},"outputTokenDetails":{}}}
 
 ",
   "data: [DONE]

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -1901,7 +1901,7 @@ describe('streamText', () => {
           "data: {"type":"finish-step"}
 
         ",
-          "data: {"type":"finish","finishReason":"stop"}
+          "data: {"type":"finish","finishReason":"stop","usage":{"inputTokens":3,"inputTokenDetails":{"noCacheTokens":3},"outputTokens":10,"outputTokenDetails":{"textTokens":10},"totalTokens":13}}
 
         ",
           "data: [DONE]
@@ -1972,7 +1972,7 @@ describe('streamText', () => {
           "data: {"type":"finish-step"}
 
         ",
-          "data: {"type":"finish","finishReason":"stop"}
+          "data: {"type":"finish","finishReason":"stop","usage":{"inputTokens":3,"inputTokenDetails":{"noCacheTokens":3},"outputTokens":10,"outputTokenDetails":{"textTokens":10},"totalTokens":13}}
 
         ",
           "data: [DONE]
@@ -2187,7 +2187,7 @@ describe('streamText', () => {
           "data: {"type":"finish-step"}
 
         ",
-          "data: {"type":"finish","finishReason":"stop"}
+          "data: {"type":"finish","finishReason":"stop","usage":{"inputTokens":3,"inputTokenDetails":{"noCacheTokens":3},"outputTokens":10,"outputTokenDetails":{"textTokens":10},"totalTokens":13}}
 
         ",
           "data: [DONE]
@@ -2247,7 +2247,7 @@ describe('streamText', () => {
           "data: {"type":"finish-step"}
 
         ",
-          "data: {"type":"finish","finishReason":"stop"}
+          "data: {"type":"finish","finishReason":"stop","usage":{"inputTokens":3,"inputTokenDetails":{"noCacheTokens":3},"outputTokens":10,"outputTokenDetails":{"textTokens":10},"totalTokens":13}}
 
         ",
           "data: [DONE]
@@ -2305,7 +2305,7 @@ describe('streamText', () => {
           "data: {"type":"finish-step"}
 
         ",
-          "data: {"type":"finish","finishReason":"stop"}
+          "data: {"type":"finish","finishReason":"stop","usage":{"inputTokens":3,"inputTokenDetails":{"noCacheTokens":3},"outputTokens":10,"outputTokenDetails":{"textTokens":10},"totalTokens":13}}
 
         ",
           "data: [DONE]
@@ -2398,6 +2398,22 @@ describe('streamText', () => {
             {
               "finishReason": "stop",
               "type": "finish",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ]
         `);
@@ -2574,6 +2590,22 @@ describe('streamText', () => {
             {
               "finishReason": "stop",
               "type": "finish",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ]
         `);
@@ -2719,6 +2751,22 @@ describe('streamText', () => {
                 "key8": "value8",
               },
               "type": "finish",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ]
         `);
@@ -2856,6 +2904,22 @@ describe('streamText', () => {
             {
               "finishReason": "stop",
               "type": "finish",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ]
         `);
@@ -3032,6 +3096,22 @@ describe('streamText', () => {
             {
               "finishReason": "stop",
               "type": "finish",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ]
         `);
@@ -3095,6 +3175,22 @@ describe('streamText', () => {
             {
               "finishReason": "stop",
               "type": "finish",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ]
         `);
@@ -3160,6 +3256,22 @@ describe('streamText', () => {
             {
               "finishReason": "stop",
               "type": "finish",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ]
         `);
@@ -3211,6 +3323,22 @@ describe('streamText', () => {
             {
               "finishReason": "stop",
               "type": "finish",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ]
         `);
@@ -3264,6 +3392,22 @@ describe('streamText', () => {
             {
               "finishReason": "stop",
               "type": "finish",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ]
         `);
@@ -3318,6 +3462,22 @@ describe('streamText', () => {
             {
               "finishReason": "stop",
               "type": "finish",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ]
         `);
@@ -3691,7 +3851,7 @@ describe('streamText', () => {
             "data: {"type":"finish-step"}
 
           ",
-            "data: {"type":"finish","finishReason":"stop"}
+            "data: {"type":"finish","finishReason":"stop","usage":{"inputTokens":3,"inputTokenDetails":{"noCacheTokens":3},"outputTokens":10,"outputTokenDetails":{"textTokens":10},"totalTokens":13}}
 
           ",
             "data: [DONE]
@@ -3758,7 +3918,7 @@ describe('streamText', () => {
             "data: {"type":"finish-step"}
 
           ",
-            "data: {"type":"finish","finishReason":"stop"}
+            "data: {"type":"finish","finishReason":"stop","usage":{"inputTokens":3,"inputTokenDetails":{"noCacheTokens":3},"outputTokens":10,"outputTokenDetails":{"textTokens":10},"totalTokens":13}}
 
           ",
             "data: [DONE]
@@ -4100,6 +4260,22 @@ describe('streamText', () => {
             {
               "finishReason": "stop",
               "type": "finish",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ],
         }
@@ -7178,6 +7354,22 @@ describe('streamText', () => {
               {
                 "finishReason": "stop",
                 "type": "finish",
+                "usage": {
+                  "cachedInputTokens": 0,
+                  "inputTokenDetails": {
+                    "cacheReadTokens": 0,
+                    "cacheWriteTokens": 0,
+                    "noCacheTokens": 6,
+                  },
+                  "inputTokens": 6,
+                  "outputTokenDetails": {
+                    "reasoningTokens": 10,
+                    "textTokens": 20,
+                  },
+                  "outputTokens": 20,
+                  "reasoningTokens": 10,
+                  "totalTokens": 26,
+                },
               },
             ]
           `);
@@ -9093,6 +9285,22 @@ describe('streamText', () => {
               {
                 "finishReason": "stop",
                 "type": "finish",
+                "usage": {
+                  "cachedInputTokens": 0,
+                  "inputTokenDetails": {
+                    "cacheReadTokens": 0,
+                    "cacheWriteTokens": 0,
+                    "noCacheTokens": 6,
+                  },
+                  "inputTokens": 6,
+                  "outputTokenDetails": {
+                    "reasoningTokens": 10,
+                    "textTokens": 20,
+                  },
+                  "outputTokens": 20,
+                  "reasoningTokens": 10,
+                  "totalTokens": 26,
+                },
               },
             ]
           `);
@@ -9746,6 +9954,22 @@ describe('streamText', () => {
               {
                 "finishReason": "stop",
                 "type": "finish",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokenDetails": {
+                    "cacheReadTokens": undefined,
+                    "cacheWriteTokens": undefined,
+                    "noCacheTokens": 3,
+                  },
+                  "inputTokens": 3,
+                  "outputTokenDetails": {
+                    "reasoningTokens": undefined,
+                    "textTokens": 10,
+                  },
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
               },
             ]
           `);
@@ -9981,6 +10205,22 @@ describe('streamText', () => {
               {
                 "finishReason": "tool-calls",
                 "type": "finish",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokenDetails": {
+                    "cacheReadTokens": undefined,
+                    "cacheWriteTokens": undefined,
+                    "noCacheTokens": 3,
+                  },
+                  "inputTokens": 3,
+                  "outputTokenDetails": {
+                    "reasoningTokens": undefined,
+                    "textTokens": 10,
+                  },
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
               },
             ]
           `);
@@ -11423,6 +11663,22 @@ describe('streamText', () => {
             {
               "finishReason": "stop",
               "type": "finish",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ]
         `);
@@ -15507,6 +15763,22 @@ describe('streamText', () => {
               {
                 "finishReason": "stop",
                 "type": "finish",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokenDetails": {
+                    "cacheReadTokens": undefined,
+                    "cacheWriteTokens": undefined,
+                    "noCacheTokens": 3,
+                  },
+                  "inputTokens": 3,
+                  "outputTokenDetails": {
+                    "reasoningTokens": undefined,
+                    "textTokens": 10,
+                  },
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
               },
             ]
           `);
@@ -15737,6 +16009,22 @@ describe('streamText', () => {
               {
                 "finishReason": "stop",
                 "type": "finish",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokenDetails": {
+                    "cacheReadTokens": undefined,
+                    "cacheWriteTokens": undefined,
+                    "noCacheTokens": 3,
+                  },
+                  "inputTokens": 3,
+                  "outputTokenDetails": {
+                    "reasoningTokens": undefined,
+                    "textTokens": 10,
+                  },
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
               },
             ]
           `);
@@ -16122,6 +16410,22 @@ describe('streamText', () => {
               {
                 "finishReason": "stop",
                 "type": "finish",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokenDetails": {
+                    "cacheReadTokens": undefined,
+                    "cacheWriteTokens": undefined,
+                    "noCacheTokens": 3,
+                  },
+                  "inputTokens": 3,
+                  "outputTokenDetails": {
+                    "reasoningTokens": undefined,
+                    "textTokens": 10,
+                  },
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
               },
             ]
           `);
@@ -18004,6 +18308,22 @@ describe('streamText', () => {
               {
                 "finishReason": "tool-calls",
                 "type": "finish",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokenDetails": {
+                    "cacheReadTokens": undefined,
+                    "cacheWriteTokens": undefined,
+                    "noCacheTokens": 3,
+                  },
+                  "inputTokens": 3,
+                  "outputTokenDetails": {
+                    "reasoningTokens": undefined,
+                    "textTokens": 10,
+                  },
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
               },
             ]
           `);
@@ -18274,6 +18594,22 @@ describe('streamText', () => {
               {
                 "finishReason": "tool-calls",
                 "type": "finish",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokenDetails": {
+                    "cacheReadTokens": undefined,
+                    "cacheWriteTokens": undefined,
+                    "noCacheTokens": 3,
+                  },
+                  "inputTokens": 3,
+                  "outputTokenDetails": {
+                    "reasoningTokens": undefined,
+                    "textTokens": 10,
+                  },
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
               },
             ]
           `);
@@ -18694,6 +19030,22 @@ describe('streamText', () => {
               {
                 "finishReason": "stop",
                 "type": "finish",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokenDetails": {
+                    "cacheReadTokens": undefined,
+                    "cacheWriteTokens": undefined,
+                    "noCacheTokens": 3,
+                  },
+                  "inputTokens": 3,
+                  "outputTokenDetails": {
+                    "reasoningTokens": undefined,
+                    "textTokens": 10,
+                  },
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
               },
             ]
           `);
@@ -19023,6 +19375,22 @@ describe('streamText', () => {
               {
                 "finishReason": "stop",
                 "type": "finish",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokenDetails": {
+                    "cacheReadTokens": undefined,
+                    "cacheWriteTokens": undefined,
+                    "noCacheTokens": 3,
+                  },
+                  "inputTokens": 3,
+                  "outputTokenDetails": {
+                    "reasoningTokens": undefined,
+                    "textTokens": 10,
+                  },
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
               },
             ]
           `);
@@ -19313,6 +19681,22 @@ describe('streamText', () => {
               {
                 "finishReason": "stop",
                 "type": "finish",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokenDetails": {
+                    "cacheReadTokens": undefined,
+                    "cacheWriteTokens": undefined,
+                    "noCacheTokens": 3,
+                  },
+                  "inputTokens": 3,
+                  "outputTokenDetails": {
+                    "reasoningTokens": undefined,
+                    "textTokens": 10,
+                  },
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
               },
             ]
           `);
@@ -19484,6 +19868,22 @@ describe('streamText', () => {
                 {
                   "finishReason": "tool-calls",
                   "type": "finish",
+                  "usage": {
+                    "cachedInputTokens": undefined,
+                    "inputTokenDetails": {
+                      "cacheReadTokens": undefined,
+                      "cacheWriteTokens": undefined,
+                      "noCacheTokens": 3,
+                    },
+                    "inputTokens": 3,
+                    "outputTokenDetails": {
+                      "reasoningTokens": undefined,
+                      "textTokens": 10,
+                    },
+                    "outputTokens": 10,
+                    "reasoningTokens": undefined,
+                    "totalTokens": 13,
+                  },
                 },
               ]
             `);

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2374,6 +2374,7 @@ However, the LLM results are expected to be small enough to not cause issues.
                 controller.enqueue({
                   type: 'finish',
                   finishReason: part.finishReason,
+                  usage: part.totalUsage,
                   ...(messageMetadataValue != null
                     ? { messageMetadata: messageMetadataValue }
                     : {}),

--- a/packages/ai/src/types/usage.ts
+++ b/packages/ai/src/types/usage.ts
@@ -3,6 +3,8 @@ import {
   JSONObject,
   LanguageModelV3Usage,
 } from '@ai-sdk/provider';
+import { z } from 'zod/v4';
+import { jsonValueSchema } from './json-value';
 
 /**
  * Represents the number of tokens used in a prompt and completion.
@@ -76,6 +78,27 @@ export type LanguageModelUsage = {
    */
   raw?: JSONObject;
 };
+
+// Helper for required properties that can be undefined (key: Type | undefined)
+const numberOrUndefined = z.union([z.number(), z.undefined()]);
+
+export const languageModelUsageSchema: z.ZodType<LanguageModelUsage> = z.object({
+  inputTokens: numberOrUndefined,
+  inputTokenDetails: z.object({
+    noCacheTokens: numberOrUndefined,
+    cacheReadTokens: numberOrUndefined,
+    cacheWriteTokens: numberOrUndefined,
+  }),
+  outputTokens: numberOrUndefined,
+  outputTokenDetails: z.object({
+    textTokens: numberOrUndefined,
+    reasoningTokens: numberOrUndefined,
+  }),
+  totalTokens: numberOrUndefined,
+  reasoningTokens: z.number().optional(),
+  cachedInputTokens: z.number().optional(),
+  raw: z.record(z.string(), jsonValueSchema.optional()).optional(),
+});
 
 /**
 Represents the number of tokens used in an embedding.

--- a/packages/ai/src/types/usage.ts
+++ b/packages/ai/src/types/usage.ts
@@ -82,23 +82,24 @@ export type LanguageModelUsage = {
 // Helper for required properties that can be undefined (key: Type | undefined)
 const numberOrUndefined = z.union([z.number(), z.undefined()]);
 
-export const languageModelUsageSchema: z.ZodType<LanguageModelUsage> = z.object({
-  inputTokens: numberOrUndefined,
-  inputTokenDetails: z.object({
-    noCacheTokens: numberOrUndefined,
-    cacheReadTokens: numberOrUndefined,
-    cacheWriteTokens: numberOrUndefined,
-  }),
-  outputTokens: numberOrUndefined,
-  outputTokenDetails: z.object({
-    textTokens: numberOrUndefined,
-    reasoningTokens: numberOrUndefined,
-  }),
-  totalTokens: numberOrUndefined,
-  reasoningTokens: z.number().optional(),
-  cachedInputTokens: z.number().optional(),
-  raw: z.record(z.string(), jsonValueSchema.optional()).optional(),
-});
+export const languageModelUsageSchema: z.ZodType<LanguageModelUsage> =
+  z.strictObject({
+    inputTokens: numberOrUndefined,
+    inputTokenDetails: z.strictObject({
+      noCacheTokens: numberOrUndefined,
+      cacheReadTokens: numberOrUndefined,
+      cacheWriteTokens: numberOrUndefined,
+    }),
+    outputTokens: numberOrUndefined,
+    outputTokenDetails: z.strictObject({
+      textTokens: numberOrUndefined,
+      reasoningTokens: numberOrUndefined,
+    }),
+    totalTokens: numberOrUndefined,
+    reasoningTokens: z.number().optional(),
+    cachedInputTokens: z.number().optional(),
+    raw: z.record(z.string(), jsonValueSchema.optional()).optional(),
+  });
 
 /**
 Represents the number of tokens used in an embedding.

--- a/packages/ai/src/types/usage.ts
+++ b/packages/ai/src/types/usage.ts
@@ -83,15 +83,15 @@ export type LanguageModelUsage = {
 const numberOrUndefined = z.union([z.number(), z.undefined()]);
 
 export const languageModelUsageSchema: z.ZodType<LanguageModelUsage> =
-  z.strictObject({
+  z.object({
     inputTokens: numberOrUndefined,
-    inputTokenDetails: z.strictObject({
+    inputTokenDetails: z.object({
       noCacheTokens: numberOrUndefined,
       cacheReadTokens: numberOrUndefined,
       cacheWriteTokens: numberOrUndefined,
     }),
     outputTokens: numberOrUndefined,
-    outputTokenDetails: z.strictObject({
+    outputTokenDetails: z.object({
       textTokens: numberOrUndefined,
       reasoningTokens: numberOrUndefined,
     }),

--- a/packages/ai/src/types/usage.ts
+++ b/packages/ai/src/types/usage.ts
@@ -82,8 +82,8 @@ export type LanguageModelUsage = {
 // Helper for required properties that can be undefined (key: Type | undefined)
 const numberOrUndefined = z.union([z.number(), z.undefined()]);
 
-export const languageModelUsageSchema: z.ZodType<LanguageModelUsage> =
-  z.object({
+export const languageModelUsageSchema: z.ZodType<LanguageModelUsage> = z.object(
+  {
     inputTokens: numberOrUndefined,
     inputTokenDetails: z.object({
       noCacheTokens: numberOrUndefined,
@@ -99,7 +99,8 @@ export const languageModelUsageSchema: z.ZodType<LanguageModelUsage> =
     reasoningTokens: z.number().optional(),
     cachedInputTokens: z.number().optional(),
     raw: z.record(z.string(), jsonValueSchema.optional()).optional(),
-  });
+  },
+);
 
 /**
 Represents the number of tokens used in an embedding.

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -17,27 +17,27 @@ import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
 export const uiMessageChunkSchema = lazySchema(() =>
   zodSchema(
     z.union([
-      z.strictObject({
+      z.object({
         type: z.literal('text-start'),
         id: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('text-delta'),
         id: z.string(),
         delta: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('text-end'),
         id: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('error'),
         errorText: z.string(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('tool-input-start'),
         toolCallId: z.string(),
         toolName: z.string(),
@@ -46,12 +46,12 @@ export const uiMessageChunkSchema = lazySchema(() =>
         dynamic: z.boolean().optional(),
         title: z.string().optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('tool-input-delta'),
         toolCallId: z.string(),
         inputTextDelta: z.string(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('tool-input-available'),
         toolCallId: z.string(),
         toolName: z.string(),
@@ -61,7 +61,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
         dynamic: z.boolean().optional(),
         title: z.string().optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('tool-input-error'),
         toolCallId: z.string(),
         toolName: z.string(),
@@ -72,12 +72,12 @@ export const uiMessageChunkSchema = lazySchema(() =>
         errorText: z.string(),
         title: z.string().optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('tool-approval-request'),
         approvalId: z.string(),
         toolCallId: z.string(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('tool-output-available'),
         toolCallId: z.string(),
         output: z.unknown(),
@@ -85,41 +85,41 @@ export const uiMessageChunkSchema = lazySchema(() =>
         dynamic: z.boolean().optional(),
         preliminary: z.boolean().optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('tool-output-error'),
         toolCallId: z.string(),
         errorText: z.string(),
         providerExecuted: z.boolean().optional(),
         dynamic: z.boolean().optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('tool-output-denied'),
         toolCallId: z.string(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('reasoning-start'),
         id: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('reasoning-delta'),
         id: z.string(),
         delta: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('reasoning-end'),
         id: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('source-url'),
         sourceId: z.string(),
         url: z.string(),
         title: z.string().optional(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('source-document'),
         sourceId: z.string(),
         mediaType: z.string(),
@@ -127,13 +127,13 @@ export const uiMessageChunkSchema = lazySchema(() =>
         filename: z.string().optional(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('file'),
         url: z.string(),
         mediaType: z.string(),
         providerMetadata: providerMetadataSchema.optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.custom<`data-${string}`>(
           (value): value is `data-${string}` =>
             typeof value === 'string' && value.startsWith('data-'),
@@ -143,18 +143,18 @@ export const uiMessageChunkSchema = lazySchema(() =>
         data: z.unknown(),
         transient: z.boolean().optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('start-step'),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('finish-step'),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('start'),
         messageId: z.string().optional(),
         messageMetadata: z.unknown().optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('finish'),
         finishReason: z
           .enum([
@@ -169,11 +169,11 @@ export const uiMessageChunkSchema = lazySchema(() =>
         usage: languageModelUsageSchema.optional(),
         messageMetadata: z.unknown().optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('abort'),
         reason: z.string().optional(),
       }),
-      z.strictObject({
+      z.object({
         type: z.literal('message-metadata'),
         messageMetadata: z.unknown(),
       }),

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -4,6 +4,7 @@ import {
   providerMetadataSchema,
 } from '../types/provider-metadata';
 import { FinishReason } from '../types/language-model';
+import { LanguageModelUsage, languageModelUsageSchema } from '../types/usage';
 import {
   InferUIMessageData,
   InferUIMessageMetadata,
@@ -165,6 +166,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
             'other',
           ] as const satisfies readonly FinishReason[])
           .optional(),
+        usage: languageModelUsageSchema.optional(),
         messageMetadata: z.unknown().optional(),
       }),
       z.strictObject({
@@ -323,6 +325,7 @@ export type UIMessageChunk<
   | {
       type: 'finish';
       finishReason?: FinishReason;
+      usage?: LanguageModelUsage;
       messageMetadata?: METADATA;
     }
   | {

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -178,7 +178,6 @@ describe('Chat', () => {
                 "role": "assistant",
               },
             ],
-            "usage": undefined,
           },
         ]
       `);
@@ -538,7 +537,6 @@ describe('Chat', () => {
                 "role": "assistant",
               },
             ],
-            "usage": undefined,
           },
         ]
       `);
@@ -775,7 +773,6 @@ describe('Chat', () => {
                 "role": "assistant",
               },
             ],
-            "usage": undefined,
           },
         ]
       `);

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -178,6 +178,7 @@ describe('Chat', () => {
                 "role": "assistant",
               },
             ],
+            "usage": undefined,
           },
         ]
       `);
@@ -537,6 +538,7 @@ describe('Chat', () => {
                 "role": "assistant",
               },
             ],
+            "usage": undefined,
           },
         ]
       `);
@@ -773,6 +775,7 @@ describe('Chat', () => {
                 "role": "assistant",
               },
             ],
+            "usage": undefined,
           },
         ]
       `);

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -694,7 +694,9 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           isDisconnect,
           isError,
           finishReason: this.activeResponse?.state.finishReason,
-          usage: this.activeResponse?.state.usage,
+          ...(this.activeResponse?.state.usage != null && {
+            usage: this.activeResponse.state.usage,
+          }),
         });
       } catch (err) {
         console.error(err);

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -5,6 +5,7 @@ import {
   InferSchema,
 } from '@ai-sdk/provider-utils';
 import { FinishReason } from '../types/language-model';
+import { LanguageModelUsage } from '../types/usage';
 import { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
 import { consumeStream } from '../util/consume-stream';
 import { SerialJobExecutor } from '../util/serial-job-executor';
@@ -124,6 +125,7 @@ export type ChatOnDataCallback<UI_MESSAGE extends UIMessage> = (
  * @param isDisconnect Indicates whether the request has been ended by a network error.
  * @param isError Indicates whether the request has been ended by an error.
  * @param finishReason The reason why the generation finished.
+ * @param usage Token usage information for the response.
  */
 export type ChatOnFinishCallback<UI_MESSAGE extends UIMessage> = (options: {
   message: UI_MESSAGE;
@@ -132,6 +134,7 @@ export type ChatOnFinishCallback<UI_MESSAGE extends UIMessage> = (options: {
   isDisconnect: boolean;
   isError: boolean;
   finishReason?: FinishReason;
+  usage?: LanguageModelUsage;
 }) => void;
 
 export interface ChatInit<UI_MESSAGE extends UIMessage> {
@@ -691,6 +694,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           isDisconnect,
           isError,
           finishReason: this.activeResponse?.state.finishReason,
+          usage: this.activeResponse?.state.usage,
         });
       } catch (err) {
         console.error(err);

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -2,6 +2,7 @@ import { FlexibleSchema, validateTypes } from '@ai-sdk/provider-utils';
 import { UIMessageStreamError } from '../error/ui-message-stream-error';
 import { ProviderMetadata } from '../types';
 import { FinishReason } from '../types/language-model';
+import { LanguageModelUsage } from '../types/usage';
 import {
   DataUIMessageChunk,
   InferUIMessageChunk,
@@ -44,6 +45,7 @@ export type StreamingUIMessageState<UI_MESSAGE extends UIMessage> = {
     }
   >;
   finishReason?: FinishReason;
+  usage?: LanguageModelUsage;
 };
 
 export function createStreamingUIMessageState<UI_MESSAGE extends UIMessage>({
@@ -685,6 +687,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             case 'finish': {
               if (chunk.finishReason != null) {
                 state.finishReason = chunk.finishReason;
+              }
+              if (chunk.usage != null) {
+                state.usage = chunk.usage;
               }
               await updateMessageMetadata(chunk.messageMetadata);
               if (chunk.messageMetadata != null) {


### PR DESCRIPTION
## Background
This pr is a fix to the reverted pr #11804 due to https://github.com/vercel/ai/pull/11804#issuecomment-3768228640

In v5, `usage` (token counts) was available in `useChat`'s `onFinish` callback via PR #2430. This was missing in v6, preventing users from tracking token usage when chat responses complete. Developers who want to track API costs or display token counts to users have no way to access this data when a response completes.

When investigating how to add the `usage` field, we found that a previous change to add `finishReason` to the schema (PR #9857) had compatibility issues reported in #11269 and #10291. These issues occurred during rolling deployments when new servers sent finish chunks with additional fields that old clients couldn't parse due to `z.strictObject()` validation rejecting unknown properties.

**new changes that differ from old pr**
To make new schema additions forward compatible, we changed from `z.strictObject()` to `z.object()` in the UI message chunks schema. This allows old clients to receive finish chunks with new fields (like `usage`) without validation errors - unknown properties are stripped rather than causing failures. There is a tradeoff with debugging (unknown properties won't be caught), but this enables safe rolling deployments.

## Summary
Added the `usage` field to the `onFinish` callback of `useChat` and made the UI message chunks schema forward compatible.

Changes:
- Added usage field to the onFinish callback in useChat
- Propagated totalUsage from the finish chunk in streamText to the UI message stream
- Added proper Zod schema (languageModelUsageSchema) for runtime validation of usage data
- Updated TypeScript types to include usage?: LanguageModelUsage in relevant interfaces
- Changed `z.strictObject()` to `z.object()` in ui-message-chunks schema for forward compatibility

## Manual Verification
1. Ran the `next-openai` example with `pnpm dev`
2. Added an `onFinish` callback to `useChat` that logs `usage`
3. Sent a chat message and verified token counts appeared in the console:
   - `inputTokens`, `outputTokens`, `totalTokens` were all populated correctly

## Checklist
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues
Fixes https://github.com/vercel/ai/issues/11598
#11269 and #10291