### PR TITLE
feat (ai, provider): default global provider video model resolution

### DIFF
--- a/.changeset/tidy-apples-glow.md
+++ b/.changeset/tidy-apples-glow.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider': patch
+'ai': patch
+---
+
+feat (ai, provider): default global provider video model resolution

--- a/.changeset/tidy-apples-glow.md
+++ b/.changeset/tidy-apples-glow.md
@@ -1,5 +1,9 @@
 ---
+'@ai-sdk/fal': patch
+'@ai-sdk/google': patch
+'@ai-sdk/google-vertex': patch
 '@ai-sdk/provider': patch
+'@ai-sdk/replicate': patch
 'ai': patch
 ---
 

--- a/examples/ai-functions/src/generate-video/gateway-google-veo-string.ts
+++ b/examples/ai-functions/src/generate-video/gateway-google-veo-string.ts
@@ -1,0 +1,18 @@
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../lib/present-video';
+import { run } from '../lib/run';
+import { withSpinner } from '../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner('Generating video...', () =>
+    generateVideo({
+      model: 'google/veo-3.1-generate-001',
+      prompt:
+        "A Selkirk Rex cat looking at koi fish in a stream alongside the Philosopher's Path in Kyoto, in the style of ukiyo-e.",
+      aspectRatio: '16:9',
+      duration: 4,
+    }),
+  );
+
+  await presentVideos(videos);
+});

