### PR TITLE
fix(provider/anthropic): parse context_management from streaming response root level

### DIFF
--- a/.changeset/fresh-ways-teach.md
+++ b/.changeset/fresh-ways-teach.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix streaming context_management field location - was incorrectly expected inside delta object but API returns it at message_delta root level

--- a/examples/ai-functions/src/stream-text/anthropic-context-management.ts
+++ b/examples/ai-functions/src/stream-text/anthropic-context-management.ts
@@ -1,0 +1,280 @@
+import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = streamText({
+    includeRawChunks: true,
+    onChunk({ chunk }) {
+      if (chunk.type === 'raw') {
+        const raw = chunk.rawValue as Record<string, unknown>;
+        if (raw.type === 'message_delta') {
+          console.log('\n=== RAW message_delta ===');
+          console.log(JSON.stringify(raw, null, 2));
+        }
+      }
+    },
+    model: anthropic('claude-haiku-4-5'),
+    messages: [
+      { role: 'user', content: 'What is the weather in San Francisco?' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tool_1',
+            toolName: 'weather',
+            input: { location: 'San Francisco' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tool_1',
+            toolName: 'weather',
+            output: {
+              type: 'json',
+              value: {
+                temperature: 72,
+                condition: 'sunny',
+                humidity: 65,
+                wind: '10 mph NW',
+                pressure: '1013 hPa',
+                visibility: '10 miles',
+                uvIndex: 6,
+                feelsLike: 74,
+              },
+            },
+          },
+        ],
+      },
+      { role: 'user', content: 'What about New York?' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tool_2',
+            toolName: 'weather',
+            input: { location: 'New York' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tool_2',
+            toolName: 'weather',
+            output: {
+              type: 'json',
+              value: {
+                temperature: 65,
+                condition: 'cloudy',
+                humidity: 78,
+                wind: '15 mph E',
+                pressure: '1010 hPa',
+                visibility: '8 miles',
+                uvIndex: 3,
+                feelsLike: 63,
+              },
+            },
+          },
+        ],
+      },
+      { role: 'user', content: 'What about Los Angeles?' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tool_3',
+            toolName: 'weather',
+            input: { location: 'Los Angeles' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tool_3',
+            toolName: 'weather',
+            output: {
+              type: 'json',
+              value: {
+                temperature: 78,
+                condition: 'sunny',
+                humidity: 45,
+                wind: '5 mph SW',
+                pressure: '1015 hPa',
+                visibility: '10 miles',
+                uvIndex: 8,
+                feelsLike: 80,
+              },
+            },
+          },
+        ],
+      },
+      { role: 'user', content: 'What about Chicago?' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tool_4',
+            toolName: 'weather',
+            input: { location: 'Chicago' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tool_4',
+            toolName: 'weather',
+            output: {
+              type: 'json',
+              value: {
+                temperature: 55,
+                condition: 'windy',
+                humidity: 60,
+                wind: '25 mph N',
+                pressure: '1008 hPa',
+                visibility: '10 miles',
+                uvIndex: 4,
+                feelsLike: 50,
+              },
+            },
+          },
+        ],
+      },
+      { role: 'user', content: 'What about Miami?' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tool_5',
+            toolName: 'weather',
+            input: { location: 'Miami' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tool_5',
+            toolName: 'weather',
+            output: {
+              type: 'json',
+              value: {
+                temperature: 85,
+                condition: 'humid',
+                humidity: 90,
+                wind: '8 mph SE',
+                pressure: '1012 hPa',
+                visibility: '9 miles',
+                uvIndex: 10,
+                feelsLike: 92,
+              },
+            },
+          },
+        ],
+      },
+      { role: 'user', content: 'What about Seattle?' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tool_6',
+            toolName: 'weather',
+            input: { location: 'Seattle' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tool_6',
+            toolName: 'weather',
+            output: {
+              type: 'json',
+              value: {
+                temperature: 58,
+                condition: 'rainy',
+                humidity: 85,
+                wind: '12 mph W',
+                pressure: '1005 hPa',
+                visibility: '5 miles',
+                uvIndex: 2,
+                feelsLike: 55,
+              },
+            },
+          },
+        ],
+      },
+      { role: 'user', content: 'compare all the cities briefly.' },
+    ],
+    tools: {
+      weather: tool({
+        description: 'Get the weather of a location',
+        inputSchema: z.object({
+          location: z.string().describe('The location to get the weather for'),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temperature: 72 + Math.floor(Math.random() * 21) - 10,
+          condition: 'sunny',
+        }),
+      }),
+    },
+    providerOptions: {
+      anthropic: {
+        contextManagement: {
+          edits: [
+            {
+              type: 'clear_tool_uses_20250919',
+              trigger: {
+                type: 'input_tokens',
+                value: 100,
+              },
+              keep: {
+                type: 'tool_uses',
+                value: 0,
+              },
+            },
+          ],
+        },
+      } satisfies AnthropicProviderOptions,
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+
+  console.log('\n');
+
+  const providerMetadata = await result.providerMetadata;
+  console.log('providerMetadata:', JSON.stringify(providerMetadata, null, 2));
+  console.log(
+    'contextManagement:',
+    providerMetadata?.anthropic?.contextManagement,
+  );
+});

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -1142,24 +1142,6 @@ export const anthropicMessagesChunkSchema = lazySchema(() =>
                 .nullish(),
             })
             .nullish(),
