### PR TITLE
fix(anthropic): add missing param in tool schema

### DIFF
--- a/.changeset/short-wombats-glow.md
+++ b/.changeset/short-wombats-glow.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): add missing param in tool schema

--- a/content/cookbook/00-guides/05-computer-use.mdx
+++ b/content/cookbook/00-guides/05-computer-use.mdx
@@ -197,6 +197,7 @@ const textEditorTool = anthropic.tools.textEditor_20250124({
     file_text,
     insert_line,
     new_str,
+    insert_text,
     old_str,
     view_range
   }) => {
@@ -208,6 +209,7 @@ const textEditorTool = anthropic.tools.textEditor_20250124({
         fileText: file_text,
         insertLine: insert_line,
         newStr: new_str,
+        insertText: insert_text,
         oldStr: old_str,
         viewRange: view_range
       });

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -499,7 +499,7 @@ The Text Editor Tool provides functionality for viewing and editing text files.
 const tools = {
   str_replace_based_edit_tool: anthropic.tools.textEditor_20250728({
     maxCharacters: 10000, // optional
-    async execute({ command, path, old_str, new_str }) {
+    async execute({ command, path, old_str, new_str, insert_text }) {
       // ...
     },
   }),
@@ -523,7 +523,8 @@ Parameters:
 - `path` (string): Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.
 - `file_text` (string, optional): Required for `create` command, with the content of the file to be created.
 - `insert_line` (number, optional): Required for `insert` command. The line number after which to insert the new string.
-- `new_str` (string, optional): New string for `str_replace` or `insert` commands.
+- `new_str` (string, optional): New string for `str_replace` command.
+- `insert_text` (string, optional): Required for `insert` command, containing the text to insert.
 - `old_str` (string, optional): Required for `str_replace` command, containing the string to replace.
 - `view_range` (number[], optional): Optional for `view` command to specify line range to show.
 

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -539,6 +539,7 @@ const textEditorTool = bedrock.tools.textEditor_20250429({
     file_text,
     insert_line,
     new_str,
+    insert_text,
     old_str,
     view_range,
   }) => {
@@ -558,6 +559,7 @@ const textEditorTool = bedrock.tools.textEditor_20241022({
     file_text,
     insert_line,
     new_str,
+    insert_text,
     old_str,
     view_range,
   }) => {
@@ -573,7 +575,8 @@ Parameters:
 - `path` (string): Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.
 - `file_text` (string, optional): Required for `create` command, with the content of the file to be created.
 - `insert_line` (number, optional): Required for `insert` command. The line number after which to insert the new string.
-- `new_str` (string, optional): New string for `str_replace` or `insert` commands.
+- `new_str` (string, optional): New string for `str_replace` command.
+- `insert_text` (string, optional): Required for `insert` command, containing the text to insert.
 - `old_str` (string, optional): Required for `str_replace` command, containing the string to replace.
 - `view_range` (number[], optional): Optional for `view` command to specify line range to show.
 
@@ -1414,7 +1417,7 @@ const result = await generateText({
   model: bedrockAnthropic('us.anthropic.claude-3-7-sonnet-20250219-v1:0'),
   tools: {
     str_replace_editor: bedrockAnthropic.tools.textEditor_20241022({
-      execute: async ({ command, path, old_str, new_str }) => {
+      execute: async ({ command, path, old_str, new_str, insert_text }) => {
         // Implement your text editing logic here
         return 'File updated successfully';
       },

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1391,6 +1391,7 @@ const textEditorTool = vertexAnthropic.tools.textEditor_20250124({
     file_text,
     insert_line,
     new_str,
+    insert_text,
     old_str,
     view_range,
   }) => {
@@ -1406,7 +1407,8 @@ Parameters:
 - `path` (string): Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.
 - `file_text` (string, optional): Required for `create` command, with the content of the file to be created.
 - `insert_line` (number, optional): Required for `insert` command. The line number after which to insert the new string.
-- `new_str` (string, optional): New string for `str_replace` or `insert` commands.
+- `new_str` (string, optional): New string for `str_replace` command.
+- `insert_text` (string, optional): Required for `insert` command, containing the text to insert.
 - `old_str` (string, optional): Required for `str_replace` command, containing the string to replace.
 - `view_range` (number[], optional): Optional for `view` command to specify line range to show.
 - `max_characters` (number, optional): Optional maximum number of characters to view in the file (only available in `textEditor_20250728`).

--- a/examples/ai-functions/src/e2e/amazon-bedrock-anthropic.test.ts
+++ b/examples/ai-functions/src/e2e/amazon-bedrock-anthropic.test.ts
@@ -216,14 +216,17 @@ README.md     build         data          node_modules  package.json  src       
         model,
         tools: {
           str_replace_editor: bedrockAnthropic.tools.textEditor_20241022({
-            async execute({ command, path, old_str, new_str }) {
+            async execute({ command, path, old_str, new_str, insert_text }) {
               switch (command) {
                 case 'view': {
                   return editorContent;
                 }
-                case 'create':
-                case 'insert': {
+                case 'create': {
                   editorContent = new_str!;
+                  return editorContent;
+                }
+                case 'insert': {
+                  editorContent = insert_text!;
                   return editorContent;
                 }
                 case 'str_replace': {

--- a/examples/ai-functions/src/e2e/google-vertex-anthropic.test.ts
+++ b/examples/ai-functions/src/e2e/google-vertex-anthropic.test.ts
@@ -209,14 +209,17 @@ README.md     build         data          node_modules  package.json  src       
         model,
         tools: {
           str_replace_editor: vertexAnthropic.tools.textEditor_20250124({
-            async execute({ command, path, old_str, new_str }) {
+            async execute({ command, path, old_str, new_str, insert_text }) {
               switch (command) {
                 case 'view': {
                   return editorContent;
                 }
-                case 'create':
-                case 'insert': {
+                case 'create': {
                   editorContent = new_str!;
+                  return editorContent;
+                }
+                case 'insert': {
+                  editorContent = insert_text!;
                   return editorContent;
                 }
                 case 'str_replace': {

--- a/examples/ai-functions/src/generate-text/amazon-bedrock-anthropic-computer-use-editor.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock-anthropic-computer-use-editor.ts
@@ -10,15 +10,18 @@ run(async () => {
     model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
     tools: {
       str_replace_editor: bedrockAnthropic.tools.textEditor_20241022({
-        async execute({ command, path, old_str, new_str }) {
+        async execute({ command, path, old_str, new_str, insert_text }) {
           console.log(`Editor command: ${command}`);
           switch (command) {
             case 'view': {
               return editorContent;
             }
-            case 'create':
-            case 'insert': {
+            case 'create': {
               editorContent = new_str!;
+              return editorContent;
+            }
+            case 'insert': {
+              editorContent = insert_text!;
               return editorContent;
             }
             case 'str_replace': {

--- a/examples/ai-functions/src/generate-text/anthropic-text-editor-tool.ts
+++ b/examples/ai-functions/src/generate-text/anthropic-text-editor-tool.ts
@@ -13,7 +13,7 @@ This is a test file.
     tools: {
       str_replace_based_edit_tool: anthropic.tools.textEditor_20250728({
         maxCharacters: 10000, // optional
-        async execute({ command, path, old_str, new_str }) {
+        async execute({ command, path, old_str, new_str, insert_text }) {
           switch (command) {
             case 'view': {
               return editorContent;
@@ -27,7 +27,7 @@ This is a test file.
               return editorContent;
             }
             case 'insert': {
-              editorContent = new_str!;
+              editorContent = insert_text!;
               return editorContent;
             }
           }
@@ -37,7 +37,8 @@ This is a test file.
         },
       }),
     },
-    prompt: 'Update my README file to talk about AI.',
+    prompt:
+      'Call insert to add "INTEGRATION TEST SUCCESS" after line 1 of editorContent',
     stopWhen: stepCountIs(5),
   });
 

--- a/examples/ai-functions/src/generate-text/google-vertex-anthropic-computer-use-editor-cache-control.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-anthropic-computer-use-editor-cache-control.ts
@@ -12,8 +12,8 @@ This is a test file.
     model: vertexAnthropic('claude-3-5-sonnet-v2@20241022'),
     tools: {
       str_replace_editor: vertexAnthropic.tools.textEditor_20241022({
-        async execute({ command, path, old_str, new_str }) {
-          console.log({ command, path, old_str, new_str });
+        async execute({ command, path, old_str, new_str, insert_text }) {
+          console.log({ command, path, old_str, new_str, insert_text });
           switch (command) {
             case 'view': {
               return editorContent;
@@ -27,7 +27,7 @@ This is a test file.
               return editorContent;
             }
             case 'insert': {
-              editorContent = new_str!;
+              editorContent = insert_text!;
               return editorContent;
             }
           }

--- a/examples/ai-functions/src/generate-text/google-vertex-anthropic-computer-use-editor.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-anthropic-computer-use-editor.ts
@@ -12,8 +12,8 @@ This is a test file.
     model: vertexAnthropic('claude-3-5-sonnet-v2@20241022'),
     tools: {
       str_replace_editor: vertexAnthropic.tools.textEditor_20241022({
-        async execute({ command, path, old_str, new_str }) {
-          console.log({ command, path, old_str, new_str });
+        async execute({ command, path, old_str, new_str, insert_text }) {
+          console.log({ command, path, old_str, new_str, insert_text });
           switch (command) {
             case 'view': {
               return editorContent;
@@ -27,7 +27,7 @@ This is a test file.
               return editorContent;
             }
             case 'insert': {
-              editorContent = new_str!;
+              editorContent = insert_text!;
               return editorContent;
             }
           }

--- a/examples/ai-functions/src/stream-text/amazon-bedrock-anthropic-computer-use-editor.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock-anthropic-computer-use-editor.ts
@@ -13,13 +13,17 @@ This is a sample README file for testing the text editor tool.
     model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
     tools: {
       str_replace_editor: bedrockAnthropic.tools.textEditor_20241022({
-        async execute({ command, path, old_str, new_str }) {
+        async execute({ command, path, old_str, new_str, insert_text }) {
           console.log(`Editor command: ${command}`);
           if (command === 'view') {
             return editorContent;
           }
           if (command === 'str_replace' && old_str && new_str) {
             editorContent = editorContent.replace(old_str, new_str);
+            return editorContent;
+          }
+          if (command === 'insert' && insert_text) {
+            editorContent = insert_text;
             return editorContent;
           }
           return editorContent;

--- a/packages/anthropic/src/tool/text-editor_20241022.ts
+++ b/packages/anthropic/src/tool/text-editor_20241022.ts
@@ -13,6 +13,7 @@ const textEditor_20241022InputSchema = lazySchema(() =>
       file_text: z.string().optional(),
       insert_line: z.number().int().optional(),
       new_str: z.string().optional(),
+      insert_text: z.string().optional(),
       old_str: z.string().optional(),
       view_range: z.array(z.number().int()).optional(),
     }),
@@ -42,9 +43,14 @@ export const textEditor_20241022 = createProviderToolFactory<
     insert_line?: number;
 
     /**
-     * Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.
+     * Optional parameter of `str_replace` command containing the new string (if not given, no string will be added).
      */
     new_str?: string;
+
+    /**
+     * Required parameter of `insert` command containing the text to insert.
+     */
+    insert_text?: string;
 
     /**
      * Required parameter of `str_replace` command containing the string in `path` to replace.

--- a/packages/anthropic/src/tool/text-editor_20250124.ts
+++ b/packages/anthropic/src/tool/text-editor_20250124.ts
@@ -13,6 +13,7 @@ const textEditor_20250124InputSchema = lazySchema(() =>
       file_text: z.string().optional(),
       insert_line: z.number().int().optional(),
       new_str: z.string().optional(),
+      insert_text: z.string().optional(),
       old_str: z.string().optional(),
       view_range: z.array(z.number().int()).optional(),
     }),
@@ -42,9 +43,14 @@ export const textEditor_20250124 = createProviderToolFactory<
     insert_line?: number;
 
     /**
-     * Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.
+     * Optional parameter of `str_replace` command containing the new string (if not given, no string will be added).
      */
     new_str?: string;
+
+    /**
+     * Required parameter of `insert` command containing the text to insert.
+     */
+    insert_text?: string;
 
     /**
      * Required parameter of `str_replace` command containing the string in `path` to replace.

--- a/packages/anthropic/src/tool/text-editor_20250429.ts
+++ b/packages/anthropic/src/tool/text-editor_20250429.ts
@@ -13,6 +13,7 @@ const textEditor_20250429InputSchema = lazySchema(() =>
       file_text: z.string().optional(),
       insert_line: z.number().int().optional(),
       new_str: z.string().optional(),
+      insert_text: z.string().optional(),
       old_str: z.string().optional(),
       view_range: z.array(z.number().int()).optional(),
     }),
@@ -43,9 +44,14 @@ export const textEditor_20250429 = createProviderToolFactory<
     insert_line?: number;
 
     /**
-     * Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.
+     * Optional parameter of `str_replace` command containing the new string (if not given, no string will be added).
      */
     new_str?: string;
+
+    /**
+     * Required parameter of `insert` command containing the text to insert.
+     */
+    insert_text?: string;
 
     /**
      * Required parameter of `str_replace` command containing the string in `path` to replace.

--- a/packages/anthropic/src/tool/text-editor_20250728.ts
+++ b/packages/anthropic/src/tool/text-editor_20250728.ts
@@ -18,6 +18,7 @@ const textEditor_20250728InputSchema = lazySchema(() =>
       file_text: z.string().optional(),
       insert_line: z.number().int().optional(),
       new_str: z.string().optional(),
+      insert_text: z.string().optional(),
       old_str: z.string().optional(),
       view_range: z.array(z.number().int()).optional(),
     }),
@@ -48,9 +49,14 @@ const factory = createProviderToolFactory<
     insert_line?: number;
 
     /**
-     * Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.
+     * Optional parameter of `str_replace` command containing the new string (if not given, no string will be added).
      */
     new_str?: string;
+
+    /**
+     * Required parameter of `insert` command containing the text to insert.
+     */
+    insert_text?: string;
 
     /**
      * Required parameter of `str_replace` command containing the string in `path` to replace.


### PR DESCRIPTION
## Background

anthropic had a docs bug where their api responded with a different param than what is reported in their docs

#12091

## Summary

add the new param in all text editor tool schemas

## Manual Verification

verified via the cli examples

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #12091