### PR TITLE
chore: fix `pnpm dev` error and warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:packages": "turbo build --filter=@ai-sdk/* --filter=ai",
     "changeset": "changeset",
     "clean": "turbo clean",
-    "dev": "turbo dev --no-cache --concurrency 16 --continue",
+    "dev": "turbo dev --cache=local:r,remote:r --concurrency 25 --continue",
     "lint": "turbo lint",
     "prepare": "husky",
     "update-references": "update-ts-references",


### PR DESCRIPTION
## Background

Tried running `pnpm dev` and it led to a warning and an error:
```
WARNING  --no-cache is deprecated and will be removed in a future major version. Use --cache=local:r,remote:r
turbo 2.4.4

  × Invalid task configuration
  ╰─▶   × You have 20 persistent tasks but `turbo` is configured for concurrency of 16. Set --concurrency to at least 21

 ELIFECYCLE  Command failed with exit code 1.
```

## Summary

* used the non-deprecated way to express "no cache"
* set concurrency to 25, to be above 20, but with a little headroom

## Manual Verification

Command successfully executes with these fixes, and without warning.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)