### PR TITLE
fix(google): remove shut down `gemini-2.5-flash-image-preview`

### DIFF
--- a/.changeset/cool-parrots-count.md
+++ b/.changeset/cool-parrots-count.md
@@ -1,0 +1,7 @@
+---
+'@example/ai-functions': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/google': patch
+---
+
+fix(google): remove shut down `gemini-2.5-flash-image-preview`

--- a/content/docs/03-ai-sdk-core/35-image-generation.mdx
+++ b/content/docs/03-ai-sdk-core/35-image-generation.mdx
@@ -257,7 +257,7 @@ const { image } = await generateImage({
 
 ## Generating Images with Language Models
 
-Some language models such as Google `gemini-2.5-flash-image-preview` support multi-modal outputs including images.
+Some language models such as Google `gemini-2.5-flash-image` support multi-modal outputs including images.
 With such models, you can access the generated images using the `files` property of the response.
 
 ```ts
@@ -265,7 +265,7 @@ import { google } from '@ai-sdk/google';
 import { generateText } from 'ai';
 
 const result = await generateText({
-  model: google('gemini-2.5-flash-image-preview'),
+  model: google('gemini-2.5-flash-image'),
   prompt: 'Generate an image of a comic cat',
 });
 

--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -1008,7 +1008,7 @@ messages.map(message => (
 
 ## Image Generation
 
-Some models such as Google `gemini-2.5-flash-image-preview` support image generation.
+Some models such as Google `gemini-2.5-flash-image` support image generation.
 When images are generated, they are exposed as files to the client.
 On the client side, you can access file parts of the message object
 and render them as images.

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -927,14 +927,14 @@ The `vertexRagStore` tool accepts the following configuration options:
 
 ### Image Outputs
 
-Gemini models with image generation capabilities (`gemini-2.5-flash-image-preview`) support image generation. Images are exposed as files in the response.
+Gemini models with image generation capabilities (`gemini-2.5-flash-image`) support image generation. Images are exposed as files in the response.
 
 ```ts
 import { google } from '@ai-sdk/google';
 import { generateText } from 'ai';
 
 const result = await generateText({
-  model: google('gemini-2.5-flash-image-preview'),
+  model: google('gemini-2.5-flash-image'),
   prompt:
     'Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme',
 });

--- a/examples/ai-functions/src/generate-image/google-gemini-editing-url.ts
+++ b/examples/ai-functions/src/generate-image/google-gemini-editing-url.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const editResult = await generateText({
-    model: google('gemini-2.5-flash-image-preview'),
+    model: google('gemini-2.5-flash-image'),
     prompt: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-image/google-gemini-editing.ts
+++ b/examples/ai-functions/src/generate-image/google-gemini-editing.ts
@@ -6,7 +6,7 @@ import { run } from '../lib/run';
 run(async () => {
   console.log('Generating base cat image...');
   const baseResult = await generateText({
-    model: google('gemini-2.5-flash-image-preview'),
+    model: google('gemini-2.5-flash-image'),
     prompt:
       'A photorealistic picture of a fluffy ginger cat sitting on a wooden table',
   });
@@ -34,7 +34,7 @@ run(async () => {
 
   console.log('Adding wizard hat...');
   const editResult = await generateText({
-    model: google('gemini-2.5-flash-image-preview'),
+    model: google('gemini-2.5-flash-image'),
     prompt: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-image/google-gemini-image.ts
+++ b/examples/ai-functions/src/generate-image/google-gemini-image.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-2.5-flash-image-preview'),
+    model: google('gemini-2.5-flash-image'),
     prompt:
       'Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme',
   });

--- a/examples/ai-functions/src/generate-image/google-gemini-minimal.ts
+++ b/examples/ai-functions/src/generate-image/google-gemini-minimal.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const { files } = await generateText({
-    model: google('gemini-2.5-flash-image-preview'),
+    model: google('gemini-2.5-flash-image'),
     prompt: 'A nano banana in a fancy restaurant',
   });
 

--- a/examples/ai-functions/src/stream-text/google-gemini-2.5-flash-image-preview-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/google-gemini-2.5-flash-image-preview-chatbot.ts
@@ -16,7 +16,7 @@ run(async () => {
     messages.push({ role: 'user', content: await terminal.question('You: ') });
 
     const result = streamText({
-      model: google('gemini-2.5-flash-image-preview'),
+      model: google('gemini-2.5-flash-image'),
       messages,
     });
 

--- a/examples/ai-functions/src/stream-text/vertex-gemini-2.5-flash-image-preview-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/vertex-gemini-2.5-flash-image-preview-chatbot.ts
@@ -16,7 +16,7 @@ run(async () => {
     messages.push({ role: 'user', content: await terminal.question('You: ') });
 
     const result = streamText({
-      model: vertex('gemini-2.5-flash-image-preview'),
+      model: vertex('gemini-2.5-flash-image'),
       messages,
     });
 

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -46,7 +46,6 @@ export type GatewayModelId =
   | 'google/gemini-2.0-flash-lite'
   | 'google/gemini-2.5-flash'
   | 'google/gemini-2.5-flash-image'
-  | 'google/gemini-2.5-flash-image-preview'
   | 'google/gemini-2.5-flash-lite'
   | 'google/gemini-2.5-flash-lite-preview-09-2025'
   | 'google/gemini-2.5-flash-preview-09-2025'

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -24,7 +24,7 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-2.0-flash-exp'
   | 'gemini-2.5-pro'
   | 'gemini-2.5-flash'
-  | 'gemini-2.5-flash-image-preview'
+  | 'gemini-2.5-flash-image'
   | 'gemini-2.5-flash-lite'
   | 'gemini-2.5-flash-lite-preview-09-2025'
   | 'gemini-2.5-flash-preview-04-17'


### PR DESCRIPTION
## Background

The `gemini-2.5-flash-image-preview` model was shut down by Google on January 15, 2026 (see https://ai.google.dev/gemini-api/docs/changelog#01-15-2026). This means several examples no longer work and documentation is obsolete.

## Summary

Replaced all occurrences of `gemini-2.5-flash-image-preview` with `gemini-2.5-flash-image` across:
- Provider packages (`@ai-sdk/google`, `@ai-sdk/gateway`)
- Documentation files
- Example code

## Manual Verification

Examples errored before, now they work.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
