### PR TITLE
feat(openai-compatible): Allow non-openai `providerOptions` keys

### DIFF
--- a/.changeset/young-doors-provide.md
+++ b/.changeset/young-doors-provide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+feat(openai-compatible): Allow non-openai `providerOptions` keys

--- a/packages/openai-compatible/src/image/openai-compatible-image-model.test.ts
+++ b/packages/openai-compatible/src/image/openai-compatible-image-model.test.ts
@@ -82,7 +82,7 @@ describe('OpenAICompatibleImageModel', () => {
       await model.doGenerate(
         createDefaultGenerateParams({
           n: 2,
-          providerOptions: { openai: { quality: 'hd' } },
+          providerOptions: { 'openai-compatible': { quality: 'hd' } },
         }),
       );
 
@@ -267,7 +267,7 @@ describe('OpenAICompatibleImageModel', () => {
       await model.doGenerate(
         createDefaultGenerateParams({
           providerOptions: {
-            openai: {
+            'openai-compatible': {
               user: 'test-user-id',
             },
           },
@@ -290,7 +290,7 @@ describe('OpenAICompatibleImageModel', () => {
       await model.doGenerate(
         createDefaultGenerateParams({
           providerOptions: {
-            openai: {},
+            'openai-compatible': {},
           },
         }),
       );

--- a/packages/openai-compatible/src/image/openai-compatible-image-model.ts
+++ b/packages/openai-compatible/src/image/openai-compatible-image-model.ts
@@ -32,6 +32,13 @@ export class OpenAICompatibleImageModel implements ImageModelV2 {
     return this.config.provider;
   }
 
+  /**
+   * The provider options key used to extract provider-specific options.
+   */
+  private get providerOptionsKey(): string {
+    return this.config.provider.split('.')[0].trim();
+  }
+
   constructor(
     readonly modelId: OpenAICompatibleImageModelId,
     private readonly config: OpenAICompatibleImageModelConfig,
@@ -76,7 +83,7 @@ export class OpenAICompatibleImageModel implements ImageModelV2 {
         prompt,
         n,
         size,
-        ...(providerOptions.openai ?? {}),
+        ...providerOptions[this.providerOptionsKey],
         response_format: 'b64_json',
       },
       failedResponseHandler: createJsonErrorResponseHandler(


### PR DESCRIPTION
## Background
In place of this backport PR: https://github.com/vercel/ai/pull/11903

## Summary
Allows non-OpenAI providerOptions keys with OpenAI-compat. Backport of the change from v6

## Manual Verification


## Checklist
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)