### PR TITLE
chore(xai): remove duplicate schema definition

### DIFF
--- a/.changeset/stupid-eels-poke.md
+++ b/.changeset/stupid-eels-poke.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+chore(xai): remove duplicate schema definition

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -387,16 +387,6 @@ export const xaiResponsesChunkSchema = z.union([
     output_index: z.number(),
   }),
   z.object({
-    type: z.literal('response.custom_tool_call_input.done'),
-    item_id: z.string(),
-    output_index: z.number(),
-  }),
-  z.object({
-    type: z.literal('response.custom_tool_call_input.delta'),
-    item_id: z.string(),
-    output_index: z.number(),
-  }),
-  z.object({
     type: z.literal('response.code_execution_call.in_progress'),
     item_id: z.string(),
     output_index: z.number(),


### PR DESCRIPTION
## Background

we had duplicate schema definition for the same chunk type

## Summary

removed the duplicates

## Manual Verification

n/a

## Checklist

- [ ] n/a ~~Tests have been added / updated (for bug fixes / features)~~
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)