### PR TITLE
fix(xai): emit text-end immediately when message completes

### DIFF
--- a/.changeset/text-end-timing.md
+++ b/.changeset/text-end-timing.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Emit text-end events immediately when message content completes, aligning with OpenAI's streaming pattern


### PR DESCRIPTION
## Summary

Aligns xAI provider streaming behavior with OpenAI's pattern for `text-end` event timing.

## Problem

Currently, xAI emits `text-end` events only in the `flush()` handler at the very end of the stream. This differs from OpenAI which emits `text-end` when the message item is done (`response.output_item.done`).

## Solution

Emit `text-end` immediately when message content completes, matching OpenAI's behavior. This gives consumers accurate timing for when text content is finished.

## Why This Matters

Applications that process streaming events need to know when text content is complete (e.g., to trigger UI updates, start processing, etc.). Deferring `text-end` to flush means consumers can't distinguish between "text is done" and "entire response is done".

## Changes

- Track `ended` state in `contentBlocks` to avoid duplicate emissions
- Emit `text-end` in `response.output_item.done` handler when message content completes
- Update `flush()` to only emit `text-end` for blocks that weren't already ended

## Checklist

- [x] Tests have been added / updated
- [x] A changeset has been added