### PR TITLE
feat(anthropic): search result blocks and custom content documents

### DIFF
--- a/.changeset/anthropic-search-results-citations.md
+++ b/.changeset/anthropic-search-results-citations.md
@@ -1,0 +1,9 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+feat(anthropic): search result blocks and custom content documents
+
+This enables Claude to cite specific passages from search results and custom content documents. File parts can now use `type: 'search_result'` or `source: { type: 'content', content: [...] }` in provider options to provide citable content.
+
+New citation types `search_result_location` and `content_block_location` are now properly parsed and returned as `source` parts with metadata including `citedText`, `source`, `searchResultIndex`, `startBlockIndex`, and `endBlockIndex`.

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -547,6 +547,143 @@ For more on prompt caching with Anthropic, see [Anthropic's Cache Control docume
   [here](/docs/foundations/prompts#provider-options).
 </Note>
 
+### Search Results and Citations
+
+Anthropic supports search result blocks and custom content documents that enable Claude to cite specific passages in its responses. You can provide these using file parts with the `providerOptions` property.
+
+```ts highlight="12-18"
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: anthropic('claude-sonnet-4-5-20250929'),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'file',
+          mediaType: 'text/plain',
+          data: 'Search result snippet about quarterly revenue growth.',
+          providerOptions: {
+            anthropic: {
+              type: 'search_result',
+              source: 'https://example.com/search/result1',
+              citations: { enabled: true },
+              title: 'Quarterly Results',
+            },
+          },
+        },
+        {
+          type: 'text',
+          text: 'Summarize the search result and include citations.',
+        },
+      ],
+    },
+  ],
+});
+```
+
+#### Configuration Options
+
+The following options are available for search result blocks:
+
+- **type** _'search_result'_
+
+  Required. Indicates this is a search result block.
+
+- **source** _string_
+
+  Required. The URL or identifier for the search result.
+
+- **citations** _object_
+
+  Set `{ enabled: true }` to enable citations. Anthropic's API requires this setting to be consistent across all search results in a request; inconsistent values will result in an API error.
+
+- **title** _string_
+
+  A title for the search result. Prefer `title` over `filename`.
+
+- **content** _array_
+
+  Custom content blocks. If not provided, the SDK derives a single text block from the file `data`.
+
+#### Custom Content Documents
+
+For pre-chunked text blocks that should be used as-is for citations without additional processing, use `source: { type: 'content', content: [...] }` with a `text/plain` file part:
+
+```ts highlight="14-21"
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: anthropic('claude-sonnet-4-5-20250929'),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'file',
+          mediaType: 'text/plain',
+          data: 'Placeholder text for the file part.',
+          providerOptions: {
+            anthropic: {
+              source: {
+                type: 'content',
+                content: [
+                  { type: 'text', text: 'First custom chunk.' },
+                  { type: 'text', text: 'Second custom chunk.' },
+                ],
+              },
+              citations: { enabled: true },
+              title: 'Custom Content Doc',
+            },
+          },
+        },
+        {
+          type: 'text',
+          text: 'Summarize the custom content and include citations.',
+        },
+      ],
+    },
+  ],
+});
+```
+
+#### Citation Metadata
+
+When citations are enabled, the response `content` array includes `source` parts with citation metadata:
+
+```ts
+const citations = result.content.filter(part => part.type === 'source');
+
+for (const citation of citations) {
+  if (
+    citation.sourceType === 'document' &&
+    citation.providerMetadata?.anthropic
+  ) {
+    const meta = citation.providerMetadata.anthropic;
+    console.log(`Cited: "${meta.citedText}"`);
+    console.log(`Title: ${citation.title}`);
+
+    // Search results include source URL and index
+    if ('searchResultIndex' in meta) {
+      console.log(`Source: ${meta.source}`);
+      console.log(`Search result index: ${meta.searchResultIndex}`);
+    }
+  }
+}
+```
+
+The `providerMetadata.anthropic` object includes:
+
+- **citedText** _string_ - The exact text that was cited
+- **source** _string_ - The source URL (search results only)
+- **searchResultIndex** _number_ - Index of the cited search result (search results only)
+- **startBlockIndex** / **endBlockIndex** _number_ - Block range of the citation
+
+For more details, see [Anthropic's Search Results documentation](https://docs.anthropic.com/en/docs/build-with-claude/search-results) and [Citations documentation](https://docs.anthropic.com/en/docs/build-with-claude/citations).
+
 ### Bash Tool
 
 The Bash Tool allows running bash commands. Here's how to create and use it:

--- a/examples/ai-functions/src/generate-text/anthropic-custom-content-documents.ts
+++ b/examples/ai-functions/src/generate-text/anthropic-custom-content-documents.ts
@@ -1,0 +1,56 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: anthropic('claude-sonnet-4-5-20250929'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            mediaType: 'text/plain',
+            data: '',
+            providerOptions: {
+              anthropic: {
+                source: {
+                  type: 'content',
+                  content: [
+                    { type: 'text' as const, text: 'First custom chunk.' },
+                    { type: 'text' as const, text: 'Second custom chunk.' },
+                  ],
+                },
+                citations: { enabled: true },
+                title: 'Custom Content Doc',
+              },
+            },
+          },
+          {
+            type: 'text',
+            text: 'Summarize the custom content and include citations.',
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log('Response:', result.text);
+
+  const citations = result.content.filter(part => part.type === 'source');
+  citations.forEach((citation, i) => {
+    if (
+      citation.sourceType === 'document' &&
+      citation.providerMetadata?.anthropic
+    ) {
+      const meta = citation.providerMetadata.anthropic;
+      console.log(
+        `\n[${i + 1}] "${meta.citedText}" (blocks ${meta.startBlockIndex}-${meta.endBlockIndex})`,
+      );
+      if (citation.title) {
+        console.log(`Title: ${citation.title}`);
+      }
+    }
+  });
+});

--- a/examples/ai-functions/src/generate-text/anthropic-search-results.ts
+++ b/examples/ai-functions/src/generate-text/anthropic-search-results.ts
@@ -1,0 +1,71 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: anthropic('claude-sonnet-4-5-20250929'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            mediaType: 'text/plain',
+            data: 'Search result snippet about quarterly revenue growth.',
+            providerOptions: {
+              anthropic: {
+                type: 'search_result',
+                source: 'https://example.com/search/result1',
+                citations: { enabled: true },
+                title: 'Quarterly Results',
+              },
+            },
+          },
+          {
+            type: 'file',
+            mediaType: 'text/plain',
+            data: '',
+            providerOptions: {
+              anthropic: {
+                type: 'search_result',
+                source: 'https://example.com/search/result2',
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: 'Additional context from the same search result.',
+                  },
+                ],
+                citations: { enabled: true },
+                title: 'Additional Context',
+              },
+            },
+          },
+          {
+            type: 'text',
+            text: 'Summarize the search result and include citations.',
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log('Response:', result.text);
+
+  const citations = result.content.filter(part => part.type === 'source');
+  citations.forEach((citation, i) => {
+    if (
+      citation.sourceType === 'document' &&
+      citation.providerMetadata?.anthropic
+    ) {
+      const meta = citation.providerMetadata.anthropic;
+      console.log(
+        `\n[${i + 1}] "${meta.citedText}" (search_result ${meta.searchResultIndex}, blocks ${meta.startBlockIndex}-${meta.endBlockIndex})`,
+      );
+      console.log(`Source: ${meta.source}`);
+      if (citation.title) {
+        console.log(`Title: ${citation.title}`);
+      }
+    }
+  });
+});

