### PR TITLE
Ai SDK broken links

### DIFF
--- a/content/cookbook/00-guides/17-gemini.mdx
+++ b/content/cookbook/00-guides/17-gemini.mdx
@@ -138,7 +138,7 @@ AI SDK Core can be paired with [AI SDK UI](/docs/ai-sdk-ui/overview), another po
 
 AI SDK UI provides robust abstractions that simplify the complex tasks of managing chat streams and UI updates on the frontend, enabling you to develop dynamic AI-driven interfaces more efficiently.
 
-With four main hooks — [`useChat`](/docs/reference/ai-sdk-ui/use-chat), [`useCompletion`](/docs/reference/ai-sdk-ui/use-completion), [`useObject`](/docs/reference/ai-sdk-ui/use-object), and [`useAssistant`](/docs/reference/ai-sdk-ui/use-assistant) — you can incorporate real-time chat capabilities, text completions, streamed JSON, and interactive assistant features into your app.
+With three main hooks — [`useChat`](/docs/reference/ai-sdk-ui/use-chat), [`useCompletion`](/docs/reference/ai-sdk-ui/use-completion), and [`useObject`](/docs/reference/ai-sdk-ui/use-object) — you can incorporate real-time chat capabilities, text completions, and streamed JSON into your app.
 
 Let's explore building a chatbot with [Next.js](https://nextjs.org), the AI SDK, and Gemini 3 Pro:
 

--- a/content/cookbook/00-guides/18-claude-4.mdx
+++ b/content/cookbook/00-guides/18-claude-4.mdx
@@ -75,7 +75,7 @@ AI SDK Core can be paired with [AI SDK UI](/docs/ai-sdk-ui/overview), another po
 
 AI SDK UI provides robust abstractions that simplify the complex tasks of managing chat streams and UI updates on the frontend, enabling you to develop dynamic AI-driven interfaces more efficiently.
 
-With four main hooks — [`useChat`](/docs/reference/ai-sdk-ui/use-chat), [`useCompletion`](/docs/reference/ai-sdk-ui/use-completion), [`useObject`](/docs/reference/ai-sdk-ui/use-object), and [`useAssistant`](/docs/reference/ai-sdk-ui/use-assistant) — you can incorporate real-time chat capabilities, text completions, streamed JSON, and interactive assistant features into your app.
+With three main hooks — [`useChat`](/docs/reference/ai-sdk-ui/use-chat), [`useCompletion`](/docs/reference/ai-sdk-ui/use-completion), and [`useObject`](/docs/reference/ai-sdk-ui/use-object) — you can incorporate real-time chat capabilities, text completions, and streamed JSON into your app.
 
 Let's explore building a chatbot with [Next.js](https://nextjs.org), the AI SDK, and Claude Sonnet 4:
 

--- a/content/cookbook/01-next/85-custom-stream-format.mdx
+++ b/content/cookbook/01-next/85-custom-stream-format.mdx
@@ -17,7 +17,7 @@ You can:
 - Parse the stream manually on the client
 - Build custom UI from your stream data
 
-For complete control over both the streaming format and the execution loop, combine this pattern with a [manual agent loop](/docs/cookbook/node/manual-agent-loop).
+For complete control over both the streaming format and the execution loop, combine this pattern with a [manual agent loop](/cookbook/node/manual-agent-loop).
 
 ## Implementation
 

--- a/content/cookbook/05-node/50-call-tools.mdx
+++ b/content/cookbook/05-node/50-call-tools.mdx
@@ -159,5 +159,5 @@ main().catch(console.error);
 When using tools, it's important to note that the model won't respond with the tool call results by default.
 This is because the model has technically already generated its response to the prompt: the tool call.
 Many use cases will require the model to summarize the results of the tool call within the context of the original prompt automatically.
-You can achieve this by [using `stopWhen`](/examples/node/tools/call-tools-multiple-steps)
+You can achieve this by [using `stopWhen`](/cookbook/node/call-tools-multiple-steps)
 which will automatically send toolResults to the model to trigger another generation.

