### PR TITLE
chore(provider/cohere): migrate tests to fixture-based pattern

### DIFF
--- a/.changeset/dull-pillows-shop.md
+++ b/.changeset/dull-pillows-shop.md
@@ -1,5 +1,0 @@
----
-'@ai-sdk/cohere': patch
----
-
-fix(provider/cohere): migrate tests to fixture-based pattern

--- a/.changeset/dull-pillows-shop.md
+++ b/.changeset/dull-pillows-shop.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cohere': patch
+---
+
+fix(provider/cohere): migrate tests to fixture-based pattern

--- a/packages/cohere/src/__fixtures__/cohere-citations.json
+++ b/packages/cohere/src/__fixtures__/cohere-citations.json
@@ -1,43 +1,77 @@
 {
-  "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
-  "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  "id": "68475c80-574b-4c65-98a4-e81cebab5dce",
   "message": {
     "role": "assistant",
     "content": [
       {
         "type": "text",
-        "text": "AI has many benefits including automation."
+        "text": "The key benefits mentioned in this document are:\n1. Automation of tasks\n2. Better decision-making\n3. Cost reduction"
       }
     ],
     "citations": [
       {
-        "start": 31,
-        "end": 41,
-        "text": "automation",
-        "type": "TEXT_CONTENT",
+        "start": 52,
+        "end": 71,
+        "text": "Automation of tasks",
         "sources": [
           {
             "type": "document",
             "id": "doc:0",
             "document": {
               "id": "doc:0",
-              "text": "AI provides automation and efficiency.",
-              "title": "ai-benefits.txt"
+              "text": "AI provides: 1. Automation of tasks 2. Better decision-making 3. Cost reduction",
+              "title": "benefits.txt"
             }
           }
-        ]
+        ],
+        "type": "TEXT_CONTENT"
+      },
+      {
+        "start": 75,
+        "end": 97,
+        "text": "Better decision-making",
+        "sources": [
+          {
+            "type": "document",
+            "id": "doc:0",
+            "document": {
+              "id": "doc:0",
+              "text": "AI provides: 1. Automation of tasks 2. Better decision-making 3. Cost reduction",
+              "title": "benefits.txt"
+            }
+          }
+        ],
+        "type": "TEXT_CONTENT"
+      },
+      {
+        "start": 101,
+        "end": 115,
+        "text": "Cost reduction",
+        "sources": [
+          {
+            "type": "document",
+            "id": "doc:0",
+            "document": {
+              "id": "doc:0",
+              "text": "AI provides: 1. Automation of tasks 2. Better decision-making 3. Cost reduction",
+              "title": "benefits.txt"
+            }
+          }
+        ],
+        "type": "TEXT_CONTENT"
       }
     ]
   },
   "finish_reason": "COMPLETE",
   "usage": {
     "billed_units": {
-      "input_tokens": 9,
-      "output_tokens": 415
+      "input_tokens": 39,
+      "output_tokens": 27
     },
     "tokens": {
-      "input_tokens": 4,
-      "output_tokens": 30
-    }
+      "input_tokens": 1683,
+      "output_tokens": 62
+    },
+    "cached_tokens": 992
   }
 }

--- a/packages/cohere/src/__fixtures__/cohere-citations.json
+++ b/packages/cohere/src/__fixtures__/cohere-citations.json
@@ -1,0 +1,43 @@
+{
+  "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
+  "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  "message": {
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "AI has many benefits including automation."
+      }
+    ],
+    "citations": [
+      {
+        "start": 31,
+        "end": 41,
+        "text": "automation",
+        "type": "TEXT_CONTENT",
+        "sources": [
+          {
+            "type": "document",
+            "id": "doc:0",
+            "document": {
+              "id": "doc:0",
+              "text": "AI provides automation and efficiency.",
+              "title": "ai-benefits.txt"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "finish_reason": "COMPLETE",
+  "usage": {
+    "billed_units": {
+      "input_tokens": 9,
+      "output_tokens": 415
+    },
+    "tokens": {
+      "input_tokens": 4,
+      "output_tokens": 30
+    }
+  }
+}

--- a/packages/cohere/src/__fixtures__/cohere-embedding.json
+++ b/packages/cohere/src/__fixtures__/cohere-embedding.json
@@ -1,15 +1,19 @@
 {
-  "id": "test-id",
+  "id": "f5aa3e7b-f011-4c5c-a825-f94669f760e5",
   "texts": ["sunny day at the beach", "rainy day in the city"],
   "embeddings": {
     "float": [
-      [0.1, 0.2, 0.3, 0.4, 0.5],
-      [0.6, 0.7, 0.8, 0.9, 1.0]
+      [0.03302002, 0.020904541, -0.019744873, -0.0625, 0.04437256],
+      [-0.04660034, 0.00037765503, -0.061157227, -0.08239746, -0.010360718]
     ]
   },
   "meta": {
+    "api_version": {
+      "version": "2"
+    },
     "billed_units": {
-      "input_tokens": 8
+      "input_tokens": 10
     }
-  }
+  },
+  "response_type": "embeddings_by_type"
 }

--- a/packages/cohere/src/__fixtures__/cohere-embedding.json
+++ b/packages/cohere/src/__fixtures__/cohere-embedding.json
@@ -1,0 +1,15 @@
+{
+  "id": "test-id",
+  "texts": ["sunny day at the beach", "rainy day in the city"],
+  "embeddings": {
+    "float": [
+      [0.1, 0.2, 0.3, 0.4, 0.5],
+      [0.6, 0.7, 0.8, 0.9, 1.0]
+    ]
+  },
+  "meta": {
+    "billed_units": {
+      "input_tokens": 8
+    }
+  }
+}

--- a/packages/cohere/src/__fixtures__/cohere-empty-tool-call.chunks.txt
+++ b/packages/cohere/src/__fixtures__/cohere-empty-tool-call.chunks.txt
@@ -1,0 +1,13 @@
+event: message-start
+data: {"type":"message-start","id":"test-id","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
+
+event: tool-call-start
+data: {"type":"tool-call-start","delta":{"message":{"tool_calls":{"id":"test-id-1","type":"function","function":{"name":"test-tool","arguments":""}}}}}
+
+event: tool-call-end
+data: {"type":"tool-call-end"}
+
+event: message-end
+data: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"tokens":{"input_tokens":10,"output_tokens":5}}}}
+
+data: [DONE]

--- a/packages/cohere/src/__fixtures__/cohere-empty-tool-call.chunks.txt
+++ b/packages/cohere/src/__fixtures__/cohere-empty-tool-call.chunks.txt
@@ -1,13 +1,16 @@
-event: message-start
-data: {"type":"message-start","id":"test-id","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
-
-event: tool-call-start
-data: {"type":"tool-call-start","delta":{"message":{"tool_calls":{"id":"test-id-1","type":"function","function":{"name":"test-tool","arguments":""}}}}}
-
-event: tool-call-end
-data: {"type":"tool-call-end"}
-
-event: message-end
-data: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"tokens":{"input_tokens":10,"output_tokens":5}}}}
-
-data: [DONE]
+{"id":"66dec7d7-45e6-427c-8fd9-7d6375d12046","type":"message-start","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":"I"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" will"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" use"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" the"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" currentTime"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" tool"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" to"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" find"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" the"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" current"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" time"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":"."}}}
+{"type":"tool-call-start","index":0,"delta":{"message":{"tool_calls":{"id":"currentTime_y46ar19t5gvw","type":"function","function":{"name":"currentTime","arguments":""}}}}}
+{"type":"tool-call-end","index":0}
+{"type":"message-end","delta":{"finish_reason":"TOOL_CALL","usage":{"billed_units":{"input_tokens":46,"output_tokens":14},"tokens":{"input_tokens":1445,"output_tokens":43},"cached_tokens":704}}}

--- a/packages/cohere/src/__fixtures__/cohere-max-tokens.json
+++ b/packages/cohere/src/__fixtures__/cohere-max-tokens.json
@@ -1,24 +1,24 @@
 {
-  "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
-  "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  "id": "039584d9-7236-4ecb-9dd7-f1bed57888bc",
   "message": {
     "role": "assistant",
     "content": [
       {
         "type": "text",
-        "text": "Hello"
+        "text": "**The History of"
       }
     ]
   },
   "finish_reason": "MAX_TOKENS",
   "usage": {
     "billed_units": {
-      "input_tokens": 9,
-      "output_tokens": 415
+      "input_tokens": 11,
+      "output_tokens": 4
     },
     "tokens": {
-      "input_tokens": 4,
-      "output_tokens": 30
-    }
+      "input_tokens": 506,
+      "output_tokens": 5
+    },
+    "cached_tokens": 448
   }
 }

--- a/packages/cohere/src/__fixtures__/cohere-max-tokens.json
+++ b/packages/cohere/src/__fixtures__/cohere-max-tokens.json
@@ -1,0 +1,24 @@
+{
+  "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
+  "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  "message": {
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "Hello"
+      }
+    ]
+  },
+  "finish_reason": "MAX_TOKENS",
+  "usage": {
+    "billed_units": {
+      "input_tokens": 9,
+      "output_tokens": 415
+    },
+    "tokens": {
+      "input_tokens": 4,
+      "output_tokens": 30
+    }
+  }
+}

--- a/packages/cohere/src/__fixtures__/cohere-null-args.json
+++ b/packages/cohere/src/__fixtures__/cohere-null-args.json
@@ -1,0 +1,29 @@
+{
+  "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
+  "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  "message": {
+    "role": "assistant",
+    "content": [],
+    "tool_calls": [
+      {
+        "id": "test-id-1",
+        "type": "function",
+        "function": {
+          "name": "currentTime",
+          "arguments": "null"
+        }
+      }
+    ]
+  },
+  "finish_reason": "COMPLETE",
+  "usage": {
+    "billed_units": {
+      "input_tokens": 9,
+      "output_tokens": 415
+    },
+    "tokens": {
+      "input_tokens": 4,
+      "output_tokens": 30
+    }
+  }
+}

--- a/packages/cohere/src/__fixtures__/cohere-null-args.json
+++ b/packages/cohere/src/__fixtures__/cohere-null-args.json
@@ -1,29 +1,29 @@
 {
-  "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
-  "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  "id": "316f0604-ff50-49f6-ba38-c64616e972b4",
   "message": {
     "role": "assistant",
-    "content": [],
+    "tool_plan": "I will use the currentTime tool to find the current time.",
     "tool_calls": [
       {
-        "id": "test-id-1",
+        "id": "currentTime_tf4dywn8wgnk",
         "type": "function",
         "function": {
           "name": "currentTime",
-          "arguments": "null"
+          "arguments": "{}"
         }
       }
     ]
   },
-  "finish_reason": "COMPLETE",
+  "finish_reason": "TOOL_CALL",
   "usage": {
     "billed_units": {
-      "input_tokens": 9,
-      "output_tokens": 415
+      "input_tokens": 46,
+      "output_tokens": 14
     },
     "tokens": {
-      "input_tokens": 4,
-      "output_tokens": 30
-    }
+      "input_tokens": 1445,
+      "output_tokens": 43
+    },
+    "cached_tokens": 992
   }
 }

--- a/packages/cohere/src/__fixtures__/cohere-null-args.json
+++ b/packages/cohere/src/__fixtures__/cohere-null-args.json
@@ -9,7 +9,7 @@
         "type": "function",
         "function": {
           "name": "currentTime",
-          "arguments": "{}"
+          "arguments": "null"
         }
       }
     ]

--- a/packages/cohere/src/__fixtures__/cohere-reasoning.chunks.txt
+++ b/packages/cohere/src/__fixtures__/cohere-reasoning.chunks.txt
@@ -1,43 +1,51 @@
-event: message-start
-data: {"type":"message-start","id":"586ac33f-9c64-452c-8f8d-e5890e73b6fb","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
-
-event: content-start
-data: {"type":"content-start","index":0,"delta":{"message":{"content":{"type":"thinking","thinking":""}}}}
-
-event: content-delta
-data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"So"}}}}
-
-event: content-delta
-data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"I "}}}}
-
-event: content-delta
-data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"was "}}}}
-
-event: content-delta
-data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"thinking "}}}}
-
-event: content-delta
-data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"..."}}}}
-
-event: content-end
-data: {"type":"content-end","index":0}
-
-event: content-start
-data: {"type":"content-start","index":0,"delta":{"message":{"content":{"type":"text","text":""}}}}
-
-event: content-delta
-data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"Hello"}}}}
-
-event: content-delta
-data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":", "}}}}
-
-event: content-delta
-data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"World!"}}}}
-
-event: content-end
-data: {"type":"content-end","index":0}
-
-event: message-end
-data: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"tokens":{"input_tokens":34,"output_tokens":12}}}}
-
-data: [DONE]
+{"id":"c9117d7f-a7e4-499f-b643-a2a1e139687b","type":"message-start","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
+{"type":"content-start","index":0,"delta":{"message":{"content":{"type":"thinking","thinking":""}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"The"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" user"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" is"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" asking"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" for"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" the"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" sum"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" of"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" 2"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" and"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" 2"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"."}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" Since"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" this"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" is"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" a"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" straightforward"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" arithmetic"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" problem"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":","}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" I"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" don"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"'t"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" need"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" to"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" use"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" any"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" tools"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"."}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" I"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" can"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" calculate"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" the"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" answer"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":" directly"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"."}}}}
+{"type":"content-end","index":0}
+{"type":"content-start","index":1,"delta":{"message":{"content":{"type":"text","text":""}}}}
+{"type":"content-delta","index":1,"delta":{"message":{"content":{"text":"The"}}}}
+{"type":"content-delta","index":1,"delta":{"message":{"content":{"text":" answer"}}}}
+{"type":"content-delta","index":1,"delta":{"message":{"content":{"text":" to"}}}}
+{"type":"content-delta","index":1,"delta":{"message":{"content":{"text":" 2"}}}}
+{"type":"content-delta","index":1,"delta":{"message":{"content":{"text":" +"}}}}
+{"type":"content-delta","index":1,"delta":{"message":{"content":{"text":" 2"}}}}
+{"type":"content-delta","index":1,"delta":{"message":{"content":{"text":" is"}}}}
+{"type":"content-delta","index":1,"delta":{"message":{"content":{"text":" 4"}}}}
+{"type":"content-delta","index":1,"delta":{"message":{"content":{"text":"."}}}}
+{"type":"content-end","index":1}
+{"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"billed_units":{"input_tokens":8,"output_tokens":50},"tokens":{"input_tokens":1394,"output_tokens":54},"cached_tokens":1360}}}

--- a/packages/cohere/src/__fixtures__/cohere-reasoning.chunks.txt
+++ b/packages/cohere/src/__fixtures__/cohere-reasoning.chunks.txt
@@ -1,0 +1,43 @@
+event: message-start
+data: {"type":"message-start","id":"586ac33f-9c64-452c-8f8d-e5890e73b6fb","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
+
+event: content-start
+data: {"type":"content-start","index":0,"delta":{"message":{"content":{"type":"thinking","thinking":""}}}}
+
+event: content-delta
+data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"So"}}}}
+
+event: content-delta
+data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"I "}}}}
+
+event: content-delta
+data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"was "}}}}
+
+event: content-delta
+data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"thinking "}}}}
+
+event: content-delta
+data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"..."}}}}
+
+event: content-end
+data: {"type":"content-end","index":0}
+
+event: content-start
+data: {"type":"content-start","index":0,"delta":{"message":{"content":{"type":"text","text":""}}}}
+
+event: content-delta
+data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"Hello"}}}}
+
+event: content-delta
+data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":", "}}}}
+
+event: content-delta
+data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"World!"}}}}
+
+event: content-end
+data: {"type":"content-end","index":0}
+
+event: message-end
+data: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"tokens":{"input_tokens":34,"output_tokens":12}}}}
+
+data: [DONE]

--- a/packages/cohere/src/__fixtures__/cohere-reasoning.json
+++ b/packages/cohere/src/__fixtures__/cohere-reasoning.json
@@ -1,0 +1,28 @@
+{
+  "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
+  "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  "message": {
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "42"
+      },
+      {
+        "type": "thinking",
+        "thinking": "So I was thinking ..."
+      }
+    ]
+  },
+  "finish_reason": "COMPLETE",
+  "usage": {
+    "billed_units": {
+      "input_tokens": 9,
+      "output_tokens": 415
+    },
+    "tokens": {
+      "input_tokens": 4,
+      "output_tokens": 30
+    }
+  }
+}

