### PR TITLE
fix: app.langwatch.com -> app.langwatch.ai

### DIFF
--- a/content/providers/05-observability/langwatch.mdx
+++ b/content/providers/05-observability/langwatch.mdx
@@ -9,7 +9,7 @@ description: Track, monitor, guardrail and evaluate your AI SDK applications wit
 
 ## Setup
 
-Obtain your `LANGWATCH_API_KEY` from the [LangWatch dashboard](https://app.langwatch.com/).
+Obtain your `LANGWATCH_API_KEY` from the [LangWatch dashboard](https://app.langwatch.ai/).
 
 <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
   <Tab>


### PR DESCRIPTION
## Background

Fixes an external link that was pointing to an incorrect LangWatch dashboard domain.

## Summary

Corrects the LangWatch dashboard URL from `app.langwatch.com` to `app.langwatch.ai` in the observability provider documentation.

## Manual Verification

- Opened the LangWatch observability docs page
- Clicked the dashboard link
- Confirmed it resolves to `https://app.langwatch.ai/`

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Validate external links in other observability provider docs

## Related Issues

N/A
