### PR TITLE
fix(amazon-bedrock/cohere): dimension option for cohere embedding models

### DIFF
--- a/.changeset/cohere-embeddings-output-dimension.md
+++ b/.changeset/cohere-embeddings-output-dimension.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/cohere': patch
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Add `outputDimension` option for Cohere embedding models to control the size of the output embedding vector (256, 512, 1024, or 1536).
+
+Unify Bedrock embedding dimension options into a single `dimensions` parameter that maps to the correct API field based on model family (Titan, Nova, or Cohere).

--- a/.changeset/cohere-embeddings-output-dimension.md
+++ b/.changeset/cohere-embeddings-output-dimension.md
@@ -4,5 +4,3 @@
 ---
 
 Add `outputDimension` option for Cohere embedding models to control the size of the output embedding vector (256, 512, 1024, or 1536).
-
-Unify Bedrock embedding dimension options into a single `dimensions` parameter that maps to the correct API field based on model family (Titan, Nova, or Cohere).

--- a/examples/ai-functions/src/embed/amazon-bedrock-cohere-dimensions.ts
+++ b/examples/ai-functions/src/embed/amazon-bedrock-cohere-dimensions.ts
@@ -3,13 +3,13 @@ import { embed } from 'ai';
 import { run } from '../lib/run';
 
 run(async () => {
-  // dimensions: 256, 512, 1024, or 1536 (default)
+  // outputDimension: 256, 512, 1024, or 1536 (default)
   const { embedding, usage, warnings } = await embed({
     model: bedrock.embedding('cohere.embed-v4:0'),
     value: 'sunny day at the beach',
     providerOptions: {
       bedrock: {
-        dimensions: 256,
+        outputDimension: 256,
       },
     },
   });

--- a/examples/ai-functions/src/embed/amazon-bedrock-cohere-dimensions.ts
+++ b/examples/ai-functions/src/embed/amazon-bedrock-cohere-dimensions.ts
@@ -1,0 +1,20 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { embed } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  // dimensions: 256, 512, 1024, or 1536 (default)
+  const { embedding, usage, warnings } = await embed({
+    model: bedrock.embedding('cohere.embed-v4:0'),
+    value: 'sunny day at the beach',
+    providerOptions: {
+      bedrock: {
+        dimensions: 256,
+      },
+    },
+  });
+
+  console.log(embedding);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/examples/ai-functions/src/embed/cohere-output-dimension.ts
+++ b/examples/ai-functions/src/embed/cohere-output-dimension.ts
@@ -1,0 +1,20 @@
+import { cohere } from '@ai-sdk/cohere';
+import { embed } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  // outputDimension: 256, 512, 1024, or 1536 (default)
+  const { embedding, usage, warnings } = await embed({
+    model: cohere.embedding('embed-v4.0'),
+    value: 'sunny day at the beach',
+    providerOptions: {
+      cohere: {
+        outputDimension: 256,
+      },
+    },
+  });
+
+  console.log(embedding);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.test.ts
@@ -169,7 +169,7 @@ describe('doEmbed', () => {
     });
   });
 
