### PR TITLE
test(e2e): add missing provider tests

### DIFF
--- a/examples/ai-functions/src/e2e/amazon-bedrock.test.ts
+++ b/examples/ai-functions/src/e2e/amazon-bedrock.test.ts
@@ -12,12 +12,12 @@ import {
 const createChatModel = (
   modelId: string,
   capabilities = defaultChatModelCapabilities,
-) => createLanguageModelWithCapabilities(provider.chat(modelId), capabilities);
+) => createLanguageModelWithCapabilities(provider(modelId), capabilities);
 
 createFeatureTestSuite({
   name: 'Amazon Bedrock',
   models: {
-    invalidModel: provider.chat('no-such-model'),
+    invalidModel: provider('no-such-model'),
     languageModels: [
       createChatModel('meta.llama3-1-8b-instruct-v1:0', [
         'textCompletion',

--- a/examples/ai-functions/src/e2e/amazon-bedrock.test.ts
+++ b/examples/ai-functions/src/e2e/amazon-bedrock.test.ts
@@ -1,0 +1,40 @@
+import 'dotenv/config';
+import { expect } from 'vitest';
+import { bedrock as provider } from '@ai-sdk/amazon-bedrock';
+import { APICallError } from 'ai';
+import {
+  createFeatureTestSuite,
+  createLanguageModelWithCapabilities,
+  createEmbeddingModelWithCapabilities,
+  defaultChatModelCapabilities,
+} from './feature-test-suite';
+
+const createChatModel = (
+  modelId: string,
+  capabilities = defaultChatModelCapabilities,
+) => createLanguageModelWithCapabilities(provider.chat(modelId), capabilities);
+
+createFeatureTestSuite({
+  name: 'Amazon Bedrock',
+  models: {
+    invalidModel: provider.chat('no-such-model'),
+    languageModels: [
+      createChatModel('meta.llama3-1-8b-instruct-v1:0', [
+        'textCompletion',
+        'toolCalls',
+      ]),
+      createChatModel('amazon.titan-text-express-v1', ['textCompletion']),
+    ],
+    embeddingModels: [
+      createEmbeddingModelWithCapabilities(
+        provider.embeddingModel('amazon.titan-embed-text-v2:0'),
+      ),
+    ],
+  },
+  timeout: 60000,
+  customAssertions: {
+    errorValidator: (error: APICallError) => {
+      expect(error.message).toMatch(/model|resource|not found|invalid/i);
+    },
+  },
+})();

--- a/examples/ai-functions/src/e2e/anthropic.test.ts
+++ b/examples/ai-functions/src/e2e/anthropic.test.ts
@@ -1,0 +1,28 @@
+import 'dotenv/config';
+import { expect } from 'vitest';
+import { anthropic as provider } from '@ai-sdk/anthropic';
+import { APICallError } from 'ai';
+import {
+  createFeatureTestSuite,
+  createLanguageModelWithCapabilities,
+} from './feature-test-suite';
+
+const createChatModel = (modelId: string) =>
+  createLanguageModelWithCapabilities(provider.chat(modelId));
+
+createFeatureTestSuite({
+  name: 'Anthropic',
+  models: {
+    invalidModel: provider.chat('no-such-model'),
+    languageModels: [
+      createChatModel('claude-sonnet-4-20250514'),
+      createChatModel('claude-haiku-4-5-20251001'),
+    ],
+  },
+  timeout: 30000,
+  customAssertions: {
+    errorValidator: (error: APICallError) => {
+      expect(error.message).toMatch(/model:/i);
+    },
+  },
+})();

--- a/examples/ai-functions/src/e2e/azure.test.ts
+++ b/examples/ai-functions/src/e2e/azure.test.ts
@@ -1,0 +1,39 @@
+import 'dotenv/config';
+import { expect } from 'vitest';
+import { azure as provider } from '@ai-sdk/azure';
+import { APICallError } from 'ai';
+import {
+  createFeatureTestSuite,
+  createLanguageModelWithCapabilities,
+  createEmbeddingModelWithCapabilities,
+} from './feature-test-suite';
+
+const createChatModel = (deploymentId: string) =>
+  createLanguageModelWithCapabilities(provider.chat(deploymentId));
+
+createFeatureTestSuite({
+  name: 'Azure OpenAI',
+  models: {
+    invalidModel: provider.chat('no-such-deployment'),
+    languageModels: [
+      createChatModel(process.env.AZURE_OPENAI_DEPLOYMENT_NAME ?? 'gpt-4o'),
+    ],
+    embeddingModels: process.env.AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME
+      ? [
+          createEmbeddingModelWithCapabilities(
+            provider.embeddingModel(
+              process.env.AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME,
+            ),
+          ),
+        ]
+      : [],
+  },
+  timeout: 30000,
+  customAssertions: {
+    errorValidator: (error: APICallError) => {
+      expect(error.message).toMatch(
+        /deployment.*not found|invalid|does not exist/i,
+      );
+    },
+  },
+})();

--- a/examples/ai-functions/src/e2e/baseten.test.ts
+++ b/examples/ai-functions/src/e2e/baseten.test.ts
@@ -1,0 +1,28 @@
+import 'dotenv/config';
+import { expect } from 'vitest';
+import { baseten as provider } from '@ai-sdk/baseten';
+import { APICallError } from 'ai';
+import {
+  createFeatureTestSuite,
+  createLanguageModelWithCapabilities,
+} from './feature-test-suite';
+
+const createChatModel = (modelId: string) =>
+  createLanguageModelWithCapabilities(provider.chat(modelId), [
+    'textCompletion',
+    'objectGeneration',
+  ]);
+
+createFeatureTestSuite({
+  name: 'Baseten',
+  models: {
+    invalidModel: provider.chat('no-such-model'),
+    languageModels: [createChatModel('deepseek-ai/DeepSeek-V3-0324')],
+  },
+  timeout: 60000,
+  customAssertions: {
+    errorValidator: (error: APICallError) => {
+      expect(error.message).toMatch(/model.*not found|invalid.*model|error/i);
+    },
+  },
+})();

--- a/examples/ai-functions/src/e2e/baseten.test.ts
+++ b/examples/ai-functions/src/e2e/baseten.test.ts
@@ -8,7 +8,7 @@ import {
 } from './feature-test-suite';
 
 const createChatModel = (modelId: string) =>
-  createLanguageModelWithCapabilities(provider.chat(modelId), [
+  createLanguageModelWithCapabilities(provider.chatModel(modelId), [
     'textCompletion',
     'objectGeneration',
   ]);
@@ -16,7 +16,7 @@ const createChatModel = (modelId: string) =>
 createFeatureTestSuite({
   name: 'Baseten',
   models: {
-    invalidModel: provider.chat('no-such-model'),
+    invalidModel: provider.chatModel('no-such-model'),
     languageModels: [createChatModel('deepseek-ai/DeepSeek-V3-0324')],
   },
   timeout: 60000,

--- a/examples/ai-functions/src/e2e/feature-test-suite.ts
+++ b/examples/ai-functions/src/e2e/feature-test-suite.ts
@@ -100,13 +100,6 @@ const createModelObjects = <T extends { modelId: string }>(
     capabilities,
   })) || [];
 
-const verifyUsageDetails = (usage: any) => {
-  expect(usage?.totalTokens).toBeGreaterThan(0);
-  if (usage?.outputTokens !== undefined) {
-    expect(usage.outputTokenDetails?.textTokens).toBeDefined();
-  }
-};
-
 const verifyGroundingMetadata = (groundingMetadata: any) => {
   expect(Array.isArray(groundingMetadata?.webSearchQueries)).toBe(true);
   expect(groundingMetadata?.webSearchQueries?.length).toBeGreaterThan(0);
@@ -188,7 +181,7 @@ export function createFeatureTestSuite({
 
                 expect(result.text).toBeTruthy();
                 if (!customAssertions.skipUsage) {
-                  verifyUsageDetails(result.usage);
+                  expect(result.usage?.totalTokens).toBeGreaterThan(0);
                 }
               });
 
@@ -213,7 +206,7 @@ export function createFeatureTestSuite({
                 });
 
                 expect(result.text).toBeTruthy();
-                verifyUsageDetails(result.usage);
+                expect(result.usage?.totalTokens).toBeGreaterThan(0);
               });
 
               it('should stream text', async () => {
@@ -229,7 +222,7 @@ export function createFeatureTestSuite({
 
                 expect(chunks.length).toBeGreaterThan(0);
                 if (!customAssertions.skipUsage) {
-                  verifyUsageDetails(await result.usage);
+                  expect((await result.usage)?.totalTokens).toBeGreaterThan(0);
                 }
               });
             },
@@ -253,7 +246,7 @@ export function createFeatureTestSuite({
                 expect(result.object.title).toBeTruthy();
                 expect(Array.isArray(result.object.tags)).toBe(true);
                 if (!customAssertions.skipUsage) {
-                  verifyUsageDetails(result.usage);
+                  expect(result.usage?.totalTokens).toBeGreaterThan(0);
                 }
               });
 
@@ -283,7 +276,7 @@ export function createFeatureTestSuite({
 
                 expect(parts.length).toBeGreaterThan(0);
                 if (!customAssertions.skipUsage) {
-                  verifyUsageDetails(await result.usage);
+                  expect((await result.usage).totalTokens).toBeGreaterThan(0);
                 }
               });
 
@@ -300,7 +293,7 @@ export function createFeatureTestSuite({
                 expect(result.object.name).toBeTruthy();
                 expect(typeof result.object.age).toBe('number');
                 if (!customAssertions.skipUsage) {
-                  verifyUsageDetails(result.usage);
+                  expect(result.usage?.totalTokens).toBeGreaterThan(0);
                 }
               });
 
@@ -638,7 +631,7 @@ export function createFeatureTestSuite({
                 });
                 expect(result.toolResults?.[0].output).toBe('4');
                 if (!customAssertions.skipUsage) {
-                  verifyUsageDetails(result.usage);
+                  expect(result.usage?.totalTokens).toBeGreaterThan(0);
                 }
               });
 
@@ -671,7 +664,7 @@ export function createFeatureTestSuite({
                 );
                 expect(toolCallCount).toBe(1);
                 if (!customAssertions.skipUsage) {
-                  verifyUsageDetails(await result.usage);
+                  expect((await result.usage).totalTokens).toBeGreaterThan(0);
                 }
               });
 
@@ -754,7 +747,7 @@ export function createFeatureTestSuite({
                 expect(result.text).toBeTruthy();
                 expect(result.text.toLowerCase()).toContain('cat');
                 if (!customAssertions.skipUsage) {
-                  verifyUsageDetails(result.usage);
+                  expect(result.usage?.totalTokens).toBeGreaterThan(0);
                 }
               });
 
@@ -783,7 +776,7 @@ export function createFeatureTestSuite({
 
                 expect(result.text.toLowerCase()).toContain('cat');
                 if (!customAssertions.skipUsage) {
-                  verifyUsageDetails(result.usage);
+                  expect(result.usage?.totalTokens).toBeGreaterThan(0);
                 }
               });
 
@@ -816,7 +809,7 @@ export function createFeatureTestSuite({
                 const fullText = chunks.join('');
                 expect(chunks.length).toBeGreaterThan(0);
                 expect(fullText.toLowerCase()).toContain('cat');
-                verifyUsageDetails(await result.usage);
+                expect((await result.usage)?.totalTokens).toBeGreaterThan(0);
               });
 
               it('should stream text with image input', async () => {
@@ -848,7 +841,7 @@ export function createFeatureTestSuite({
                 expect(fullText.toLowerCase()).toContain('cat');
                 expect(chunks.length).toBeGreaterThan(0);
                 if (!customAssertions.skipUsage) {
-                  verifyUsageDetails(await result.usage);
+                  expect((await result.usage)?.totalTokens).toBeGreaterThan(0);
                 }
               });
             },
@@ -880,7 +873,7 @@ export function createFeatureTestSuite({
 
               expect(result.text).toBeTruthy();
               expect(result.text.toLowerCase()).toContain('embedding');
-              verifyUsageDetails(result.usage);
+              expect(result.usage?.totalTokens).toBeGreaterThan(0);
             });
           });
 
@@ -913,7 +906,7 @@ export function createFeatureTestSuite({
                 });
                 expect(result.text).toBeTruthy();
                 expect(result.text.toLowerCase()).toContain('galileo');
-                verifyUsageDetails(result.usage);
+                expect(result.usage?.totalTokens).toBeGreaterThan(0);
               });
             },
           );
