### PR TITLE
fix(ai): use toolCallId for parallel tool execution tracking

### DIFF
--- a/.changeset/fix-toolcallid-tracking.md
+++ b/.changeset/fix-toolcallid-tracking.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Use toolCallId instead of generateId for parallel tool execution tracking to prevent premature stream closure

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -309,7 +309,11 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
 
             // Only execute tools that are not provider-executed:
             if (tool.execute != null && toolCall.providerExecuted !== true) {
-              const toolExecutionId = generateId(); // use our own id to guarantee uniqueness
+              // Use toolCallId for tracking - it's unique per tool call from the LLM.
+              // Don't use generateId() here because frameworks can override it for
+              // message grouping (returning the same ID for all tools in a request),
+              // which would cause the Set to track only one tool instead of all.
+              const toolExecutionId = toolCall.toolCallId;
               outstandingToolResults.add(toolExecutionId);
 
               // Note: we don't await the tool execution here (by leaving out 'await' on recordSpan),


### PR DESCRIPTION
## Background

Split from #11907 per review feedback to separate from the close guard fix.

The generateId parameter serves a valid purpose: allowing frameworks to control message IDs for grouping. For example, @convex-dev/agent overrides it to return the same ID for all messages in a request:

```
generateId: pendingMessageId
  ? () => pendingMessageId ?? crypto.randomUUID()
  : undefined,
```

However, generateId() was also being used internally to track outstanding tool executions via a Set. When a framework returns the same ID for message grouping, the Set tracks only one entry instead of N tools:

Tool A: outstandingToolResults.add("msg-123") → Set: {"msg-123"}
Tool B: outstandingToolResults.add("msg-123") → Set: {"msg-123"} (duplicate ignored)
Tool C: outstandingToolResults.add("msg-123") → Set: {"msg-123"}
Tool B completes: outstandingToolResults.delete("msg-123") → Set: {} (empty!)
attemptClose() sees empty set → closes stream prematurely
Tool A and C results are LOST

## Summary

Use toolCall.toolCallId instead of generateId() for tool execution tracking.                                                                                                                                            

toolCallId is unique per tool call from the LLM and is the correct identifier for tracking individual tool executions. This separates the concerns of message ID generation (user-controlled) from internal tool execution tracking (implementation detail).

## Manual Verification

The included test deterministically reproduces the issue:
- Simulates framework behavior with generateId returning a constant
- Without fix: only 1 of 3 tool results captured
- With fix: all 3 tool results captured

Also tested end-to-end with @convex-dev/agent and Gemini 2.5 Flash with 5+ parallel tool calls.  

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

- Split from #11907                                                                                                                                                                                                     
- Discovered while testing @convex-dev/agent AI SDK v6 compatibility (get-convex/agent#208)
