### PR TITLE
feat(ai): move includeRawChunks into include setting as rawChunks

### DIFF
--- a/.changeset/move-include-raw-chunks.md
+++ b/.changeset/move-include-raw-chunks.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+feat(ai): move `includeRawChunks` into `experimental_include` setting as `rawChunks`
+
+Added `rawChunks` option to the `experimental_include` setting in `streamText`. This allows controlling raw chunk inclusion through the same unified `experimental_include` configuration used for other data retention settings. The existing `includeRawChunks` parameter is now deprecated in favor of `experimental_include: { rawChunks: true }`.

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -277,7 +277,7 @@ export function streamText<
   experimental_repairToolCall: repairToolCall,
   experimental_transform: transform,
   experimental_download: download,
-  includeRawChunks = false,
+  includeRawChunks: includeRawChunksDeprecated = false,
   onChunk,
   onError = ({ error }) => {
     console.error(error);
@@ -390,6 +390,8 @@ export function streamText<
      * When enabled, you will receive raw chunks with type 'raw' that contain the unprocessed data from the provider.
      * This allows access to cutting-edge provider features not yet wrapped by the AI SDK.
      * Defaults to false.
+     *
+     * @deprecated Use `experimental_include: { rawChunks: true }` instead.
      */
     includeRawChunks?: boolean;
 
@@ -444,6 +446,16 @@ export function streamText<
        * @default true
        */
       requestBody?: boolean;
+
+      /**
+       * Whether to include raw chunks from the provider in the stream.
+       * When enabled, you will receive raw chunks with type 'raw' that
+       * contain the unprocessed data from the provider.
+       * This allows access to cutting-edge provider features not yet
+       * wrapped by the AI SDK.
+       * @default false
+       */
+      rawChunks?: boolean;
     };
 
     /**
@@ -454,6 +466,9 @@ export function streamText<
       generateId?: IdGenerator;
     };
   }): StreamTextResult<TOOLS, OUTPUT> {
+  // include.rawChunks takes precedence over deprecated includeRawChunks
+  const includeRawChunks = include?.rawChunks ?? includeRawChunksDeprecated;
+
   const totalTimeoutMs = getTotalTimeoutMs(timeout);
   const stepTimeoutMs = getStepTimeoutMs(timeout);
   const chunkTimeoutMs = getChunkTimeoutMs(timeout);
@@ -699,7 +714,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
     generateId: () => string;
     experimental_context: unknown;
     download: DownloadFunction | undefined;
-    include: { requestBody?: boolean } | undefined;
+    include: { requestBody?: boolean; rawChunks?: boolean } | undefined;
 
     // callbacks:
     onChunk: undefined | StreamTextOnChunkCallback<TOOLS>;


### PR DESCRIPTION
## Background

`streamText` and `generateText` have an `experimental_include` setting for controlling what data is included in step results (e.g., `requestBody`, `responseBody`). The `includeRawChunks` parameter on `streamText` serves a similar purpose but lives as a separate top-level option. This PR moves it into the unified `experimental_include` setting as `rawChunks`.

## Summary

- Added `rawChunks?: boolean` option to the `experimental_include` setting in `streamText`
- Deprecated the top-level `includeRawChunks` parameter with `@deprecated` JSDoc pointing to the new setting
- `experimental_include.rawChunks` takes precedence when both are specified; the deprecated parameter continues to work as a fallback for backward compatibility
- Added 4 new tests covering the new setting and precedence behavior

**Usage:**
```ts
const result = streamText({
  model,
  prompt: 'test prompt',
  // New way (preferred):
  experimental_include: { rawChunks: true },
  // Old way (deprecated):
  // includeRawChunks: true,
});
```

## Manual Verification

- All 298 stream-text tests pass
- Full ai package test suite passes (1,769 tests across 87 files)
- Lint, typecheck, and prettier all pass

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

Closes #12132