### PR TITLE
chore: include sources in npm packages

### DIFF
--- a/.changeset/gorgeous-candles-fold.md
+++ b/.changeset/gorgeous-candles-fold.md
@@ -1,0 +1,48 @@
+---
+'@ai-sdk/black-forest-labs': patch
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/huggingface': patch
+'@ai-sdk/test-server': patch
+'@ai-sdk/assemblyai': patch
+'@ai-sdk/elevenlabs': patch
+'@ai-sdk/llamaindex': patch
+'@ai-sdk/perplexity': patch
+'@ai-sdk/togetherai': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/deepinfra': patch
+'@ai-sdk/fireworks': patch
+'@ai-sdk/langchain': patch
+'@ai-sdk/replicate': patch
+'@ai-sdk/cerebras': patch
+'@ai-sdk/deepgram': patch
+'@ai-sdk/deepseek': patch
+'@ai-sdk/devtools': patch
+'@ai-sdk/angular': patch
+'@ai-sdk/baseten': patch
+'@ai-sdk/codemod': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/valibot': patch
+'@ai-sdk/cohere': patch
+'@ai-sdk/gladia': patch
+'@ai-sdk/google': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/prodia': patch
+'@ai-sdk/vercel': patch
+'@ai-sdk/azure': patch
+'@ai-sdk/react': patch
+'@ai-sdk/revai': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/hume': patch
+'@ai-sdk/lmnt': patch
+'@ai-sdk/luma': patch
+'@ai-sdk/fal': patch
+'@ai-sdk/mcp': patch
+'@ai-sdk/rsc': patch
+'@ai-sdk/vue': patch
+'@ai-sdk/xai': patch
+---
+
+chore: add src folders to package bundle

--- a/packages/amazon-bedrock/package.json
+++ b/packages/amazon-bedrock/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md",
     "anthropic/index.d.ts"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md",
     "internal.d.ts"

--- a/packages/assemblyai/package.json
+++ b/packages/assemblyai/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/baseten/package.json
+++ b/packages/baseten/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/black-forest-labs/package.json
+++ b/packages/black-forest-labs/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md"
   ],
   "scripts": {

--- a/packages/cerebras/package.json
+++ b/packages/cerebras/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -5,6 +5,7 @@
   "sideEffects": false,
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/cohere/package.json
+++ b/packages/cohere/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/deepgram/package.json
+++ b/packages/deepgram/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/deepinfra/package.json
+++ b/packages/deepinfra/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/deepseek/package.json
+++ b/packages/deepseek/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -17,6 +17,7 @@
   },
   "files": [
     "dist",
+    "src",
     "bin"
   ],
   "scripts": {

--- a/packages/elevenlabs/package.json
+++ b/packages/elevenlabs/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/fal/package.json
+++ b/packages/fal/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/fireworks/package.json
+++ b/packages/fireworks/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -9,6 +9,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/gladia/package.json
+++ b/packages/gladia/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md",
     "edge.d.ts",

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md",
     "internal.d.ts"

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/huggingface/package.json
+++ b/packages/huggingface/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/hume/package.json
+++ b/packages/hume/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/llamaindex/package.json
+++ b/packages/llamaindex/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/lmnt/package.json
+++ b/packages/lmnt/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/luma/package.json
+++ b/packages/luma/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md",
     "internal.d.ts"

--- a/packages/mistral/package.json
+++ b/packages/mistral/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/openai-compatible/package.json
+++ b/packages/openai-compatible/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md",
     "internal.d.ts"

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md",
     "internal.d.ts"

--- a/packages/perplexity/package.json
+++ b/packages/perplexity/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/prodia/package.json
+++ b/packages/prodia/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md"
   ],
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/replicate/package.json
+++ b/packages/replicate/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/revai/package.json
+++ b/packages/revai/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -35,6 +35,7 @@
   },
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/togetherai/package.json
+++ b/packages/togetherai/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/xai/package.json
+++ b/packages/xai/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],


### PR DESCRIPTION
## Background

The npm packages do not include the sources. However, sources include JSDocs which can be helpful when coding agents grep `node_modules` contents. The sources can also be relevant to other bundlers and human readers.

## Summary

Include `src` folder in remaining npm packages.

## Related Issues
Similar to #11790