### PR TITLE
fix(ai): auto-populate `originalMessages` in `createAgentUIStream`

### DIFF
--- a/.changeset/hungry-onions-fix.md
+++ b/.changeset/hungry-onions-fix.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): auto-populate `originalMessages` in `createAgentUIStream`

--- a/packages/ai/src/agent/create-agent-ui-stream-response.test.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.test.ts
@@ -221,7 +221,7 @@ describe('createAgentUIStreamResponse', () => {
     it('should return the UI message stream response', () => {
       expect(decodedChunks).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start"}
+          "data: {"type":"start","messageId":"msg-2"}
 
         ",
           "data: {"type":"start-step"}
@@ -253,6 +253,107 @@ describe('createAgentUIStreamResponse', () => {
         ",
         ]
       `);
+    });
+  });
+
+  describe('when using onFinish without originalMessages', () => {
+    it('should call onFinish callback and complete stream without errors', async () => {
+      let onFinishCalled = false;
+      let finishMessages: unknown[] | undefined;
+
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV3({
+          doStream: async () => {
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'stream-start',
+                  warnings: [],
+                },
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Done!' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: {
+                    inputTokens: {
+                      total: 5,
+                      noCache: 5,
+                      cacheRead: undefined,
+                      cacheWrite: undefined,
+                    },
+                    outputTokens: {
+                      total: 5,
+                      text: 5,
+                      reasoning: undefined,
+                    },
+                  },
+                  providerMetadata: undefined,
+                },
+              ]),
+            };
+          },
+        }),
+        tools: {
+          testTool: tool({
+            description: 'Test tool',
+            inputSchema: z.object({ value: z.string() }),
+            outputSchema: z.object({ result: z.string() }),
+          }),
+        },
+      });
+
+      const response = await createAgentUIStreamResponse({
+        agent,
+        uiMessages: [
+          {
+            role: 'user',
+            id: 'msg-1',
+            parts: [{ type: 'text' as const, text: 'Run test tool' }],
+          },
+          {
+            role: 'assistant',
+            id: 'msg-2',
+            parts: [
+              {
+                type: 'tool-testTool' as const,
+                toolCallId: 'call-1',
+                state: 'output-available',
+                input: { value: 'test' },
+                output: { result: 'success' },
+              },
+            ],
+          },
+        ],
+        // Note: originalMessages is NOT provided, relying on auto-population
+        onFinish: ({ messages }) => {
+          onFinishCalled = true;
+          finishMessages = messages;
+        },
+      });
+
+      // Consume the response to trigger onFinish
+      const decoder = new TextDecoder();
+      const encodedStream = response.body!;
+      const chunks = await convertReadableStreamToArray(encodedStream);
+      const decodedChunks = chunks.map(chunk => decoder.decode(chunk));
+
+      // Verify stream completed successfully
+      expect(
+        decodedChunks.some(chunk => chunk.includes('"type":"finish"')),
+      ).toBe(true);
+
+      // Verify onFinish was called with messages
+      expect(onFinishCalled).toBe(true);
+      expect(finishMessages).toBeDefined();
+      expect(finishMessages!.length).toBe(2);
     });
   });
 });

--- a/packages/ai/src/agent/create-agent-ui-stream-response.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.ts
@@ -14,6 +14,9 @@ import { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-on-step-fin
  *
  * @param agent - The agent to run.
  * @param uiMessages - The input UI messages.
+ * @param originalMessages - The original messages for state reconstruction.
+ *   Defaults to the validated uiMessages. Used for message ID management
+ *   and to provide proper context for callbacks like onFinish.
  * @param abortSignal - Abort signal. Optional.
  * @param timeout - Timeout in milliseconds. Optional.
  * @param options - The options for the agent. Optional.

--- a/packages/ai/src/agent/create-agent-ui-stream-response.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.ts
@@ -14,9 +14,6 @@ import { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-on-step-fin
  *
  * @param agent - The agent to run.
  * @param uiMessages - The input UI messages.
- * @param originalMessages - The original messages for state reconstruction.
- *   Defaults to the validated uiMessages. Used for message ID management
- *   and to provide proper context for callbacks like onFinish.
  * @param abortSignal - Abort signal. Optional.
  * @param timeout - Timeout in milliseconds. Optional.
  * @param options - The options for the agent. Optional.

--- a/packages/ai/src/agent/create-agent-ui-stream.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.ts
@@ -15,9 +15,6 @@ import { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-on-step-fin
  *
  * @param agent - The agent to run.
  * @param uiMessages - The input UI messages.
- * @param originalMessages - The original messages for state reconstruction.
- *   Defaults to the validated uiMessages. Used for message ID management
- *   and to provide proper context for callbacks like onFinish.
  * @param abortSignal - The abort signal. Optional.
  * @param timeout - Timeout in milliseconds. Optional.
  * @param options - The options for the agent.

--- a/packages/ai/src/agent/create-agent-ui-stream.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.ts
@@ -47,6 +47,7 @@ export async function createAgentUIStream<
     | StreamTextTransform<TOOLS>
     | Array<StreamTextTransform<TOOLS>>;
   onStepFinish?: ToolLoopAgentOnStepFinishCallback<TOOLS>;
+  // TODO `originalMessages` is part of this for bc, omit in v7
 } & UIMessageStreamOptions<
   UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
 >): Promise<
@@ -76,6 +77,7 @@ export async function createAgentUIStream<
 
   return result.toUIMessageStream({
     ...uiMessageStreamOptions,
+    // TODO reading `originalMessages` is here for bc, always use `validatedMessages` in v7
     originalMessages:
       uiMessageStreamOptions.originalMessages ?? validatedMessages,
   });

--- a/packages/ai/src/agent/create-agent-ui-stream.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.ts
@@ -15,6 +15,9 @@ import { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-on-step-fin
  *
  * @param agent - The agent to run.
  * @param uiMessages - The input UI messages.
+ * @param originalMessages - The original messages for state reconstruction.
+ *   Defaults to the validated uiMessages. Used for message ID management
+ *   and to provide proper context for callbacks like onFinish.
  * @param abortSignal - The abort signal. Optional.
  * @param timeout - Timeout in milliseconds. Optional.
  * @param options - The options for the agent.
@@ -74,5 +77,9 @@ export async function createAgentUIStream<
     onStepFinish,
   });
 
-  return result.toUIMessageStream(uiMessageStreamOptions);
+  return result.toUIMessageStream({
+    ...uiMessageStreamOptions,
+    originalMessages:
+      uiMessageStreamOptions.originalMessages ?? validatedMessages,
+  });
 }


### PR DESCRIPTION
## Background

When using `createAgentUIStreamResponse` with the `onFinish` callback, streams would fail when handling tool approval scenarios. The issue occurred because when `originalMessages` was not provided, the internal state started empty, preventing proper message state reconstruction needed for tool continuation requests after approval/rejection.

The user discovered that explicitly passing `originalMessages: body.messages` worked around the issue, but this should have been the default behavior when not provided, especially since `onFinish` doesn't work without it.

## Summary

This PR fixes the bug by auto-populating `originalMessages` from the validated `uiMessages` in `createAgentUIStream` when not explicitly provided. This ensures proper state reconstruction for callbacks like `onFinish` while maintaining backward compatibility.

Changes:
- Auto-populate `originalMessages` with `validatedMessages` as the default in `createAgentUIStream`
- Added JSDoc comments explaining the purpose and default behavior of `originalMessages` parameter
  - Docs on this parameter were previously missing for `createAgentUIStream` and `createAgentUIStreamResponse`
- Added new test case verifying `onFinish` works without explicitly providing `originalMessages`
- Updated test snapshot to reflect correct behavior
  - This change should be reasonable because it's a tool call continuation, so the message ID must match the one of the last message

## Manual Verification

I verified this with the reproduction case from the issue:
1. Created a test with `ToolLoopAgent` using a tool that requires approval
2. Called `createAgentUIStreamResponse` with `onFinish` callback but without `originalMessages`
3. Verified the stream completes successfully and `onFinish` is called with proper message state
4. Confirmed no errors occur during tool continuation

The new test case demonstrates that the stream now works correctly without requiring users to manually pass `originalMessages`.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #12139
