### PR TITLE
small change on the gateway inline error, and changeset

### DIFF
--- a/.changeset/six-moons-tease.md
+++ b/.changeset/six-moons-tease.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+Inline fullMessage variable in GatewayError constructor

--- a/packages/gateway/src/errors/gateway-error.ts
+++ b/packages/gateway/src/errors/gateway-error.ts
@@ -21,9 +21,7 @@ export abstract class GatewayError extends Error {
     cause?: unknown;
     generationId?: string;
   }) {
-    // Include generationId in message so it's visible in stack traces
-    const fullMessage = generationId ? `${message} [${generationId}]` : message;
-    super(fullMessage);
+    super(generationId ? `${message} [${generationId}]` : message);
     this.statusCode = statusCode;
     this.cause = cause;
     this.generationId = generationId;


### PR DESCRIPTION
## Background

  PR feedback requested inlining the `fullMessage` variable and removing the unnecessary comment. (https://github.com/vercel/ai/pull/11798#pullrequestreview-3689353322)

  ## Summary

  Inline `fullMessage` variable directly in the `super()` call in `GatewayError` constructor.

  ## Checklist

  - [ ] Tests have been added / updated (for bug fixes / features)
  - [ ] Documentation has been added / updated (for bug fixes / features)
  - [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
  - [x] I have reviewed this pull request (self-review)
