### PR TITLE
fix(google-vertex): fix video generation polling endpoint

### DIFF
--- a/examples/ai-functions/src/generate-video/vertex-veo.ts
+++ b/examples/ai-functions/src/generate-video/vertex-veo.ts
@@ -1,15 +1,9 @@
 import { vertex } from '@ai-sdk/google-vertex';
 import { experimental_generateVideo } from 'ai';
-import { presentVideos } from '../../lib/present-video';
-import { run } from '../../lib/run';
-import { withSpinner } from '../../lib/spinner';
+import { presentVideos } from '../lib/present-video';
+import { run } from '../lib/run';
+import { withSpinner } from '../lib/spinner';
 
-// ⚠️ CURRENTLY NOT WORKING ⚠️
-// Vertex AI Veo models have an issue with operation polling that prevents them from working.
-// The operation is created successfully but cannot be polled for completion.
-//
-// RECOMMENDATION: Use Google Generative AI instead (see google-veo.ts)
-//
 // Note: Requires GOOGLE_VERTEX_LOCATION to be set to a specific region (e.g., us-central1)
 // Veo models are not available in the 'global' region
 run(async () => {


### PR DESCRIPTION
## Background

  Vertex AI video generation was broken - the operation polling URL was incorrect, causing all video generation requests to fail after the initial request succeeded.

  ## Summary

  - Fixed polling to use `POST /models/{modelId}:fetchPredictOperation` with `{ operationName }` in body
  - Previously used `GET /v1beta1/{operationName}` which returned 404
  - Moved `vertex-veo.ts` example out of `later/` folder and removed "NOT WORKING" warning

  ## Manual Verification

  - Ran `pnpm tsx src/generate-video/vertex-veo.ts` and confirmed video generation polling now works

  ## Checklist

  - [x] Tests have been added / updated (for bug fixes / features)
  - [x] I have reviewed this pull request (self-review)