### PR TITLE
docs(amazon-bedrock): add cache point ttl documentation and examples

### DIFF
--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -348,7 +348,21 @@ console.log('Response:', result.object);
 
 In messages, you can use the `providerOptions` property to set cache points. Set the `bedrock` property in the `providerOptions` object to `{ cachePoint: { type: 'default' } }` to create a cache point.
 
-Cache usage information is returned in the `providerMetadata` object`. See examples below.
+You can also specify a TTL (time-to-live) for cache points using the `ttl` property. Supported values are `'5m'` (5 minutes, default) and `'1h'` (1 hour). The 1-hour TTL is only supported by Claude Opus 4.5, Claude Haiku 4.5, and Claude Sonnet 4.5.
+
+```ts
+providerOptions: {
+  bedrock: { cachePoint: { type: 'default', ttl: '1h' } },
+}
+```
+
+<Note>
+  When using multiple cache points with different TTLs, cache entries with
+  longer TTL must appear before shorter TTLs (i.e., 1-hour cache entries must
+  come before 5-minute cache entries).
+</Note>
+
+Cache usage information is returned in the `providerMetadata` object. See examples below.
 
 <Note>
   Cache points have model-specific token minimums and limits. For example,

--- a/examples/ai-functions/src/generate-text/amazon-bedrock-cache-point-ttl.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock-cache-point-ttl.ts
@@ -1,0 +1,32 @@
+import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { generateText } from 'ai';
+import fs from 'node:fs';
+import { run } from '../lib/run';
+
+const errorMessage = fs.readFileSync('data/error-message.txt', 'utf8');
+
+run(async () => {
+  const result = await generateText({
+    model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    maxOutputTokens: 512,
+    messages: [
+      {
+        role: 'system',
+        content: `You are a helpful assistant. You may be asked about ${errorMessage}.`,
+        providerOptions: {
+          bedrock: { cachePoint: { type: 'default', ttl: '1h' } },
+        },
+      },
+      {
+        role: 'user',
+        content: 'Explain the error message',
+      },
+    ],
+  });
+
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Cache token usage:', result.providerMetadata?.bedrock?.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/amazon-bedrock-cache-point-ttl.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock-cache-point-ttl.ts
@@ -1,0 +1,37 @@
+import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { streamText } from 'ai';
+import fs from 'node:fs';
+import { run } from '../lib/run';
+
+const errorMessage = fs.readFileSync('data/error-message.txt', 'utf8');
+
+run(async () => {
+  const result = streamText({
+    model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    messages: [
+      {
+        role: 'system',
+        content: `You are a helpful assistant. You may be asked about ${errorMessage}.`,
+        providerOptions: {
+          bedrock: { cachePoint: { type: 'default', ttl: '1h' } },
+        },
+      },
+      {
+        role: 'user',
+        content: 'Explain the error message',
+      },
+    ],
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log(
+    'Cache token usage:',
+    (await result.providerMetadata)?.bedrock?.usage,
+  );
+  console.log('Finish reason:', await result.finishReason);
+});


### PR DESCRIPTION
## background

follow-up to #12124 which added ttl support for bedrock prompt caching

## summary

- add documentation for cache point ttl options (`'5m'` and `'1h'`) to amazon-bedrock provider docs
- add note about ttl ordering constraint (longer ttls must come before shorter ttls)
- add generate-text example demonstrating 1h ttl with claude sonnet 4.5
- add stream-text example demonstrating 1h ttl with claude sonnet 4.5

## checklist

- [ ] tests have been added / updated (for bug fixes / features)
- [x] documentation has been added / updated (for bug fixes / features)
- [ ] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

follows up on #12124