### PR TITLE
refactor(examples): use Output API for bedrock-anthropic object examples

### DIFF
--- a/examples/ai-functions/src/generate-object/amazon-bedrock-anthropic.ts
+++ b/examples/ai-functions/src/generate-object/amazon-bedrock-anthropic.ts
@@ -1,28 +1,30 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { generateObject } from 'ai';
+import { generateText, Output } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 import { run } from '../lib/run';
 
 run(async () => {
-  const result = await generateObject({
+  const result = await generateText({
     model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
-    schema: z.object({
-      recipe: z.object({
-        name: z.string(),
-        ingredients: z.array(
-          z.object({
-            name: z.string(),
-            amount: z.string(),
-          }),
-        ),
-        steps: z.array(z.string()),
+    output: Output.object({
+      schema: z.object({
+        recipe: z.object({
+          name: z.string(),
+          ingredients: z.array(
+            z.object({
+              name: z.string(),
+              amount: z.string(),
+            }),
+          ),
+          steps: z.array(z.string()),
+        }),
       }),
     }),
     prompt: 'Generate a lasagna recipe.',
   });
 
-  console.log('Recipe:', JSON.stringify(result.object, null, 2));
+  console.log('Recipe:', JSON.stringify(result.output, null, 2));
   console.log();
   console.log('Finish reason:', result.finishReason);
   console.log('Usage:', result.usage);

--- a/examples/ai-functions/src/stream-object/amazon-bedrock-anthropic.ts
+++ b/examples/ai-functions/src/stream-object/amazon-bedrock-anthropic.ts
@@ -24,10 +24,9 @@ run(async () => {
     prompt: 'Generate a lasagna recipe.',
   });
 
-  for await (const part of result.fullStream) {
-    if (part.type === 'text-delta') {
-      process.stdout.write(part.text);
-    }
+  for await (const partialOutput of result.partialOutputStream) {
+    console.clear();
+    console.log(partialOutput);
   }
 
   console.log('\n\n--- Final ---');

--- a/examples/ai-functions/src/stream-object/amazon-bedrock-anthropic.ts
+++ b/examples/ai-functions/src/stream-object/amazon-bedrock-anthropic.ts
@@ -1,34 +1,37 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { streamObject } from 'ai';
+import { Output, streamText } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 import { run } from '../lib/run';
 
 run(async () => {
-  const result = streamObject({
+  const result = streamText({
     model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
-    schema: z.object({
-      recipe: z.object({
-        name: z.string(),
-        ingredients: z.array(
-          z.object({
-            name: z.string(),
-            amount: z.string(),
-          }),
-        ),
-        steps: z.array(z.string()),
+    output: Output.object({
+      schema: z.object({
+        recipe: z.object({
+          name: z.string(),
+          ingredients: z.array(
+            z.object({
+              name: z.string(),
+              amount: z.string(),
+            }),
+          ),
+          steps: z.array(z.string()),
+        }),
       }),
     }),
     prompt: 'Generate a lasagna recipe.',
   });
 
-  for await (const partialObject of result.partialObjectStream) {
-    console.clear();
-    console.log('Partial object:', JSON.stringify(partialObject, null, 2));
+  for await (const part of result.fullStream) {
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
   }
 
-  console.log('\n--- Final ---');
-  console.log('Object:', JSON.stringify(await result.object, null, 2));
+  console.log('\n\n--- Final ---');
+  console.log('Output:', JSON.stringify(await result.output, null, 2));
   console.log('Finish reason:', await result.finishReason);
   console.log('Usage:', await result.usage);
 });


### PR DESCRIPTION
## summary

- replace deprecated `streamObject`/`generateObject` with `streamText`/`generateText` using `Output.object()`

## related

follow-up to #11878 per [review comment](https://github.com/vercel/ai/pull/11878#discussion_r2710369125)