### PR TITLE
chore: simplify list npm package skill with script

### DIFF
--- a/skills/list-npm-package-content/SKILL.md
+++ b/skills/list-npm-package-content/SKILL.md
@@ -1,96 +1,21 @@
 ---
 name: list-npm-package-content
-description: List the contents of an npm package tarball before publishing. Use when the user wants to see what files are included in an npm bundle, verify package contents, check tarball size, or debug npm publish issues.
+description: List the contents of an npm package tarball before publishing. Use when the user wants to see what files are included in an npm bundle, verify package contents, or debug npm publish issues.
 ---
 
 # List npm Package Content
 
-This skill helps you list the exact contents of an npm package tarball - the same files that would be uploaded to npm and downloaded by users.
+This skill lists the exact contents of an npm package tarball - the same files that would be uploaded to npm and downloaded by users.
 
-## Prerequisites
+## Usage
 
-- Package must be built first (run `pnpm build` or equivalent)
-- Run commands from the package directory (e.g., `packages/ai`)
-
-## Step-by-Step Instructions
-
-### Step 1: Build the Package
+Run the script from the package directory (e.g., `packages/ai`):
 
 ```bash
-pnpm build
+bash scripts/list-package-files.sh
 ```
 
-### Step 2: Create the Tarball
-
-```bash
-pnpm pack
-```
-
-This creates a `.tgz` file (e.g., `ai-6.0.46.tgz`) and runs any `prepack`/`postpack` scripts defined in `package.json`.
-
-### Step 3: List Tarball Contents
-
-List all files in the tarball:
-
-```bash
-tar -tzf *.tgz
-```
-
-Or with more detail (sizes):
-
-```bash
-tar -tvzf *.tgz
-```
-
-### Step 4: Check Tarball Size
-
-```bash
-ls -lh *.tgz
-```
-
-### Step 5: Extract and Browse (Optional)
-
-To inspect files in detail:
-
-```bash
-mkdir -p /tmp/inspect-bundle
-tar -xzf *.tgz -C /tmp/inspect-bundle
-ls -la /tmp/inspect-bundle/package/
-```
-
-Check unpacked size:
-
-```bash
-du -sh /tmp/inspect-bundle/package/
-```
-
-### Step 6: Cleanup
-
-Always clean up after inspection:
-
-```bash
-# Remove tarball
-rm *.tgz
-
-# Remove extracted files (if extracted)
-rm -rf /tmp/inspect-bundle
-```
-
-## Quick One-Liner
-
-To list contents without leaving artifacts:
-
-```bash
-pnpm build && pnpm pack && tar -tzf *.tgz && rm *.tgz
-```
-
-## Alternative: Dry Run
-
-To see what would be published without creating a tarball (note: this runs prepack which may have side effects):
-
-```bash
-npm publish --dry-run
-```
+The script will build the package, create a tarball, list its contents, and clean up automatically.
 
 ## Understanding Package Contents
 
@@ -101,22 +26,3 @@ The files included are determined by:
 3. **`.gitignore`** - used if no `.npmignore` exists
 4. **Always included**: `package.json`, `README`, `LICENSE`, `CHANGELOG`
 5. **Always excluded**: `.git`, `node_modules`, `.npmrc`, etc.
-
-## Troubleshooting
-
-**Tarball larger than expected?**
-
-- Check if `src/` is included (common for source maps)
-- Check if `docs/` or other non-essential directories are listed in `files`
-- Use `tar -tvzf *.tgz | sort -k3 -n` to find largest files
-
-**Missing files?**
-
-- Verify the file/directory is listed in the `files` field of `package.json`
-- Check `.npmignore` isn't excluding it
-- Ensure the file exists after build
-
-**prepack script failing?**
-
-- Some packages copy files during prepack (e.g., docs)
-- Ensure source files exist before running `pnpm pack`

--- a/skills/list-npm-package-content/scripts/list-package-files.sh
+++ b/skills/list-npm-package-content/scripts/list-package-files.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+# Build, pack, list contents, cleanup
+pnpm build
+pnpm pack
+tar -tzf *.tgz
+rm *.tgz

--- a/skills/list-npm-package-content/scripts/list-package-files.sh
+++ b/skills/list-npm-package-content/scripts/list-package-files.sh
@@ -3,6 +3,6 @@ set -e
 
 # Build, pack, list contents, cleanup
 pnpm build
-pnpm pack
-tar -tzf *.tgz
-rm *.tgz
+tarball=$(pnpm pack | tail -1)
+tar -tzf "$tarball"
+rm "$tarball"


### PR DESCRIPTION
## Background

The list npm package skill was overly complex (which wastes tokens and slows down agents).

## Summary

Refactor the list npm package skill to use a script.

## Related Issues

Builds on #11957