### PR TITLE
fix(provider/openai-compatible): Fix cache token reporting

### DIFF
--- a/packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.ts
+++ b/packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.ts
@@ -5,6 +5,7 @@ export function convertOpenAICompatibleChatUsage(
     | {
         prompt_tokens?: number | null;
         completion_tokens?: number | null;
+        cached_tokens?: number | null;
         prompt_tokens_details?: {
           cached_tokens?: number | null;
         } | null;
@@ -34,7 +35,8 @@ export function convertOpenAICompatibleChatUsage(
 
   const promptTokens = usage.prompt_tokens ?? 0;
   const completionTokens = usage.completion_tokens ?? 0;
-  const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens ?? 0;
+  const cacheReadTokens =
+    usage.prompt_tokens_details?.cached_tokens ?? usage.cached_tokens ?? 0;
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? 0;
 

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -100,6 +100,7 @@ describe('doGenerate', () => {
       prompt_tokens?: number;
       total_tokens?: number;
       completion_tokens?: number;
+      cached_tokens?: number;
       prompt_tokens_details?: {
         cached_tokens?: number;
       };
@@ -1324,6 +1325,43 @@ describe('doGenerate', () => {
             "prompt_tokens_details": {
               "cached_tokens": 5,
             },
+            "total_tokens": 50,
+          },
+        }
+      `);
+    });
+
+    it('should handle top-level cached_tokens (Moonshot style)', async () => {
+      prepareJsonResponse({
+        usage: {
+          prompt_tokens: 20,
+          completion_tokens: 30,
+          total_tokens: 50,
+          cached_tokens: 8,
+        },
+      });
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.usage).toMatchInlineSnapshot(`
+        {
+          "inputTokens": {
+            "cacheRead": 8,
+            "cacheWrite": undefined,
+            "noCache": 12,
+            "total": 20,
+          },
+          "outputTokens": {
+            "reasoning": 0,
+            "text": 30,
+            "total": 30,
+          },
+          "raw": {
+            "cached_tokens": 8,
+            "completion_tokens": 30,
+            "prompt_tokens": 20,
             "total_tokens": 50,
           },
         }

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -721,6 +721,7 @@ const openaiCompatibleTokenUsageSchema = z
     prompt_tokens: z.number().nullish(),
     completion_tokens: z.number().nullish(),
     total_tokens: z.number().nullish(),
+    cached_tokens: z.number().nullish(),
     prompt_tokens_details: z
       .object({
         cached_tokens: z.number().nullish(),


### PR DESCRIPTION
## Background
Some providers like moonshot return cached input token counts in the top-level

## Summary
AI SDK previously expected it in a nested field, but this also checks the top level for it too.

## Manual Verification

## Checklist
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)