### PR TITLE
fix(anthropic): add insert_text param to text_editor_20250728 schema

### DIFF
--- a/packages/anthropic/src/tool/text-editor_20250728.ts
+++ b/packages/anthropic/src/tool/text-editor_20250728.ts
@@ -18,6 +18,7 @@ const textEditor_20250728InputSchema = lazySchema(() =>
       file_text: z.string().optional(),
       insert_line: z.number().int().optional(),
       new_str: z.string().optional(),
+      insert_text: z.string().optional(),
       old_str: z.string().optional(),
       view_range: z.array(z.number().int()).optional(),
     }),
@@ -51,6 +52,12 @@ const factory = createProviderToolFactory<
      * Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.
      */
     new_str?: string;
+
+    /**
+     * Alternative parameter name for `insert` command containing the string to insert.
+     * Claude models output this field instead of `new_str` for insert operations.
+     */
+    insert_text?: string;
 
     /**
      * Required parameter of `str_replace` command containing the string in `path` to replace.


### PR DESCRIPTION
## Description

Claude models output `insert_text` (not `new_str`) for the insert command in the text_editor tool. This causes Zod to strip the field as an unrecognized key, breaking insert operations.

This PR adds `insert_text` to the Zod schema and TypeScript interface for `text_editor_20250728`.

## Reproduction

```bash
curl https://api.anthropic.com/v1/messages \
  -H "x-api-key: $ANTHROPIC_API_KEY" \
  -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d '{
    "model":"claude-opus-4-5",
    "max_tokens":200,
    "tools":[{"type":"text_editor_20250728","name":"str_replace_based_edit_tool"}],
    "messages":[{"role":"user","content":"Call insert to add HELLO after line 2 of /tmp/test.txt"}],
    "tool_choice":{"type":"tool","name":"str_replace_based_edit_tool"}
  }'
```

**Claude outputs:**
```json
{
  "command": "insert",
  "path": "/tmp/test.txt",
  "insert_line": 2,
  "insert_text": "HELLO\n"
}
```

## Changes

- Added `insert_text: z.string().optional()` to Zod schema
- Added `insert_text?: string` to TypeScript interface with JSDoc

Fixes #12091