### PR TITLE
chore: changeset to trigger v5 release

### DIFF
--- a/.changeset/many-schools-heal.md
+++ b/.changeset/many-schools-heal.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/anthropic': patch
+---
+
+trigger for backport release


### PR DESCRIPTION
changeset added for all the PRs/commits that didn't have a proper version release

- https://github.com/vercel/ai/pull/12023/changes
- https://github.com/vercel/ai/pull/12028/changes
- https://github.com/vercel/ai/pull/12051/changes
- https://github.com/vercel/ai/pull/12080/changes
- https://github.com/vercel/ai/pull/12103/changes
- https://github.com/vercel/ai/pull/12033/changes