--- a/examples/ai-functions/src/stream-text/anthropic-custom-content-documents.ts
+++ b/examples/ai-functions/src/stream-text/anthropic-custom-content-documents.ts
@@ -1,0 +1,67 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { streamText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: anthropic('claude-sonnet-4-5-20250929'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            mediaType: 'text/plain',
+            data: '',
+            providerOptions: {
+              anthropic: {
+                source: {
+                  type: 'content',
+                  content: [
+                    { type: 'text' as const, text: 'First custom chunk.' },
+                    { type: 'text' as const, text: 'Second custom chunk.' },
+                  ],
+                },
+                citations: { enabled: true },
+                title: 'Custom Content Doc',
+              },
+            },
+          },
+          {
+            type: 'text',
+            text: 'Summarize the custom content and include citations.',
+          },
+        ],
+      },
+    ],
+  });
+
+  let citationCount = 0;
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'source':
+        if (
+          part.sourceType === 'document' &&
+          part.providerMetadata?.anthropic
+        ) {
+          const meta = part.providerMetadata.anthropic;
+          console.log(
+            `\n\n[${++citationCount}] "${meta.citedText}" (blocks ${meta.startBlockIndex}-${meta.endBlockIndex})`,
+          );
+          if (part.title) {
+            console.log(`Title: ${part.title}`);
+          }
+        }
+        break;
+      case 'error':
+        console.error('Error:', part.error);
+        break;
+    }
+  }
+
+  console.log(`\n\nTotal citations: ${citationCount}`);
+});

