### PR TITLE
chore: fix package name typo

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@example/ai-functionstions",
+  "name": "@example/ai-functions",
   "version": "0.0.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
typo in the example package name