### PR TITLE
fix(ai): pass reasoning text in telemetry

### DIFF
--- a/.changeset/weak-emus-cover.md
+++ b/.changeset/weak-emus-cover.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): pass reasoning text in telemetry

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -39,6 +39,7 @@ exports[`streamText > options.stopWhen > 2 steps: initial, tool-result > should 
       "ai.response.model": "mock-model-id",
       "ai.response.msToFinish": 500,
       "ai.response.msToFirstChunk": 100,
+      "ai.response.reasoning": "thinking",
       "ai.response.text": "",
       "ai.response.timestamp": "1970-01-01T00:00:00.000Z",
       "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"}}]",

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -2890,6 +2890,32 @@ describe('generateText', () => {
 
       expect(tracer.jsonSpans).toMatchSnapshot();
     });
+
+    it('should record reasoning in telemetry when present', async () => {
+      await generateText({
+        model: modelWithReasoning,
+        prompt: 'test-input',
+        experimental_telemetry: {
+          isEnabled: true,
+          tracer,
+        },
+      });
+
+      // Check that reasoning is recorded in both spans
+      const rootSpan = tracer.jsonSpans.find(
+        span => span.name === 'ai.generateText',
+      );
+      const doGenerateSpan = tracer.jsonSpans.find(
+        span => span.name === 'ai.generateText.doGenerate',
+      );
+
+      expect(rootSpan?.attributes['ai.response.reasoning']).toBe(
+        'I will open the conversation with witty banter.\n',
+      );
+      expect(doGenerateSpan?.attributes['ai.response.reasoning']).toBe(
+        'I will open the conversation with witty banter.\n',
+      );
+    });
   });
 
   describe('tool callbacks', () => {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -54,6 +54,7 @@ import { VERSION } from '../version';
 import { collectToolApprovals } from './collect-tool-approvals';
 import { ContentPart } from './content-part';
 import { executeToolCall } from './execute-tool-call';
+import { extractReasoningContent } from './extract-reasoning-content';
 import { extractTextContent } from './extract-text-content';
 import { GenerateTextResult } from './generate-text-result';
 import { DefaultGeneratedFile } from './generated-file';
@@ -625,6 +626,9 @@ export async function generateText<
                         'ai.response.text': {
                           output: () => extractTextContent(result.content),
                         },
+                        'ai.response.reasoning': {
+                          output: () => extractReasoningContent(result.content),
+                        },
                         'ai.response.toolCalls': {
                           output: () => {
                             const toolCalls = asToolCalls(result.content);
@@ -878,6 +882,10 @@ export async function generateText<
                 currentModelResponse.finishReason.unified,
               'ai.response.text': {
                 output: () => extractTextContent(currentModelResponse.content),
+              },
+              'ai.response.reasoning': {
+                output: () =>
+                  extractReasoningContent(currentModelResponse.content),
               },
               'ai.response.toolCalls': {
                 output: () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1018,6 +1018,9 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
               attributes: {
                 'ai.response.finishReason': finishReason,
                 'ai.response.text': { output: () => finalStep.text },
+                'ai.response.reasoning': {
+                  output: () => finalStep.reasoningText,
+                },
                 'ai.response.toolCalls': {
                   output: () =>
                     finalStep.toolCalls?.length
@@ -1716,6 +1719,19 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                             'ai.response.finishReason': stepFinishReason,
                             'ai.response.text': {
                               output: () => activeText,
+                            },
+                            'ai.response.reasoning': {
+                              output: () => {
+                                const reasoningParts = recordedContent.filter(
+                                  (
+                                    c,
+                                  ): c is { type: 'reasoning'; text: string } =>
+                                    c.type === 'reasoning',
+                                );
+                                return reasoningParts.length > 0
+                                  ? reasoningParts.map(r => r.text).join('\n')
+                                  : undefined;
+                              },
                             },
                             'ai.response.toolCalls': {
                               output: () => stepToolCallsJson,


### PR DESCRIPTION
## Background

we weren't passing the reasoning text through to OTel for the core functions

## Summary

capture the reasoning text with the helper functions and then propagate through to otel attributes

## Manual Verification

fixed and verified via the examples `examples/ai-functions/src/generate-text/anthropic-with-langfuse-telemetry.ts` and also for the streamText function

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] na ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

look into if this relates to the issue https://github.com/vercel/ai/issues/8823