### PR TITLE
feat (examples): add duration tracking to video spinner

### DIFF
--- a/examples/ai-functions/src/lib/present-video.ts
+++ b/examples/ai-functions/src/lib/present-video.ts
@@ -12,20 +12,16 @@ const OUTPUT_DIR = 'output';
 export async function presentVideos(videos: GeneratedFile[]) {
   const timestamp = Date.now();
   for (const [index, video] of videos.entries()) {
-    // Videos from providers may be URLs (stored as base64 strings) or actual video data
-    const videoData = video.uint8Array;
-
-    // Determine the file extension based on media type
     const mediaType = video.mediaType || 'video/mp4';
     const extension = mediaType.split('/')[1] || 'mp4';
 
-    // Save the video to a file
     fs.mkdirSync(OUTPUT_DIR, { recursive: true });
     const filePath = path.join(
       OUTPUT_DIR,
       `video-${timestamp}-${index}.${extension}`,
     );
 
+    const videoData = video.uint8Array;
     await fs.promises.writeFile(filePath, videoData);
     console.log(`Saved video to ${filePath}`);
     console.log(`  Media type: ${mediaType}`);

--- a/examples/ai-functions/src/lib/spinner.ts
+++ b/examples/ai-functions/src/lib/spinner.ts
@@ -8,20 +8,22 @@ export class Spinner {
   private interval: ReturnType<typeof setInterval> | null = null;
   private message: string;
   private stream = process.stderr;
+  private startTime: number | null = null;
 
-  constructor(message: string = 'Loading...') {
+  constructor(message = 'Loading...') {
     this.message = message;
   }
 
   start(): this {
     if (this.interval) return this;
+    this.startTime = performance.now();
 
     // Hide cursor
     this.stream.write('\x1B[?25l');
 
     this.interval = setInterval(() => {
       const frame = this.frames[this.currentFrame];
-      this.stream.write(`\r${frame} ${this.message}`);
+      this.stream.write(`\r${frame} ${this.message}${this.formatDuration()}`);
       this.currentFrame = (this.currentFrame + 1) % this.frames.length;
     }, 80);
 
@@ -44,11 +46,22 @@ export class Spinner {
   }
 
   succeed(message?: string): void {
-    this.stop(`✔ ${message || this.message}`);
+    this.stop(`✔ ${message || this.message}${this.formatDuration()}`);
   }
 
   fail(message?: string): void {
-    this.stop(`✖ ${message || this.message}`);
+    this.stop(`✖ ${message || this.message}${this.formatDuration()}`);
+  }
+
+  private formatDuration(): string {
+    if (this.startTime === null) return '';
+    const ms = performance.now() - this.startTime;
+    if (ms < 1000) return ` (${Math.round(ms)}ms)`;
+    const seconds = ms / 1000;
+    if (seconds < 60) return ` (${seconds.toFixed(1)}s)`;
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return ` (${minutes}m ${remainingSeconds.toFixed(1)}s)`;
   }
 
   update(message: string): void {


### PR DESCRIPTION
## Background

The spinner component in the AI Functions example lacked timing information.

## Summary

- Added duration tracking to the `Spinner` class that shows elapsed time in ms, seconds, or minutes format
- Minor cleanup of the `presentVideos` function

## Manual Verification

Ran `vertex-veo.ts` example video generation.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)