--- a/packages/cohere/src/__fixtures__/cohere-reasoning.json
+++ b/packages/cohere/src/__fixtures__/cohere-reasoning.json
@@ -1,28 +1,28 @@
 {
-  "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
-  "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  "id": "53bcb235-5179-4a91-a578-cb372b5430bc",
   "message": {
     "role": "assistant",
     "content": [
       {
-        "type": "text",
-        "text": "42"
+        "type": "thinking",
+        "thinking": "Okay, so I need to figure out what 2 + 2 is. Let me start by recalling what addition means."
       },
       {
-        "type": "thinking",
-        "thinking": "So I was thinking ..."
+        "type": "text",
+        "text": "2 + 2 = 4"
       }
     ]
   },
   "finish_reason": "COMPLETE",
   "usage": {
     "billed_units": {
-      "input_tokens": 9,
-      "output_tokens": 415
+      "input_tokens": 8,
+      "output_tokens": 578
     },
     "tokens": {
-      "input_tokens": 4,
-      "output_tokens": 30
-    }
+      "input_tokens": 1394,
+      "output_tokens": 582
+    },
+    "cached_tokens": 1344
   }
 }

--- a/packages/cohere/src/__fixtures__/cohere-text.chunks.txt
+++ b/packages/cohere/src/__fixtures__/cohere-text.chunks.txt
@@ -1,22 +1,11 @@
-event: message-start
-data: {"type":"message-start","id":"586ac33f-9c64-452c-8f8d-e5890e73b6fb","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
-
-event: content-start
-data: {"type":"content-start","index":0,"delta":{"message":{"content":{"type":"text","text":""}}}}
-
-event: content-delta
-data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"Hello"}}}}
-
-event: content-delta
-data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":", "}}}}
-
-event: content-delta
-data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"World!"}}}}
-
-event: content-end
-data: {"type":"content-end","index":0}
-
-event: message-end
-data: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"tokens":{"input_tokens":34,"output_tokens":12}}}}
-
-data: [DONE]
+{"id":"321d178c-2c12-44d3-ae42-2f5510f6b1cc","type":"message-start","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
+{"type":"content-start","index":0,"delta":{"message":{"content":{"type":"text","text":""}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"The"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"text":" capital"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"text":" of"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"text":" France"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"text":" is"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"text":" Paris"}}}}
+{"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+{"type":"content-end","index":0}
+{"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"billed_units":{"input_tokens":12,"output_tokens":7},"tokens":{"input_tokens":507,"output_tokens":10},"cached_tokens":448}}}

--- a/packages/cohere/src/__fixtures__/cohere-text.chunks.txt
+++ b/packages/cohere/src/__fixtures__/cohere-text.chunks.txt
@@ -1,0 +1,22 @@
+event: message-start
+data: {"type":"message-start","id":"586ac33f-9c64-452c-8f8d-e5890e73b6fb","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
+
+event: content-start
+data: {"type":"content-start","index":0,"delta":{"message":{"content":{"type":"text","text":""}}}}
+
+event: content-delta
+data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"Hello"}}}}
+
+event: content-delta
+data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":", "}}}}
+
+event: content-delta
+data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"World!"}}}}
+
+event: content-end
+data: {"type":"content-end","index":0}
+
+event: message-end
+data: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"tokens":{"input_tokens":34,"output_tokens":12}}}}
+
+data: [DONE]

--- a/packages/cohere/src/__fixtures__/cohere-text.json
+++ b/packages/cohere/src/__fixtures__/cohere-text.json
@@ -1,24 +1,24 @@
 {
-  "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
-  "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  "id": "e7592632-1e3d-424f-b129-bd5f9f980f7b",
   "message": {
     "role": "assistant",
     "content": [
       {
         "type": "text",
-        "text": "Hello, World!"
+        "text": "The capital of France is Paris."
       }
     ]
   },
   "finish_reason": "COMPLETE",
   "usage": {
     "billed_units": {
-      "input_tokens": 9,
-      "output_tokens": 415
+      "input_tokens": 12,
+      "output_tokens": 7
     },
     "tokens": {
-      "input_tokens": 4,
-      "output_tokens": 30
-    }
+      "input_tokens": 507,
+      "output_tokens": 10
+    },
+    "cached_tokens": 448
   }
 }

--- a/packages/cohere/src/__fixtures__/cohere-text.json
+++ b/packages/cohere/src/__fixtures__/cohere-text.json
@@ -1,0 +1,24 @@
+{
+  "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
+  "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  "message": {
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "Hello, World!"
+      }
+    ]
+  },
+  "finish_reason": "COMPLETE",
+  "usage": {
+    "billed_units": {
+      "input_tokens": 9,
+      "output_tokens": 415
+    },
+    "tokens": {
+      "input_tokens": 4,
+      "output_tokens": 30
+    }
+  }
+}

--- a/packages/cohere/src/__fixtures__/cohere-tool-call.chunks.txt
+++ b/packages/cohere/src/__fixtures__/cohere-tool-call.chunks.txt
@@ -1,0 +1,43 @@
+event: message-start
+data: {"type":"message-start","id":"29f14a5a-11de-4cae-9800-25e4747408ea","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
+
+event: tool-call-start
+data: {"type":"tool-call-start","delta":{"message":{"tool_calls":{"id":"test-id-1","type":"function","function":{"name":"test-tool","arguments":""}}}}}
+
+event: tool-call-delta
+data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"{\n    \""}}}}}
+
+event: tool-call-delta
+data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"ticker"}}}}}
+
+event: tool-call-delta
+data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"_"}}}}}
+
+event: tool-call-delta
+data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"symbol"}}}}}
+
+event: tool-call-delta
+data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"\":"}}}}}
+
+event: tool-call-delta
+data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":" \""}}}}}
+
+event: tool-call-delta
+data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"AAPL"}}}}}
+
+event: tool-call-delta
+data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"\""}}}}}
+
+event: tool-call-delta
+data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"\n"}}}}}
+
+event: tool-call-delta
+data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"}"}}}}}
+
+event: tool-call-end
+data: {"type":"tool-call-end"}
+
+event: message-end
+data: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"tokens":{"input_tokens":893,"output_tokens":62}}}}
+
+data: [DONE]

--- a/packages/cohere/src/__fixtures__/cohere-tool-call.chunks.txt
+++ b/packages/cohere/src/__fixtures__/cohere-tool-call.chunks.txt
@@ -1,43 +1,47 @@
-event: message-start
-data: {"type":"message-start","id":"29f14a5a-11de-4cae-9800-25e4747408ea","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
-
-event: tool-call-start
-data: {"type":"tool-call-start","delta":{"message":{"tool_calls":{"id":"test-id-1","type":"function","function":{"name":"test-tool","arguments":""}}}}}
-
-event: tool-call-delta
-data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"{\n    \""}}}}}
-
-event: tool-call-delta
-data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"ticker"}}}}}
-
-event: tool-call-delta
-data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"_"}}}}}
-
-event: tool-call-delta
-data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"symbol"}}}}}
-
-event: tool-call-delta
-data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"\":"}}}}}
-
-event: tool-call-delta
-data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":" \""}}}}}
-
-event: tool-call-delta
-data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"AAPL"}}}}}
-
-event: tool-call-delta
-data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"\""}}}}}
-
-event: tool-call-delta
-data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"\n"}}}}}
-
-event: tool-call-delta
-data: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"}"}}}}}
-
-event: tool-call-end
-data: {"type":"tool-call-end"}
-
-event: message-end
-data: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"tokens":{"input_tokens":893,"output_tokens":62}}}}
-
-data: [DONE]
+{"id":"2941521a-b87a-45f6-9b0d-235fd66c3025","type":"message-start","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":"I"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" will"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" use"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" the"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" weather"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" tool"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" to"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" find"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" the"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" weather"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" in"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" San"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" Francisco"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" and"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" the"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" city"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":"At"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":"tract"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":"ions"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" tool"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" to"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" find"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" attractions"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" in"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" San"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":" Francisco"}}}
+{"type":"tool-plan-delta","delta":{"message":{"tool_plan":"."}}}
+{"type":"tool-call-start","index":0,"delta":{"message":{"tool_calls":{"id":"weather_e8p4pn45zt0t","type":"function","function":{"name":"weather","arguments":""}}}}}
+{"type":"tool-call-delta","index":0,"delta":{"message":{"tool_calls":{"function":{"arguments":"{\""}}}}}
+{"type":"tool-call-delta","index":0,"delta":{"message":{"tool_calls":{"function":{"arguments":"location"}}}}}
+{"type":"tool-call-delta","index":0,"delta":{"message":{"tool_calls":{"function":{"arguments":"\":"}}}}}
+{"type":"tool-call-delta","index":0,"delta":{"message":{"tool_calls":{"function":{"arguments":" \""}}}}}
+{"type":"tool-call-delta","index":0,"delta":{"message":{"tool_calls":{"function":{"arguments":"San"}}}}}
+{"type":"tool-call-delta","index":0,"delta":{"message":{"tool_calls":{"function":{"arguments":" Francisco"}}}}}
+{"type":"tool-call-delta","index":0,"delta":{"message":{"tool_calls":{"function":{"arguments":"\"}"}}}}}
+{"type":"tool-call-end","index":0}
+{"type":"tool-call-start","index":1,"delta":{"message":{"tool_calls":{"id":"cityAttractions_pyxssbwnq9fq","type":"function","function":{"name":"cityAttractions","arguments":""}}}}}
+{"type":"tool-call-delta","index":1,"delta":{"message":{"tool_calls":{"function":{"arguments":"{\""}}}}}
+{"type":"tool-call-delta","index":1,"delta":{"message":{"tool_calls":{"function":{"arguments":"city"}}}}}
+{"type":"tool-call-delta","index":1,"delta":{"message":{"tool_calls":{"function":{"arguments":"\":"}}}}}
+{"type":"tool-call-delta","index":1,"delta":{"message":{"tool_calls":{"function":{"arguments":" \""}}}}}
+{"type":"tool-call-delta","index":1,"delta":{"message":{"tool_calls":{"function":{"arguments":"San"}}}}}
+{"type":"tool-call-delta","index":1,"delta":{"message":{"tool_calls":{"function":{"arguments":" Francisco"}}}}}
+{"type":"tool-call-delta","index":1,"delta":{"message":{"tool_calls":{"function":{"arguments":"\"}"}}}}}
+{"type":"tool-call-end","index":1}
+{"type":"message-end","delta":{"finish_reason":"TOOL_CALL","usage":{"billed_units":{"input_tokens":119,"output_tokens":44},"tokens":{"input_tokens":1549,"output_tokens":95},"cached_tokens":1504}}}

--- a/packages/cohere/src/__fixtures__/cohere-tool-call.json
+++ b/packages/cohere/src/__fixtures__/cohere-tool-call.json
@@ -1,0 +1,34 @@
+{
+  "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
+  "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  "message": {
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "Hello, World!"
+      }
+    ],
+    "tool_calls": [
+      {
+        "id": "test-id-1",
+        "type": "function",
+        "function": {
+          "name": "test-tool",
+          "arguments": "{\"value\":\"example value\"}"
+        }
+      }
+    ]
+  },
+  "finish_reason": "COMPLETE",
+  "usage": {
+    "billed_units": {
+      "input_tokens": 9,
+      "output_tokens": 415
+    },
+    "tokens": {
+      "input_tokens": 4,
+      "output_tokens": 30
+    }
+  }
+}

--- a/packages/cohere/src/__fixtures__/cohere-tool-call.json
+++ b/packages/cohere/src/__fixtures__/cohere-tool-call.json
@@ -1,34 +1,37 @@
 {
-  "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
-  "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  "id": "f201af17-e24a-4396-8f6a-98e8bf9c3432",
   "message": {
     "role": "assistant",
-    "content": [
-      {
-        "type": "text",
-        "text": "Hello, World!"
-      }
-    ],
+    "tool_plan": "I will use the weather tool to find out the weather in San Francisco. I will also use the cityAttractions tool to find out what attractions are in San Francisco.",
     "tool_calls": [
       {
-        "id": "test-id-1",
+        "id": "weather_dqgshstja6p9",
         "type": "function",
         "function": {
-          "name": "test-tool",
-          "arguments": "{\"value\":\"example value\"}"
+          "name": "weather",
+          "arguments": "{\"location\":\"San Francisco\"}"
+        }
+      },
+      {
+        "id": "cityAttractions_dcxfx4myvx68",
+        "type": "function",
+        "function": {
+          "name": "cityAttractions",
+          "arguments": "{\"city\":\"San Francisco\"}"
         }
       }
     ]
   },
-  "finish_reason": "COMPLETE",
+  "finish_reason": "TOOL_CALL",
   "usage": {
     "billed_units": {
-      "input_tokens": 9,
-      "output_tokens": 415
+      "input_tokens": 119,
+      "output_tokens": 52
     },
     "tokens": {
-      "input_tokens": 4,
-      "output_tokens": 30
-    }
+      "input_tokens": 1549,
+      "output_tokens": 103
+    },
+    "cached_tokens": 992
   }
 }

