### PR TITLE
feat,docs(openai,azure):provide Responses API providerMetadata types at the provider-specific metadata / reasoning part metadata

### DIFF
--- a/.changeset/afraid-readers-begin.md
+++ b/.changeset/afraid-readers-begin.md
@@ -1,0 +1,12 @@
+---
+'@ai-sdk/openai': patch
+'@ai-sdk/azure': patch
+---
+
+Provide Responses API providerMetadata types at the message / reasoning level.
+
+- Export the following types for use in client code:
+  - `OpenaiResponsesProviderMetadata`
+  - `OpenaiResponsesReasoningProviderMetadata`
+  - `AzureResponsesProviderMetadata`
+  - `AzureResponsesReasoningProviderMetadata`

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -255,24 +255,34 @@ The following provider options are available:
 
 The OpenAI responses provider also returns provider-specific metadata:
 
+For Responses models, you can type this metadata using `OpenaiResponsesProviderMetadata`:
+
 ```ts
-const { providerMetadata } = await generateText({
-  model: openai.responses('gpt-5'),
+import { openai, type OpenaiResponsesProviderMetadata } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: openai('gpt-5'),
 });
 
-const openaiMetadata = providerMetadata?.openai;
+const providerMetadata = result.providerMetadata as
+  | OpenaiResponsesProviderMetadata
+  | undefined;
+
+const { responseId, logprobs, serviceTier } = providerMetadata?.openai ?? {};
+
+// responseId can be used to continue a conversation (previousResponseId).
+console.log(responseId);
 ```
 
-The following OpenAI-specific metadata is returned:
+The following OpenAI-specific metadata may be returned:
 
-- **responseId** _string_
+- **responseId** _string | null | undefined_
   The ID of the response. Can be used to continue a conversation.
-
-- **cachedPromptTokens** _number_
-  The number of prompt tokens that were a cache hit.
-
-- **reasoningTokens** _number_
-  The number of reasoning tokens that the model generated.
+- **logprobs** _(optional)_
+  Log probabilities of output tokens (when enabled).
+- **serviceTier** _(optional)_
+  Service tier information returned by the API.
 
 #### Reasoning Output
 
