### PR TITLE
feat: add typed approval data schema support for tool definitions

### DIFF
--- a/.changeset/tool-approval-data.md
+++ b/.changeset/tool-approval-data.md
@@ -1,0 +1,51 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+Add support for extra data in tool approval responses with typed schema.
+
+- Added `data` field to `ToolApprovalResponse` type for passing extra data with approval responses
+- Added `approvalData` field to `ToolExecutionOptions` so the approval data is available in tool `execute` functions
+- Added `approvalDataSchema` field to `Tool` type for defining the schema of approval data with full type inference
+- Added `APPROVAL_DATA` type parameter to `Tool`, `ToolExecutionOptions`, and `ToolExecuteFunction` types
+- Added `InferToolApprovalData` helper type for inferring the approval data type from a tool
+- Updated `ChatAddToolApproveResponseFunction` to accept a `data` parameter
+- Updated `UIToolInvocation` approval object to include optional `data` field
+
+This allows users to pass additional information when approving tool calls (e.g., user notes, selected options, confirmation details) that can then be used during tool execution with full type safety.
+
+Example usage:
+
+```tsx
+import { tool } from 'ai';
+import { z } from 'zod';
+
+// Define a tool with a typed approval data schema
+const myTool = tool({
+  inputSchema: z.object({ command: z.string() }),
+  needsApproval: true,
+  // Define the schema for approval data - this enables type inference
+  approvalDataSchema: z.object({
+    userNote: z.string().optional(),
+    selectedOption: z.enum(['fast', 'thorough']),
+  }),
+  execute: async ({ command }, options) => {
+    // approvalData is now typed based on approvalDataSchema
+    const { approvalData } = options;
+    console.log('Selected option:', approvalData?.selectedOption);
+    console.log('User note:', approvalData?.userNote);
+    // ... execute the tool
+  },
+});
+
+// In your approval UI component:
+addToolApprovalResponse({
+  id: invocation.approval.id,
+  approved: true,
+  data: {
+    userNote: 'Approved for testing',
+    selectedOption: 'fast',
+  },
+});
+```

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -18,6 +18,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   messages,
   abortSignal,
   experimental_context,
+  approvalData,
   onPreliminaryToolResult,
 }: {
   toolCall: TypedToolCall<TOOLS>;
@@ -27,6 +28,11 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   messages: ModelMessage[];
   abortSignal: AbortSignal | undefined;
   experimental_context: unknown;
+  /**
+   * Extra data provided with the approval response.
+   * Available when the tool required approval and was approved.
+   */
+  approvalData?: unknown;
   onPreliminaryToolResult?: (result: TypedToolResult<TOOLS>) => void;
 }): Promise<ToolOutput<TOOLS> | undefined> {
   const { toolName, toolCallId, input } = toolCall;
@@ -65,6 +71,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
             messages,
             abortSignal,
             experimental_context,
+            approvalData,
           },
         });
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1205,6 +1205,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                   messages: initialMessages,
                   abortSignal,
                   experimental_context,
+                  approvalData: toolApproval.approvalResponse.data,
                   onPreliminaryToolResult: result => {
                     toolExecutionStepStreamController?.enqueue(result);
                   },

--- a/packages/ai/src/generate-text/tool-set.ts
+++ b/packages/ai/src/generate-text/tool-set.ts
@@ -2,9 +2,14 @@ import { Tool } from '@ai-sdk/provider-utils';
 
 export type ToolSet = Record<
   string,
-  (Tool<never, never> | Tool<any, any> | Tool<any, never> | Tool<never, any>) &
+  (
+    | Tool<never, never, never>
+    | Tool<any, any, any>
+    | Tool<any, never, any>
+    | Tool<never, any, any>
+  ) &
     Pick<
