### PR TITLE
fix(openai): filter duplicate items when passing conversationID

### DIFF
--- a/.changeset/tasty-mangos-confess.md
+++ b/.changeset/tasty-mangos-confess.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): filter duplicate items when passing conversationID

--- a/examples/ai-functions/src/generate-text/11813-repro.ts
+++ b/examples/ai-functions/src/generate-text/11813-repro.ts
@@ -1,0 +1,79 @@
+import { generateText, streamText, tool } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { z } from 'zod';
+import { stepCountIs } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY environment variable is required');
+  }
+
+  console.log('Step 1: Creating conversation via OpenAI API...');
+  const createConvResponse = await fetch(
+    'https://api.openai.com/v1/conversations',
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    },
+  );
+
+  if (!createConvResponse.ok) {
+    const errorText = await createConvResponse.text();
+    throw new Error(
+      `Failed to create conversation: ${createConvResponse.status} - ${errorText}`,
+    );
+  }
+
+  const convData = await createConvResponse.json();
+  const conversationId = convData.id;
+  console.log(`Created conversation: ${conversationId}\n`);
+
+  console.log('Step 2: Adding initial message to conversation...');
+  const initial = await generateText({
+    model: openai.responses('gpt-4o'),
+    prompt: 'Hi, my name is Alice.',
+    providerOptions: {
+      openai: { conversation: conversationId },
+    },
+  });
+
+  console.log('Step 3: Making request with tools');
+
+  try {
+    const result = await streamText({
+      model: openai.responses('gpt-4o'),
+      prompt: 'What is the current weather in San Francisco? Use the tool.',
+      tools: {
+        getWeather: tool({
+          description: 'Get the current weather in a location',
+          inputSchema: z.object({
+            location: z.string().describe('The city to get weather for'),
+          }),
+          execute: async ({ location }) => {
+            return { location, temperature: 68, condition: 'foggy' };
+          },
+        }),
+      },
+      stopWhen: stepCountIs(5),
+      providerOptions: {
+        openai: { conversation: conversationId },
+      },
+    });
+
+    // Consume the stream
+    let fullText = '';
+    for await (const chunk of result.textStream) {
+      fullText += chunk;
+    }
+
+    console.log(`\nFinal response: "${fullText.substring(0, 100)}..."`);
+  } catch (error: any) {
+    console.log(error.message || error);
+  }
+});

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -40,6 +40,7 @@ export async function convertToOpenAIResponsesInput({
   providerOptionsName,
   fileIdPrefixes,
   store,
+  hasConversation = false,
   hasLocalShellTool = false,
   hasShellTool = false,
   hasApplyPatchTool = false,
@@ -50,6 +51,7 @@ export async function convertToOpenAIResponsesInput({
   providerOptionsName: string;
   fileIdPrefixes?: readonly string[];
   store: boolean;
+  hasConversation?: boolean; // when true, skip assistant messages that already have item IDs
   hasLocalShellTool?: boolean;
   hasShellTool?: boolean;
   hasApplyPatchTool?: boolean;
@@ -158,6 +160,11 @@ export async function convertToOpenAIResponsesInput({
                 | string
                 | undefined;
 
+              // when using conversation, skip items that already exist in the conversation context to avoid "Duplicate item found" errors
+              if (hasConversation && id != null) {
+                break;
+              }
+
               // item references reduce the payload size
               if (store && id != null) {
                 input.push({ type: 'item_reference', id });
@@ -183,6 +190,11 @@ export async function convertToOpenAIResponsesInput({
                 ).providerMetadata?.[providerOptionsName]?.itemId) as
                 | string
                 | undefined;
+
+              if (hasConversation && id != null) {
+                break;
+              }
+
               if (part.providerExecuted) {
                 if (store && id != null) {
                   input.push({ type: 'item_reference', id });
@@ -267,6 +279,10 @@ export async function convertToOpenAIResponsesInput({
                 break;
               }
 
+              if (hasConversation) {
+                break;
+              }
+
               if (store) {
                 const itemId =
                   (
@@ -296,6 +312,10 @@ export async function convertToOpenAIResponsesInput({
               });
 
               const reasoningId = providerOptions?.itemId;
+
+              if (hasConversation && reasoningId != null) {
+                break;
+              }
 
               if (reasoningId != null) {
                 const reasoningMessage = reasoningMessages[reasoningId];

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -206,6 +206,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
         providerOptionsName,
         fileIdPrefixes: this.config.fileIdPrefixes,
         store: openaiOptions?.store ?? true,
+        hasConversation: openaiOptions?.conversation != null,
         hasLocalShellTool: hasOpenAITool('openai.local_shell'),
         hasShellTool: hasOpenAITool('openai.shell'),
         hasApplyPatchTool: hasOpenAITool('openai.apply_patch'),


### PR DESCRIPTION
## Background

when using/passing conversation ID (for stateful messages) in the openai provider, with tool calls, the provider sent the full conversation history with every request. this clashed with the already present message history provider via conversation ID.

which led to an error as seen in #11813 where duplicate item ids were found

## Summary

introduce a flag `hasConversation` that allows us to skip re-sending assistant messages that already exist in the conversation (identified by having an item ID)

## Manual Verification

verified via the repro script in `examples/ai-functions/src/generate-text/11813-repro.ts` (will be removed after review) + tests added that simulate this scenario

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11813 