### PR TITLE
fix(anthropic, ai): preserve error_code through UI message flow for provider tools

### DIFF
--- a/.changeset/fix-provider-tool-error-code.md
+++ b/.changeset/fix-provider-tool-error-code.md
@@ -1,0 +1,27 @@
+---
+'@ai-sdk/anthropic': patch
+'ai': patch
+---
+
+fix(anthropic, ai): preserve error_code through UI message flow for provider tools
+
+**Issue 1 (fallback)**: When provider-executed tools (web_fetch, code_execution) return errors without
+an explicit error code, the fallback was 'unknown' which is not a valid Anthropic error code. Changed
+to 'unavailable'.
+
+**Issue 2 (preservation)**: The original error_code (like 'url_not_allowed') was lost when stored in
+UI state - it became a plain errorText string, losing the structured error. On subsequent requests,
+the Anthropic converter tried to parse errorText but failed, falling back to 'unavailable'.
+
+The fix preserves errorCode through the entire UI message flow:
+
+1. Extract errorCode from tool-error objects in stream-text.ts
+2. Add errorCode to tool-output-error UI chunks and UIToolInvocation types
+3. Pass errorCode through process-ui-message-stream.ts
+4. Include errorCode in createToolModelOutput for error-json type
+5. Anthropic converter now receives the preserved errorCode
+
+This ensures that specific error codes like 'url_not_allowed' are properly returned to the Anthropic
+API on subsequent requests, instead of falling back to 'unavailable'.
+
+Fixes #12203

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2360,10 +2360,22 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
             case 'tool-error': {
               const dynamic = isDynamic(part);
 
+              // Extract errorCode from error object if available (for provider-executed tools)
+              const errorCode =
+                typeof part.error === 'object' &&
+                part.error !== null &&
+                'errorCode' in part.error &&
+                typeof (part.error as Record<string, unknown>).errorCode ===
+                  'string'
+                  ? ((part.error as Record<string, unknown>)
+                      .errorCode as string)
+                  : undefined;
+
               controller.enqueue({
                 type: 'tool-output-error',
                 toolCallId: part.toolCallId,
                 errorText: onError(part.error),
+                ...(errorCode != null ? { errorCode } : {}),
                 ...(part.providerExecuted != null
                   ? { providerExecuted: part.providerExecuted }
                   : {}),

--- a/packages/ai/src/prompt/create-tool-model-output.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.ts
@@ -7,17 +7,25 @@ export async function createToolModelOutput({
   output,
   tool,
   errorMode,
+  errorCode,
 }: {
   toolCallId: string;
   input: unknown;
   output: unknown;
   tool: Tool | undefined;
   errorMode: 'none' | 'text' | 'json';
+  errorCode?: string;
 }): Promise<ToolResultOutput> {
   if (errorMode === 'text') {
     return { type: 'error-text', value: getErrorMessage(output) };
   } else if (errorMode === 'json') {
-    return { type: 'error-json', value: toJSONValue(output) };
+    return {
+      type: 'error-json',
+      value:
+        errorCode != null
+          ? { errorCode, errorText: getErrorMessage(output) }
+          : toJSONValue(output),
+    };
   }
 
   if (tool?.toModelOutput) {

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -88,6 +88,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
         type: z.literal('tool-output-error'),
         toolCallId: z.string(),
         errorText: z.string(),
+        errorCode: z.string().optional(),
         providerExecuted: z.boolean().optional(),
         dynamic: z.boolean().optional(),
       }),
@@ -266,6 +267,7 @@ export type UIMessageChunk<
       type: 'tool-output-error';
       toolCallId: string;
       errorText: string;
+      errorCode?: string;
       providerExecuted?: boolean;
       dynamic?: boolean;
     }

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -216,6 +216,10 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                         tool: options?.tools?.[toolName],
                         errorMode:
                           part.state === 'output-error' ? 'json' : 'none',
+                        errorCode:
+                          part.state === 'output-error'
+                            ? part.errorCode
+                            : undefined,
                       }),
                       ...(part.callProviderMetadata != null
                         ? { providerOptions: part.callProviderMetadata }

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -151,6 +151,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   input: unknown;
                   rawInput?: unknown;
                   errorText: string;
+                  errorCode?: string;
                   providerExecuted?: boolean;
                   providerMetadata?: ProviderMetadata;
                 }
@@ -170,6 +171,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               anyPart.input = anyOptions.input;
               anyPart.output = anyOptions.output;
               anyPart.errorText = anyOptions.errorText;
