### PR TITLE
fix(ai): Mark deferred tool call resolved on tool-error to avoid endless streamSteps.

### DIFF
--- a/.changeset/fix-deferred-tool-error.md
+++ b/.changeset/fix-deferred-tool-error.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fixed infinite `streamStep` loop when provider-executed tools with deferred results fail. The `pendingDeferredToolCalls` map now correctly clears entries on `tool-error` in addition to `tool-result`, preventing endless stream invocations after tool failures.

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1687,13 +1687,14 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                       tool?.type === 'provider' &&
                       tool.supportsDeferredResults
                     ) {
-                      // Check if this tool call already has a result in the current step
-                      const hasResultInStep = stepToolOutputs.some(
+                      // Check if this tool call already has a result or error in the current step
+                      const hasResultOrErrorInStep = stepToolOutputs.some(
                         output =>
-                          output.type === 'tool-result' &&
+                          (output.type === 'tool-result' ||
+                            output.type === 'tool-error') &&
                           output.toolCallId === toolCall.toolCallId,
                       );
-                      if (!hasResultInStep) {
+                      if (!hasResultOrErrorInStep) {
                         pendingDeferredToolCalls.set(toolCall.toolCallId, {
                           toolName: toolCall.toolName,
                         });
@@ -1701,9 +1702,12 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                     }
                   }
 
-                  // Mark deferred tool calls as resolved when we receive their results
+                  // Mark deferred tool calls as resolved when we receive their results or errors.
                   for (const output of stepToolOutputs) {
-                    if (output.type === 'tool-result') {
+                    if (
+                      output.type === 'tool-result' ||
+                      output.type === 'tool-error'
+                    ) {
                       pendingDeferredToolCalls.delete(output.toolCallId);
                     }
                   }


### PR DESCRIPTION
## Background

When using provider-executed tools (like Anthropic's `code_execution`) that support deferred results, if the tool fails and the provider streams back a tool result error packet, the SDK would enter an infinite loop calling `streamStep`.

This happens because the `pendingDeferredToolCalls` map only cleared entries when receiving `tool-result` parts, not `tool-error` (transformed from `tool-result` part in `run-tools-transformation.ts`) parts. 

Since the pending map was never cleared on `tool-error` output type, the loop condition `pendingDeferredToolCalls.size > 0` remained true indefinitely, causing endless stream invocations even after the provider signaled `end_turn`.

Introduced in 
- https://github.com/vercel/ai/pull/11262

## Summary

Updated the `pendingDeferredToolCalls` logic in `stream-text.ts` to handle `tool-error` (transformed `tool-result` chunk) in addition to `tool-result`:

1. When checking if a tool call already has a result (to avoid adding it to pending), now checks for both `tool-result` and `tool-error` output type.
2. When clearing resolved tool calls from the pending map, now deletes on both `tool-result` and `tool-error` output type.

## Manual Verification

Reproduced the issue by simulating a provider-executed tool failure that returns `tool-error`. Before the fix, the stream would hang indefinitely. After the fix, the stream properly terminates when receiving the error.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11996