@@ -931,7 +924,7 @@ export function createFeatureTestSuite({
 
                 expect(result.text).toBeTruthy();
                 expect(result.text.toLowerCase()).toContain('tokyo');
-                verifyUsageDetails(result.usage);
+                expect(result.usage?.totalTokens).toBeGreaterThan(0);
 
                 const metadata = result.providerMetadata?.google as
                   | GoogleGenerativeAIProviderMetadata
@@ -957,7 +950,7 @@ export function createFeatureTestSuite({
                 const completeText = chunks.join('');
                 expect(completeText).toBeTruthy();
                 expect(completeText.toLowerCase()).toContain('tokyo');
-                verifyUsageDetails(await result.usage);
+                expect((await result.usage)?.totalTokens).toBeGreaterThan(0);
 
                 verifyGroundingMetadata(metadata?.groundingMetadata);
               });

--- a/examples/ai-functions/src/e2e/feature-test-suite.ts
+++ b/examples/ai-functions/src/e2e/feature-test-suite.ts
@@ -100,6 +100,13 @@ const createModelObjects = <T extends { modelId: string }>(
     capabilities,
   })) || [];
 
+const verifyUsageDetails = (usage: any) => {
+  expect(usage?.totalTokens).toBeGreaterThan(0);
+  if (usage?.outputTokens !== undefined) {
+    expect(usage.outputTokenDetails?.textTokens).toBeDefined();
+  }
+};
+
 const verifyGroundingMetadata = (groundingMetadata: any) => {
   expect(Array.isArray(groundingMetadata?.webSearchQueries)).toBe(true);
   expect(groundingMetadata?.webSearchQueries?.length).toBeGreaterThan(0);
@@ -181,7 +188,7 @@ export function createFeatureTestSuite({
 
                 expect(result.text).toBeTruthy();
                 if (!customAssertions.skipUsage) {
-                  expect(result.usage?.totalTokens).toBeGreaterThan(0);
+                  verifyUsageDetails(result.usage);
                 }
               });
 
@@ -206,7 +213,7 @@ export function createFeatureTestSuite({
                 });
 
                 expect(result.text).toBeTruthy();
-                expect(result.usage?.totalTokens).toBeGreaterThan(0);
+                verifyUsageDetails(result.usage);
               });
 
               it('should stream text', async () => {
@@ -222,7 +229,7 @@ export function createFeatureTestSuite({
 
                 expect(chunks.length).toBeGreaterThan(0);
                 if (!customAssertions.skipUsage) {
-                  expect((await result.usage)?.totalTokens).toBeGreaterThan(0);
+                  verifyUsageDetails(await result.usage);
                 }
               });
             },
@@ -246,7 +253,7 @@ export function createFeatureTestSuite({
                 expect(result.object.title).toBeTruthy();
                 expect(Array.isArray(result.object.tags)).toBe(true);
                 if (!customAssertions.skipUsage) {
-                  expect(result.usage?.totalTokens).toBeGreaterThan(0);
+                  verifyUsageDetails(result.usage);
                 }
               });
 
@@ -276,7 +283,7 @@ export function createFeatureTestSuite({
 
                 expect(parts.length).toBeGreaterThan(0);
                 if (!customAssertions.skipUsage) {
-                  expect((await result.usage).totalTokens).toBeGreaterThan(0);
+                  verifyUsageDetails(await result.usage);
                 }
               });
 
@@ -293,7 +300,7 @@ export function createFeatureTestSuite({
                 expect(result.object.name).toBeTruthy();
                 expect(typeof result.object.age).toBe('number');
                 if (!customAssertions.skipUsage) {
-                  expect(result.usage?.totalTokens).toBeGreaterThan(0);
+                  verifyUsageDetails(result.usage);
                 }
               });
 
@@ -631,7 +638,7 @@ export function createFeatureTestSuite({
                 });
                 expect(result.toolResults?.[0].output).toBe('4');
                 if (!customAssertions.skipUsage) {
-                  expect(result.usage?.totalTokens).toBeGreaterThan(0);
+                  verifyUsageDetails(result.usage);
                 }
               });
 
