### PR TITLE
feat(mcp): capture tool title from server

### DIFF
--- a/.changeset/real-vans-count.md
+++ b/.changeset/real-vans-count.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+feat(mcp): capture server title from top level

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -503,14 +503,13 @@ class DefaultMCPClient implements MCPClient {
       const listToolsResult = await this.listTools();
       for (const {
         name,
-        // title,
+        title,
         description,
         inputSchema,
         annotations,
         _meta,
       } of listToolsResult.tools) {
-        // const resolvedTitle = title ?? annotations?.title;
-        const resolvedTitle = annotations?.title;
+        const resolvedTitle = title ?? annotations?.title;
         if (schemas !== 'automatic' && !(name in schemas)) {
           continue;
         }

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -503,12 +503,13 @@ class DefaultMCPClient implements MCPClient {
       const listToolsResult = await this.listTools();
       for (const {
         name,
+        title,
         description,
         inputSchema,
         annotations,
         _meta,
       } of listToolsResult.tools) {
-        const title = annotations?.title;
+        const resolvedTitle = title ?? annotations?.title;
         if (schemas !== 'automatic' && !(name in schemas)) {
           continue;
         }
@@ -535,7 +536,7 @@ class DefaultMCPClient implements MCPClient {
           schemas === 'automatic'
             ? dynamicTool({
                 description,
-                title,
+                title: resolvedTitle,
                 inputSchema: jsonSchema({
                   ...inputSchema,
                   properties: inputSchema.properties ?? {},
@@ -545,7 +546,7 @@ class DefaultMCPClient implements MCPClient {
               })
             : tool({
                 description,
-                title,
+                title: resolvedTitle,
                 inputSchema: schemas[name].inputSchema,
                 ...(outputSchema != null ? { outputSchema } : {}),
                 execute,

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -503,13 +503,14 @@ class DefaultMCPClient implements MCPClient {
       const listToolsResult = await this.listTools();
       for (const {
         name,
-        title,
+        // title,
         description,
         inputSchema,
         annotations,
         _meta,
       } of listToolsResult.tools) {
-        const resolvedTitle = title ?? annotations?.title;
+        // const resolvedTitle = title ?? annotations?.title;
+        const resolvedTitle = annotations?.title;
         if (schemas !== 'automatic' && !(name in schemas)) {
           continue;
         }

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -138,10 +138,10 @@ const PaginatedResultSchema = ResultSchema.extend({
 const ToolSchema = z
   .object({
     name: z.string(),
-    // /**
-    //  * @see https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool
-    //  */
-    // title: z.optional(z.string()),
+    /**
+     * @see https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool
+     */
+    title: z.optional(z.string()),
     description: z.optional(z.string()),
     inputSchema: z
       .object({

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -138,6 +138,10 @@ const PaginatedResultSchema = ResultSchema.extend({
 const ToolSchema = z
   .object({
     name: z.string(),
+    /**
+     * @see https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool
+     */
+    title: z.optional(z.string()),
     description: z.optional(z.string()),
     inputSchema: z
       .object({

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -138,10 +138,10 @@ const PaginatedResultSchema = ResultSchema.extend({
 const ToolSchema = z
   .object({
     name: z.string(),
-    /**
-     * @see https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool
-     */
-    title: z.optional(z.string()),
+    // /**
+    //  * @see https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool
+    //  */
+    // title: z.optional(z.string()),
     description: z.optional(z.string()),
     inputSchema: z
       .object({


### PR DESCRIPTION
## Background

Recent spec change introduced the tool title and we previously extracted it via the annotations.

## Summary

added a top level property that will use the tool title the server emits, with fallback on the annotations title

## Manual Verification

n/a

## Checklist

- [ ] n/a ~~Tests have been added / updated (for bug fixes / features)~~
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11891 