### PR TITLE
docs: simple highlight change in nextjs getting started

### DIFF
--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -257,7 +257,7 @@ Let's enhance your chatbot by adding a simple weather tool.
 
 Modify your `app/api/chat/route.ts` file to include the new weather tool:
 
-```tsx filename="app/api/chat/route.ts" highlight="2,13-27"
+```tsx filename="app/api/chat/route.ts" highlight="2,11-25"
 import { streamText, UIMessage, convertToModelMessages, tool } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';


### PR DESCRIPTION
## Background
While reading the documentation, I noticed a small code highlighting issue in the section where the new Weather tool is introduced.
The code block was not highlighted correctly, which made it slightly confusing to read.

<img width="570" height="689" alt="Screenshot 2026-01-24 at 5 54 53 PM" src="https://github.com/user-attachments/assets/4fbe9b2f-531b-4577-b298-d8d2a848cc74" />

## Summary

This PR fixes a minor code highlighting issue in the documentation related to the Weather tool example.
The change improves readability without altering any functionality or behavior.

## Manual Verification

This is a documentation-only change.
There is currently no way to view the docs locally, so verification was done by:

Reviewing the Markdown/code block changes directly
Ensuring the correct language tag is used for syntax highlighting
Confirming the change aligns with existing documentation patterns

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)