### PR TITLE
feat(gateway): add support for Opus 4.6

### DIFF
--- a/.changeset/nervous-shirts-share.md
+++ b/.changeset/nervous-shirts-share.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(anthropic): add support for Opus 4.6


### PR DESCRIPTION
This was missing in #12287.