-  it('should pass dimensions for Cohere v4 embedding models', async () => {
+  it('should pass outputDimension for Cohere v4 embedding models', async () => {
     const cohereV4Model = new BedrockEmbeddingModel('cohere.embed-v4:0', {
       baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
       headers: mockConfigHeaders,
@@ -180,7 +180,7 @@ describe('doEmbed', () => {
       values: [testValues[0]],
       providerOptions: {
         bedrock: {
-          dimensions: 256,
+          outputDimension: 256,
         },
       },
     });
@@ -314,12 +314,12 @@ describe('should support Nova embeddings', () => {
     });
   });
 
-  it('should pass dimensions for Nova embeddings', async () => {
+  it('should pass embeddingDimension for Nova embeddings', async () => {
     const { embeddings } = await model.doEmbed({
       values: [testValues[0]],
       providerOptions: {
         bedrock: {
-          dimensions: 256,
+          embeddingDimension: 256,
         },
       },
     });

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.ts
@@ -81,7 +81,7 @@ export class BedrockEmbeddingModel implements EmbeddingModelV3 {
           singleEmbeddingParams: {
             embeddingPurpose:
               bedrockOptions.embeddingPurpose ?? 'GENERIC_INDEX',
-            embeddingDimension: bedrockOptions.embeddingDimension ?? 1024,
+            embeddingDimension: bedrockOptions.dimensions ?? 1024,
             text: {
               truncationMode: bedrockOptions.truncate ?? 'END',
               value: values[0],
@@ -95,6 +95,7 @@ export class BedrockEmbeddingModel implements EmbeddingModelV3 {
             input_type: bedrockOptions.inputType ?? 'search_query',
             texts: [values[0]],
             truncate: bedrockOptions.truncate,
+            output_dimension: bedrockOptions.dimensions,
           }
         : {
             inputText: values[0],

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.ts
@@ -81,7 +81,7 @@ export class BedrockEmbeddingModel implements EmbeddingModelV3 {
           singleEmbeddingParams: {
             embeddingPurpose:
               bedrockOptions.embeddingPurpose ?? 'GENERIC_INDEX',
-            embeddingDimension: bedrockOptions.dimensions ?? 1024,
+            embeddingDimension: bedrockOptions.embeddingDimension ?? 1024,
             text: {
               truncationMode: bedrockOptions.truncate ?? 'END',
               value: values[0],
@@ -95,7 +95,7 @@ export class BedrockEmbeddingModel implements EmbeddingModelV3 {
             input_type: bedrockOptions.inputType ?? 'search_query',
             texts: [values[0]],
             truncate: bedrockOptions.truncate,
-            output_dimension: bedrockOptions.dimensions,
+            output_dimension: bedrockOptions.outputDimension,
           }
         : {
             inputText: values[0],

--- a/packages/amazon-bedrock/src/bedrock-embedding-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-options.ts
@@ -9,20 +9,27 @@ export type BedrockEmbeddingModelId =
 
 export const bedrockEmbeddingProviderOptions = z.object({
   /**
-   * The number of dimensions for the output embeddings.
-   *
-   * Supported values vary by model family:
-   * - Titan (`amazon.titan-embed-text-v2:0`): 256, 512, 1024 (default: 1024)
-   * - Nova (`amazon.nova-*`): 256, 384, 1024, 3072 (default: 1024)
-   * - Cohere (`cohere.embed-v4:0` and newer): 256, 512, 1024, 1536 (default: 1536)
+   * The number of dimensions the resulting output embeddings should have (defaults to 1024).
+   * Only supported in amazon.titan-embed-text-v2:0.
    */
-  dimensions: z.number().optional(),
+  dimensions: z
+    .union([z.literal(1024), z.literal(512), z.literal(256)])
+    .optional(),
 
   /**
    * Flag indicating whether or not to normalize the output embeddings. Defaults to true.
    * Only supported in amazon.titan-embed-text-v2:0.
    */
   normalize: z.boolean().optional(),
+
+  /**
+   * The number of dimensions for Nova embedding models (defaults to 1024).
+   * Supported values: 256, 384, 1024, 3072.
+   * Only supported in amazon.nova-* embedding models.
+   */
+  embeddingDimension: z
+    .union([z.literal(256), z.literal(384), z.literal(1024), z.literal(3072)])
+    .optional(),
 
   /**
    * The purpose of the embedding. Defaults to 'GENERIC_INDEX'.
@@ -56,4 +63,12 @@ export const bedrockEmbeddingProviderOptions = z.object({
    * Supported in Cohere and Nova embedding models. Defaults to 'END' for Nova models.
    */
   truncate: z.enum(['NONE', 'START', 'END']).optional(),
+
+  /**
+   * The number of dimensions the resulting output embeddings should have (defaults to 1536).
+   * Only supported in cohere.embed-v4:0 and newer Cohere embedding models.
+   */
+  outputDimension: z
+    .union([z.literal(256), z.literal(512), z.literal(1024), z.literal(1536)])
+    .optional(),
 });

--- a/packages/amazon-bedrock/src/bedrock-embedding-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-options.ts
@@ -9,27 +9,20 @@ export type BedrockEmbeddingModelId =
 
 export const bedrockEmbeddingProviderOptions = z.object({
   /**
-   * The number of dimensions the resulting output embeddings should have (defaults to 1024).
-   * Only supported in amazon.titan-embed-text-v2:0.
+   * The number of dimensions for the output embeddings.
+   *
+   * Supported values vary by model family:
+   * - Titan (`amazon.titan-embed-text-v2:0`): 256, 512, 1024 (default: 1024)
+   * - Nova (`amazon.nova-*`): 256, 384, 1024, 3072 (default: 1024)
+   * - Cohere (`cohere.embed-v4:0` and newer): 256, 512, 1024, 1536 (default: 1536)
    */
-  dimensions: z
-    .union([z.literal(1024), z.literal(512), z.literal(256)])
-    .optional(),
+  dimensions: z.number().optional(),
 
   /**
-   * Flag indicating whether or not to normalize the output embeddings. Defaults to true
+   * Flag indicating whether or not to normalize the output embeddings. Defaults to true.
    * Only supported in amazon.titan-embed-text-v2:0.
    */
   normalize: z.boolean().optional(),
-
-  /**
-   * The number of dimensions for Nova embedding models (defaults to 1024).
-   * Supported values: 256, 384, 1024, 3072.
-   * Only supported in amazon.nova-* embedding models.
-   */
-  embeddingDimension: z
-    .union([z.literal(256), z.literal(384), z.literal(1024), z.literal(3072)])
-    .optional(),
 
   /**
    * The purpose of the embedding. Defaults to 'GENERIC_INDEX'.

--- a/packages/cohere/src/cohere-embedding-model.test.ts
+++ b/packages/cohere/src/cohere-embedding-model.test.ts
@@ -111,6 +111,27 @@ describe('doEmbed', () => {
     });
   });
 
+  it('should pass the output_dimension setting', async () => {
+    prepareJsonResponse();
+
+    await provider.embeddingModel('embed-v4.0').doEmbed({
+      values: testValues,
+      providerOptions: {
+        cohere: {
+          outputDimension: 256,
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'embed-v4.0',
+      embedding_types: ['float'],
+      texts: testValues,
+      input_type: 'search_query',
+      output_dimension: 256,
+    });
+  });
+
   it('should pass headers', async () => {
     prepareJsonResponse();
 

--- a/packages/cohere/src/cohere-embedding-model.ts
+++ b/packages/cohere/src/cohere-embedding-model.ts
@@ -80,6 +80,7 @@ export class CohereEmbeddingModel implements EmbeddingModelV3 {
         texts: values,
         input_type: embeddingOptions?.inputType ?? 'search_query',
         truncate: embeddingOptions?.truncate,
+        output_dimension: embeddingOptions?.outputDimension,
       },
       failedResponseHandler: cohereFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(

--- a/packages/cohere/src/cohere-embedding-options.ts
+++ b/packages/cohere/src/cohere-embedding-options.ts
@@ -32,6 +32,17 @@ export const cohereEmbeddingOptions = z.object({
    * - "END": Will discard the end of the input until the remaining input is exactly the maximum input token length for the model.
    */
   truncate: z.enum(['NONE', 'START', 'END']).optional(),
+
+  /**
+   * The number of dimensions of the output embedding.
+   * Only available for `embed-v4.0` and newer models.
+   *
+   * Possible values are `256`, `512`, `1024`, and `1536`.
+   * The default is `1536`.
+   */
+  outputDimension: z
+    .union([z.literal(256), z.literal(512), z.literal(1024), z.literal(1536)])
+    .optional(),
 });
 
 export type CohereEmbeddingOptions = z.infer<typeof cohereEmbeddingOptions>;


### PR DESCRIPTION
## Background

Cohere's Embed v4 API supports an `output_dimension` parameter that allows controlling the size of the output embedding vector (256, 512, 1024, or 1536). This is useful for reducing storage costs and improving performance when full-dimension embeddings aren't needed.

## Summary

**Cohere Provider (`@ai-sdk/cohere`):**
- Add `outputDimension` option to `cohereEmbeddingOptions` schema (256, 512, 1024, 1536)
- Pass `output_dimension` to the Cohere API in embedding requests
- Add test coverage for the new option
- Add example demonstrating usage with `embed-v4.0`

**Amazon Bedrock Provider (`@ai-sdk/amazon-bedrock`):**
- Add `outputDimension` option for Cohere embedding models on Bedrock (matching the Cohere provider naming)
- Pass `output_dimension` to the Bedrock Cohere API
- Add test coverage for the new option
- Add example demonstrating usage with `cohere.embed-v4:0`

## Manual Verification

- Ran unit tests for both `@ai-sdk/cohere` and `@ai-sdk/amazon-bedrock` packages
- Verified the Cohere example against the real Cohere API with `embed-v4.0` model, confirming the embedding length matches the requested dimension (256)

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #12135 