### PR TITLE
docs: Fix outdated link to v0 models API in 02-vercel.mdx

### DIFF
--- a/content/providers/01-ai-sdk-providers/02-vercel.mdx
+++ b/content/providers/01-ai-sdk-providers/02-vercel.mdx
@@ -5,7 +5,7 @@ description: Learn how to use Vercel's v0 models with the AI SDK.
 
 # Vercel Provider
 
-The [Vercel](https://vercel.com) provider gives you access to the [v0 API](https://vercel.com/docs/v0/api), designed for building modern web applications. The v0 models support text and image inputs and provide fast streaming responses.
+The [Vercel](https://vercel.com) provider gives you access to the [v0 API](https://v0.app/docs/api/model), designed for building modern web applications. The v0 models support text and image inputs and provide fast streaming responses.
 
 You can create your Vercel API key at [v0.dev](https://v0.dev/chat/settings/keys).
 


### PR DESCRIPTION
This link was giving a 404. Update to the current v0 models API page.

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

This link was giving a 404 when clicked; presumably was pointing to an older version of the page. 

## Summary

Updated the link to the current v0 models API page.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

