### PR TITLE
feat(fal): add Kling motion control examples and improve type documentation

### DIFF
--- a/examples/ai-functions/src/generate-video/fal-kling-motion-local.ts
+++ b/examples/ai-functions/src/generate-video/fal-kling-motion-local.ts
@@ -1,0 +1,98 @@
+/**
+ * FAL Kling Motion Control - Local Files Example
+ *
+ * Transfers motion from a reference video to a character image.
+ * This version uploads local files to FAL storage first.
+ *
+ * Usage:
+ *   FAL_API_KEY="key" pnpm tsx src/generate-video/fal-kling-motion-local.ts <image-path> <video-path>
+ */
+
+import { fal } from '@ai-sdk/fal';
+import { fal as falClient } from '@fal-ai/client';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const args = process.argv.slice(2);
+if (args.length < 2) {
+  console.log(
+    'Usage: pnpm tsx src/generate-video/fal-kling-motion-local.ts <image-path> <video-path>',
+  );
+  process.exit(1);
+}
+
+const IMAGE_PATH = args[0];
+const VIDEO_PATH = args[1];
+
+if (!fs.existsSync(IMAGE_PATH)) {
+  console.error(`Error: Image not found: ${IMAGE_PATH}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(VIDEO_PATH)) {
+  console.error(`Error: Video not found: ${VIDEO_PATH}`);
+  process.exit(1);
+}
+
+async function uploadToFal(filePath: string): Promise<string> {
+  const buffer = fs.readFileSync(filePath);
+  const ext = path.extname(filePath).toLowerCase();
+  const mimeTypes: Record<string, string> = {
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.mp4': 'video/mp4',
+    '.webm': 'video/webm',
+    '.mov': 'video/quicktime',
+  };
+  const mimeType = mimeTypes[ext] || 'application/octet-stream';
+  const fileName = path.basename(filePath);
+
+  const file = new File([buffer], fileName, { type: mimeType });
+  return await falClient.storage.upload(file);
+}
+
+async function main() {
+  console.log('=== FAL Kling Motion Control (Local Files) ===\n');
+
+  // Upload files to FAL storage
+  console.log('Uploading image...');
+  const imageUrl = await uploadToFal(IMAGE_PATH);
+  console.log(`  → ${imageUrl}`);
+
+  console.log('Uploading video...');
+  const videoUrl = await uploadToFal(VIDEO_PATH);
+  console.log(`  → ${videoUrl}`);
+
+  console.log('\nGenerating video...');
+  const startTime = Date.now();
+
+  const result = await generateVideo({
+    model: fal.video('kling-video/v2.6/pro/motion-control'),
+    prompt: {
+      files: [imageUrl],
+      text: 'natural lighting, high quality',
+    },
+    providerOptions: {
+      fal: {
+        video_url: videoUrl,
+        character_orientation: 'image',
+        keep_original_sound: true,
+        pollTimeoutMs: 600000,
+      },
+    },
+  });
+
+  const elapsed = Math.round((Date.now() - startTime) / 1000);
+  console.log(`\nCompleted in ${elapsed}s`);
+
+  // Save video
+  const outputDir = path.join(process.cwd(), 'output');
+  if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
+  const outputPath = path.join(outputDir, `kling-motion-${Date.now()}.mp4`);
+  fs.writeFileSync(outputPath, Buffer.from(await result.video.uint8Array));
+  console.log('Saved to:', outputPath);
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/generate-video/fal-kling-motion.ts
+++ b/examples/ai-functions/src/generate-video/fal-kling-motion.ts
@@ -1,0 +1,59 @@
+/**
+ * FAL Kling Motion Control Example
+ *
+ * Transfers motion from a reference video to a character image.
+ *
+ * Usage:
+ *   FAL_API_KEY="key" pnpm tsx src/generate-video/fal-kling-motion.ts
+ */
+
+import { fal } from '@ai-sdk/fal';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// You'll need to provide URLs for your image and video
+// These can be:
+// - Public URLs (https://...)
+// - FAL storage URLs (https://v3b.fal.media/...)
+const CHARACTER_IMAGE_URL = 'YOUR_IMAGE_URL_HERE';
+const MOTION_VIDEO_URL = 'YOUR_VIDEO_URL_HERE';
+
+async function main() {
+  console.log('=== FAL Kling Motion Control ===\n');
+  console.log('Generating video...');
+  const startTime = Date.now();
+
+  const result = await generateVideo({
+    model: fal.video('kling-video/v2.6/pro/motion-control'),
+    prompt: {
+      // Pass the character image URL directly
+      files: [CHARACTER_IMAGE_URL],
+      text: 'natural lighting, high quality',
+    },
+    providerOptions: {
+      fal: {
+        // Reference video URL - motion will be transferred from this
+        video_url: MOTION_VIDEO_URL,
+        // Output orientation: 'image' or 'video'
+        character_orientation: 'image',
+        // Keep audio from reference video
+        keep_original_sound: true,
+        // Increase timeout for long generations
+        pollTimeoutMs: 600000, // 10 minutes
+      },
+    },
+  });
+
+  const elapsed = Math.round((Date.now() - startTime) / 1000);
+  console.log(`\nCompleted in ${elapsed}s`);
+
+  // Save the video
+  const outputDir = path.join(process.cwd(), 'output');
+  if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
+  const outputPath = path.join(outputDir, `kling-motion-${Date.now()}.mp4`);
+  fs.writeFileSync(outputPath, Buffer.from(await result.video.uint8Array));
+  console.log('Saved to:', outputPath);
+}
+
+main().catch(console.error);

--- a/packages/fal/src/fal-video-settings.ts
+++ b/packages/fal/src/fal-video-settings.ts
@@ -1,10 +1,35 @@
+/**
+ * FAL video model identifiers.
+ *
+ * @see https://fal.ai/models - Browse all FAL video models
+ *
+ * @example Text-to-video models
+ * ```typescript
+ * fal.video('luma-dream-machine')
+ * fal.video('hunyuan-video')
+ * ```
+ *
+ * @example Motion control (image + video → video)
+ * ```typescript
+ * // Requires image_url and video_url in providerOptions
+ * fal.video('kling-video/v2.6/pro/motion-control')
+ * ```
+ */
 export type FalVideoModelId =
+  // Luma models - text-to-video
   | 'luma-dream-machine'
   | 'luma-ray-2'
   | 'luma-ray-2-flash'
+  // Minimax models - text-to-video
   | 'minimax-video'
   | 'minimax-video-01'
+  // Hunyuan - text-to-video
   | 'hunyuan-video'
+  // Kling Motion Control - image + video → video
+  // Requires: image_url, video_url in providerOptions.fal
+  | 'kling-video/v2.6/pro/motion-control'
+  | 'kling-video/v2.6/standard/motion-control'
+  // Allow any other model ID
   | (string & {});
 
 export interface FalVideoSettings {}


### PR DESCRIPTION
## Background

  Users don't have clear guidance on how to use FAL's Kling motion control models with the AI SDK.

  ## Summary

  - Added Kling model IDs to `FalVideoModelId` type
  - Added JSDoc comments to `FalVideoCallOptions` for Kling-specific params
  - Added two example files showing how to use Kling motion control:
    - `fal-kling-motion.ts` - using URLs
    - `fal-kling-motion-local.ts` - uploading local files via `@fal-ai/client`

  ## Checklist

  - [ ] Tests have been added / updated (for bug fixes / features)
  - [ ] Documentation has been added / updated (for bug fixes / features)
  - [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
  - [x] I have reviewed this pull request (self-review)