### PR TITLE
docs: update tool call streaming version reference from v5 to v6

### DIFF
--- a/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
@@ -517,7 +517,7 @@ Dynamic tools are useful when integrating with:
 
 ## Tool call streaming
 
-Tool call streaming is **enabled by default** in AI SDK 5.0, allowing you to stream tool calls while they are being generated. This provides a better user experience by showing tool inputs as they are generated in real-time.
+Tool call streaming is **enabled by default** in AI SDK 6.0, allowing you to stream tool calls while they are being generated. This provides a better user experience by showing tool inputs as they are generated in real-time.
 
 ```tsx filename='app/api/chat/route.ts'
 export async function POST(req: Request) {
@@ -526,7 +526,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: __MODEL__,
     messages: await convertToModelMessages(messages),
-    // toolCallStreaming is enabled by default in v5
+    // toolCallStreaming is enabled by default in v6
     // ...
   });
 


### PR DESCRIPTION
Updated references to AI SDK version in the tool call streaming documentation section to reflect current v6 instead of v5.

## Changes
- Updated "AI SDK 5.0" to "AI SDK 6.0" in the tool call streaming section header
- Updated comment from "v5" to "v6" in code example

Fixes outdated version reference in documentation at https://ai-sdk.dev/docs/ai-sdk-ui/chatbot-tool-usage#tool-call-streaming