### PR TITLE
ci(triage): use `origin/` to to avoid ambiguity

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -269,7 +269,7 @@ jobs:
             - Only assign labels if you're reasonably confident (>0.6) about the relevance
             - If the issue mentiones React Native or Expo, add the "ai/ui" label and "expo" label
             - If the issue is about adding a new provider or another 3rd party tool, add documentation, ai/provider, and provider/community labels.
-            - If the issue looks like "🤖 Provider API update - <PROVIDER HERE>@11.1.0", then assign ai/provider and provider/<PROVIDER HERE>.
+            - If the issue looks like "🤖 Provider API update - <PROVIDER HERE>@11.1.0", then assign ai/provider and provider/<PROVIDER HERE>. These pull requests are always for a known provider, NEVER apply the provider/community label.
 
             Examples
 

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -3,7 +3,7 @@ name: Triage
 on:
   issues:
     types: [opened, reopened]
-  pull_request_target: 
+  pull_request_target:
     types: [opened]
     branches:
       - main
@@ -47,8 +47,9 @@ jobs:
       - name: Get changed file paths
         id: get-changed-files
         run: |
-          changed_files=$(git diff --name-only ${{ github.event.pull_request.base.ref }})
-          echo $changed_files
+          git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+          changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD)
+          echo "changed_files=$changed_files"
           echo "changed_files=$changed_files" >> $GITHUB_OUTPUT
 
       - name: Determine appropriate labels
@@ -268,7 +269,7 @@ jobs:
             - Only assign labels if you're reasonably confident (>0.6) about the relevance
             - If the issue mentiones React Native or Expo, add the "ai/ui" label and "expo" label
             - If the issue is about adding a new provider or another 3rd party tool, add documentation, ai/provider, and provider/community labels.
-            - If the issue looks like "🤖 Provider API update - <PROVIDER HERE>@11.1.0", then assign ai/provider and provider/<PROVIDER HERE>. These pull requests are always for a known provider, NEVER apply the provider/community label.
+            - If the issue looks like "🤖 Provider API update - <PROVIDER HERE>@11.1.0", then assign ai/provider and provider/<PROVIDER HERE>.
 
             Examples
 


### PR DESCRIPTION
should fix build errors such as https://github.com/vercel/ai/actions/runs/21186844722/job/60943658910?pr=11904#step:5:7