### PR TITLE
fix(provider/anthropic): populate outputTokens.text field in usage

### DIFF
--- a/.changeset/smart-ways-cover.md
+++ b/.changeset/smart-ways-cover.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(provider/anthropic): populate outputTokens.text field in usage

--- a/examples/ai-functions/src/generate-text/anthropic-usage-tokens.ts
+++ b/examples/ai-functions/src/generate-text/anthropic-usage-tokens.ts
@@ -1,0 +1,34 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import 'dotenv/config';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: anthropic('claude-sonnet-4-20250514'),
+    prompt: 'What is 2 + 2? Reply with just the number.',
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Usage:');
+  console.log('  Input tokens:', result.usage.inputTokens);
+  console.log('  Output tokens:', result.usage.outputTokens);
+  console.log();
+  console.log('Output token details:');
+  console.log('  textTokens:', result.usage.outputTokenDetails?.textTokens);
+  console.log(
+    '  reasoningTokens:',
+    result.usage.outputTokenDetails?.reasoningTokens,
+  );
+  console.log();
+
+  if (result.usage.outputTokenDetails?.textTokens === undefined) {
+    console.log(
+      'BUG: textTokens is undefined but should be',
+      result.usage.outputTokens,
+    );
+  } else {
+    console.log('OK: textTokens is correctly populated');
+  }
+});

