### PR TITLE
feat (provider/gateway): add video generation support

### DIFF
--- a/.changeset/nervous-phones-mate.md
+++ b/.changeset/nervous-phones-mate.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): add video generation support

--- a/examples/ai-functions/src/generate-video/gateway-google-veo.ts
+++ b/examples/ai-functions/src/generate-video/gateway-google-veo.ts
@@ -1,0 +1,17 @@
+import { gateway, experimental_generateVideo } from 'ai';
+import { presentVideos } from '../lib/present-video';
+import { run } from '../lib/run';
+import { withSpinner } from '../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner('Generating video...', () =>
+    experimental_generateVideo({
+      model: gateway.videoModel('google/veo-3.1-generate-001'),
+      prompt: 'A resplendent quetzal flying through the rainforest.',
+      aspectRatio: '16:9',
+      duration: 4,
+    }),
+  );
+
+  await presentVideos(videos);
+});

--- a/packages/ai/scripts/check-bundle-size.ts
+++ b/packages/ai/scripts/check-bundle-size.ts
@@ -3,7 +3,7 @@ import { writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 // Bundle size limits in bytes
-const LIMIT = 550 * 1024;
+const LIMIT = 555 * 1024;
 
 interface BundleResult {
   size: number;

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -105,7 +105,9 @@ const gatewayAvailableModelsResponseSchema = lazySchema(() =>
             provider: z.string(),
             modelId: z.string(),
           }),
-          modelType: z.enum(['language', 'embedding', 'image']).nullish(),
+          modelType: z
+            .enum(['embedding', 'image', 'language', 'video'])
+            .nullish(),
         }),
       ),
     }),

