### PR TITLE
feat(groq): expose reasoningTokens in usage data

### DIFF
--- a/.changeset/swift-donuts-smile.md
+++ b/.changeset/swift-donuts-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/groq': patch
+---
+
+feat(groq): expose reasoningTokens in usage data

--- a/packages/groq/src/convert-groq-usage.test.ts
+++ b/packages/groq/src/convert-groq-usage.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import { convertGroqUsage } from './convert-groq-usage';
+
+describe('convertGroqUsage', () => {
+  it('should return undefined values when usage is null', () => {
+    const result = convertGroqUsage(null);
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: undefined,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: undefined,
+        text: undefined,
+        reasoning: undefined,
+      },
+      raw: undefined,
+    });
+  });
+
+  it('should return undefined values when usage is undefined', () => {
+    const result = convertGroqUsage(undefined);
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: undefined,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: undefined,
+        text: undefined,
+        reasoning: undefined,
+      },
+      raw: undefined,
+    });
+  });
+
+  it('should convert basic usage without token details', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 20,
+      completion_tokens: 10,
+    });
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 20,
+        noCache: 20,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 10,
+        text: 10,
+        reasoning: undefined,
+      },
+      raw: {
+        prompt_tokens: 20,
+        completion_tokens: 10,
+      },
+    });
+  });
+
+  it('should extract reasoning tokens from completion_tokens_details', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 79,
+      completion_tokens: 40,
+      completion_tokens_details: {
+        reasoning_tokens: 21,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 79,
+        noCache: 79,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 40,
+        text: 19, // 40 - 21 = 19
+        reasoning: 21,
+      },
+      raw: {
+        prompt_tokens: 79,
+        completion_tokens: 40,
+        completion_tokens_details: {
+          reasoning_tokens: 21,
+        },
+      },
+    });
+  });
+
+  it('should handle null reasoning_tokens in completion_tokens_details', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 20,
+      completion_tokens: 10,
+      completion_tokens_details: {
+        reasoning_tokens: null,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 20,
+        noCache: 20,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 10,
+        text: 10,
+        reasoning: undefined,
+      },
+      raw: {
+        prompt_tokens: 20,
+        completion_tokens: 10,
+        completion_tokens_details: {
+          reasoning_tokens: null,
+        },
+      },
+    });
+  });
+
+  it('should handle null completion_tokens_details', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 20,
+      completion_tokens: 10,
+      completion_tokens_details: null,
+    });
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 20,
+        noCache: 20,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 10,
+        text: 10,
+        reasoning: undefined,
+      },
+      raw: {
+        prompt_tokens: 20,
+        completion_tokens: 10,
+        completion_tokens_details: null,
+      },
+    });
+  });
+
+  it('should handle zero reasoning tokens', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 20,
+      completion_tokens: 10,
+      completion_tokens_details: {
+        reasoning_tokens: 0,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 20,
+        noCache: 20,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 10,
+        text: 10,
+        reasoning: 0,
+      },
+      raw: {
+        prompt_tokens: 20,
+        completion_tokens: 10,
+        completion_tokens_details: {
+          reasoning_tokens: 0,
+        },
+      },
+    });
+  });
+
+  it('should handle all tokens being reasoning tokens', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 20,
+      completion_tokens: 50,
+      completion_tokens_details: {
+        reasoning_tokens: 50,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 20,
+        noCache: 20,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 50,
+        text: 0, // 50 - 50 = 0
+        reasoning: 50,
+      },
+      raw: {
+        prompt_tokens: 20,
+        completion_tokens: 50,
+        completion_tokens_details: {
+          reasoning_tokens: 50,
+        },
+      },
+    });
+  });
+
+  it('should handle missing prompt_tokens and completion_tokens', () => {
+    const result = convertGroqUsage({});
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 0,
+        noCache: 0,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 0,
+        text: 0,
+        reasoning: undefined,
+      },
+      raw: {},
+    });
+  });
+});

--- a/packages/groq/src/convert-groq-usage.ts
+++ b/packages/groq/src/convert-groq-usage.ts
@@ -11,6 +11,12 @@ export function convertGroqUsage(
             }
           | null
           | undefined;
+        completion_tokens_details?:
+          | {
+              reasoning_tokens?: number | null | undefined;
+            }
+          | null
+          | undefined;
       }
     | undefined
     | null,