--- a/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
@@ -629,7 +629,7 @@ Both files have been exported and are ready for download!",
     },
     "outputTokens": {
       "reasoning": undefined,
-      "text": undefined,
+      "text": 1359,
       "total": 1359,
     },
     "raw": {
@@ -5131,7 +5131,7 @@ The presentation has",
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 5558,
         "total": 5558,
       },
       "raw": {
@@ -10191,7 +10191,7 @@ Both",
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 2479,
         "total": 2479,
       },
       "raw": {
@@ -11505,7 +11505,7 @@ The Fibonacci sequence starts with 0, ",
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 771,
         "total": 771,
       },
       "raw": {
@@ -12142,7 +12142,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > json schema response format
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 305,
         "total": 305,
       },
       "raw": {
@@ -12263,7 +12263,7 @@ It simply echoed back",
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 83,
         "total": 83,
       },
       "raw": {
@@ -13158,7 +13158,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -13236,7 +13236,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -13314,7 +13314,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -13392,7 +13392,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -13470,7 +13470,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -13548,7 +13548,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -13626,7 +13626,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -13704,7 +13704,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -13782,7 +13782,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -13860,7 +13860,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -13938,7 +13938,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -14016,7 +14016,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -14094,7 +14094,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -14172,7 +14172,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 725,
         "total": 725,
       },
       "raw": {
@@ -14692,7 +14692,7 @@ The",
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 197,
         "total": 197,
       },
       "raw": {
@@ -14907,7 +14907,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > tool search tool > bm25 var
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 158,
         "total": 158,
       },
       "raw": {
@@ -15008,7 +15008,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > tool search tool > bm25 var
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 41,
         "total": 41,
       },
       "raw": {
@@ -15225,7 +15225,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > tool search tool > regex va
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 163,
         "total": 163,
       },
       "raw": {
@@ -15355,7 +15355,7 @@ The weather in",
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 67,
         "total": 67,
       },
       "raw": {
@@ -15771,7 +15771,7 @@ The page also discusses",
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 446,
         "total": 446,
       },
       "raw": {
@@ -16704,7 +16704,7 @@ The main tech story today appears to be Apple's significant",
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": undefined,
+        "text": 795,
         "total": 795,
       },
       "raw": {

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -940,7 +940,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           },
           "outputTokens": {
             "reasoning": undefined,
-            "text": undefined,
+            "text": 5,
             "total": 5,
           },
           "raw": {
@@ -1515,7 +1515,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             },
             "outputTokens": {
               "reasoning": undefined,
-              "text": undefined,
+              "text": 50,
               "total": 50,
             },
             "raw": {
@@ -1677,7 +1677,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             },
             "outputTokens": {
               "reasoning": undefined,
-              "text": undefined,
+              "text": 50,
               "total": 50,
             },
             "raw": {
@@ -4316,7 +4316,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                 },
                 "outputTokens": {
                   "reasoning": undefined,
-                  "text": undefined,
+                  "text": 47,
                   "total": 47,
                 },
                 "raw": {
@@ -4465,7 +4465,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                 },
                 "outputTokens": {
                   "reasoning": undefined,
-                  "text": undefined,
+                  "text": 47,
                   "total": 47,
                 },
                 "raw": {
@@ -4659,7 +4659,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                   },
                   "outputTokens": {
                     "reasoning": undefined,
-                    "text": undefined,
+                    "text": 28,
                     "total": 28,
                   },
                   "raw": {
@@ -4854,7 +4854,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               },
               "outputTokens": {
                 "reasoning": undefined,
-                "text": undefined,
+                "text": 227,
                 "total": 227,
               },
               "raw": {
@@ -4995,7 +4995,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               },
               "outputTokens": {
                 "reasoning": undefined,
-                "text": undefined,
+                "text": 227,
                 "total": 227,
               },
               "raw": {
@@ -5093,7 +5093,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               },
               "outputTokens": {
                 "reasoning": undefined,
-                "text": undefined,
+                "text": 227,
                 "total": 227,
               },
               "raw": {
@@ -5177,7 +5177,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               },
               "outputTokens": {
                 "reasoning": undefined,
-                "text": undefined,
+                "text": 227,
                 "total": 227,
               },
               "raw": {
@@ -5329,7 +5329,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               },
               "outputTokens": {
                 "reasoning": undefined,
-                "text": undefined,
+                "text": 65,
                 "total": 65,
               },
               "raw": {
@@ -5588,7 +5588,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               },
               "outputTokens": {
                 "reasoning": undefined,
-                "text": undefined,
+                "text": 227,
                 "total": 227,
               },
               "raw": {
@@ -5683,7 +5683,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               },
               "outputTokens": {
                 "reasoning": undefined,
-                "text": undefined,
+                "text": 227,
                 "total": 227,
               },
               "raw": {
@@ -5798,7 +5798,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                 },
                 "outputTokens": {
                   "reasoning": undefined,
-                  "text": undefined,
+                  "text": 227,
                   "total": 227,
                 },
                 "raw": {
@@ -5863,7 +5863,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                 },
                 "outputTokens": {
                   "reasoning": undefined,
-                  "text": undefined,
+                  "text": 227,
                   "total": 227,
                 },
                 "raw": {
@@ -6115,7 +6115,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                 },
                 "outputTokens": {
                   "reasoning": undefined,
-                  "text": undefined,
+                  "text": 227,
                   "total": 227,
                 },
                 "raw": {
@@ -6324,7 +6324,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                   },
                   "outputTokens": {
                     "reasoning": undefined,
-                    "text": undefined,
+                    "text": 65,
                     "total": 65,
                   },
                   "raw": {
@@ -6439,7 +6439,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                   },
                   "outputTokens": {
                     "reasoning": undefined,
-                    "text": undefined,
+                    "text": 48,
                     "total": 48,
                   },
                   "raw": {

--- a/packages/anthropic/src/convert-anthropic-messages-usage.test.ts
+++ b/packages/anthropic/src/convert-anthropic-messages-usage.test.ts
@@ -1,0 +1,148 @@
+import { convertAnthropicMessagesUsage } from './convert-anthropic-messages-usage';
+import { describe, it, expect } from 'vitest';
+
+describe('convertAnthropicMessagesUsage', () => {
+  it('should convert basic usage', () => {
+    const result = convertAnthropicMessagesUsage({
+      input_tokens: 100,
+      output_tokens: 50,
+    });
+
+    expect(result).toEqual({
+      inputTokens: {
+        total: 100,
+        noCache: 100,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+      outputTokens: {
+        total: 50,
+        text: 50,
+        reasoning: undefined,
+      },
+      raw: {
+        input_tokens: 100,
+        output_tokens: 50,
+      },
+    });
+  });
+
+  it('should set text to output tokens since anthropic has no reasoning breakdown', () => {
+    const result = convertAnthropicMessagesUsage({
+      input_tokens: 200,
+      output_tokens: 150,
+    });
+
+    expect(result.outputTokens.text).toBe(150);
+    expect(result.outputTokens.total).toBe(150);
+    expect(result.outputTokens.reasoning).toBeUndefined();
+  });
+
+  it('should convert usage with cache creation tokens', () => {
+    const result = convertAnthropicMessagesUsage({
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_creation_input_tokens: 500,
+    });
+
+    expect(result).toEqual({
+      inputTokens: {
+        total: 600,
+        noCache: 100,
+        cacheRead: 0,
+        cacheWrite: 500,
+      },
+      outputTokens: {
+        total: 50,
+        text: 50,
+        reasoning: undefined,
+      },
+      raw: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 500,
+      },
+    });
+  });
+
+  it('should convert usage with cache read tokens', () => {
+    const result = convertAnthropicMessagesUsage({
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_read_input_tokens: 300,
+    });
+
+    expect(result).toEqual({
+      inputTokens: {
+        total: 400,
+        noCache: 100,
+        cacheRead: 300,
+        cacheWrite: 0,
+      },
+      outputTokens: {
+        total: 50,
+        text: 50,
+        reasoning: undefined,
+      },
+      raw: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 300,
+      },
+    });
+  });
+
+  it('should convert usage with both cache creation and read tokens', () => {
+    const result = convertAnthropicMessagesUsage({
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_creation_input_tokens: 500,
+      cache_read_input_tokens: 300,
+    });
+
+    expect(result).toEqual({
+      inputTokens: {
+        total: 900,
+        noCache: 100,
+        cacheRead: 300,
+        cacheWrite: 500,
+      },
+      outputTokens: {
+        total: 50,
+        text: 50,
+        reasoning: undefined,
+      },
+      raw: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 500,
+        cache_read_input_tokens: 300,
+      },
+    });
+  });
+
+  it('should handle null cache tokens', () => {
+    const result = convertAnthropicMessagesUsage({
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_creation_input_tokens: null,
+      cache_read_input_tokens: null,
+    });
+
+    expect(result.inputTokens.cacheRead).toBe(0);
+    expect(result.inputTokens.cacheWrite).toBe(0);
+  });
+
+  it('should preserve raw usage data', () => {
+    const rawUsage = {
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_creation_input_tokens: 500,
+      cache_read_input_tokens: 300,
+    };
+
+    const result = convertAnthropicMessagesUsage(rawUsage);
+
+    expect(result.raw).toEqual(rawUsage);
+  });
+});

