### PR TITLE
fix: unused variable in amazon bedrock anthropic logic

### DIFF
--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -241,9 +241,6 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
 
     if (maxReasoningEffort != null) {
       if (isAnthropicModel) {
-        // Anthropic models use output_config.effort with beta header
-        const existingBetas =
-          bedrockOptions.additionalModelRequestFields?.anthropic_beta ?? [];
         bedrockOptions.additionalModelRequestFields = {
           ...bedrockOptions.additionalModelRequestFields,
           output_config: {


### PR DESCRIPTION
missed in #12305

(ideally this should have been flagged by CI in some way?)