--- a/examples/ai-functions/src/stream-text/anthropic-search-results.ts
+++ b/examples/ai-functions/src/stream-text/anthropic-search-results.ts
@@ -1,0 +1,82 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { streamText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: anthropic('claude-sonnet-4-5-20250929'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            mediaType: 'text/plain',
+            data: 'Search result snippet about quarterly revenue growth.',
+            providerOptions: {
+              anthropic: {
+                type: 'search_result',
+                source: 'https://example.com/search/result1',
+                citations: { enabled: true },
+                title: 'Quarterly Results',
+              },
+            },
+          },
+          {
+            type: 'file',
+            mediaType: 'text/plain',
+            data: '',
+            providerOptions: {
+              anthropic: {
+                type: 'search_result',
+                source: 'https://example.com/search/result2',
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: 'Additional context from the same search result.',
+                  },
+                ],
+                citations: { enabled: true },
+                title: 'Additional Context',
+              },
+            },
+          },
+          {
+            type: 'text',
+            text: 'Summarize the search result and include citations.',
+          },
+        ],
+      },
+    ],
+  });
+
+  let citationCount = 0;
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'source':
+        if (
+          part.sourceType === 'document' &&
+          part.providerMetadata?.anthropic
+        ) {
+          const meta = part.providerMetadata.anthropic;
+          console.log(
+            `\n\n[${++citationCount}] "${meta.citedText}" (search_result ${meta.searchResultIndex}, blocks ${meta.startBlockIndex}-${meta.endBlockIndex})`,
+          );
+          console.log(`Source: ${meta.source}`);
+          if (part.title) {
+            console.log(`Title: ${part.title}`);
+          }
+        }
+        break;
+      case 'error':
+        console.error('Error:', part.error);
+        break;
+    }
+  }
+
+  console.log(`\n\nTotal citations: ${citationCount}`);
+});

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -20,6 +20,7 @@ export interface AnthropicUserMessage {
     | AnthropicTextContent
     | AnthropicImageContent
     | AnthropicDocumentContent
+    | AnthropicSearchResultContent
     | AnthropicToolResultContent
   >;
 }
@@ -56,6 +57,11 @@ export interface AnthropicTextContent {
   cache_control: AnthropicCacheControl | undefined;
 }
 
+type AnthropicTextBlock = {
+  type: 'text';
+  text: string;
+};
+
 export interface AnthropicThinkingContent {
   type: 'thinking';
   thinking: string;
@@ -84,6 +90,10 @@ type AnthropicContentSource =
       url: string;
     }
   | {
+      type: 'content';
+      content: AnthropicTextBlock[];
+    }
+  | {
       type: 'text';
       media_type: 'text/plain';
       data: string;
@@ -100,6 +110,15 @@ export interface AnthropicDocumentContent {
   source: AnthropicContentSource;
   title?: string;
   context?: string;
+  citations?: { enabled: boolean };
+  cache_control: AnthropicCacheControl | undefined;
+}
+
+export interface AnthropicSearchResultContent {
+  type: 'search_result';
+  source: string;
+  title: string;
+  content: AnthropicTextBlock[];
   citations?: { enabled: boolean };
   cache_control: AnthropicCacheControl | undefined;
 }
@@ -551,6 +570,15 @@ export const anthropicMessagesResponseSchema = lazySchema(() =>
                     encrypted_index: z.string(),
                   }),
                   z.object({
+                    type: z.literal('search_result_location'),
+                    cited_text: z.string(),
+                    source: z.string(),
+                    title: z.string(),
+                    search_result_index: z.number(),
+                    start_block_index: z.number(),
+                    end_block_index: z.number(),
+                  }),
+                  z.object({
                     type: z.literal('page_location'),
                     cited_text: z.string(),
                     document_index: z.number(),
@@ -565,6 +593,14 @@ export const anthropicMessagesResponseSchema = lazySchema(() =>
                     document_title: z.string().nullable(),
                     start_char_index: z.number(),
                     end_char_index: z.number(),
+                  }),
+                  z.object({
+                    type: z.literal('content_block_location'),
+                    cited_text: z.string(),
+                    document_index: z.number(),
+                    document_title: z.string().nullable(),
+                    start_block_index: z.number(),
+                    end_block_index: z.number(),
                   }),
                 ]),
               )
