### PR TITLE
feat(anthropic): add support for Opus 4.6 fast mode

### DIFF
--- a/.changeset/blue-tables-pretend.md
+++ b/.changeset/blue-tables-pretend.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(anthropic): add support for Opus 4.6 fast mode

--- a/examples/ai-functions/src/generate-text/anthropic-fast-mode.ts
+++ b/examples/ai-functions/src/generate-text/anthropic-fast-mode.ts
@@ -1,0 +1,20 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
+import { print } from '../lib/print';
+
+run(async () => {
+  const result = await generateText({
+    model: anthropic('claude-opus-4-6'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+    providerOptions: {
+      anthropic: {
+        speed: 'fast',
+      },
+    },
+  });
+
+  print('Content:', result.content);
+  print('Usage:', result.usage);
+  print('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/anthropic-fast-mode.ts
+++ b/examples/ai-functions/src/stream-text/anthropic-fast-mode.ts
@@ -1,0 +1,22 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { streamText } from 'ai';
+import { print } from '../lib/print';
+import { printFullStream } from '../lib/print-full-stream';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: anthropic('claude-opus-4-6'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+    providerOptions: {
+      anthropic: {
+        speed: 'fast',
+      },
+    },
+  });
+
+  printFullStream({ result });
+
+  print('Usage:', await result.usage);
+  print('Finish reason:', await result.finishReason);
+});

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -4059,6 +4059,48 @@ describe('AnthropicMessagesLanguageModel', () => {
       expect(result.warnings).toStrictEqual([]);
     });
 
+    it('should set speed and fast-mode beta header', async () => {
+      prepareJsonResponse({});
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            speed: 'fast',
+          } satisfies AnthropicProviderOptions,
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "max_tokens": 4096,
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "claude-3-haiku-20240307",
+          "speed": "fast",
+        }
+      `);
+      expect(await server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+        {
+          "anthropic-beta": "fast-mode-2026-02-01",
+          "anthropic-version": "2023-06-01",
+          "content-type": "application/json",
+          "x-api-key": "test-api-key",
+        }
+      `);
+
+      expect(result.warnings).toStrictEqual([]);
+    });
+
     describe('context management', () => {
       it('should send context_management in request body', async () => {
         prepareJsonResponse({});

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -350,6 +350,9 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       ...(anthropicOptions?.effort && {
         output_config: { effort: anthropicOptions.effort },
       }),
+      ...(anthropicOptions?.speed && {
+        speed: anthropicOptions.speed,
+      }),
 
       // structured output:
       ...(useStructuredOutput &&
@@ -552,6 +555,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
 
     if (anthropicOptions?.effort) {
       betas.add('effort-2025-11-24');
+    }
+
+    if (anthropicOptions?.speed) {
+      betas.add('fast-mode-2026-02-01');
     }
 
     // only when streaming: enable fine-grained tool streaming

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -170,6 +170,12 @@ export const anthropicProviderOptions = z.object({
    */
   effort: z.enum(['low', 'medium', 'high', 'max']).optional(),
 
+  /**
+   * Enable fast mode for faster inference (2.5x faster output token speeds).
+   * Only supported with claude-opus-4-6.
+   */
+  speed: z.literal('fast').optional(),
+
   contextManagement: z
     .object({
       edits: z.array(


### PR DESCRIPTION
## Background

Anthropic released fast mode for Opus 4.6: https://code.claude.com/docs/en/fast-mode

## Summary

Added support for Anthropic's fast mode in the `@ai-sdk/anthropic` package. Users can now enable fast mode by setting `speed: 'fast'` in provider options when using `claude-opus-4-6`.

**Implementation:**
- Added `speed` option to `anthropicProviderOptions` schema (accepts `'fast'` value)
- Pass `speed` parameter in the Messages API request body when set
- Automatically add `fast-mode-2026-02-01` beta header when speed is enabled
- Added unit test to verify request body and headers are correctly set

**Usage:**
```ts
import { anthropic } from '@ai-sdk/anthropic';
import { generateText } from 'ai';

const result = await generateText({
  model: anthropic('claude-opus-4-6'),
  prompt: 'Hello!',
  providerOptions: {
    anthropic: {
      speed: 'fast',
    },
  },
});
```

**Note:** Fast mode is only supported directly with the Anthropic API (see https://code.claude.com/docs/en/fast-mode#requirements), not third-party providers like Amazon Bedrock or Google Vertex — so those provider packages don't require an update at this point.

## Manual Verification

Created and ran two example scripts demonstrating fast mode:
- `examples/ai-functions/src/generate-text/anthropic-fast-mode.ts` - generateText with fast mode
- `examples/ai-functions/src/stream-text/anthropic-fast-mode.ts` - streamText with fast mode

Both examples successfully generated output and respected the `speed` parameter, with responses including `speed=fast` as expected.

Aside: I found a bug where `response.usage.raw` when streaming Anthropic requests is not the _actual_ raw usage data - unknown fields in the data (like `speed=fast`) gets stripped, which defeats the purpose of a "raw" response field. I manually verified `speed=fast` is included in the response, but the AI SDK strips it. Will fix in a follow up PR because it's not just scoped to this.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
