### PR TITLE
chore(provider/google): add tests and docs for imageConfig.imageSize

### DIFF
--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -181,24 +181,32 @@ The following optional provider options are available for Google Generative AI m
 
     Optional. If set to true, thought summaries are returned, which are synthisized versions of the model's raw thoughts and offer insights into the model's internal reasoning process.
 
-- **imageConfig** _\{ aspectRatio: string \}_
+- **imageConfig** _\{ aspectRatio?: string, imageSize?: string \}_
 
   Optional. Configuration for the models image generation. Only supported by specific [Google Generative AI models](https://ai.google.dev/gemini-api/docs/image-generation).
 
   - **aspectRatio** _string_
 
-  Model defaults to generate 1:1 squares, or to matching the output image size to that of your input image. Can be one of the following:
+    Model defaults to generate 1:1 squares, or to matching the output image size to that of your input image. Can be one of the following:
 
-  - 1:1
-  - 2:3
-  - 3:2
-  - 3:4
-  - 4:3
-  - 4:5
-  - 5:4
-  - 9:16
-  - 16:9
-  - 21:9
+    - 1:1
+    - 2:3
+    - 3:2
+    - 3:4
+    - 4:3
+    - 4:5
+    - 5:4
+    - 9:16
+    - 16:9
+    - 21:9
+
+  - **imageSize** _string_
+
+    Controls the output image resolution. Defaults to 1K. Can be one of the following:
+
+    - 1K
+    - 2K
+    - 4K
 
 ### Thinking
 

--- a/examples/ai-functions/src/generate-text/google-image-size.ts
+++ b/examples/ai-functions/src/generate-text/google-image-size.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-2.0-flash-exp'),
+    model: google('gemini-3-pro-image-preview'),
     prompt: 'Generate a high-quality landscape photo of mountains at sunset',
     providerOptions: {
       google: {

--- a/examples/ai-functions/src/generate-text/google-image-size.ts
+++ b/examples/ai-functions/src/generate-text/google-image-size.ts
@@ -1,0 +1,30 @@
+import { google } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import { presentImages } from '../lib/present-image';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: google('gemini-2.0-flash-exp'),
+    prompt: 'Generate a high-quality landscape photo of mountains at sunset',
+    providerOptions: {
+      google: {
+        responseModalities: ['TEXT', 'IMAGE'],
+        imageConfig: {
+          aspectRatio: '16:9',
+          imageSize: '4K',
+        },
+      },
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log('Image size requested: 4K');
+  console.log('Aspect ratio: 16:9');
+
+  for (const file of result.files) {
+    if (file.mediaType.startsWith('image/')) {
+      await presentImages([file]);
+    }
+  }
+});

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -2046,6 +2046,54 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should pass imageConfig.imageSize in provider options', async () => {
+    prepareJsonResponse({});
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        google: {
+          imageConfig: {
+            imageSize: '4K',
+          },
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      generationConfig: {
+        imageConfig: {
+          imageSize: '4K',
+        },
+      },
+    });
+  });
+
+  it('should pass imageConfig with both aspectRatio and imageSize', async () => {
+    prepareJsonResponse({});
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        google: {
+          imageConfig: {
+            aspectRatio: '16:9',
+            imageSize: '2K',
+          },
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      generationConfig: {
+        imageConfig: {
+          aspectRatio: '16:9',
+          imageSize: '2K',
+        },
+      },
+    });
+  });
+
   it('should pass retrievalConfig in provider options', async () => {
     prepareJsonResponse({ url: TEST_URL_GEMINI_2_0_FLASH_EXP });
 


### PR DESCRIPTION
## background

the `imageSize` provider option was added in commit fff8d59 (nov 2025) but shipped without any tests. this pr adds tests to verify the feature works correctly and provides an example for users

## summary

- add tests for `imageConfig.imageSize` in google language model
- add test for combined `aspectRatio` + `imageSize` usage
- add example file demonstrating the feature
- add documentation for `imageSize` option

## verification

```bash
cd packages/google && pnpm build && pnpm test
```

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [x] documentation has been added / updated (for bug fixes / features)
- [ ] a _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] i have reviewed this pull request (self-review)

## related issues

closes #11924