### PR TITLE
fix(deepinfra): correct token usage for Gemini/Gemma models

### DIFF
--- a/.changeset/ebb251f4-deepinfra-usage-fix.md
+++ b/.changeset/ebb251f4-deepinfra-usage-fix.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/deepinfra': patch
+---
+
+fix: correct token usage calculation for Gemini/Gemma models
+
+DeepInfra's API returns incorrect token usage data for Gemini/Gemma models where completion_tokens is smaller than reasoning_tokens, violating the OpenAI-compatible spec. This resulted in negative text token counts.
+
+The fix detects when reasoning_tokens > completion_tokens and corrects completion_tokens to equal reasoning_tokens, ensuring accurate token usage reporting.

--- a/.changeset/ebb251f4-deepinfra-usage-fix.md
+++ b/.changeset/ebb251f4-deepinfra-usage-fix.md
@@ -1,9 +1,0 @@
----
-'@ai-sdk/deepinfra': patch
----
-
-fix: correct token usage calculation for Gemini/Gemma models
-
-DeepInfra's API returns incorrect token usage data for Gemini/Gemma models where completion_tokens is smaller than reasoning_tokens, violating the OpenAI-compatible spec. This resulted in negative text token counts.
-
-The fix detects when reasoning_tokens > completion_tokens and corrects completion_tokens to equal reasoning_tokens, ensuring accurate token usage reporting.

--- a/.changeset/khaki-bananas-punch.md
+++ b/.changeset/khaki-bananas-punch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/deepinfra': patch
+---
+
+fix: correct token usage calculation for Gemini/Gemma models

--- a/packages/deepinfra/src/deepinfra-chat-language-model.test.ts
+++ b/packages/deepinfra/src/deepinfra-chat-language-model.test.ts
@@ -54,11 +54,11 @@ describe('DeepInfraChatLanguageModel', () => {
       });
 
       // The usage should be corrected:
-      // - completion_tokens should be set to reasoning_tokens (1081) since it was incorrectly smaller
-      // - text tokens should be 0 (since all tokens are reasoning tokens)
+      // - completion_tokens should be text + reasoning: 84 + 1081 = 1165
+      // - text tokens should be 84 (the original completion_tokens value)
       // - reasoning tokens should be 1081
-      expect(result.usage.outputTokens.total).toBe(1081);
-      expect(result.usage.outputTokens.text).toBe(0);
+      expect(result.usage.outputTokens.total).toBe(1165); // 84 + 1081
+      expect(result.usage.outputTokens.text).toBe(84);
       expect(result.usage.outputTokens.reasoning).toBe(1081);
     });
 

--- a/packages/deepinfra/src/deepinfra-chat-language-model.test.ts
+++ b/packages/deepinfra/src/deepinfra-chat-language-model.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DeepInfraChatLanguageModel } from './deepinfra-chat-language-model';
+
+describe('DeepInfraChatLanguageModel', () => {
+  describe('usage calculation', () => {
+    it('should fix incorrect completion_tokens for gemini/gemma models when reasoning_tokens > completion_tokens', async () => {
+      const responseBody = {
+        id: 'test-id',
+        object: 'chat.completion',
+        created: 1234567890,
+        model: 'google/gemma-2-9b-it',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: 'Test response',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        // This is the problematic usage data from DeepInfra for gemini/gemma models
+        usage: {
+          prompt_tokens: 19,
+          completion_tokens: 84,
+          total_tokens: 1184,
+          prompt_tokens_details: null,
+          completion_tokens_details: {
+            reasoning_tokens: 1081,
+          },
+        },
+      };
+
+      const model = new DeepInfraChatLanguageModel('google/gemma-2-9b-it', {
+        provider: 'deepinfra.chat',
+        url: () => 'https://api.deepinfra.com/v1/openai/chat/completions',
+        headers: () => ({ Authorization: 'Bearer test-key' }),
+        fetch: vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          text: async () => JSON.stringify(responseBody),
+          json: async () => responseBody,
+        }) as any,
+      });
+
+      const result = await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Test prompt' }],
+          },
+        ],
+      });
+
+      // The usage should be corrected:
+      // - completion_tokens should be set to reasoning_tokens (1081) since it was incorrectly smaller
+      // - text tokens should be 0 (since all tokens are reasoning tokens)
+      // - reasoning tokens should be 1081
+      expect(result.usage.outputTokens.total).toBe(1081);
+      expect(result.usage.outputTokens.text).toBe(0);
+      expect(result.usage.outputTokens.reasoning).toBe(1081);
+    });
+
+    it('should not modify usage for non-gemini models with correct data', async () => {
+      const responseBody = {
+        id: 'test-id',
+        object: 'chat.completion',
+        created: 1234567890,
+        model: 'mistralai/Mixtral-8x7B-Instruct-v0.1',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: 'Test response',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 18,
+          completion_tokens: 475,
+          total_tokens: 493,
+          prompt_tokens_details: null,
+        },
+      };
+
+      const model = new DeepInfraChatLanguageModel(
+        'mistralai/Mixtral-8x7B-Instruct-v0.1',
+        {
+          provider: 'deepinfra.chat',
+          url: () => 'https://api.deepinfra.com/v1/openai/chat/completions',
+          headers: () => ({ Authorization: 'Bearer test-key' }),
+          fetch: vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            text: async () => JSON.stringify(responseBody),
+            json: async () => responseBody,
+          }) as any,
+        },
+      );
+
+      const result = await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Test prompt' }],
+          },
+        ],
+      });
+
+      expect(result.usage.outputTokens.total).toBe(475);
+      expect(result.usage.outputTokens.text).toBe(475);
+      expect(result.usage.outputTokens.reasoning).toBe(0);
+    });
+  });
+});

