### PR TITLE
fix(openai-compatible): include reasoning_content in assistant messages for multi-turn tool calls

### DIFF
--- a/.changeset/violet-planets-serve.md
+++ b/.changeset/violet-planets-serve.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+fix(openai-compatible): include reasoning_content in assistant messages for multi-turn tool calls

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -144,6 +144,7 @@ export function convertToOpenAICompatibleChatMessages(
 
       case 'assistant': {
         let text = '';
+        let reasoning = '';
         const toolCalls: Array<{
           id: string;
           type: 'function';
@@ -160,6 +161,10 @@ export function convertToOpenAICompatibleChatMessages(
           switch (part.type) {
             case 'text': {
               text += part.text;
+              break;
+            }
+            case 'reasoning': {
+              reasoning += part.text;
               break;
             }
             case 'tool-call': {
@@ -193,6 +198,7 @@ export function convertToOpenAICompatibleChatMessages(
         messages.push({
           role: 'assistant',
           content: text,
+          ...(reasoning.length > 0 ? { reasoning_content: reasoning } : {}),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           ...metadata,
         });

--- a/packages/openai-compatible/src/chat/openai-compatible-api-types.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-api-types.ts
@@ -58,6 +58,7 @@ export interface OpenAICompatibleAssistantMessage
   extends JsonRecord<OpenAICompatibleMessageToolCall> {
   role: 'assistant';
   content?: string | null;
+  reasoning_content?: string;
   tool_calls?: Array<OpenAICompatibleMessageToolCall>;
 }
 


### PR DESCRIPTION
## Background
Gateway customer reported issue with reasoning content with kimi k2.5: https://vercel.slack.com/archives/C099VQB75TP/p1769494679870539

## Summary
- Fixes "thinking is enabled but reasoning_content is missing in assistant tool call message" 
- Extracts reasoning parts from AI SDK assistant messages and maps them to reasoning_content in outbound OpenAI-compatible requests

## Manual Verification
Ran an example multi-turn tool call script with the affected model and confirmed it didn't work before these changes, but works after

## Checklist
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)