### PR TITLE
docs: migrate generateObject to generateText with structured output

### DIFF
--- a/content/cookbook/01-next/30-generate-object.mdx
+++ b/content/cookbook/01-next/30-generate-object.mdx
@@ -4,9 +4,9 @@ description: Learn how to generate object using the AI SDK and Next.js
 tags: ['next', 'structured data']
 ---
 
-# Generate Object
+# Generate Structured Data
 
-Earlier functions like `generateText` and `streamText` gave us the ability to generate unstructured text. However, if you want to generate structured data like JSON, you can provide a schema that describes the structure of your desired object to the `generateObject` function.
+Earlier functions like `generateText` and `streamText` gave us the ability to generate unstructured text. However, if you want to generate structured data like JSON, you can use the `generateText` function with the `output` property to specify a schema that describes the structure of your desired object.
 
 The function requires you to provide a schema using [zod](https://zod.dev), a library for defining schemas for JavaScript objects. By using zod, you can also use it to validate the generated object and ensure that it conforms to the specified structure.
 
@@ -83,31 +83,33 @@ export default function Page() {
 
 ## Server
 
-Let's create a route handler for `/api/completion` that will generate an object based on the input prompt. The route will call the `generateObject` function from the `ai` module, which will then generate an object based on the input prompt and return it.
+Let's create a route handler for `/api/completion` that will generate an object based on the input prompt. The route will call the `generateText` function with the `output` property from the `ai` module, which will then generate a structured object based on the input prompt and return it.
 
 ```typescript filename='app/api/completion/route.ts'
-import { generateObject } from 'ai';
+import { generateText, Output } from 'ai';
 import { z } from 'zod';
 
 export async function POST(req: Request) {
   const { prompt }: { prompt: string } = await req.json();
 
-  const result = await generateObject({
+  const { output } = await generateText({
     model: 'openai/gpt-4o',
     system: 'You generate three notifications for a messages app.',
     prompt,
-    schema: z.object({
-      notifications: z.array(
-        z.object({
-          name: z.string().describe('Name of a fictional person.'),
-          message: z.string().describe('Do not use emojis or links.'),
-          minutesAgo: z.number(),
-        }),
-      ),
+    output: Output.object({
+      schema: z.object({
+        notifications: z.array(
+          z.object({
+            name: z.string().describe('Name of a fictional person.'),
+            message: z.string().describe('Do not use emojis or links.'),
+            minutesAgo: z.number(),
+          }),
+        ),
+      }),
     }),
   });
 
-  return result.toJsonResponse();
+  return NextResponse.json(output);
 }
 ```
 

--- a/content/cookbook/01-next/30-generate-object.mdx
+++ b/content/cookbook/01-next/30-generate-object.mdx
@@ -88,6 +88,7 @@ Let's create a route handler for `/api/completion` that will generate an object 
 ```typescript filename='app/api/completion/route.ts'
 import { generateText, Output } from 'ai';
 import { z } from 'zod';
+import { NextResponse } from 'next/server';
 
 export async function POST(req: Request) {
   const { prompt }: { prompt: string } = await req.json();

--- a/content/cookbook/05-node/30-generate-object-reasoning.mdx
+++ b/content/cookbook/05-node/30-generate-object-reasoning.mdx
@@ -12,7 +12,7 @@ You may want to use these models to generate structured data. However, most (lik
 One solution is to pass the output from a reasoning model through a smaller model that can output structured data (like gpt-4o-mini). These lightweight models can efficiently extract the structured data while adding very little overhead in terms of speed and cost.
 
 ```ts
-import { generateObject, generateText } from 'ai';
+import { generateText, Output } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -23,23 +23,24 @@ async function main() {
       'Predict the top 3 largest city by 2050. For each, return the name, the country, the reason why it will on the list, and the estimated population in millions.',
   });
 
-  const { object } = await generateObject({
+  const { output } = await generateText({
     model: 'openai/gpt-4o-mini',
     prompt: 'Extract the desired information from this text: \n' + rawOutput,
-    schema: z.object({
-      name: z.string().describe('the name of the city'),
-      country: z.string().describe('the name of the country'),
-      reason: z
-        .string()
-        .describe(
-          'the reason why the city will be one of the largest cities by 2050',
-        ),
-      estimatedPopulation: z.number(),
+    output: Output.array({
+      element: z.object({
+        name: z.string().describe('the name of the city'),
+        country: z.string().describe('the name of the country'),
+        reason: z
+          .string()
+          .describe(
+            'the reason why the city will be one of the largest cities by 2050',
+          ),
+        estimatedPopulation: z.number(),
+      }),
     }),
-    output: 'array',
   });
 
-  console.log(object);
+  console.log(output);
 }
 
 main().catch(console.error);

--- a/content/cookbook/05-node/30-generate-object.mdx
+++ b/content/cookbook/05-node/30-generate-object.mdx
@@ -6,30 +6,32 @@ tags: ['node', 'structured data']
 
 # Generate Object
 
-Earlier functions like `generateText` and `streamText` gave us the ability to generate unstructured text. However, if you want to generate structured data like JSON, you can provide a schema that describes the structure of your desired object to the `generateObject` function.
+Earlier functions like `generateText` and `streamText` gave us the ability to generate unstructured text. However, if you want to generate structured data like JSON, you can use the `generateText` function with the `output` property to specify a schema that describes the structure of your desired object.
 
 The function requires you to provide a schema using [zod](https://zod.dev), a library for defining schemas for JavaScript objects. By using zod, you can also use it to validate the generated object and ensure that it conforms to the specified structure.
 
 ```ts file='index.ts'
-import { generateObject } from 'ai';
+import { generateText, Output } from 'ai';
 import { z } from 'zod';
 
-const result = await generateObject({
-  model: 'openai/gpt-4.1',
-  schema: z.object({
-    recipe: z.object({
-      name: z.string(),
-      ingredients: z.array(
-        z.object({
-          name: z.string(),
-          amount: z.string(),
-        }),
-      ),
-      steps: z.array(z.string()),
+const { output } = await generateText({
+  model: 'openai/gpt-4o',
+  prompt: 'Generate a lasagna recipe.',
+  output: Output.object({
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({
+            name: z.string(),
+            amount: z.string(),
+          }),
+        ),
+        steps: z.array(z.string()),
+      }),
     }),
   }),
-  prompt: 'Generate a lasagna recipe.',
 });
 
-console.log(JSON.stringify(result.object.recipe, null, 2));
+console.log(JSON.stringify(output.recipe, null, 2));
 ```


### PR DESCRIPTION
## Background

<!-- Why was this change necessary? -->
The `generateObject` function has been deprecated in the AI SDK. The recommended approach is now to use `generateText` with the `output` property and `Output.object()` to generate structured data.

## Summary

<!-- What did you change? -->
- Updated cookbook examples to use `generateText` with `Output.object()` instead of the deprecated `generateObject`
- Updated examples in both Next.js and Node.js cookbooks
- Fixed reasoning model example to use `Output.array()` for array outputs

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

