### PR TITLE
docs(google): fix providerMetadata example output

### DIFF
--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -362,7 +362,7 @@ const { text: meatLasagna, providerMetadata } = await generateText({
 });
 
 // Check cached token count in usage metadata
-console.log('Cached tokens:', providerMetadata.google?.usageMetadata);
+console.log('Cached tokens:', providerMetadata.google);
 // e.g.
 // {
 //   groundingMetadata: null,

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -577,7 +577,7 @@ const { text: meatLasagna, providerMetadata } = await generateText({
 });
 
 // Check cached token count in usage metadata
-console.log('Cached tokens:', providerMetadata.google?.usageMetadata);
+console.log('Cached tokens:', providerMetadata.google);
 // e.g.
 // {
 //   groundingMetadata: null,


### PR DESCRIPTION
## Background

the implicit caching examples in both google generative ai and google vertex docs had incorrect example output - the console.log accessed `providerMetadata.google?.usageMetadata` but the example output showed the parent `providerMetadata.google` object structure.

## Summary

- fix console.log in google generative ai docs to show `providerMetadata.google` to match example output
- fix console.log in google vertex docs to show `providerMetadata.google` to match example output

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)