### PR TITLE
fix(gateway): lazy-load @vercel/oidc to prevent Metro bundler failure…

### DIFF
--- a/packages/gateway/src/vercel-environment.ts
+++ b/packages/gateway/src/vercel-environment.ts
@@ -1,6 +1,39 @@
-import { getContext } from '@vercel/oidc';
-export { getVercelOidcToken } from '@vercel/oidc';
+/**
+ * Lazily imports `@vercel/oidc` to avoid module resolution failures in
+ * environments where the package cannot be resolved (e.g. React Native
+ * with Metro bundler — see https://github.com/vercel/ai/issues/12313).
+ *
+ * `@vercel/oidc` is only functional inside Vercel Functions, so it is
+ * safe to return graceful fallbacks when the module is unavailable.
+ */
+async function loadVercelOidc(): Promise<
+  typeof import('@vercel/oidc') | undefined
+> {
+  try {
+    return await import('@vercel/oidc');
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      error.message.includes('Cannot find module')
+    ) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+export async function getVercelOidcToken(): Promise<string> {
+  const oidc = await loadVercelOidc();
+  if (!oidc) {
+    throw new Error(
+      '@vercel/oidc is not available in this environment. ' +
+        'Provide an API key via the AI_GATEWAY_API_KEY environment variable instead.',
+    );
+  }
+  return oidc.getVercelOidcToken();
+}
 
 export async function getVercelRequestId(): Promise<string | undefined> {
-  return getContext().headers?.['x-vercel-id'];
+  const oidc = await loadVercelOidc();
+  return oidc?.getContext().headers?.['x-vercel-id'];
 }


### PR DESCRIPTION
## Background

React Native builds fail because Metro attempts to statically resolve `@vercel/oidc`, which is not compatible with Metro's module resolution.

Since `@vercel/oidc` does not expose a `main` field that Metro understands, the bundler crashes with a module resolution error.

## Summary

This PR replaces the static import of `@vercel/oidc` with a guarded dynamic import inside `vercel-environment.ts`.

- Uses lazy `import()` to prevent Metro from resolving the module at build time
- Gracefully falls back when `@vercel/oidc` is unavailable
- Adds safe error handling to avoid swallowing unrelated runtime errors

## Manual Verification

- Built `@ai-sdk/gateway` successfully (ESM, CJS, DTS)
- Installed the packed gateway into a minimal Expo (React Native) project
- Verified that Metro no longer crashes during bundling
- Confirmed no breaking behavior in Node/Vercel environments

Closes #12313.