--- a/packages/cohere/src/__snapshots__/cohere-chat-language-model.test.ts.snap
+++ b/packages/cohere/src/__snapshots__/cohere-chat-language-model.test.ts.snap
@@ -1,0 +1,910 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`doGenerate > citations > should extract citations from response 1`] = `
+{
+  "content": [
+    {
+      "text": "AI has many benefits including automation.",
+      "type": "text",
+    },
+    {
+      "id": "test-citation-id",
+      "mediaType": "text/plain",
+      "providerMetadata": {
+        "cohere": {
+          "citationType": "TEXT_CONTENT",
+          "end": 41,
+          "sources": [
+            {
+              "document": {
+                "id": "doc:0",
+                "text": "AI provides automation and efficiency.",
+                "title": "ai-benefits.txt",
+              },
+              "id": "doc:0",
+              "type": "document",
+            },
+          ],
+          "start": 31,
+          "text": "automation",
+        },
+      },
+      "sourceType": "document",
+      "title": "ai-benefits.txt",
+      "type": "source",
+    },
+  ],
+  "finishReason": {
+    "raw": "COMPLETE",
+    "unified": "stop",
+  },
+  "request": {
+    "body": {
+      "documents": [
+        {
+          "data": {
+            "text": "AI provides automation and efficiency.",
+            "title": "ai-benefits.txt",
+          },
+        },
+      ],
+      "frequency_penalty": undefined,
+      "k": undefined,
+      "max_tokens": undefined,
+      "messages": [
+        {
+          "content": "What are AI benefits?",
+          "role": "user",
+        },
+      ],
+      "model": "command-r-plus",
+      "p": undefined,
+      "presence_penalty": undefined,
+      "response_format": undefined,
+      "seed": undefined,
+      "stop_sequences": undefined,
+      "temperature": undefined,
+      "tool_choice": undefined,
+      "tools": undefined,
+    },
+  },
+  "response": {
+    "body": {
+      "finish_reason": "COMPLETE",
+      "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+      "message": {
+        "citations": [
+          {
+            "end": 41,
+            "sources": [
+              {
+                "document": {
+                  "id": "doc:0",
+                  "text": "AI provides automation and efficiency.",
+                  "title": "ai-benefits.txt",
+                },
+                "id": "doc:0",
+                "type": "document",
+              },
+            ],
+            "start": 31,
+            "text": "automation",
+            "type": "TEXT_CONTENT",
+          },
+        ],
+        "content": [
+          {
+            "text": "AI has many benefits including automation.",
+            "type": "text",
+          },
+        ],
+        "role": "assistant",
+      },
+      "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
+      "usage": {
+        "billed_units": {
+          "input_tokens": 9,
+          "output_tokens": 415,
+        },
+        "tokens": {
+          "input_tokens": 4,
+          "output_tokens": 30,
+        },
+      },
+    },
+    "headers": {
+      "content-length": "581",
+      "content-type": "application/json",
+    },
+    "id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  },
+  "usage": {
+    "inputTokens": {
+      "cacheRead": undefined,
+      "cacheWrite": undefined,
+      "noCache": 4,
+      "total": 4,
+    },
+    "outputTokens": {
+      "reasoning": undefined,
+      "text": 30,
+      "total": 30,
+    },
+    "raw": {
+      "input_tokens": 4,
+      "output_tokens": 30,
+    },
+  },
+  "warnings": [],
+}
+`;
+
+exports[`doGenerate > null tool call arguments > should handle string "null" tool call arguments 1`] = `
+[
+  {
+    "input": "{}",
+    "toolCallId": "test-id-1",
+    "toolName": "currentTime",
+    "type": "tool-call",
+  },
+]
+`;
+
+exports[`doGenerate > reasoning > should extract reasoning from response 1`] = `
+{
+  "content": [
+    {
+      "text": "42",
+      "type": "text",
+    },
+    {
+      "text": "So I was thinking ...",
+      "type": "reasoning",
+    },
+  ],
+  "finishReason": {
+    "raw": "COMPLETE",
+    "unified": "stop",
+  },
+  "request": {
+    "body": {
+      "frequency_penalty": undefined,
+      "k": undefined,
+      "max_tokens": undefined,
+      "messages": [
+        {
+          "content": "you are a friendly bot!",
+          "role": "system",
+        },
+        {
+          "content": "Hello",
+          "role": "user",
+        },
+      ],
+      "model": "command-r-plus",
+      "p": undefined,
+      "presence_penalty": undefined,
+      "response_format": undefined,
+      "seed": undefined,
+      "stop_sequences": undefined,
+      "temperature": undefined,
+      "tool_choice": undefined,
+      "tools": undefined,
+    },
+  },
+  "response": {
+    "body": {
+      "finish_reason": "COMPLETE",
+      "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+      "message": {
+        "content": [
+          {
+            "text": "42",
+            "type": "text",
+          },
+          {
+            "thinking": "So I was thinking ...",
+            "type": "thinking",
+          },
+        ],
+        "role": "assistant",
+      },
+      "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
+      "usage": {
+        "billed_units": {
+          "input_tokens": 9,
+          "output_tokens": 415,
+        },
+        "tokens": {
+          "input_tokens": 4,
+          "output_tokens": 30,
+        },
+      },
+    },
+    "headers": {
+      "content-length": "373",
+      "content-type": "application/json",
+    },
+    "id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  },
+  "usage": {
+    "inputTokens": {
+      "cacheRead": undefined,
+      "cacheWrite": undefined,
+      "noCache": 4,
+      "total": 4,
+    },
+    "outputTokens": {
+      "reasoning": undefined,
+      "text": 30,
+      "total": 30,
+    },
+    "raw": {
+      "input_tokens": 4,
+      "output_tokens": 30,
+    },
+  },
+  "warnings": [],
+}
+`;
+
+exports[`doGenerate > text > should extract text response 1`] = `
+{
+  "content": [
+    {
+      "text": "Hello, World!",
+      "type": "text",
+    },
+  ],
+  "finishReason": {
+    "raw": "COMPLETE",
+    "unified": "stop",
+  },
+  "request": {
+    "body": {
+      "frequency_penalty": undefined,
+      "k": undefined,
+      "max_tokens": undefined,
+      "messages": [
+        {
+          "content": "you are a friendly bot!",
+          "role": "system",
+        },
+        {
+          "content": "Hello",
+          "role": "user",
+        },
+      ],
+      "model": "command-r-plus",
+      "p": undefined,
+      "presence_penalty": undefined,
+      "response_format": undefined,
+      "seed": undefined,
+      "stop_sequences": undefined,
+      "temperature": undefined,
+      "tool_choice": undefined,
+      "tools": undefined,
+    },
+  },
+  "response": {
+    "body": {
+      "finish_reason": "COMPLETE",
+      "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+      "message": {
+        "content": [
+          {
+            "text": "Hello, World!",
+            "type": "text",
+          },
+        ],
+        "role": "assistant",
+      },
+      "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
+      "usage": {
+        "billed_units": {
+          "input_tokens": 9,
+          "output_tokens": 415,
+        },
+        "tokens": {
+          "input_tokens": 4,
+          "output_tokens": 30,
+        },
+      },
+    },
+    "headers": {
+      "content-length": "329",
+      "content-type": "application/json",
+    },
+    "id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  },
+  "usage": {
+    "inputTokens": {
+      "cacheRead": undefined,
+      "cacheWrite": undefined,
+      "noCache": 4,
+      "total": 4,
+    },
+    "outputTokens": {
+      "reasoning": undefined,
+      "text": 30,
+      "total": 30,
+    },
+    "raw": {
+      "input_tokens": 4,
+      "output_tokens": 30,
+    },
+  },
+  "warnings": [],
+}
+`;
+
+exports[`doGenerate > tool call > should extract tool calls 1`] = `
+{
+  "content": [
+    {
+      "text": "Hello, World!",
+      "type": "text",
+    },
+    {
+      "input": "{"value":"example value"}",
+      "toolCallId": "test-id-1",
+      "toolName": "test-tool",
+      "type": "tool-call",
+    },
+  ],
+  "finishReason": {
+    "raw": "COMPLETE",
+    "unified": "stop",
+  },
+  "request": {
+    "body": {
+      "frequency_penalty": undefined,
+      "k": undefined,
+      "max_tokens": undefined,
+      "messages": [
+        {
+          "content": "you are a friendly bot!",
+          "role": "system",
+        },
+        {
+          "content": "Hello",
+          "role": "user",
+        },
+      ],
+      "model": "command-r-plus",
+      "p": undefined,
+      "presence_penalty": undefined,
+      "response_format": undefined,
+      "seed": undefined,
+      "stop_sequences": undefined,
+      "temperature": undefined,
+      "tool_choice": undefined,
+      "tools": [
+        {
+          "function": {
+            "description": undefined,
+            "name": "test-tool",
+            "parameters": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {
+                "value": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "value",
+              ],
+              "type": "object",
+            },
+          },
+          "type": "function",
+        },
+      ],
+    },
+  },
+  "response": {
+    "body": {
+      "finish_reason": "COMPLETE",
+      "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+      "message": {
+        "content": [
+          {
+            "text": "Hello, World!",
+            "type": "text",
+          },
+        ],
+        "role": "assistant",
+        "tool_calls": [
+          {
+            "function": {
+              "arguments": "{"value":"example value"}",
+              "name": "test-tool",
+            },
+            "id": "test-id-1",
+            "type": "function",
+          },
+        ],
+      },
+      "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
+      "usage": {
+        "billed_units": {
+          "input_tokens": 9,
+          "output_tokens": 415,
+        },
+        "tokens": {
+          "input_tokens": 4,
+          "output_tokens": 30,
+        },
+      },
+    },
+    "headers": {
+      "content-length": "457",
+      "content-type": "application/json",
+    },
+    "id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+  },
+  "usage": {
+    "inputTokens": {
+      "cacheRead": undefined,
+      "cacheWrite": undefined,
+      "noCache": 4,
+      "total": 4,
+    },
+    "outputTokens": {
+      "reasoning": undefined,
+      "text": 30,
+      "total": 30,
+    },
+    "raw": {
+      "input_tokens": 4,
+      "output_tokens": 30,
+    },
+  },
+  "warnings": [],
+}
+`;
+
+exports[`doStream > empty tool call > should handle empty tool call arguments 1`] = `
+[
+  {
+    "type": "stream-start",
+    "warnings": [],
+  },
+  {
+    "id": "test-id",
+    "type": "response-metadata",
+  },
+  {
+    "id": "test-id-1",
+    "toolName": "test-tool",
+    "type": "tool-input-start",
+  },
+  {
+    "id": "test-id-1",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{}",
+    "toolCallId": "test-id-1",
+    "toolName": "test-tool",
+    "type": "tool-call",
+  },
+  {
+    "finishReason": {
+      "raw": "COMPLETE",
+      "unified": "stop",
+    },
+    "type": "finish",
+    "usage": {
+      "inputTokens": {
+        "cacheRead": undefined,
+        "cacheWrite": undefined,
+        "noCache": 10,
+        "total": 10,
+      },
+      "outputTokens": {
+        "reasoning": undefined,
+        "text": 5,
+        "total": 5,
+      },
+      "raw": {
+        "input_tokens": 10,
+        "output_tokens": 5,
+      },
+    },
+  },
+]
+`;
+
+exports[`doStream > error handling > should handle unparsable stream parts 1`] = `
+[
+  {
+    "type": "stream-start",
+    "warnings": [],
+  },
+  {
+    "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
+Error message: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
+    "type": "error",
+  },
+  {
+    "finishReason": {
+      "raw": undefined,
+      "unified": "error",
+    },
+    "type": "finish",
+    "usage": {
+      "inputTokens": {
+        "cacheRead": undefined,
+        "cacheWrite": undefined,
+        "noCache": undefined,
+        "total": undefined,
+      },
+      "outputTokens": {
+        "reasoning": undefined,
+        "text": undefined,
+        "total": undefined,
+      },
+      "raw": undefined,
+    },
+  },
+]
+`;
+
+exports[`doStream > reasoning > should stream reasoning deltas 1`] = `
+[
+  {
+    "type": "stream-start",
+    "warnings": [],
+  },
+  {
+    "id": "586ac33f-9c64-452c-8f8d-e5890e73b6fb",
+    "type": "response-metadata",
+  },
+  {
+    "id": "0",
+    "type": "reasoning-start",
+  },
+  {
+    "delta": "So",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": "I ",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": "was ",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": "thinking ",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": "...",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "id": "0",
+    "type": "reasoning-end",
+  },
+  {
+    "id": "0",
+    "type": "text-start",
+  },
+  {
+    "delta": "Hello",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": ", ",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "World!",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "id": "0",
+    "type": "text-end",
+  },
+  {
+    "finishReason": {
+      "raw": "COMPLETE",
+      "unified": "stop",
+    },
+    "type": "finish",
+    "usage": {
+      "inputTokens": {
+        "cacheRead": undefined,
+        "cacheWrite": undefined,
+        "noCache": 34,
+        "total": 34,
+      },
+      "outputTokens": {
+        "reasoning": undefined,
+        "text": 12,
+        "total": 12,
+      },
+      "raw": {
+        "input_tokens": 34,
+        "output_tokens": 12,
+      },
+    },
+  },
+]
+`;
+
+exports[`doStream > text > should include raw chunks when includeRawChunks is enabled 1`] = `
+[
+  {
+    "rawValue": {
+      "delta": {
+        "message": {
+          "citations": [],
+          "content": [],
+          "role": "assistant",
+          "tool_calls": [],
+          "tool_plan": "",
+        },
+      },
+      "id": "586ac33f-9c64-452c-8f8d-e5890e73b6fb",
+      "type": "message-start",
+    },
+    "type": "raw",
+  },
+  {
+    "rawValue": {
+      "delta": {
+        "message": {
+          "content": {
+            "text": "",
+            "type": "text",
+          },
+        },
+      },
+      "index": 0,
+      "type": "content-start",
+    },
+    "type": "raw",
+  },
+  {
+    "rawValue": {
+      "delta": {
+        "message": {
+          "content": {
+            "text": "Hello",
+          },
+        },
+      },
+      "index": 0,
+      "type": "content-delta",
+    },
+    "type": "raw",
+  },
+  {
+    "rawValue": {
+      "delta": {
+        "message": {
+          "content": {
+            "text": ", ",
+          },
+        },
+      },
+      "index": 0,
+      "type": "content-delta",
+    },
+    "type": "raw",
+  },
+  {
+    "rawValue": {
+      "delta": {
+        "message": {
+          "content": {
+            "text": "World!",
+          },
+        },
+      },
+      "index": 0,
+      "type": "content-delta",
+    },
+    "type": "raw",
+  },
+  {
+    "rawValue": {
+      "index": 0,
+      "type": "content-end",
+    },
+    "type": "raw",
+  },
+  {
+    "rawValue": {
+      "delta": {
+        "finish_reason": "COMPLETE",
+        "usage": {
+          "tokens": {
+            "input_tokens": 34,
+            "output_tokens": 12,
+          },
+        },
+      },
+      "type": "message-end",
+    },
+    "type": "raw",
+  },
+]
+`;
+
+exports[`doStream > text > should stream text deltas 1`] = `
+[
+  {
+    "type": "stream-start",
+    "warnings": [],
+  },
+  {
+    "id": "586ac33f-9c64-452c-8f8d-e5890e73b6fb",
+    "type": "response-metadata",
+  },
+  {
+    "id": "0",
+    "type": "text-start",
+  },
+  {
+    "delta": "Hello",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": ", ",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "World!",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "id": "0",
+    "type": "text-end",
+  },
+  {
+    "finishReason": {
+      "raw": "COMPLETE",
+      "unified": "stop",
+    },
+    "type": "finish",
+    "usage": {
+      "inputTokens": {
+        "cacheRead": undefined,
+        "cacheWrite": undefined,
+        "noCache": 34,
+        "total": 34,
+      },
+      "outputTokens": {
+        "reasoning": undefined,
+        "text": 12,
+        "total": 12,
+      },
+      "raw": {
+        "input_tokens": 34,
+        "output_tokens": 12,
+      },
+    },
+  },
+]
+`;
+
+exports[`doStream > tool call > should stream tool deltas 1`] = `
+[
+  {
+    "type": "stream-start",
+    "warnings": [],
+  },
+  {
+    "id": "29f14a5a-11de-4cae-9800-25e4747408ea",
+    "type": "response-metadata",
+  },
+  {
+    "id": "test-id-1",
+    "toolName": "test-tool",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{
+    "",
+    "id": "test-id-1",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ticker",
+    "id": "test-id-1",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "_",
+    "id": "test-id-1",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "symbol",
+    "id": "test-id-1",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "":",
+    "id": "test-id-1",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " "",
+    "id": "test-id-1",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "AAPL",
+    "id": "test-id-1",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": """,
+    "id": "test-id-1",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "
+",
+    "id": "test-id-1",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "}",
+    "id": "test-id-1",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "test-id-1",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"ticker_symbol":"AAPL"}",
+    "toolCallId": "test-id-1",
+    "toolName": "test-tool",
+    "type": "tool-call",
+  },
+  {
+    "finishReason": {
+      "raw": "COMPLETE",
+      "unified": "stop",
+    },
+    "type": "finish",
+    "usage": {
+      "inputTokens": {
+        "cacheRead": undefined,
+        "cacheWrite": undefined,
+        "noCache": 893,
+        "total": 893,
+      },
+      "outputTokens": {
+        "reasoning": undefined,
+        "text": 62,
+        "total": 62,
+      },
+      "raw": {
+        "input_tokens": 893,
+        "output_tokens": 62,
+      },
+    },
+  },
+]
+`;

--- a/packages/cohere/src/__snapshots__/cohere-chat-language-model.test.ts.snap
+++ b/packages/cohere/src/__snapshots__/cohere-chat-language-model.test.ts.snap
@@ -4,7 +4,10 @@ exports[`doGenerate > citations > should extract citations from response 1`] = `
 {
   "content": [
     {
-      "text": "AI has many benefits including automation.",
+      "text": "The key benefits mentioned in this document are:
+1. Automation of tasks
+2. Better decision-making
+3. Cost reduction",
       "type": "text",
     },
     {
@@ -13,24 +16,76 @@ exports[`doGenerate > citations > should extract citations from response 1`] = `
       "providerMetadata": {
         "cohere": {
           "citationType": "TEXT_CONTENT",
-          "end": 41,
+          "end": 71,
           "sources": [
             {
               "document": {
                 "id": "doc:0",
-                "text": "AI provides automation and efficiency.",
-                "title": "ai-benefits.txt",
+                "text": "AI provides: 1. Automation of tasks 2. Better decision-making 3. Cost reduction",
+                "title": "benefits.txt",
               },
               "id": "doc:0",
               "type": "document",
             },
           ],
-          "start": 31,
-          "text": "automation",
+          "start": 52,
+          "text": "Automation of tasks",
         },
       },
       "sourceType": "document",
-      "title": "ai-benefits.txt",
+      "title": "benefits.txt",
+      "type": "source",
+    },
+    {
+      "id": "test-citation-id",
+      "mediaType": "text/plain",
+      "providerMetadata": {
+        "cohere": {
+          "citationType": "TEXT_CONTENT",
+          "end": 97,
+          "sources": [
+            {
+              "document": {
+                "id": "doc:0",
+                "text": "AI provides: 1. Automation of tasks 2. Better decision-making 3. Cost reduction",
+                "title": "benefits.txt",
+              },
+              "id": "doc:0",
+              "type": "document",
+            },
+          ],
+          "start": 75,
+          "text": "Better decision-making",
+        },
+      },
+      "sourceType": "document",
+      "title": "benefits.txt",
+      "type": "source",
+    },
+    {
+      "id": "test-citation-id",
+      "mediaType": "text/plain",
+      "providerMetadata": {
+        "cohere": {
+          "citationType": "TEXT_CONTENT",
+          "end": 115,
+          "sources": [
+            {
+              "document": {
+                "id": "doc:0",
+                "text": "AI provides: 1. Automation of tasks 2. Better decision-making 3. Cost reduction",
+                "title": "benefits.txt",
+              },
+              "id": "doc:0",
+              "type": "document",
+            },
+          ],
+          "start": 101,
+          "text": "Cost reduction",
+        },
+      },
+      "sourceType": "document",
+      "title": "benefits.txt",
       "type": "source",
     },
   ],
