### PR TITLE
fix (provider/google): make `segment` optional in `groundingSupports` schema

### DIFF
--- a/.changeset/grounding-supports-segment-optional.md
+++ b/.changeset/grounding-supports-segment-optional.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix (provider/google): make `segment` optional in `groundingSupports` schema
+
+The Google Generative AI API sometimes returns grounding supports without a `segment` field. This change makes the `segment` field optional to handle these responses correctly.

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -242,6 +242,20 @@ describe('groundingMetadataSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('validates groundingSupports with missing segment', () => {
+    const metadata = {
+      groundingSupports: [
+        {
+          // Missing `segment`
+          groundingChunkIndices: [0],
+        },
+      ],
+    };
+
+    const result = groundingMetadataSchema.safeParse(metadata);
+    expect(result.success).toBe(true);
+  });
+
   it('rejects invalid data types', () => {
     const metadata = {
       webSearchQueries: 'not an array', // Should be an array

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -840,11 +840,13 @@ export const getGroundingMetadataSchema = () =>
     groundingSupports: z
       .array(
         z.object({
-          segment: z.object({
-            startIndex: z.number().nullish(),
-            endIndex: z.number().nullish(),
-            text: z.string().nullish(),
-          }),
+          segment: z
+            .object({
+              startIndex: z.number().nullish(),
+              endIndex: z.number().nullish(),
+              text: z.string().nullish(),
+            })
+            .nullish(),
           segment_text: z.string().nullish(),
           groundingChunkIndices: z.array(z.number()).nullish(),
           supportChunkIndices: z.array(z.number()).nullish(),


### PR DESCRIPTION
## Summary

- Makes the `segment` field optional in the `groundingSupports` schema
- The Google Generative AI API sometimes returns grounding supports without a `segment` field, causing validation failures

## Test plan

- [x] All existing tests pass 
- [x] Schema change is backwards compatible (existing responses with `segment` still work)

Fixes #12001
