### PR TITLE
docs(devtools): correct middleware function call in README example

### DIFF
--- a/.changeset/fix-devtools-readme-typo.md
+++ b/.changeset/fix-devtools-readme-typo.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/devtools": patch
+---
+
+Fix typo in README.md: `devToolsMiddleware` should be called as a function `devToolsMiddleware()`.

--- a/.changeset/fix-devtools-readme-typo.md
+++ b/.changeset/fix-devtools-readme-typo.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk/devtools": patch
+'@ai-sdk/devtools': patch
 ---
 
 Fix typo in README.md: `devToolsMiddleware` should be called as a function `devToolsMiddleware()`.

--- a/packages/devtools/README.md
+++ b/packages/devtools/README.md
@@ -26,7 +26,7 @@ import { wrapLanguageModel } from 'ai';
 import { devToolsMiddleware } from '@ai-sdk/devtools';
 
 const model = wrapLanguageModel({
-  middleware: devToolsMiddleware,
+  middleware: devToolsMiddleware(),
   model: yourModel,
 });
 ```


### PR DESCRIPTION
## Background

The README example shows incorrect usage of `devToolsMiddleware`. It was passed as a reference instead of being called as a factory function, which would cause runtime errors.

## Summary

- Fixed the middleware usage example in `packages/devtools/README.md`
- Changed `middleware: devToolsMiddleware` to `middleware: devToolsMiddleware()`

The `devToolsMiddleware` is a factory function that returns a `LanguageModelV3Middleware` instance, so it needs to be invoked with `()`.

## Checklist

- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)