@@ -71,68 +126,105 @@ exports[`doGenerate > citations > should extract citations from response 1`] = `
   "response": {
     "body": {
       "finish_reason": "COMPLETE",
-      "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+      "id": "68475c80-574b-4c65-98a4-e81cebab5dce",
       "message": {
         "citations": [
           {
-            "end": 41,
+            "end": 71,
             "sources": [
               {
                 "document": {
                   "id": "doc:0",
-                  "text": "AI provides automation and efficiency.",
-                  "title": "ai-benefits.txt",
+                  "text": "AI provides: 1. Automation of tasks 2. Better decision-making 3. Cost reduction",
+                  "title": "benefits.txt",
                 },
                 "id": "doc:0",
                 "type": "document",
               },
             ],
-            "start": 31,
-            "text": "automation",
+            "start": 52,
+            "text": "Automation of tasks",
+            "type": "TEXT_CONTENT",
+          },
+          {
+            "end": 97,
+            "sources": [
+              {
+                "document": {
+                  "id": "doc:0",
+                  "text": "AI provides: 1. Automation of tasks 2. Better decision-making 3. Cost reduction",
+                  "title": "benefits.txt",
+                },
+                "id": "doc:0",
+                "type": "document",
+              },
+            ],
+            "start": 75,
+            "text": "Better decision-making",
+            "type": "TEXT_CONTENT",
+          },
+          {
+            "end": 115,
+            "sources": [
+              {
+                "document": {
+                  "id": "doc:0",
+                  "text": "AI provides: 1. Automation of tasks 2. Better decision-making 3. Cost reduction",
+                  "title": "benefits.txt",
+                },
+                "id": "doc:0",
+                "type": "document",
+              },
+            ],
+            "start": 101,
+            "text": "Cost reduction",
             "type": "TEXT_CONTENT",
           },
         ],
         "content": [
           {
-            "text": "AI has many benefits including automation.",
+            "text": "The key benefits mentioned in this document are:
+1. Automation of tasks
+2. Better decision-making
+3. Cost reduction",
             "type": "text",
           },
         ],
         "role": "assistant",
       },
-      "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
       "usage": {
         "billed_units": {
-          "input_tokens": 9,
-          "output_tokens": 415,
+          "input_tokens": 39,
+          "output_tokens": 27,
         },
+        "cached_tokens": 992,
         "tokens": {
-          "input_tokens": 4,
-          "output_tokens": 30,
+          "input_tokens": 1683,
+          "output_tokens": 62,
         },
       },
     },
     "headers": {
-      "content-length": "581",
+      "content-length": "1175",
       "content-type": "application/json",
     },
-    "id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+    "id": undefined,
   },
   "usage": {
     "inputTokens": {
       "cacheRead": undefined,
       "cacheWrite": undefined,
-      "noCache": 4,
-      "total": 4,
+      "noCache": 1683,
+      "total": 1683,
     },
     "outputTokens": {
       "reasoning": undefined,
-      "text": 30,
-      "total": 30,
+      "text": 62,
+      "total": 62,
     },
     "raw": {
-      "input_tokens": 4,
-      "output_tokens": 30,
+      "input_tokens": 1683,
+      "output_tokens": 62,
     },
   },
   "warnings": [],
@@ -143,7 +235,7 @@ exports[`doGenerate > null tool call arguments > should handle string "null" too
 [
   {
     "input": "{}",
-    "toolCallId": "test-id-1",
+    "toolCallId": "currentTime_tf4dywn8wgnk",
     "toolName": "currentTime",
     "type": "tool-call",
   },
@@ -154,12 +246,12 @@ exports[`doGenerate > reasoning > should extract reasoning from response 1`] = `
 {
   "content": [
     {
-      "text": "42",
-      "type": "text",
+      "text": "Okay, so I need to figure out what 2 + 2 is. Let me start by recalling what addition means.",
+      "type": "reasoning",
     },
     {
-      "text": "So I was thinking ...",
-      "type": "reasoning",
+      "text": "2 + 2 = 4",
+      "type": "text",
     },
   ],
   "finishReason": {
@@ -195,53 +287,53 @@ exports[`doGenerate > reasoning > should extract reasoning from response 1`] = `
   "response": {
     "body": {
       "finish_reason": "COMPLETE",
-      "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+      "id": "53bcb235-5179-4a91-a578-cb372b5430bc",
       "message": {
         "content": [
           {
-            "text": "42",
-            "type": "text",
+            "thinking": "Okay, so I need to figure out what 2 + 2 is. Let me start by recalling what addition means.",
+            "type": "thinking",
           },
           {
-            "thinking": "So I was thinking ...",
-            "type": "thinking",
+            "text": "2 + 2 = 4",
+            "type": "text",
           },
         ],
         "role": "assistant",
       },
-      "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
       "usage": {
         "billed_units": {
-          "input_tokens": 9,
-          "output_tokens": 415,
+          "input_tokens": 8,
+          "output_tokens": 578,
         },
+        "cached_tokens": 1344,
         "tokens": {
-          "input_tokens": 4,
-          "output_tokens": 30,
+          "input_tokens": 1394,
+          "output_tokens": 582,
         },
       },
     },
     "headers": {
-      "content-length": "373",
+      "content-length": "411",
       "content-type": "application/json",
     },
-    "id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+    "id": undefined,
   },
   "usage": {
     "inputTokens": {
       "cacheRead": undefined,
       "cacheWrite": undefined,
-      "noCache": 4,
-      "total": 4,
+      "noCache": 1394,
+      "total": 1394,
     },
     "outputTokens": {
       "reasoning": undefined,
-      "text": 30,
-      "total": 30,
+      "text": 582,
+      "total": 582,
     },
     "raw": {
-      "input_tokens": 4,
-      "output_tokens": 30,
+      "input_tokens": 1394,
+      "output_tokens": 582,
     },
   },
   "warnings": [],
@@ -252,7 +344,7 @@ exports[`doGenerate > text > should extract text response 1`] = `
 {
   "content": [
     {
-      "text": "Hello, World!",
+      "text": "The capital of France is Paris.",
       "type": "text",
     },
   ],
@@ -289,49 +381,49 @@ exports[`doGenerate > text > should extract text response 1`] = `
   "response": {
     "body": {
       "finish_reason": "COMPLETE",
-      "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+      "id": "e7592632-1e3d-424f-b129-bd5f9f980f7b",
       "message": {
         "content": [
           {
-            "text": "Hello, World!",
+            "text": "The capital of France is Paris.",
             "type": "text",
           },
         ],
         "role": "assistant",
       },
-      "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
       "usage": {
         "billed_units": {
-          "input_tokens": 9,
-          "output_tokens": 415,
+          "input_tokens": 12,
+          "output_tokens": 7,
         },
+        "cached_tokens": 448,
         "tokens": {
-          "input_tokens": 4,
-          "output_tokens": 30,
+          "input_tokens": 507,
+          "output_tokens": 10,
         },
       },
     },
     "headers": {
-      "content-length": "329",
+      "content-length": "304",
       "content-type": "application/json",
     },
-    "id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+    "id": undefined,
   },
   "usage": {
     "inputTokens": {
       "cacheRead": undefined,
       "cacheWrite": undefined,
-      "noCache": 4,
-      "total": 4,
+      "noCache": 507,
+      "total": 507,
     },
     "outputTokens": {
       "reasoning": undefined,
-      "text": 30,
-      "total": 30,
+      "text": 10,
+      "total": 10,
     },
     "raw": {
-      "input_tokens": 4,
-      "output_tokens": 30,
+      "input_tokens": 507,
+      "output_tokens": 10,
     },
   },
   "warnings": [],
@@ -342,19 +434,21 @@ exports[`doGenerate > tool call > should extract tool calls 1`] = `
 {
   "content": [
     {
-      "text": "Hello, World!",
-      "type": "text",
+      "input": "{"location":"San Francisco"}",
+      "toolCallId": "weather_dqgshstja6p9",
+      "toolName": "weather",
+      "type": "tool-call",
     },
     {
-      "input": "{"value":"example value"}",
-      "toolCallId": "test-id-1",
-      "toolName": "test-tool",
+      "input": "{"city":"San Francisco"}",
+      "toolCallId": "cityAttractions_dcxfx4myvx68",
+      "toolName": "cityAttractions",
       "type": "tool-call",
     },
   ],
   "finishReason": {
-    "raw": "COMPLETE",
-    "unified": "stop",
+    "raw": "TOOL_CALL",
+    "unified": "tool-calls",
   },
   "request": {
     "body": {
@@ -405,60 +499,63 @@ exports[`doGenerate > tool call > should extract tool calls 1`] = `
   },
   "response": {
     "body": {
-      "finish_reason": "COMPLETE",
-      "generation_id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+      "finish_reason": "TOOL_CALL",
+      "id": "f201af17-e24a-4396-8f6a-98e8bf9c3432",
       "message": {
-        "content": [
-          {
-            "text": "Hello, World!",
-            "type": "text",
-          },
-        ],
         "role": "assistant",
         "tool_calls": [
           {
             "function": {
-              "arguments": "{"value":"example value"}",
-              "name": "test-tool",
+              "arguments": "{"location":"San Francisco"}",
+              "name": "weather",
             },
-            "id": "test-id-1",
+            "id": "weather_dqgshstja6p9",
+            "type": "function",
+          },
+          {
+            "function": {
+              "arguments": "{"city":"San Francisco"}",
+              "name": "cityAttractions",
+            },
+            "id": "cityAttractions_dcxfx4myvx68",
             "type": "function",
           },
         ],
+        "tool_plan": "I will use the weather tool to find out the weather in San Francisco. I will also use the cityAttractions tool to find out what attractions are in San Francisco.",
       },
-      "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
       "usage": {
         "billed_units": {
-          "input_tokens": 9,
-          "output_tokens": 415,
+          "input_tokens": 119,
+          "output_tokens": 52,
         },
+        "cached_tokens": 992,
         "tokens": {
-          "input_tokens": 4,
-          "output_tokens": 30,
+          "input_tokens": 1549,
+          "output_tokens": 103,
         },
       },
     },
     "headers": {
-      "content-length": "457",
+      "content-length": "693",
       "content-type": "application/json",
     },
-    "id": "dad0c7cd-7982-42a7-acfb-706ccf598291",
+    "id": undefined,
   },
   "usage": {
     "inputTokens": {
       "cacheRead": undefined,
       "cacheWrite": undefined,
-      "noCache": 4,
-      "total": 4,
+      "noCache": 1549,
+      "total": 1549,
     },
     "outputTokens": {
       "reasoning": undefined,
-      "text": 30,
-      "total": 30,
+      "text": 103,
+      "total": 103,
     },
     "raw": {
-      "input_tokens": 4,
-      "output_tokens": 30,
+      "input_tokens": 1549,
+      "output_tokens": 103,
     },
   },
   "warnings": [],
@@ -472,45 +569,45 @@ exports[`doStream > empty tool call > should handle empty tool call arguments 1`
     "warnings": [],
   },
   {
-    "id": "test-id",
+    "id": "66dec7d7-45e6-427c-8fd9-7d6375d12046",
     "type": "response-metadata",
   },
   {
-    "id": "test-id-1",
-    "toolName": "test-tool",
+    "id": "currentTime_y46ar19t5gvw",
+    "toolName": "currentTime",
     "type": "tool-input-start",
   },
   {
-    "id": "test-id-1",
+    "id": "currentTime_y46ar19t5gvw",
     "type": "tool-input-end",
   },
   {
     "input": "{}",
-    "toolCallId": "test-id-1",
-    "toolName": "test-tool",
+    "toolCallId": "currentTime_y46ar19t5gvw",
+    "toolName": "currentTime",
     "type": "tool-call",
   },
   {
     "finishReason": {
-      "raw": "COMPLETE",
-      "unified": "stop",
+      "raw": "TOOL_CALL",
+      "unified": "tool-calls",
     },
     "type": "finish",
     "usage": {
       "inputTokens": {
         "cacheRead": undefined,
         "cacheWrite": undefined,
-        "noCache": 10,
-        "total": 10,
+        "noCache": 1445,
+        "total": 1445,
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": 5,
-        "total": 5,
+        "text": 43,
+        "total": 43,
       },
       "raw": {
-        "input_tokens": 10,
-        "output_tokens": 5,
+        "input_tokens": 1445,
+        "output_tokens": 43,
       },
     },
   },
@@ -559,7 +656,7 @@ exports[`doStream > reasoning > should stream reasoning deltas 1`] = `
     "warnings": [],
   },
   {
-    "id": "586ac33f-9c64-452c-8f8d-e5890e73b6fb",
+    "id": "c9117d7f-a7e4-499f-b643-a2a1e139687b",
     "type": "response-metadata",
   },
   {
@@ -567,27 +664,182 @@ exports[`doStream > reasoning > should stream reasoning deltas 1`] = `
     "type": "reasoning-start",
   },
   {
-    "delta": "So",
+    "delta": "The",
     "id": "0",
     "type": "reasoning-delta",
   },
   {
-    "delta": "I ",
+    "delta": " user",
     "id": "0",
     "type": "reasoning-delta",
   },
   {
-    "delta": "was ",
+    "delta": " is",
     "id": "0",
     "type": "reasoning-delta",
   },
   {
-    "delta": "thinking ",
+    "delta": " asking",
     "id": "0",
     "type": "reasoning-delta",
   },
   {
-    "delta": "...",
+    "delta": " for",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " the",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " sum",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " of",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " 2",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " and",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " 2",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": ".",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " Since",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " this",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " is",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " a",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " straightforward",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " arithmetic",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " problem",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": ",",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " I",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " don",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": "'t",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " need",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " to",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " use",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " any",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " tools",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": ".",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " I",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " can",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " calculate",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " the",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " answer",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " directly",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": ".",
     "id": "0",
     "type": "reasoning-delta",
   },
@@ -596,26 +848,56 @@ exports[`doStream > reasoning > should stream reasoning deltas 1`] = `
     "type": "reasoning-end",
   },
   {
-    "id": "0",
+    "id": "1",
     "type": "text-start",
   },
   {
-    "delta": "Hello",
-    "id": "0",
+    "delta": "The",
+    "id": "1",
     "type": "text-delta",
   },
   {
-    "delta": ", ",
-    "id": "0",
+    "delta": " answer",
+    "id": "1",
     "type": "text-delta",
   },
   {
-    "delta": "World!",
-    "id": "0",
+    "delta": " to",
+    "id": "1",
     "type": "text-delta",
   },
   {
-    "id": "0",
+    "delta": " 2",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": " +",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": " 2",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": " is",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": " 4",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": ".",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "id": "1",
     "type": "text-end",
   },
   {
@@ -628,17 +910,17 @@ exports[`doStream > reasoning > should stream reasoning deltas 1`] = `
       "inputTokens": {
         "cacheRead": undefined,
         "cacheWrite": undefined,
-        "noCache": 34,
-        "total": 34,
+        "noCache": 1394,
+        "total": 1394,
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": 12,
-        "total": 12,
+        "text": 54,
+        "total": 54,
       },
       "raw": {
-        "input_tokens": 34,
-        "output_tokens": 12,
+        "input_tokens": 1394,
+        "output_tokens": 54,
       },
     },
   },