--- a/packages/deepinfra/src/deepinfra-chat-language-model.ts
+++ b/packages/deepinfra/src/deepinfra-chat-language-model.ts
@@ -1,0 +1,170 @@
+import {
+  LanguageModelV3CallOptions,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamResult,
+} from '@ai-sdk/provider';
+import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
+import { FetchFunction } from '@ai-sdk/provider-utils';
+
+type DeepInfraChatConfig = {
+  provider: string;
+  url: (options: { path: string; modelId?: string }) => string;
+  headers: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+};
+
+export class DeepInfraChatLanguageModel extends OpenAICompatibleChatLanguageModel {
+  constructor(modelId: string, config: DeepInfraChatConfig) {
+    super(modelId, config);
+  }
+
+  /**
+   * Fixes incorrect token usage for Gemini/Gemma models from DeepInfra.
+   *
+   * DeepInfra's API returns completion_tokens that are smaller than reasoning_tokens
+   * for Gemini/Gemma models, which violates the OpenAI-compatible spec.
+   * According to the spec, completion_tokens should include reasoning_tokens.
+   *
+   * Example of incorrect data from DeepInfra:
+   * {
+   *   "completion_tokens": 84,
+   *   "completion_tokens_details": {
+   *     "reasoning_tokens": 1081
+   *   }
+   * }
+   *
+   * This would result in negative text tokens: 84 - 1081 = -997
+   *
+   * The fix: If reasoning_tokens > completion_tokens, set completion_tokens = reasoning_tokens
+   */
+  private fixUsageForGeminiModels(usage: any): typeof usage {
+    if (!usage || !usage.completion_tokens_details?.reasoning_tokens) {
+      return usage;
+    }
+
+    const completionTokens = usage.completion_tokens ?? 0;
+    const reasoningTokens = usage.completion_tokens_details.reasoning_tokens;
+
+    // If reasoning tokens exceed completion tokens, the API data is incorrect
+    if (reasoningTokens > completionTokens) {
+      return {
+        ...usage,
+        // Set completion_tokens to reasoning_tokens since all tokens are reasoning tokens
+        completion_tokens: reasoningTokens,
+        // Update total_tokens if present
+        total_tokens:
+          usage.total_tokens != null
+            ? usage.total_tokens + (reasoningTokens - completionTokens)
+            : undefined,
+      };
+    }
+
+    return usage;
+  }
+
+  async doGenerate(
+    options: LanguageModelV3CallOptions,
+  ): Promise<LanguageModelV3GenerateResult> {
+    const result = await super.doGenerate(options);
+
+    // Fix usage if needed
+    if (result.usage?.raw) {
+      const fixedRawUsage = this.fixUsageForGeminiModels(result.usage.raw);
+      if (fixedRawUsage !== result.usage.raw) {
+        // Recalculate usage with fixed data
+        const promptTokens = fixedRawUsage.prompt_tokens ?? 0;
+        const completionTokens = fixedRawUsage.completion_tokens ?? 0;
+        const cacheReadTokens =
+          fixedRawUsage.prompt_tokens_details?.cached_tokens ?? 0;
+        const reasoningTokens =
+          fixedRawUsage.completion_tokens_details?.reasoning_tokens ?? 0;
+
+        return {
+          ...result,
+          usage: {
+            inputTokens: {
+              total: promptTokens,
+              noCache: promptTokens - cacheReadTokens,
+              cacheRead: cacheReadTokens,
+              cacheWrite: undefined,
+            },
+            outputTokens: {
+              total: completionTokens,
+              text: completionTokens - reasoningTokens,
+              reasoning: reasoningTokens,
+            },
+            raw: fixedRawUsage,
+          },
+        };
+      }
+    }
+
+    return result;
+  }
+
+  async doStream(
+    options: LanguageModelV3CallOptions,
+  ): Promise<LanguageModelV3StreamResult> {
+    const result = await super.doStream(options);
+
+    // Wrap the stream to fix usage in the final chunk
+    const originalStream = result.stream;
+    const fixUsage = this.fixUsageForGeminiModels.bind(this);
+
+    const transformedStream = new ReadableStream({
+      async start(controller) {
+        const reader = originalStream.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            // Fix usage in finish chunks
+            if (value.type === 'finish' && value.usage?.raw) {
+              const fixedRawUsage = fixUsage(value.usage.raw);
+              if (fixedRawUsage !== value.usage.raw) {
+                const promptTokens = fixedRawUsage.prompt_tokens ?? 0;
+                const completionTokens = fixedRawUsage.completion_tokens ?? 0;
+                const cacheReadTokens =
+                  fixedRawUsage.prompt_tokens_details?.cached_tokens ?? 0;
+                const reasoningTokens =
+                  fixedRawUsage.completion_tokens_details?.reasoning_tokens ??
+                  0;
+
+                controller.enqueue({
+                  ...value,
+                  usage: {
+                    inputTokens: {
+                      total: promptTokens,
+                      noCache: promptTokens - cacheReadTokens,
+                      cacheRead: cacheReadTokens,
+                      cacheWrite: undefined,
+                    },
+                    outputTokens: {
+                      total: completionTokens,
+                      text: completionTokens - reasoningTokens,
+                      reasoning: reasoningTokens,
+                    },
+                    raw: fixedRawUsage,
+                  },
+                });
+              } else {
+                controller.enqueue(value);
+              }
+            } else {
+              controller.enqueue(value);
+            }
+          }
+          controller.close();
+        } catch (error) {
+          controller.error(error);
+        }
+      },
+    });
+
+    return {
+      ...result,
+      stream: transformedStream,
+    };
+  }
+}

