### PR TITLE
chore(openai-compatible): add docs to package

### DIFF
--- a/.changeset/long-knives-mate.md
+++ b/.changeset/long-knives-mate.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+chore(openai-compatible): add docs to package

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -89,6 +89,17 @@ You can use the following optional settings to customize the provider instance:
 
   Set to true if the provider supports structured outputs. Only relevant for `provider()`, `provider.chatModel()`, and `provider.languageModel()`.
 
+- **transformRequestBody** _(args: Record&lt;string, any&gt;) =&gt; Record&lt;string, any&gt;_
+
+  Optional function to transform the request body before sending it to the API.
+  This is useful for proxy providers that may require a different request format
+  than the official OpenAI API.
+
+- **metadataExtractor** _MetadataExtractor_
+
+  Optional metadata extractor to capture provider-specific metadata from API responses.
+  See [Custom Metadata Extraction](#custom-metadata-extraction) for details.
+
 ## Language Models
 
 You can create provider models using a provider instance.
@@ -97,6 +108,23 @@ The first argument is the model id, e.g. `model-id`.
 ```ts
 const model = provider('model-id');
 ```
+
+You can also use the following factory methods:
+
+- `provider.languageModel('model-id')` - creates a chat language model (same as `provider('model-id')`)
+- `provider.chatModel('model-id')` - creates a chat language model
+
+### Supported Capabilities
+
+Chat models created with this provider support the following capabilities:
+
+- **Text generation** - Generate text completions
+- **Streaming** - Stream text responses in real-time
+- **Tool calling** - Call tools/functions with streaming support
+- **Structured outputs** - Generate JSON with schema validation (when `supportsStructuredOutputs` is enabled)
+- **Reasoning content** - Support for models that return reasoning/thinking tokens (e.g., DeepSeek R1)
+- **System messages** - Support for system prompts
+- **Multi-modal inputs** - Support for images and other content types (provider-dependent)
 
 ### Example
 
@@ -139,10 +167,13 @@ type ExampleEmbeddingModelIds =
   | 'bert-base-uncased'
   | (string & {});
 
+type ExampleImageModelIds = 'dall-e-3' | 'stable-diffusion-xl' | (string & {});
+
 const model = createOpenAICompatible<
   ExampleChatModelIds,
   ExampleCompletionModelIds,
-  ExampleEmbeddingModelIds
+  ExampleEmbeddingModelIds,
+  ExampleImageModelIds
 >({
   name: 'example',
   apiKey: process.env.PROVIDER_API_KEY,
@@ -274,6 +305,158 @@ const { images } = await generateImage({
   URL-based images and convert them to the appropriate format.
 </Note>
 
+## Embedding Models
+
+You can create embedding models using the `.embeddingModel()` factory method:
+
+```ts
+const model = provider.embeddingModel('model-id');
+```
+
+### Example
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { embed } from 'ai';
+
+const provider = createOpenAICompatible({
+  name: 'providerName',
+  apiKey: process.env.PROVIDER_API_KEY,
+  baseURL: 'https://api.provider.com/v1',
+});
+
+const { embedding } = await embed({
+  model: provider.embeddingModel('text-embedding-model'),
+  value: 'The quick brown fox jumps over the lazy dog',
+});
+```
+
+### Embedding Model Options
+
+The following provider options are available for embedding models via `providerOptions`:
+
+- **dimensions** _number_
+
+  The number of dimensions the resulting output embeddings should have.
+  Only supported in models that allow dimension configuration.
+
+- **user** _string_
+
+  A unique identifier representing your end-user, which can help providers to
+  monitor and detect abuse.
+
+```ts
+const { embedding } = await embed({
+  model: provider.embeddingModel('text-embedding-model'),
+  value: 'The quick brown fox jumps over the lazy dog',
+  providerOptions: {
+    providerName: {
+      dimensions: 512,
+      user: 'user-123',
+    },
+  },
+});
+```
+
+## Completion Models
+
+You can create completion models (for text completion, not chat) using the `.completionModel()` factory method:
+
+```ts
+const model = provider.completionModel('model-id');
+```
+
+### Example
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText } from 'ai';
+
+const provider = createOpenAICompatible({
+  name: 'providerName',
+  apiKey: process.env.PROVIDER_API_KEY,
+  baseURL: 'https://api.provider.com/v1',
+});
+
+const { text } = await generateText({
+  model: provider.completionModel('completion-model-id'),
+  prompt: 'The quick brown fox',
+});
+```
+
+### Completion Model Options
+
+The following provider options are available for completion models via `providerOptions`:
+
+- **echo** _boolean_
+
+  Echo back the prompt in addition to the completion.
+
+- **logitBias** _Record&lt;string, number&gt;_
+
+  Modify the likelihood of specified tokens appearing in the completion.
+  Accepts a JSON object that maps tokens (specified by their token ID) to an
+  associated bias value from -100 to 100.
+
+- **suffix** _string_
+
+  The suffix that comes after a completion of inserted text.
+
+- **user** _string_
+
+  A unique identifier representing your end-user, which can help providers to
+  monitor and detect abuse.
+
+```ts
+const { text } = await generateText({
+  model: provider.completionModel('completion-model-id'),
+  prompt: 'The quick brown fox',
+  providerOptions: {
+    providerName: {
+      echo: true,
+      suffix: ' The end.',
+      user: 'user-123',
+    },
+  },
+});
+```
+
+## Chat Model Options
+
+The following provider options are available for chat models via `providerOptions`:
+
+- **user** _string_
+
+  A unique identifier representing your end-user, which can help the provider to
+  monitor and detect abuse.
+
+- **reasoningEffort** _string_
+
+  Reasoning effort for reasoning models. The exact values depend on the provider.
+
+- **textVerbosity** _string_
+
+  Controls the verbosity of the generated text. The exact values depend on the provider.
+
+- **strictJsonSchema** _boolean_
+
+  Whether to use strict JSON schema validation. When true, the model uses constrained
+  decoding to guarantee schema compliance. Only used when the provider supports
+  structured outputs and a schema is provided. Defaults to `true`.
+
+```ts
+const { text } = await generateText({
+  model: provider('model-id'),
+  prompt: 'Solve this step by step: What is 15 * 23?',
+  providerOptions: {
+    providerName: {
+      user: 'user-123',
+      reasoningEffort: 'high',
+    },
+  },
+});
+```
+
 ## Provider-specific options
 
 The OpenAI Compatible provider supports adding provider-specific options to the request body. These are specified with the `providerOptions` field in the request body.
@@ -322,6 +505,8 @@ Metadata extractors work with both streaming and non-streaming chat completions 
 Here's an example metadata extractor that captures both standard and custom provider data:
 
 ```typescript
+import { MetadataExtractor } from '@ai-sdk/openai-compatible';
+
 const myMetadataExtractor: MetadataExtractor = {
   // Process complete, non-streaming responses
   extractMetadata: ({ parsedBody }) => {

--- a/packages/openai-compatible/package.json
+++ b/packages/openai-compatible/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "docs/**/*",
     "src",
     "!src/**/*.test.ts",
     "!src/**/*.test-d.ts",
@@ -17,10 +18,15 @@
     "README.md",
     "internal.d.ts"
   ],
+  "directories": {
+    "doc": "./docs"
+  },
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
     "build:watch": "pnpm clean && tsup --watch",
-    "clean": "del-cli dist *.tsbuildinfo",
+    "clean": "del-cli dist docs *.tsbuildinfo",
+    "prepack": "mkdir -p docs && cp ../../content/providers/02-openai-compatible-providers/index.mdx ./docs/",
+    "postpack": "del-cli docs",
     "lint": "eslint \"./**/*.ts*\"",
     "type-check": "tsc --build",
     "prettier-check": "prettier --check \"./**/*.ts*\"",


### PR DESCRIPTION
## Background

The documentation for the `openai-compatible` provider was outdated and not included in the npm package.

## Summary

- include docs page in openai-compatible provider npm package
- update openai-compatible docs page
