### PR TITLE
fix (docs/xai): escape apostrophes in grok-2-image model notes

### DIFF
--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -805,6 +805,6 @@ const { images } = await generateImage({
 
 ### Model Capabilities
 
-| Model          | Sizes              | Notes                                                                                                                                                                                                    |
-| -------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `grok-2-image` | 1024x768 (default) | xAI's text-to-image generation model, designed to create high-quality images from text prompts. It's trained on a diverse dataset and can generate images across various styles, subjects, and settings. |
+| Model          | Sizes              | Notes                                                                                                                                                                                                              |
+| -------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `grok-2-image` | 1024x768 (default) | xAI&apos;s text-to-image generation model, designed to create high-quality images from text prompts. It&apos;s trained on a diverse dataset and can generate images across various styles, subjects, and settings. |


### PR DESCRIPTION
## Background

Fixed HTML entity encoding in the xAI provider documentation to ensure proper rendering of apostrophes.

## Summary

Replaced apostrophes in the xAI documentation with their HTML entity equivalent (`&apos;`) to prevent rendering issues in the markdown table.

## Checklist

- [x] Documentation has been updated
- [x] I have reviewed this pull request (self-review)