### PR TITLE
feat: report image generation usage info in Gateway

### DIFF
--- a/.changeset/loud-apples-shop.md
+++ b/.changeset/loud-apples-shop.md
@@ -1,5 +1,0 @@
----
-'@ai-sdk/gateway': patch
----
-
-fix: image generation via Gateway warning schema mismatch

--- a/.changeset/loud-apples-shop.md
+++ b/.changeset/loud-apples-shop.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix: image generation via Gateway warning schema mismatch

--- a/.changeset/moody-geese-move.md
+++ b/.changeset/moody-geese-move.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat: report image generation usage info in Gateway

--- a/packages/gateway/src/gateway-image-model.test.ts
+++ b/packages/gateway/src/gateway-image-model.test.ts
@@ -440,6 +440,85 @@ describe('GatewayImageModel', () => {
       expect(result.response.headers).toBeDefined();
     });
 
+    it('should return usage when provided', async () => {
+      server.urls['https://api.test.com/image-model'].response = {
+        type: 'json-value',
+        body: {
+          images: ['base64-1'],
+          usage: {
+            inputTokens: 27,
+            outputTokens: 6240,
+            totalTokens: 6267,
+          },
+        },
+      };
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.usage).toEqual({
+        inputTokens: 27,
+        outputTokens: 6240,
+        totalTokens: 6267,
+      });
+    });
+
+    it('should return usage with partial token counts', async () => {
+      server.urls['https://api.test.com/image-model'].response = {
+        type: 'json-value',
+        body: {
+          images: ['base64-1'],
+          usage: {
+            inputTokens: 10,
+          },
+        },
+      };
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.usage).toEqual({
+        inputTokens: 10,
+        outputTokens: undefined,
+        totalTokens: undefined,
+      });
+    });
+
+    it('should not include usage when not provided', async () => {
+      prepareJsonResponse({
+        images: ['base64-1'],
+      });
+
+      const result = await createTestModel().doGenerate({
+        prompt: 'Test prompt',
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.usage).toBeUndefined();
+    });
+
     it('should merge custom headers with config headers', async () => {
       prepareJsonResponse();
 

--- a/packages/gateway/src/gateway-image-model.ts
+++ b/packages/gateway/src/gateway-image-model.ts
@@ -129,16 +129,26 @@ const providerMetadataEntrySchema = z
   })
   .catchall(z.unknown());
 
+const gatewayImageWarningSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('unsupported'),
+    feature: z.string(),
+    details: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('compatibility'),
+    feature: z.string(),
+    details: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('other'),
+    message: z.string(),
+  }),
+]);
+
 const gatewayImageResponseSchema = z.object({
   images: z.array(z.string()), // Always base64 strings over the wire
-  warnings: z
-    .array(
-      z.object({
-        type: z.literal('other'),
-        message: z.string(),
-      }),
-    )
-    .optional(),
+  warnings: z.array(gatewayImageWarningSchema).optional(),
   providerMetadata: z
     .record(z.string(), providerMetadataEntrySchema)
     .optional(),

--- a/packages/gateway/src/gateway-image-model.ts
+++ b/packages/gateway/src/gateway-image-model.ts
@@ -95,6 +95,13 @@ export class GatewayImageModel implements ImageModelV3 {
           modelId: this.modelId,
           headers: responseHeaders,
         },
+        ...(responseBody.usage != null && {
+          usage: {
+            inputTokens: responseBody.usage.inputTokens ?? undefined,
+            outputTokens: responseBody.usage.outputTokens ?? undefined,
+            totalTokens: responseBody.usage.totalTokens ?? undefined,
+          },
+        }),
       };
     } catch (error) {
       throw asGatewayError(error, await parseAuthMethod(resolvedHeaders));
@@ -146,10 +153,17 @@ const gatewayImageWarningSchema = z.discriminatedUnion('type', [
   }),
 ]);
 
+const gatewayImageUsageSchema = z.object({
+  inputTokens: z.number().nullish(),
+  outputTokens: z.number().nullish(),
+  totalTokens: z.number().nullish(),
+});
+
 const gatewayImageResponseSchema = z.object({
   images: z.array(z.string()), // Always base64 strings over the wire
   warnings: z.array(gatewayImageWarningSchema).optional(),
   providerMetadata: z
     .record(z.string(), providerMetadataEntrySchema)
     .optional(),
+  usage: gatewayImageUsageSchema.optional(),
 });


### PR DESCRIPTION
## Background
- `GatewayImageModel.doGenerate` didn't parse or return the usage field from the gateway server response

## Summary
- Add usage to the response schema and return it from `doGenerate`, converting nullish values to undefined to match `ImageModelV3Usage`

## Manual Verification
Built the new package and ran a query locally with local gateway dev server, got usage info

## Checklist
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)