-      Tool<any, any>,
+      Tool<any, any, any>,
       | 'execute'
       | 'onInputAvailable'
       | 'onInputStart'

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -12,6 +12,7 @@ export {
   type FlexibleSchema,
   type IdGenerator,
   type InferSchema,
+  type InferToolApprovalData,
   type InferToolInput,
   type InferToolOutput,
   type Schema,

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -69,6 +69,7 @@ export type ChatAddToolApproveResponseFunction = ({
   id,
   approved,
   reason,
+  data,
 }: {
   id: string;
 
@@ -81,6 +82,13 @@ export type ChatAddToolApproveResponseFunction = ({
    * Optional reason for the approval or denial.
    */
   reason?: string;
+
+  /**
+   * Optional extra data to pass with the approval response.
+   * This data will be available in the tool's execute function via `options.approvalData`.
+   * Can be used for user input during approval (e.g., confirmation notes, selected options).
+   */
+  data?: unknown;
 }) => void | PromiseLike<void>;
 
 export type ChatStatus = 'submitted' | 'streaming' | 'ready' | 'error';
@@ -433,6 +441,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     id,
     approved,
     reason,
+    data,
   }) =>
     this.jobExecutor.run(async () => {
       const messages = this.state.messages;
@@ -447,7 +456,12 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           ? {
               ...part,
               state: 'approval-responded',
-              approval: { id, approved, reason },
+              approval: {
+                id,
+                approved,
+                reason,
+                ...(data !== undefined ? { data } : {}),
+              },
             }
           : part;
 

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -268,6 +268,9 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                       approved: toolPart.approval.approved,
                       reason: toolPart.approval.reason,
                       providerExecuted: toolPart.providerExecuted,
+                      ...(toolPart.approval.data !== undefined
+                        ? { data: toolPart.approval.data }
+                        : {}),
                     });
                   }
 

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -266,6 +266,10 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         id: string;
         approved: boolean;
         reason?: string;
+        /**
+         * Extra data provided with the approval response.
+         */
+        data?: unknown;
       };
     }
   | {
@@ -279,6 +283,10 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         id: string;
         approved: true;
         reason?: string;
+        /**
+         * Extra data provided with the approval response.
+         */
+        data?: unknown;
       };
     }
   | {
@@ -292,6 +300,10 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         id: string;
         approved: true;
         reason?: string;
+        /**
+         * Extra data provided with the approval response.
+         */
+        data?: unknown;
       };
     }
   | {
@@ -304,6 +316,10 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         id: string;
         approved: false;
         reason?: string;
+        /**
+         * Extra data provided with the approval response.
+         */
+        data?: unknown;
       };
     }
 );
@@ -371,6 +387,10 @@ export type DynamicToolUIPart = {
         id: string;
         approved: boolean;
         reason?: string;
+        /**
+         * Extra data provided with the approval response.
+         */
+        data?: unknown;
       };
     }
   | {
@@ -384,6 +404,10 @@ export type DynamicToolUIPart = {
         id: string;
         approved: true;
         reason?: string;
+        /**
+         * Extra data provided with the approval response.
+         */
+        data?: unknown;
       };
     }
   | {
@@ -396,6 +420,10 @@ export type DynamicToolUIPart = {
         id: string;
         approved: true;
         reason?: string;
+        /**
+         * Extra data provided with the approval response.
+         */
+        data?: unknown;
       };
     }
   | {
@@ -408,6 +436,10 @@ export type DynamicToolUIPart = {
         id: string;
         approved: false;
         reason?: string;
+        /**
+         * Extra data provided with the approval response.
+         */
+        data?: unknown;
       };
     }
 );

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -125,6 +125,7 @@ const uiMessagesSchema = lazySchema(() =>
                     id: z.string(),
                     approved: z.boolean(),
                     reason: z.string().optional(),
+                    data: z.unknown().optional(),
                   }),
                 }),
                 z.object({
@@ -143,6 +144,7 @@ const uiMessagesSchema = lazySchema(() =>
                       id: z.string(),
                       approved: z.literal(true),
                       reason: z.string().optional(),
+                      data: z.unknown().optional(),
                     })
                     .optional(),
                 }),
@@ -162,6 +164,7 @@ const uiMessagesSchema = lazySchema(() =>
                       id: z.string(),
                       approved: z.literal(true),
                       reason: z.string().optional(),
+                      data: z.unknown().optional(),
                     })
                     .optional(),
                 }),
