### PR TITLE
chore: add pre-commit hook for pnpm i

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,17 @@
-# Skip formatting if ARTISANAL_MODE is set
+# Skip all checks if ARTISANAL_MODE is set
 if [ -n "$ARTISANAL_MODE" ]; then
-  echo "ARTISANAL_MODE is set, skipping lint-staged"
+  echo "ARTISANAL_MODE is set, skipping pre-commit hooks"
   exit 0
+fi
+
+# Run pnpm install if any package.json files are staged.
+# Note: This is not done via lint-staged because lint-staged would run
+# pnpm install once per staged package.json file, whereas this runs it
+# only once regardless of how many package.json files are staged.
+if git diff --cached --name-only | grep -q 'package\.json$'; then
+  echo "package.json changes detected, running pnpm install..."
+  pnpm install
+  git add pnpm-lock.yaml
 fi
 
 pnpm lint-staged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ pnpm tsx src/stream-text/openai.ts    # Run a specific example
 - **Config**: Defined in root `package.json`
 - **Settings**: Single quotes, trailing commas, 2-space indentation, no tabs
 - **Pre-commit hook**: Automatically formats staged files on commit via `lint-staged`
+- **Auto-install**: If `package.json` changes are staged, `pnpm install` runs automatically
 
 ### Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,8 +118,7 @@ pnpm tsx src/stream-text/openai.ts    # Run a specific example
 - **Tool**: Prettier
 - **Config**: Defined in root `package.json`
 - **Settings**: Single quotes, trailing commas, 2-space indentation, no tabs
-- **Pre-commit hook**: Automatically formats staged files on commit via `lint-staged`
-- **Auto-install**: If `package.json` changes are staged, `pnpm install` runs automatically
+- **Pre-commit hook**: Automatically formats staged files on commit via `lint-staged`. If `package.json` changes are staged, `pnpm install` runs automatically
 
 ### Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ We greatly appreciate your pull requests. Here are the steps to submit them:
 
 3. **Add a codemod**: If the change introduces a deprecation or a breaking change, add a codemod if possible. See [how to contribute codemods](contributing/codemods.md)
 4. **Commit Your Changes**: Ensure your commits are succinct and clear, detailing what modifications have been made and the reasons behind them. We don't require a specific commit message format, but please be descriptive.
-5. **Formatting**: A pre-commit hook automatically formats your staged files using `lint-staged` when you commit. If you need to skip this (e.g., for work-in-progress commits), set `ARTISANAL_MODE=1` before committing: `ARTISANAL_MODE=1 git commit -m "message"`.
+5. **Pre-commit hooks**: A pre-commit hook automatically formats your staged files using `lint-staged` when you commit. If you stage any `package.json` changes, `pnpm install` runs automatically to keep the lockfile in sync. If you need to skip these hooks (e.g., for work-in-progress commits), set `ARTISANAL_MODE=1` before committing: `ARTISANAL_MODE=1 git commit -m "message"`.
 6. **Push the Changes to Your GitHub Repository**: After committing your changes, push them to your GitHub repository.
 7. **Open a Pull Request**: Propose your changes for review. Furnish a lucid title and description of your contributions. Make sure to link any relevant issues your PR resolves. We use the following PR title format:
 


### PR DESCRIPTION
## Background

From time to time, package.json files change but the lockfile is not updated. This leads to immediate CI failures.

## Summary

Ensure that the lockfile is always updated when `package.json` files change (via a pre-commit hook).

## Related Issues

Follow up from #11972