-          context_management: z
-            .object({
-              applied_edits: z.array(
-                z.union([
-                  z.object({
-                    type: z.literal('clear_tool_uses_20250919'),
-                    cleared_tool_uses: z.number(),
-                    cleared_input_tokens: z.number(),
-                  }),
-                  z.object({
-                    type: z.literal('clear_thinking_20251015'),
-                    cleared_thinking_turns: z.number(),
-                    cleared_input_tokens: z.number(),
-                  }),
-                ]),
-              ),
-            })
-            .nullish(),
         }),
         usage: z.looseObject({
           input_tokens: z.number().nullish(),
@@ -1167,6 +1149,24 @@ export const anthropicMessagesChunkSchema = lazySchema(() =>
           cache_creation_input_tokens: z.number().nullish(),
           cache_read_input_tokens: z.number().nullish(),
         }),
+        context_management: z
+          .object({
+            applied_edits: z.array(
+              z.union([
+                z.object({
+                  type: z.literal('clear_tool_uses_20250919'),
+                  cleared_tool_uses: z.number(),
+                  cleared_input_tokens: z.number(),
+                }),
+                z.object({
+                  type: z.literal('clear_thinking_20251015'),
+                  cleared_thinking_turns: z.number(),
+                  cleared_input_tokens: z.number(),
+                }),
+              ]),
+            ),
+          })
+          .nullish(),
       }),
       z.object({
         type: z.literal('message_stop'),

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -1981,9 +1981,9 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                     }
                   : null;
 
-              if (value.delta.context_management) {
+              if (value.context_management) {
                 contextManagement = mapAnthropicResponseContextManagement(
-                  value.delta.context_management,
+                  value.context_management,
                 );
               }
 


### PR DESCRIPTION
## background

the `contextManagement` field in `providerMetadata` was always `null` when using `streamText` with the Anthropic provider, even though the API correctly returns `context_management` in the response.

the issue was twofold:
1. the zod schema expected `context_management` inside the `delta` object
2. the code read from `value.delta.context_management`

but Anthropic's API returns `context_management` at the root level of the `message_delta` event (sibling to `delta` and `usage`):

```json
{
  "type": "message_delta",
  "delta": {"stop_reason": "end_turn"},
  "usage": {...},
  "context_management": {"applied_edits": [...]}
}
```

see [Anthropic's context management docs](https://docs.anthropic.com/en/docs/build-with-claude/context-management)

## summary

- moved `context_management` in the streaming schema from inside `delta` to the root level of `message_delta`
- updated code to read from `value.context_management` instead of `value.delta.context_management`
- added unit test for streaming context_management parsing

## verification

<details>
<summary>before fix</summary>

```
contextManagement: null
```

</details>

<details>
<summary>after fix</summary>

```
contextManagement: {
  appliedEdits: [
    {
      type: 'clear_tool_uses_20250919',
      clearedToolUses: 6,
      clearedInputTokens: 149
    }
  ]
}
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

fixes #12148