### PR TITLE
fix(examples): fix sveltekit-openai type errors

### DIFF
--- a/examples/sveltekit-openai/src/lib/components/ui/button/button.svelte
+++ b/examples/sveltekit-openai/src/lib/components/ui/button/button.svelte
@@ -1,50 +1,6 @@
-<script lang="ts" module>
-  import type { WithElementRef } from 'bits-ui';
-  import type {
-    HTMLAnchorAttributes,
-    HTMLButtonAttributes,
-  } from 'svelte/elements';
-  import { type VariantProps, tv } from 'tailwind-variants';
-
-  export const buttonVariants = tv({
-    base: 'ring-offset-background focus-visible:ring-ring inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
-    variants: {
-      variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-        destructive:
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        outline:
-          'border-input bg-background hover:bg-accent hover:text-accent-foreground border',
-        secondary:
-          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
-      },
-      size: {
-        default: 'h-10 px-4 py-2',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8',
-        icon: 'h-10 w-10',
-      },
-    },
-    defaultVariants: {
-      variant: 'default',
-      size: 'default',
-    },
-  });
-
-  export type ButtonVariant = VariantProps<typeof buttonVariants>['variant'];
-  export type ButtonSize = VariantProps<typeof buttonVariants>['size'];
-
-  export type ButtonProps = WithElementRef<HTMLButtonAttributes> &
-    WithElementRef<HTMLAnchorAttributes> & {
-      variant?: ButtonVariant;
-      size?: ButtonSize;
-    };
-</script>
-
 <script lang="ts">
   import { cn } from '$lib/utils.js';
+  import { buttonVariants, type ButtonProps } from './variants.js';
 
   let {
     class: className,

--- a/examples/sveltekit-openai/src/lib/components/ui/button/index.ts
+++ b/examples/sveltekit-openai/src/lib/components/ui/button/index.ts
@@ -1,17 +1,17 @@
-import Root, {
+import Root from './button.svelte';
+import {
+  buttonVariants,
   type ButtonProps,
   type ButtonSize,
   type ButtonVariant,
-  buttonVariants,
-} from './button.svelte';
+} from './variants.js';
 
 export {
   Root,
-  type ButtonProps as Props,
-  //
   Root as Button,
   buttonVariants,
   type ButtonProps,
+  type ButtonProps as Props,
   type ButtonSize,
   type ButtonVariant,
 };

--- a/examples/sveltekit-openai/src/lib/components/ui/button/variants.ts
+++ b/examples/sveltekit-openai/src/lib/components/ui/button/variants.ts
@@ -1,0 +1,41 @@
+import type { WithElementRef } from 'bits-ui';
+import type {
+  HTMLAnchorAttributes,
+  HTMLButtonAttributes,
+} from 'svelte/elements';
+import { type VariantProps, tv } from 'tailwind-variants';
+
+export const buttonVariants = tv({
+  base: 'ring-offset-background focus-visible:ring-ring inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  variants: {
+    variant: {
+      default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+      destructive:
+        'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+      outline:
+        'border-input bg-background hover:bg-accent hover:text-accent-foreground border',
+      secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+      ghost: 'hover:bg-accent hover:text-accent-foreground',
+      link: 'text-primary underline-offset-4 hover:underline',
+    },
+    size: {
+      default: 'h-10 px-4 py-2',
+      sm: 'h-9 rounded-md px-3',
+      lg: 'h-11 rounded-md px-8',
+      icon: 'h-10 w-10',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    size: 'default',
+  },
+});
+
+export type ButtonVariant = VariantProps<typeof buttonVariants>['variant'];
+export type ButtonSize = VariantProps<typeof buttonVariants>['size'];
+
+export type ButtonProps = WithElementRef<HTMLButtonAttributes> &
+  WithElementRef<HTMLAnchorAttributes> & {
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+  };

--- a/examples/sveltekit-openai/src/routes/api/chat/+server.ts
+++ b/examples/sveltekit-openai/src/routes/api/chat/+server.ts
@@ -12,7 +12,7 @@ export const POST = async ({ request }: { request: Request }) => {
 
   const result = streamText({
     model: openai('gpt-4o'),
-    messages: convertToModelMessages(messages),
+    messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(5), // multi-steps for server-side tools
     tools: {
       // server-side tool with execute function:


### PR DESCRIPTION
## background

the sveltekit-openai example had type errors breaking CI:
1. svelte 5 module script exports aren't properly recognized by typescript ([known issue](https://github.com/sveltejs/svelte/issues/13886))
2. `convertToModelMessages` is now async and requires `await`

## summary

- move button types and variants from `<script module>` to separate `variants.ts` file
- update button component and index to import from the new file
- add `await` before `convertToModelMessages` call in server route

## checklist

- [ ] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [ ] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)