### PR TITLE
ONHOLD feat(ai): add per-tool timeout option

### DIFF
--- a/.changeset/slow-doors-judge.md
+++ b/.changeset/slow-doors-judge.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+add per-tool timeout option for automatic tool execution abort

--- a/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
@@ -150,6 +150,13 @@ export const weatherTool = tool({
                 'Optional function that is called when a tool call can be started, even if the execute function is not provided.',
             },
             {
+              name: 'timeout',
+              isOptional: true,
+              type: 'number',
+              description:
+                'Optional timeout in milliseconds for tool execution. If the tool execution takes longer than the specified timeout, the tool call will be aborted and a tool error will be returned.',
+            },
+            {
               name: 'providerOptions',
               isOptional: true,
               type: 'ProviderOptions',

--- a/examples/ai-functions/src/tools/tool-timeout.ts
+++ b/examples/ai-functions/src/tools/tool-timeout.ts
@@ -1,0 +1,56 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  console.log('Testing tool with 2 second timeout (should succeed)...\n');
+
+  const result1 = await generateText({
+    model: openai('gpt-4o-mini'),
+    tools: {
+      fastTool: tool({
+        description: 'A fast tool that completes quickly',
+        inputSchema: z.object({
+          input: z.string(),
+        }),
+        timeout: 2000,
+        execute: async ({ input }) => {
+          await new Promise(resolve => setTimeout(resolve, 100));
+          return { result: `Processed: ${input}` };
+        },
+      }),
+    },
+    toolChoice: 'required',
+    prompt: 'Call the fastTool with input "hello"',
+  });
+
+  console.log('Fast tool result:');
+  console.log(JSON.stringify(result1.content, null, 2));
+  console.log();
+
+  console.log('Testing tool with 100ms timeout (should fail)...\n');
+
+  const result2 = await generateText({
+    model: openai('gpt-4o-mini'),
+    tools: {
+      slowTool: tool({
+        description: 'A slow tool that takes too long',
+        inputSchema: z.object({
+          input: z.string(),
+        }),
+        timeout: 100,
+        execute: async ({ input }) => {
+          await new Promise(resolve => setTimeout(resolve, 2000));
+          return { result: `Processed: ${input}` };
+        },
+      }),
+    },
+    toolChoice: 'required',
+    prompt: 'Call the slowTool with input "hello"',
+  });
+
+  console.log('Slow tool result (should show tool-error):');
+  console.log(JSON.stringify(result2.content, null, 2));
+});

--- a/packages/ai/src/util/create-abort-error-promise.ts
+++ b/packages/ai/src/util/create-abort-error-promise.ts
@@ -1,0 +1,22 @@
+export function createAbortErrorPromise(
+  signal: AbortSignal | undefined,
+): Promise<never> | undefined {
+  if (signal == null) {
+    return undefined;
+  }
+
+  return new Promise((_, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+
+    signal.addEventListener(
+      'abort',
+      () => {
+        reject(signal.reason);
+      },
+      { once: true },
+    );
+  });
+}

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -324,6 +324,11 @@ export function dynamicTool(tool: {
    * Whether the tool needs approval before it can be executed.
    */
   needsApproval?: boolean | ToolNeedsApprovalFunction<unknown>;
+
+  /**
+   * Optional timeout in milliseconds for tool execution.
+   */
+  timeout?: number;
 }): Tool<unknown, unknown> & {
   type: 'dynamic';
 } {

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -160,6 +160,13 @@ functionality that can be fully encapsulated in the provider.
   strict?: boolean;
 
   /**
+   * Optional timeout in milliseconds for tool execution.
+   * If the tool execution takes longer than the specified timeout,
+   * the tool call will be aborted.
+   */
+  timeout?: number;
+
+  /**
    * Optional function that is called when the argument streaming starts.
    * Only called when the tool is used in a streaming context.
    */


### PR DESCRIPTION
## Background

users requested a simpler way to add timeouts to individual tools without manually wrapping with `AbortSignal.timeout()` in the execute function

## Summary

- add `timeout` property to tool type for per-tool timeout configuration
- tool execution automatically aborts and returns `tool-error` if timeout exceeded
- abort signal is merged with any existing abort signal from generateText/streamText

## Verification

- tests pass
- example verified with openai: fast tool succeeds, slow tool times out correctly

## Checklist

- [x] tests have been added / updated (for bug fixes / features)
- [x] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## Related Issues

Fixes #11975