### PR TITLE
feat(amazon-bedrock): add TTL support for prompt caching

### DIFF
--- a/.changeset/gentle-humans-smash.md
+++ b/.changeset/gentle-humans-smash.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+add TTL support for prompt caching

--- a/packages/amazon-bedrock/src/bedrock-api-types.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-api-types.test.ts
@@ -1,0 +1,22 @@
+import { createBedrockCachePoint } from './bedrock-api-types';
+import { describe, it, expect } from 'vitest';
+
+describe('createBedrockCachePoint', () => {
+  it('should return default cache point when no TTL is provided', () => {
+    const result = createBedrockCachePoint();
+
+    expect(result).toEqual({ cachePoint: { type: 'default' } });
+  });
+
+  it('should create cache point with 5m TTL', () => {
+    const result = createBedrockCachePoint('5m');
+
+    expect(result).toEqual({ cachePoint: { type: 'default', ttl: '5m' } });
+  });
+
+  it('should create cache point with 1h TTL', () => {
+    const result = createBedrockCachePoint('1h');
+
+    expect(result).toEqual({ cachePoint: { type: 'default', ttl: '1h' } });
+  });
+});

--- a/packages/amazon-bedrock/src/bedrock-api-types.ts
+++ b/packages/amazon-bedrock/src/bedrock-api-types.ts
@@ -35,11 +35,31 @@ export interface BedrockUserMessage {
   content: Array<BedrockContentBlock>;
 }
 
-export const BEDROCK_CACHE_POINT = {
-  cachePoint: { type: 'default' },
-} as const;
+/**
+ * Cache TTL options for Bedrock prompt caching.
+ * @see https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+ *
+ * - '5m': 5-minute TTL (default, supported by all models)
+ * - '1h': 1-hour TTL (supported by Claude Opus 4.5, Claude Haiku 4.5, Claude Sonnet 4.5)
+ */
+export type BedrockCacheTTL = '5m' | '1h';
 
-export type BedrockCachePoint = { cachePoint: { type: 'default' } };
+export type BedrockCachePoint = {
+  cachePoint: { type: 'default'; ttl?: BedrockCacheTTL };
+};
+
+/**
+ * Creates a cache point with an optional TTL.
+ * @param ttl - Cache TTL ('5m' or '1h'). If not provided, uses the default 5-minute TTL.
+ */
+export function createBedrockCachePoint(
+  ttl?: BedrockCacheTTL,
+): BedrockCachePoint {
+  return {
+    cachePoint: { type: 'default', ttl },
+  };
+}
+
 export type BedrockSystemContentBlock = { text: string } | BedrockCachePoint;
 
 export interface BedrockGuardrailConfiguration {

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -35,6 +35,46 @@ describe('system messages', () => {
       messages: [],
     });
   });
+
+  it('should add cache point with 5m TTL to system message', async () => {
+    const result = await convertToBedrockChatMessages([
+      {
+        role: 'system',
+        content: 'Hello',
+        providerOptions: {
+          bedrock: { cachePoint: { type: 'default', ttl: '5m' } },
+        },
+      },
+    ]);
+
+    expect(result).toEqual({
+      system: [
+        { text: 'Hello' },
+        { cachePoint: { type: 'default', ttl: '5m' } },
+      ],
+      messages: [],
+    });
+  });
+
+  it('should add cache point with 1h TTL to system message', async () => {
+    const result = await convertToBedrockChatMessages([
+      {
+        role: 'system',
+        content: 'Hello',
+        providerOptions: {
+          bedrock: { cachePoint: { type: 'default', ttl: '1h' } },
+        },
+      },
+    ]);
+
+    expect(result).toEqual({
+      system: [
+        { text: 'Hello' },
+        { cachePoint: { type: 'default', ttl: '1h' } },
+      ],
+      messages: [],
+    });
+  });
 });
 
 describe('user messages', () => {
@@ -269,6 +309,56 @@ describe('user messages', () => {
       system: [],
     });
   });
