### PR TITLE
fix(ai): DeepInfra completion tokens calculation for gemini models

### DIFF
--- a/.changeset/lazy-crews-clap.md
+++ b/.changeset/lazy-crews-clap.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+fix(ai): DeepInfra completion tokens calculation for gemini models


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

We noticed in ai-gateway logs that Deepinfra's gemini models' output tokens are negative.

## Summary

<!-- What did you change? -->

Deepinfra's issue with how they convert gemini response to openai-compat, this is a raw output from them where completion tokens < reasoning tokens. For openai-compat, completion tokens should include reasoning tokens.
```
  "prompt_tokens": 19,
  "completion_tokens": 84,
  "total_tokens": 1184,
  "prompt_tokens_details": null,
  "completion_tokens_details": {
    "reasoning_tokens": 1081
  }
```

They use vllm, and the issue should be [here](https://github.com/vllm-project/vllm/blob/5019c59dd2d34feb2bc6e52699a36059eacf64a9/vllm/entrypoints/openai/engine/protocol.py#L104) where they don't treat `complete_token_details`.

Added a conditional logic to override their calculation issues for the models we are seeing issues for but keeping the other models unchanged.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

- Verified with streaming and non-streaming tests on both gemini models with Deepinfra
- Verified with additional unit tests

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

[A PR](https://github.com/vllm-project/vllm/pull/18067) is open on vllm related to reasoning tokens calculation, but it is making progress very slowly, I subscribed to it. If reasoning tokens are incorporated by vllm, I can revert the code changes here.