@@ -928,6 +938,52 @@ for (const part of result.content) {
   content](https://platform.openai.com/docs/api-reference/container-files/retrieveContainerFileContent)
   API.
 </Note>
+
+#### Typed providerMetadata in Reasoning Parts
+
+When using the OpenAI Responses API, reasoning output parts can include provider metadata.
+To handle this metadata in a type-safe way, use `OpenaiResponsesReasoningProviderMetadata`.
+
+For reasoning parts, when `part.type === 'reasoning'`, the `providerMetadata` is provided in the form of `OpenaiResponsesReasoningProviderMetadata`.
+
+This metadata includes the following fields:
+
+- `itemId`  
+  The ID of the reasoning item in the Responses API.
+- `reasoningEncryptedContent` (optional)  
+  Encrypted reasoning content (only returned when requested via `include: ['reasoning.encrypted_content']`).
+
+```ts
+import {
+  openai,
+  type OpenaiResponsesReasoningProviderMetadata,
+  type OpenAIResponsesProviderOptions,
+} from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: openai('gpt-5'),
+  prompt: 'How many "r"s are in the word "strawberry"?',
+  providerOptions: {
+    openai: {
+      store: false,
+      include: ['reasoning.encrypted_content'],
+    } satisfies OpenAIResponsesProviderOptions,
+  },
+});
+
+for (const part of result.content) {
+  if (part.type === 'reasoning') {
+    const providerMetadata = part.providerMetadata as
+      | OpenaiResponsesReasoningProviderMetadata
+      | undefined;
+
+    const { itemId, reasoningEncryptedContent } =
+      providerMetadata?.openai ?? {};
+    console.log(itemId, reasoningEncryptedContent);
+  }
+}
+```
 
 #### Typed providerMetadata in Source Document Parts
 

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -342,7 +342,7 @@ const { responseId, logprobs, serviceTier } = providerMetadata?.azure ?? {};
 console.log(responseId);
 ```
 
-The following AzureOpenAI-specific metadata may be returned:
+The following Azure-specific metadata may be returned:
 
 - **responseId** _string | null | undefined_
   The ID of the response. Can be used to continue a conversation.
@@ -688,7 +688,7 @@ const result = await generateText({
   model: azure('your-deployment-name'),
   prompt: 'How many "r"s are in the word "strawberry"?',
   providerOptions: {
-    openai: {
+    azure: {
       store: false,
       include: ['reasoning.encrypted_content'],
     } satisfies OpenAIResponsesProviderOptions,

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -322,24 +322,34 @@ The following provider options are available:
 
 The Azure OpenAI provider also returns provider-specific metadata:
 
+For Responses models (`azure(deploymentName)`), you can type this metadata using `AzureResponsesProviderMetadata`:
+
 ```ts
-const { providerMetadata } = await generateText({
+import { azure, type AzureResponsesProviderMetadata } from '@ai-sdk/azure';
+import { generateText } from 'ai';
+
+const result = await generateText({
   model: azure('your-deployment-name'),
 });
 
-const openaiMetadata = providerMetadata?.openai;
+const providerMetadata = result.providerMetadata as
+  | AzureResponsesProviderMetadata
+  | undefined;
+
+const { responseId, logprobs, serviceTier } = providerMetadata?.azure ?? {};
+
+// responseId can be used to continue a conversation (previousResponseId).
+console.log(responseId);
 ```
 
-The following OpenAI-specific metadata is returned:
+The following Azure-specific metadata may be returned:
 
-- **responseId** _string_
+- **responseId** _string | null | undefined_
   The ID of the response. Can be used to continue a conversation.
-
-- **cachedPromptTokens** _number_
-  The number of prompt tokens that were a cache hit.
-
-- **reasoningTokens** _number_
-  The number of reasoning tokens that the model generated.
+- **logprobs** _(optional)_
+  Log probabilities of output tokens (when enabled).
+- **serviceTier** _(optional)_
+  Service tier information returned by the API.
 
 <Note>
   The providerMetadata is only returned with the default responses API, and is
@@ -651,6 +661,51 @@ for (const part of result.content) {
   content](https://platform.openai.com/docs/api-reference/container-files/retrieveContainerFileContent)
   API.
 </Note>
+
+#### Typed providerMetadata in Reasoning Parts
+
+When using the Azure OpenAI Responses API, reasoning output parts can include provider metadata.
+To handle this metadata in a type-safe way, use `AzureResponsesReasoningProviderMetadata`.
+
+For reasoning parts, when `part.type === 'reasoning'`, the `providerMetadata` is provided in the form of `AzureResponsesReasoningProviderMetadata`.
+
+This metadata includes the following fields:
+
+- `itemId`  
+  The ID of the reasoning item in the Responses API.
+- `reasoningEncryptedContent` (optional)  
+  Encrypted reasoning content (only returned when requested via `include: ['reasoning.encrypted_content']`).
+
+```ts
+import {
+  azure,
+  type AzureResponsesReasoningProviderMetadata,
+  type OpenAIResponsesProviderOptions,
+} from '@ai-sdk/azure';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: azure('your-deployment-name'),
+  prompt: 'How many "r"s are in the word "strawberry"?',
+  providerOptions: {
+    openai: {
+      store: false,
+      include: ['reasoning.encrypted_content'],
+    } satisfies OpenAIResponsesProviderOptions,
+  },
+});
+
+for (const part of result.content) {
+  if (part.type === 'reasoning') {
+    const providerMetadata = part.providerMetadata as
+      | AzureResponsesReasoningProviderMetadata
+      | undefined;
+
+    const { itemId, reasoningEncryptedContent } = providerMetadata?.azure ?? {};
+    console.log(itemId, reasoningEncryptedContent);
+  }
+}
+```
 
 #### Typed providerMetadata in Source Document Parts
 

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -342,7 +342,7 @@ const { responseId, logprobs, serviceTier } = providerMetadata?.azure ?? {};
 console.log(responseId);
 ```
 
-The following Azure-specific metadata may be returned:
+The following AzureOpenAI-specific metadata may be returned:
 
 - **responseId** _string | null | undefined_
   The ID of the response. Can be used to continue a conversation.

--- a/examples/ai-functions/src/generate-text/azure-reasoning-encrypted-content.ts
+++ b/examples/ai-functions/src/generate-text/azure-reasoning-encrypted-content.ts
@@ -11,7 +11,7 @@ run(async () => {
     model: azure('gpt-5'),
     prompt: 'How many "r"s are in the word "strawberry"?',
     providerOptions: {
-      openai: {
+      azure: {
         reasoningEffort: 'low',
         reasoningSummary: 'detailed',
         store: false,

--- a/examples/ai-functions/src/generate-text/azure-reasoning.ts
+++ b/examples/ai-functions/src/generate-text/azure-reasoning.ts
@@ -1,10 +1,10 @@
-import { generateText } from 'ai';
-import { run } from '../lib/run';
 import {
   azure,
   AzureResponsesReasoningProviderMetadata,
   OpenAIResponsesProviderOptions,
 } from '@ai-sdk/azure';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
@@ -14,8 +14,6 @@ run(async () => {
       openai: {
         reasoningEffort: 'low',
         reasoningSummary: 'detailed',
-        store: false,
-        include: ['reasoning.encrypted_content'], // Use encrypted reasoning items
       } satisfies OpenAIResponsesProviderOptions,
     },
   });
@@ -34,8 +32,8 @@ run(async () => {
         } = providerMetadata;
         console.log(`itemId: ${itemId}`);
 
-        // In the Responses API, explicitly setting store to false opts out of both conversation history and reasoning token storage.
-        // As a result, reasoningEncryptedContent is used to restore the reasoning tokens for the conversation history.
+        // In the Responses API, store is set to true by default, so conversation history is cached.
+        // The reasoning tokens from that interaction are also cached, and as a result, reasoningEncryptedContent returns null.
         console.log(`reasoningEncryptedContent: ${reasoningEncryptedContent}`);
         break;
       }

--- a/examples/ai-functions/src/generate-text/azure-reasoning.ts
+++ b/examples/ai-functions/src/generate-text/azure-reasoning.ts
@@ -11,7 +11,7 @@ run(async () => {
     model: azure('gpt-5'),
     prompt: 'How many "r"s are in the word "strawberry"?',
     providerOptions: {
-      openai: {
+      azure: {
         reasoningEffort: 'low',
         reasoningSummary: 'detailed',
       } satisfies OpenAIResponsesProviderOptions,

--- a/examples/ai-functions/src/generate-text/openai-logprobs.ts
+++ b/examples/ai-functions/src/generate-text/openai-logprobs.ts
@@ -1,10 +1,10 @@
-import { openai } from '@ai-sdk/openai';
+import { openai, OpenaiResponsesProviderMetadata } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: openai('gpt-3.5-turbo'),
+    model: openai('gpt-4.1-mini'),
     prompt: 'Invent a new holiday and describe its traditions.',
     providerOptions: {
       openai: {
@@ -13,5 +13,27 @@ run(async () => {
     },
   });
 
-  console.log(result.providerMetadata?.openai.logprobs);
+  const providerMetadata = result.providerMetadata as
+    | OpenaiResponsesProviderMetadata
+    | undefined;
+  if (!providerMetadata) return;
+  const {
+    openai: { responseId, logprobs, serviceTier },
+  } = providerMetadata;
+  responseId && console.log(`responseId: ${responseId}`);
+  serviceTier && console.log(`serviceTier: ${serviceTier}`);
+  if (!logprobs) return;
+  let printed = 0;
+  for (const logprob of logprobs) {
+    if (logprob != null) {
+      for (const token_info of logprob) {
+        console.log(
+          `token: ${token_info.token} , logprob: ${token_info.logprob} , top_logprobs: ${JSON.stringify(token_info.top_logprobs)}`,
+        );
+      }
+      console.log();
+      printed++;
+    }
+    if (printed >= 5) break; // Output only the first 5 entries to prevent excessive logging
+  }
 });

--- a/examples/ai-functions/src/generate-text/openai-reasoning-encrypted-content.ts
+++ b/examples/ai-functions/src/generate-text/openai-reasoning-encrypted-content.ts
@@ -1,58 +1,50 @@
-import { generateText, stepCountIs, tool } from 'ai';
-import { z } from 'zod';
+import { generateText } from 'ai';
 import { run } from '../lib/run';
-import { openai } from '@ai-sdk/openai';
+import {
+  openai,
+  OpenAIResponsesProviderOptions,
+  OpenaiResponsesReasoningProviderMetadata,
+} from '@ai-sdk/openai';
 
 run(async () => {
   const result = await generateText({
-    model: openai.responses('gpt-5.1-codex-max'),
-    tools: {
-      calculator: tool({
-        description:
-          'A minimal calculator for basic arithmetic. Call it once per step.',
-        inputSchema: z.object({
-          a: z.number().describe('First operand.'),
-          b: z.number().describe('Second operand.'),
-          op: z
-            .enum(['add', 'subtract', 'multiply', 'divide'])
-            .default('add')
-            .describe('Arithmetic operation to perform.'),
-        }),
-        execute: async ({ a, b, op }) => {
-          switch (op) {
-            case 'add':
-              return { result: a + b };
-            case 'subtract':
-              return { result: a - b };
-            case 'multiply':
-              return { result: a * b };
-            case 'divide':
-              if (b === 0) {
-                return 'Cannot divide by zero.';
-              }
-              return { result: a / b };
-          }
-        },
-      }),
-    },
-    stopWhen: stepCountIs(20),
+    model: openai('gpt-5'),
+    prompt: 'How many "r"s are in the word "strawberry"?',
     providerOptions: {
       openai: {
-        reasoningEffort: 'high',
-        maxCompletionTokens: 32_000,
+        reasoningEffort: 'low',
+        reasoningSummary: 'detailed',
         store: false,
-        include: ['reasoning.encrypted_content'],
-        reasoningSummary: 'auto',
-      },
+        include: ['reasoning.encrypted_content'], // Use encrypted reasoning items
+      } satisfies OpenAIResponsesProviderOptions,
     },
-    messages: [
-      {
-        role: 'user',
-        content:
-          'Use the calculator tool to add 12 and 7, then multiply that sum by 3 then multiply by 10. Call the tool separately for each arithmetic step and only 1 tool call per step and report the final result.',
-      },
-    ],
   });
 
-  console.dir(result.response, { depth: Infinity });
+  for (const part of result.content) {
+    switch (part.type) {
+      case 'reasoning': {
+        console.log('--- reasoning ---');
+        console.log(part.text);
+        const providerMetadata = part.providerMetadata as
+          | OpenaiResponsesReasoningProviderMetadata
+          | undefined;
+        if (!providerMetadata) break;
+        const {
+          openai: { itemId, reasoningEncryptedContent },
+        } = providerMetadata;
+        console.log(`itemId: ${itemId}`);
+
+        // In the Responses API, explicitly setting store to false opts out of both conversation history and reasoning token storage.
+        // As a result, reasoningEncryptedContent is used to restore the reasoning tokens for the conversation history.
+        console.log(`reasoningEncryptedContent: ${reasoningEncryptedContent}`);
+        break;
+      }
+      case 'text': {
+        console.log('--- text ---');
+        console.log(part.text);
+        break;
+      }
+    }
+    console.log();
+  }
 });

--- a/examples/ai-functions/src/generate-text/openai-reasoning.ts
+++ b/examples/ai-functions/src/generate-text/openai-reasoning.ts
@@ -1,4 +1,8 @@
-import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import {
+  openai,
+  OpenAIResponsesProviderOptions,
+  OpenaiResponsesReasoningProviderMetadata,
+} from '@ai-sdk/openai';
 import { generateText } from 'ai';
 import { run } from '../lib/run';
 
@@ -14,6 +18,31 @@ run(async () => {
     },
   });
 
-  console.log(JSON.stringify(result.request.body, null, 2));
-  console.log(JSON.stringify(result.content, null, 2));
+  for (const part of result.content) {
+    switch (part.type) {
+      case 'reasoning': {
+        console.log('--- reasoning ---');
+        console.log(part.text);
+        const providerMetadata = part.providerMetadata as
+          | OpenaiResponsesReasoningProviderMetadata
+          | undefined;
+        if (!providerMetadata) break;
+        const {
+          openai: { itemId, reasoningEncryptedContent },
+        } = providerMetadata;
+        console.log(`itemId: ${itemId}`);
+
+        // In the Responses API, store is set to true by default, so conversation history is cached.
+        // The reasoning tokens from that interaction are also cached, and as a result, reasoningEncryptedContent returns null.
+        console.log(`reasoningEncryptedContent: ${reasoningEncryptedContent}`);
+        break;
+      }
+      case 'text': {
+        console.log('--- text ---');
+        console.log(part.text);
+        break;
+      }
+    }
+    console.log();
+  }
 });

--- a/examples/ai-functions/src/generate-text/openai-responses-previous-response-id.ts
+++ b/examples/ai-functions/src/generate-text/openai-responses-previous-response-id.ts
@@ -1,4 +1,8 @@
-import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import {
+  openai,
+  OpenaiResponsesProviderMetadata,
+  OpenAIResponsesProviderOptions,
+} from '@ai-sdk/openai';
 import { generateText } from 'ai';
 import { run } from '../lib/run';
 
@@ -8,13 +12,21 @@ run(async () => {
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 
+  const providerMetadata = result1.providerMetadata as
+    | OpenaiResponsesProviderMetadata
+    | undefined;
+  if (!providerMetadata) return;
+
+  const {
+    openai: { responseId: previousResponseId },
+  } = providerMetadata;
+
   const result2 = await generateText({
     model: openai.responses('gpt-4o-mini'),
     prompt: 'Summarize in 2 sentences',
     providerOptions: {
       openai: {
-        previousResponseId: result1.providerMetadata?.openai
-          .responseId as string,
+        previousResponseId,
       } satisfies OpenAIResponsesProviderOptions,
     },
   });

--- a/examples/ai-functions/src/stream-text/azure-fullstream-logprobs.ts
+++ b/examples/ai-functions/src/stream-text/azure-fullstream-logprobs.ts
@@ -1,4 +1,4 @@
-import { azure } from '@ai-sdk/azure';
+import { azure, AzureResponsesProviderMetadata } from '@ai-sdk/azure';
 import { streamText } from 'ai';
 import { run } from '../lib/run';
 
@@ -21,10 +21,37 @@ run(async () => {
       }
 
       case 'finish-step': {
+        console.log();
         console.log(`finishReason: ${part.finishReason}`);
-        console.log('metadata:', JSON.stringify(part.providerMetadata)); // object: { string, number, array}
-        console.log('Logprobs:', part.providerMetadata?.azure.logprobs); // object: { string, number, array}
+        const providerMetadata = part.providerMetadata as
+          | AzureResponsesProviderMetadata
+          | undefined;
+        if (!providerMetadata) continue;
+        const {
+          azure: { responseId, logprobs, serviceTier },
+        } = providerMetadata;
+        responseId && console.log(`responseId: ${responseId}`);
+        serviceTier && console.log(`serviceTier: ${serviceTier}`);
+        if (!logprobs) continue;
+        let printed = 0;
+        for (const logprob of logprobs) {
+          if (logprob != null) {
+            for (const token_info of logprob) {
+              console.log(
+                `token: ${token_info.token} , logprob: ${token_info.logprob} , top_logprobs: ${JSON.stringify(token_info.top_logprobs)}`,
+              );
+            }
+            console.log();
+            printed++;
+          }
+          if (printed >= 5) break; // Output only the first 5 entries to prevent excessive logging
+        }
+        break;
       }
+
+      case 'error':
+        console.error('Error:', part.error);
+        break;
     }
   }
 });

--- a/examples/ai-functions/src/stream-text/azure-reasoning-encrypted-content.ts
+++ b/examples/ai-functions/src/stream-text/azure-reasoning-encrypted-content.ts
@@ -11,7 +11,7 @@ run(async () => {
     model: azure('gpt-5'),
     prompt: 'How many "r"s are in the word "strawberry"?',
     providerOptions: {
-      openai: {
+      azure: {
         reasoningEffort: 'low',
         reasoningSummary: 'detailed',
         store: false,

--- a/examples/ai-functions/src/stream-text/azure-reasoning.ts
+++ b/examples/ai-functions/src/stream-text/azure-reasoning.ts
@@ -1,10 +1,10 @@
-import { streamText } from 'ai';
-import { run } from '../lib/run';
 import {
   azure,
   AzureResponsesReasoningProviderMetadata,
   OpenAIResponsesProviderOptions,
 } from '@ai-sdk/azure';
+import { streamText } from 'ai';
+import { run } from '../lib/run';
 
 run(async () => {
   const result = streamText({
@@ -14,8 +14,6 @@ run(async () => {
       openai: {
         reasoningEffort: 'low',
         reasoningSummary: 'detailed',
-        store: false,
-        include: ['reasoning.encrypted_content'], // Use encrypted reasoning items
       } satisfies OpenAIResponsesProviderOptions,
     },
   });
@@ -42,8 +40,8 @@ run(async () => {
         } = providerMetadata;
         console.log(`itemId: ${itemId}`);
 
-        // In the Responses API, explicitly setting store to false opts out of both conversation history and reasoning token storage.
-        // As a result, reasoningEncryptedContent is used to restore the reasoning tokens for the conversation history.
+        // In the Responses API, store is set to true by default, so conversation history is cached.
+        // The reasoning tokens from that interaction are also cached, and as a result, reasoningEncryptedContent returns null.
         console.log(`reasoningEncryptedContent: ${reasoningEncryptedContent}`);
         break;
 

--- a/examples/ai-functions/src/stream-text/azure-reasoning.ts
+++ b/examples/ai-functions/src/stream-text/azure-reasoning.ts
@@ -11,7 +11,7 @@ run(async () => {
     model: azure('gpt-5'),
     prompt: 'How many "r"s are in the word "strawberry"?',
     providerOptions: {
-      openai: {
+      azure: {
         reasoningEffort: 'low',
         reasoningSummary: 'detailed',
       } satisfies OpenAIResponsesProviderOptions,

--- a/examples/ai-functions/src/stream-text/openai-reasoning-encrypted-content.ts
+++ b/examples/ai-functions/src/stream-text/openai-reasoning-encrypted-content.ts
@@ -1,57 +1,23 @@
-import { stepCountIs, streamText, tool } from 'ai';
-import { z } from 'zod';
+import { streamText } from 'ai';
 import { run } from '../lib/run';
-import { openai } from '@ai-sdk/openai';
+import {
+  openai,
+  OpenAIResponsesProviderOptions,
+  OpenaiResponsesReasoningProviderMetadata,
+} from '@ai-sdk/openai';
 
 run(async () => {
   const result = streamText({
-    model: openai.responses('gpt-5.1-codex-max'),
-    tools: {
-      calculator: tool({
-        description:
-          'A minimal calculator for basic arithmetic. Call it once per step.',
-        inputSchema: z.object({
-          a: z.number().describe('First operand.'),
-          b: z.number().describe('Second operand.'),
-          op: z
-            .enum(['add', 'subtract', 'multiply', 'divide'])
-            .default('add')
-            .describe('Arithmetic operation to perform.'),
-        }),
-        execute: async ({ a, b, op }) => {
-          switch (op) {
-            case 'add':
-              return { result: a + b };
-            case 'subtract':
-              return { result: a - b };
-            case 'multiply':
-              return { result: a * b };
-            case 'divide':
-              if (b === 0) {
-                return 'Cannot divide by zero.';
-              }
-              return { result: a / b };
-          }
-        },
-      }),
-    },
-    stopWhen: stepCountIs(20),
+    model: openai('gpt-5'),
+    prompt: 'How many "r"s are in the word "strawberry"?',
     providerOptions: {
       openai: {
-        reasoningEffort: 'high',
-        maxCompletionTokens: 32_000,
+        reasoningEffort: 'low',
+        reasoningSummary: 'detailed',
         store: false,
-        include: ['reasoning.encrypted_content'],
-        reasoningSummary: 'auto',
-      },
+        include: ['reasoning.encrypted_content'], // Use encrypted reasoning items
+      } satisfies OpenAIResponsesProviderOptions,
     },
-    messages: [
-      {
-        role: 'user',
-        content:
-          'Use the calculator tool to add 12 and 7, then multiply that sum by 3 then multiply by 10. Call the tool separately for each arithmetic step and only 1 tool call per step and report the final result.',
-      },
-    ],
   });
 
   for await (const chunk of result.fullStream) {
@@ -67,8 +33,18 @@ run(async () => {
       case 'reasoning-end':
         process.stdout.write('\x1b[0m');
         process.stdout.write('\n');
-        console.log('providerMetadata:', chunk.providerMetadata);
-        process.stdout.write('\n');
+        const providerMetadata = chunk.providerMetadata as
+          | OpenaiResponsesReasoningProviderMetadata
+          | undefined;
+        if (!providerMetadata) break;
+        const {
+          openai: { itemId, reasoningEncryptedContent },
+        } = providerMetadata;
+        console.log(`itemId: ${itemId}`);
+
+        // In the Responses API, explicitly setting store to false opts out of both conversation history and reasoning token storage.
+        // As a result, reasoningEncryptedContent is used to restore the reasoning tokens for the conversation history.
+        console.log(`reasoningEncryptedContent: ${reasoningEncryptedContent}`);
         break;
 
       case 'text-start':

--- a/examples/ai-functions/src/stream-text/openai-reasoning.ts
+++ b/examples/ai-functions/src/stream-text/openai-reasoning.ts
@@ -1,4 +1,8 @@
-import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import {
+  openai,
+  OpenAIResponsesProviderOptions,
+  OpenaiResponsesReasoningProviderMetadata,
+} from '@ai-sdk/openai';
 import { streamText } from 'ai';
 import { run } from '../lib/run';
 
@@ -27,6 +31,18 @@ run(async () => {
       case 'reasoning-end':
         process.stdout.write('\x1b[0m');
         process.stdout.write('\n');
+        const providerMetadata = chunk.providerMetadata as
+          | OpenaiResponsesReasoningProviderMetadata
+          | undefined;
+        if (!providerMetadata) break;
+        const {
+          openai: { itemId, reasoningEncryptedContent },
+        } = providerMetadata;
+        console.log(`itemId: ${itemId}`);
+
+        // In the Responses API, store is set to true by default, so conversation history is cached.
+        // The reasoning tokens from that interaction are also cached, and as a result, reasoningEncryptedContent returns null.
+        console.log(`reasoningEncryptedContent: ${reasoningEncryptedContent}`);
         break;
 
       case 'text-start':

--- a/examples/ai-functions/src/stream-text/openai-responses-service-tier.ts
+++ b/examples/ai-functions/src/stream-text/openai-responses-service-tier.ts
@@ -1,4 +1,4 @@
-import { openai } from '@ai-sdk/openai';
+import { openai, OpenaiResponsesProviderMetadata } from '@ai-sdk/openai';
 import { streamText } from 'ai';
 import { run } from '../lib/run';
 
@@ -14,13 +14,15 @@ run(async () => {
   });
 
   await result.consumeStream();
-  const providerMetadata = await result.providerMetadata;
+  const providerMetadata = await (result.providerMetadata as Promise<
+    OpenaiResponsesProviderMetadata | undefined
+  >);
 
-  console.log('Provider metadata:', providerMetadata);
-  // Provider metadata: {
-  //   openai: {
-  //     responseId: '...',
-  //     serviceTier: 'flex'
-  //   }
-  // }
+  if (!providerMetadata) return;
+  const {
+    openai: { responseId, serviceTier },
+  } = providerMetadata;
+
+  responseId && console.log(`responseId: ${responseId}`);
+  serviceTier && console.log(`serviceTier: ${serviceTier}`);
 });

--- a/examples/next-openai/app/api/chat-openai-previous-response-id/route.ts
+++ b/examples/next-openai/app/api/chat-openai-previous-response-id/route.ts
@@ -1,10 +1,13 @@
-import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import {
+  openai,
+  OpenaiResponsesProviderMetadata,
+  OpenAIResponsesProviderOptions,
+} from '@ai-sdk/openai';
 import {
   convertToModelMessages,
   createUIMessageStream,
   createUIMessageStreamResponse,
   InferUITools,
-  ProviderMetadata,
   stepCountIs,
   streamText,
   UIMessage,
@@ -17,14 +20,14 @@ const tools = {
 
 type Tools = InferUITools<typeof tools>;
 type Data = {
-  providerMetadata: ProviderMetadata;
+  providerMetadata: OpenaiResponsesProviderMetadata;
 };
 
 export type PreviousResponseIdUIMessage = UIMessage<unknown, Data, Tools>;
 
 export type PreviousResponseIdRequestBody = {
   message: PreviousResponseIdUIMessage;
-  previousProviderMetadata: ProviderMetadata | undefined;
+  previousProviderMetadata: OpenaiResponsesProviderMetadata | undefined;
 };
 
 export async function POST(req: Request) {
@@ -34,9 +37,9 @@ export async function POST(req: Request) {
     reqJson as PreviousResponseIdRequestBody;
 
   // Extract the prior OpenAI responseId so the Responses API can replay history.
-  const previousResponseId: string | undefined =
-    typeof previousProviderMetadata?.openai?.responseId === 'string'
-      ? previousProviderMetadata?.openai?.responseId
+  const previousResponseId: string | null | undefined =
+    !!previousProviderMetadata
+      ? previousProviderMetadata.openai.responseId
       : undefined;
 
   const stream = createUIMessageStream<PreviousResponseIdUIMessage>({
@@ -61,7 +64,7 @@ export async function POST(req: Request) {
             // Return provider metadata so the client can persist the latest responseId.
             writer.write({
               type: 'data-providerMetadata',
-              data: providerMetadata,
+              data: providerMetadata as OpenaiResponsesProviderMetadata,
               transient: true,
             });
           }

--- a/examples/next-openai/app/chat-openai-previous-response-id/page.tsx
+++ b/examples/next-openai/app/chat-openai-previous-response-id/page.tsx
@@ -7,13 +7,16 @@ import {
 import { Response } from '@/components/ai-elements/response';
 import ChatInput from '@/components/chat-input';
 import { ReasoningView } from '@/components/reasoning-view';
+import { OpenaiResponsesProviderMetadata } from '@ai-sdk/openai';
 import { useChat } from '@ai-sdk/react';
-import { DefaultChatTransport, ProviderMetadata } from 'ai';
+import { DefaultChatTransport } from 'ai';
 import { useRef } from 'react';
 
 export default function OpenPreviousResponseIdPage() {
   // Keep the last provider metadata so we can supply previousResponseId on the next request.
-  const providerMetadataRef = useRef<ProviderMetadata | undefined>(undefined);
+  const providerMetadataRef = useRef<
+    OpenaiResponsesProviderMetadata | undefined
+  >(undefined);
 
   const { error, status, sendMessage, messages, regenerate } =
     useChat<PreviousResponseIdUIMessage>({

--- a/packages/azure/src/azure-openai-provider-metadata.ts
+++ b/packages/azure/src/azure-openai-provider-metadata.ts
@@ -1,7 +1,12 @@
 import {
+  ResponsesProviderMetadata,
   ResponsesSourceDocumentProviderMetadata,
   ResponsesTextProviderMetadata,
 } from '@ai-sdk/openai/internal';
+
+export type AzureResponsesProviderMetadata = {
+  azure: ResponsesProviderMetadata;
+};
 
 export type AzureResponsesTextProviderMetadata = {
   azure: ResponsesTextProviderMetadata;

--- a/packages/azure/src/azure-openai-provider-metadata.ts
+++ b/packages/azure/src/azure-openai-provider-metadata.ts
@@ -1,11 +1,16 @@
 import {
   ResponsesProviderMetadata,
+  ResponsesReasoningProviderMetadata,
   ResponsesSourceDocumentProviderMetadata,
   ResponsesTextProviderMetadata,
 } from '@ai-sdk/openai/internal';
 
 export type AzureResponsesProviderMetadata = {
   azure: ResponsesProviderMetadata;
+};
+
+export type AzureResponsesReasoningProviderMetadata = {
+  azure: ResponsesReasoningProviderMetadata;
 };
 
 export type AzureResponsesTextProviderMetadata = {

--- a/packages/azure/src/index.ts
+++ b/packages/azure/src/index.ts
@@ -10,6 +10,7 @@ export type {
 } from './azure-openai-provider';
 export type {
   AzureResponsesProviderMetadata,
+  AzureResponsesReasoningProviderMetadata,
   AzureResponsesTextProviderMetadata,
   AzureResponsesSourceDocumentProviderMetadata,
 } from './azure-openai-provider-metadata';

--- a/packages/azure/src/index.ts
+++ b/packages/azure/src/index.ts
@@ -9,6 +9,7 @@ export type {
   AzureOpenAIProviderSettings,
 } from './azure-openai-provider';
 export type {
+  AzureResponsesProviderMetadata,
   AzureResponsesTextProviderMetadata,
   AzureResponsesSourceDocumentProviderMetadata,
 } from './azure-openai-provider-metadata';

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -3,6 +3,7 @@ export type { OpenAIProvider, OpenAIProviderSettings } from './openai-provider';
 export type { OpenAIResponsesProviderOptions } from './responses/openai-responses-options';
 export type { OpenAIChatLanguageModelOptions } from './chat/openai-chat-options';
 export type {
+  OpenaiResponsesProviderMetadata,
   OpenaiResponsesTextProviderMetadata,
   OpenaiResponsesSourceDocumentProviderMetadata,
 } from './responses/openai-responses-provider-metadata';

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -4,6 +4,7 @@ export type { OpenAIResponsesProviderOptions } from './responses/openai-response
 export type { OpenAIChatLanguageModelOptions } from './chat/openai-chat-options';
 export type {
   OpenaiResponsesProviderMetadata,
+  OpenaiResponsesReasoningProviderMetadata,
   OpenaiResponsesTextProviderMetadata,
   OpenaiResponsesSourceDocumentProviderMetadata,
 } from './responses/openai-responses-provider-metadata';

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -866,7 +866,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
     const providerMetadata: SharedV3ProviderMetadata = {
       [providerOptionsName]: {
-        responseId: response.id ?? null,
+        responseId: response.id,
         ...(logprobs.length > 0 ? { logprobs } : {}),
         ...(typeof response.service_tier === 'string'
           ? { serviceTier: response.service_tier }
@@ -1783,7 +1783,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
           flush(controller) {
             const providerMetadata: SharedV3ProviderMetadata = {
               [providerOptionsName]: {
-                responseId,
+                responseId: responseId ?? undefined,
                 ...(logprobs.length > 0 ? { logprobs } : {}),
                 ...(serviceTier !== undefined ? { serviceTier } : {}),
               } satisfies ResponsesProviderMetadata,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -64,6 +64,7 @@ import {
 import { prepareResponsesTools } from './openai-responses-prepare-tools';
 import {
   ResponsesProviderMetadata,
+  ResponsesReasoningProviderMetadata,
   ResponsesSourceDocumentProviderMetadata,
   ResponsesTextProviderMetadata,
 } from './openai-responses-provider-metadata';
@@ -499,7 +500,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 [providerOptionsName]: {
                   itemId: part.id,
                   reasoningEncryptedContent: part.encrypted_content ?? null,
-                },
+                } satisfies ResponsesReasoningProviderMetadata,
               },
             });
           }
@@ -1187,7 +1188,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                       itemId: value.item.id,
                       reasoningEncryptedContent:
                         value.item.encrypted_content ?? null,
-                    },
+                    } satisfies ResponsesReasoningProviderMetadata,
                   },
                 });
               }
@@ -1495,7 +1496,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                         itemId: value.item.id,
                         reasoningEncryptedContent:
                           value.item.encrypted_content ?? null,
-                      },
+                      } satisfies ResponsesReasoningProviderMetadata,
                     },
                   });
                 }
@@ -1640,7 +1641,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                       type: 'reasoning-end',
                       id: `${value.item_id}:${summaryIndex}`,
                       providerMetadata: {
-                        [providerOptionsName]: { itemId: value.item_id },
+                        [providerOptionsName]: {
+                          itemId: value.item_id,
+                        } satisfies ResponsesReasoningProviderMetadata,
                       },
                     });
                     activeReasoningPart.summaryParts[summaryIndex] =
@@ -1657,7 +1660,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                       reasoningEncryptedContent:
                         activeReasoning[value.item_id]?.encryptedContent ??
                         null,
-                    },
+                    } satisfies ResponsesReasoningProviderMetadata,
                   },
                 });
               }
@@ -1669,7 +1672,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 providerMetadata: {
                   [providerOptionsName]: {
                     itemId: value.item_id,
-                  },
+                  } satisfies ResponsesReasoningProviderMetadata,
                 },
               });
             } else if (value.type === 'response.reasoning_summary_part.done') {
@@ -1680,7 +1683,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                   type: 'reasoning-end',
                   id: `${value.item_id}:${value.summary_index}`,
                   providerMetadata: {
-                    [providerOptionsName]: { itemId: value.item_id },
+                    [providerOptionsName]: {
+                      itemId: value.item_id,
+                    } satisfies ResponsesReasoningProviderMetadata,
                   },
                 });
 

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -866,7 +866,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
     const providerMetadata: SharedV3ProviderMetadata = {
       [providerOptionsName]: {
-        responseId: response.id,
+        responseId: response.id ?? null,
         ...(logprobs.length > 0 ? { logprobs } : {}),
         ...(typeof response.service_tier === 'string'
           ? { serviceTier: response.service_tier }

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -1783,7 +1783,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
           flush(controller) {
             const providerMetadata: SharedV3ProviderMetadata = {
               [providerOptionsName]: {
-                responseId: responseId ?? undefined,
+                responseId: responseId,
                 ...(logprobs.length > 0 ? { logprobs } : {}),
                 ...(serviceTier !== undefined ? { serviceTier } : {}),
               } satisfies ResponsesProviderMetadata,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -867,7 +867,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
     const providerMetadata: SharedV3ProviderMetadata = {
       [providerOptionsName]: {
-        responseId: response.id ?? null,
+        responseId: response.id,
         ...(logprobs.length > 0 ? { logprobs } : {}),
         ...(typeof response.service_tier === 'string'
           ? { serviceTier: response.service_tier }

--- a/packages/openai/src/responses/openai-responses-provider-metadata.ts
+++ b/packages/openai/src/responses/openai-responses-provider-metadata.ts
@@ -12,7 +12,7 @@ type ResponsesOutputTextAnnotationProviderMetadata = Extract<
 >['annotation'];
 
 export type ResponsesProviderMetadata = {
-  responseId: string | null;
+  responseId?: string;
   logprobs?: Array<OpenAIResponsesLogprobs>;
   serviceTier?: string;
 };

--- a/packages/openai/src/responses/openai-responses-provider-metadata.ts
+++ b/packages/openai/src/responses/openai-responses-provider-metadata.ts
@@ -12,7 +12,7 @@ type ResponsesOutputTextAnnotationProviderMetadata = Extract<
 >['annotation'];
 
 export type ResponsesProviderMetadata = {
-  responseId?: string;
+  responseId?: string | null;
   logprobs?: Array<OpenAIResponsesLogprobs>;
   serviceTier?: string;
 };

--- a/packages/openai/src/responses/openai-responses-provider-metadata.ts
+++ b/packages/openai/src/responses/openai-responses-provider-metadata.ts
@@ -17,6 +17,15 @@ export type ResponsesProviderMetadata = {
   serviceTier?: string;
 };
 
+export type ResponsesReasoningProviderMetadata = {
+  itemId: string;
+  reasoningEncryptedContent?: string | null;
+};
+
+export type OpenaiResponsesReasoningProviderMetadata = {
+  openai: ResponsesReasoningProviderMetadata;
+};
+
 export type OpenaiResponsesProviderMetadata = {
   openai: ResponsesProviderMetadata;
 };

--- a/packages/openai/src/responses/openai-responses-provider-metadata.ts
+++ b/packages/openai/src/responses/openai-responses-provider-metadata.ts
@@ -12,7 +12,7 @@ type ResponsesOutputTextAnnotationProviderMetadata = Extract<
 >['annotation'];
 
 export type ResponsesProviderMetadata = {
-  responseId?: string | null;
+  responseId: string | null;
   logprobs?: Array<OpenAIResponsesLogprobs>;
   serviceTier?: string;
 };

--- a/packages/openai/src/responses/openai-responses-provider-metadata.ts
+++ b/packages/openai/src/responses/openai-responses-provider-metadata.ts
@@ -12,7 +12,7 @@ type ResponsesOutputTextAnnotationProviderMetadata = Extract<
 >['annotation'];
 
 export type ResponsesProviderMetadata = {
-  responseId: string | null;
+  responseId: string | null | undefined;
   logprobs?: Array<OpenAIResponsesLogprobs>;
   serviceTier?: string;
 };

--- a/packages/openai/src/responses/openai-responses-provider-metadata.ts
+++ b/packages/openai/src/responses/openai-responses-provider-metadata.ts
@@ -1,4 +1,7 @@
-import { openaiResponsesChunkSchema } from './openai-responses-api';
+import {
+  openaiResponsesChunkSchema,
+  OpenAIResponsesLogprobs,
+} from './openai-responses-api';
 import { InferSchema } from '@ai-sdk/provider-utils';
 
 type OpenaiResponsesChunk = InferSchema<typeof openaiResponsesChunkSchema>;
@@ -7,6 +10,16 @@ type ResponsesOutputTextAnnotationProviderMetadata = Extract<
   OpenaiResponsesChunk,
   { type: 'response.output_text.annotation.added' }
 >['annotation'];
+
+export type ResponsesProviderMetadata = {
+  responseId: string | null;
+  logprobs?: Array<OpenAIResponsesLogprobs>;
+  serviceTier?: string;
+};
+
+export type OpenaiResponsesProviderMetadata = {
+  openai: ResponsesProviderMetadata;
+};
 
 export type ResponsesTextProviderMetadata = {
   itemId: string;


### PR DESCRIPTION
## Background

The Responses API attaches provider-specific metadata to messages and reasoning parts, but until now there were no exported, typed helpers for accessing this metadata in a type-safe way from client code.

As a result, users had to rely on untyped or loosely typed access to `providerMetadata`, especially when working with response IDs, logprobs, service tier information, or reasoning-related metadata.

## Summary

This PR adds and documents typed providerMetadata helpers for the Responses API at the message and reasoning level.

- Export new providerMetadata types for both OpenAI and Azure:
  - `OpenaiResponsesProviderMetadata`
  - `OpenaiResponsesReasoningProviderMetadata`
  - `AzureResponsesProviderMetadata`
  - `AzureResponsesReasoningProviderMetadata`
- Ensure providerMetadata construction is type-checked internally using `satisfies`.
- Update OpenAI and Azure provider documentation with:
  - Typed examples for accessing message-level providerMetadata.
  - New sections describing typed providerMetadata in reasoning parts.
- Update examples to demonstrate practical usage of the new types
  (e.g. `responseId`, `logprobs`, `serviceTier`, `reasoningEncryptedContent`).

No behavior changes are introduced; this change improves type safety, documentation, and developer ergonomics.

## Manual Verification

### examples in `examples/ai-functions`
Edited for add types and run tests.
- pnpm tsx src/generate-text/azure-reasoning-encrypted-content.ts
- pnpm tsx src/generate-text/azure-reasoning.ts
- pnpm tsx src/generate-text/openai-logprobs.ts
- pnpm tsx src/generate-text/openai-reasoning-encrypted-content.ts
- pnpm tsx src/generate-text/openai-reasoning.ts
- pnpm tsx src/generate-text/openai-responses-previous-response-id.ts
- pnpm tsx src/stream-text/azure-fullstream-logprobs.ts
- pnpm tsx src/stream-text/azure-reasoning-encrypted-content.ts
- pnpm tsx src/stream-text/azure-reasoning.ts
- pnpm tsx src/stream-text/openai-fullstream-logprobs.ts
- pnpm tsx src/stream-text/openai-reasoning-encrypted-content.ts
- pnpm tsx src/stream-text/openai-reasoning.ts
- pnpm tsx src/stream-text/openai-responses-service-tier.ts

### examples in `examples/next-openai`
Edited for add types and run tests.
- http://localhost:3000/chat-openai-previous-response-id

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

#10266