### PR TITLE
feat(amazon-bedrock): add support for new Anthropic adaptive thinking and reasoning effort including max

### DIFF
--- a/.changeset/unlucky-cows-decide.md
+++ b/.changeset/unlucky-cows-decide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+feat(amazon-bedrock): add support for new Anthropic adaptive thinking and effort max

--- a/.changeset/unlucky-cows-decide.md
+++ b/.changeset/unlucky-cows-decide.md
@@ -2,4 +2,4 @@
 '@ai-sdk/amazon-bedrock': patch
 ---
 
-feat(amazon-bedrock): add support for new Anthropic adaptive thinking and effort max
+feat(amazon-bedrock): add support for new Anthropic adaptive thinking and reasoning effort including max

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -1489,7 +1489,7 @@ const result = await generateText({
 
 Anthropic has reasoning support for Claude 3.7 and Claude 4 models on Bedrock, including:
 
-- `us.anthropic.claude-opus-4-6-v1:0`
+- `us.anthropic.claude-opus-4-6-v1`
 - `us.anthropic.claude-opus-4-5-20251101-v1:0`
 - `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
 - `us.anthropic.claude-opus-4-20250514-v1:0`
@@ -1526,7 +1526,7 @@ on how to integrate reasoning into your chatbot.
 
 | Model                                          | Image Input         | Object Generation   | Tool Usage          | Computer Use        | Reasoning           |
 | ---------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
-| `us.anthropic.claude-opus-4-6-v1:0`            | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `us.anthropic.claude-opus-4-6-v1`              | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `us.anthropic.claude-opus-4-5-20251101-v1:0`   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `us.anthropic.claude-opus-4-20250514-v1:0`     | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/examples/ai-functions/src/generate-text/amazon-bedrock-reasoning-adaptive.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock-reasoning-adaptive.ts
@@ -1,0 +1,27 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText, stepCountIs } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: bedrock('us.anthropic.claude-3-7-sonnet-20250219-v1:0'),
+    prompt: 'How many "r"s are in the word "strawberry"?',
+    providerOptions: {
+      bedrock: {
+        reasoningConfig: { type: 'adaptive', maxReasoningEffort: 'max' },
+      },
+    },
+    maxRetries: 0,
+    stopWhen: stepCountIs(5),
+  });
+
+  console.log('Reasoning:');
+  console.log(result.reasoning);
+  console.log();
+
+  console.log('Text:');
+  console.log(result.text);
+  console.log();
+
+  console.log('Warnings:', result.warnings);
+});

--- a/examples/ai-functions/src/generate-text/amazon-bedrock-reasoning-adaptive.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock-reasoning-adaptive.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: bedrock('us.anthropic.claude-3-7-sonnet-20250219-v1:0'),
+    model: bedrock('us.anthropic.claude-opus-4-6-v1'),
     prompt: 'How many "r"s are in the word "strawberry"?',
     providerOptions: {
       bedrock: {

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-options.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-options.ts
@@ -1,5 +1,5 @@
 export type BedrockAnthropicModelId =
-  | 'anthropic.claude-opus-4-6-v1:0'
+  | 'anthropic.claude-opus-4-6-v1'
   | 'anthropic.claude-opus-4-5-20251101-v1:0'
   | 'anthropic.claude-sonnet-4-5-20250929-v1:0'
   | 'anthropic.claude-opus-4-20250514-v1:0'
@@ -13,7 +13,7 @@ export type BedrockAnthropicModelId =
   | 'anthropic.claude-3-opus-20240229-v1:0'
   | 'anthropic.claude-3-sonnet-20240229-v1:0'
   | 'anthropic.claude-3-haiku-20240307-v1:0'
-  | 'us.anthropic.claude-opus-4-6-v1:0'
+  | 'us.anthropic.claude-opus-4-6-v1'
   | 'us.anthropic.claude-opus-4-5-20251101-v1:0'
   | 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
   | 'us.anthropic.claude-opus-4-20250514-v1:0'

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -3643,10 +3643,10 @@ describe('doGenerate', () => {
     expect(requestBody.additionalModelRequestFields?.thinking).toBeUndefined();
   });
 
-  it('should warn when Anthropic model receives maxReasoningEffort (generate)', async () => {
+  it('should pass maxReasoningEffort as output_config.effort for Anthropic models (generate)', async () => {
     prepareJsonResponse({});
 
-    const result = await model.doGenerate({
+    await model.doGenerate({
       prompt: TEST_PROMPT,
       providerOptions: {
         bedrock: {
@@ -3662,12 +3662,8 @@ describe('doGenerate', () => {
     expect(
       requestBody.additionalModelRequestFields?.reasoningConfig,
     ).toBeUndefined();
-
-    expect(result.warnings).toContainEqual({
-      type: 'unsupported',
-      feature: 'maxReasoningEffort',
-      details:
-        'maxReasoningEffort applies only to Amazon Nova models on Bedrock and will be ignored for this model.',
+    expect(requestBody.additionalModelRequestFields?.output_config).toEqual({
+      effort: 'medium',
     });
   });
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -177,9 +177,13 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
     }
 
     const isAnthropicModel = this.modelId.includes('anthropic');
+    const thinkingType = bedrockOptions.reasoningConfig?.type;
     const isThinkingRequested =
-      bedrockOptions.reasoningConfig?.type === 'enabled';
-    const thinkingBudget = bedrockOptions.reasoningConfig?.budgetTokens;
+      thinkingType === 'enabled' || thinkingType === 'adaptive';
+    const thinkingBudget =
+      thinkingType === 'enabled'
+        ? bedrockOptions.reasoningConfig?.budgetTokens
+        : undefined;
     const isAnthropicThinkingEnabled = isAnthropicModel && isThinkingRequested;
 
     const inferenceConfig = {
@@ -190,28 +194,45 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       ...(stopSequences != null && { stopSequences }),
     };
 
-    if (isAnthropicThinkingEnabled && thinkingBudget != null) {
-      if (inferenceConfig.maxTokens != null) {
-        inferenceConfig.maxTokens += thinkingBudget;
-      } else {
-        inferenceConfig.maxTokens = thinkingBudget + 4096; // Default + thinking budget maxTokens = 4096, TODO update default in v5
+    if (isAnthropicThinkingEnabled) {
+      if (thinkingBudget != null) {
+        if (inferenceConfig.maxTokens != null) {
+          inferenceConfig.maxTokens += thinkingBudget;
+        } else {
+          inferenceConfig.maxTokens = thinkingBudget + 4096; // Default + thinking budget maxTokens = 4096, TODO update default in v5
+        }
+        bedrockOptions.additionalModelRequestFields = {
+          ...bedrockOptions.additionalModelRequestFields,
+          thinking: {
+            type: 'enabled',
+            budget_tokens: thinkingBudget,
+          },
+        };
+      } else if (thinkingType === 'adaptive') {
+        bedrockOptions.additionalModelRequestFields = {
+          ...bedrockOptions.additionalModelRequestFields,
+          thinking: {
+            type: 'adaptive',
+          },
+        };
       }
-      // Add them to additional model request fields
-      // Add thinking config to additionalModelRequestFields
-      bedrockOptions.additionalModelRequestFields = {
-        ...bedrockOptions.additionalModelRequestFields,
-        thinking: {
-          type: bedrockOptions.reasoningConfig?.type,
-          budget_tokens: thinkingBudget,
-        },
-      };
-    } else if (!isAnthropicModel && thinkingBudget != null) {
-      warnings.push({
-        type: 'unsupported',
-        feature: 'budgetTokens',
-        details:
-          'budgetTokens applies only to Anthropic models on Bedrock and will be ignored for this model.',
-      });
+    } else if (!isAnthropicModel) {
+      if (bedrockOptions.reasoningConfig?.budgetTokens != null) {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'budgetTokens',
+          details:
+            'budgetTokens applies only to Anthropic models on Bedrock and will be ignored for this model.',
+        });
+      }
+      if (thinkingType === 'adaptive') {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'adaptive thinking',
+          details:
+            'adaptive thinking type applies only to Anthropic models on Bedrock.',
+        });
+      }
     }
 
     const maxReasoningEffort =
@@ -230,9 +251,9 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
         bedrockOptions.additionalModelRequestFields = {
           ...bedrockOptions.additionalModelRequestFields,
           reasoningConfig: {
-            ...(bedrockOptions.reasoningConfig?.type != null && {
-              type: bedrockOptions.reasoningConfig.type,
-            }),
+            ...(thinkingType != null &&
+              thinkingType !== 'adaptive' && { type: thinkingType }),
+            ...(thinkingBudget != null && { budgetTokens: thinkingBudget }),
             maxReasoningEffort,
           },
         };

--- a/packages/amazon-bedrock/src/bedrock-chat-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-options.ts
@@ -100,9 +100,15 @@ export const bedrockProviderOptions = z.object({
   additionalModelRequestFields: z.record(z.string(), z.any()).optional(),
   reasoningConfig: z
     .object({
-      type: z.union([z.literal('enabled'), z.literal('disabled')]).optional(),
+      type: z
+        .union([
+          z.literal('enabled'),
+          z.literal('disabled'),
+          z.literal('adaptive'),
+        ])
+        .optional(),
       budgetTokens: z.number().optional(),
-      maxReasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+      maxReasoningEffort: z.enum(['low', 'medium', 'high', 'max']).optional(),
     })
     .optional(),
   /**


### PR DESCRIPTION
## Background

Anthropic's `adaptive` thinking type and `effort` parameter were not supported in the Amazon Bedrock provider. Additionally, the new Opus 4.6 model IDs were using incorrect format (using `:0` suffix which is no longer relevant), affecting typeahead/autocomplete.

## Summary

- Adds support for `adaptive` thinking type for Anthropic models via `reasoningConfig.type`
- Adds support for Anthropic's `effort` parameter via `reasoningConfig.maxReasoningEffort` (including new `max` value which is exclusive to Opus 4.6)
- Fixes Opus 4.6 model IDs to use correct format without `:0` suffix where applicable

## Manual Verification

Ran the example `examples/ai-functions/src/generate-text/amazon-bedrock-reasoning-adaptive.ts` which successfully uses adaptive thinking with `maxReasoningEffort: 'max'` and produces reasoning output.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Follow up to #12287