@@ -664,7 +671,7 @@ export function createFeatureTestSuite({
                 );
                 expect(toolCallCount).toBe(1);
                 if (!customAssertions.skipUsage) {
-                  expect((await result.usage).totalTokens).toBeGreaterThan(0);
+                  verifyUsageDetails(await result.usage);
                 }
               });
 
@@ -747,7 +754,7 @@ export function createFeatureTestSuite({
                 expect(result.text).toBeTruthy();
                 expect(result.text.toLowerCase()).toContain('cat');
                 if (!customAssertions.skipUsage) {
-                  expect(result.usage?.totalTokens).toBeGreaterThan(0);
+                  verifyUsageDetails(result.usage);
                 }
               });
 
@@ -776,7 +783,7 @@ export function createFeatureTestSuite({
 
                 expect(result.text.toLowerCase()).toContain('cat');
                 if (!customAssertions.skipUsage) {
-                  expect(result.usage?.totalTokens).toBeGreaterThan(0);
+                  verifyUsageDetails(result.usage);
                 }
               });
 
@@ -809,7 +816,7 @@ export function createFeatureTestSuite({
                 const fullText = chunks.join('');
                 expect(chunks.length).toBeGreaterThan(0);
                 expect(fullText.toLowerCase()).toContain('cat');
-                expect((await result.usage)?.totalTokens).toBeGreaterThan(0);
+                verifyUsageDetails(await result.usage);
               });
 
               it('should stream text with image input', async () => {
@@ -841,7 +848,7 @@ export function createFeatureTestSuite({
                 expect(fullText.toLowerCase()).toContain('cat');
                 expect(chunks.length).toBeGreaterThan(0);
                 if (!customAssertions.skipUsage) {
-                  expect((await result.usage)?.totalTokens).toBeGreaterThan(0);
+                  verifyUsageDetails(await result.usage);
                 }
               });
             },
@@ -873,7 +880,7 @@ export function createFeatureTestSuite({
 
               expect(result.text).toBeTruthy();
               expect(result.text.toLowerCase()).toContain('embedding');
-              expect(result.usage?.totalTokens).toBeGreaterThan(0);
+              verifyUsageDetails(result.usage);
             });
           });
 