@@ -34,6 +40,12 @@ export function convertGroqUsage(
 
   const promptTokens = usage.prompt_tokens ?? 0;
   const completionTokens = usage.completion_tokens ?? 0;
+  const reasoningTokens =
+    usage.completion_tokens_details?.reasoning_tokens ?? undefined;
+  const textTokens =
+    reasoningTokens != null
+      ? completionTokens - reasoningTokens
+      : completionTokens;
 
   return {
     inputTokens: {
@@ -44,8 +56,8 @@ export function convertGroqUsage(
     },
     outputTokens: {
       total: completionTokens,
-      text: completionTokens,
-      reasoning: undefined,
+      text: textTokens,
+      reasoning: reasoningTokens,
     },
     raw: usage,
   };

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -60,6 +60,9 @@ describe('doGenerate', () => {
       prompt_tokens_details?: {
         cached_tokens?: number;
       };
+      completion_tokens_details?: {
+        reasoning_tokens?: number;
+      };
     };
     finish_reason?: string;
     created?: number;
@@ -248,6 +251,47 @@ describe('doGenerate', () => {
             "cached_tokens": 15,
           },
           "total_tokens": 25,
+        },
+      }
+    `);
+  });
+
+  it('should extract reasoning tokens from completion_tokens_details', async () => {
+    prepareJsonResponse({
+      usage: {
+        prompt_tokens: 79,
+        total_tokens: 119,
+        completion_tokens: 40,
+        completion_tokens_details: {
+          reasoning_tokens: 21,
+        },
+      },
+    });
+
+    const { usage } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(usage).toMatchInlineSnapshot(`
+      {
+        "inputTokens": {
+          "cacheRead": undefined,
+          "cacheWrite": undefined,
+          "noCache": 79,
+          "total": 79,
+        },
+        "outputTokens": {
+          "reasoning": 21,
+          "text": 19,
+          "total": 40,
+        },
+        "raw": {
+          "completion_tokens": 40,
+          "completion_tokens_details": {
+            "reasoning_tokens": 21,
+          },
+          "prompt_tokens": 79,
+          "total_tokens": 119,
         },
       }
     `);
@@ -1072,6 +1116,65 @@ describe('doStream', () => {
           },
         },
       ]
+    `);
+  });
+
+  it('should stream reasoning tokens from completion_tokens_details', async () => {
+    server.urls['https://api.groq.com/openai/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1702657020,"model":"openai/gpt-oss-120b",` +
+          `"system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1702657020,"model":"openai/gpt-oss-120b",` +
+          `"system_fingerprint":null,"choices":[{"index":1,"delta":{"content":"42"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1702657020,"model":"openai/gpt-oss-120b",` +
+          `"system_fingerprint":null,"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1729171479,"model":"openai/gpt-oss-120b",` +
+          `"system_fingerprint":"fp_10c08bf97d","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],` +
+          `"x_groq":{"id":"req_01jadadp0femyae9kav1gpkhe8","usage":{"queue_time":0.061348671,"prompt_tokens":79,"prompt_time":0.000211569,` +
+          `"completion_tokens":40,"completion_time":0.798181818,"total_tokens":119,"total_time":0.798393387,` +
+          `"completion_tokens_details":{"reasoning_tokens":21}}}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const chunks = await convertReadableStreamToArray(stream);
+    const finishChunk = chunks.find(chunk => chunk.type === 'finish');
+
+    expect(finishChunk).toMatchInlineSnapshot(`
+      {
+        "finishReason": {
+          "raw": "stop",
+          "unified": "stop",
+        },
+        "type": "finish",
+        "usage": {
+          "inputTokens": {
+            "cacheRead": undefined,
+            "cacheWrite": undefined,
+            "noCache": 79,
+            "total": 79,
+          },
+          "outputTokens": {
+            "reasoning": 21,
+            "text": 19,
+            "total": 40,
+          },
+          "raw": {
+            "completion_tokens": 40,
+            "completion_tokens_details": {
+              "reasoning_tokens": 21,
+            },
+            "prompt_tokens": 79,
+            "total_tokens": 119,
+          },
+        },
+      }
     `);
   });
 

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -283,6 +283,12 @@ export class GroqChatLanguageModel implements LanguageModelV3 {
               }
             | null
             | undefined;
+          completion_tokens_details?:
+            | {
+                reasoning_tokens?: number | null | undefined;
+              }
+            | null
+            | undefined;
         }
       | undefined = undefined;
     let isFirstChunk = true;
@@ -585,6 +591,11 @@ const groqChatResponseSchema = z.object({
           cached_tokens: z.number().nullish(),
         })
         .nullish(),
+      completion_tokens_details: z
+        .object({
+          reasoning_tokens: z.number().nullish(),
+        })
+        .nullish(),
     })
     .nullish(),
 });
@@ -631,6 +642,11 @@ const groqChatChunkSchema = z.union([
             prompt_tokens_details: z
               .object({
                 cached_tokens: z.number().nullish(),
+              })
+              .nullish(),
+            completion_tokens_details: z
+              .object({
+                reasoning_tokens: z.number().nullish(),
               })
               .nullish(),
           })


### PR DESCRIPTION
## Background

#11879 

[spec here](https://console.groq.com/docs/api-reference#chat-create:~:text=Show%20properties-,reasoning_tokens,-integer)

## Summary

updated the schema to capture the `reasoning_tokens` from `completion_tokens_details`

## Manual Verification

n/a but added a separate unit test file

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11879 