--- a/packages/deepinfra/src/deepinfra-provider.test.ts
+++ b/packages/deepinfra/src/deepinfra-provider.test.ts
@@ -1,7 +1,7 @@
 import { DeepInfraImageModel } from './deepinfra-image-model';
 import { createDeepInfra } from './deepinfra-provider';
+import { DeepInfraChatLanguageModel } from './deepinfra-chat-language-model';
 import {
-  OpenAICompatibleChatLanguageModel,
   OpenAICompatibleCompletionLanguageModel,
   OpenAICompatibleEmbeddingModel,
 } from '@ai-sdk/openai-compatible';
@@ -10,11 +10,14 @@ import { loadApiKey } from '@ai-sdk/provider-utils';
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 
 // Add type assertion for the mocked class
-const OpenAICompatibleChatLanguageModelMock =
-  OpenAICompatibleChatLanguageModel as unknown as Mock;
+const DeepInfraChatLanguageModelMock =
+  DeepInfraChatLanguageModel as unknown as Mock;
+
+vi.mock('./deepinfra-chat-language-model', () => ({
+  DeepInfraChatLanguageModel: vi.fn(),
+}));
 
 vi.mock('@ai-sdk/openai-compatible', () => ({
-  OpenAICompatibleChatLanguageModel: vi.fn(),
   OpenAICompatibleCompletionLanguageModel: vi.fn(),
   OpenAICompatibleEmbeddingModel: vi.fn(),
 }));
