### PR TITLE
Ai SDK RSS broken link

### DIFF
--- a/.github/ISSUE_RSS_FEED_FIX.md
+++ b/.github/ISSUE_RSS_FEED_FIX.md
@@ -1,12 +1,15 @@
 # RSS Feed Broken Link Fix
 
 ## Issue
+
 The broken link checker reported that `https://ai-sdk.dev/rss.xml` returns a 404 error on 2026-02-02 (reported in Slack #feedback-docs channel).
 
 ## Root Cause
-The issue is in the **vercel/ai-elements** repository, not in this repository (vercel/ai). 
+
+The issue is in the **vercel/ai-elements** repository, not in this repository (vercel/ai).
 
 The AI Elements documentation site has:
+
 - RSS feed route handler at `apps/docs/app/[lang]/rss.xml/route.ts`
 - RSS button that links to `/rss.xml`
 - But no rewrite rule to map `/rss.xml` to `/en/rss.xml`
@@ -14,9 +17,12 @@ The AI Elements documentation site has:
 This causes the RSS feed to be inaccessible at the path referenced by the RSS button.
 
 ## Fix Applied
+
 Created issue in ai-elements repository with the solution:
+
 - **Issue**: https://github.com/vercel/ai-elements/issues/353
 - **Fix**: Add rewrite rule in `apps/docs/next.config.mjs` to map `/rss.xml` to `/en/rss.xml`
 
 ## No Changes Needed in This Repository
+
 The vercel/ai repository content does not reference the RSS feed, and the issue is isolated to the AI Elements documentation site configuration.

--- a/.github/ISSUE_RSS_FEED_FIX.md
+++ b/.github/ISSUE_RSS_FEED_FIX.md
@@ -1,0 +1,22 @@
+# RSS Feed Broken Link Fix
+
+## Issue
+The broken link checker reported that `https://ai-sdk.dev/rss.xml` returns a 404 error on 2026-02-02 (reported in Slack #feedback-docs channel).
+
+## Root Cause
+The issue is in the **vercel/ai-elements** repository, not in this repository (vercel/ai). 
+
+The AI Elements documentation site has:
+- RSS feed route handler at `apps/docs/app/[lang]/rss.xml/route.ts`
+- RSS button that links to `/rss.xml`
+- But no rewrite rule to map `/rss.xml` to `/en/rss.xml`
+
+This causes the RSS feed to be inaccessible at the path referenced by the RSS button.
+
+## Fix Applied
+Created issue in ai-elements repository with the solution:
+- **Issue**: https://github.com/vercel/ai-elements/issues/353
+- **Fix**: Add rewrite rule in `apps/docs/next.config.mjs` to map `/rss.xml` to `/en/rss.xml`
+
+## No Changes Needed in This Repository
+The vercel/ai repository content does not reference the RSS feed, and the issue is isolated to the AI Elements documentation site configuration.


### PR DESCRIPTION
## Background

A broken RSS feed link (`https://ai-sdk.dev/rss.xml`) was reported. This PR documents the investigation into the issue and clarifies that the fix is required in a different repository.

## Summary

This PR adds a new file, `.github/ISSUE_RSS_FEED_FIX.md`, to document the root cause of the broken RSS feed link on `ai-sdk.dev`. The investigation determined that the issue is located within the `vercel/ai-elements` repository, not `vercel/ai`. The added documentation explains the problem and links to the corresponding issue created in the `ai-elements` repository for the actual resolution.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

The actual fix for the RSS feed link needs to be implemented in the `vercel/ai-elements` repository.

## Related Issues

See also: vercel/ai-elements#353

---
[Slack Thread](https://vercel.slack.com/archives/C02F56A54LU/p1770022804191519?thread_ts=1770022804.191519&cid=C02F56A54LU)

<a href="https://cursor.com/background-agent?bcId=bc-a842efde-244d-553e-8c31-5a98b2cea918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a842efde-244d-553e-8c31-5a98b2cea918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

