### PR TITLE
fix(ai): improve type validation error messages with field paths and entity identifiers

### DIFF
--- a/.changeset/early-elephants-play.md
+++ b/.changeset/early-elephants-play.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/provider': patch
+'ai': patch
+---
+
+fix: improve type validation error messages with field paths and entity identifiers

--- a/.changeset/early-elephants-play.md
+++ b/.changeset/early-elephants-play.md
@@ -4,4 +4,4 @@
 'ai': patch
 ---
 
-fix: improve type validation error messages with field paths and entity identifiers
+fix(ai): improve type validation error messages with field paths and entity identifiers

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -1,3 +1,4 @@
+import { TypeValidationContext } from '@ai-sdk/provider';
 import { FlexibleSchema, validateTypes } from '@ai-sdk/provider-utils';
 import { UIMessageStreamError } from '../error/ui-message-stream-error';
 import { ProviderMetadata } from '../types';
@@ -288,6 +289,10 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 await validateTypes({
                   value: mergedMetadata,
                   schema: messageMetadataSchema,
+                  context: {
+                    field: 'message.metadata',
+                    entityId: state.message.id,
+                  },
                 });
               }
 
@@ -710,9 +715,24 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               if (isDataUIMessageChunk(chunk)) {
                 // validate data chunk if dataPartSchemas is provided
                 if (dataPartSchemas?.[chunk.type] != null) {
+                  const partIdx = state.message.parts.findIndex(
+                    p =>
+                      'id' in p &&
+                      'data' in p &&
+                      p.id === chunk.id &&
+                      p.type === chunk.type,
+                  );
+                  const actualPartIdx =
+                    partIdx >= 0 ? partIdx : state.message.parts.length;
+
                   await validateTypes({
                     value: chunk.data,
                     schema: dataPartSchemas[chunk.type],
+                    context: {
+                      field: `message.parts[${actualPartIdx}].data`,
+                      entityName: chunk.type,
+                      entityId: chunk.id,
+                    },
                   });
                 }
 

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -172,7 +172,7 @@ describe('validateUIMessages', () => {
           }),
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        [AI_TypeValidationError: Type validation failed: Value: {"foo":123}.
+        [AI_TypeValidationError: Type validation failed for messages[0].metadata (id: "1"): Value: {"foo":123}.
         Error message: [
           {
             "expected": "string",
@@ -512,7 +512,7 @@ describe('validateUIMessages', () => {
           },
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        [AI_TypeValidationError: Type validation failed: Value: {"foo":123}.
+        [AI_TypeValidationError: Type validation failed for messages[0].parts[0].data (foo): Value: {"foo":123}.
         Error message: [
           {
             "expected": "string",
@@ -541,7 +541,7 @@ describe('validateUIMessages', () => {
           },
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        [AI_TypeValidationError: Type validation failed: Value: {"foo":"bar"}.
+        [AI_TypeValidationError: Type validation failed for messages[0].parts[0].data (bar): Value: {"foo":"bar"}.
         Error message: No data schema found for data part bar]
       `);
     });
@@ -1142,7 +1142,7 @@ describe('validateUIMessages', () => {
           },
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        [AI_TypeValidationError: Type validation failed: Value: {"foo":"bar"}.
+        [AI_TypeValidationError: Type validation failed for messages[0].parts[0].input (bar, id: "1"): Value: {"foo":"bar"}.
         Error message: No tool schema found for tool part bar]
       `);
     });
@@ -1170,7 +1170,7 @@ describe('validateUIMessages', () => {
           },
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        [AI_TypeValidationError: Type validation failed: Value: {"foo":123}.
+        [AI_TypeValidationError: Type validation failed for messages[0].parts[0].input (foo, id: "1"): Value: {"foo":123}.
         Error message: [
           {
             "expected": "string",
@@ -1208,7 +1208,7 @@ describe('validateUIMessages', () => {
           },
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
-        [AI_TypeValidationError: Type validation failed: Value: {"result":123}.
+        [AI_TypeValidationError: Type validation failed for messages[0].parts[0].output (foo, id: "1"): Value: {"result":123}.
         Error message: [
           {
             "expected": "string",

--- a/packages/provider-utils/src/validate-types.ts
+++ b/packages/provider-utils/src/validate-types.ts
@@ -1,4 +1,4 @@
-import { TypeValidationError } from '@ai-sdk/provider';
+import { TypeValidationContext, TypeValidationError } from '@ai-sdk/provider';
 import { FlexibleSchema, asSchema } from './schema';
 
 /**
@@ -8,19 +8,22 @@ import { FlexibleSchema, asSchema } from './schema';
  * @template T - The type of the object to validate.
  * @param {string} options.value - The object to validate.
  * @param {Validator<T>} options.schema - The schema to use for validating the JSON.
+ * @param {TypeValidationContext} options.context - Optional context about what is being validated.
  * @returns {Promise<T>} - The typed object.
  */
 export async function validateTypes<OBJECT>({
   value,
   schema,
+  context,
 }: {
   value: unknown;
   schema: FlexibleSchema<OBJECT>;
+  context?: TypeValidationContext;
 }): Promise<OBJECT> {
-  const result = await safeValidateTypes({ value, schema });
+  const result = await safeValidateTypes({ value, schema, context });
 
   if (!result.success) {
-    throw TypeValidationError.wrap({ value, cause: result.error });
+    throw TypeValidationError.wrap({ value, cause: result.error, context });
   }
 
   return result.value;
@@ -33,14 +36,17 @@ export async function validateTypes<OBJECT>({
  * @template T - The type of the object to validate.
  * @param {string} options.value - The JSON object to validate.
  * @param {Validator<T>} options.schema - The schema to use for validating the JSON.
+ * @param {TypeValidationContext} options.context - Optional context about what is being validated.
  * @returns An object with either a `success` flag and the parsed and typed data, or a `success` flag and an error object.
  */
 export async function safeValidateTypes<OBJECT>({
   value,
   schema,
+  context,
 }: {
   value: unknown;
   schema: FlexibleSchema<OBJECT>;
+  context?: TypeValidationContext;
 }): Promise<
   | {
       success: true;
@@ -68,13 +74,13 @@ export async function safeValidateTypes<OBJECT>({
 
     return {
       success: false,
-      error: TypeValidationError.wrap({ value, cause: result.error }),
+      error: TypeValidationError.wrap({ value, cause: result.error, context }),
       rawValue: value,
     };
   } catch (error) {
     return {
       success: false,
-      error: TypeValidationError.wrap({ value, cause: error }),
+      error: TypeValidationError.wrap({ value, cause: error, context }),
       rawValue: value,
     };
   }

--- a/packages/provider/src/errors/index.ts
+++ b/packages/provider/src/errors/index.ts
@@ -11,5 +11,6 @@ export { LoadSettingError } from './load-setting-error';
 export { NoContentGeneratedError } from './no-content-generated-error';
 export { NoSuchModelError } from './no-such-model-error';
 export { TooManyEmbeddingValuesForCallError } from './too-many-embedding-values-for-call-error';
+export type { TypeValidationContext } from './type-validation-error';
 export { TypeValidationError } from './type-validation-error';
 export { UnsupportedFunctionalityError } from './unsupported-functionality-error';

--- a/packages/provider/src/errors/type-validation-error.ts
+++ b/packages/provider/src/errors/type-validation-error.ts
@@ -5,22 +5,68 @@ const name = 'AI_TypeValidationError';
 const marker = `vercel.ai.error.${name}`;
 const symbol = Symbol.for(marker);
 
+export interface TypeValidationContext {
+  /**
+   * Field path in dot notation (e.g., "message.metadata", "message.parts[3].data")
+   */
+  field?: string;
+
+  /**
+   * Entity name (e.g., tool name, data type name)
+   */
+  entityName?: string;
+
+  /**
+   * Entity identifier (e.g., message ID, tool call ID)
+   */
+  entityId?: string;
+}
+
 export class TypeValidationError extends AISDKError {
   private readonly [symbol] = true; // used in isInstance
 
   readonly value: unknown;
+  readonly context?: TypeValidationContext;
 
-  constructor({ value, cause }: { value: unknown; cause: unknown }) {
+  constructor({
+    value,
+    cause,
+    context,
+  }: {
+    value: unknown;
+    cause: unknown;
+    context?: TypeValidationContext;
+  }) {
+    let contextPrefix = 'Type validation failed';
+
+    if (context?.field) {
+      contextPrefix += ` for ${context.field}`;
+    }
+
+    if (context?.entityName || context?.entityId) {
+      contextPrefix += ' (';
+      const parts: string[] = [];
+      if (context.entityName) {
+        parts.push(context.entityName);
+      }
+      if (context.entityId) {
+        parts.push(`id: "${context.entityId}"`);
+      }
+      contextPrefix += parts.join(', ');
+      contextPrefix += ')';
+    }
+
     super({
       name,
       message:
-        `Type validation failed: ` +
+        `${contextPrefix}: ` +
         `Value: ${JSON.stringify(value)}.\n` +
         `Error message: ${getErrorMessage(cause)}`,
       cause,
     });
 
     this.value = value;
+    this.context = context;
   }
 
   static isInstance(error: unknown): error is TypeValidationError {
@@ -29,23 +75,34 @@ export class TypeValidationError extends AISDKError {
 
   /**
    * Wraps an error into a TypeValidationError.
-   * If the cause is already a TypeValidationError with the same value, it returns the cause.
+   * If the cause is already a TypeValidationError with the same value and context, it returns the cause.
    * Otherwise, it creates a new TypeValidationError.
    *
    * @param {Object} params - The parameters for wrapping the error.
    * @param {unknown} params.value - The value that failed validation.
    * @param {unknown} params.cause - The original error or cause of the validation failure.
+   * @param {TypeValidationContext} params.context - Optional context about what is being validated.
    * @returns {TypeValidationError} A TypeValidationError instance.
    */
   static wrap({
     value,
     cause,
+    context,
   }: {
     value: unknown;
     cause: unknown;
+    context?: TypeValidationContext;
   }): TypeValidationError {
-    return TypeValidationError.isInstance(cause) && cause.value === value
-      ? cause
-      : new TypeValidationError({ value, cause });
+    if (
+      TypeValidationError.isInstance(cause) &&
+      cause.value === value &&
+      cause.context?.field === context?.field &&
+      cause.context?.entityName === context?.entityName &&
+      cause.context?.entityId === context?.entityId
+    ) {
+      return cause;
+    }
+
+    return new TypeValidationError({ value, cause, context });
   }
 }


### PR DESCRIPTION
## Background

Validation errors from `safeValidateUIMessages` and streaming validation lacked context about what was being validated, making debugging difficult.

**Before:**
```
Type validation failed: Value: undefined.
Error message: Required
```

**After:**
```
Type validation failed for messages[0].metadata (id: "msg-123"): Value: undefined.
Error message: Required
```

Alternative to #10154: This PR focuses on addressing the lack of context closer to the root, and includes the full field identifier to help finding the culprit more quickly.

## Summary

Added optional context tracking to `TypeValidationError` to include field paths (e.g., `messages[0].parts[1].data`) and entity identifiers (e.g., message ID, tool call ID) in validation error messages.

**Approach:**
- Introduced `TypeValidationContext` interface with `field`, `entityName`, and `entityId` properties
- Extended `TypeValidationError` and validation utilities to accept and format context
- Updated all validation call sites in `validate-ui-messages.ts` and `process-ui-message-stream.ts` to provide context with index tracking

The change is backward compatible (context is optional) and includes a minor performance improvement by consolidating data/tool validation into a single loop.

## Manual Verification

To verify the improved error messages:

```typescript
import { validateUIMessages } from 'ai';
import { z } from 'zod';

try {
  await validateUIMessages({
    messages: [{
      id: 'msg-123',
      role: 'user',
      metadata: { userId: 123 }, // wrong type
      parts: [{ type: 'text', text: 'Hello' }],
    }],
    metadataSchema: z.object({ userId: z.string() }),
  });
} catch (error) {
  console.log(error.message);
  // Shows: "Type validation failed for messages[0].metadata (id: "msg-123"): ..."
}
```

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Issue #10137 also mentions fixing documentation for metadata schema examples. That's not the primary issue raised though, and will be addressed in a separate PR.

## Related Issues

Fixes #10137
