### PR TITLE
fix(ui): use local activeResponse in finally block to prevent TypeError

### DIFF
--- a/.changeset/fix-activeresponse-finally.md
+++ b/.changeset/fix-activeresponse-finally.md
@@ -1,0 +1,14 @@
+---
+'ai': patch
+---
+
+Fix TypeError in onFinish when activeResponse is undefined
+
+Fixed a bug where `this.activeResponse` could be undefined in the finally block of `makeRequest`, causing a TypeError when calling `onFinish`. This happened when:
+
+1. An error was thrown before `this.activeResponse` was assigned
+2. A concurrent `makeRequest` call overwrote `this.activeResponse`
+
+The fix uses a local variable to capture `activeResponse` at the start of the try block, ensuring it's available in the finally block regardless of concurrent operations.
+
+Fixes #8477


### PR DESCRIPTION
## Summary

This PR fixes a bug where `this.activeResponse` could be undefined in the finally block of `makeRequest`, causing a TypeError when calling `onFinish`.

## Problem

The issue occurred when:
1. An error was thrown before `this.activeResponse` was assigned
2. A concurrent `makeRequest` call overwrote `this.activeResponse`

This caused:
```
TypeError: Cannot read properties of undefined (reading 'state')
```

## Solution

The fix uses a local variable to capture `activeResponse` at the start of the try block:
1. Declare `let activeResponse` before the try block
2. Assign to the local var in the try block
3. Use the local var with null check in the finally block

This ensures the reference is stable and available even if `this.activeResponse` is modified by concurrent operations.

## Credit

Thanks to @codybrouwers for identifying the root cause and providing the patch in the issue comments.

Fixes #8477