### PR TITLE
fix(package/togetherai): only include `n` when requesting multiple images

### DIFF
--- a/.changeset/grumpy-adults-bathe.md
+++ b/.changeset/grumpy-adults-bathe.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/togetherai': patch
+---
+
+fix(package/togetherai): only include `n` when requesting multiple images

--- a/packages/togetherai/src/togetherai-image-model.test.ts
+++ b/packages/togetherai/src/togetherai-image-model.test.ts
@@ -58,11 +58,35 @@ describe('doGenerate', () => {
       model: 'stabilityai/stable-diffusion-xl',
       prompt,
       seed: 42,
-      n: 1,
       width: 1024,
       height: 1024,
       response_format: 'base64',
       additional_param: 'value',
+    });
+  });
+
+  it('should include n parameter when requesting multiple images', async () => {
+    const model = createBasicModel();
+
+    await model.doGenerate({
+      prompt,
+      files: undefined,
+      mask: undefined,
+      n: 3,
+      size: '1024x1024',
+      seed: 42,
+      providerOptions: {},
+      aspectRatio: undefined,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'stabilityai/stable-diffusion-xl',
+      prompt,
+      seed: 42,
+      n: 3,
+      width: 1024,
+      height: 1024,
+      response_format: 'base64',
     });
   });
 
@@ -301,7 +325,6 @@ describe('Image Editing', () => {
       {
         "image_url": "https://example.com/input.jpg",
         "model": "stabilityai/stable-diffusion-xl",
-        "n": 1,
         "prompt": "Make the shirt yellow",
         "response_format": "base64",
       }
@@ -456,7 +479,6 @@ describe('Image Editing', () => {
         "guidance": 3.5,
         "image_url": "https://example.com/input.jpg",
         "model": "stabilityai/stable-diffusion-xl",
-        "n": 1,
         "prompt": "Transform the style",
         "response_format": "base64",
         "steps": 28,

--- a/packages/togetherai/src/togetherai-image-model.ts
+++ b/packages/togetherai/src/togetherai-image-model.ts
@@ -100,7 +100,7 @@ export class TogetherAIImageModel implements ImageModelV3 {
         model: this.modelId,
         prompt,
         seed,
-        n,
+        ...(n > 1 ? { n } : {}),
         ...(splitSize && {
           width: parseInt(splitSize[0]),
           height: parseInt(splitSize[1]),


### PR DESCRIPTION
## Background
Models like `google/gemini-3-pro-image` don't support the `n` parameter, but we were sending it anyways

## Summary
Only send `n` if >1

## Manual Verification
Example script works and produces an image with `google/gemini-3-pro-image`

## Checklist
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)