--- a/content/docs/02-foundations/03-prompts.mdx
+++ b/content/docs/02-foundations/03-prompts.mdx
@@ -168,7 +168,7 @@ const messages: ModelMessage[] = [
   AI SDK UI hooks like [`useChat`](/docs/reference/ai-sdk-ui/use-chat) return
   arrays of `UIMessage` objects, which do not support provider options. We
   recommend using the
-  [`convertToModelMessages`](/docs/reference/ai-sdk-ui/convert-to-core-messages)
+  [`convertToModelMessages`](/docs/reference/ai-sdk-ui/convert-to-model-messages)
   function to convert `UIMessage` objects to
   [`ModelMessage`](/docs/reference/ai-sdk-core/model-message) objects before
   applying or appending message(s) or message parts with `providerOptions`.

--- a/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
@@ -142,7 +142,7 @@ for await (const chunk of stream) {
 - The agent **must** implement the `.stream({ prompt, ... })` method and define its supported `tools` property.
 - This utility returns an async iterable for maximal streaming flexibility. For HTTP responses, see [`createAgentUIStreamResponse`](/docs/reference/ai-sdk-core/create-agent-ui-stream-response) (Web) or [`pipeAgentUIStreamToResponse`](/docs/reference/ai-sdk-core/pipe-agent-ui-stream-to-response) (Node.js).
 - The `uiMessages` parameter is named `uiMessages`, **not** just `messages`.
-- You can provide advanced options via [`UIMessageStreamOptions`](/docs/reference/ai-sdk-core/ui-message-stream-options) (for example, to include sources or usage).
+- You can provide advanced options via `UIMessageStreamOptions` (for example, to include sources or usage).
 - To cancel the stream, pass an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) via the `abortSignal` parameter.
 
 ## See Also
@@ -150,6 +150,5 @@ for await (const chunk of stream) {
 - [`Agent`](/docs/reference/ai-sdk-core/agent)
 - [`ToolLoopAgent`](/docs/reference/ai-sdk-core/tool-loop-agent)
 - [`UIMessage`](/docs/reference/ai-sdk-core/ui-message)
-- [`UIMessageStreamOptions`](/docs/reference/ai-sdk-core/ui-message-stream-options)
 - [`createAgentUIStreamResponse`](/docs/reference/ai-sdk-core/create-agent-ui-stream-response)
 - [`pipeAgentUIStreamToResponse`](/docs/reference/ai-sdk-core/pipe-agent-ui-stream-to-response)

--- a/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
@@ -99,7 +99,7 @@ export async function POST(request: Request) {
       type: 'UIMessageStreamOptions',
       isRequired: false,
       description:
-        'Other UI message output options—such as `sendSources` and more. See [`UIMessageStreamOptions`](/docs/reference/ai-sdk-core/ui-message-stream-options).',
+        'Other UI message output options—such as `sendSources` and more.',
     },
     {
       name: 'headers',
@@ -170,5 +170,4 @@ export async function POST(request: Request) {
 - [`Agent`](/docs/reference/ai-sdk-core/agent)
 - [`ToolLoopAgent`](/docs/reference/ai-sdk-core/tool-loop-agent)
 - [`UIMessage`](/docs/reference/ai-sdk-core/ui-message)
-- [`UIMessageStreamOptions`](/docs/reference/ai-sdk-core/ui-message-stream-options)
 - [`createAgentUIStream`](/docs/reference/ai-sdk-core/create-agent-ui-stream)

--- a/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
@@ -147,5 +147,4 @@ app.post('/chat', async (req, res) => {
 
 - [`createAgentUIStreamResponse`](/docs/reference/ai-sdk-core/create-agent-ui-stream-response)
 - [`Agent`](/docs/reference/ai-sdk-core/agent)
-- [`UIMessageStreamOptions`](/docs/reference/ai-sdk-core/ui-message-stream-options)
 - [`UIMessage`](/docs/reference/ai-sdk-core/ui-message)

--- a/content/docs/07-reference/01-ai-sdk-core/69-add-tool-input-examples-middleware.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/69-add-tool-input-examples-middleware.mdx
@@ -56,7 +56,7 @@ function addToolInputExamplesMiddleware(options?: {
 
 ### Returns
 
-A [LanguageModelMiddleware](/docs/03-ai-sdk-core/40-middleware) that:
+A [LanguageModelMiddleware](/docs/ai-sdk-core/middleware) that:
 
 - Locates function tools with an `inputExamples` property.
 - Serializes each input example (by default as JSON, or using your custom formatter).

--- a/content/docs/07-reference/02-ai-sdk-ui/47-infer-ui-tool.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/47-infer-ui-tool.mdx
@@ -72,4 +72,4 @@ type WeatherUITool = InferUITool<typeof weatherTool>;
 ## Related
 
 - [`InferUITools`](/docs/reference/ai-sdk-ui/infer-ui-tools) - Infer types for a tool set
-- [`ToolUIPart`](/docs/reference/ai-sdk-ui/tool-ui-part) - Tool part type for UI messages
+- [`ToolUIPart`](/docs/reference/ai-sdk-core/ui-message#tooluipart) - Tool part type for UI messages


### PR DESCRIPTION
## Background

This change was necessary to fix several broken documentation links for `ai-sdk.dev` that were reported.

## Summary

This PR addresses multiple broken documentation links across the AI SDK codebase, improving the accuracy and navigability of the documentation. Key fixes include:

*   **Middleware link**: Corrected `/docs/03-ai-sdk-core/40-middleware` to `/docs/ai-sdk-core/middleware` in `add-tool-input-examples-middleware.mdx`.
*   **Manual agent loop**: Updated `/docs/cookbook/node/manual-agent-loop` to `/cookbook/node/manual-agent-loop` in `custom-stream-format.mdx`.
*   **UIMessageStreamOptions references**: Removed broken links to a non-existent page in `create-agent-ui-stream.mdx`, `create-agent-ui-stream-response.mdx`, and `pipe-agent-ui-stream-to-response.mdx`.
*   **Convert messages function**: Fixed `/docs/reference/ai-sdk-ui/convert-to-core-messages` to `/docs/reference/ai-sdk-ui/convert-to-model-messages` in `prompts.mdx`.
*   **ToolUIPart reference**: Corrected `/docs/reference/ai-sdk-ui/tool-ui-part` to `/docs/reference/ai-sdk-core/ui-message#tooluipart` in `infer-ui-tool.mdx`.
*   **`useAssistant` hook**: Removed deprecated references from `claude-4.mdx` and `gemini.mdx` (the hook was removed in v5.0).
*   **Call tools example**: Fixed `/examples/node/tools/call-tools-multiple-steps` to `/cookbook/node/call-tools-multiple-steps` in `call-tools.mdx`.

## Manual Verification

Not applicable, as these are documentation link fixes.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

The `/rss.xml` broken links reported for the `/elements` pages are not fixable within this repository, as the `elements` folder does not exist here. This issue likely needs to be addressed in the `vercel/front` repository or the site's build configuration.

---
[Slack Thread](https://vercel.slack.com/archives/C02F56A54LU/p1769504411412189?thread_ts=1769504411.412189&cid=C02F56A54LU)

<a href="https://cursor.com/background-agent?bcId=bc-90ef6f2d-0591-4527-86d4-7c0f494b6457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90ef6f2d-0591-4527-86d4-7c0f494b6457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

