### PR TITLE
feat(ui, react): add `resetToolApproval` method to useChat

### DIFF
--- a/.changeset/gentle-coats-do.md
+++ b/.changeset/gentle-coats-do.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/react': patch
+'ai': patch
+---
+
+feat(ui): add `resetToolApproval` method to useChat

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -473,6 +473,12 @@ Allows you to easily create a conversational user interface for your chatbot app
         'Function to respond to a tool approval request. The id should match the approval id from the tool call. If sendAutomaticallyWhen is configured, it may trigger an automatic submission.',
     },
     {
+      name: 'resetToolApproval',
+      type: '(options: { id: string }) => void | PromiseLike<void>',
+      description:
+        'Function to reset a tool approval response back to the requested state. The id should match the approval id from the tool call. This allows users to change their response to a tool approval request.',
+    },
+    {
       name: 'addToolResult',
       type: '(options: { tool: string; toolCallId: string; output: unknown } | { tool: string; toolCallId: string; state: "output-error", errorText: string }) => void',
       description: 'Deprecated. Use addToolOutput instead.',

--- a/examples/next-openai/app/test-tool-approval/page.tsx
+++ b/examples/next-openai/app/test-tool-approval/page.tsx
@@ -10,12 +10,16 @@ import { WeatherWithApprovalAgentUIMessage } from '@/agent/weather-with-approval
 import WeatherWithApprovalView from '@/components/tool/weather-with-approval-view';
 
 export default function TestToolApproval() {
-  const { status, sendMessage, messages, addToolApprovalResponse } =
-    useChat<WeatherWithApprovalAgentUIMessage>({
-      transport: new DefaultChatTransport({ api: '/api/chat-tool-approval' }),
-      sendAutomaticallyWhen:
-        lastAssistantMessageIsCompleteWithApprovalResponses,
-    });
+  const {
+    status,
+    sendMessage,
+    messages,
+    addToolApprovalResponse,
+    resetToolApproval,
+  } = useChat<WeatherWithApprovalAgentUIMessage>({
+    transport: new DefaultChatTransport({ api: '/api/chat-tool-approval' }),
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+  });
 
   console.log(structuredClone(messages));
 
@@ -36,6 +40,7 @@ export default function TestToolApproval() {
                     key={index}
                     invocation={part}
                     addToolApprovalResponse={addToolApprovalResponse}
+                    resetToolApproval={resetToolApproval}
                   />
                 );
             }

--- a/examples/next-openai/components/tool/weather-with-approval-view.tsx
+++ b/examples/next-openai/components/tool/weather-with-approval-view.tsx
@@ -1,12 +1,17 @@
 import type { WeatherUIToolWithApprovalInvocation } from '@/tool/weather-tool-with-approval';
-import type { ChatAddToolApproveResponseFunction } from 'ai';
+import type {
+  ChatAddToolApproveResponseFunction,
+  ChatResetToolApprovalFunction,
+} from 'ai';
 
 export default function WeatherWithApprovalView({
   invocation,
   addToolApprovalResponse,
+  resetToolApproval,
 }: {
   invocation: WeatherUIToolWithApprovalInvocation;
   addToolApprovalResponse: ChatAddToolApproveResponseFunction;
+  resetToolApproval: ChatResetToolApprovalFunction;
 }) {
   switch (invocation.state) {
     case 'approval-requested':
@@ -43,7 +48,19 @@ export default function WeatherWithApprovalView({
       return (
         <div className="text-gray-500">
           Can I retrieve the weather for {invocation.input.city}?
-          <div>{invocation.approval.approved ? 'Approved' : 'Denied'}</div>
+          <div>
+            {invocation.approval.approved ? 'Approved' : 'Denied'}
+            <button
+              className="px-4 py-2 ml-2 text-white bg-gray-500 rounded transition-colors hover:bg-gray-600"
+              onClick={() =>
+                resetToolApproval({
+                  id: invocation.approval.id,
+                })
+              }
+            >
+              Reset
+            </button>
+          </div>
         </div>
       );
 

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -8,6 +8,7 @@ export {
   type ChatOnFinishCallback,
   type ChatOnToolCallCallback,
   type ChatRequestOptions,
+  type ChatResetToolApprovalFunction,
   type ChatState,
   type ChatStatus,
   type CreateUIMessage,

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -34,6 +34,7 @@ export type UseChatHelpers<UI_MESSAGE extends UIMessage> = {
   | 'addToolResult'
   | 'addToolOutput'
   | 'addToolApprovalResponse'
+  | 'resetToolApproval'
   | 'status'
   | 'messages'
   | 'clearError'
@@ -169,5 +170,6 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     addToolResult: chatRef.current.addToolOutput,
     addToolOutput: chatRef.current.addToolOutput,
     addToolApprovalResponse: chatRef.current.addToolApprovalResponse,
+    resetToolApproval: chatRef.current.resetToolApproval,
   };
 }


### PR DESCRIPTION
## Background

When using tool approval workflows, users may want to reset a tool approval response back to the requested state. This allows users to change their mind after responding to a tool approval request, without needing to reload the entire chat.

## Summary

Added a new `resetToolApproval` method to the `useChat` hook that:
- Accepts an `id` parameter (the approval ID)
- Resets a tool part's state from `approval-responded` back to `approval-requested`
- Removes the `approved` and `reason` fields from the approval object

## Manual Verification

Run UI test in `next-openai` example at http://localhost:3000/test-tool-approval
![output](https://github.com/user-attachments/assets/dcea2235-1fef-4e80-a9a2-6fa7ca4d3ef3)


## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
