### PR TITLE
build: add Slack notifications for critical workflow failures

### DIFF
--- a/.github/workflows/slack-team-review-notification.yml
+++ b/.github/workflows/slack-team-review-notification.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   notify-slack:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: debug
         run: cat $GITHUB_EVENT_PATH
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "Checking requested teams..."
           teams='${{ toJson(github.event.pull_request.requested_teams) }}'
-          
+
           # Check if ai-sdk team is in the requested teams
           if echo "$teams" | jq -e '.[] | select(.slug == "ai-sdk")' > /dev/null; then
             echo "ai_sdk_requested=true" >> $GITHUB_OUTPUT
@@ -29,10 +29,10 @@ jobs:
       - name: Send Slack notification
         if: steps.check_team.outputs.ai_sdk_requested == 'true'
         run: |
-          curl ${{ env.SLACK_SEND_MESSAGE_URL }} -X POST -H "Content-Type: application/json" -d '{"channel_id": "${{ env.CHANNEL_ID }}", "number": "${{ env.NUMBER }}", "title": ${{ toJson(env.TITLE) }}, "url": "${{ env.URL }}"}'
+          curl ${{ env.SLACK_PR_REVIEW_REQUEST_URL }} -X POST -H "Content-Type: application/json" -d '{"channel_id": "${{ env.CHANNEL_ID }}", "number": "${{ env.NUMBER }}", "title": ${{ toJson(env.TITLE) }}, "url": "${{ env.URL }}"}'
         env:
-          SLACK_SEND_MESSAGE_URL: ${{ secrets.SLACK_SEND_MESSAGE_URL }}
-          CHANNEL_ID: "C050WU03V3N"
+          SLACK_PR_REVIEW_REQUEST_URL: ${{ secrets.SLACK_PR_REVIEW_REQUEST_URL }}
+          CHANNEL_ID: 'C050WU03V3N'
           NUMBER: ${{ github.event.pull_request.number }}
           TITLE: ${{ github.event.pull_request.title }}
           URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/slack-workflow-failure-notification.yml
+++ b/.github/workflows/slack-workflow-failure-notification.yml
@@ -1,0 +1,25 @@
+name: Slack Workflow Failure Notification
+
+on:
+  workflow_run:
+    workflows:
+      - 'Auto-merge Release PRs'
+      - 'Backport'
+      - 'Release'
+    types:
+      - completed
+
+jobs:
+  notify-on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+
+    steps:
+      - name: Send Slack notification
+        run: |
+          curl ${{ env.SLACK_WORKFLOW_FAILURE_URL }} -X POST -H "Content-Type: application/json" -d '{"channel_id": "${{ env.CHANNEL_ID }}", "workflow_name": "${{ env.WORKFLOW_NAME }}", "workflow_url": "${{ env.WORKFLOW_URL }}"}'
+        env:
+          SLACK_WORKFLOW_FAILURE_URL: ${{ secrets.SLACK_WORKFLOW_FAILURE_URL }}
+          CHANNEL_ID: 'C050WU03V3N'
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}


### PR DESCRIPTION
## Background

As part of #12223, we need observability for critical GitHub Action workflows (Auto-merge Release PRs, Backport, and Release) to ensure the team is notified when they fail unexpectedly.

## Summary

- Created new workflow `.github/workflows/slack-workflow-failure-notification.yml` that monitors the three critical workflows and sends Slack notifications to #team-ai-sdk when they fail
- Renamed `SLACK_SEND_MESSAGE_URL` to `SLACK_PR_REVIEW_REQUEST_URL` in `.github/workflows/slack-team-review-notification.yml` to better reflect its specific purpose (PR review requests vs general notifications)

The failure notification format:
```
❌ GitHub Action Workflow failed: <workflow name>
<workflow run URL>
```

## Manual Verification

Tested the Slack webhook endpoint with curl to verify the message format works correctly.

## Tasks

Before merging, the following GitHub secrets need to be created:

- [x] Create `SLACK_PR_REVIEW_REQUEST_URL` secret (new name for existing `SLACK_SEND_MESSAGE_URL`)
- [x] Create `SLACK_WORKFLOW_FAILURE_URL` secret with the workflow failure webhook endpoint
- [x] Once merged, remove obsolete `SLACK_SEND_MESSAGE_URL`)

## Checklist

- [ ] ~~Tests have been added / updated (for bug fixes / features)~~
- [ ] ~~Documentation has been added / updated (for bug fixes / features)~~
- [ ] ~~A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)~~
- [ ] I have reviewed this pull request (self-review)

## Related Issues

Fixes #12223