### PR TITLE
feat: adds disallowPromptTraining gateway provider options

### DIFF
--- a/.changeset/chilly-mangos-hang.md
+++ b/.changeset/chilly-mangos-hang.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(provider/gateway): adds disallowPromptTraining gateway provider options

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -522,6 +522,10 @@ The following gateway provider options are available:
 
   Restricts routing requests to providers that have zero data retention policies.
 
+- **disallowPromptTraining** _boolean_
+
+  Restricts routing requests to providers that do not use prompts for model training.
+
 You can combine these options to have fine-grained control over routing and tracking:
 
 ```ts
@@ -581,6 +585,27 @@ const { text } = await generateText({
   providerOptions: {
     gateway: {
       zeroDataRetention: true,
+    } satisfies GatewayProviderOptions,
+  },
+});
+```
+
+#### Disallow Prompt Training Example
+
+Set `disallowPromptTraining` to true to ensure requests are only routed to providers
+that do not use prompts for model training. When `disallowPromptTraining` is `false` or not
+specified, there is no enforcement of restricting routing.
+
+```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4.5',
+  prompt: 'Analyze this proprietary business data...',
+  providerOptions: {
+    gateway: {
+      disallowPromptTraining: true,
     } satisfies GatewayProviderOptions,
   },
 });

--- a/examples/ai-functions/src/stream-text/gateway-provider-options-disallow-prompt-training.ts
+++ b/examples/ai-functions/src/stream-text/gateway-provider-options-disallow-prompt-training.ts
@@ -1,0 +1,27 @@
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { streamText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: 'openai/gpt-oss-120b',
+    prompt: 'Tell me the history of the tenrec in a few sentences.',
+    providerOptions: {
+      gateway: {
+        disallowPromptTraining: true,
+      } satisfies GatewayProviderOptions,
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(await result.providerMetadata, null, 2),
+  );
+});

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -59,6 +59,12 @@ const gatewayProviderOptions = lazySchema(() =>
        * used.
        */
       zeroDataRetention: z.boolean().optional(),
+      /**
+       * Whether to filter by only providers that do not train on prompt data.
+       * When enabled, only providers that have agreements with Vercel AI Gateway
+       * to not use prompts for model training will be used.
+       */
+      disallowPromptTraining: z.boolean().optional(),
     }),
   ),
 );


### PR DESCRIPTION
## Background
Gateway is adding a new option for `disallowPromptTraining`

## Summary
Adds it as a provider option

## Manual Verification


## Checklist
- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)