@@ -179,6 +182,7 @@ const uiMessagesSchema = lazySchema(() =>
                     id: z.string(),
                     approved: z.literal(false),
                     reason: z.string().optional(),
+                    data: z.unknown().optional(),
                   }),
                 }),
                 z.object({
@@ -231,6 +235,7 @@ const uiMessagesSchema = lazySchema(() =>
                     id: z.string(),
                     approved: z.boolean(),
                     reason: z.string().optional(),
+                    data: z.unknown().optional(),
                   }),
                 }),
                 z.object({
@@ -248,6 +253,7 @@ const uiMessagesSchema = lazySchema(() =>
                       id: z.string(),
                       approved: z.literal(true),
                       reason: z.string().optional(),
+                      data: z.unknown().optional(),
                     })
                     .optional(),
                 }),
@@ -266,6 +272,7 @@ const uiMessagesSchema = lazySchema(() =>
                       id: z.string(),
                       approved: z.literal(true),
                       reason: z.string().optional(),
+                      data: z.unknown().optional(),
                     })
                     .optional(),
                 }),
@@ -282,6 +289,7 @@ const uiMessagesSchema = lazySchema(() =>
                     id: z.string(),
                     approved: z.literal(false),
                     reason: z.string().optional(),
+                    data: z.unknown().optional(),
                   }),
                 }),
               ]),

--- a/packages/provider-utils/src/types/index.ts
+++ b/packages/provider-utils/src/types/index.ts
@@ -19,6 +19,7 @@ export type { SystemModelMessage } from './system-model-message';
 export {
   dynamicTool,
   tool,
+  type InferToolApprovalData,
   type InferToolInput,
   type InferToolOutput,
   type Tool,

--- a/packages/provider-utils/src/types/tool-approval-response.ts
+++ b/packages/provider-utils/src/types/tool-approval-response.ts
@@ -1,7 +1,7 @@
 /**
  * Tool approval response prompt part.
  */
-export type ToolApprovalResponse = {
+export type ToolApprovalResponse<DATA = unknown> = {
   type: 'tool-approval-response';
 
   /**
@@ -24,4 +24,11 @@ export type ToolApprovalResponse = {
    * Only provider-executed tool approval responses should be sent to the model.
    */
   providerExecuted?: boolean;
+
+  /**
+   * Optional extra data provided with the approval response.
+   * This data is passed to the tool's execute function when the tool is approved.
+   * Can be used for user input during approval (e.g., confirmation notes, options).
+   */
+  data?: DATA;
 };


### PR DESCRIPTION
## Summary

- Adds `approvalDataSchema` field to `Tool` type, enabling typed approval data with full type inference in tool `execute` functions
- Adds `data` field to `ToolApprovalResponse`, `ChatAddToolApproveResponseFunction`, and `UIToolInvocation` approval objects so extra data can flow from the approval UI through to tool execution
- Adds `approvalData` field to `ToolExecutionOptions` making the typed data available in `execute`
- Adds `InferToolApprovalData` helper type and `APPROVAL_DATA` type parameter to `Tool`, `ToolExecuteFunction`, and `ToolExecutionOptions`
- Includes changeset

This allows users to pass additional structured information when approving tool calls (e.g., user notes, selected options, confirmation details) that is then available during tool execution with full type safety.

### Example

```tsx
const myTool = tool({
  inputSchema: z.object({ command: z.string() }),
  needsApproval: true,
  approvalDataSchema: z.object({
    userNote: z.string().optional(),
    selectedOption: z.enum(['fast', 'thorough']),
  }),
  execute: async ({ command }, options) => {
    // approvalData is typed based on approvalDataSchema
    const { approvalData } = options;
    console.log('Selected option:', approvalData?.selectedOption);
  },
});
```

## Test plan

- [ ] Verify type inference works correctly for `approvalData` in `execute` when `approvalDataSchema` is provided
- [ ] Verify `approvalData` is `unknown` when no `approvalDataSchema` is defined
- [ ] Verify `data` flows from `addToolApprovalResponse` through to `ToolExecutionOptions.approvalData` in both `generateText` and `streamText`
- [ ] Verify existing tools without `approvalDataSchema` continue to work unchanged
- [ ] Run `pnpm test` to confirm no regressions


Made with [Cursor](https://cursor.com)