--- a/packages/ai/src/model/resolve-model.ts
+++ b/packages/ai/src/model/resolve-model.ts
@@ -130,15 +130,16 @@ export function resolveVideoModel(
     const provider = getGlobalProvider();
     // TODO AI SDK v7
     // @ts-expect-error - videoModel support is experimental
-    if (!provider.videoModel) {
+    const videoModel = provider.videoModel
+
+    if (!videoModel) {
       throw new Error(
         'The default provider does not support video models. ' +
           'Please use a Experimental_VideoModelV3 object from a provider (e.g., fal.video("model-id")).',
       );
     }
-    // TODO AI SDK v7
-    // @ts-expect-error - videoModel support is experimental
-    return provider.videoModel(model);
+
+    return videoModel(model);
   }
 
   if (model.specificationVersion !== 'v3') {

--- a/packages/ai/src/model/resolve-model.ts
+++ b/packages/ai/src/model/resolve-model.ts
@@ -130,12 +130,12 @@ export function resolveVideoModel(
     const provider = getGlobalProvider();
     // TODO AI SDK v7
     // @ts-expect-error - videoModel support is experimental
-    const videoModel = provider.videoModel
+    const videoModel = provider.videoModel;
 
     if (!videoModel) {
       throw new Error(
         'The default provider does not support video models. ' +
-          'Please use a Experimental_VideoModelV3 object from a provider (e.g., fal.video("model-id")).',
+          'Please use a Experimental_VideoModelV3 object from a provider (e.g., vertex.video("model-id")).',
       );
     }
 

--- a/packages/ai/src/model/resolve-model.ts
+++ b/packages/ai/src/model/resolve-model.ts
@@ -128,12 +128,16 @@ export function resolveVideoModel(
 ): Experimental_VideoModelV3 {
   if (typeof model === 'string') {
     const provider = getGlobalProvider();
+    // TODO AI SDK v7
+    // @ts-expect-error - videoModel support is experimental
     if (!provider.videoModel) {
       throw new Error(
         'The default provider does not support video models. ' +
           'Please use a Experimental_VideoModelV3 object from a provider (e.g., fal.video("model-id")).',
       );
     }
+    // TODO AI SDK v7
+    // @ts-expect-error - videoModel support is experimental
     return provider.videoModel(model);
   }
 

--- a/packages/ai/src/model/resolve-model.ts
+++ b/packages/ai/src/model/resolve-model.ts
@@ -127,10 +127,14 @@ export function resolveVideoModel(
   model: VideoModel,
 ): Experimental_VideoModelV3 {
   if (typeof model === 'string') {
-    throw new Error(
-      'Video models cannot be resolved from strings. ' +
-        'Please use a Experimental_VideoModelV3 object from a provider (e.g., fal.video("model-id")).',
-    );
+    const provider = getGlobalProvider();
+    if (!provider.videoModel) {
+      throw new Error(
+        'The default provider does not support video models. ' +
+          'Please use a Experimental_VideoModelV3 object from a provider (e.g., fal.video("model-id")).',
+      );
+    }
+    return provider.videoModel(model);
   }
 
   if (model.specificationVersion !== 'v3') {

--- a/packages/ai/src/registry/custom-provider.ts
+++ b/packages/ai/src/registry/custom-provider.ts
@@ -153,8 +153,11 @@ export function customProvider<
         return videoModels[modelId];
       }
 
-      if (fallbackProvider?.videoModel) {
-        return fallbackProvider.videoModel(modelId);
+      // TODO AI SDK v7
+      // @ts-expect-error - videoModel support is experimental
+      const videoModel = fallbackProvider?.videoModel;
+      if (videoModel) {
+        return videoModel(modelId);
       }
 
       throw new NoSuchModelError({ modelId, modelType: 'videoModel' });

--- a/packages/ai/src/registry/custom-provider.ts
+++ b/packages/ai/src/registry/custom-provider.ts
@@ -1,5 +1,6 @@
 import {
   EmbeddingModelV3,
+  Experimental_VideoModelV3,
   ImageModelV3,
   LanguageModelV3,
   NoSuchModelError,
@@ -33,6 +34,7 @@ export function customProvider<
   TRANSCRIPTION_MODELS extends Record<string, TranscriptionModelV3>,
   SPEECH_MODELS extends Record<string, SpeechModelV3>,
   RERANKING_MODELS extends Record<string, RerankingModelV3>,
+  VIDEO_MODELS extends Record<string, Experimental_VideoModelV3>,
 >({
   languageModels,
   embeddingModels,
@@ -40,6 +42,7 @@ export function customProvider<
   transcriptionModels,
   speechModels,
   rerankingModels,
+  videoModels,
   fallbackProvider: fallbackProviderArg,
 }: {
   languageModels?: LANGUAGE_MODELS;
@@ -48,6 +51,7 @@ export function customProvider<
   transcriptionModels?: TRANSCRIPTION_MODELS;
   speechModels?: SPEECH_MODELS;
   rerankingModels?: RERANKING_MODELS;
+  videoModels?: VIDEO_MODELS;
   fallbackProvider?: ProviderV3 | ProviderV2;
 }): ProviderV3 & {
   languageModel(modelId: ExtractModelId<LANGUAGE_MODELS>): LanguageModelV3;
@@ -58,6 +62,7 @@ export function customProvider<
   ): TranscriptionModelV3;
   rerankingModel(modelId: ExtractModelId<RERANKING_MODELS>): RerankingModelV3;
   speechModel(modelId: ExtractModelId<SPEECH_MODELS>): SpeechModelV3;
+  videoModel(modelId: ExtractModelId<VIDEO_MODELS>): Experimental_VideoModelV3;
 } {
   const fallbackProvider = fallbackProviderArg
     ? asProviderV3(fallbackProviderArg)
@@ -140,6 +145,19 @@ export function customProvider<
       }
 
       throw new NoSuchModelError({ modelId, modelType: 'rerankingModel' });
+    },
+    videoModel(
+      modelId: ExtractModelId<VIDEO_MODELS>,
+    ): Experimental_VideoModelV3 {
+      if (videoModels != null && modelId in videoModels) {
+        return videoModels[modelId];
+      }
+
+      if (fallbackProvider?.videoModel) {
+        return fallbackProvider.videoModel(modelId);
+      }
+
+      throw new NoSuchModelError({ modelId, modelType: 'videoModel' });
     },
   };
 }

--- a/packages/fal/src/fal-provider.ts
+++ b/packages/fal/src/fal-provider.ts
@@ -68,6 +68,11 @@ export interface FalProvider extends ProviderV3 {
   video(modelId: FalVideoModelId): Experimental_VideoModelV3;
 
   /**
+   * Creates a model for video generation.
+   */
+  videoModel(modelId: FalVideoModelId): Experimental_VideoModelV3;
+
+  /**
    * Creates a model for speech generation.
    */
   speech(modelId: FalSpeechModelId): SpeechModelV3;
@@ -180,7 +185,6 @@ export function createFal(options: FalProviderSettings = {}): FalProvider {
     specificationVersion: 'v3' as const,
     imageModel: createImageModel,
     image: createImageModel,
-    video: createVideoModel,
     languageModel: (modelId: string) => {
       throw new NoSuchModelError({
         modelId,
@@ -191,6 +195,8 @@ export function createFal(options: FalProviderSettings = {}): FalProvider {
     embeddingModel,
     textEmbeddingModel: embeddingModel,
     transcription: createTranscriptionModel,
+    video: createVideoModel,
+    videoModel: createVideoModel,
   };
 }
 

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -65,11 +65,6 @@ export interface GoogleVertexProvider extends ProviderV3 {
    */
   imageModel(modelId: GoogleVertexImageModelId): ImageModelV3;
 
-  /**
-   * Creates a model for video generation.
-   */
-  video(modelId: GoogleVertexVideoModelId): Experimental_VideoModelV3;
-
   tools: typeof googleVertexTools;
 
   /**
@@ -78,6 +73,16 @@ export interface GoogleVertexProvider extends ProviderV3 {
   textEmbeddingModel(
     modelId: GoogleVertexEmbeddingModelId,
   ): GoogleVertexEmbeddingModel;
+
+  /**
+   * Creates a model for video generation.
+   */
+  video(modelId: GoogleVertexVideoModelId): Experimental_VideoModelV3;
+
+  /**
+   * Creates a model for video generation.
+   */
+  videoModel(modelId: GoogleVertexVideoModelId): Experimental_VideoModelV3;
 }
 
 export interface GoogleVertexProviderSettings {
@@ -230,6 +235,7 @@ export function createVertex(
   provider.image = createImageModel;
   provider.imageModel = createImageModel;
   provider.video = createVideoModel;
+  provider.videoModel = createVideoModel;
   provider.tools = googleVertexTools;
 
   return provider;

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -43,11 +43,6 @@ export interface GoogleGenerativeAIProvider extends ProviderV3 {
   ): ImageModelV3;
 
   /**
-   * Creates a model for video generation.
-   */
-  video(modelId: GoogleGenerativeAIVideoModelId): Experimental_VideoModelV3;
-
-  /**
    * @deprecated Use `chat()` instead.
    */
   generativeAI(modelId: GoogleGenerativeAIModelId): LanguageModelV3;
@@ -73,6 +68,18 @@ export interface GoogleGenerativeAIProvider extends ProviderV3 {
   textEmbeddingModel(
     modelId: GoogleGenerativeAIEmbeddingModelId,
   ): EmbeddingModelV3;
+
+  /**
+   * Creates a model for video generation.
+   */
+  video(modelId: GoogleGenerativeAIVideoModelId): Experimental_VideoModelV3;
+
+  /**
+   * Creates a model for video generation.
+   */
+  videoModel(
+    modelId: GoogleGenerativeAIVideoModelId,
+  ): Experimental_VideoModelV3;
 
   tools: typeof googleTools;
 }
@@ -208,6 +215,7 @@ export function createGoogleGenerativeAI(
   provider.image = createImageModel;
   provider.imageModel = createImageModel;
   provider.video = createVideoModel;
+  provider.videoModel = createVideoModel;
   provider.tools = googleTools;
 
   return provider as GoogleGenerativeAIProvider;

--- a/packages/provider/src/errors/no-such-model-error.ts
+++ b/packages/provider/src/errors/no-such-model-error.ts
@@ -14,7 +14,8 @@ export class NoSuchModelError extends AISDKError {
     | 'imageModel'
     | 'transcriptionModel'
     | 'speechModel'
-    | 'rerankingModel';
+    | 'rerankingModel'
+    | 'videoModel';
 
   constructor({
     errorName = name,
@@ -30,7 +31,8 @@ export class NoSuchModelError extends AISDKError {
       | 'imageModel'
       | 'transcriptionModel'
       | 'speechModel'
-      | 'rerankingModel';
+      | 'rerankingModel'
+      | 'videoModel';
     message?: string;
   }) {
     super({ name: errorName, message });

--- a/packages/provider/src/provider/v3/provider-v3.ts
+++ b/packages/provider/src/provider/v3/provider-v3.ts
@@ -91,14 +91,4 @@ export interface ProviderV3 {
    * @throws {NoSuchModelError} If no such model exists.
    */
   rerankingModel?(modelId: string): RerankingModelV3;
-
-  /**
-   * Returns the video model with the given id.
-   * The model id is then passed to the provider function to get the model.
-   *
-   * @param {string} modelId - The id of the model to return.
-   *
-   * @returns {VideoModel} The video model associated with the id
-   */
-  videoModel?(modelId: string): VideoModelV3;
 }

--- a/packages/provider/src/provider/v3/provider-v3.ts
+++ b/packages/provider/src/provider/v3/provider-v3.ts
@@ -4,7 +4,6 @@ import { LanguageModelV3 } from '../../language-model/v3/language-model-v3';
 import { RerankingModelV3 } from '../../reranking-model/v3/reranking-model-v3';
 import { SpeechModelV3 } from '../../speech-model/v3/speech-model-v3';
 import { TranscriptionModelV3 } from '../../transcription-model/v3/transcription-model-v3';
-import { VideoModelV3 } from '../../video-model/v3/video-model-v3';
 
 /**
  * Provider for language, text embedding, and image generation models.

--- a/packages/provider/src/provider/v3/provider-v3.ts
+++ b/packages/provider/src/provider/v3/provider-v3.ts
@@ -4,6 +4,7 @@ import { LanguageModelV3 } from '../../language-model/v3/language-model-v3';
 import { RerankingModelV3 } from '../../reranking-model/v3/reranking-model-v3';
 import { SpeechModelV3 } from '../../speech-model/v3/speech-model-v3';
 import { TranscriptionModelV3 } from '../../transcription-model/v3/transcription-model-v3';
+import { VideoModelV3 } from '../../video-model/v3/video-model-v3';
 
 /**
  * Provider for language, text embedding, and image generation models.
@@ -90,4 +91,14 @@ export interface ProviderV3 {
    * @throws {NoSuchModelError} If no such model exists.
    */
   rerankingModel?(modelId: string): RerankingModelV3;
+
+  /**
+   * Returns the video model with the given id.
+   * The model id is then passed to the provider function to get the model.
+   *
+   * @param {string} modelId - The id of the model to return.
+   *
+   * @returns {VideoModel} The video model associated with the id
+   */
+  videoModel?(modelId: string): VideoModelV3;
 }

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -48,14 +48,19 @@ export interface ReplicateProvider extends ProviderV3 {
   imageModel(modelId: ReplicateImageModelId): ReplicateImageModel;
 
   /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
+
+  /**
    * Creates a Replicate video generation model.
    */
   video(modelId: ReplicateVideoModelId): Experimental_VideoModelV3;
 
   /**
-   * @deprecated Use `embeddingModel` instead.
+   * Creates a Replicate video generation model.
    */
-  textEmbeddingModel(modelId: string): never;
+  videoModel(modelId: ReplicateVideoModelId): Experimental_VideoModelV3;
 }
 
 /**
@@ -104,7 +109,6 @@ export function createReplicate(
     specificationVersion: 'v3' as const,
     image: createImageModel,
     imageModel: createImageModel,
-    video: createVideoModel,
     languageModel: (modelId: string) => {
       throw new NoSuchModelError({
         modelId,
@@ -113,6 +117,8 @@ export function createReplicate(
     },
     embeddingModel,
     textEmbeddingModel: embeddingModel,
+    video: createVideoModel,
+    videoModel: createVideoModel,
   };
 }
 


### PR DESCRIPTION
## Background

Previously, video models could not be resolved from strings, requiring explicit provider objects. This limitation made it inconsistent with other model types in the SDK that support string-based resolution.

## Summary

Added support for resolving video models from strings using the global default provider. This change:

- Updates `resolveVideoModel` to use the global provider when a string is provided
- Adds video model support to the custom provider implementation
- Updates error handling to provide better guidance when the default provider doesn't support video models
- Adds `videoModel` to the `ProviderV3` interface

## Manual Verification

Verified that video models can now be resolved from strings when a global provider is set, and appropriate error messages are shown when the provider doesn't support video models.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)