--- a/packages/gateway/src/gateway-model-entry.ts
+++ b/packages/gateway/src/gateway-model-entry.ts
@@ -49,7 +49,7 @@ export interface GatewayLanguageModelEntry {
   /**
    * Optional field to differentiate between model types.
    */
-  modelType?: 'language' | 'embedding' | 'image' | null;
+  modelType?: 'language' | 'embedding' | 'image' | 'video' | null;
 }
 
 export type GatewayLanguageModelSpecification = Pick<

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -16,8 +16,10 @@ import {
 import { GatewayLanguageModel } from './gateway-language-model';
 import { GatewayEmbeddingModel } from './gateway-embedding-model';
 import { GatewayImageModel } from './gateway-image-model';
+import { GatewayVideoModel } from './gateway-video-model';
 import type { GatewayEmbeddingModelId } from './gateway-embedding-model-settings';
 import type { GatewayImageModelId } from './gateway-image-model-settings';
+import type { GatewayVideoModelId } from './gateway-video-model-settings';
 import { gatewayTools } from './gateway-tools';
 import { getVercelOidcToken, getVercelRequestId } from './vercel-environment';
 import type { GatewayModelId } from './gateway-language-model-settings';
@@ -25,6 +27,7 @@ import type {
   LanguageModelV3,
   EmbeddingModelV3,
   ImageModelV3,
+  Experimental_VideoModelV3,
   ProviderV3,
 } from '@ai-sdk/provider';
 import { withUserAgentSuffix } from '@ai-sdk/provider-utils';
@@ -62,6 +65,11 @@ export interface GatewayProvider extends ProviderV3 {
    * Creates a model for generating images.
    */
   imageModel(modelId: GatewayImageModelId): ImageModelV3;
+
+  /**
+   * Creates a model for generating videos.
+   */
+  videoModel(modelId: GatewayVideoModelId): Experimental_VideoModelV3;
 
   /**
    * Gateway-specific tools executed server-side.
@@ -254,6 +262,16 @@ export function createGatewayProvider(
   };
   provider.embeddingModel = createEmbeddingModel;
   provider.textEmbeddingModel = createEmbeddingModel;
+  provider.videoModel = (modelId: GatewayVideoModelId) => {
+    return new GatewayVideoModel(modelId, {
+      provider: 'gateway',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+      o11yHeaders: createO11yHeaders(),
+    });
+  };
+  provider.video = provider.videoModel;
   provider.tools = gatewayTools;
 
   return provider;

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -39,6 +39,11 @@ export interface GatewayProvider extends ProviderV3 {
   /**
    * Creates a model for text generation.
    */
+  chat(modelId: GatewayModelId): LanguageModelV3;
+
+  /**
+   * Creates a model for text generation.
+   */
   languageModel(modelId: GatewayModelId): LanguageModelV3;
 
   /**
@@ -54,6 +59,11 @@ export interface GatewayProvider extends ProviderV3 {
   /**
    * Creates a model for generating text embeddings.
    */
+  embedding(modelId: GatewayEmbeddingModelId): EmbeddingModelV3;
+
+  /**
+   * Creates a model for generating text embeddings.
+   */
   embeddingModel(modelId: GatewayEmbeddingModelId): EmbeddingModelV3;
 
   /**
@@ -64,7 +74,17 @@ export interface GatewayProvider extends ProviderV3 {
   /**
    * Creates a model for generating images.
    */
+  image(modelId: GatewayImageModelId): ImageModelV3;
+
+  /**
+   * Creates a model for generating images.
+   */
   imageModel(modelId: GatewayImageModelId): ImageModelV3;
+
+  /**
+   * Creates a model for generating videos.
+   */
+  video(modelId: GatewayVideoModelId): Experimental_VideoModelV3;
 
   /**
    * Creates a model for generating videos.
@@ -271,9 +291,11 @@ export function createGatewayProvider(
       o11yHeaders: createO11yHeaders(),
     });
   };
+  provider.chat = provider.languageModel;
+  provider.embedding = provider.embeddingModel;
+  provider.image = provider.imageModel;
   provider.video = provider.videoModel;
   provider.tools = gatewayTools;
-
   return provider;
 }
 

--- a/packages/gateway/src/gateway-video-model-settings.ts
+++ b/packages/gateway/src/gateway-video-model-settings.ts
@@ -1,0 +1,1 @@
+export type GatewayVideoModelId = 'google/veo-3.1-generate-001' | (string & {});

--- a/packages/gateway/src/gateway-video-model.test.ts
+++ b/packages/gateway/src/gateway-video-model.test.ts
@@ -1,0 +1,787 @@
+import { describe, it, expect } from 'vitest';
+import { GatewayVideoModel } from './gateway-video-model';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import type { GatewayConfig } from './gateway-config';
+
+const TEST_MODEL_ID = 'google/veo-2.0-generate-001';
+
+const createTestModel = (
+  config: Partial<
+    GatewayConfig & { o11yHeaders?: Record<string, string> }
+  > = {},
+) => {
+  return new GatewayVideoModel(TEST_MODEL_ID, {
+    provider: 'gateway',
+    baseURL: 'https://api.test.com',
+    headers: () => ({
+      Authorization: 'Bearer test-token',
+      'ai-gateway-auth-method': 'api-key',
+    }),
+    fetch: globalThis.fetch,
+    o11yHeaders: config.o11yHeaders || {},
+    ...config,
+  });
+};
+
+describe('GatewayVideoModel', () => {
+  const server = createTestServer({
+    'https://api.test.com/video-model': {},
+  });
+
+  describe('constructor', () => {
+    it('should create instance with correct properties', () => {
+      const model = createTestModel();
+
+      expect(model.modelId).toBe(TEST_MODEL_ID);
+      expect(model.provider).toBe('gateway');
+      expect(model.specificationVersion).toBe('v3');
+      expect(model.maxVideosPerCall).toBe(Number.MAX_SAFE_INTEGER);
+    });
+
+    it('should avoid client-side splitting for video models', () => {
+      const model = new GatewayVideoModel('fal/luma-ray-2', {
+        provider: 'gateway',
+        baseURL: 'https://api.test.com',
+        headers: async () => ({}),
+        fetch: globalThis.fetch,
+        o11yHeaders: {},
+      });
+
+      expect(model.maxVideosPerCall).toBe(Number.MAX_SAFE_INTEGER);
+    });
+
+    it('should accept custom provider name', () => {
+      const model = new GatewayVideoModel(TEST_MODEL_ID, {
+        provider: 'custom-gateway',
+        baseURL: 'https://api.test.com',
+        headers: async () => ({}),
+        fetch: globalThis.fetch,
+        o11yHeaders: {},
+      });
+
+      expect(model.provider).toBe('custom-gateway');
+    });
+  });
+
+  describe('doGenerate', () => {
+    type VideoData =
+      | { type: 'url'; url: string; mediaType: string }
+      | { type: 'base64'; data: string; mediaType: string };
+
+    function prepareJsonResponse({
+      videos = [
+        {
+          type: 'base64' as const,
+          data: 'base64-video-1',
+          mediaType: 'video/mp4',
+        },
+      ],
+      warnings,
+      providerMetadata,
+    }: {
+      videos?: VideoData[];
+      warnings?: Array<{ type: 'other'; message: string }>;
+      providerMetadata?: Record<string, unknown>;
+    } = {}) {
+      server.urls['https://api.test.com/video-model'].response = {
+        type: 'json-value',
+        body: {
+          videos,
+          ...(warnings && { warnings }),
+          ...(providerMetadata && { providerMetadata }),
+        },
+      };
+    }
+
+    it('should send correct request headers', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doGenerate({
+        prompt: 'A beautiful sunset over mountains',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const headers = server.calls[0].requestHeaders;
+      expect(headers).toMatchObject({
+        authorization: 'Bearer test-token',
+        'ai-video-model-specification-version': '3',
+        'ai-model-id': TEST_MODEL_ID,
+      });
+    });
+
+    it('should send correct request body with all parameters', async () => {
+      prepareJsonResponse({
+        videos: [{ type: 'base64', data: 'base64-1', mediaType: 'video/mp4' }],
+      });
+
+      const prompt = 'A cat playing piano';
+      await createTestModel().doGenerate({
+        prompt,
+        image: undefined,
+        n: 1,
+        aspectRatio: '16:9',
+        resolution: '1920x1080',
+        duration: 5,
+        fps: 24,
+        seed: 42,
+        providerOptions: {
+          fal: { motionStrength: 0.8 },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).toEqual({
+        prompt,
+        n: 1,
+        aspectRatio: '16:9',
+        resolution: '1920x1080',
+        duration: 5,
+        fps: 24,
+        seed: 42,
+        providerOptions: { fal: { motionStrength: 0.8 } },
+      });
+    });
+
+    it('should omit optional parameters when not provided', async () => {
+      prepareJsonResponse();
+
+      const prompt = 'A simple prompt';
+      await createTestModel().doGenerate({
+        prompt,
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).toEqual({
+        prompt,
+        n: 1,
+        providerOptions: {},
+      });
+      expect(requestBody).not.toHaveProperty('aspectRatio');
+      expect(requestBody).not.toHaveProperty('resolution');
+      expect(requestBody).not.toHaveProperty('duration');
+      expect(requestBody).not.toHaveProperty('fps');
+      expect(requestBody).not.toHaveProperty('seed');
+    });
+
+    it('should return videos array correctly', async () => {
+      const mockVideos: VideoData[] = [
+        { type: 'base64', data: 'base64-video-1', mediaType: 'video/mp4' },
+        { type: 'base64', data: 'base64-video-2', mediaType: 'video/webm' },
+      ];
+      prepareJsonResponse({ videos: mockVideos });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 2,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.videos).toEqual(mockVideos);
+    });
+
+    it('should return URL-type videos correctly', async () => {
+      const mockVideos: VideoData[] = [
+        {
+          type: 'url',
+          url: 'https://example.com/video.mp4',
+          mediaType: 'video/mp4',
+        },
+      ];
+      prepareJsonResponse({ videos: mockVideos });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.videos).toEqual(mockVideos);
+    });
+
+    it('should return provider metadata correctly', async () => {
+      const mockProviderMetadata = {
+        fal: {
+          videos: [{ duration: 5.0, fps: 24, width: 1280, height: 720 }],
+        },
+        gateway: {
+          routing: { provider: 'fal' },
+          cost: '0.15',
+        },
+      };
+
+      prepareJsonResponse({
+        videos: [{ type: 'base64', data: 'base64-1', mediaType: 'video/mp4' }],
+        providerMetadata: mockProviderMetadata,
+      });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.providerMetadata).toEqual(mockProviderMetadata);
+    });
+
+    it('should handle provider metadata without videos field', async () => {
+      prepareJsonResponse({
+        videos: [{ type: 'base64', data: 'base64-1', mediaType: 'video/mp4' }],
+        providerMetadata: {
+          gateway: {
+            routing: { provider: 'google' },
+            cost: '0.10',
+          },
+        },
+      });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.providerMetadata).toEqual({
+        gateway: {
+          routing: { provider: 'google' },
+          cost: '0.10',
+        },
+      });
+    });
+
+    it('should handle empty provider metadata', async () => {
+      prepareJsonResponse({
+        videos: [{ type: 'base64', data: 'base64-1', mediaType: 'video/mp4' }],
+        providerMetadata: {},
+      });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.providerMetadata).toEqual({});
+    });
+
+    it('should handle undefined provider metadata', async () => {
+      prepareJsonResponse({
+        videos: [{ type: 'base64', data: 'base64-1', mediaType: 'video/mp4' }],
+      });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.providerMetadata).toBeUndefined();
+    });
+
+    it('should return warnings when provided', async () => {
+      const mockWarnings = [
+        { type: 'other' as const, message: 'Duration exceeds maximum' },
+      ];
+
+      prepareJsonResponse({
+        videos: [{ type: 'base64', data: 'base64-1', mediaType: 'video/mp4' }],
+        warnings: mockWarnings,
+      });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.warnings).toEqual(mockWarnings);
+    });
+
+    it('should return empty warnings array when not provided', async () => {
+      prepareJsonResponse({
+        videos: [{ type: 'base64', data: 'base64-1', mediaType: 'video/mp4' }],
+      });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('should include response metadata', async () => {
+      prepareJsonResponse({
+        videos: [{ type: 'base64', data: 'base64-1', mediaType: 'video/mp4' }],
+      });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.response.modelId).toBe(TEST_MODEL_ID);
+      expect(result.response.timestamp).toBeInstanceOf(Date);
+      expect(result.response.headers).toBeDefined();
+    });
+
+    it('should merge custom headers with config headers', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        headers: {
+          'X-Custom-Header': 'custom-value',
+        },
+        providerOptions: {},
+      });
+
+      const headers = server.calls[0].requestHeaders;
+      expect(headers).toMatchObject({
+        authorization: 'Bearer test-token',
+        'x-custom-header': 'custom-value',
+        'ai-video-model-specification-version': '3',
+        'ai-model-id': TEST_MODEL_ID,
+      });
+    });
+
+    it('should include o11y headers', async () => {
+      prepareJsonResponse();
+
+      await createTestModel({
+        o11yHeaders: {
+          'ai-o11y-deployment-id': 'dpl_123',
+          'ai-o11y-environment': 'production',
+        },
+      }).doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const headers = server.calls[0].requestHeaders;
+      expect(headers).toMatchObject({
+        'ai-o11y-deployment-id': 'dpl_123',
+        'ai-o11y-environment': 'production',
+      });
+    });
+
+    it('should pass abort signal to fetch', async () => {
+      prepareJsonResponse();
+
+      const abortController = new AbortController();
+      await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        abortSignal: abortController.signal,
+        providerOptions: {},
+      });
+
+      expect(server.calls.length).toBe(1);
+    });
+
+    it('should handle API errors correctly', async () => {
+      server.urls['https://api.test.com/video-model'].response = {
+        type: 'error',
+        status: 400,
+        body: JSON.stringify({
+          error: {
+            message: 'Invalid request',
+            code: 'invalid_request',
+          },
+        }),
+      };
+
+      await expect(
+        createTestModel().doGenerate({
+          prompt: 'Test prompt',
+          image: undefined,
+          n: 1,
+          aspectRatio: undefined,
+          resolution: undefined,
+          duration: undefined,
+          fps: undefined,
+          seed: undefined,
+          providerOptions: {},
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('should handle authentication errors', async () => {
+      server.urls['https://api.test.com/video-model'].response = {
+        type: 'error',
+        status: 401,
+        body: JSON.stringify({
+          error: {
+            message: 'Unauthorized',
+            code: 'unauthorized',
+          },
+        }),
+      };
+
+      await expect(
+        createTestModel().doGenerate({
+          prompt: 'Test prompt',
+          image: undefined,
+          n: 1,
+          aspectRatio: undefined,
+          resolution: undefined,
+          duration: undefined,
+          fps: undefined,
+          seed: undefined,
+          providerOptions: {},
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('should include providerOptions object in request body', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {
+          fal: {
+            motionStrength: 0.8,
+            loop: true,
+          },
+          google: {
+            enhancePrompt: true,
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).toEqual({
+        prompt: 'Test prompt',
+        n: 1,
+        providerOptions: {
+          fal: {
+            motionStrength: 0.8,
+            loop: true,
+          },
+          google: {
+            enhancePrompt: true,
+          },
+        },
+      });
+    });
+
+    it('should handle empty provider options', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).toEqual({
+        prompt: 'Test prompt',
+        n: 1,
+        providerOptions: {},
+      });
+    });
+
+    it('should handle different model IDs', async () => {
+      prepareJsonResponse();
+
+      const customModelId = 'fal/luma-ray-2';
+      const model = new GatewayVideoModel(customModelId, {
+        provider: 'gateway',
+        baseURL: 'https://api.test.com',
+        headers: async () => ({}),
+        fetch: globalThis.fetch,
+        o11yHeaders: {},
+      });
+
+      await model.doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const headers = server.calls[0].requestHeaders;
+      expect(headers).toMatchObject({
+        'ai-model-id': customModelId,
+      });
+    });
+
+    it('should handle complex provider metadata with multiple providers', async () => {
+      prepareJsonResponse({
+        videos: [{ type: 'base64', data: 'base64-1', mediaType: 'video/mp4' }],
+        providerMetadata: {
+          fal: {
+            videos: [{ duration: 5.0, fps: 24, width: 1920, height: 1080 }],
+            usage: { computeUnits: 10 },
+          },
+          gateway: {
+            routing: {
+              provider: 'fal',
+              attempts: [
+                { provider: 'google', success: false },
+                { provider: 'fal', success: true },
+              ],
+            },
+            cost: '0.20',
+            marketCost: '0.30',
+            generationId: 'gen-xyz-789',
+          },
+        },
+      });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        image: undefined,
+        n: 1,
+        aspectRatio: undefined,
+        resolution: undefined,
+        duration: undefined,
+        fps: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.providerMetadata).toEqual({
+        fal: {
+          videos: [{ duration: 5.0, fps: 24, width: 1920, height: 1080 }],
+          usage: { computeUnits: 10 },
+        },
+        gateway: {
+          routing: {
+            provider: 'fal',
+            attempts: [
+              { provider: 'google', success: false },
+              { provider: 'fal', success: true },
+            ],
+          },
+          cost: '0.20',
+          marketCost: '0.30',
+          generationId: 'gen-xyz-789',
+        },
+      });
+    });
+
+    describe('image file encoding for image-to-video', () => {
+      it('should encode Uint8Array image to base64 string', async () => {
+        prepareJsonResponse();
+
+        const binaryData = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
+
+        await createTestModel().doGenerate({
+          prompt: 'Animate this image',
+          image: {
+            type: 'file',
+            mediaType: 'image/png',
+            data: binaryData,
+          },
+          n: 1,
+          aspectRatio: undefined,
+          resolution: undefined,
+          duration: undefined,
+          fps: undefined,
+          seed: undefined,
+          providerOptions: {},
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.image).toEqual({
+          type: 'file',
+          mediaType: 'image/png',
+          data: 'SGVsbG8=', // "Hello" in base64
+        });
+      });
+
+      it('should pass through image with string data unchanged', async () => {
+        prepareJsonResponse();
+
+        await createTestModel().doGenerate({
+          prompt: 'Animate this image',
+          image: {
+            type: 'file',
+            mediaType: 'image/png',
+            data: 'already-base64-encoded',
+          },
+          n: 1,
+          aspectRatio: undefined,
+          resolution: undefined,
+          duration: undefined,
+          fps: undefined,
+          seed: undefined,
+          providerOptions: {},
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.image).toEqual({
+          type: 'file',
+          mediaType: 'image/png',
+          data: 'already-base64-encoded',
+        });
+      });
+
+      it('should pass through URL-type image unchanged', async () => {
+        prepareJsonResponse();
+
+        await createTestModel().doGenerate({
+          prompt: 'Animate this image',
+          image: {
+            type: 'url',
+            url: 'https://example.com/image.png',
+          },
+          n: 1,
+          aspectRatio: undefined,
+          resolution: undefined,
+          duration: undefined,
+          fps: undefined,
+          seed: undefined,
+          providerOptions: {},
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.image).toEqual({
+          type: 'url',
+          url: 'https://example.com/image.png',
+        });
+      });
+
+      it('should preserve providerOptions on image during encoding', async () => {
+        prepareJsonResponse();
+
+        const binaryData = new Uint8Array([72, 101, 108, 108, 111]);
+
+        await createTestModel().doGenerate({
+          prompt: 'Animate this image',
+          image: {
+            type: 'file',
+            mediaType: 'image/png',
+            data: binaryData,
+            providerOptions: { fal: { enhanceImage: true } },
+          },
+          n: 1,
+          aspectRatio: undefined,
+          resolution: undefined,
+          duration: undefined,
+          fps: undefined,
+          seed: undefined,
+          providerOptions: {},
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.image).toEqual({
+          type: 'file',
+          mediaType: 'image/png',
+          data: 'SGVsbG8=',
+          providerOptions: { fal: { enhanceImage: true } },
+        });
+      });
+    });
+  });
+});

--- a/packages/gateway/src/gateway-video-model.ts
+++ b/packages/gateway/src/gateway-video-model.ts
@@ -1,0 +1,167 @@
+import type {
+  Experimental_VideoModelV3,
+  Experimental_VideoModelV3CallOptions,
+  Experimental_VideoModelV3File,
+  Experimental_VideoModelV3VideoData,
+  SharedV3ProviderMetadata,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertUint8ArrayToBase64,
+  createJsonResponseHandler,
+  createJsonErrorResponseHandler,
+  postJsonToApi,
+  resolve,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import type { GatewayConfig } from './gateway-config';
+import { asGatewayError } from './errors';
+import { parseAuthMethod } from './errors/parse-auth-method';
+
+export class GatewayVideoModel implements Experimental_VideoModelV3 {
+  readonly specificationVersion = 'v3' as const;
+  // Set a very large number to prevent client-side splitting of requests
+  readonly maxVideosPerCall = Number.MAX_SAFE_INTEGER;
+
+  constructor(
+    readonly modelId: string,
+    private readonly config: GatewayConfig & {
+      provider: string;
+      o11yHeaders: Resolvable<Record<string, string>>;
+    },
+  ) {}
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  async doGenerate({
+    prompt,
+    n,
+    aspectRatio,
+    resolution,
+    duration,
+    fps,
+    seed,
+    image,
+    providerOptions,
+    headers,
+    abortSignal,
+  }: Experimental_VideoModelV3CallOptions): Promise<{
+    videos: Array<Experimental_VideoModelV3VideoData>;
+    warnings: Array<{ type: 'other'; message: string }>;
+    providerMetadata?: SharedV3ProviderMetadata;
+    response: {
+      timestamp: Date;
+      modelId: string;
+      headers: Record<string, string> | undefined;
+    };
+  }> {
+    const resolvedHeaders = await resolve(this.config.headers());
+    try {
+      const {
+        responseHeaders,
+        value: responseBody,
+        rawValue,
+      } = await postJsonToApi({
+        url: this.getUrl(),
+        headers: combineHeaders(
+          resolvedHeaders,
+          headers ?? {},
+          this.getModelConfigHeaders(),
+          await resolve(this.config.o11yHeaders),
+        ),
+        body: {
+          prompt,
+          n,
+          ...(aspectRatio && { aspectRatio }),
+          ...(resolution && { resolution }),
+          ...(duration && { duration }),
+          ...(fps && { fps }),
+          ...(seed && { seed }),
+          ...(providerOptions && { providerOptions }),
+          ...(image && { image: maybeEncodeVideoFile(image) }),
+        },
+        successfulResponseHandler: createJsonResponseHandler(
+          gatewayVideoResponseSchema,
+        ),
+        failedResponseHandler: createJsonErrorResponseHandler({
+          errorSchema: z.any(),
+          errorToMessage: data => data,
+        }),
+        ...(abortSignal && { abortSignal }),
+        fetch: this.config.fetch,
+      });
+
+      return {
+        videos: responseBody.videos,
+        warnings: responseBody.warnings ?? [],
+        providerMetadata:
+          responseBody.providerMetadata as SharedV3ProviderMetadata,
+        response: {
+          timestamp: new Date(),
+          modelId: this.modelId,
+          headers: responseHeaders,
+        },
+      };
+    } catch (error) {
+      throw asGatewayError(error, await parseAuthMethod(resolvedHeaders));
+    }
+  }
+
+  private getUrl() {
+    return `${this.config.baseURL}/video-model`;
+  }
+
+  private getModelConfigHeaders() {
+    return {
+      'ai-video-model-specification-version': '3',
+      'ai-model-id': this.modelId,
+    };
+  }
+}
+
+function maybeEncodeVideoFile(file: Experimental_VideoModelV3File) {
+  if (file.type === 'file' && file.data instanceof Uint8Array) {
+    return {
+      ...file,
+      data: convertUint8ArrayToBase64(file.data),
+    };
+  }
+  return file;
+}
+
+const providerMetadataEntrySchema = z
+  .object({
+    videos: z.array(z.unknown()).optional(),
+  })
+  .catchall(z.unknown());
+
+const gatewayVideoDataSchema = z.union([
+  z.object({
+    type: z.literal('url'),
+    url: z.string(),
+    mediaType: z.string(),
+  }),
+  z.object({
+    type: z.literal('base64'),
+    data: z.string(),
+    mediaType: z.string(),
+  }),
+]);
+
+const gatewayVideoResponseSchema = z.object({
+  videos: z.array(gatewayVideoDataSchema),
+  warnings: z
+    .array(
+      z.object({
+        type: z.literal('other'),
+        message: z.string(),
+      }),
+    )
+    .optional(),
+  providerMetadata: z
+    .record(z.string(), providerMetadataEntrySchema)
+    .optional(),
+});

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,4 +1,5 @@
 export type { GatewayModelId } from './gateway-language-model-settings';
+export type { GatewayVideoModelId } from './gateway-video-model-settings';
 export type {
   GatewayLanguageModelEntry,
   GatewayLanguageModelSpecification,


### PR DESCRIPTION
## Background

The Gateway provider in AI SDK currently supports language, embedding, and image generation models, but lacks support for video generation. This change adds video generation capabilities to the Gateway provider, allowing users to generate videos using various models like Google's Veo.

## Summary

This PR adds video generation support to the Gateway provider by:

1. Creating a new `GatewayVideoModel` class that implements the `Experimental_VideoModelV3` interface
2. Adding a `videoModel()` method to the `GatewayProvider` interface
3. Defining supported video model IDs in a new `GatewayVideoModelId` type
4. Adding comprehensive tests for the new video generation functionality

## Manual Verification

Ran example script against a development gateway server.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)