### PR TITLE
feat: add additional callbacks to LangChain/LangGraph

### DIFF
--- a/.changeset/stream-callbacks-lifecycle.md
+++ b/.changeset/stream-callbacks-lifecycle.md
@@ -1,0 +1,11 @@
+---
+"@ai-sdk/langchain": patch
+---
+
+Add `onFinish`, `onError`, and `onAbort` callbacks to `StreamCallbacks` for `toUIMessageStream`.
+
+- `onFinish(state)`: Called on successful completion with final LangGraph state (or `undefined` for other stream types)
+- `onError(error)`: Called when stream encounters an error
+- `onAbort()`: Called when stream is aborted
+
+Also adds `parseLangGraphEvent` helper for parsing LangGraph event tuples.

--- a/.changeset/stream-callbacks-lifecycle.md
+++ b/.changeset/stream-callbacks-lifecycle.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk/langchain": patch
+'@ai-sdk/langchain': patch
 ---
 
 Add `onFinish`, `onError`, and `onAbort` callbacks to `StreamCallbacks` for `toUIMessageStream`.

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -2041,3 +2041,250 @@ describe('toUIMessageStream with LangGraph HITL fixture', () => {
     );
   });
 });
+
+describe('toUIMessageStream callbacks', () => {
+  it('should call onFinish with final state for LangGraph streams', async () => {
+    const onFinish = vi.fn();
+    const valuesData = {
+      messages: [{ id: 'ai-1', type: 'ai', content: 'Hello!' }],
+    };
+
+    const inputStream = convertArrayToReadableStream([['values', valuesData]]);
+    await convertReadableStreamToArray(
+      toUIMessageStream(inputStream, { onFinish }),
+    );
+
+    expect(onFinish).toHaveBeenCalledWith(valuesData);
+  });
+
+  it('should call onFinish with last values data when multiple values events', async () => {
+    const onFinish = vi.fn();
+
+    const inputStream = convertArrayToReadableStream([
+      ['values', { messages: [], step: 1 }],
+      ['values', { messages: [{ id: 'ai-1' }], step: 2 }],
+    ]);
+    await convertReadableStreamToArray(
+      toUIMessageStream(inputStream, { onFinish }),
+    );
+
+    expect(onFinish).toHaveBeenCalledWith({ messages: [{ id: 'ai-1' }], step: 2 });
+  });
+
+  it('should call onFinish with undefined for model streams', async () => {
+    const onFinish = vi.fn();
+
+    const inputStream = convertArrayToReadableStream([
+      new AIMessageChunk({ content: 'Hello', id: 'test-1' }),
+    ]);
+    await convertReadableStreamToArray(
+      toUIMessageStream(inputStream, { onFinish }),
+    );
+
+    expect(onFinish).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should call onFinish with undefined for streamEvents streams', async () => {
+    const onFinish = vi.fn();
+
+    const inputStream = convertArrayToReadableStream([
+      {
+        event: 'on_chat_model_stream',
+        data: { chunk: { id: 'msg-1', content: 'Hello' } },
+      },
+    ]);
+    await convertReadableStreamToArray(
+      toUIMessageStream(inputStream, { onFinish }),
+    );
+
+    expect(onFinish).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should call onError when stream errors', async () => {
+    const onError = vi.fn();
+    const onFinish = vi.fn();
+
+    async function* errorStream(): AsyncGenerator<unknown> {
+      yield ['values', { messages: [] }];
+      throw new Error('Stream failed');
+    }
+
+    await convertReadableStreamToArray(
+      toUIMessageStream(errorStream() as AsyncIterable<AIMessageChunk>, {
+        onError,
+        onFinish,
+      }),
+    );
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'Stream failed' }));
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('should call onAbort when stream is aborted', async () => {
+    const onAbort = vi.fn();
+    const onError = vi.fn();
+    const onFinish = vi.fn();
+
+    async function* abortStream(): AsyncGenerator<unknown> {
+      yield ['values', { messages: [] }];
+      throw new DOMException('Aborted', 'AbortError');
+    }
+
+    await convertReadableStreamToArray(
+      toUIMessageStream(abortStream() as AsyncIterable<AIMessageChunk>, {
+        onAbort,
+        onError,
+        onFinish,
+      }),
+    );
+
+    expect(onAbort).toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('should call onFinal before onFinish on success', async () => {
+    const callOrder: string[] = [];
+
+    const callbacks = {
+      onFinal: () => {
+        callOrder.push('onFinal');
+      },
+      onFinish: () => {
+        callOrder.push('onFinish');
+      },
+    };
+
+    const inputStream = convertArrayToReadableStream([
+      ['values', { messages: [] }],
+    ]);
+    await convertReadableStreamToArray(toUIMessageStream(inputStream, callbacks));
+
+    expect(callOrder).toEqual(['onFinal', 'onFinish']);
+  });
+
+  it('should call onFinal before onError on error', async () => {
+    const callOrder: string[] = [];
+
+    async function* errorStream(): AsyncGenerator<unknown> {
+      yield ['values', { messages: [] }];
+      throw new Error('Stream failed');
+    }
+
+    const callbacks = {
+      onFinal: () => {
+        callOrder.push('onFinal');
+      },
+      onError: () => {
+        callOrder.push('onError');
+      },
+    };
+
+    const stream = toUIMessageStream(
+      errorStream() as AsyncIterable<AIMessageChunk>,
+      callbacks,
+    );
+    await convertReadableStreamToArray(stream);
+
+    expect(callOrder).toEqual(['onFinal', 'onError']);
+  });
+
+  it('should call onFinal before onAbort on abort', async () => {
+    const callOrder: string[] = [];
+
+    async function* abortStream(): AsyncGenerator<unknown> {
+      yield ['values', { messages: [] }];
+      throw new DOMException('Aborted', 'AbortError');
+    }
+
+    const callbacks = {
+      onFinal: () => {
+        callOrder.push('onFinal');
+      },
+      onAbort: () => {
+        callOrder.push('onAbort');
+      },
+    };
+
+    const stream = toUIMessageStream(
+      abortStream() as AsyncIterable<AIMessageChunk>,
+      callbacks,
+    );
+    await convertReadableStreamToArray(stream);
+
+    expect(callOrder).toEqual(['onFinal', 'onAbort']);
+  });
+
+  it('should support typed state with generic parameter', async () => {
+    interface ChatState {
+      messages: Array<{ role: string; content: string }>;
+      escalated: boolean;
+    }
+
+    const onFinish = vi.fn();
+    const valuesData: ChatState = {
+      messages: [{ role: 'assistant', content: 'Hello' }],
+      escalated: false,
+    };
+
+    const inputStream = convertArrayToReadableStream([['values', valuesData]]);
+    await convertReadableStreamToArray(
+      toUIMessageStream<ChatState>(inputStream, { onFinish }),
+    );
+
+    expect(onFinish).toHaveBeenCalledWith(valuesData);
+  });
+
+  it('should await async callbacks in order', async () => {
+    const results: string[] = [];
+
+    const inputStream = convertArrayToReadableStream([
+      ['values', { messages: [] }],
+    ]);
+    await convertReadableStreamToArray(
+      toUIMessageStream(inputStream, {
+        onStart: async () => {
+          results.push('start');
+        },
+        onFinal: async () => {
+          results.push('final');
+        },
+        onFinish: async () => {
+          results.push('finish');
+        },
+      }),
+    );
+
+    expect(results).toEqual(['start', 'final', 'finish']);
+  });
+
+  it('should pass accumulated text to onFinal even on error', async () => {
+    const onFinal = vi.fn();
+
+    async function* partialStream(): AsyncGenerator<AIMessageChunk> {
+      yield new AIMessageChunk({ content: 'Hello', id: 'msg-1' });
+      yield new AIMessageChunk({ content: ' World', id: 'msg-1' });
+      throw new Error('Mid-stream error');
+    }
+
+    await convertReadableStreamToArray(
+      toUIMessageStream(partialStream(), { onFinal }),
+    );
+
+    expect(onFinal).toHaveBeenCalledWith('Hello World');
+  });
+
+  it('should handle [namespace, type, data] format for values events', async () => {
+    const onFinish = vi.fn();
+    const valuesData = { messages: [{ id: 'ai-1', content: 'Hello' }] };
+
+    const inputStream = convertArrayToReadableStream([
+      ['some-namespace', 'values', valuesData],
+    ]);
+    await convertReadableStreamToArray(
+      toUIMessageStream(inputStream, { onFinish }),
+    );
+
+    expect(onFinish).toHaveBeenCalledWith(valuesData);
+  });
+});

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -2068,7 +2068,10 @@ describe('toUIMessageStream callbacks', () => {
       toUIMessageStream(inputStream, { onFinish }),
     );
 
-    expect(onFinish).toHaveBeenCalledWith({ messages: [{ id: 'ai-1' }], step: 2 });
+    expect(onFinish).toHaveBeenCalledWith({
+      messages: [{ id: 'ai-1' }],
+      step: 2,
+    });
   });
 
   it('should call onFinish with undefined for model streams', async () => {
@@ -2116,7 +2119,9 @@ describe('toUIMessageStream callbacks', () => {
       }),
     );
 
-    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'Stream failed' }));
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Stream failed' }),
+    );
     expect(onFinish).not.toHaveBeenCalled();
   });
 
