### PR TITLE
fix(google-vertex): pass express API key as header instead of URL search parameter

### DIFF
--- a/.changeset/cuddly-planes-train.md
+++ b/.changeset/cuddly-planes-train.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+set Google Vertex Express API key as header instead of URL argument

--- a/packages/google-vertex/src/google-vertex-provider.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider.test.ts
@@ -305,8 +305,12 @@ describe('google-vertex-provider', () => {
     );
 
     expect(originalFetch).toHaveBeenCalledWith(
-      'https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.5-pro:streamGenerateContent?key=test-api-key',
-      {},
+      'https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.5-pro:streamGenerateContent',
+      {
+        headers: {
+       "x-goog-api-key": "test-api-key",
+     },
+   },
     );
 
     vi.unstubAllGlobals();

--- a/packages/google-vertex/src/google-vertex-provider.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider.test.ts
@@ -308,9 +308,9 @@ describe('google-vertex-provider', () => {
       'https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.5-pro:streamGenerateContent',
       {
         headers: {
-       "x-goog-api-key": "test-api-key",
-     },
-   },
+          'x-goog-api-key': 'test-api-key',
+        },
+      },
     );
 
     vi.unstubAllGlobals();

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -5,6 +5,7 @@ import {
   generateId,
   loadOptionalSetting,
   loadSetting,
+  normalizeHeaders,
   resolve,
   Resolvable,
   withoutTrailingSlash,
@@ -31,7 +32,7 @@ function createExpressModeFetch(
     const modifiedInit: RequestInit = {
       ...init,
       headers: {
-        ...(init?.headers ?? {}),
+        ...(init?.headers ? normalizeHeaders(init.headers) : {}),
         'x-goog-api-key': apiKey,
       },
     };

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -22,14 +22,20 @@ import { googleVertexTools } from './google-vertex-tools';
 const EXPRESS_MODE_BASE_URL =
   'https://aiplatform.googleapis.com/v1/publishers/google';
 
+// set `x-goog-api-key` header to API key for express mode
 function createExpressModeFetch(
   apiKey: string,
   customFetch?: FetchFunction,
 ): FetchFunction {
   return async (url, init) => {
-    const urlWithKey = new URL(url.toString());
-    urlWithKey.searchParams.set('key', apiKey);
-    return (customFetch ?? fetch)(urlWithKey.toString(), init);
+    const modifiedInit: RequestInit = {
+      ...init,
+      headers: {
+        ...(init?.headers ?? {}),
+        'x-goog-api-key': apiKey,
+      },
+    };
+    return (customFetch ?? fetch)(url.toString(), modifiedInit);
   };
 }
 


### PR DESCRIPTION
## Background

The original PR (https://github.com/vercel/ai/pull/10931) stated "requires the api key to be added as a search parameter" but on this page it says that it can be passed as header as well:
https://cloud.google.com/resources/cloud-express-faqs?hl=en

That is preferable since URLs get logged and that can leak API keys

## Summary

Replace query search parameter with header

## Manual Verification

https://github.com/vercel/ai/pull/10931#issuecomment-3776277613

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

#10931 

<!-- https://linear.app/vercel/issue/VULN-6692/google-vertex-provider-exposes-api-keys-in-url-query-parameters -->