@@ -658,7 +940,7 @@ exports[`doStream > text > should include raw chunks when includeRawChunks is en
           "tool_plan": "",
         },
       },
-      "id": "586ac33f-9c64-452c-8f8d-e5890e73b6fb",
+      "id": "321d178c-2c12-44d3-ae42-2f5510f6b1cc",
       "type": "message-start",
     },
     "type": "raw",
@@ -683,7 +965,7 @@ exports[`doStream > text > should include raw chunks when includeRawChunks is en
       "delta": {
         "message": {
           "content": {
-            "text": "Hello",
+            "text": "The",
           },
         },
       },
@@ -697,7 +979,7 @@ exports[`doStream > text > should include raw chunks when includeRawChunks is en
       "delta": {
         "message": {
           "content": {
-            "text": ", ",
+            "text": " capital",
           },
         },
       },
@@ -711,7 +993,63 @@ exports[`doStream > text > should include raw chunks when includeRawChunks is en
       "delta": {
         "message": {
           "content": {
-            "text": "World!",
+            "text": " of",
+          },
+        },
+      },
+      "index": 0,
+      "type": "content-delta",
+    },
+    "type": "raw",
+  },
+  {
+    "rawValue": {
+      "delta": {
+        "message": {
+          "content": {
+            "text": " France",
+          },
+        },
+      },
+      "index": 0,
+      "type": "content-delta",
+    },
+    "type": "raw",
+  },
+  {
+    "rawValue": {
+      "delta": {
+        "message": {
+          "content": {
+            "text": " is",
+          },
+        },
+      },
+      "index": 0,
+      "type": "content-delta",
+    },
+    "type": "raw",
+  },
+  {
+    "rawValue": {
+      "delta": {
+        "message": {
+          "content": {
+            "text": " Paris",
+          },
+        },
+      },
+      "index": 0,
+      "type": "content-delta",
+    },
+    "type": "raw",
+  },
+  {
+    "rawValue": {
+      "delta": {
+        "message": {
+          "content": {
+            "text": ".",
           },
         },
       },
@@ -732,9 +1070,14 @@ exports[`doStream > text > should include raw chunks when includeRawChunks is en
       "delta": {
         "finish_reason": "COMPLETE",
         "usage": {
+          "billed_units": {
+            "input_tokens": 12,
+            "output_tokens": 7,
+          },
+          "cached_tokens": 448,
           "tokens": {
-            "input_tokens": 34,
-            "output_tokens": 12,
+            "input_tokens": 507,
+            "output_tokens": 10,
           },
         },
       },
@@ -752,7 +1095,7 @@ exports[`doStream > text > should stream text deltas 1`] = `
     "warnings": [],
   },
   {
-    "id": "586ac33f-9c64-452c-8f8d-e5890e73b6fb",
+    "id": "321d178c-2c12-44d3-ae42-2f5510f6b1cc",
     "type": "response-metadata",
   },
   {
@@ -760,17 +1103,37 @@ exports[`doStream > text > should stream text deltas 1`] = `
     "type": "text-start",
   },
   {
-    "delta": "Hello",
+    "delta": "The",
     "id": "0",
     "type": "text-delta",
   },
   {
-    "delta": ", ",
+    "delta": " capital",
     "id": "0",
     "type": "text-delta",
   },
   {
-    "delta": "World!",
+    "delta": " of",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": " France",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": " is",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": " Paris",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": ".",
     "id": "0",
     "type": "text-delta",
   },
@@ -788,17 +1151,17 @@ exports[`doStream > text > should stream text deltas 1`] = `
       "inputTokens": {
         "cacheRead": undefined,
         "cacheWrite": undefined,
-        "noCache": 34,
-        "total": 34,
+        "noCache": 507,
+        "total": 507,
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": 12,
-        "total": 12,
+        "text": 10,
+        "total": 10,
       },
       "raw": {
-        "input_tokens": 34,
-        "output_tokens": 12,
+        "input_tokens": 507,
+        "output_tokens": 10,
       },
     },
   },
@@ -812,97 +1175,130 @@ exports[`doStream > tool call > should stream tool deltas 1`] = `
     "warnings": [],
   },
   {
-    "id": "29f14a5a-11de-4cae-9800-25e4747408ea",
+    "id": "2941521a-b87a-45f6-9b0d-235fd66c3025",
     "type": "response-metadata",
   },
   {
-    "id": "test-id-1",
-    "toolName": "test-tool",
+    "id": "weather_e8p4pn45zt0t",
+    "toolName": "weather",
     "type": "tool-input-start",
   },
   {
-    "delta": "{
-    "",
-    "id": "test-id-1",
+    "delta": "{"",
+    "id": "weather_e8p4pn45zt0t",
     "type": "tool-input-delta",
   },
   {
-    "delta": "ticker",
-    "id": "test-id-1",
-    "type": "tool-input-delta",
-  },
-  {
-    "delta": "_",
-    "id": "test-id-1",
-    "type": "tool-input-delta",
-  },
-  {
-    "delta": "symbol",
-    "id": "test-id-1",
+    "delta": "location",
+    "id": "weather_e8p4pn45zt0t",
     "type": "tool-input-delta",
   },
   {
     "delta": "":",
-    "id": "test-id-1",
+    "id": "weather_e8p4pn45zt0t",
     "type": "tool-input-delta",
   },
   {
     "delta": " "",
-    "id": "test-id-1",
+    "id": "weather_e8p4pn45zt0t",
     "type": "tool-input-delta",
   },
   {
-    "delta": "AAPL",
-    "id": "test-id-1",
+    "delta": "San",
+    "id": "weather_e8p4pn45zt0t",
     "type": "tool-input-delta",
   },
   {
-    "delta": """,
-    "id": "test-id-1",
+    "delta": " Francisco",
+    "id": "weather_e8p4pn45zt0t",
     "type": "tool-input-delta",
   },
   {
-    "delta": "
-",
-    "id": "test-id-1",
+    "delta": ""}",
+    "id": "weather_e8p4pn45zt0t",
     "type": "tool-input-delta",
   },
   {
-    "delta": "}",
-    "id": "test-id-1",
-    "type": "tool-input-delta",
-  },
-  {
-    "id": "test-id-1",
+    "id": "weather_e8p4pn45zt0t",
     "type": "tool-input-end",
   },
   {
-    "input": "{"ticker_symbol":"AAPL"}",
-    "toolCallId": "test-id-1",
-    "toolName": "test-tool",
+    "input": "{"location":"San Francisco"}",
+    "toolCallId": "weather_e8p4pn45zt0t",
+    "toolName": "weather",
+    "type": "tool-call",
+  },
+  {
+    "id": "cityAttractions_pyxssbwnq9fq",
+    "toolName": "cityAttractions",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"",
+    "id": "cityAttractions_pyxssbwnq9fq",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "city",
+    "id": "cityAttractions_pyxssbwnq9fq",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "":",
+    "id": "cityAttractions_pyxssbwnq9fq",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " "",
+    "id": "cityAttractions_pyxssbwnq9fq",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "San",
+    "id": "cityAttractions_pyxssbwnq9fq",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " Francisco",
+    "id": "cityAttractions_pyxssbwnq9fq",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""}",
+    "id": "cityAttractions_pyxssbwnq9fq",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "cityAttractions_pyxssbwnq9fq",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"city":"San Francisco"}",
+    "toolCallId": "cityAttractions_pyxssbwnq9fq",
+    "toolName": "cityAttractions",
     "type": "tool-call",
   },
   {
     "finishReason": {
-      "raw": "COMPLETE",
-      "unified": "stop",
+      "raw": "TOOL_CALL",
+      "unified": "tool-calls",
     },
     "type": "finish",
     "usage": {
       "inputTokens": {
         "cacheRead": undefined,
         "cacheWrite": undefined,
-        "noCache": 893,
-        "total": 893,
+        "noCache": 1549,
+        "total": 1549,
       },
       "outputTokens": {
         "reasoning": undefined,
-        "text": 62,
-        "total": 62,
+        "text": 95,
+        "total": 95,
       },
       "raw": {
-        "input_tokens": 893,
-        "output_tokens": 62,
+        "input_tokens": 1549,
+        "output_tokens": 95,
       },
     },
   },

--- a/packages/cohere/src/__snapshots__/cohere-embedding-model.test.ts.snap
+++ b/packages/cohere/src/__snapshots__/cohere-embedding-model.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`doEmbed > should expose the raw response 1`] = `
+exports[`doEmbed > should expose the raw response 2`] = `
 {
   "body": {
     "embeddings": {

--- a/packages/cohere/src/__snapshots__/cohere-embedding-model.test.ts.snap
+++ b/packages/cohere/src/__snapshots__/cohere-embedding-model.test.ts.snap
@@ -6,34 +6,38 @@ exports[`doEmbed > should expose the raw response 1`] = `
     "embeddings": {
       "float": [
         [
-          0.1,
-          0.2,
-          0.3,
-          0.4,
-          0.5,
+          0.03302002,
+          0.020904541,
+          -0.019744873,
+          -0.0625,
+          0.04437256,
         ],
         [
-          0.6,
-          0.7,
-          0.8,
-          0.9,
-          1,
+          -0.04660034,
+          0.00037765503,
+          -0.061157227,
+          -0.08239746,
+          -0.010360718,
         ],
       ],
     },
-    "id": "test-id",
+    "id": "f5aa3e7b-f011-4c5c-a825-f94669f760e5",
     "meta": {
+      "api_version": {
+        "version": "2",
+      },
       "billed_units": {
-        "input_tokens": 8,
+        "input_tokens": 10,
       },
     },
+    "response_type": "embeddings_by_type",
     "texts": [
       "sunny day at the beach",
       "rainy day in the city",
     ],
   },
   "headers": {
-    "content-length": "185",
+    "content-length": "363",
     "content-type": "application/json",
     "test-header": "test-value",
   },

--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -42,14 +42,14 @@ function prepareChunksFixtureResponse(
   filename: string,
   headers?: Record<string, string>,
 ) {
-  const raw = fs.readFileSync(
-    `src/__fixtures__/${filename}.chunks.txt`,
-    'utf8',
-  );
-  const chunks = raw
-    .split('\n\n')
-    .filter(chunk => chunk.trim() !== '')
-    .map(chunk => `${chunk}\n\n`);
+  const chunks = fs
+    .readFileSync(`src/__fixtures__/${filename}.chunks.txt`, 'utf8')
+    .split('\n')
+    .filter(line => line.trim() !== '')
+    .map(line => {
+      const parsed = JSON.parse(line);
+      return `event: ${parsed.type}\ndata: ${line}\n\n`;
+    });
 
   server.urls['https://api.cohere.com/v2/chat'].response = {
     type: 'stream-chunks',
@@ -574,7 +574,7 @@ describe('doGenerate', () => {
       });
 
       expect(response?.headers).toStrictEqual({
-        'content-length': '329',
+        'content-length': '304',
         'content-type': 'application/json',
         'test-header': 'test-value',
       });
@@ -672,7 +672,9 @@ describe('doStream', () => {
           chunk.type === 'tool-call' ? chunk.toolCallId : chunk.id,
         );
 
-      expect(new Set(toolCallIds)).toStrictEqual(new Set(['test-id-1']));
+      expect(new Set(toolCallIds)).toStrictEqual(
+        new Set(['weather_e8p4pn45zt0t', 'cityAttractions_pyxssbwnq9fq']),
+      );
     });
   });
 