--- a/packages/anthropic/src/convert-anthropic-messages-usage.ts
+++ b/packages/anthropic/src/convert-anthropic-messages-usage.ts
@@ -24,7 +24,7 @@ export function convertAnthropicMessagesUsage(
     },
     outputTokens: {
       total: outputTokens,
-      text: undefined,
+      text: outputTokens,
       reasoning: undefined,
     },
     raw: usage,


### PR DESCRIPTION
## background

the anthropic provider was returning `outputTokens.text: undefined` instead of the actual output token count

other providers (openai, google, cohere, mistral, bedrock) correctly populate the `text` field. anthropic was the only provider with this bug

## summary

- fix `convert-anthropic-messages-usage.ts` to set `text: outputTokens` instead of `text: undefined`
- add new test file `convert-anthropic-messages-usage.test.ts` with 7 tests
- add example `anthropic-usage-tokens.ts` to verify fix
- update 29 snapshots that now correctly show `text` populated

## verification

1. reverted fix, ran tests - 34 tests failed showing `text: undefined`
2. reverted fix, ran example - output showed "BUG: textTokens is undefined but should be 5"
3. applied fix, ran tests - all 260 tests pass
4. applied fix, ran example - output showed "OK: textTokens is correctly populated" with `textTokens: 5`

## checklist

- [x] tests have been added / updated
- [ ] documentation has been added / updated (n/a - internal fix)
- [x] a _patch_ changeset for relevant packages has been added
- [x] i have reviewed this pull request
