### PR TITLE
skills: tag internal contributor skills to not be picked up by npx skills add

### DIFF
--- a/skills/capture-api-response-test-fixture/SKILL.md
+++ b/skills/capture-api-response-test-fixture/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: capture-api-response-test-fixture
 description: Capture API response test fixture.
+metadata:
+  internal: true
 ---
 
 ### API Response Test Fixtures

--- a/skills/develop-ai-functions-example/SKILL.md
+++ b/skills/develop-ai-functions-example/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: develop-ai-functions-example
 description: Develop examples for AI SDK functions. Use when creating, running, or modifying examples under examples/ai-functions/src to validate provider support, demonstrate features, or create test fixtures.
+metadata:
+  internal: true
 ---
 
 ## AI Functions Examples

--- a/skills/list-npm-package-content/SKILL.md
+++ b/skills/list-npm-package-content/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: list-npm-package-content
 description: List the contents of an npm package tarball before publishing. Use when the user wants to see what files are included in an npm bundle, verify package contents, or debug npm publish issues.
+metadata:
+  internal: true
 ---
 
 # List npm Package Content


### PR DESCRIPTION
was creating confusion:
https://x.com/piros_dev/status/2015906320872841384