### PR TITLE
fix(ui): respect `Promise<false>` when returned by `sendAutomaticallyWhen`

### DIFF
--- a/.changeset/orange-eyes-nail.md
+++ b/.changeset/orange-eyes-nail.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ui): respect `Promise<false>` when returned by `sendAutomaticallyWhen`

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -467,12 +467,16 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       if (
         this.status !== 'streaming' &&
         this.status !== 'submitted' &&
-        this.sendAutomaticallyWhen?.({ messages: this.state.messages })
+        this.sendAutomaticallyWhen
       ) {
-        // no await to avoid deadlocking
-        this.makeRequest({
-          trigger: 'submit-message',
-          messageId: this.lastMessage?.id,
+        this.shouldSendAutomatically().then(shouldSend => {
+          if (shouldSend) {
+            // no await to avoid deadlocking
+            this.makeRequest({
+              trigger: 'submit-message',
+              messageId: this.lastMessage?.id,
+            });
+          }
         });
       }
     });
@@ -525,12 +529,16 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       if (
         this.status !== 'streaming' &&
         this.status !== 'submitted' &&
-        this.sendAutomaticallyWhen?.({ messages: this.state.messages })
+        this.sendAutomaticallyWhen
       ) {
-        // no await to avoid deadlocking
-        this.makeRequest({
-          trigger: 'submit-message',
-          messageId: this.lastMessage?.id,
+        this.shouldSendAutomatically().then(shouldSend => {
+          if (shouldSend) {
+            // no await to avoid deadlocking
+            this.makeRequest({
+              trigger: 'submit-message',
+              messageId: this.lastMessage?.id,
+            });
+          }
         });
       }
     });
@@ -548,6 +556,21 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       this.activeResponse.abortController.abort();
     }
   };
+
+  private async shouldSendAutomatically(): Promise<boolean> {
+    if (!this.sendAutomaticallyWhen) return false;
+
+    const result = this.sendAutomaticallyWhen({
+      messages: this.state.messages,
+    });
+
+    // Check if result is a promise
+    if (result && typeof result === 'object' && 'then' in result) {
+      return await result;
+    }
+
+    return result as boolean;
+  }
 
   private async makeRequest({
     trigger,
@@ -700,10 +723,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     }
 
     // automatically send the message if the sendAutomaticallyWhen function returns true
-    if (
-      this.sendAutomaticallyWhen?.({ messages: this.state.messages }) &&
-      !isError
-    ) {
+    if (!isError && (await this.shouldSendAutomatically())) {
       await this.makeRequest({
         trigger: 'submit-message',
         messageId: this.lastMessage?.id,


### PR DESCRIPTION
## Background

The `sendAutomaticallyWhen` option in the UI chat API supports returning both boolean values and `Promise<boolean>` to control automatic message submission. However, since its introduction in PR #7536, the promise-based implementation has been broken when the function returns `Promise<false>`. The code was calling the function but not awaiting the promise result, causing the automatic send to always trigger regardless of the resolved value - which only works with `Promise<true>`.

## Summary

This PR fixes the handling of `sendAutomaticallyWhen` when it returns a `Promise<false>` via a new private method `shouldSendAutomatically()` that properly awaits promise results before deciding whether to send.

Key changes:
- Added `shouldSendAutomatically()` helper method that checks if the result is a promise and awaits it
- Updated all three call sites (`addMessage`, `addToolOutput`, and end of `makeRequest`) to use the new helper
- Added test coverage for the promise-based scenario

## Manual Verification

N/A

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

N/A