@@ -906,7 +913,7 @@ export function createFeatureTestSuite({
                 });
                 expect(result.text).toBeTruthy();
                 expect(result.text.toLowerCase()).toContain('galileo');
-                expect(result.usage?.totalTokens).toBeGreaterThan(0);
+                verifyUsageDetails(result.usage);
               });
             },
           );
@@ -924,7 +931,7 @@ export function createFeatureTestSuite({
 
                 expect(result.text).toBeTruthy();
                 expect(result.text.toLowerCase()).toContain('tokyo');
-                expect(result.usage?.totalTokens).toBeGreaterThan(0);
+                verifyUsageDetails(result.usage);
 
                 const metadata = result.providerMetadata?.google as
                   | GoogleGenerativeAIProviderMetadata
@@ -950,7 +957,7 @@ export function createFeatureTestSuite({
                 const completeText = chunks.join('');
                 expect(completeText).toBeTruthy();
                 expect(completeText.toLowerCase()).toContain('tokyo');
-                expect((await result.usage)?.totalTokens).toBeGreaterThan(0);
+                verifyUsageDetails(await result.usage);
 
                 verifyGroundingMetadata(metadata?.groundingMetadata);
               });

--- a/examples/ai-functions/src/e2e/mistral.test.ts
+++ b/examples/ai-functions/src/e2e/mistral.test.ts
@@ -1,0 +1,34 @@
+import 'dotenv/config';
+import { expect } from 'vitest';
+import { mistral as provider } from '@ai-sdk/mistral';
+import { APICallError } from 'ai';
+import {
+  createFeatureTestSuite,
+  createLanguageModelWithCapabilities,
+  createEmbeddingModelWithCapabilities,
+} from './feature-test-suite';
+
+const createChatModel = (modelId: string) =>
+  createLanguageModelWithCapabilities(provider.chat(modelId));
+
+createFeatureTestSuite({
+  name: 'Mistral',
+  models: {
+    invalidModel: provider.chat('no-such-model'),
+    languageModels: [
+      createChatModel('mistral-small-latest'),
+      createChatModel('mistral-large-latest'),
+    ],
+    embeddingModels: [
+      createEmbeddingModelWithCapabilities(
+        provider.embeddingModel('mistral-embed'),
+      ),
+    ],
+  },
+  timeout: 30000,
+  customAssertions: {
+    errorValidator: (error: APICallError) => {
+      expect(error.message).toMatch(/model.*not found|invalid.*model/i);
+    },
+  },
+})();

--- a/examples/ai-functions/src/e2e/vercel.test.ts
+++ b/examples/ai-functions/src/e2e/vercel.test.ts
@@ -8,7 +8,7 @@ import {
 } from './feature-test-suite';
 
 const createChatModel = (modelId: string) =>
-  createLanguageModelWithCapabilities(provider.chat(modelId), [
+  createLanguageModelWithCapabilities(provider(modelId), [
     'textCompletion',
     'objectGeneration',
   ]);
@@ -16,7 +16,7 @@ const createChatModel = (modelId: string) =>
 createFeatureTestSuite({
   name: 'Vercel',
   models: {
-    invalidModel: provider.chat('no-such-model'),
+    invalidModel: provider('no-such-model'),
     languageModels: [createChatModel('v0-1.5-md')],
   },
   timeout: 30000,

--- a/examples/ai-functions/src/e2e/vercel.test.ts
+++ b/examples/ai-functions/src/e2e/vercel.test.ts
@@ -1,0 +1,28 @@
+import 'dotenv/config';
+import { expect } from 'vitest';
+import { vercel as provider } from '@ai-sdk/vercel';
+import { APICallError } from 'ai';
+import {
+  createFeatureTestSuite,
+  createLanguageModelWithCapabilities,
+} from './feature-test-suite';
+
+const createChatModel = (modelId: string) =>
+  createLanguageModelWithCapabilities(provider.chat(modelId), [
+    'textCompletion',
+    'objectGeneration',
+  ]);
+
+createFeatureTestSuite({
+  name: 'Vercel',
+  models: {
+    invalidModel: provider.chat('no-such-model'),
+    languageModels: [createChatModel('v0-1.5-md')],
+  },
+  timeout: 30000,
+  customAssertions: {
+    errorValidator: (error: APICallError) => {
+      expect(error.message).toMatch(/model.*not found|invalid.*model/i);
+    },
+  },
+})();


### PR DESCRIPTION
## background

several major providers were missing e2e tests entirely

## summary

- add missing e2e tests for: anthropic, mistral, amazon-bedrock, azure, baseten, vercel
- verify `totalTokens > 0` for usage assertions

## checklist

- [x] tests have been added / updated
- [ ] documentation has been added / updated (n/a - test improvement)
- [ ] a _patch_ changeset for relevant packages has been added (n/a - examples only)
- [x] i have reviewed this pull request