+              if (anyOptions.errorCode !== undefined) {
+                anyPart.errorCode = anyOptions.errorCode;
+              }
               anyPart.rawInput = anyOptions.rawInput;
               anyPart.preliminary = anyOptions.preliminary;
               if (options.title !== undefined) {
@@ -192,6 +196,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 output: anyOptions.output,
                 rawInput: anyOptions.rawInput,
                 errorText: anyOptions.errorText,
+                ...(anyOptions.errorCode !== undefined
+                  ? { errorCode: anyOptions.errorCode }
+                  : {}),
                 providerExecuted: anyOptions.providerExecuted,
                 preliminary: anyOptions.preliminary,
                 ...(anyOptions.providerMetadata != null
@@ -228,6 +235,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   state: 'output-error';
                   input: unknown;
                   errorText: string;
+                  errorCode?: string;
                   providerMetadata?: ProviderMetadata;
                 }
             ),
@@ -247,6 +255,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               anyPart.input = anyOptions.input;
               anyPart.output = anyOptions.output;
               anyPart.errorText = anyOptions.errorText;
+              if (anyOptions.errorCode !== undefined) {
+                anyPart.errorCode = anyOptions.errorCode;
+              }
               anyPart.rawInput = anyOptions.rawInput ?? anyPart.rawInput;
               anyPart.preliminary = anyOptions.preliminary;
               if (options.title !== undefined) {
@@ -268,6 +279,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 input: anyOptions.input,
                 output: anyOptions.output,
                 errorText: anyOptions.errorText,
+                ...(anyOptions.errorCode !== undefined
+                  ? { errorCode: anyOptions.errorCode }
+                  : {}),
                 preliminary: anyOptions.preliminary,
                 providerExecuted: anyOptions.providerExecuted,
                 title: options.title,
@@ -641,6 +655,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   state: 'output-error',
                   input: (toolInvocation as any).input,
                   errorText: chunk.errorText,
+                  errorCode: chunk.errorCode,
                   providerExecuted: chunk.providerExecuted,
                   title: toolInvocation.title,
                 });
@@ -652,6 +667,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   input: (toolInvocation as any).input,
                   rawInput: (toolInvocation as any).rawInput,
                   errorText: chunk.errorText,
+                  errorCode: chunk.errorCode,
                   providerExecuted: chunk.providerExecuted,
                   title: toolInvocation.title,
                 });

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -287,6 +287,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
       rawInput?: unknown; // TODO AI SDK 6: remove this field, input should be unknown
       output?: never;
       errorText: string;
+      errorCode?: string;
       callProviderMetadata?: ProviderMetadata;
       approval?: {
         id: string;
@@ -391,6 +392,7 @@ export type DynamicToolUIPart = {
       input: unknown;
       output?: never;
       errorText: string;
+      errorCode?: string;
       callProviderMetadata?: ProviderMetadata;
       approval?: {
         id: string;

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -1495,7 +1495,7 @@ describe('assistant messages', () => {
       {
         "cache_control": undefined,
         "content": {
-          "error_code": "unknown",
+          "error_code": "unavailable",
           "type": "web_fetch_tool_result_error",
         },
         "tool_use_id": "srvtoolu_test123",

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -692,7 +692,7 @@ export async function convertToAnthropicMessagesPrompt({
                         tool_use_id: part.toolCallId,
                         content: {
                           type: 'code_execution_tool_result_error' as const,
-                          error_code: errorInfo.errorCode ?? 'unknown',
+                          error_code: errorInfo.errorCode ?? 'unavailable',
                         },
                         cache_control: cacheControl,
                       });
@@ -703,7 +703,7 @@ export async function convertToAnthropicMessagesPrompt({
                         cache_control: cacheControl,
                         content: {
                           type: 'bash_code_execution_tool_result_error' as const,
-                          error_code: errorInfo.errorCode ?? 'unknown',
+                          error_code: errorInfo.errorCode ?? 'unavailable',
                         },
                       });
                     }
@@ -821,7 +821,7 @@ export async function convertToAnthropicMessagesPrompt({
                         errorCode:
                           typeof extractedErrorCode === 'string'
                             ? extractedErrorCode
-                            : 'unknown',
+                            : 'unavailable',
                       };
                     }
 
@@ -830,7 +830,7 @@ export async function convertToAnthropicMessagesPrompt({
                       tool_use_id: part.toolCallId,
                       content: {
                         type: 'web_fetch_tool_result_error',
-                        error_code: errorValue.errorCode ?? 'unknown',
+                        error_code: errorValue.errorCode ?? 'unavailable',
                       },
                       cache_control: cacheControl,
                     });


### PR DESCRIPTION
Fixes #12203

When `web_fetch` or other provider tools return errors like `url_not_allowed`, the error code was getting lost in UI state. On the next message, the SDK fell back to `'unknown'` which Anthropic rejects with a 400.

Two fixes here:

1. **Preserve the error code** - Added `errorCode` field through the UI message flow so it survives round-trips
2. **Valid fallback** - Changed fallback from `'unknown'` to `'unavailable'` (a valid Anthropic error code)

The flow now: provider returns error → extract errorCode → store in UI state → pass to createToolModelOutput → Anthropic converter gets the original code back.

Tests pass, let me know if anything needs tweaking!