### PR TITLE
fix(xai): add dummy usage data when response.usage is missing

### DIFF
--- a/.changeset/many-trees-draw.md
+++ b/.changeset/many-trees-draw.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(xai): add dummy usage data when response.usage is missing

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -2211,6 +2211,85 @@ describe('XaiResponsesLanguageModel', () => {
         });
       });
     });
+
+    describe('missing usage handling', () => {
+      function prepareStreamChunksNoUsage(chunks: string[]) {
+        server.urls['https://api.x.ai/v1/responses'].response = {
+          type: 'stream-chunks',
+          chunks: [...chunks.map(c => `data: ${c}\n\n`), 'data: [DONE]\n\n'],
+        };
+      }
+
+      it('should handle missing usage in streaming response', async () => {
+        prepareStreamChunksNoUsage([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast',
+              created_at: 1700000000,
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_text.delta',
+            output_index: 0,
+            content_index: 0,
+            delta: 'Hello',
+          }),
+          JSON.stringify({
+            type: 'response.completed',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast',
+              created_at: 1700000000,
+              status: 'completed',
+              output: [
+                {
+                  type: 'message',
+                  id: 'msg_001',
+                  role: 'assistant',
+                  status: 'completed',
+                  content: [{ type: 'output_text', text: 'Hello' }],
+                },
+              ],
+              // usage field is omitted
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+        const finishPart = parts.find(p => p.type === 'finish');
+
+        expect(finishPart).toMatchObject({
+          type: 'finish',
+          finishReason: {
+            unified: 'stop',
+            raw: 'completed',
+          },
+          usage: {
+            inputTokens: {
+              total: 0,
+              noCache: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+            },
+            outputTokens: {
+              total: 0,
+              text: 0,
+              reasoning: 0,
+            },
+          },
+        });
+      });
+    });
   });
 
   describe('schema validation', () => {

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -874,7 +874,19 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
               }
             }
 
-            controller.enqueue({ type: 'finish', finishReason, usage: usage! });
+            controller.enqueue({
+              type: 'finish',
+              finishReason,
+              usage: usage ?? {
+                inputTokens: {
+                  total: 0,
+                  noCache: 0,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                },
+                outputTokens: { total: 0, text: 0, reasoning: 0 },
+              },
+            });
           },
         }),
       ),

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -287,7 +287,12 @@ export class XaiChatLanguageModel implements LanguageModelV3 {
         unified: mapXaiFinishReason(choice.finish_reason),
         raw: choice.finish_reason ?? undefined,
       },
-      usage: convertXaiChatUsage(response.usage!), // defined when there is no error
+      usage: response.usage
+        ? convertXaiChatUsage(response.usage)
+        : {
+            inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+            outputTokens: { total: 0, text: 0, reasoning: 0 },
+          },
       request: { body },
       response: {
         ...getResponseMetadata(response),
@@ -573,7 +578,19 @@ export class XaiChatLanguageModel implements LanguageModelV3 {
               }
             }
 
-            controller.enqueue({ type: 'finish', finishReason, usage: usage! });
+            controller.enqueue({
+              type: 'finish',
+              finishReason,
+              usage: usage ?? {
+                inputTokens: {
+                  total: 0,
+                  noCache: 0,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                },
+                outputTokens: { total: 0, text: 0, reasoning: 0 },
+              },
+            });
           },
         }),
       ),


### PR DESCRIPTION
## Background

similar to how we handle when response.usage is undefined or null in doGenerate [for xai responses language model](https://github.com/vercel/ai/blob/a29b93435a2c0ed74c092952e6245f2ee3d4ac8d/packages/xai/src/responses/xai-responses-language-model.ts#L400-L403), we were missing the handling for the same in doStream and completely in xai chat language model

this led to the errors as seen in #12280 

## Summary

add dummy values for usage when the model doesn't return one so that we don't break the stream

## Manual Verification

n/a

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] na ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #12280