### PR TITLE
fix: clear input after use-completion submit

### DIFF
--- a/.changeset/twenty-points-smell.md
+++ b/.changeset/twenty-points-smell.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': major
+---
+
+clear input after useCompletion submit

--- a/packages/react/src/use-completion.ts
+++ b/packages/react/src/use-completion.ts
@@ -181,7 +181,12 @@ export function useCompletion({
   const handleSubmit = useCallback(
     (event?: { preventDefault?: () => void }) => {
       event?.preventDefault?.();
-      return input ? complete(input) : undefined;
+
+      if (input) {
+        complete(input);
+        setInput(''); // Clear input after submission
+        return input;
+      }
     },
     [input, complete],
   );

--- a/packages/react/src/use-completion.ui.test.tsx
+++ b/packages/react/src/use-completion.ui.test.tsx
@@ -86,6 +86,12 @@ describe('stream data stream', () => {
         });
       });
     });
+
+    it('should clear input after submit', async () => {
+      await waitFor(() => {
+        expect(screen.getByTestId('input')).toHaveValue('');
+      });
+    });
   });
 
   describe('loading state', () => {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Align to Doc introduction, useCompletion should clear input after submit

## Summary

<!-- What did you change? -->

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

(https://github.com/vercel/ai/issues/7259)
