### PR TITLE
docs: fix broken link in migration guide v5

### DIFF
--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -1386,7 +1386,7 @@ const { messages } = useChat({
 });
 ```
 
-For a complete example of sharing chat state across components, see the [Share Chat State Across Components](/docs/cookbook/use-shared-chat-context) recipe.
+For a complete example of sharing chat state across components, see the [Share Chat State Across Components](/cookbook/next/use-shared-chat-context) recipe.
 
 #### Chat Transport Architecture
 


### PR DESCRIPTION
Fix broken link