### PR TITLE
fix(ci): use github api for changed files in triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
 
       - name: Fetch existing labels
         id: fetch-labels
@@ -47,10 +48,9 @@ jobs:
       - name: Get changed file paths
         id: get-changed-files
         run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
-          changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD)
-          echo "changed_files=$changed_files"
-          echo "changed_files=$changed_files" >> $GITHUB_OUTPUT
+          files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD)
+          echo "files=$files"
+          echo "files=$files" >> $GITHUB_OUTPUT
 
       - name: Determine appropriate labels
         id: classify-issue


### PR DESCRIPTION
## background

triage workflow fails for PRs targeting `release-v5.0` because shallow checkout doesn't have enough history to find merge base:
```
fatal: origin/release-v5.0...HEAD: no merge base
```

also, output variable was `changed_files` but prompt referenced `outputs.files`

## summary

- add `fetch-depth: 0` to checkout step to fetch full history
- fix output variable name from `changed_files` to `files`
- remove redundant `git fetch` command

## checklist

- [ ] tests have been added / updated (n/a - ci workflow)
- [ ] documentation has been added / updated (n/a)
- [ ] a _patch_ changeset for relevant packages has been added (n/a)
- [x] i have reviewed this pull request