@@ -2158,7 +2163,9 @@ describe('toUIMessageStream callbacks', () => {
     const inputStream = convertArrayToReadableStream([
       ['values', { messages: [] }],
     ]);
-    await convertReadableStreamToArray(toUIMessageStream(inputStream, callbacks));
+    await convertReadableStreamToArray(
+      toUIMessageStream(inputStream, callbacks),
+    );
 
     expect(callOrder).toEqual(['onFinal', 'onFinish']);
   });

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -34,9 +34,7 @@ import {
 export function parseLangGraphEvent(
   event: unknown[],
 ): [type: unknown, data: unknown] {
-  return event.length === 3
-    ? [event[1], event[2]]
-    : [event[0], event[1]];
+  return event.length === 3 ? [event[1], event[2]] : [event[0], event[1]];
 }
 
 /**

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -25,6 +25,21 @@ import {
 } from './types';
 
 /**
+ * Parses a LangGraph event tuple into [type, data].
+ * Handles both 2-element [type, data] and 3-element [namespace, type, data] formats.
+ *
+ * @param event - The raw LangGraph event array.
+ * @returns A tuple of [type, data].
+ */
+export function parseLangGraphEvent(
+  event: unknown[],
+): [type: unknown, data: unknown] {
+  return event.length === 3
+    ? [event[1], event[2]]
+    : [event[0], event[1]];
+}
+
+/**
  * Converts a ToolResultPart to a LangChain ToolMessage
  * @param block - The ToolResultPart to convert.
  * @returns The converted ToolMessage.
@@ -959,7 +974,7 @@ export function processLangGraphEvent(
     toolCallInfoByIndex,
     emittedToolCallsByKey,
   } = state;
-  const [type, data] = event.length === 3 ? event.slice(1) : event;
+  const [type, data] = parseLangGraphEvent(event);
 
   switch (type) {
     case 'custom': {


### PR DESCRIPTION
## Background

When using LangGraph with `toUIMessageStream`, there's no way to access the final graph state after stream completion. The existing `onFinal` callback only provides aggregated text, not the full state object containing tool calls, custom fields, or other graph-specific data.

Currently, consumers must wrap the raw LangGraph stream with custom logic before passing to `toUIMessageStream`:

```typescript
// Current workaround
const stream = withOnSuccess(rawStream, async finalState => {
  await sendAnalytics(finalState);
});
const uiStream = toUIMessageStream(stream);
```

## Summary

Extends `StreamCallbacks` with three new callbacks:

| Callback          | When Called           | Receives                                                |
| ----------------- | --------------------- | ------------------------------------------------------- |
| `onFinish(state)` | Successful completion | LangGraph state (or `undefined` for model/streamEvents) |
| `onError(error)`  | Stream error          | The `Error` object                                      |
| `onAbort()`       | Stream aborted        | Nothing                                                 |

```typescript
toUIMessageStream<MyGraphState>(graphStream, {
  onFinish: async finalState => {
    if (finalState) {
      await saveConversation(finalState.messages);
    }
  },
  onError: error => logger.error('Stream failed', error),
  onAbort: () => logger.warn('Client disconnected'),
});
```

**Callback lifecycle:**

| Outcome | `onFinal`   | `onFinish` | `onError` | `onAbort` |
| ------- | ----------- | ---------- | --------- | --------- |
| Success | ✓ (text)    | ✓ (state)  | -         | -         |
| Error   | ✓ (partial) | -          | ✓         | -         |
| Abort   | ✓ (partial) | -          | -         | ✓         |

**Other changes:**

- Added `parseLangGraphEvent` helper to `utils.ts` (extracts duplicated logic)
- Updated README with callbacks documentation

**Design rationale:**

This aligns with the core SDK's `streamText` callback pattern:

| Core SDK   | This PR    | Notes                                       |
| ---------- | ---------- | ------------------------------------------- |
| `onFinish` | `onFinish` | Success only, receives result data          |
| `onError`  | `onError`  | Error path                                  |
| `onAbort`  | `onAbort`  | Abort path                                  |
| -          | `onFinal`  | Langchain-specific legacy (aggregated text) |

The naming overlap between `onFinal` and `onFinish` exists because `onFinal` was added to the langchain package before the core SDK standardized on `onFinish`. We preserve `onFinal` for backward compatibility.

**Trade-offs:**

- `onFinish` receives `undefined` for non-LangGraph streams (consistent lifecycle vs. conditional invocation)
- Abort detection only catches standard `AbortError`; edge cases go to `onError`
- Type safety is opt-in via generic parameter
- `onFinish` currently only receives `state`, not a rich event object like core SDK

## Manual Verification

Verified callback behavior using the `next-langchain` example with a local LangGraph agent. Confirmed:

- `onFinish` receives complete state after successful stream
- `onError` fires on thrown errors
- `onAbort` fires when request is cancelled via AbortController

## Future Work

**Consolidate `onFinal` into `onFinish` (breaking change):**

The ideal API would deprecate `onFinal` and have `onFinish` receive a unified result object:

```typescript
interface StreamCallbacks<TState = unknown> {
  onStart?: () => void;
  onChunk?: (text: string) => void;
  onFinish?: (result: StreamResult<TState>) => void;
}

type StreamResult<TState> =
  | { status: 'success'; text: string; state: TState | undefined }
  | { status: 'error'; text: string; error: Error }
  | { status: 'abort'; text: string };
```

This would:

- Eliminate the confusing `onFinal` vs `onFinish` naming
- Always call `onFinish` (success, error, or abort)
- Match the pattern users expect from the core SDK

**Enrich `onFinish` event data:**

The core SDK's `onFinish` receives rich metadata (`usage`, `finishReason`, `steps`, etc.). We could expand ours:

```typescript
onFinish?: (event: {
  text: string;           // accumulated text
  state: TState | undefined;  // LangGraph state
  // Future additions:
  messages?: UIMessage[]; // extracted from state
  duration?: number;      // stream duration in ms
}) => void;
```

**Other improvements:**

- Add `onStepStart`/`onStepFinish` callbacks for LangGraph step transitions
- Expand abort detection to handle more edge cases (e.g., `ECONNRESET`) if users report issues
