### PR TITLE
fix(xai): emit reasoning-start before reasoning-end for encrypted reasoning

### DIFF
--- a/.changeset/lemon-books-poke.md
+++ b/.changeset/lemon-books-poke.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(xai): emit reasoning-start before reasoning-end for encrypted reasoning

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -1273,6 +1273,120 @@ describe('XaiResponsesLanguageModel', () => {
         `);
       });
 
+      it('should emit reasoning-start before reasoning-end when reasoning_summary_part.added is not sent', async () => {
+        // This test covers the case where xAI sends encrypted reasoning without
+        // streaming the reasoning summary text (no reasoning_summary_part.added events)
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'reasoning',
+              id: 'rs_456',
+              status: 'in_progress',
+              summary: [],
+            },
+            output_index: 0,
+          }),
+          // Note: No response.reasoning_summary_part.added event
+          // This happens with encrypted reasoning when store=false
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'reasoning',
+              id: 'rs_456',
+              status: 'completed',
+              summary: [],
+              encrypted_content: 'encrypted_reasoning_content_xyz',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'message',
+              id: 'msg_789',
+              role: 'assistant',
+              status: 'in_progress',
+              content: [],
+            },
+            output_index: 1,
+          }),
+          JSON.stringify({
+            type: 'response.output_text.delta',
+            item_id: 'msg_789',
+            output_index: 1,
+            content_index: 0,
+            delta: 'The answer is 42.',
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 20 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        // Verify reasoning-start is emitted before reasoning-end
+        const reasoningStart = parts.find(
+          part => part.type === 'reasoning-start',
+        );
+        const reasoningEnd = parts.find(part => part.type === 'reasoning-end');
+
+        expect(reasoningStart).toMatchInlineSnapshot(`
+          {
+            "id": "reasoning-rs_456",
+            "providerMetadata": {
+              "xai": {
+                "itemId": "rs_456",
+              },
+            },
+            "type": "reasoning-start",
+          }
+        `);
+
+        expect(reasoningEnd).toMatchInlineSnapshot(`
+          {
+            "id": "reasoning-rs_456",
+            "providerMetadata": {
+              "xai": {
+                "itemId": "rs_456",
+                "reasoningEncryptedContent": "encrypted_reasoning_content_xyz",
+              },
+            },
+            "type": "reasoning-end",
+          }
+        `);
+
+        // Verify reasoning-start comes before reasoning-end in the stream
+        const reasoningStartIndex = parts.findIndex(
+          part => part.type === 'reasoning-start',
+        );
+        const reasoningEndIndex = parts.findIndex(
+          part => part.type === 'reasoning-end',
+        );
+        expect(reasoningStartIndex).toBeLessThan(reasoningEndIndex);
+      });
+
       it('should stream x_search tool call', async () => {
         prepareChunksFixtureResponse('xai-x-search-tool');
 

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -400,7 +400,6 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
       string,
       { encryptedContent?: string | null }
     > = {};
-    const startedReasoningBlocks = new Set<string>();
 
     const self = this;
 
@@ -443,7 +442,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
             if (event.type === 'response.reasoning_summary_part.added') {
               const blockId = `reasoning-${event.item_id}`;
 
-              startedReasoningBlocks.add(blockId);
+              activeReasoning[event.item_id] = {};
               controller.enqueue({
                 type: 'reasoning-start',
                 id: blockId,
@@ -571,8 +570,8 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
 
                   // Emit reasoning-start if not already emitted (e.g., for encrypted reasoning
                   // where reasoning_summary_part.added events may not be sent)
-                  if (!startedReasoningBlocks.has(blockId)) {
-                    startedReasoningBlocks.add(blockId);
+                  if (!(part.id in activeReasoning)) {
+                    activeReasoning[part.id] = {};
                     controller.enqueue({
                       type: 'reasoning-start',
                       id: blockId,

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -400,6 +400,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
       string,
       { encryptedContent?: string | null }
     > = {};
+    const startedReasoningBlocks = new Set<string>();
 
     const self = this;
 
@@ -442,6 +443,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
             if (event.type === 'response.reasoning_summary_part.added') {
               const blockId = `reasoning-${event.item_id}`;
 
+              startedReasoningBlocks.add(blockId);
               controller.enqueue({
                 type: 'reasoning-start',
                 id: blockId,
@@ -565,9 +567,26 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
               const part = event.item;
               if (part.type === 'reasoning') {
                 if (event.type === 'response.output_item.done') {
+                  const blockId = `reasoning-${part.id}`;
+
+                  // Emit reasoning-start if not already emitted (e.g., for encrypted reasoning
+                  // where reasoning_summary_part.added events may not be sent)
+                  if (!startedReasoningBlocks.has(blockId)) {
+                    startedReasoningBlocks.add(blockId);
+                    controller.enqueue({
+                      type: 'reasoning-start',
+                      id: blockId,
+                      providerMetadata: {
+                        xai: {
+                          ...(part.id && { itemId: part.id }),
+                        },
+                      },
+                    });
+                  }
+
                   controller.enqueue({
                     type: 'reasoning-end',
-                    id: `reasoning-${part.id}`,
+                    id: blockId,
                     providerMetadata: {
                       xai: {
                         ...(part.encrypted_content && {


### PR DESCRIPTION
## Summary

Fixes "reasoning part not found" errors when streaming responses from xAI models with encrypted reasoning (e.g., `grok-4-fast-reasoning`, `grok-4.1-fast-reasoning`).

## Problem

When xAI returns encrypted reasoning content, the `response.output_item.done` event may arrive without a prior `response.reasoning_summary_part.added` event. This caused `reasoning-end` to be emitted without a preceding `reasoning-start`, which the AI SDK's stream processing logic cannot handle.

The AI SDK tracks active reasoning parts and expects `reasoning-start` before `reasoning-end`:
```
reasoning part reasoning-rs_XXX not found
```

## Solution

Track which reasoning blocks have had `reasoning-start` emitted. Before emitting `reasoning-end`, check if `reasoning-start` was already emitted for that block. If not, emit `reasoning-start` first.

## Test Plan

- Run existing xai package tests: `pnpm test --filter @ai-sdk/xai`
- Test streaming with `xai/grok-4-fast-reasoning` model to verify no "reasoning part not found" errors