### PR TITLE
docs(examples): Anthropic adaptive and extended thinking on Google Vertex

### DIFF
--- a/.changeset/angry-tigers-yell.md
+++ b/.changeset/angry-tigers-yell.md
@@ -1,0 +1,5 @@
+---
+'@example/ai-functions': patch
+---
+
+chore: add examples for Anthropic adaptive and extended thinking on Google Vertex

--- a/examples/ai-functions/src/generate-text/google-vertex-anthropic-adaptive-thinking.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-anthropic-adaptive-thinking.ts
@@ -1,7 +1,5 @@
-import {
-  vertexAnthropic,
-  AnthropicProviderOptions,
-} from '@ai-sdk/google-vertex/anthropic';
+import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
+import { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 import { run } from '../lib/run';
 

--- a/examples/ai-functions/src/generate-text/google-vertex-anthropic-adaptive-thinking.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-anthropic-adaptive-thinking.ts
@@ -1,0 +1,32 @@
+import {
+  vertexAnthropic,
+  AnthropicProviderOptions,
+} from '@ai-sdk/google-vertex/anthropic';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: vertexAnthropic('claude-opus-4-6'),
+    prompt: 'How many "r"s are in the word "strawberry"?',
+    providerOptions: {
+      anthropic: {
+        thinking: { type: 'adaptive' },
+        effort: 'max',
+      } satisfies AnthropicProviderOptions,
+    },
+    maxRetries: 0,
+  });
+
+  console.log('Reasoning:');
+  console.log(result.reasoning);
+  console.log();
+
+  console.log('Text:');
+  console.log(result.text);
+  console.log();
+
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+  console.log('Warnings:', result.warnings);
+});

--- a/examples/ai-functions/src/generate-text/google-vertex-anthropic-thinking.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-anthropic-thinking.ts
@@ -1,0 +1,31 @@
+import {
+  vertexAnthropic,
+  AnthropicProviderOptions,
+} from '@ai-sdk/google-vertex/anthropic';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: vertexAnthropic('claude-sonnet-4-5@20250929'),
+    prompt: 'How many "r"s are in the word "strawberry"?',
+    providerOptions: {
+      anthropic: {
+        thinking: { type: 'enabled', budgetTokens: 10000 },
+      } satisfies AnthropicProviderOptions,
+    },
+    maxRetries: 0,
+  });
+
+  console.log('Reasoning:');
+  console.log(result.reasoning);
+  console.log();
+
+  console.log('Text:');
+  console.log(result.text);
+  console.log();
+
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+  console.log('Warnings:', result.warnings);
+});

--- a/examples/ai-functions/src/generate-text/google-vertex-anthropic-thinking.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-anthropic-thinking.ts
@@ -1,7 +1,5 @@
-import {
-  vertexAnthropic,
-  AnthropicProviderOptions,
-} from '@ai-sdk/google-vertex/anthropic';
+import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
+import { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 import { run } from '../lib/run';
 


### PR DESCRIPTION
## Background

These examples were created to verify that Anthropic's thinking capabilities (both extended thinking and the new adaptive thinking feature) work correctly on Google Vertex AI.

## Summary

Added two new example files demonstrating Anthropic thinking modes via Google Vertex:
- `google-vertex-anthropic-thinking.ts` - Shows extended thinking with a budget
- `google-vertex-anthropic-adaptive-thinking.ts` - Shows adaptive thinking with max effort

## Manual Verification

Ran both examples locally against Google Vertex AI to confirm everything is working on Vertex.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Related to PRs:
- #12305
- #12287