+
+  it('should add cache point with 5m TTL to user message', async () => {
+    const result = await convertToBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+        providerOptions: {
+          bedrock: { cachePoint: { type: 'default', ttl: '5m' } },
+        },
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { text: 'Hello' },
+            { cachePoint: { type: 'default', ttl: '5m' } },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
+
+  it('should add cache point with 1h TTL to user message', async () => {
+    const result = await convertToBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+        providerOptions: {
+          bedrock: { cachePoint: { type: 'default', ttl: '1h' } },
+        },
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { text: 'Hello' },
+            { cachePoint: { type: 'default', ttl: '1h' } },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
 });
 
 describe('assistant messages', () => {
@@ -398,6 +488,56 @@ describe('assistant messages', () => {
         {
           role: 'assistant',
           content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
+        },
+      ],
+      system: [],
+    });
+  });
+
+  it('should add cache point with 5m TTL to assistant message', async () => {
+    const result = await convertToBedrockChatMessages([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello' }],
+        providerOptions: {
+          bedrock: { cachePoint: { type: 'default', ttl: '5m' } },
+        },
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { text: 'Hello' },
+            { cachePoint: { type: 'default', ttl: '5m' } },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
+
+  it('should add cache point with 1h TTL to assistant message', async () => {
+    const result = await convertToBedrockChatMessages([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello' }],
+        providerOptions: {
+          bedrock: { cachePoint: { type: 'default', ttl: '1h' } },
+        },
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { text: 'Hello' },
+            { cachePoint: { type: 'default', ttl: '1h' } },
+          ],
         },
       ],
       system: [],

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -7,7 +7,6 @@ import {
 } from '@ai-sdk/provider';
 import { convertToBase64, parseProviderOptions } from '@ai-sdk/provider-utils';
 import {
-  BEDROCK_CACHE_POINT,
   BEDROCK_DOCUMENT_MIME_TYPES,
   BEDROCK_IMAGE_MIME_TYPES,
   BedrockAssistantMessage,
@@ -27,7 +26,15 @@ import { normalizeToolCallId } from './normalize-tool-call-id';
 function getCachePoint(
   providerMetadata: SharedV3ProviderMetadata | undefined,
 ): BedrockCachePoint | undefined {
-  return providerMetadata?.bedrock?.cachePoint as BedrockCachePoint | undefined;
+  const cachePointConfig = providerMetadata?.bedrock?.cachePoint as
+    | BedrockCachePoint['cachePoint']
+    | undefined;
+
+  if (!cachePointConfig) {
+    return undefined;
+  }
+
+  return { cachePoint: cachePointConfig };
 }
 
 async function shouldEnableCitations(
@@ -73,8 +80,9 @@ export async function convertToBedrockChatMessages(
 
         for (const message of block.messages) {
           system.push({ text: message.content });
-          if (getCachePoint(message.providerOptions)) {
-            system.push(BEDROCK_CACHE_POINT);
+          const cachePoint = getCachePoint(message.providerOptions);
+          if (cachePoint) {
+            system.push(cachePoint);
           }
         }
         break;
@@ -220,8 +228,9 @@ export async function convertToBedrockChatMessages(
             }
           }
 
-          if (getCachePoint(providerOptions)) {
-            bedrockContent.push(BEDROCK_CACHE_POINT);
+          const cachePoint = getCachePoint(providerOptions);
+          if (cachePoint) {
+            bedrockContent.push(cachePoint);
           }
         }
 
@@ -316,8 +325,9 @@ export async function convertToBedrockChatMessages(
               }
             }
           }
-          if (getCachePoint(message.providerOptions)) {
-            bedrockContent.push(BEDROCK_CACHE_POINT);
+          const cachePoint = getCachePoint(message.providerOptions);
+          if (cachePoint) {
+            bedrockContent.push(cachePoint);
           }
         }
 


### PR DESCRIPTION
## Summary

- Add configurable TTL options ('5m' and '1h') for Bedrock prompt caching
- Add `BedrockCacheTTL` type and `createBedrockCachePoint()` helper function
- Update cache point handling to properly support TTL configuration
- Previously, cache points only used the default 5-minute TTL

The 1-hour TTL option is supported by Claude Opus 4.5, Claude Haiku 4.5, and Claude Sonnet 4.5.
