### PR TITLE
fix(google): make codeExecutionResult.output optional in response schema

### DIFF
--- a/.changeset/fix-google-code-execution-optional-output.md
+++ b/.changeset/fix-google-code-execution-optional-output.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(google): make `codeExecutionResult.output` optional in response schema
+
+Gemini 3 Flash omits the `output` field in `codeExecutionResult` when code execution produces no text output (e.g., only saves files). The Zod response schema now accepts a missing `output` field and defaults it to an empty string.

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -263,7 +263,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
           toolName: 'code_execution',
           result: {
             outcome: part.codeExecutionResult.outcome,
-            output: part.codeExecutionResult.output,
+            output: part.codeExecutionResult.output ?? '',
           },
         });
         // Clear the ID after use to avoid accidental reuse.
@@ -476,7 +476,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                       toolName: 'code_execution',
                       result: {
                         outcome: part.codeExecutionResult.outcome,
-                        output: part.codeExecutionResult.output,
+                        output: part.codeExecutionResult.output ?? '',
                       },
                     });
                     // Clear the ID after use.
@@ -895,7 +895,7 @@ const getContentSchema = () =>
             codeExecutionResult: z
               .object({
                 outcome: z.string(),
-                output: z.string(),
+                output: z.string().nullish(),
               })
               .nullish(),
             text: z.string().nullish(),


### PR DESCRIPTION
## Background

When using `vertex.tools.codeExecution({})` with Gemini 3 Flash (`gemini-3-flash-preview`), `generateText` throws `AI_APICallError: Invalid JSON response` because the Zod response schema requires `codeExecutionResult.output` to be a `string`. However, Gemini 3 Flash omits the `output` field entirely when code execution produces no text output (e.g., only saves files via PIL without printing to stdout).

## Summary

- Made the `output` field `.nullish()` in the `codeExecutionResult` Zod schema within `getContentSchema()`, which is shared by both the response and chunk schemas
- Default missing `output` to an empty string (`''`) in both `doGenerate` and `doStream` code paths to maintain a consistent `string` type downstream
- Added regression tests for both `doGenerate` and `doStream` with a missing `output` field

## Manual Verification

- All 231 tests in `@ai-sdk/google` pass (10 test files)
- Full typecheck passes (`pnpm type-check:full`)
- Lint and prettier pass

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

Closes #12217