### PR TITLE
fix(ai): parse structured output when finishReason is tool-calls 

### DIFF
--- a/.changeset/fix-tools-output-parsing.md
+++ b/.changeset/fix-tools-output-parsing.md
@@ -1,0 +1,10 @@
+---
+'ai': patch
+---
+
+fix: Parse structured output even when finishReason is 'tool-calls' if text content exists
+
+When using custom tools with structured output (Output.object()), the final step may have
+finishReason='tool-calls' even though valid JSON output is present. This fix attempts to
+parse the output when an explicit output schema is provided and there's text content,
+regardless of the finish reason.

--- a/examples/ai-functions/src/generate-text/google-vertex-custom-tools-output-object.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-custom-tools-output-object.ts
@@ -1,0 +1,29 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateText, Output, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  const { output } = await generateText({
+    model: vertex('gemini-3-pro-preview'),
+    tools: {
+      calculate: tool({
+        description: 'Calculate something',
+        inputSchema: z.object({
+          input: z.number().describe('The number to calculate'),
+        }),
+        execute: async ({ input }) => {
+          console.log('Calculating', input);
+          return { result: input * 2 };
+        },
+      }),
+    },
+    stopWhen: stepCountIs(5),
+    output: Output.object({
+      schema: z.object({ answer: z.string() }),
+    }),
+    prompt: 'Use the tool to calculate 5*2 and give me a structured answer',
+  });
+
+  console.log('Output:', output);
+});

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -901,9 +901,16 @@ A function that attempts to repair a tool call that failed to parse.
           experimental_context,
         });
 
-        // parse output only if the last step was finished with "stop":
+        // parse output if:
+        // 1. The last step was finished with "stop", OR
+        // 2. An explicit output schema was provided AND there's text content to parse
+        //    (handles cases where finishReason is 'tool-calls' but valid output exists)
         let resolvedOutput;
-        if (lastStep.finishReason === 'stop') {
+        const shouldParseOutput =
+          lastStep.finishReason === 'stop' ||
+          (output != null && lastStep.text != null && lastStep.text.length > 0);
+
+        if (shouldParseOutput) {
           const outputSpecification = output ?? text();
           resolvedOutput = await outputSpecification.parseCompleteOutput(
             { text: lastStep.text },


### PR DESCRIPTION
## Summary                                                                                                           
  - Fixes issue where `Output.object()` with custom tools throws `NoOutputGeneratedError` when Gemini returns          
  `finishReason: 'tool-calls'` with valid JSON output                                                                  
                                                                                                                       
  ## Background                                                                                                        
  When using custom tools with structured output (`Output.object()`) with Gemini models (via `@ai-sdk/google-vertex`), 
  the SDK throws `AI_NoOutputGeneratedError` because structured output parsing is skipped.                             
                                                                                                                       
  **Root cause**: In `generate-text.ts`, output is only parsed when `finishReason === 'stop'`. However, with Gemini +  
  custom tools, the final step may return `finishReason: 'tool-calls'` even when valid JSON output is present in the   
  response.                                                                                                            
                                                                                                                       
  This happens because:                                                                                                
  1. Gemini's `STOP` finish reason gets mapped to `'tool-calls'` when `hasToolCalls` is true                           
  2. The output parsing gate at line 906 only parses when `finishReason === 'stop'`                                    
  3. Result: valid structured output is ignored, `NoOutputGeneratedError` is thrown                                    
                                                                                                                       
  ## Changes                                                                                                           
  - Modified output parsing logic to also parse when an explicit output schema is provided AND text content exists     
  - Added unit tests for the new behavior                                                                              
  - Added reproduction example for Google Vertex + custom tools + structured output                                    
                                                                                                                       
  ## Test plan                                                                                                         
  - [x] Added unit tests for parsing with `finishReason: 'tool-calls'`                                                 
  - [x] Existing test for "should not parse output when finish reason is tool-calls" still passes (no text content     
  case)                                                                                                                
  - [x] Type check passes