### PR TITLE
Feat/xai tool calls finish reason

### DIFF
--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -374,6 +374,7 @@ export class XaiChatLanguageModel implements LanguageModelV3 {
       unified: 'other',
       raw: undefined,
     };
+    let rawFinishReason: string | null | undefined;
     // a new boolean var that tracks if tool calls present in doStream or not
     let hasStreamedToolCalls = false;
     let usage: LanguageModelV3Usage | undefined = undefined;
@@ -440,12 +441,7 @@ export class XaiChatLanguageModel implements LanguageModelV3 {
 
             // update finish reason if present
             if (choice?.finish_reason != null) {
-              finishReason = {
-                unified: hasStreamedToolCalls
-                  ? 'tool-calls'
-                  : mapXaiFinishReason(choice.finish_reason),
-                raw: choice.finish_reason,
-              };
+              rawFinishReason = choice.finish_reason;
             }
 
             // exit if no delta to process
@@ -587,6 +583,13 @@ export class XaiChatLanguageModel implements LanguageModelV3 {
                 });
               }
             }
+
+            finishReason = {
+              unified: hasStreamedToolCalls
+                ? 'tool-calls'
+                : mapXaiFinishReason(rawFinishReason),
+              raw: rawFinishReason ?? undefined,
+            };
 
             controller.enqueue({ type: 'finish', finishReason, usage: usage! });
           },


### PR DESCRIPTION
This commit provides a follow-up fix to the xAI provider's handling of `finishReason` in streaming responses, specifically when tool calls are involved.

Previously, a `finishReason` (`unified`) for streaming responses might have been incorrectly computed if a single streaming chunk contained both a raw `finish_reason` (e.g., "stop") and `tool_calls`. This was due to an order-of-operations issue where the `finishReason` was evaluated within the `transform` function before `hasStreamedToolCalls` was definitively set based on all processed chunks.

To resolve this, the computation of the `unified` `finishReason` in the `doStream` method has been deferred. The `rawFinishReason` is now stored in the `transform` function, and the final `unified` `finishReason` is computed in the `flush` handler. This ensures that `hasStreamedToolCalls` accurately reflects all tool calls encountered throughout the stream, leading to a consistently correct `'tool-calls'` `finishReason` when appropriate.