@@ -55,8 +58,7 @@ describe('DeepInfraProvider', () => {
       const model = provider('model-id');
 
       // Use the mocked version
-      const constructorCall =
-        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const constructorCall = DeepInfraChatLanguageModelMock.mock.calls[0];
       const config = constructorCall[1];
       config.headers();
 
@@ -76,8 +78,7 @@ describe('DeepInfraProvider', () => {
       const provider = createDeepInfra(options);
       const model = provider('model-id');
 
-      const constructorCall =
-        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const constructorCall = DeepInfraChatLanguageModelMock.mock.calls[0];
       const config = constructorCall[1];
       config.headers();
 
@@ -93,7 +94,7 @@ describe('DeepInfraProvider', () => {
       const modelId = 'foo-model-id';
 
       const model = provider(modelId);
-      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+      expect(model).toBeInstanceOf(DeepInfraChatLanguageModel);
     });
   });
 
@@ -104,8 +105,8 @@ describe('DeepInfraProvider', () => {
 
       const model = provider.chatModel(modelId);
 
-      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
-      expect(OpenAICompatibleChatLanguageModelMock).toHaveBeenCalledWith(
+      expect(model).toBeInstanceOf(DeepInfraChatLanguageModel);
+      expect(DeepInfraChatLanguageModelMock).toHaveBeenCalledWith(
         modelId,
         expect.objectContaining({
           provider: 'deepinfra.chat',

--- a/packages/deepinfra/src/deepinfra-provider.ts
+++ b/packages/deepinfra/src/deepinfra-provider.ts
@@ -5,7 +5,6 @@ import {
   ImageModelV3,
 } from '@ai-sdk/provider';
 import {
-  OpenAICompatibleChatLanguageModel,
   OpenAICompatibleCompletionLanguageModel,
   OpenAICompatibleEmbeddingModel,
 } from '@ai-sdk/openai-compatible';
@@ -20,6 +19,7 @@ import { DeepInfraEmbeddingModelId } from './deepinfra-embedding-options';
 import { DeepInfraCompletionModelId } from './deepinfra-completion-options';
 import { DeepInfraImageModelId } from './deepinfra-image-settings';
 import { DeepInfraImageModel } from './deepinfra-image-model';
+import { DeepInfraChatLanguageModel } from './deepinfra-chat-language-model';
 import { VERSION } from './version';
 
 export interface DeepInfraProviderSettings {
@@ -118,7 +118,7 @@ export function createDeepInfra(
   });
 
   const createChatModel = (modelId: DeepInfraChatModelId) => {
-    return new OpenAICompatibleChatLanguageModel(
+    return new DeepInfraChatLanguageModel(
       modelId,
       getCommonModelConfig('chat'),
     );


### PR DESCRIPTION
## Background

DeepInfra's API returns incorrect token usage data for Gemini/Gemma models, as reported in issue #12225. The API provides `completion_tokens` values that are smaller than `reasoning_tokens`, which violates the OpenAI-compatible specification where `completion_tokens` should include `reasoning_tokens`.

For example, the API returns:
```json
{
  "completion_tokens": 84,
  "reasoning_tokens": 1081
}
```

This causes the SDK to calculate text tokens as `completion_tokens - reasoning_tokens = 84 - 1081 = -997`, resulting in negative values.

## Summary

Created a custom `DeepInfraChatLanguageModel` class that extends `OpenAICompatibleChatLanguageModel` to fix the token usage calculation:

## Manual Verification

Running [examples/ai-functions/src/generate-text/deepinfra.ts](https://github.com/vercel/ai/blob/1ad315e1a014e5766152e89ec8d21c9ffb5a6939/examples/ai-functions/src/generate-text/deepinfra.ts) with `model: deepinfra('google/gemini-2.5-pro')`

Output before fix (note the negative `outputTokenDetails.textTokens`

```
Usage: {
  inputTokens: 9,
  inputTokenDetails: { noCacheTokens: 9, cacheReadTokens: 0, cacheWriteTokens: undefined },
  outputTokens: 1124,
  outputTokenDetails: { textTokens: -417, reasoningTokens: 1541 },
  totalTokens: 1133,
  raw: {
    prompt_tokens: 9,
    completion_tokens: 1124,
    total_tokens: 2674,
    prompt_tokens_details: null,
    completion_tokens_details: { reasoning_tokens: 1541 }
  },
  reasoningTokens: 1541,
  cachedInputTokens: 0
}
```

after fix

```
Usage: {
  inputTokens: 9,
  inputTokenDetails: { noCacheTokens: 9, cacheReadTokens: 0, cacheWriteTokens: undefined },
  outputTokens: 2554,
  outputTokenDetails: { textTokens: 1132, reasoningTokens: 1422 },
  totalTokens: 2563,
  raw: {
    prompt_tokens: 9,
    completion_tokens: 2554,
    total_tokens: 3985,
    prompt_tokens_details: null,
    completion_tokens_details: { reasoning_tokens: 1422 }
  },
  reasoningTokens: 1422,
  cachedInputTokens: 0
}
```

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run \`pnpm changeset\` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

This fix is a workaround for DeepInfra's API issue. If DeepInfra fixes their token calculation on their end (there's an [open PR on vllm](https://github.com/vllm-project/vllm/pull/18067)), this workaround can potentially be removed.

## Related Issues

Fixes #12225