### PR TITLE
fix(openai-compat): add metadata extractor to provider settings

### DIFF
--- a/.changeset/new-baboons-develop.md
+++ b/.changeset/new-baboons-develop.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+fix(openai-compat): add metadata extractor to provider settings

--- a/packages/openai-compatible/src/openai-compatible-provider.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.test.ts
@@ -326,4 +326,29 @@ describe('OpenAICompatibleProvider', () => {
       ).toBe(undefined);
     });
   });
+
+  describe('metadataExtractor setting', () => {
+    it('should pass metadataExtractor to chat model', () => {
+      const mockExtractor = {
+        extractMetadata: async () => undefined,
+        createStreamExtractor: () => ({
+          processChunk: () => {},
+          buildMetadata: () => undefined,
+        }),
+      };
+
+      const provider = createOpenAICompatible({
+        baseURL: 'https://api.example.com',
+        name: 'test-provider',
+        metadataExtractor: mockExtractor,
+      });
+
+      provider.chatModel('chat-model');
+
+      expect(
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0][1]
+          .metadataExtractor,
+      ).toBe(mockExtractor);
+    });
+  });
 });

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -13,6 +13,7 @@ import {
   OpenAICompatibleChatConfig,
   OpenAICompatibleChatLanguageModel,
 } from './chat/openai-compatible-chat-language-model';
+import { MetadataExtractor } from './chat/openai-compatible-metadata-extractor';
 import { OpenAICompatibleCompletionLanguageModel } from './completion/openai-compatible-completion-language-model';
 import { OpenAICompatibleEmbeddingModel } from './embedding/openai-compatible-embedding-model';
 import { OpenAICompatibleImageModel } from './image/openai-compatible-image-model';
@@ -96,6 +97,13 @@ Include usage information in streaming responses.
    * than the official OpenAI API.
    */
   transformRequestBody?: (args: Record<string, any>) => Record<string, any>;
+
+  /**
+   * Optional metadata extractor to capture provider-specific metadata from API responses.
+   * This is useful for extracting non-standard fields, experimental features,
+   * or provider-specific metrics from both streaming and non-streaming responses.
+   */
+  metadataExtractor?: MetadataExtractor;
 }
 
 /**
@@ -154,6 +162,7 @@ export function createOpenAICompatible<
       includeUsage: options.includeUsage,
       supportsStructuredOutputs: options.supportsStructuredOutputs,
       transformRequestBody: options.transformRequestBody,
+      metadataExtractor: options.metadataExtractor,
     });
 
   const createCompletionModel = (modelId: COMPLETION_MODEL_IDS) =>


### PR DESCRIPTION
## Background

#4715 

`metadataExtractor` wasn't a valid property in `OpenAICompatibleProviderSettings` even though the docs specified it

## Summary

- adds the type to the provider settings interface
- passes it through to the chat model

## Manual Verification

gives a type error when we try to set that property when defining a provider via `createOpenAICompatible()` - verified by adding a unit test

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #4715 