--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -412,13 +412,21 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'command-r-plus',
-        messages: [
-          { role: 'system', content: 'you are a friendly bot!' },
-          { role: 'user', content: 'Hello' },
-        ],
-      });
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "you are a friendly bot!",
+              "role": "system",
+            },
+            {
+              "content": "Hello",
+              "role": "user",
+            },
+          ],
+          "model": "command-r-plus",
+        }
+      `);
     });
 
     it('should pass tools', async () => {
@@ -442,34 +450,43 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'command-r-plus',
-        messages: [
-          {
-            role: 'system',
-            content: 'you are a friendly bot!',
-          },
-          { role: 'user', content: 'Hello' },
-        ],
-        tool_choice: 'NONE',
-        tools: [
-          {
-            type: 'function',
-            function: {
-              name: 'test-tool',
-              parameters: {
-                type: 'object',
-                properties: {
-                  value: { type: 'string' },
-                },
-                required: ['value'],
-                additionalProperties: false,
-                $schema: 'http://json-schema.org/draft-07/schema#',
-              },
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "you are a friendly bot!",
+              "role": "system",
             },
-          },
-        ],
-      });
+            {
+              "content": "Hello",
+              "role": "user",
+            },
+          ],
+          "model": "command-r-plus",
+          "tool_choice": "NONE",
+          "tools": [
+            {
+              "function": {
+                "name": "test-tool",
+                "parameters": {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "additionalProperties": false,
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "value",
+                  ],
+                  "type": "object",
+                },
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
     });
 
     it('should pass headers', async () => {
@@ -487,12 +504,14 @@ describe('doGenerate', () => {
         },
       });
 
-      expect(server.calls[0].requestHeaders).toStrictEqual({
-        authorization: 'Bearer test-api-key',
-        'content-type': 'application/json',
-        'custom-provider-header': 'provider-header-value',
-        'custom-request-header': 'request-header-value',
-      });
+      expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+        {
+          "authorization": "Bearer test-api-key",
+          "content-type": "application/json",
+          "custom-provider-header": "provider-header-value",
+          "custom-request-header": "request-header-value",
+        }
+      `);
     });
 
     it('should pass response format', async () => {
@@ -510,23 +529,35 @@ describe('doGenerate', () => {
         },
       });
 
-      expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'command-r-plus',
-        messages: [
-          { role: 'system', content: 'you are a friendly bot!' },
-          { role: 'user', content: 'Hello' },
-        ],
-        response_format: {
-          type: 'json_object',
-          json_schema: {
-            type: 'object',
-            properties: {
-              text: { type: 'string' },
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "you are a friendly bot!",
+              "role": "system",
             },
-            required: ['text'],
+            {
+              "content": "Hello",
+              "role": "user",
+            },
+          ],
+          "model": "command-r-plus",
+          "response_format": {
+            "json_schema": {
+              "properties": {
+                "text": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "text",
+              ],
+              "type": "object",
+            },
+            "type": "json_object",
           },
-        },
-      });
+        }
+      `);
     });
 
     it('should send request body', async () => {
@@ -573,11 +604,13 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(response?.headers).toStrictEqual({
-        'content-length': '304',
-        'content-type': 'application/json',
-        'test-header': 'test-value',
-      });
+      expect(response?.headers).toMatchInlineSnapshot(`
+        {
+          "content-length": "304",
+          "content-type": "application/json",
+          "test-header": "test-value",
+        }
+      `);
     });
   });
 });
@@ -671,10 +704,6 @@ describe('doStream', () => {
         .map(chunk =>
           chunk.type === 'tool-call' ? chunk.toolCallId : chunk.id,
         );
-
-      expect(new Set(toolCallIds)).toStrictEqual(
-        new Set(['weather_e8p4pn45zt0t', 'cityAttractions_pyxssbwnq9fq']),
-      );
     });
   });
 
@@ -736,20 +765,22 @@ describe('doStream', () => {
         includeRawChunks: false,
       });
 
-      expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        stream: true,
-        model: 'command-r-plus',
-        messages: [
-          {
-            role: 'system',
-            content: 'you are a friendly bot!',
-          },
-          {
-            role: 'user',
-            content: 'Hello',
-          },
-        ],
-      });
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "you are a friendly bot!",
+              "role": "system",
+            },
+            {
+              "content": "Hello",
+              "role": "user",
+            },
+          ],
+          "model": "command-r-plus",
+          "stream": true,
+        }
+      `);
     });
 
     it('should pass headers', async () => {
@@ -768,12 +799,14 @@ describe('doStream', () => {
         includeRawChunks: false,
       });
 
-      expect(server.calls[0].requestHeaders).toStrictEqual({
-        authorization: 'Bearer test-api-key',
-        'content-type': 'application/json',
-        'custom-provider-header': 'provider-header-value',
-        'custom-request-header': 'request-header-value',
-      });
+      expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+        {
+          "authorization": "Bearer test-api-key",
+          "content-type": "application/json",
+          "custom-provider-header": "provider-header-value",
+          "custom-request-header": "request-header-value",
+        }
+      `);
     });
 
     it('should send request body', async () => {
@@ -823,12 +856,14 @@ describe('doStream', () => {
         includeRawChunks: false,
       });
 
-      expect(response?.headers).toStrictEqual({
-        'content-type': 'text/event-stream',
-        'cache-control': 'no-cache',
-        connection: 'keep-alive',
-        'test-header': 'test-value',
-      });
+      expect(response?.headers).toMatchInlineSnapshot(`
+        {
+          "cache-control": "no-cache",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream",
+          "test-header": "test-value",
+        }
+      `);
     });
   });
 });

--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -4,8 +4,9 @@ import {
   convertReadableStreamToArray,
   isNodeVersion,
 } from '@ai-sdk/provider-utils/test';
+import fs from 'node:fs';
 import { createCohere } from './cohere-provider';
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 
 const TEST_PROMPT: LanguageModelV3Prompt = [
   {
@@ -24,264 +25,68 @@ const server = createTestServer({
   'https://api.cohere.com/v2/chat': {},
 });
 
-describe('doGenerate', () => {
-  function prepareJsonResponse({
-    content = [],
-    tool_calls,
-    finish_reason = 'COMPLETE',
-    tokens = {
-      input_tokens: 4,
-      output_tokens: 30,
-    },
-    generation_id = 'dad0c7cd-7982-42a7-acfb-706ccf598291',
+function prepareJsonFixtureResponse(
+  filename: string,
+  headers?: Record<string, string>,
+) {
+  server.urls['https://api.cohere.com/v2/chat'].response = {
+    type: 'json-value',
     headers,
-  }: {
-    content?: Array<
-      { type: 'text'; text: string } | { type: 'thinking'; thinking: string }
-    >;
-    tool_calls?: any;
-    finish_reason?: string;
-    tokens?: {
-      input_tokens: number;
-      output_tokens: number;
-    };
-    generation_id?: string;
-    headers?: Record<string, string>;
-  } = {}) {
-    server.urls['https://api.cohere.com/v2/chat'].response = {
-      type: 'json-value',
-      headers,
-      body: {
-        response_id: '0cf61ae0-1f60-4c18-9802-be7be809e712',
-        generation_id,
-        message: {
-          role: 'assistant',
-          content,
-          ...(tool_calls ? { tool_calls } : {}),
-        },
-        finish_reason,
-        usage: {
-          billed_units: { input_tokens: 9, output_tokens: 415 },
-          tokens,
-        },
-      },
-    };
-  }
+    body: JSON.parse(
+      fs.readFileSync(`src/__fixtures__/${filename}.json`, 'utf8'),
+    ),
+  };
+}
 
-  it('should extract text response', async () => {
-    prepareJsonResponse({ content: [{ type: 'text', text: 'Hello, World!' }] });
+function prepareChunksFixtureResponse(
+  filename: string,
+  headers?: Record<string, string>,
+) {
+  const raw = fs.readFileSync(
+    `src/__fixtures__/${filename}.chunks.txt`,
+    'utf8',
+  );
+  const chunks = raw
+    .split('\n\n')
+    .filter(chunk => chunk.trim() !== '')
+    .map(chunk => `${chunk}\n\n`);
 
-    const { content } = await model.doGenerate({
-      prompt: TEST_PROMPT,
+  server.urls['https://api.cohere.com/v2/chat'].response = {
+    type: 'stream-chunks',
+    headers,
+    chunks,
+  };
+}
+
+describe('doGenerate', () => {
+  describe('text', () => {
+    beforeEach(() => {
+      prepareJsonFixtureResponse('cohere-text');
     });
 
-    expect(content).toMatchInlineSnapshot(`
-      [
-        {
-          "text": "Hello, World!",
-          "type": "text",
-        },
-      ]
-    `);
-  });
+    it('should extract text response', async () => {
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
 
-  it('should extract tool calls', async () => {
-    prepareJsonResponse({
-      content: [{ type: 'text', text: 'Hello, World!' }],
-      tool_calls: [
-        {
-          id: 'test-id-1',
-          type: 'function',
-          function: {
-            name: 'test-tool',
-            arguments: '{"value":"example value"}',
-          },
-        },
-      ],
-    });
-
-    const { content, finishReason } = await model.doGenerate({
-      tools: [
-        {
-          type: 'function',
-          name: 'test-tool',
-          inputSchema: {
-            type: 'object',
-            properties: { value: { type: 'string' } },
-            required: ['value'],
-            additionalProperties: false,
-            $schema: 'http://json-schema.org/draft-07/schema#',
-          },
-        },
-      ],
-      prompt: TEST_PROMPT,
-    });
-
-    expect(content).toMatchInlineSnapshot(`
-      [
-        {
-          "text": "Hello, World!",
-          "type": "text",
-        },
-        {
-          "input": "{"value":"example value"}",
-          "toolCallId": "test-id-1",
-          "toolName": "test-tool",
-          "type": "tool-call",
-        },
-      ]
-    `);
-    expect(finishReason).toMatchInlineSnapshot(`
-      {
-        "raw": "COMPLETE",
-        "unified": "stop",
-      }
-    `);
-  });
-
-  it('should extract usage', async () => {
-    prepareJsonResponse({
-      tokens: { input_tokens: 20, output_tokens: 5 },
-    });
-
-    const { usage } = await model.doGenerate({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(usage).toMatchInlineSnapshot(`
-      {
-        "inputTokens": {
-          "cacheRead": undefined,
-          "cacheWrite": undefined,
-          "noCache": 20,
-          "total": 20,
-        },
-        "outputTokens": {
-          "reasoning": undefined,
-          "text": 5,
-          "total": 5,
-        },
-        "raw": {
-          "input_tokens": 20,
-          "output_tokens": 5,
-        },
-      }
-    `);
-  });
-
-  it('should send additional response information', async () => {
-    prepareJsonResponse({
-      content: [{ type: 'text', text: '' }],
-      generation_id: 'test-id',
-    });
-
-    const { response } = await model.doGenerate({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(response).toMatchInlineSnapshot(`
-      {
-        "body": {
-          "finish_reason": "COMPLETE",
-          "generation_id": "test-id",
-          "message": {
-            "content": [
-              {
-                "text": "",
-                "type": "text",
-              },
-            ],
-            "role": "assistant",
-          },
-          "response_id": "0cf61ae0-1f60-4c18-9802-be7be809e712",
-          "usage": {
-            "billed_units": {
-              "input_tokens": 9,
-              "output_tokens": 415,
-            },
-            "tokens": {
-              "input_tokens": 4,
-              "output_tokens": 30,
-            },
-          },
-        },
-        "headers": {
-          "content-length": "287",
-          "content-type": "application/json",
-        },
-        "id": "test-id",
-      }
-    `);
-  });
-
-  it('should extract finish reason', async () => {
-    prepareJsonResponse({
-      finish_reason: 'MAX_TOKENS',
-    });
-
-    const { finishReason } = await model.doGenerate({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(finishReason).toMatchInlineSnapshot(`
-      {
-        "raw": "MAX_TOKENS",
-        "unified": "length",
-      }
-    `);
-  });
-
-  it('should expose the raw response headers', async () => {
-    prepareJsonResponse({
-      content: [{ type: 'text', text: '' }],
-      headers: { 'test-header': 'test-value' },
-    });
-
-    const { response } = await model.doGenerate({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(response?.headers).toStrictEqual({
-      // default headers:
-      'content-length': '316',
-      'content-type': 'application/json',
-
-      // custom header
-      'test-header': 'test-value',
+      expect(result).toMatchSnapshot();
     });
   });
 
-  it('should pass model and messages', async () => {
-    prepareJsonResponse();
-
-    await model.doGenerate({
-      prompt: TEST_PROMPT,
+  describe('tool call', () => {
+    beforeEach(() => {
+      prepareJsonFixtureResponse('cohere-tool-call');
     });
 
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'command-r-plus',
-      messages: [
-        { role: 'system', content: 'you are a friendly bot!' },
-        { role: 'user', content: 'Hello' },
-      ],
-    });
-  });
-
-  describe('should pass tools', async () => {
-    it('should support "none" tool choice', async () => {
-      prepareJsonResponse();
-
-      await model.doGenerate({
-        toolChoice: { type: 'none' },
+    it('should extract tool calls', async () => {
+      const result = await model.doGenerate({
         tools: [
           {
             type: 'function',
             name: 'test-tool',
             inputSchema: {
               type: 'object',
-              properties: {
-                value: { type: 'string' },
-              },
+              properties: { value: { type: 'string' } },
               required: ['value'],
               additionalProperties: false,
               $schema: 'http://json-schema.org/draft-07/schema#',
@@ -291,190 +96,90 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'command-r-plus',
-        messages: [
-          {
-            role: 'system',
-            content: 'you are a friendly bot!',
-          },
-          { role: 'user', content: 'Hello' },
-        ],
-        tool_choice: 'NONE',
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe('null tool call arguments', () => {
+    beforeEach(() => {
+      prepareJsonFixtureResponse('cohere-null-args');
+    });
+
+    it('should handle string "null" tool call arguments', async () => {
+      const { content } = await model.doGenerate({
         tools: [
           {
             type: 'function',
-            function: {
-              name: 'test-tool',
-              parameters: {
-                type: 'object',
-                properties: {
-                  value: { type: 'string' },
-                },
-                required: ['value'],
-                additionalProperties: false,
-                $schema: 'http://json-schema.org/draft-07/schema#',
-              },
+            name: 'currentTime',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+              required: [],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
             },
           },
         ],
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'What is the current time?' }],
+          },
+        ],
       });
+
+      expect(content).toMatchSnapshot();
     });
   });
 
-  it('should pass headers', async () => {
-    prepareJsonResponse();
-
-    const provider = createCohere({
-      apiKey: 'test-api-key',
-      headers: {
-        'Custom-Provider-Header': 'provider-header-value',
-      },
+  describe('reasoning', () => {
+    beforeEach(() => {
+      prepareJsonFixtureResponse('cohere-reasoning');
     });
 
-    await provider('command-r-plus').doGenerate({
-      prompt: TEST_PROMPT,
-      headers: {
-        'Custom-Request-Header': 'request-header-value',
-      },
+    it('should extract reasoning from response', async () => {
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result).toMatchSnapshot();
     });
-
-    expect(server.calls[0].requestHeaders).toStrictEqual({
-      authorization: 'Bearer test-api-key',
-      'content-type': 'application/json',
-      'custom-provider-header': 'provider-header-value',
-      'custom-request-header': 'request-header-value',
-    });
-  });
-
-  it('should pass response format', async () => {
-    prepareJsonResponse();
-
-    await model.doGenerate({
-      prompt: TEST_PROMPT,
-      responseFormat: {
-        type: 'json',
-        schema: {
-          type: 'object',
-          properties: {
-            text: { type: 'string' },
-          },
-          required: ['text'],
-        },
-      },
-    });
-
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'command-r-plus',
-      messages: [
-        { role: 'system', content: 'you are a friendly bot!' },
-        { role: 'user', content: 'Hello' },
-      ],
-      response_format: {
-        type: 'json_object',
-        json_schema: {
-          type: 'object',
-          properties: {
-            text: { type: 'string' },
-          },
-          required: ['text'],
-        },
-      },
-    });
-  });
-
-  it('should send request body', async () => {
-    prepareJsonResponse({ content: [{ type: 'text', text: '' }] });
-
-    const { request } = await model.doGenerate({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(request).toMatchInlineSnapshot(`
-      {
-        "body": {
-          "frequency_penalty": undefined,
-          "k": undefined,
-          "max_tokens": undefined,
-          "messages": [
-            {
-              "content": "you are a friendly bot!",
-              "role": "system",
-            },
-            {
-              "content": "Hello",
-              "role": "user",
-            },
-          ],
-          "model": "command-r-plus",
-          "p": undefined,
-          "presence_penalty": undefined,
-          "response_format": undefined,
-          "seed": undefined,
-          "stop_sequences": undefined,
-          "temperature": undefined,
-          "tool_choice": undefined,
-          "tools": undefined,
-        },
-      }
-    `);
-  });
-
-  it('should handle string "null" tool call arguments', async () => {
-    prepareJsonResponse({
-      content: [],
-      tool_calls: [
-        {
-          id: 'test-id-1',
-          type: 'function',
-          function: {
-            name: 'currentTime',
-            arguments: 'null',
-          },
-        },
-      ],
-    });
-
-    const { content } = await model.doGenerate({
-      tools: [
-        {
-          type: 'function',
-          name: 'currentTime',
-          inputSchema: {
-            type: 'object',
-            properties: {},
-            required: [],
-            additionalProperties: false,
-            $schema: 'http://json-schema.org/draft-07/schema#',
-          },
-        },
-      ],
-      prompt: [
-        {
-          role: 'user',
-          content: [{ type: 'text', text: 'What is the current time?' }],
-        },
-      ],
-    });
-
-    expect(content).toMatchInlineSnapshot(`
-      [
-        {
-          "input": "{}",
-          "toolCallId": "test-id-1",
-          "toolName": "currentTime",
-          "type": "tool-call",
-        },
-      ]
-    `);
   });
 
   describe('citations', () => {
-    it('should extract text documents and send to API', async () => {
-      prepareJsonResponse({
-        content: [{ type: 'text', text: 'Hello, World!' }],
+    beforeEach(() => {
+      prepareJsonFixtureResponse('cohere-citations');
+    });
+
+    it('should extract citations from response', async () => {
+      const mockGenerateId = vi.fn().mockReturnValue('test-citation-id');
+      const testProvider = createCohere({
+        apiKey: 'test-api-key',
+        generateId: mockGenerateId,
+      });
+      const testModel = testProvider('command-r-plus');
+
+      const result = await testModel.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'What are AI benefits?' },
+              {
+                type: 'file',
+                data: 'AI provides automation and efficiency.',
+                mediaType: 'text/plain',
+                filename: 'ai-benefits.txt',
+              },
+            ],
+          },
+        ],
       });
 
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should extract text documents and send to API', async () => {
       await model.doGenerate({
         prompt: [
           {
@@ -514,10 +219,6 @@ describe('doGenerate', () => {
     });
 
     it('should extract multiple text documents', async () => {
-      prepareJsonResponse({
-        content: [{ type: 'text', text: 'Hello, World!' }],
-      });
-
       await model.doGenerate({
         prompt: [
           {
@@ -569,10 +270,6 @@ describe('doGenerate', () => {
     });
 
     it('should support JSON files', async () => {
-      prepareJsonResponse({
-        content: [{ type: 'text', text: 'Hello, World!' }],
-      });
-
       await model.doGenerate({
         prompt: [
           {
@@ -612,10 +309,6 @@ describe('doGenerate', () => {
     });
 
     it('should throw error for unsupported file types', async () => {
-      prepareJsonResponse({
-        content: [{ type: 'text', text: 'Hello, World!' }],
-      });
-
       await expect(
         model.doGenerate({
           prompt: [
@@ -639,10 +332,6 @@ describe('doGenerate', () => {
     });
 
     it('should successfully process supported text media types', async () => {
-      prepareJsonResponse({
-        content: [{ type: 'text', text: 'Hello, World!' }],
-      });
-
       await model.doGenerate({
         prompt: [
           {
@@ -684,113 +373,7 @@ describe('doGenerate', () => {
       });
     });
 
-    it('should extract citations from response', async () => {
-      const mockGenerateId = vi.fn().mockReturnValue('test-citation-id');
-      const testProvider = createCohere({
-        apiKey: 'test-api-key',
-        generateId: mockGenerateId,
-      });
-      const testModel = testProvider('command-r-plus');
-
-      server.urls['https://api.cohere.com/v2/chat'].response = {
-        type: 'json-value',
-        body: {
-          response_id: '0cf61ae0-1f60-4c18-9802-be7be809e712',
-          generation_id: 'dad0c7cd-7982-42a7-acfb-706ccf598291',
-          message: {
-            role: 'assistant',
-            content: [
-              {
-                type: 'text',
-                text: 'AI has many benefits including automation.',
-              },
-            ],
-            citations: [
-              {
-                start: 31,
-                end: 41,
-                text: 'automation',
-                type: 'TEXT_CONTENT',
-                sources: [
-                  {
-                    type: 'document',
-                    id: 'doc:0',
-                    document: {
-                      id: 'doc:0',
-                      text: 'AI provides automation and efficiency.',
-                      title: 'ai-benefits.txt',
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-          finish_reason: 'COMPLETE',
-          usage: {
-            billed_units: { input_tokens: 9, output_tokens: 415 },
-            tokens: { input_tokens: 4, output_tokens: 30 },
-          },
-        },
-      };
-
-      const { content } = await testModel.doGenerate({
-        prompt: [
-          {
-            role: 'user',
-            content: [
-              { type: 'text', text: 'What are AI benefits?' },
-              {
-                type: 'file',
-                data: 'AI provides automation and efficiency.',
-                mediaType: 'text/plain',
-                filename: 'ai-benefits.txt',
-              },
-            ],
-          },
-        ],
-      });
-
-      expect(content).toMatchInlineSnapshot(`
-        [
-          {
-            "text": "AI has many benefits including automation.",
-            "type": "text",
-          },
-          {
-            "id": "test-citation-id",
-            "mediaType": "text/plain",
-            "providerMetadata": {
-              "cohere": {
-                "citationType": "TEXT_CONTENT",
-                "end": 41,
-                "sources": [
-                  {
-                    "document": {
-                      "id": "doc:0",
-                      "text": "AI provides automation and efficiency.",
-                      "title": "ai-benefits.txt",
-                    },
-                    "id": "doc:0",
-                    "type": "document",
-                  },
-                ],
-                "start": 31,
-                "text": "automation",
-              },
-            },
-            "sourceType": "document",
-            "title": "ai-benefits.txt",
-            "type": "source",
-          },
-        ]
-      `);
-    });
-
     it('should not include documents parameter when no files present', async () => {
-      prepareJsonResponse({
-        content: [{ type: 'text', text: 'Hello, World!' }],
-      });
-
       await model.doGenerate({
         prompt: TEST_PROMPT,
       });
@@ -800,792 +383,431 @@ describe('doGenerate', () => {
     });
   });
 
-  it('should extract reasoning from response', async () => {
-    prepareJsonResponse({
-      content: [
-        { type: 'text', text: '42' },
-        { type: 'thinking', thinking: 'So I was thinking ...' },
-      ],
+  describe('request', () => {
+    beforeEach(() => {
+      prepareJsonFixtureResponse('cohere-text');
     });
 
-    const { content } = await model.doGenerate({
-      prompt: TEST_PROMPT,
+    it('should pass model and messages', async () => {
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'command-r-plus',
+        messages: [
+          { role: 'system', content: 'you are a friendly bot!' },
+          { role: 'user', content: 'Hello' },
+        ],
+      });
     });
 
-    expect(content).toMatchInlineSnapshot(`
-      [
-        {
-          "text": "42",
-          "type": "text",
+    it('should pass tools', async () => {
+      await model.doGenerate({
+        toolChoice: { type: 'none' },
+        tools: [
+          {
+            type: 'function',
+            name: 'test-tool',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                value: { type: 'string' },
+              },
+              required: ['value'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'command-r-plus',
+        messages: [
+          {
+            role: 'system',
+            content: 'you are a friendly bot!',
+          },
+          { role: 'user', content: 'Hello' },
+        ],
+        tool_choice: 'NONE',
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'test-tool',
+              parameters: {
+                type: 'object',
+                properties: {
+                  value: { type: 'string' },
+                },
+                required: ['value'],
+                additionalProperties: false,
+                $schema: 'http://json-schema.org/draft-07/schema#',
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it('should pass headers', async () => {
+      const provider = createCohere({
+        apiKey: 'test-api-key',
+        headers: {
+          'Custom-Provider-Header': 'provider-header-value',
         },
-        {
-          "text": "So I was thinking ...",
-          "type": "reasoning",
+      });
+
+      await provider('command-r-plus').doGenerate({
+        prompt: TEST_PROMPT,
+        headers: {
+          'Custom-Request-Header': 'request-header-value',
         },
-      ]
-    `);
+      });
+
+      expect(server.calls[0].requestHeaders).toStrictEqual({
+        authorization: 'Bearer test-api-key',
+        'content-type': 'application/json',
+        'custom-provider-header': 'provider-header-value',
+        'custom-request-header': 'request-header-value',
+      });
+    });
+
+    it('should pass response format', async () => {
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              text: { type: 'string' },
+            },
+            required: ['text'],
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'command-r-plus',
+        messages: [
+          { role: 'system', content: 'you are a friendly bot!' },
+          { role: 'user', content: 'Hello' },
+        ],
+        response_format: {
+          type: 'json_object',
+          json_schema: {
+            type: 'object',
+            properties: {
+              text: { type: 'string' },
+            },
+            required: ['text'],
+          },
+        },
+      });
+    });
+
+    it('should send request body', async () => {
+      const { request } = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(request).toMatchInlineSnapshot(`
+        {
+          "body": {
+            "frequency_penalty": undefined,
+            "k": undefined,
+            "max_tokens": undefined,
+            "messages": [
+              {
+                "content": "you are a friendly bot!",
+                "role": "system",
+              },
+              {
+                "content": "Hello",
+                "role": "user",
+              },
+            ],
+            "model": "command-r-plus",
+            "p": undefined,
+            "presence_penalty": undefined,
+            "response_format": undefined,
+            "seed": undefined,
+            "stop_sequences": undefined,
+            "temperature": undefined,
+            "tool_choice": undefined,
+            "tools": undefined,
+          },
+        }
+      `);
+    });
+
+    it('should expose the raw response headers', async () => {
+      prepareJsonFixtureResponse('cohere-text', {
+        'test-header': 'test-value',
+      });
+
+      const { response } = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(response?.headers).toStrictEqual({
+        'content-length': '329',
+        'content-type': 'application/json',
+        'test-header': 'test-value',
+      });
+    });
   });
 });
 
 describe('doStream', () => {
-  function prepareStreamResponse({
-    content = [],
-    usage = {
-      input_tokens: 17,
-      output_tokens: 244,
-    },
-    finish_reason = 'COMPLETE',
-    headers,
-  }: {
-    content?: Array<
-      | { type: 'text'; deltas: string[] }
-      | { type: 'thinking'; deltas: string[] }
-    >;
-    usage?: {
-      input_tokens: number;
-      output_tokens: number;
-    };
-    finish_reason?: string;
-    headers?: Record<string, string>;
-  } = {}) {
-    const allEvents: string[] = [];
-
-    content.forEach(contentItem => {
-      if (contentItem.type === 'thinking') {
-        allEvents.push(
-          `event: content-start\ndata: {"type":"content-start","index":0,"delta":{"message":{"content":{"type":"thinking","thinking":""}}}}\n\n`,
-          ...contentItem.deltas.map(
-            text =>
-              `event: content-delta\ndata: {"type":"content-delta","index":0,"delta":{"message":{"content":{"thinking":"${text}"}}}}\n\n`,
-          ),
-          `event: content-end\ndata: {"type":"content-end","index":0}\n\n`,
-        );
-      } else if (contentItem.type === 'text') {
-        allEvents.push(
-          `event: content-start\ndata: {"type":"content-start","index":0,"delta":{"message":{"content":{"type":"text","text":""}}}}\n\n`,
-          ...contentItem.deltas.map(
-            text =>
-              `event: content-delta\ndata: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"${text}"}}}}\n\n`,
-          ),
-          `event: content-end\ndata: {"type":"content-end","index":0}\n\n`,
-        );
-      }
+  describe('text', () => {
+    beforeEach(() => {
+      prepareChunksFixtureResponse('cohere-text');
     });
 
-    server.urls['https://api.cohere.com/v2/chat'].response = {
-      type: 'stream-chunks',
-      headers,
-      chunks: [
-        `event: message-start\ndata: {"type":"message-start","id":"586ac33f-9c64-452c-8f8d-e5890e73b6fb","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}\n\n`,
-        ...allEvents,
-        `event: message-end\ndata: {"type":"message-end","delta":` +
-          `{"finish_reason":"${finish_reason}",` +
-          `"usage":{"tokens":{"input_tokens":${usage.input_tokens},"output_tokens":${usage.output_tokens}}}}}\n\n`,
-        `data: [DONE]\n\n`,
-      ],
-    };
-  }
-
-  it('should stream text deltas', async () => {
-    prepareStreamResponse({
-      content: [{ type: 'text', deltas: ['Hello', ', ', 'World!'] }],
-      finish_reason: 'COMPLETE',
-      usage: {
-        input_tokens: 34,
-        output_tokens: 12,
-      },
-    });
-
-    const { stream } = await model.doStream({
-      prompt: TEST_PROMPT,
-      includeRawChunks: false,
-    });
-
-    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
-      [
-        {
-          "type": "stream-start",
-          "warnings": [],
-        },
-        {
-          "id": "586ac33f-9c64-452c-8f8d-e5890e73b6fb",
-          "type": "response-metadata",
-        },
-        {
-          "id": "0",
-          "type": "text-start",
-        },
-        {
-          "delta": "Hello",
-          "id": "0",
-          "type": "text-delta",
-        },
-        {
-          "delta": ", ",
-          "id": "0",
-          "type": "text-delta",
-        },
-        {
-          "delta": "World!",
-          "id": "0",
-          "type": "text-delta",
-        },
-        {
-          "id": "0",
-          "type": "text-end",
-        },
-        {
-          "finishReason": {
-            "raw": "COMPLETE",
-            "unified": "stop",
-          },
-          "type": "finish",
-          "usage": {
-            "inputTokens": {
-              "cacheRead": undefined,
-              "cacheWrite": undefined,
-              "noCache": 34,
-              "total": 34,
-            },
-            "outputTokens": {
-              "reasoning": undefined,
-              "text": 12,
-              "total": 12,
-            },
-            "raw": {
-              "input_tokens": 34,
-              "output_tokens": 12,
-            },
-          },
-        },
-      ]
-    `);
-  });
-
-  it('should stream reasoning deltas', async () => {
-    prepareStreamResponse({
-      content: [
-        { type: 'thinking', deltas: ['So', 'I ', 'was ', 'thinking ', '...'] },
-        { type: 'text', deltas: ['Hello', ', ', 'World!'] },
-      ],
-      finish_reason: 'COMPLETE',
-      usage: {
-        input_tokens: 34,
-        output_tokens: 12,
-      },
-    });
-
-    const { stream } = await model.doStream({
-      prompt: TEST_PROMPT,
-      includeRawChunks: false,
-    });
-
-    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
-      [
-        {
-          "type": "stream-start",
-          "warnings": [],
-        },
-        {
-          "id": "586ac33f-9c64-452c-8f8d-e5890e73b6fb",
-          "type": "response-metadata",
-        },
-        {
-          "id": "0",
-          "type": "reasoning-start",
-        },
-        {
-          "delta": "So",
-          "id": "0",
-          "type": "reasoning-delta",
-        },
-        {
-          "delta": "I ",
-          "id": "0",
-          "type": "reasoning-delta",
-        },
-        {
-          "delta": "was ",
-          "id": "0",
-          "type": "reasoning-delta",
-        },
-        {
-          "delta": "thinking ",
-          "id": "0",
-          "type": "reasoning-delta",
-        },
-        {
-          "delta": "...",
-          "id": "0",
-          "type": "reasoning-delta",
-        },
-        {
-          "id": "0",
-          "type": "reasoning-end",
-        },
-        {
-          "id": "0",
-          "type": "text-start",
-        },
-        {
-          "delta": "Hello",
-          "id": "0",
-          "type": "text-delta",
-        },
-        {
-          "delta": ", ",
-          "id": "0",
-          "type": "text-delta",
-        },
-        {
-          "delta": "World!",
-          "id": "0",
-          "type": "text-delta",
-        },
-        {
-          "id": "0",
-          "type": "text-end",
-        },
-        {
-          "finishReason": {
-            "raw": "COMPLETE",
-            "unified": "stop",
-          },
-          "type": "finish",
-          "usage": {
-            "inputTokens": {
-              "cacheRead": undefined,
-              "cacheWrite": undefined,
-              "noCache": 34,
-              "total": 34,
-            },
-            "outputTokens": {
-              "reasoning": undefined,
-              "text": 12,
-              "total": 12,
-            },
-            "raw": {
-              "input_tokens": 34,
-              "output_tokens": 12,
-            },
-          },
-        },
-      ]
-    `);
-  });
-
-  it('should stream tool deltas', async () => {
-    server.urls['https://api.cohere.com/v2/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        `event: message-start\ndata: {"type":"message-start","id":"29f14a5a-11de-4cae-9800-25e4747408ea","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}\n\n`,
-        `event: tool-call-start\ndata: {"type":"tool-call-start","delta":{"message":{"tool_calls":{"id":"test-id-1","type":"function","function":{"name":"test-tool","arguments":""}}}}}\n\n`,
-        `event: tool-call-delta\ndata: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"{\\n    \\""}}}}}\n\n`,
-        `event: tool-call-delta\ndata: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"ticker"}}}}}\n\n`,
-        `event: tool-call-delta\ndata: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"_"}}}}}\n\n`,
-        `event: tool-call-delta\ndata: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"symbol"}}}}}\n\n`,
-        `event: tool-call-delta\ndata: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"\\":"}}}}}\n\n`,
-        `event: tool-call-delta\ndata: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":" \\""}}}}}\n\n`,
-        `event: tool-call-delta\ndata: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"AAPL"}}}}}\n\n`,
-        `event: tool-call-delta\ndata: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"\\""}}}}}\n\n`,
-        `event: tool-call-delta\ndata: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"\\n"}}}}}\n\n`,
-        `event: tool-call-delta\ndata: {"type":"tool-call-delta","delta":{"message":{"tool_calls":{"function":{"arguments":"}"}}}}}\n\n`,
-        `event: tool-call-end\ndata: {"type":"tool-call-end"}\n\n`,
-        `event: message-end\ndata: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"tokens":{"input_tokens":893,"output_tokens":62}}}}\n\n`,
-        `data: [DONE]\n\n`,
-      ],
-    };
-
-    const { stream } = await model.doStream({
-      prompt: TEST_PROMPT,
-      tools: [
-        {
-          type: 'function',
-          name: 'test-tool',
-          inputSchema: {
-            type: 'object',
-            properties: { value: { type: 'string' } },
-            required: ['value'],
-            additionalProperties: false,
-            $schema: 'http://json-schema.org/draft-07/schema#',
-          },
-        },
-      ],
-      includeRawChunks: false,
-    });
-
-    const responseArray = await convertReadableStreamToArray(stream);
-
-    expect(responseArray).toMatchInlineSnapshot(`
-      [
-        {
-          "type": "stream-start",
-          "warnings": [],
-        },
-        {
-          "id": "29f14a5a-11de-4cae-9800-25e4747408ea",
-          "type": "response-metadata",
-        },
-        {
-          "id": "test-id-1",
-          "toolName": "test-tool",
-          "type": "tool-input-start",
-        },
-        {
-          "delta": "{
-          "",
-          "id": "test-id-1",
-          "type": "tool-input-delta",
-        },
-        {
-          "delta": "ticker",
-          "id": "test-id-1",
-          "type": "tool-input-delta",
-        },
-        {
-          "delta": "_",
-          "id": "test-id-1",
-          "type": "tool-input-delta",
-        },
-        {
-          "delta": "symbol",
-          "id": "test-id-1",
-          "type": "tool-input-delta",
-        },
-        {
-          "delta": "":",
-          "id": "test-id-1",
-          "type": "tool-input-delta",
-        },
-        {
-          "delta": " "",
-          "id": "test-id-1",
-          "type": "tool-input-delta",
-        },
-        {
-          "delta": "AAPL",
-          "id": "test-id-1",
-          "type": "tool-input-delta",
-        },
-        {
-          "delta": """,
-          "id": "test-id-1",
-          "type": "tool-input-delta",
-        },
-        {
-          "delta": "
-      ",
-          "id": "test-id-1",
-          "type": "tool-input-delta",
-        },
-        {
-          "delta": "}",
-          "id": "test-id-1",
-          "type": "tool-input-delta",
-        },
-        {
-          "id": "test-id-1",
-          "type": "tool-input-end",
-        },
-        {
-          "input": "{"ticker_symbol":"AAPL"}",
-          "toolCallId": "test-id-1",
-          "toolName": "test-tool",
-          "type": "tool-call",
-        },
-        {
-          "finishReason": {
-            "raw": "COMPLETE",
-            "unified": "stop",
-          },
-          "type": "finish",
-          "usage": {
-            "inputTokens": {
-              "cacheRead": undefined,
-              "cacheWrite": undefined,
-              "noCache": 893,
-              "total": 893,
-            },
-            "outputTokens": {
-              "reasoning": undefined,
-              "text": 62,
-              "total": 62,
-            },
-            "raw": {
-              "input_tokens": 893,
-              "output_tokens": 62,
-            },
-          },
-        },
-      ]
-    `);
-
-    // Check if the tool call ID is the same in the tool call delta and the tool call
-    const toolCallIds = responseArray
-      .filter(
-        chunk =>
-          chunk.type === 'tool-input-delta' || chunk.type === 'tool-call',
-      )
-      .map(chunk => (chunk.type === 'tool-call' ? chunk.toolCallId : chunk.id));
-
-    expect(new Set(toolCallIds)).toStrictEqual(new Set(['test-id-1']));
-  });
-
-  it.skipIf(isNodeVersion(20))(
-    'should handle unparsable stream parts',
-    async () => {
-      server.urls['https://api.cohere.com/v2/chat'].response = {
-        type: 'stream-chunks',
-        chunks: [`event: foo-message\ndata: {unparsable}\n\n`],
-      };
-
+    it('should stream text deltas', async () => {
       const { stream } = await model.doStream({
         prompt: TEST_PROMPT,
         includeRawChunks: false,
       });
 
-      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
-        [
+      expect(await convertReadableStreamToArray(stream)).toMatchSnapshot();
+    });
+
+    it('should include raw chunks when includeRawChunks is enabled', async () => {
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: true,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+
+      expect(chunks.filter(chunk => chunk.type === 'raw')).toMatchSnapshot();
+    });
+
+    it('should not include raw chunks when includeRawChunks is false', async () => {
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+
+      expect(chunks.filter(chunk => chunk.type === 'raw')).toHaveLength(0);
+    });
+  });
+
+  describe('reasoning', () => {
+    beforeEach(() => {
+      prepareChunksFixtureResponse('cohere-reasoning');
+    });
+
+    it('should stream reasoning deltas', async () => {
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toMatchSnapshot();
+    });
+  });
+
+  describe('tool call', () => {
+    beforeEach(() => {
+      prepareChunksFixtureResponse('cohere-tool-call');
+    });
+
+    it('should stream tool deltas', async () => {
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+        tools: [
           {
-            "type": "stream-start",
-            "warnings": [],
-          },
-          {
-            "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
-        Error message: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
-            "type": "error",
-          },
-          {
-            "finishReason": {
-              "raw": undefined,
-              "unified": "error",
+            type: 'function',
+            name: 'test-tool',
+            inputSchema: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
             },
-            "type": "finish",
-            "usage": {
-              "inputTokens": {
-                "cacheRead": undefined,
-                "cacheWrite": undefined,
-                "noCache": undefined,
-                "total": undefined,
-              },
-              "outputTokens": {
-                "reasoning": undefined,
-                "text": undefined,
-                "total": undefined,
-              },
-              "raw": undefined,
+          },
+        ],
+        includeRawChunks: false,
+      });
+
+      const responseArray = await convertReadableStreamToArray(stream);
+
+      expect(responseArray).toMatchSnapshot();
+
+      const toolCallIds = responseArray
+        .filter(
+          chunk =>
+            chunk.type === 'tool-input-delta' || chunk.type === 'tool-call',
+        )
+        .map(chunk =>
+          chunk.type === 'tool-call' ? chunk.toolCallId : chunk.id,
+        );
+
+      expect(new Set(toolCallIds)).toStrictEqual(new Set(['test-id-1']));
+    });
+  });
+
+  describe('empty tool call', () => {
+    beforeEach(() => {
+      prepareChunksFixtureResponse('cohere-empty-tool-call');
+    });
+
+    it('should handle empty tool call arguments', async () => {
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+        tools: [
+          {
+            type: 'function',
+            name: 'test-tool',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+              required: [],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
             },
           },
-        ]
+        ],
+        includeRawChunks: false,
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toMatchSnapshot();
+    });
+  });
+
+  describe('error handling', () => {
+    it.skipIf(isNodeVersion(20))(
+      'should handle unparsable stream parts',
+      async () => {
+        server.urls['https://api.cohere.com/v2/chat'].response = {
+          type: 'stream-chunks',
+          chunks: [`event: foo-message\ndata: {unparsable}\n\n`],
+        };
+
+        const { stream } = await model.doStream({
+          prompt: TEST_PROMPT,
+          includeRawChunks: false,
+        });
+
+        expect(await convertReadableStreamToArray(stream)).toMatchSnapshot();
+      },
+    );
+  });
+
+  describe('request', () => {
+    beforeEach(() => {
+      prepareChunksFixtureResponse('cohere-text');
+    });
+
+    it('should pass the messages and the model', async () => {
+      await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        stream: true,
+        model: 'command-r-plus',
+        messages: [
+          {
+            role: 'system',
+            content: 'you are a friendly bot!',
+          },
+          {
+            role: 'user',
+            content: 'Hello',
+          },
+        ],
+      });
+    });
+
+    it('should pass headers', async () => {
+      const provider = createCohere({
+        apiKey: 'test-api-key',
+        headers: {
+          'Custom-Provider-Header': 'provider-header-value',
+        },
+      });
+
+      await provider('command-r-plus').doStream({
+        prompt: TEST_PROMPT,
+        headers: {
+          'Custom-Request-Header': 'request-header-value',
+        },
+        includeRawChunks: false,
+      });
+
+      expect(server.calls[0].requestHeaders).toStrictEqual({
+        authorization: 'Bearer test-api-key',
+        'content-type': 'application/json',
+        'custom-provider-header': 'provider-header-value',
+        'custom-request-header': 'request-header-value',
+      });
+    });
+
+    it('should send request body', async () => {
+      const { request } = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      expect(request).toMatchInlineSnapshot(`
+        {
+          "body": {
+            "frequency_penalty": undefined,
+            "k": undefined,
+            "max_tokens": undefined,
+            "messages": [
+              {
+                "content": "you are a friendly bot!",
+                "role": "system",
+              },
+              {
+                "content": "Hello",
+                "role": "user",
+              },
+            ],
+            "model": "command-r-plus",
+            "p": undefined,
+            "presence_penalty": undefined,
+            "response_format": undefined,
+            "seed": undefined,
+            "stop_sequences": undefined,
+            "stream": true,
+            "temperature": undefined,
+            "tool_choice": undefined,
+            "tools": undefined,
+          },
+        }
       `);
-    },
-  );
-
-  it('should expose the raw response headers', async () => {
-    prepareStreamResponse({
-      content: [],
-      headers: { 'test-header': 'test-value' },
     });
 
-    const { response } = await model.doStream({
-      prompt: TEST_PROMPT,
-      includeRawChunks: false,
+    it('should expose the raw response headers', async () => {
+      prepareChunksFixtureResponse('cohere-text', {
+        'test-header': 'test-value',
+      });
+
+      const { response } = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      expect(response?.headers).toStrictEqual({
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+        'test-header': 'test-value',
+      });
     });
-
-    expect(response?.headers).toStrictEqual({
-      // default headers:
-      'content-type': 'text/event-stream',
-      'cache-control': 'no-cache',
-      connection: 'keep-alive',
-
-      // custom header
-      'test-header': 'test-value',
-    });
-  });
-
-  it('should pass the messages and the model', async () => {
-    prepareStreamResponse();
-
-    await model.doStream({
-      prompt: TEST_PROMPT,
-      includeRawChunks: false,
-    });
-
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      stream: true,
-      model: 'command-r-plus',
-      messages: [
-        {
-          role: 'system',
-          content: 'you are a friendly bot!',
-        },
-        {
-          role: 'user',
-          content: 'Hello',
-        },
-      ],
-    });
-  });
-
-  it('should pass headers', async () => {
-    prepareStreamResponse();
-
-    const provider = createCohere({
-      apiKey: 'test-api-key',
-      headers: {
-        'Custom-Provider-Header': 'provider-header-value',
-      },
-    });
-
-    await provider('command-r-plus').doStream({
-      prompt: TEST_PROMPT,
-      headers: {
-        'Custom-Request-Header': 'request-header-value',
-      },
-      includeRawChunks: false,
-    });
-
-    expect(server.calls[0].requestHeaders).toStrictEqual({
-      authorization: 'Bearer test-api-key',
-      'content-type': 'application/json',
-      'custom-provider-header': 'provider-header-value',
-      'custom-request-header': 'request-header-value',
-    });
-  });
-
-  it('should send request body', async () => {
-    prepareStreamResponse();
-
-    const { request } = await model.doStream({
-      prompt: TEST_PROMPT,
-      includeRawChunks: false,
-    });
-
-    expect(request).toMatchInlineSnapshot(`
-      {
-        "body": {
-          "frequency_penalty": undefined,
-          "k": undefined,
-          "max_tokens": undefined,
-          "messages": [
-            {
-              "content": "you are a friendly bot!",
-              "role": "system",
-            },
-            {
-              "content": "Hello",
-              "role": "user",
-            },
-          ],
-          "model": "command-r-plus",
-          "p": undefined,
-          "presence_penalty": undefined,
-          "response_format": undefined,
-          "seed": undefined,
-          "stop_sequences": undefined,
-          "stream": true,
-          "temperature": undefined,
-          "tool_choice": undefined,
-          "tools": undefined,
-        },
-      }
-    `);
-  });
-
-  it('should handle empty tool call arguments', async () => {
-    server.urls['https://api.cohere.com/v2/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        `event: message-start\ndata: {"type":"message-start","id":"test-id","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}\n\n`,
-        `event: tool-call-start\ndata: {"type":"tool-call-start","delta":{"message":{"tool_calls":{"id":"test-id-1","type":"function","function":{"name":"test-tool","arguments":""}}}}}\n\n`,
-        `event: tool-call-end\ndata: {"type":"tool-call-end"}\n\n`,
-        `event: message-end\ndata: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"tokens":{"input_tokens":10,"output_tokens":5}}}}\n\n`,
-        `data: [DONE]\n\n`,
-      ],
-    };
-
-    const { stream } = await model.doStream({
-      prompt: TEST_PROMPT,
-      tools: [
-        {
-          type: 'function',
-          name: 'test-tool',
-          inputSchema: {
-            type: 'object',
-            properties: {},
-            required: [],
-            additionalProperties: false,
-            $schema: 'http://json-schema.org/draft-07/schema#',
-          },
-        },
-      ],
-      includeRawChunks: false,
-    });
-
-    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
-      [
-        {
-          "type": "stream-start",
-          "warnings": [],
-        },
-        {
-          "id": "test-id",
-          "type": "response-metadata",
-        },
-        {
-          "id": "test-id-1",
-          "toolName": "test-tool",
-          "type": "tool-input-start",
-        },
-        {
-          "id": "test-id-1",
-          "type": "tool-input-end",
-        },
-        {
-          "input": "{}",
-          "toolCallId": "test-id-1",
-          "toolName": "test-tool",
-          "type": "tool-call",
-        },
-        {
-          "finishReason": {
-            "raw": "COMPLETE",
-            "unified": "stop",
-          },
-          "type": "finish",
-          "usage": {
-            "inputTokens": {
-              "cacheRead": undefined,
-              "cacheWrite": undefined,
-              "noCache": 10,
-              "total": 10,
-            },
-            "outputTokens": {
-              "reasoning": undefined,
-              "text": 5,
-              "total": 5,
-            },
-            "raw": {
-              "input_tokens": 10,
-              "output_tokens": 5,
-            },
-          },
-        },
-      ]
-    `);
-  });
-
-  it('should include raw chunks when includeRawChunks is enabled', async () => {
-    prepareStreamResponse({
-      content: [{ type: 'text', deltas: ['Hello', ' World!'] }],
-    });
-
-    const { stream } = await model.doStream({
-      prompt: TEST_PROMPT,
-      includeRawChunks: true,
-    });
-
-    const chunks = await convertReadableStreamToArray(stream);
-
-    expect(chunks.filter(chunk => chunk.type === 'raw')).toMatchInlineSnapshot(`
-      [
-        {
-          "rawValue": {
-            "delta": {
-              "message": {
-                "citations": [],
-                "content": [],
-                "role": "assistant",
-                "tool_calls": [],
-                "tool_plan": "",
-              },
-            },
-            "id": "586ac33f-9c64-452c-8f8d-e5890e73b6fb",
-            "type": "message-start",
-          },
-          "type": "raw",
-        },
-        {
-          "rawValue": {
-            "delta": {
-              "message": {
-                "content": {
-                  "text": "",
-                  "type": "text",
-                },
-              },
-            },
-            "index": 0,
-            "type": "content-start",
-          },
-          "type": "raw",
-        },
-        {
-          "rawValue": {
-            "delta": {
-              "message": {
-                "content": {
-                  "text": "Hello",
-                },
-              },
-            },
-            "index": 0,
-            "type": "content-delta",
-          },
-          "type": "raw",
-        },
-        {
-          "rawValue": {
-            "delta": {
-              "message": {
-                "content": {
-                  "text": " World!",
-                },
-              },
-            },
-            "index": 0,
-            "type": "content-delta",
-          },
-          "type": "raw",
-        },
-        {
-          "rawValue": {
-            "index": 0,
-            "type": "content-end",
-          },
-          "type": "raw",
-        },
-        {
-          "rawValue": {
-            "delta": {
-              "finish_reason": "COMPLETE",
-              "usage": {
-                "tokens": {
-                  "input_tokens": 17,
-                  "output_tokens": 244,
-                },
-              },
-            },
-            "type": "message-end",
-          },
-          "type": "raw",
-        },
-      ]
-    `);
-  });
-
-  it('should not include raw chunks when includeRawChunks is false', async () => {
-    prepareStreamResponse({
-      content: [{ type: 'text', deltas: ['Hello', ' World!'] }],
-    });
-
-    const { stream } = await model.doStream({
-      prompt: TEST_PROMPT,
-      includeRawChunks: false,
-    });
-
-    const chunks = await convertReadableStreamToArray(stream);
-
-    expect(chunks.filter(chunk => chunk.type === 'raw')).toHaveLength(0);
   });
 });

--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -73,6 +73,25 @@ describe('doGenerate', () => {
     });
   });
 
+  describe('max tokens', () => {
+    beforeEach(() => {
+      prepareJsonFixtureResponse('cohere-max-tokens');
+    });
+
+    it('should map MAX_TOKENS finish reason to length', async () => {
+      const { finishReason } = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(finishReason).toMatchInlineSnapshot(`
+        {
+          "raw": "MAX_TOKENS",
+          "unified": "length",
+        }
+      `);
+    });
+  });
+
   describe('tool call', () => {
     beforeEach(() => {
       prepareJsonFixtureResponse('cohere-tool-call');

--- a/packages/cohere/src/cohere-embedding-model.test.ts
+++ b/packages/cohere/src/cohere-embedding-model.test.ts
@@ -38,8 +38,8 @@ describe('doEmbed', () => {
     const { embeddings } = await model.doEmbed({ values: testValues });
 
     expect(embeddings).toStrictEqual([
-      [0.1, 0.2, 0.3, 0.4, 0.5],
-      [0.6, 0.7, 0.8, 0.9, 1.0],
+      [0.03302002, 0.020904541, -0.019744873, -0.0625, 0.04437256],
+      [-0.04660034, 0.00037765503, -0.061157227, -0.08239746, -0.010360718],
     ]);
   });
 
@@ -51,7 +51,7 @@ describe('doEmbed', () => {
     const { response } = await model.doEmbed({ values: testValues });
 
     expect(response?.headers).toStrictEqual({
-      'content-length': '185',
+      'content-length': '363',
       'content-type': 'application/json',
       'test-header': 'test-value',
     });
@@ -61,7 +61,7 @@ describe('doEmbed', () => {
   it('should extract usage', async () => {
     const { usage } = await model.doEmbed({ values: testValues });
 
-    expect(usage).toStrictEqual({ tokens: 8 });
+    expect(usage).toStrictEqual({ tokens: 10 });
   });
 
   it('should pass the model and the values', async () => {

--- a/packages/cohere/src/cohere-embedding-model.test.ts
+++ b/packages/cohere/src/cohere-embedding-model.test.ts
@@ -37,10 +37,24 @@ describe('doEmbed', () => {
   it('should extract embedding', async () => {
     const { embeddings } = await model.doEmbed({ values: testValues });
 
-    expect(embeddings).toStrictEqual([
-      [0.03302002, 0.020904541, -0.019744873, -0.0625, 0.04437256],
-      [-0.04660034, 0.00037765503, -0.061157227, -0.08239746, -0.010360718],
-    ]);
+    expect(embeddings).toMatchInlineSnapshot(`
+      [
+        [
+          0.03302002,
+          0.020904541,
+          -0.019744873,
+          -0.0625,
+          0.04437256,
+        ],
+        [
+          -0.04660034,
+          0.00037765503,
+          -0.061157227,
+          -0.08239746,
+          -0.010360718,
+        ],
+      ]
+    `);
   });
 
   it('should expose the raw response', async () => {
@@ -50,29 +64,42 @@ describe('doEmbed', () => {
 
     const { response } = await model.doEmbed({ values: testValues });
 
-    expect(response?.headers).toStrictEqual({
-      'content-length': '363',
-      'content-type': 'application/json',
-      'test-header': 'test-value',
-    });
+    expect(response?.headers).toMatchInlineSnapshot(`
+      {
+        "content-length": "363",
+        "content-type": "application/json",
+        "test-header": "test-value",
+      }
+    `);
     expect(response).toMatchSnapshot();
   });
 
   it('should extract usage', async () => {
     const { usage } = await model.doEmbed({ values: testValues });
 
-    expect(usage).toStrictEqual({ tokens: 10 });
+    expect(usage).toMatchInlineSnapshot(`
+      {
+        "tokens": 10,
+      }
+    `);
   });
 
   it('should pass the model and the values', async () => {
     await model.doEmbed({ values: testValues });
 
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'embed-english-v3.0',
-      embedding_types: ['float'],
-      texts: testValues,
-      input_type: 'search_query',
-    });
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "embedding_types": [
+          "float",
+        ],
+        "input_type": "search_query",
+        "model": "embed-english-v3.0",
+        "texts": [
+          "sunny day at the beach",
+          "rainy day in the city",
+        ],
+      }
+    `);
   });
 
   it('should pass the input_type setting', async () => {
@@ -85,12 +112,19 @@ describe('doEmbed', () => {
       },
     });
 
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'embed-english-v3.0',
-      embedding_types: ['float'],
-      texts: testValues,
-      input_type: 'search_document',
-    });
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "embedding_types": [
+          "float",
+        ],
+        "input_type": "search_document",
+        "model": "embed-english-v3.0",
+        "texts": [
+          "sunny day at the beach",
+          "rainy day in the city",
+        ],
+      }
+    `);
   });
 
   it('should pass the output_dimension setting', async () => {
@@ -103,13 +137,20 @@ describe('doEmbed', () => {
       },
     });
 
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'embed-v4.0',
-      embedding_types: ['float'],
-      texts: testValues,
-      input_type: 'search_query',
-      output_dimension: 256,
-    });
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "embedding_types": [
+          "float",
+        ],
+        "input_type": "search_query",
+        "model": "embed-v4.0",
+        "output_dimension": 256,
+        "texts": [
+          "sunny day at the beach",
+          "rainy day in the city",
+        ],
+      }
+    `);
   });
 
   it('should pass headers', async () => {
@@ -129,12 +170,14 @@ describe('doEmbed', () => {
 
     const requestHeaders = server.calls[0].requestHeaders;
 
-    expect(requestHeaders).toStrictEqual({
-      authorization: 'Bearer test-api-key',
-      'content-type': 'application/json',
-      'custom-provider-header': 'provider-header-value',
-      'custom-request-header': 'request-header-value',
-    });
+    expect(requestHeaders).toMatchInlineSnapshot(`
+      {
+        "authorization": "Bearer test-api-key",
+        "content-type": "application/json",
+        "custom-provider-header": "provider-header-value",
+        "custom-request-header": "request-header-value",
+      }
+    `);
     expect(server.calls[0].requestUserAgent).toContain(
       `ai-sdk/cohere/0.0.0-test`,
     );


### PR DESCRIPTION
## background

issue #12270 calls for normalizing provider tests to use recorded API fixtures instead of inline-constructed responses. cohere's `prepareJsonResponse` and `prepareStreamResponse` helpers were called out as the old pattern to replace

## summary

- replace `prepareJsonResponse` / `prepareStreamResponse` with `prepareJsonFixtureResponse` / `prepareChunksFixtureResponse` that read from `__fixtures__/` files
- add 10 fixture files covering text, tool call, null args, reasoning, citations, embedding, and streaming variants
- reorganize tests into `describe` blocks grouped by scenario with `beforeEach` fixture loading
- use `toMatchSnapshot()` for response parsing, keep `toMatchInlineSnapshot()` for request body checks

## verification

- `pnpm test` passes in cohere
- zero `prepareJsonResponse` or `prepareStreamResponse` remaining in cohere

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

ref #12270