### PR TITLE
feat (provider/gateway): add parallel search tool

### DIFF
--- a/.changeset/late-items-help.md
+++ b/.changeset/late-items-help.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): add parallel search tool

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -424,6 +424,115 @@ for await (const part of result.fullStream) {
 }
 ```
 
+#### Parallel Search
+
+The Parallel Search tool enables models to search the web using [Parallel AI's Search API](https://docs.parallel.ai/api-reference/search-beta/search). This tool is optimized for LLM consumption, returning relevant excerpts from web pages that can replace multiple keyword searches with a single call.
+
+```ts
+import { gateway, generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-5-nano',
+  prompt: 'Research the latest developments in quantum computing.',
+  tools: {
+    parallel_search: gateway.tools.parallelSearch(),
+  },
+});
+
+console.log(result.text);
+console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+```
+
+You can also configure the search with optional parameters:
+
+```ts
+import { gateway, generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-5-nano',
+  prompt: 'Find detailed information about TypeScript 5.0 features.',
+  tools: {
+    parallel_search: gateway.tools.parallelSearch({
+      mode: 'agentic',
+      maxResults: 5,
+      sourcePolicy: {
+        includeDomains: ['typescriptlang.org', 'github.com'],
+      },
+      excerpts: {
+        maxCharsPerResult: 8000,
+      },
+    }),
+  },
+});
+
+console.log(result.text);
+console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+```
+
+The Parallel Search tool supports the following optional configuration options:
+
+- **mode** _'one-shot' | 'agentic'_
+
+  Mode preset for different use cases:
+
+  - `'one-shot'` - Comprehensive results with longer excerpts for single-response answers (default)
+  - `'agentic'` - Concise, token-efficient results optimized for multi-step agentic workflows
+
+- **maxResults** _number_
+
+  Maximum number of results to return (1-20). Defaults to 10 if not specified.
+
+- **sourcePolicy** _object_
+
+  Source policy for controlling which domains to include/exclude:
+
+  - `includeDomains` - List of domains to include in search results
+  - `excludeDomains` - List of domains to exclude from search results
+  - `afterDate` - Only include results published after this date (ISO 8601 format)
+
+- **excerpts** _object_
+
+  Excerpt configuration for controlling result length:
+
+  - `maxCharsPerResult` - Maximum characters per result
+  - `maxCharsTotal` - Maximum total characters across all results
+
+- **fetchPolicy** _object_
+
+  Fetch policy for controlling content freshness:
+
+  - `maxAgeSeconds` - Maximum age in seconds for cached content (set to 0 for always fresh)
+
+The tool works with both `generateText` and `streamText`:
+
+```ts
+import { gateway, streamText } from 'ai';
+
+const result = streamText({
+  model: 'openai/gpt-5-nano',
+  prompt: 'Research the latest AI safety guidelines.',
+  tools: {
+    parallel_search: gateway.tools.parallelSearch(),
+  },
+});
+
+for await (const part of result.fullStream) {
+  switch (part.type) {
+    case 'text-delta':
+      process.stdout.write(part.text);
+      break;
+    case 'tool-call':
+      console.log('\nTool call:', JSON.stringify(part, null, 2));
+      break;
+    case 'tool-result':
+      console.log('\nTool result:', JSON.stringify(part, null, 2));
+      break;
+  }
+}
+```
+
 ### Usage Tracking with User and Tags
 
 Track usage per end-user and categorize requests with tags:

--- a/examples/ai-functions/src/generate-text/gateway-tool-parallel-search-params.ts
+++ b/examples/ai-functions/src/generate-text/gateway-tool-parallel-search-params.ts
@@ -1,0 +1,37 @@
+import { gateway, generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: 'openai/gpt-5-nano',
+    prompt: `Search for the latest research on quantum computing breakthroughs.`,
+    tools: {
+      parallel_search: gateway.tools.parallelSearch({
+        mode: 'agentic',
+        maxResults: 5,
+        sourcePolicy: {
+          includeDomains: ['nature.com', 'arxiv.org', 'science.org'],
+        },
+        excerpts: {
+          maxCharsPerResult: 8000,
+        },
+      }),
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Reasoning:', result.reasoning);
+  console.log();
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(result.providerMetadata, null, 2),
+  );
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/generate-text/gateway-tool-parallel-search.ts
+++ b/examples/ai-functions/src/generate-text/gateway-tool-parallel-search.ts
@@ -1,0 +1,29 @@
+import { gateway, generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: 'openai/gpt-5-nano',
+    prompt:
+      'Use the parallelSearch tool to find current information about renewable energy developments in 2025. You must search the web first before answering.',
+    tools: {
+      parallel_search: gateway.tools.parallelSearch(),
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Reasoning:', result.reasoning);
+  console.log();
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(result.providerMetadata, null, 2),
+  );
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/stream-text/gateway-tool-parallel-search-params.ts
+++ b/examples/ai-functions/src/stream-text/gateway-tool-parallel-search-params.ts
@@ -1,0 +1,61 @@
+import { createGateway, streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const gateway = createGateway({
+    baseURL: 'http://localhost:3000/v1/ai',
+  });
+
+  const result = streamText({
+    model: gateway('openai/gpt-5-nano'),
+    prompt: `Search for the latest research on quantum computing breakthroughs.`,
+    tools: {
+      parallel_search: gateway.tools.parallelSearch({
+        mode: 'agentic',
+        maxResults: 5,
+        sourcePolicy: {
+          includeDomains: ['nature.com', 'arxiv.org', 'science.org'],
+        },
+        excerpts: {
+          maxCharsPerResult: 8000,
+        },
+      }),
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'reasoning-delta':
+        process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);
+        break;
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'tool-call':
+        console.log('\nTool call:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-result':
+        console.log('\nTool result:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-error':
+        console.log('\nTool error:', JSON.stringify(part, null, 2));
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Tool calls:', JSON.stringify(await result.toolCalls, null, 2));
+  console.log(
+    'Tool results:',
+    JSON.stringify(await result.toolResults, null, 2),
+  );
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(await result.providerMetadata, null, 2),
+  );
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/stream-text/gateway-tool-parallel-search.ts
+++ b/examples/ai-functions/src/stream-text/gateway-tool-parallel-search.ts
@@ -1,0 +1,48 @@
+import { gateway, streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: 'openai/gpt-5-nano',
+    prompt: `Search for current information about renewable energy developments in 2025.`,
+    tools: {
+      parallel_search: gateway.tools.parallelSearch(),
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'reasoning-delta':
+        process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);
+        break;
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'tool-call':
+        console.log('\nTool call:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-result':
+        console.log('\nTool result:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-error':
+        console.log('\nTool error:', JSON.stringify(part, null, 2));
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Tool calls:', JSON.stringify(await result.toolCalls, null, 2));
+  console.log(
+    'Tool results:',
+    JSON.stringify(await result.toolResults, null, 2),
+  );
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(await result.providerMetadata, null, 2),
+  );
+}
+
+main().catch(console.error);

--- a/packages/gateway/src/gateway-tools.ts
+++ b/packages/gateway/src/gateway-tools.ts
@@ -1,9 +1,20 @@
+import { parallelSearch } from './tool/parallel-search';
 import { perplexitySearch } from './tool/perplexity-search';
 
 /**
  * Gateway-specific provider-defined tools.
  */
 export const gatewayTools = {
+  /**
+   * Search the web using Parallel AI's Search API for LLM-optimized excerpts.
+   *
+   * Takes a natural language objective and returns relevant excerpts,
+   * replacing multiple keyword searches with a single call for broad
+   * or complex queries. Supports different search types for depth vs
+   * breadth tradeoffs.
+   */
+  parallelSearch,
+
   /**
    * Search the web using Perplexity's Search API for real-time information,
    * news, research papers, and articles.

--- a/packages/gateway/src/tool/parallel-search.ts
+++ b/packages/gateway/src/tool/parallel-search.ts
@@ -1,0 +1,295 @@
+import {
+  createProviderToolFactoryWithOutputSchema,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod';
+
+export interface ParallelSearchSourcePolicy {
+  /**
+   * List of domains to include in search results.
+   * Example: ['wikipedia.org', 'nature.com']
+   */
+  includeDomains?: string[];
+
+  /**
+   * List of domains to exclude from search results.
+   * Example: ['reddit.com', 'twitter.com']
+   */
+  excludeDomains?: string[];
+
+  /**
+   * Only include results published after this date (ISO 8601 format).
+   * Example: '2024-01-01'
+   */
+  afterDate?: string;
+}
+
+export interface ParallelSearchExcerpts {
+  /**
+   * Maximum characters per result.
+   */
+  maxCharsPerResult?: number;
+
+  /**
+   * Maximum total characters across all results.
+   */
+  maxCharsTotal?: number;
+}
+
+export interface ParallelSearchFetchPolicy {
+  /**
+   * Maximum age in seconds for cached content.
+   * Set to 0 to always fetch fresh content.
+   */
+  maxAgeSeconds?: number;
+}
+
+export interface ParallelSearchConfig {
+  /**
+   * Mode preset for different use cases:
+   * - "one-shot": Comprehensive results with longer excerpts for single-response answers (default)
+   * - "agentic": Concise, token-efficient results for multi-step agentic workflows
+   */
+  mode?: 'one-shot' | 'agentic';
+
+  /**
+   * Default maximum number of results to return (1-20).
+   * Defaults to 10 if not specified.
+   */
+  maxResults?: number;
+
+  /**
+   * Default source policy for controlling which domains to include/exclude.
+   */
+  sourcePolicy?: ParallelSearchSourcePolicy;
+
+  /**
+   * Default excerpt configuration for controlling result length.
+   */
+  excerpts?: ParallelSearchExcerpts;
+
+  /**
+   * Default fetch policy for controlling content freshness.
+   */
+  fetchPolicy?: ParallelSearchFetchPolicy;
+}
+
+export interface ParallelSearchResult {
+  /** URL of the search result */
+  url: string;
+  /** Title of the search result */
+  title: string;
+  /** Extracted text excerpt/content from the page */
+  excerpt: string;
+  /** Publication date of the content (may be null) */
+  publishDate?: string | null;
+  /** Relevance score for the result */
+  relevanceScore?: number;
+}
+
+export interface ParallelSearchResponse {
+  /** Unique identifier for this search request */
+  searchId: string;
+  /** Array of search results */
+  results: ParallelSearchResult[];
+}
+
+export interface ParallelSearchError {
+  /** Error type */
+  error:
+    | 'api_error'
+    | 'rate_limit'
+    | 'timeout'
+    | 'invalid_input'
+    | 'configuration_error'
+    | 'unknown';
+  /** HTTP status code if applicable */
+  statusCode?: number;
+  /** Human-readable error message */
+  message: string;
+}
+
+export interface ParallelSearchInput {
+  /**
+   * Natural-language description of the web research goal.
+   * Include source or freshness guidance and broader context from the task.
+   * Maximum 5000 characters.
+   */
+  objective: string;
+
+  /**
+   * Optional search queries to supplement the objective.
+   * Maximum 200 characters per query.
+   */
+  search_queries?: string[];
+
+  /**
+   * Mode preset for different use cases:
+   * - "one-shot": Comprehensive results with longer excerpts
+   * - "agentic": Concise, token-efficient results for multi-step workflows
+   */
+  mode?: 'one-shot' | 'agentic';
+
+  /**
+   * Maximum number of results to return (1-20).
+   * Defaults to 10 if not specified.
+   */
+  max_results?: number;
+
+  /**
+   * Source policy for controlling which domains to include/exclude.
+   */
+  source_policy?: {
+    include_domains?: string[];
+    exclude_domains?: string[];
+    after_date?: string;
+  };
+
+  /**
+   * Excerpt configuration for controlling result length.
+   */
+  excerpts?: {
+    max_chars_per_result?: number;
+    max_chars_total?: number;
+  };
+
+  /**
+   * Fetch policy for controlling content freshness.
+   */
+  fetch_policy?: {
+    max_age_seconds?: number;
+  };
+}
+
+export type ParallelSearchOutput = ParallelSearchResponse | ParallelSearchError;
+
+const parallelSearchInputSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      objective: z
+        .string()
+        .describe(
+          'Natural-language description of the web research goal, including source or freshness guidance and broader context from the task. Maximum 5000 characters.',
+        ),
+
+      search_queries: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Optional search queries to supplement the objective. Maximum 200 characters per query.',
+        ),
+
+      mode: z
+        .enum(['one-shot', 'agentic'])
+        .optional()
+        .describe(
+          'Mode preset: "one-shot" for comprehensive results with longer excerpts (default), "agentic" for concise, token-efficient results for multi-step workflows.',
+        ),
+
+      max_results: z
+        .number()
+        .optional()
+        .describe(
+          'Maximum number of results to return (1-20). Defaults to 10 if not specified.',
+        ),
+
+      source_policy: z
+        .object({
+          include_domains: z
+            .array(z.string())
+            .optional()
+            .describe('List of domains to include in search results.'),
+          exclude_domains: z
+            .array(z.string())
+            .optional()
+            .describe('List of domains to exclude from search results.'),
+          after_date: z
+            .string()
+            .optional()
+            .describe(
+              'Only include results published after this date (ISO 8601 format).',
+            ),
+        })
+        .optional()
+        .describe(
+          'Source policy for controlling which domains to include/exclude and freshness.',
+        ),
+
+      excerpts: z
+        .object({
+          max_chars_per_result: z
+            .number()
+            .optional()
+            .describe('Maximum characters per result.'),
+          max_chars_total: z
+            .number()
+            .optional()
+            .describe('Maximum total characters across all results.'),
+        })
+        .optional()
+        .describe('Excerpt configuration for controlling result length.'),
+
+      fetch_policy: z
+        .object({
+          max_age_seconds: z
+            .number()
+            .optional()
+            .describe(
+              'Maximum age in seconds for cached content. Set to 0 to always fetch fresh content.',
+            ),
+        })
+        .optional()
+        .describe('Fetch policy for controlling content freshness.'),
+    }),
+  ),
+);
+
+const parallelSearchOutputSchema = lazySchema(() =>
+  zodSchema(
+    z.union([
+      // Success response
+      z.object({
+        searchId: z.string(),
+        results: z.array(
+          z.object({
+            url: z.string(),
+            title: z.string(),
+            excerpt: z.string(),
+            publishDate: z.string().nullable().optional(),
+            relevanceScore: z.number().optional(),
+          }),
+        ),
+      }),
+      // Error response
+      z.object({
+        error: z.enum([
+          'api_error',
+          'rate_limit',
+          'timeout',
+          'invalid_input',
+          'configuration_error',
+          'unknown',
+        ]),
+        statusCode: z.number().optional(),
+        message: z.string(),
+      }),
+    ]),
+  ),
+);
+
+export const parallelSearchToolFactory =
+  createProviderToolFactoryWithOutputSchema<
+    ParallelSearchInput,
+    ParallelSearchOutput,
+    ParallelSearchConfig
+  >({
+    id: 'gateway.parallel_search',
+    inputSchema: parallelSearchInputSchema,
+    outputSchema: parallelSearchOutputSchema,
+  });
+
+export const parallelSearch = (
+  config: ParallelSearchConfig = {},
+): ReturnType<typeof parallelSearchToolFactory> =>
+  parallelSearchToolFactory(config);


### PR DESCRIPTION
## Background

AI Gateway is adding support for the parallel.ai search tool.

## Summary

Added a new Parallel Search tool to the AI SDK Gateway provider that enables models to search the web using Parallel AI's Search API. This tool is optimized for LLM consumption and supports different search types for depth vs breadth tradeoffs.

## Manual Verification

Tested the Parallel Search tool with both `generateText` and `streamText` functions using various search queries and configuration options. Verified that the tool correctly processes natural language objectives and returns relevant search results in the expected format.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)