### PR TITLE
fix(provider-utils): export only types from standard-schema package

### DIFF
--- a/.changeset/grumpy-rats-doubt.md
+++ b/.changeset/grumpy-rats-doubt.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix(provider-utils): export only types from standard-schema package

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -60,7 +60,7 @@ export * from './without-trailing-slash';
 export * from './types';
 
 // external re-exports
-export * from '@standard-schema/spec';
+export type * from '@standard-schema/spec';
 export {
   EventSourceParserStream,
   type EventSourceMessage,


### PR DESCRIPTION
## Background

#12156 

electron apps were crashing at runtime with the error `Cannot find module '@standard-schema/spec'` because bundlers can't statically analyze the dynamic require() pattern in the built output

basically

```
export * from '@standard-schema/spec';
```
gets compiled into 
```
__reExport(src_exports, require("@standard-schema/spec"), module.exports);
```

## Summary

the fix is just to export the types from '@standard-schema/spec' since types are erased at compile time, eliminating the runtime require() entirely

## Manual Verification

check the provider-utils `dist/index.js`

which originally had the require package statement - after fix, it is no longer there

## Checklist

- [ ] na ~~Tests have been added / updated (for bug fixes / features)~~
- [ ] na ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #12156 