@@ -1139,6 +1175,15 @@ export const anthropicMessagesChunkSchema = lazySchema(() =>
                 encrypted_index: z.string(),
               }),
               z.object({
+                type: z.literal('search_result_location'),
+                cited_text: z.string(),
+                source: z.string(),
+                title: z.string(),
+                search_result_index: z.number(),
+                start_block_index: z.number(),
+                end_block_index: z.number(),
+              }),
+              z.object({
                 type: z.literal('page_location'),
                 cited_text: z.string(),
                 document_index: z.number(),
@@ -1153,6 +1198,14 @@ export const anthropicMessagesChunkSchema = lazySchema(() =>
                 document_title: z.string().nullable(),
                 start_char_index: z.number(),
                 end_char_index: z.number(),
+              }),
+              z.object({
+                type: z.literal('content_block_location'),
+                cited_text: z.string(),
+                document_index: z.number(),
+                document_title: z.string().nullable(),
+                start_block_index: z.number(),
+                end_block_index: z.number(),
               }),
             ]),
           }),


### PR DESCRIPTION
## Background

Anthropic's API supports search result blocks and custom content documents that enable Claude to cite specific passages in responses. This functionality was not exposed through the AI SDK, limiting users who want to build RAG applications with proper source attribution.

https://platform.claude.com/docs/en/build-with-claude/search-results
https://platform.claude.com/docs/en/build-with-claude/citations#custom-content-documents

## Summary

Adds support for Anthropic's search result blocks and custom content documents, enabling Claude to cite specific passages from user-provided content.

Search results can be passed as file parts with provider options specifying `type: 'search_result'` along with a source URL. Custom content documents use `source: { type: 'content', content: [...] }` for pre-chunked text that Claude can cite directly.

Two new citation location types are now parsed in responses: `search_result_location` and `content_block_location`. These return as `source` parts with provider metadata containing the cited text, source URL, search result index, and block ranges.

Includes streaming support with full test coverage for both generateText and streamText flows. Documentation updated with usage examples and configuration options.

## Manual Verification

Ran the example files to verify end-to-end functionality:
- `pnpm tsx src/generate-text/anthropic-search-results.ts`
- `pnpm tsx src/stream-text/anthropic-search-results.ts`
- `pnpm tsx src/generate-text/anthropic-custom-content-documents.ts`
- `pnpm tsx src/stream-text/anthropic-custom-content-documents.ts`

Confirmed that:
- Search results are sent correctly to the Anthropic API
- Citations are returned and parsed with correct metadata
- Streaming works with citations appearing in real-time

```bash
% pnpm tsx src/generate-text/anthropic-custom-content-documents.ts
Response: The document contains a first custom chunk and a second custom chunk.

[1] "First custom chunk." (blocks 0-1)
Title: Custom Content Doc

[2] "Second custom chunk." (blocks 1-2)
Title: Custom Content Doc
```
```bash
% pnpm tsx src/stream-text/anthropic-custom-content-documents.ts
The document contains two simple custom chunks. 

[1] "First custom chunk." (blocks 0-1)
Title: Custom Content Doc
The first is labeled as "First custom chunk." 

[2] "Second custom chunk." (blocks 1-2)
Title: Custom Content Doc
The second is labeled as "Second custom chunk."

Total citations: 2
```
```bash
% pnpm tsx src/generate-text/anthropic-search-results.ts
Response: Based on the search results provided, I can see there is information about quarterly revenue growth and additional context from the same search result. However, the search results only contain brief snippets without specific details, so I cannot provide a more comprehensive summary of the actual content or findings.

[1] "Search result snippet about quarterly revenue growth." (search_result 0, blocks 0-1)
Source: https://example.com/search/result1
Title: Quarterly Results

[2] "Additional context from the same search result." (search_result 1, blocks 0-1)
Source: https://example.com/search/result2
Title: Additional Context
```
```bash
% pnpm tsx src/stream-text/anthropic-search-results.ts
Based on the search results provided, I can see there is 

[1] "Search result snippet about quarterly revenue growth." (search_result 0, blocks 0-1)
Source: https://example.com/search/result1
Title: Quarterly Results
information about quarterly revenue growth and 

[2] "Additional context from the same search result." (search_result 1, blocks 0-1)
Source: https://example.com/search/result2
Title: Additional Context
additional context from the same search result. 

However, the search results only contain brief snippet descriptions without the actual detailed content, so I cannot provide a comprehensive summary of the specific findings, data, or conclusions. To give you a meaningful summary, I would need access to the full content of these search results.

Total citations: 2
```

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Add support for returning `search_result` blocks from tool calls. Need to double-check if custom content documents can be returned from tool calls. Will be done in a subsequent PR.