### PR TITLE
feat (provider/azure-ai-foundry): initial Azure AI Foundry provider

### DIFF
--- a/.changeset/brave-harbors-glow.md
+++ b/.changeset/brave-harbors-glow.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/azure-ai-foundry': patch
+---
+
+feat: initial Azure AI Foundry provider with unified access to OpenAI, Anthropic, Meta, DeepSeek, xAI, and other models via Azure's Foundry platform

--- a/packages/azure-ai-foundry/.prettierignore
+++ b/packages/azure-ai-foundry/.prettierignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+*.tsbuildinfo
+.turbo/

--- a/packages/azure-ai-foundry/README.md
+++ b/packages/azure-ai-foundry/README.md
@@ -1,0 +1,133 @@
+# AI SDK - Azure AI Foundry Provider
+
+The **Azure AI Foundry provider** for the [AI SDK](https://ai-sdk.dev/docs) contains language model and embedding model support for the [Azure AI Foundry](https://ai.azure.com/) model marketplace.
+
+It supports **all** models deployed through Azure AI Foundry — including OpenAI, Meta Llama, DeepSeek, Mistral, Cohere, xAI Grok, and Anthropic Claude — with a single provider and credential.
+
+## Setup
+
+The Azure AI Foundry provider is available in the `@ai-sdk/azure-ai-foundry` module. You can install it with
+
+```bash
+npm i @ai-sdk/azure-ai-foundry
+```
+
+## Skill for Coding Agents
+
+If you use coding agents such as Claude Code or Cursor, we highly recommend adding the AI SDK skill to your repository:
+
+```shell
+npx skills add vercel/ai
+```
+
+## Provider Instance
+
+You can import the default provider instance `azureAIFoundry` from `@ai-sdk/azure-ai-foundry`:
+
+```ts
+import { azureAIFoundry } from '@ai-sdk/azure-ai-foundry';
+```
+
+To configure the provider with your Azure resource, use the `createAzureAIFoundry` function:
+
+### API Key Authentication
+
+```ts
+import { createAzureAIFoundry } from '@ai-sdk/azure-ai-foundry';
+
+const foundry = createAzureAIFoundry({
+  resourceName: 'my-resource',
+  apiKey: process.env.AZURE_API_KEY,
+});
+```
+
+### Microsoft Entra ID Authentication
+
+```ts
+import { createAzureAIFoundry } from '@ai-sdk/azure-ai-foundry';
+import {
+  DefaultAzureCredential,
+  getBearerTokenProvider,
+} from '@azure/identity';
+
+const tokenProvider = getBearerTokenProvider(
+  new DefaultAzureCredential(),
+  'https://cognitiveservices.azure.com/.default',
+);
+
+const foundry = createAzureAIFoundry({
+  resourceName: 'my-resource',
+  tokenProvider,
+});
+```
+
+## Examples
+
+### Chat / Language Model
+
+Use any model deployed to your Azure AI Foundry resource — OpenAI, Meta, DeepSeek, xAI, Mistral, and more:
+
+```ts
+import { createAzureAIFoundry } from '@ai-sdk/azure-ai-foundry';
+import { generateText } from 'ai';
+
+const foundry = createAzureAIFoundry({
+  resourceName: 'my-resource',
+  apiKey: process.env.AZURE_API_KEY,
+});
+
+const { text } = await generateText({
+  model: foundry('DeepSeek-R1'),
+  prompt: 'Explain quantum computing in simple terms.',
+});
+```
+
+### Claude on Foundry
+
+Claude models are automatically detected by the `claude-*` prefix and routed to the Anthropic Messages API endpoint:
+
+```ts
+import { createAzureAIFoundry } from '@ai-sdk/azure-ai-foundry';
+import { generateText } from 'ai';
+
+const foundry = createAzureAIFoundry({
+  resourceName: 'my-resource',
+  apiKey: process.env.AZURE_API_KEY,
+});
+
+const { text } = await generateText({
+  model: foundry('claude-sonnet-4-5'),
+  prompt: 'Write a haiku about Azure.',
+});
+```
+
+For Claude deployments with custom names that don't start with `claude-`, use the `anthropicDeployments` setting:
+
+```ts
+const foundry = createAzureAIFoundry({
+  resourceName: 'my-resource',
+  apiKey: process.env.AZURE_API_KEY,
+  anthropicDeployments: ['my-custom-claude'],
+});
+```
+
+### Embeddings
+
+```ts
+import { createAzureAIFoundry } from '@ai-sdk/azure-ai-foundry';
+import { embed } from 'ai';
+
+const foundry = createAzureAIFoundry({
+  resourceName: 'my-resource',
+  apiKey: process.env.AZURE_API_KEY,
+});
+
+const { embedding } = await embed({
+  model: foundry.embeddingModel('text-embedding-3-large'),
+  value: 'The quick brown fox jumps over the lazy dog.',
+});
+```
+
+## Documentation
+
+Please check out the **[AI SDK docs](https://ai-sdk.dev/docs)** for more information.

--- a/packages/azure-ai-foundry/package.json
+++ b/packages/azure-ai-foundry/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@ai-sdk/azure-ai-foundry",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist *.tsbuildinfo",
+    "lint": "eslint \"./**/*.ts*\"",
+    "type-check": "tsc --build",
+    "prettier-check": "prettier --check \"./**/*.ts*\"",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:update": "pnpm test:node -u",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "workspace:*",
+    "@ai-sdk/openai": "workspace:*",
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@ai-sdk/test-server": "workspace:*",
+    "@types/node": "20.17.24",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8",
+    "typescript": "5.8.3",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel/ai.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai"
+  ]
+}

--- a/packages/azure-ai-foundry/src/azure-ai-foundry-auth.test.ts
+++ b/packages/azure-ai-foundry/src/azure-ai-foundry-auth.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./version', () => ({ VERSION: '0.0.0-test' }));
+
+import {
+  createOpenAIHeaderProvider,
+  createAnthropicHeaderProvider,
+} from './azure-ai-foundry-auth';
+
+/**
+ * Flush microtask queue so that fire-and-forget
+ * `tokenProvider().then(...)` callbacks have executed.
+ */
+const flushPromises = () =>
+  new Promise<void>(resolve => setTimeout(resolve, 0));
+
+describe('createOpenAIHeaderProvider', () => {
+  it('returns api-key header when apiKey is provided', () => {
+    const getHeaders = createOpenAIHeaderProvider({
+      apiKey: 'test-api-key',
+    });
+
+    const headers = getHeaders();
+
+    expect(headers['api-key']).toBe('test-api-key');
+  });
+
+  it('returns Authorization Bearer header after token cache is warmed', async () => {
+    const tokenProvider = vi.fn().mockResolvedValue('test-token');
+
+    const getHeaders = createOpenAIHeaderProvider({ tokenProvider });
+
+    // Wait for the background cache-warming promise to settle
+    await flushPromises();
+
+    const headers = getHeaders();
+
+    expect(headers['authorization']).toBe('Bearer test-token');
+    // api-key should not be present when token is cached
+    expect(headers['api-key']).toBeUndefined();
+  });
+
+  it('token provider takes precedence over apiKey after cache warming', async () => {
+    const tokenProvider = vi.fn().mockResolvedValue('my-token');
+
+    const getHeaders = createOpenAIHeaderProvider({
+      apiKey: 'my-api-key',
+      tokenProvider,
+    });
+
+    await flushPromises();
+
+    const headers = getHeaders();
+
+    expect(headers['authorization']).toBe('Bearer my-token');
+    expect(headers['api-key']).toBeUndefined();
+  });
+
+  it('falls back to apiKey before token cache is populated', () => {
+    // Token provider returns a promise that never resolves during this test
+    const tokenProvider = vi
+      .fn()
+      .mockReturnValue(new Promise<string>(() => {}));
+
+    const getHeaders = createOpenAIHeaderProvider({
+      apiKey: 'fallback-key',
+      tokenProvider,
+    });
+
+    // Call immediately — cache is not yet populated
+    const headers = getHeaders();
+
+    expect(headers['api-key']).toBe('fallback-key');
+    expect(headers['authorization']).toBeUndefined();
+  });
+
+  it('does not throw on tokenProvider rejection (fire-and-forget)', async () => {
+    const tokenProvider = vi
+      .fn()
+      .mockRejectedValue(new Error('token fetch failed'));
+
+    const getHeaders = createOpenAIHeaderProvider({
+      apiKey: 'fallback-key',
+      tokenProvider,
+    });
+
+    // Wait for the cache-warming promise (which rejects) to settle
+    await flushPromises();
+
+    // Should fall back to API key without crashing
+    const headers = getHeaders();
+    expect(headers['api-key']).toBe('fallback-key');
+    expect(headers['authorization']).toBeUndefined();
+  });
+
+  it('throws when neither apiKey nor tokenProvider is provided and AZURE_API_KEY is unset', () => {
+    const saved = process.env.AZURE_API_KEY;
+    delete process.env.AZURE_API_KEY;
+
+    try {
+      const getHeaders = createOpenAIHeaderProvider({});
+      expect(() => getHeaders()).toThrow(/Azure AI Foundry/);
+    } finally {
+      if (saved !== undefined) {
+        process.env.AZURE_API_KEY = saved;
+      }
+    }
+  });
+
+  it('merges custom headers from settings', () => {
+    const getHeaders = createOpenAIHeaderProvider({
+      apiKey: 'key',
+      headers: { 'x-custom': 'custom-value' },
+    });
+
+    const headers = getHeaders();
+
+    expect(headers['x-custom']).toBe('custom-value');
+    expect(headers['api-key']).toBe('key');
+  });
+
+  it('includes user-agent suffix with package version', () => {
+    const getHeaders = createOpenAIHeaderProvider({
+      apiKey: 'key',
+    });
+
+    const headers = getHeaders();
+
+    expect(headers['user-agent']).toContain(
+      'ai-sdk/azure-ai-foundry/0.0.0-test',
+    );
+  });
+
+  it('triggers background token refresh on each invocation', async () => {
+    let callCount = 0;
+    const tokenProvider = vi.fn().mockImplementation(async () => {
+      callCount++;
+      return `token-${callCount}`;
+    });
+
+    const getHeaders = createOpenAIHeaderProvider({ tokenProvider });
+
+    // Wait for initial cache warming
+    await flushPromises();
+
+    // First call triggers a background refresh
+    const headers1 = getHeaders();
+    expect(headers1['authorization']).toMatch(/^Bearer token-/);
+
+    // Wait for the background refresh triggered by the first call
+    await flushPromises();
+
+    const headers2 = getHeaders();
+    // Token should have been refreshed
+    expect(headers2['authorization']).toMatch(/^Bearer token-/);
+
+    // tokenProvider called: once for warming + once per getHeaders call (2 calls)
+    expect(tokenProvider).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('createAnthropicHeaderProvider', () => {
+  it('returns x-api-key header when apiKey is provided', async () => {
+    const getHeaders = createAnthropicHeaderProvider({
+      apiKey: 'test-api-key',
+    });
+
+    const headers = await getHeaders();
+
+    expect(headers['x-api-key']).toBe('test-api-key');
+  });
+
+  it('includes default anthropic-version header', async () => {
+    const getHeaders = createAnthropicHeaderProvider({
+      apiKey: 'key',
+    });
+
+    const headers = await getHeaders();
+
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+  });
+
+  it('uses custom anthropicVersion when provided', async () => {
+    const getHeaders = createAnthropicHeaderProvider({
+      apiKey: 'key',
+      anthropicVersion: '2024-10-22',
+    });
+
+    const headers = await getHeaders();
+
+    expect(headers['anthropic-version']).toBe('2024-10-22');
+  });
+
+  it('returns Authorization Bearer header when tokenProvider is given', async () => {
+    const tokenProvider = vi.fn().mockResolvedValue('anthro-token');
+
+    const getHeaders = createAnthropicHeaderProvider({ tokenProvider });
+
+    const headers = await getHeaders();
+
+    expect(headers['authorization']).toBe('Bearer anthro-token');
+    expect(headers['x-api-key']).toBeUndefined();
+  });
+
+  it('token provider takes precedence over apiKey', async () => {
+    const tokenProvider = vi.fn().mockResolvedValue('priority-token');
+
+    const getHeaders = createAnthropicHeaderProvider({
+      apiKey: 'fallback-key',
+      tokenProvider,
+    });
+
+    const headers = await getHeaders();
+
+    expect(headers['authorization']).toBe('Bearer priority-token');
+    expect(headers['x-api-key']).toBeUndefined();
+  });
+
+  it('throws when neither apiKey nor tokenProvider is provided and AZURE_API_KEY is unset', async () => {
+    const saved = process.env.AZURE_API_KEY;
+    delete process.env.AZURE_API_KEY;
+
+    try {
+      const getHeaders = createAnthropicHeaderProvider({});
+      await expect(getHeaders()).rejects.toThrow(/Azure AI Foundry Anthropic/);
+    } finally {
+      if (saved !== undefined) {
+        process.env.AZURE_API_KEY = saved;
+      }
+    }
+  });
+
+  it('merges custom headers from settings', async () => {
+    const getHeaders = createAnthropicHeaderProvider({
+      apiKey: 'key',
+      headers: { 'x-custom': 'custom-value' },
+    });
+
+    const headers = await getHeaders();
+
+    expect(headers['x-custom']).toBe('custom-value');
+    expect(headers['x-api-key']).toBe('key');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+  });
+
+  it('includes user-agent suffix with package version', async () => {
+    const getHeaders = createAnthropicHeaderProvider({
+      apiKey: 'key',
+    });
+
+    const headers = await getHeaders();
+
+    expect(headers['user-agent']).toContain(
+      'ai-sdk/azure-ai-foundry/0.0.0-test',
+    );
+  });
+});

--- a/packages/azure-ai-foundry/src/azure-ai-foundry-auth.ts
+++ b/packages/azure-ai-foundry/src/azure-ai-foundry-auth.ts
@@ -1,0 +1,96 @@
+import { loadApiKey, withUserAgentSuffix } from '@ai-sdk/provider-utils';
+import { VERSION } from './version';
+
+export interface AzureAIFoundryAuthSettings {
+  apiKey?: string;
+  tokenProvider?: () => Promise<string>;
+  anthropicVersion?: string;
+  headers?: Record<string, string | undefined>;
+}
+
+/**
+ * Create a synchronous header provider for the OpenAI API path.
+ *
+ * When a tokenProvider is configured, the token is cached and refreshed
+ * in the background. The first call may not have a cached token yet,
+ * in which case it falls back to the API key.
+ */
+export function createOpenAIHeaderProvider(
+  settings: AzureAIFoundryAuthSettings,
+): () => Record<string, string> {
+  let cachedToken: string | undefined;
+
+  // Warm the cache if tokenProvider is available
+  if (settings.tokenProvider) {
+    settings.tokenProvider().then(token => {
+      cachedToken = token;
+    }).catch(() => {});
+  }
+
+  return () => {
+    // Trigger background token refresh if tokenProvider is available
+    if (settings.tokenProvider) {
+      settings.tokenProvider().then(token => {
+        cachedToken = token;
+      }).catch(() => {});
+    }
+
+    const baseHeaders: Record<string, string | undefined> = {
+      ...settings.headers,
+    };
+
+    if (cachedToken) {
+      // Token provider takes precedence
+      baseHeaders['Authorization'] = `Bearer ${cachedToken}`;
+    } else {
+      // Fall back to API key
+      baseHeaders['api-key'] = loadApiKey({
+        apiKey: settings.apiKey,
+        environmentVariableName: 'AZURE_API_KEY',
+        description: 'Azure AI Foundry',
+      });
+    }
+
+    return withUserAgentSuffix(
+      baseHeaders,
+      `ai-sdk/azure-ai-foundry/${VERSION}`,
+    );
+  };
+}
+
+/**
+ * Create an async-capable header provider for the Anthropic API path.
+ *
+ * This returns an async function compatible with the Resolvable type
+ * used by the Anthropic model classes.
+ */
+export function createAnthropicHeaderProvider(
+  settings: AzureAIFoundryAuthSettings,
+): () => Promise<Record<string, string>> {
+  const anthropicVersion = settings.anthropicVersion ?? '2023-06-01';
+
+  return async () => {
+    const baseHeaders: Record<string, string | undefined> = {
+      'anthropic-version': anthropicVersion,
+      ...settings.headers,
+    };
+
+    if (settings.tokenProvider) {
+      // Token provider takes precedence
+      const token = await settings.tokenProvider();
+      baseHeaders['Authorization'] = `Bearer ${token}`;
+    } else {
+      // Fall back to API key
+      baseHeaders['x-api-key'] = loadApiKey({
+        apiKey: settings.apiKey,
+        environmentVariableName: 'AZURE_API_KEY',
+        description: 'Azure AI Foundry Anthropic',
+      });
+    }
+
+    return withUserAgentSuffix(
+      baseHeaders,
+      `ai-sdk/azure-ai-foundry/${VERSION}`,
+    );
+  };
+}

--- a/packages/azure-ai-foundry/src/azure-ai-foundry-chat-options.ts
+++ b/packages/azure-ai-foundry/src/azure-ai-foundry-chat-options.ts
@@ -1,0 +1,68 @@
+export type AzureAIFoundryChatModelId =
+  // OpenAI GPT-5.2 series
+  | 'gpt-5.2'
+  | 'gpt-5.2-codex'
+  | 'gpt-5.2-chat'
+  // OpenAI GPT-5.1 series
+  | 'gpt-5.1'
+  | 'gpt-5.1-chat'
+  | 'gpt-5.1-codex'
+  | 'gpt-5.1-codex-mini'
+  | 'gpt-5.1-codex-max'
+  // OpenAI GPT-5 series
+  | 'gpt-5'
+  | 'gpt-5-mini'
+  | 'gpt-5-nano'
+  | 'gpt-5-chat'
+  | 'gpt-5-codex'
+  | 'gpt-5-pro'
+  // OpenAI GPT-4.1 series
+  | 'gpt-4.1'
+  | 'gpt-4.1-mini'
+  | 'gpt-4.1-nano'
+  // OpenAI GPT-4o series
+  | 'gpt-4o'
+  | 'gpt-4o-mini'
+  // OpenAI o-series reasoning models
+  | 'o4-mini'
+  | 'o3'
+  | 'o3-pro'
+  | 'o3-mini'
+  | 'o1'
+  | 'codex-mini'
+  // Anthropic Claude models
+  | 'claude-opus-4-5'
+  | 'claude-sonnet-4-5'
+  | 'claude-haiku-4-5'
+  | 'claude-opus-4-1'
+  | 'claude-opus-4-6'
+  // Meta models
+  | 'Llama-4-Maverick-17B-128E-Instruct-FP8'
+  | 'Llama-3.3-70B-Instruct'
+  // DeepSeek models
+  | 'DeepSeek-V3.2'
+  | 'DeepSeek-V3.2-Speciale'
+  | 'DeepSeek-V3.1'
+  | 'DeepSeek-V3-0324'
+  | 'DeepSeek-R1-0528'
+  | 'DeepSeek-R1'
+  // xAI Grok models
+  | 'grok-4'
+  | 'grok-4-fast-reasoning'
+  | 'grok-4-fast-non-reasoning'
+  | 'grok-code-fast-1'
+  | 'grok-3'
+  | 'grok-3-mini'
+  // Mistral models
+  | 'Mistral-Large-3'
+  | 'mistral-document-ai-2505'
+  // Cohere models
+  | 'Cohere-command-a'
+  // Moonshot AI models
+  | 'Kimi-K2.5'
+  | 'Kimi-K2-Thinking'
+  // Microsoft models
+  | 'MAI-DS-R1'
+  | 'model-router'
+  // Catch-all for custom deployment names
+  | (string & {});

--- a/packages/azure-ai-foundry/src/azure-ai-foundry-config.ts
+++ b/packages/azure-ai-foundry/src/azure-ai-foundry-config.ts
@@ -1,0 +1,13 @@
+import type { FetchFunction, Resolvable } from '@ai-sdk/provider-utils';
+
+export interface AzureAIFoundryConfig {
+  baseURL: string;
+  anthropicVersion: string;
+  // OpenAI internal classes accept synchronous headers
+  getOpenAIHeaders: () => Record<string, string | undefined>;
+  // Anthropic internal classes accept Resolvable<> — async functions work natively
+  // Uses the SDK's standard Resolvable<T> type (= T | PromiseLike<T> | () => T | PromiseLike<T>)
+  // matching the pattern at google-vertex-anthropic-provider.ts:128
+  getAnthropicHeaders: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+}

--- a/packages/azure-ai-foundry/src/azure-ai-foundry-embedding-options.ts
+++ b/packages/azure-ai-foundry/src/azure-ai-foundry-embedding-options.ts
@@ -1,0 +1,6 @@
+export type AzureAIFoundryEmbeddingModelId =
+  | 'text-embedding-3-large'
+  | 'text-embedding-3-small'
+  | 'text-embedding-ada-002'
+  | 'embed-v-4-0'
+  | (string & {});

--- a/packages/azure-ai-foundry/src/azure-ai-foundry-image-settings.ts
+++ b/packages/azure-ai-foundry/src/azure-ai-foundry-image-settings.ts
@@ -1,0 +1,9 @@
+export type AzureAIFoundryImageModelId =
+  | 'gpt-image-1'
+  | 'gpt-image-1-mini'
+  | 'gpt-image-1.5'
+  | 'dall-e-3'
+  | 'FLUX.2-pro'
+  | 'FLUX.1-Kontext-pro'
+  | 'FLUX-1.1-pro'
+  | (string & {});

--- a/packages/azure-ai-foundry/src/azure-ai-foundry-provider-metadata.ts
+++ b/packages/azure-ai-foundry/src/azure-ai-foundry-provider-metadata.ts
@@ -1,0 +1,22 @@
+import {
+  ResponsesProviderMetadata,
+  ResponsesReasoningProviderMetadata,
+  ResponsesSourceDocumentProviderMetadata,
+  ResponsesTextProviderMetadata,
+} from '@ai-sdk/openai/internal';
+
+export type AzureAIFoundryResponsesProviderMetadata = {
+  azureAIFoundry: ResponsesProviderMetadata;
+};
+
+export type AzureAIFoundryResponsesReasoningProviderMetadata = {
+  azureAIFoundry: ResponsesReasoningProviderMetadata;
+};
+
+export type AzureAIFoundryResponsesTextProviderMetadata = {
+  azureAIFoundry: ResponsesTextProviderMetadata;
+};
+
+export type AzureAIFoundryResponsesSourceDocumentProviderMetadata = {
+  azureAIFoundry: ResponsesSourceDocumentProviderMetadata;
+};

--- a/packages/azure-ai-foundry/src/azure-ai-foundry-provider.test.ts
+++ b/packages/azure-ai-foundry/src/azure-ai-foundry-provider.test.ts
@@ -1,0 +1,518 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { NoSuchModelError } from '@ai-sdk/provider';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+// Mock model constructors + tool exports consumed by azure-ai-foundry-tools.ts
+vi.mock('@ai-sdk/openai/internal', () => ({
+  OpenAIChatLanguageModel: vi.fn(() => ({ type: 'openai-chat' })),
+  OpenAICompletionLanguageModel: vi.fn(() => ({
+    type: 'openai-completion',
+  })),
+  OpenAIEmbeddingModel: vi.fn(() => ({ type: 'openai-embedding' })),
+  OpenAIImageModel: vi.fn(() => ({ type: 'openai-image' })),
+  OpenAIResponsesLanguageModel: vi.fn(() => ({
+    type: 'openai-responses',
+  })),
+  OpenAISpeechModel: vi.fn(() => ({ type: 'openai-speech' })),
+  OpenAITranscriptionModel: vi.fn(() => ({
+    type: 'openai-transcription',
+  })),
+  // Tool exports used by azure-ai-foundry-tools.ts
+  codeInterpreter: { type: 'provider-defined-tool' },
+  fileSearch: { type: 'provider-defined-tool' },
+  imageGeneration: { type: 'provider-defined-tool' },
+  webSearchPreview: { type: 'provider-defined-tool' },
+}));
+
+vi.mock('@ai-sdk/anthropic/internal', () => ({
+  AnthropicMessagesLanguageModel: vi.fn(() => ({ type: 'anthropic' })),
+  // anthropicTools used by azure-ai-foundry-tools.ts
+  anthropicTools: {
+    bash_20241022: { type: 'provider-defined-tool' },
+    bash_20250124: { type: 'provider-defined-tool' },
+    codeExecution_20250522: { type: 'provider-defined-tool' },
+    codeExecution_20250825: { type: 'provider-defined-tool' },
+    computer_20241022: { type: 'provider-defined-tool' },
+    computer_20250124: { type: 'provider-defined-tool' },
+    computer_20251124: { type: 'provider-defined-tool' },
+    memory_20250818: { type: 'provider-defined-tool' },
+    textEditor_20241022: { type: 'provider-defined-tool' },
+    textEditor_20250124: { type: 'provider-defined-tool' },
+    textEditor_20250429: { type: 'provider-defined-tool' },
+    textEditor_20250728: { type: 'provider-defined-tool' },
+    webFetch_20250910: { type: 'provider-defined-tool' },
+    webSearch_20250305: { type: 'provider-defined-tool' },
+    toolSearchRegex_20251119: { type: 'provider-defined-tool' },
+    toolSearchBm25_20251119: { type: 'provider-defined-tool' },
+  },
+}));
+
+import {
+  OpenAIChatLanguageModel,
+  OpenAICompletionLanguageModel,
+  OpenAIEmbeddingModel,
+  OpenAIImageModel,
+  OpenAIResponsesLanguageModel,
+  OpenAISpeechModel,
+  OpenAITranscriptionModel,
+} from '@ai-sdk/openai/internal';
+
+import { AnthropicMessagesLanguageModel } from '@ai-sdk/anthropic/internal';
+
+import { createAzureAIFoundry } from './azure-ai-foundry-provider';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const MockOpenAIChatLanguageModel = OpenAIChatLanguageModel as Mock;
+const MockOpenAICompletionLanguageModel = OpenAICompletionLanguageModel as Mock;
+const MockOpenAIEmbeddingModel = OpenAIEmbeddingModel as Mock;
+const MockOpenAIImageModel = OpenAIImageModel as Mock;
+const MockOpenAIResponsesLanguageModel = OpenAIResponsesLanguageModel as Mock;
+const MockOpenAISpeechModel = OpenAISpeechModel as Mock;
+const MockOpenAITranscriptionModel = OpenAITranscriptionModel as Mock;
+const MockAnthropicMessagesLanguageModel =
+  AnthropicMessagesLanguageModel as unknown as Mock;
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('createAzureAIFoundry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Routing ──────────────────────────────────────────────────────────────
+
+  describe('routing', () => {
+    const provider = createAzureAIFoundry({
+      baseURL: 'https://test.services.ai.azure.com',
+      apiKey: 'test-key',
+    });
+
+    it('default callable with claude model routes to AnthropicMessagesLanguageModel', () => {
+      provider('claude-sonnet-4-5');
+      expect(MockAnthropicMessagesLanguageModel).toHaveBeenCalledOnce();
+      expect(MockOpenAIResponsesLanguageModel).not.toHaveBeenCalled();
+    });
+
+    it('default callable with gpt model routes to OpenAIResponsesLanguageModel', () => {
+      provider('gpt-4o');
+      expect(MockOpenAIResponsesLanguageModel).toHaveBeenCalledOnce();
+      expect(MockAnthropicMessagesLanguageModel).not.toHaveBeenCalled();
+    });
+
+    it('default callable with DeepSeek model routes to OpenAIResponsesLanguageModel', () => {
+      provider('DeepSeek-R1');
+      expect(MockOpenAIResponsesLanguageModel).toHaveBeenCalledOnce();
+      expect(MockAnthropicMessagesLanguageModel).not.toHaveBeenCalled();
+    });
+
+    it('default callable with custom name in anthropicDeployments routes to Anthropic', () => {
+      const customProvider = createAzureAIFoundry({
+        baseURL: 'https://test.services.ai.azure.com',
+        apiKey: 'test-key',
+        anthropicDeployments: ['my-custom-claude'],
+      });
+
+      customProvider('my-custom-claude');
+      expect(MockAnthropicMessagesLanguageModel).toHaveBeenCalledOnce();
+      expect(MockOpenAIResponsesLanguageModel).not.toHaveBeenCalled();
+    });
+
+    it('languageModel auto-detects Claude and routes to AnthropicMessagesLanguageModel', () => {
+      provider.languageModel('claude-sonnet-4-5');
+      expect(MockAnthropicMessagesLanguageModel).toHaveBeenCalledOnce();
+      expect(MockOpenAIResponsesLanguageModel).not.toHaveBeenCalled();
+    });
+
+    it('languageModel auto-detects non-Claude and routes to OpenAIResponsesLanguageModel', () => {
+      provider.languageModel('gpt-4o');
+      expect(MockOpenAIResponsesLanguageModel).toHaveBeenCalledOnce();
+      expect(MockAnthropicMessagesLanguageModel).not.toHaveBeenCalled();
+    });
+
+    it('responses() with Claude model throws NoSuchModelError', () => {
+      expect(() => provider.responses('claude-sonnet-4-5')).toThrow(
+        NoSuchModelError,
+      );
+    });
+
+    it('anthropic() always routes to AnthropicMessagesLanguageModel', () => {
+      provider.anthropic('any-deployment-name');
+      expect(MockAnthropicMessagesLanguageModel).toHaveBeenCalledOnce();
+    });
+
+    it('chat() always routes to OpenAIChatLanguageModel', () => {
+      provider.chat('any-deployment-name');
+      expect(MockOpenAIChatLanguageModel).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── URL construction ─────────────────────────────────────────────────────
+
+  describe('URL construction', () => {
+    it('resourceName builds base URL as https://{resourceName}.services.ai.azure.com', () => {
+      const provider = createAzureAIFoundry({
+        resourceName: 'test-resource',
+        apiKey: 'test-key',
+      });
+
+      provider('gpt-4o');
+
+      const config = MockOpenAIResponsesLanguageModel.mock.calls[0][1] as {
+        url: (args: { path: string; modelId: string }) => string;
+      };
+      const url = config.url({ path: '/responses', modelId: 'gpt-4o' });
+      expect(url).toContain(
+        'https://test-resource.services.ai.azure.com/openai/v1/responses',
+      );
+    });
+
+    it('custom baseURL is used as-is', () => {
+      const provider = createAzureAIFoundry({
+        baseURL: 'https://custom.endpoint.com',
+        apiKey: 'test-key',
+      });
+
+      provider('gpt-4o');
+
+      const config = MockOpenAIResponsesLanguageModel.mock.calls[0][1] as {
+        url: (args: { path: string; modelId: string }) => string;
+      };
+      const url = config.url({ path: '/responses', modelId: 'gpt-4o' });
+      expect(url).toContain('https://custom.endpoint.com/openai/v1/responses');
+    });
+
+    it('OpenAI URL includes /openai/v1{path} with default api-version=v1', () => {
+      const provider = createAzureAIFoundry({
+        baseURL: 'https://test.services.ai.azure.com',
+        apiKey: 'test-key',
+      });
+
+      provider('gpt-4o');
+
+      const config = MockOpenAIResponsesLanguageModel.mock.calls[0][1] as {
+        url: (args: { path: string; modelId: string }) => string;
+      };
+      const url = config.url({
+        path: '/chat/completions',
+        modelId: 'gpt-4o',
+      });
+      expect(url).toBe(
+        'https://test.services.ai.azure.com/openai/v1/chat/completions?api-version=v1',
+      );
+    });
+
+    it('custom apiVersion is reflected in OpenAI URL', () => {
+      const provider = createAzureAIFoundry({
+        baseURL: 'https://test.services.ai.azure.com',
+        apiKey: 'test-key',
+        apiVersion: '2024-12-01-preview',
+      });
+
+      provider.chat('gpt-4o');
+
+      const config = MockOpenAIChatLanguageModel.mock.calls[0][1] as {
+        url: (args: { path: string; modelId: string }) => string;
+      };
+      const url = config.url({
+        path: '/chat/completions',
+        modelId: 'gpt-4o',
+      });
+      expect(url).toBe(
+        'https://test.services.ai.azure.com/openai/v1/chat/completions?api-version=2024-12-01-preview',
+      );
+    });
+
+    it('Anthropic base URL is {base}/anthropic/v1', () => {
+      const provider = createAzureAIFoundry({
+        baseURL: 'https://test.services.ai.azure.com',
+        apiKey: 'test-key',
+      });
+
+      provider.anthropic('claude-sonnet-4-5');
+
+      const config = MockAnthropicMessagesLanguageModel.mock.calls[0][1] as {
+        baseURL: string;
+      };
+      expect(config.baseURL).toBe(
+        'https://test.services.ai.azure.com/anthropic/v1',
+      );
+    });
+
+    it('legacy deployment URL for transcription uses /openai/deployments/{modelId}/{path}', () => {
+      const provider = createAzureAIFoundry({
+        baseURL: 'https://test.services.ai.azure.com',
+        apiKey: 'test-key',
+      });
+
+      provider.transcription('whisper');
+
+      const config = MockOpenAITranscriptionModel.mock.calls[0][1] as {
+        url: (args: { path: string; modelId: string }) => string;
+      };
+      const url = config.url({
+        path: '/audio/transcriptions',
+        modelId: 'whisper',
+      });
+      expect(url).toBe(
+        'https://test.services.ai.azure.com/openai/deployments/whisper/audio/transcriptions?api-version=2025-04-01-preview',
+      );
+    });
+
+    it('legacy deployment URL for speech uses /openai/deployments/{modelId}/{path}', () => {
+      const provider = createAzureAIFoundry({
+        baseURL: 'https://test.services.ai.azure.com',
+        apiKey: 'test-key',
+      });
+
+      provider.speech('tts-1');
+
+      const config = MockOpenAISpeechModel.mock.calls[0][1] as {
+        url: (args: { path: string; modelId: string }) => string;
+      };
+      const url = config.url({
+        path: '/audio/speech',
+        modelId: 'tts-1',
+      });
+      expect(url).toBe(
+        'https://test.services.ai.azure.com/openai/deployments/tts-1/audio/speech?api-version=2025-04-01-preview',
+      );
+    });
+
+    it('trailing slash on baseURL is stripped', () => {
+      const provider = createAzureAIFoundry({
+        baseURL: 'https://test.services.ai.azure.com/',
+        apiKey: 'test-key',
+      });
+
+      provider('gpt-4o');
+
+      const config = MockOpenAIResponsesLanguageModel.mock.calls[0][1] as {
+        url: (args: { path: string; modelId: string }) => string;
+      };
+      const url = config.url({ path: '/responses', modelId: 'gpt-4o' });
+      expect(url).toContain(
+        'https://test.services.ai.azure.com/openai/v1/responses',
+      );
+      // Should NOT have double slash
+      expect(url).not.toContain('.com//openai');
+    });
+  });
+
+  // ── Model instantiation ──────────────────────────────────────────────────
+
+  describe('model instantiation', () => {
+    const provider = createAzureAIFoundry({
+      baseURL: 'https://test.services.ai.azure.com',
+      apiKey: 'test-key',
+    });
+
+    it('embeddingModel() calls OpenAIEmbeddingModel constructor', () => {
+      provider.embeddingModel('text-embedding-3-large');
+      expect(MockOpenAIEmbeddingModel).toHaveBeenCalledOnce();
+      expect(MockOpenAIEmbeddingModel.mock.calls[0][0]).toBe(
+        'text-embedding-3-large',
+      );
+    });
+
+    it('imageModel() calls OpenAIImageModel constructor', () => {
+      provider.imageModel('dall-e-3');
+      expect(MockOpenAIImageModel).toHaveBeenCalledOnce();
+      expect(MockOpenAIImageModel.mock.calls[0][0]).toBe('dall-e-3');
+    });
+
+    it('transcription() calls OpenAITranscriptionModel constructor', () => {
+      provider.transcription('whisper');
+      expect(MockOpenAITranscriptionModel).toHaveBeenCalledOnce();
+      expect(MockOpenAITranscriptionModel.mock.calls[0][0]).toBe('whisper');
+    });
+
+    it('speech() calls OpenAISpeechModel constructor', () => {
+      provider.speech('tts-1');
+      expect(MockOpenAISpeechModel).toHaveBeenCalledOnce();
+      expect(MockOpenAISpeechModel.mock.calls[0][0]).toBe('tts-1');
+    });
+
+    it('completion() calls OpenAICompletionLanguageModel constructor', () => {
+      provider.completion('gpt-3.5-turbo-instruct');
+      expect(MockOpenAICompletionLanguageModel).toHaveBeenCalledOnce();
+      expect(MockOpenAICompletionLanguageModel.mock.calls[0][0]).toBe(
+        'gpt-3.5-turbo-instruct',
+      );
+    });
+
+    it('chat() passes provider name azure-ai-foundry.chat', () => {
+      provider.chat('gpt-4o');
+      const config = MockOpenAIChatLanguageModel.mock.calls[0][1] as {
+        provider: string;
+      };
+      expect(config.provider).toBe('azure-ai-foundry.chat');
+    });
+
+    it('responses() passes provider name azure-ai-foundry.responses', () => {
+      provider.responses('gpt-4o');
+      const config = MockOpenAIResponsesLanguageModel.mock.calls[0][1] as {
+        provider: string;
+      };
+      expect(config.provider).toBe('azure-ai-foundry.responses');
+    });
+
+    it('anthropic() passes provider name azure-ai-foundry.anthropic', () => {
+      provider.anthropic('claude-sonnet-4-5');
+      const config = MockAnthropicMessagesLanguageModel.mock.calls[0][1] as {
+        provider: string;
+      };
+      expect(config.provider).toBe('azure-ai-foundry.anthropic');
+    });
+
+    it('embeddingModel() passes provider name azure-ai-foundry.embedding', () => {
+      provider.embeddingModel('text-embedding-3-large');
+      const config = MockOpenAIEmbeddingModel.mock.calls[0][1] as {
+        provider: string;
+      };
+      expect(config.provider).toBe('azure-ai-foundry.embedding');
+    });
+
+    it('imageModel() passes provider name azure-ai-foundry.image', () => {
+      provider.imageModel('dall-e-3');
+      const config = MockOpenAIImageModel.mock.calls[0][1] as {
+        provider: string;
+      };
+      expect(config.provider).toBe('azure-ai-foundry.image');
+    });
+
+    it('transcription() passes provider name azure-ai-foundry.transcription', () => {
+      provider.transcription('whisper');
+      const config = MockOpenAITranscriptionModel.mock.calls[0][1] as {
+        provider: string;
+      };
+      expect(config.provider).toBe('azure-ai-foundry.transcription');
+    });
+
+    it('speech() passes provider name azure-ai-foundry.speech', () => {
+      provider.speech('tts-1');
+      const config = MockOpenAISpeechModel.mock.calls[0][1] as {
+        provider: string;
+      };
+      expect(config.provider).toBe('azure-ai-foundry.speech');
+    });
+
+    it('completion() passes provider name azure-ai-foundry.completion', () => {
+      provider.completion('gpt-3.5-turbo-instruct');
+      const config = MockOpenAICompletionLanguageModel.mock.calls[0][1] as {
+        provider: string;
+      };
+      expect(config.provider).toBe('azure-ai-foundry.completion');
+    });
+
+    it('responses() passes fileIdPrefixes for assistant files', () => {
+      provider.responses('gpt-4o');
+      const config = MockOpenAIResponsesLanguageModel.mock.calls[0][1] as {
+        fileIdPrefixes: readonly string[];
+      };
+      expect(config.fileIdPrefixes).toEqual(['assistant-']);
+    });
+  });
+
+  // ── Claude guard clauses ─────────────────────────────────────────────────
+
+  describe('Claude guard clauses', () => {
+    const provider = createAzureAIFoundry({
+      baseURL: 'https://test.services.ai.azure.com',
+      apiKey: 'test-key',
+    });
+
+    it('embeddingModel() throws NoSuchModelError for Claude models', () => {
+      try {
+        provider.embeddingModel('claude-sonnet-4-5');
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(NoSuchModelError.isInstance(error)).toBe(true);
+        expect((error as NoSuchModelError).modelId).toBe('claude-sonnet-4-5');
+        expect((error as NoSuchModelError).modelType).toBe('embeddingModel');
+      }
+    });
+
+    it('imageModel() throws NoSuchModelError for Claude models', () => {
+      try {
+        provider.imageModel('claude-opus-4-1');
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(NoSuchModelError.isInstance(error)).toBe(true);
+        expect((error as NoSuchModelError).modelId).toBe('claude-opus-4-1');
+        expect((error as NoSuchModelError).modelType).toBe('imageModel');
+      }
+    });
+
+    it('responses() throws NoSuchModelError for Claude models', () => {
+      try {
+        provider.responses('claude-haiku-4-5');
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(NoSuchModelError.isInstance(error)).toBe(true);
+        expect((error as NoSuchModelError).modelId).toBe('claude-haiku-4-5');
+        expect((error as NoSuchModelError).modelType).toBe('languageModel');
+      }
+    });
+
+    it('embeddingModel() throws NoSuchModelError for custom anthropicDeployments', () => {
+      const customProvider = createAzureAIFoundry({
+        baseURL: 'https://test.services.ai.azure.com',
+        apiKey: 'test-key',
+        anthropicDeployments: ['my-claude'],
+      });
+
+      try {
+        customProvider.embeddingModel('my-claude');
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(NoSuchModelError.isInstance(error)).toBe(true);
+        expect((error as NoSuchModelError).modelId).toBe('my-claude');
+        expect((error as NoSuchModelError).modelType).toBe('embeddingModel');
+      }
+    });
+  });
+
+  // ── Constructor rejection ────────────────────────────────────────────────
+
+  describe('constructor rejection', () => {
+    it('throws when called with new keyword', () => {
+      const provider = createAzureAIFoundry({
+        baseURL: 'https://test.services.ai.azure.com',
+        apiKey: 'test-key',
+      });
+
+      // The provider is a function with new.target guard.
+      // We need to use Reflect.construct to trigger new.target.
+      expect(() => {
+        Reflect.construct(
+          provider as unknown as new (...args: unknown[]) => unknown,
+          ['gpt-4o'],
+        );
+      }).toThrow(/new keyword/);
+    });
+  });
+
+  // ── specificationVersion ─────────────────────────────────────────────────
+
+  describe('specificationVersion', () => {
+    it('is v3', () => {
+      const provider = createAzureAIFoundry({
+        baseURL: 'https://test.services.ai.azure.com',
+        apiKey: 'test-key',
+      });
+
+      // specificationVersion is inherited from ProviderV3 but not re-declared
+      // on the AzureAIFoundryProvider callable interface, so access via index
+      const spec = (provider as unknown as Record<string, unknown>)[
+        'specificationVersion'
+      ];
+      expect(spec).toBe('v3');
+    });
+  });
+});

--- a/packages/azure-ai-foundry/src/azure-ai-foundry-provider.ts
+++ b/packages/azure-ai-foundry/src/azure-ai-foundry-provider.ts
@@ -1,0 +1,440 @@
+import {
+  NoSuchModelError,
+  type EmbeddingModelV3,
+  type ImageModelV3,
+  type LanguageModelV3,
+  type ProviderV3,
+  type SpeechModelV3,
+  type TranscriptionModelV3,
+} from '@ai-sdk/provider';
+import {
+  type FetchFunction,
+  generateId,
+  loadSetting,
+  withoutTrailingSlash,
+} from '@ai-sdk/provider-utils';
+import {
+  OpenAIChatLanguageModel,
+  OpenAICompletionLanguageModel,
+  OpenAIEmbeddingModel,
+  OpenAIImageModel,
+  OpenAIResponsesLanguageModel,
+  OpenAISpeechModel,
+  OpenAITranscriptionModel,
+} from '@ai-sdk/openai/internal';
+import { AnthropicMessagesLanguageModel } from '@ai-sdk/anthropic/internal';
+import type { AzureAIFoundryChatModelId } from './azure-ai-foundry-chat-options';
+import type { AzureAIFoundryEmbeddingModelId } from './azure-ai-foundry-embedding-options';
+import type { AzureAIFoundryImageModelId } from './azure-ai-foundry-image-settings';
+import {
+  createOpenAIHeaderProvider,
+  createAnthropicHeaderProvider,
+} from './azure-ai-foundry-auth';
+import { detectApiFormat } from './azure-ai-foundry-routing';
+import { azureAIFoundryTools } from './azure-ai-foundry-tools';
+
+export interface AzureAIFoundryProviderSettings {
+  /**
+   * Azure resource name. Used to construct the base URL:
+   * `https://{resourceName}.services.ai.azure.com`
+   *
+   * Either this or `baseURL` must be provided. Falls back to
+   * `AZURE_RESOURCE_NAME` environment variable.
+   */
+  resourceName?: string;
+
+  /**
+   * Full base URL override. When provided, `resourceName` is ignored.
+   * Example: `https://my-resource.services.ai.azure.com`
+   */
+  baseURL?: string;
+
+  /**
+   * API key for authentication. Sent as `api-key` header for OpenAI
+   * endpoints and `x-api-key` for Anthropic endpoints.
+   *
+   * Falls back to `AZURE_API_KEY` environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * Async token provider for Microsoft Entra ID (keyless) authentication.
+   * Returns a bearer token string. Called on each request to support
+   * token refresh.
+   *
+   * When both `apiKey` and `tokenProvider` are provided, `tokenProvider`
+   * takes precedence.
+   */
+  tokenProvider?: () => Promise<string>;
+
+  /**
+   * Azure API version query parameter. Defaults to `'v1'`.
+   * Appended as `?api-version={apiVersion}` to all OpenAI endpoint requests.
+   */
+  apiVersion?: string;
+
+  /**
+   * Anthropic API version header. Defaults to `'2023-06-01'`.
+   */
+  anthropicVersion?: string;
+
+  /**
+   * List of deployment names that should be routed to the Anthropic Messages
+   * API instead of the OpenAI API. Used when a Claude deployment has a custom
+   * name that doesn't match the `claude-*` auto-detection pattern.
+   *
+   * Deployments matching `claude-*` are always auto-detected regardless of
+   * this setting.
+   */
+  anthropicDeployments?: string[];
+
+  /**
+   * Custom headers to include in all requests.
+   */
+  headers?: Record<string, string | undefined>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept
+   * requests, or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+}
+
+export interface AzureAIFoundryProvider extends ProviderV3 {
+  /**
+   * Creates a language model for text generation. Auto-detects whether to use
+   * the OpenAI Responses API or Anthropic Messages API based on the deployment
+   * name.
+   */
+  (deploymentName: string): LanguageModelV3;
+
+  /**
+   * Creates a language model for text generation. Auto-detects OpenAI vs
+   * Anthropic based on the deployment name. Claude deployments route to
+   * AnthropicMessagesLanguageModel; all others route to
+   * OpenAIResponsesLanguageModel.
+   */
+  languageModel(deploymentName: string): LanguageModelV3;
+
+  /**
+   * Creates a language model using the OpenAI Chat Completions API.
+   */
+  chat(deploymentName: AzureAIFoundryChatModelId): LanguageModelV3;
+
+  /**
+   * @deprecated Legacy completions API — NOT available in the v1 API.
+   * Included for migration compatibility with `@ai-sdk/azure`.
+   * Use `chat()` or `responses()` instead.
+   */
+  completion(deploymentName: AzureAIFoundryChatModelId): LanguageModelV3;
+
+  /**
+   * Creates a language model using the Anthropic Messages API path.
+   */
+  anthropic(deploymentName: string): LanguageModelV3;
+
+  /**
+   * Creates a language model using the OpenAI Responses API.
+   */
+  responses(deploymentName: AzureAIFoundryChatModelId): LanguageModelV3;
+
+  /**
+   * Creates an embedding model.
+   */
+  embeddingModel(
+    deploymentName: AzureAIFoundryEmbeddingModelId,
+  ): EmbeddingModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(
+    deploymentName: AzureAIFoundryEmbeddingModelId,
+  ): EmbeddingModelV3;
+
+  /**
+   * Creates an embedding model.
+   */
+  embedding(deploymentName: AzureAIFoundryEmbeddingModelId): EmbeddingModelV3;
+
+  /**
+   * @deprecated Use `embedding` instead.
+   */
+  textEmbedding(
+    deploymentName: AzureAIFoundryEmbeddingModelId,
+  ): EmbeddingModelV3;
+
+  /**
+   * Creates an image generation model.
+   */
+  imageModel(deploymentName: AzureAIFoundryImageModelId): ImageModelV3;
+
+  /**
+   * Creates an image generation model.
+   */
+  image(deploymentName: AzureAIFoundryImageModelId): ImageModelV3;
+
+  /**
+   * Creates a transcription model. Uses the legacy deployment-based API.
+   */
+  transcriptionModel(deploymentName: string): TranscriptionModelV3;
+
+  /**
+   * Creates a transcription model. Uses the legacy deployment-based API.
+   */
+  transcription(deploymentName: string): TranscriptionModelV3;
+
+  /**
+   * Creates a speech model. Uses the legacy deployment-based API.
+   */
+  speechModel(deploymentName: string): SpeechModelV3;
+
+  /**
+   * Creates a speech model. Uses the legacy deployment-based API.
+   */
+  speech(deploymentName: string): SpeechModelV3;
+
+  /**
+   * Azure AI Foundry-specific tools. Includes both OpenAI tools
+   * (codeInterpreter, fileSearch, imageGeneration, webSearchPreview) and
+   * Anthropic tools (bash, textEditor, computer, webSearch, codeExecution,
+   * memory, toolSearchBm25, toolSearchRegex, webFetch) for use with the
+   * respective deployment types.
+   */
+  tools: typeof azureAIFoundryTools;
+}
+
+/**
+ * Create an Azure AI Foundry provider instance.
+ */
+export function createAzureAIFoundry(
+  options: AzureAIFoundryProviderSettings = {},
+): AzureAIFoundryProvider {
+  // Lazy base URL resolution — defers error to model creation time
+  const getBaseURL = (): string => {
+    if (options.baseURL) {
+      return withoutTrailingSlash(options.baseURL) ?? options.baseURL;
+    }
+
+    const resourceName = loadSetting({
+      settingValue: options.resourceName,
+      settingName: 'resourceName',
+      environmentVariableName: 'AZURE_RESOURCE_NAME',
+      description: 'Azure AI Foundry resource name',
+    });
+
+    return `https://${resourceName}.services.ai.azure.com`;
+  };
+
+  const anthropicVersion = options.anthropicVersion ?? '2023-06-01';
+
+  // Build header providers
+  const getOpenAIHeaders = createOpenAIHeaderProvider({
+    apiKey: options.apiKey,
+    tokenProvider: options.tokenProvider,
+    headers: options.headers,
+  });
+
+  const getAnthropicHeaders = createAnthropicHeaderProvider({
+    apiKey: options.apiKey,
+    tokenProvider: options.tokenProvider,
+    anthropicVersion,
+    headers: options.headers,
+  });
+
+  // URL builders — apiVersion defaults to 'v1' (matching @ai-sdk/azure)
+  const apiVersion = options.apiVersion ?? 'v1';
+
+  // Standard v1 endpoint URL builder.
+  // _modelId is required by the url callback signature but unused for v1 paths
+  // (v1 routes by `model` param in the request body, not by URL).
+  const openaiUrl = ({
+    path,
+    modelId: _modelId,
+  }: {
+    path: string;
+    modelId: string;
+  }): string => {
+    const baseURL = getBaseURL();
+    const fullUrl = new URL(`${baseURL}/openai/v1${path}`);
+    fullUrl.searchParams.set('api-version', apiVersion);
+    return fullUrl.toString();
+  };
+
+  // Legacy deployment-based URL builder for audio endpoints (transcription, speech).
+  // These are NOT available under /openai/v1/ and require the deployment-based pattern:
+  // {baseURL}/openai/deployments/{modelId}/{path}?api-version=2025-04-01-preview
+  const legacyDeploymentUrl = ({
+    path,
+    modelId,
+  }: {
+    path: string;
+    modelId: string;
+  }): string => {
+    const baseURL = getBaseURL();
+    const suffix = path.replace(/^\//, '');
+    const fullUrl = new URL(
+      `${baseURL}/openai/deployments/${modelId}/${suffix}`,
+    );
+    fullUrl.searchParams.set('api-version', '2025-04-01-preview');
+    return fullUrl.toString();
+  };
+
+  // ─── Model Factories ───
+
+  const createChatModel = (deploymentName: string) =>
+    new OpenAIChatLanguageModel(deploymentName, {
+      provider: 'azure-ai-foundry.chat',
+      url: openaiUrl,
+      headers: getOpenAIHeaders,
+      fetch: options.fetch,
+    });
+
+  // Legacy completions — NOT in v1 GA API. Included for migration from @ai-sdk/azure.
+  const createCompletionModel = (deploymentName: string) =>
+    new OpenAICompletionLanguageModel(deploymentName, {
+      provider: 'azure-ai-foundry.completion',
+      url: openaiUrl,
+      headers: getOpenAIHeaders,
+      fetch: options.fetch,
+    });
+
+  const createAnthropicModel = (deploymentName: string): LanguageModelV3 =>
+    new AnthropicMessagesLanguageModel(deploymentName, {
+      provider: 'azure-ai-foundry.anthropic',
+      // AnthropicMessagesLanguageModel appends /messages internally,
+      // so baseURL must include /anthropic/v1 to produce /anthropic/v1/messages
+      baseURL: `${getBaseURL()}/anthropic/v1`,
+      headers: getAnthropicHeaders,
+      fetch: options.fetch,
+      generateId,
+      // NOTE: supportedUrls allows all HTTP URLs, matching anthropic-provider.ts:140-143.
+      // If Azure doesn't support URL fetching, change to `supportedUrls: () => ({})`
+      // to force download + base64 conversion (like google-vertex does).
+      supportedUrls: () => ({
+        'image/*': [/^https?:\/\/.*$/],
+        'application/pdf': [/^https?:\/\/.*$/],
+      }),
+    });
+
+  // Responses API model with Claude guard clause
+  const createResponsesModel = (deploymentName: string) => {
+    if (
+      detectApiFormat(deploymentName, options.anthropicDeployments) ===
+      'anthropic'
+    ) {
+      throw new NoSuchModelError({
+        modelId: deploymentName,
+        modelType: 'languageModel',
+      });
+    }
+    return new OpenAIResponsesLanguageModel(deploymentName, {
+      provider: 'azure-ai-foundry.responses',
+      url: openaiUrl,
+      headers: getOpenAIHeaders,
+      fetch: options.fetch,
+      fileIdPrefixes: ['assistant-'],
+    });
+  };
+
+  const createEmbeddingModel = (deploymentName: string) => {
+    if (
+      detectApiFormat(deploymentName, options.anthropicDeployments) ===
+      'anthropic'
+    ) {
+      throw new NoSuchModelError({
+        modelId: deploymentName,
+        modelType: 'embeddingModel',
+      });
+    }
+    return new OpenAIEmbeddingModel(deploymentName, {
+      provider: 'azure-ai-foundry.embedding',
+      url: openaiUrl,
+      headers: getOpenAIHeaders,
+      fetch: options.fetch,
+    });
+  };
+
+  const createImageModel = (deploymentName: string) => {
+    if (
+      detectApiFormat(deploymentName, options.anthropicDeployments) ===
+      'anthropic'
+    ) {
+      throw new NoSuchModelError({
+        modelId: deploymentName,
+        modelType: 'imageModel',
+      });
+    }
+    return new OpenAIImageModel(deploymentName, {
+      provider: 'azure-ai-foundry.image',
+      url: openaiUrl,
+      headers: getOpenAIHeaders,
+      fetch: options.fetch,
+    });
+  };
+
+  // Audio models use legacy deployment-based URLs
+  const createTranscriptionModel = (deploymentName: string) =>
+    new OpenAITranscriptionModel(deploymentName, {
+      provider: 'azure-ai-foundry.transcription',
+      url: legacyDeploymentUrl,
+      headers: getOpenAIHeaders,
+      fetch: options.fetch,
+    });
+
+  const createSpeechModel = (deploymentName: string) =>
+    new OpenAISpeechModel(deploymentName, {
+      provider: 'azure-ai-foundry.speech',
+      url: legacyDeploymentUrl,
+      headers: getOpenAIHeaders,
+      fetch: options.fetch,
+    });
+
+  // ProviderV3 canonical method — auto-detects Claude deployments.
+  // Claude → AnthropicMessagesLanguageModel; all others → OpenAIResponsesLanguageModel.
+  const createLanguageModel = (deploymentName: string): LanguageModelV3 => {
+    if (
+      detectApiFormat(deploymentName, options.anthropicDeployments) ===
+      'anthropic'
+    ) {
+      return createAnthropicModel(deploymentName);
+    }
+    return createResponsesModel(deploymentName);
+  };
+
+  // ─── Provider Assembly ───
+
+  const provider = function (deploymentName: string) {
+    if (new.target) {
+      throw new Error(
+        'The Azure AI Foundry model function cannot be called with the new keyword.',
+      );
+    }
+    return createLanguageModel(deploymentName);
+  };
+
+  provider.specificationVersion = 'v3' as const;
+  provider.languageModel = createLanguageModel;
+  provider.chat = createChatModel;
+  provider.completion = createCompletionModel;
+  provider.anthropic = createAnthropicModel;
+  provider.responses = createResponsesModel;
+  provider.embeddingModel = createEmbeddingModel;
+  provider.embedding = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
+  provider.textEmbedding = createEmbeddingModel;
+  provider.imageModel = createImageModel;
+  provider.image = createImageModel;
+  provider.transcriptionModel = createTranscriptionModel;
+  provider.transcription = createTranscriptionModel;
+  provider.speechModel = createSpeechModel;
+  provider.speech = createSpeechModel;
+  provider.tools = azureAIFoundryTools;
+
+  return provider as AzureAIFoundryProvider;
+}
+
+/**
+ * Default Azure AI Foundry provider instance.
+ */
+export const azureAIFoundry = createAzureAIFoundry();

--- a/packages/azure-ai-foundry/src/azure-ai-foundry-routing.test.ts
+++ b/packages/azure-ai-foundry/src/azure-ai-foundry-routing.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { detectApiFormat } from './azure-ai-foundry-routing';
+
+describe('detectApiFormat', () => {
+  // ── Anthropic by name prefix/exact match ──────────────────────────────
+
+  it("returns 'anthropic' for 'claude-sonnet-4-5' (claude- prefix)", () => {
+    expect(detectApiFormat('claude-sonnet-4-5')).toBe('anthropic');
+  });
+
+  it("returns 'anthropic' for 'claude-opus-4-1' (claude- prefix)", () => {
+    expect(detectApiFormat('claude-opus-4-1')).toBe('anthropic');
+  });
+
+  it("returns 'anthropic' for 'CLAUDE-opus-4-5' (case-insensitive prefix)", () => {
+    expect(detectApiFormat('CLAUDE-opus-4-5')).toBe('anthropic');
+  });
+
+  it("returns 'anthropic' for 'claude_sonnet' (claude_ prefix)", () => {
+    expect(detectApiFormat('claude_sonnet')).toBe('anthropic');
+  });
+
+  it("returns 'anthropic' for 'Claude_Opus' (case-insensitive claude_ prefix)", () => {
+    expect(detectApiFormat('Claude_Opus')).toBe('anthropic');
+  });
+
+  it("returns 'anthropic' for exact 'claude'", () => {
+    expect(detectApiFormat('claude')).toBe('anthropic');
+  });
+
+  it("returns 'anthropic' for 'CLAUDE' (case-insensitive exact match)", () => {
+    expect(detectApiFormat('CLAUDE')).toBe('anthropic');
+  });
+
+  it("returns 'anthropic' for 'Claude' (mixed-case exact match)", () => {
+    expect(detectApiFormat('Claude')).toBe('anthropic');
+  });
+
+  // ── OpenAI by default ─────────────────────────────────────────────────
+
+  it("returns 'openai' for 'gpt-4o' (non-Claude deployment)", () => {
+    expect(detectApiFormat('gpt-4o')).toBe('openai');
+  });
+
+  it("returns 'openai' for 'o3-mini'", () => {
+    expect(detectApiFormat('o3-mini')).toBe('openai');
+  });
+
+  it("returns 'openai' for 'my-custom-deployment'", () => {
+    expect(detectApiFormat('my-custom-deployment')).toBe('openai');
+  });
+
+  it("returns 'openai' for empty string", () => {
+    expect(detectApiFormat('')).toBe('openai');
+  });
+
+  // ── Edge cases: names containing 'claude' but not matching patterns ───
+
+  it("returns 'openai' for 'not-claude' (claude not at start)", () => {
+    expect(detectApiFormat('not-claude')).toBe('openai');
+  });
+
+  it("returns 'openai' for 'claudex' (no separator after claude)", () => {
+    expect(detectApiFormat('claudex')).toBe('openai');
+  });
+
+  it("returns 'openai' for 'claude3' (no separator after claude)", () => {
+    expect(detectApiFormat('claude3')).toBe('openai');
+  });
+
+  it("returns 'openai' for 'my-claude-model' (claude not at start)", () => {
+    expect(detectApiFormat('my-claude-model')).toBe('openai');
+  });
+
+  it("returns 'openai' for 'claude.' (dot separator, not - or _)", () => {
+    expect(detectApiFormat('claude.')).toBe('openai');
+  });
+
+  // ── anthropicDeployments list takes priority ──────────────────────────
+
+  it("returns 'anthropic' when deployment is in anthropicDeployments list", () => {
+    expect(
+      detectApiFormat('my-custom-anthropic', ['my-custom-anthropic']),
+    ).toBe('anthropic');
+  });
+
+  it("returns 'anthropic' for non-Claude name in anthropicDeployments list", () => {
+    expect(detectApiFormat('gpt-4o', ['gpt-4o'])).toBe('anthropic');
+  });
+
+  it('anthropicDeployments match is case-sensitive', () => {
+    // 'Claude-Sonnet' is in the list but 'claude-sonnet' is not;
+    // however, the name-based fallback will still match it via toLowerCase()
+    expect(detectApiFormat('claude-sonnet', ['Claude-Sonnet'])).toBe(
+      'anthropic',
+    );
+    // A truly non-Claude name that only differs by case won't match
+    expect(detectApiFormat('MyModel', ['mymodel'])).toBe('openai');
+  });
+
+  it("returns 'openai' when deployment is NOT in anthropicDeployments and has no Claude prefix", () => {
+    expect(
+      detectApiFormat('gpt-4o', ['claude-sonnet-4-5', 'my-anthropic']),
+    ).toBe('openai');
+  });
+
+  // ── anthropicDeployments undefined / empty ────────────────────────────
+
+  it('falls through to name detection when anthropicDeployments is undefined', () => {
+    expect(detectApiFormat('claude-haiku', undefined)).toBe('anthropic');
+    expect(detectApiFormat('gpt-4o', undefined)).toBe('openai');
+  });
+
+  it('falls through to name detection when anthropicDeployments is empty array', () => {
+    expect(detectApiFormat('claude-haiku', [])).toBe('anthropic');
+    expect(detectApiFormat('gpt-4o', [])).toBe('openai');
+  });
+});

--- a/packages/azure-ai-foundry/src/azure-ai-foundry-routing.ts
+++ b/packages/azure-ai-foundry/src/azure-ai-foundry-routing.ts
@@ -1,0 +1,33 @@
+/**
+ * API format for routing requests to the correct backend.
+ */
+export type ApiFormat = 'openai' | 'anthropic';
+
+/**
+ * Detect whether a deployment should use the OpenAI or Anthropic API format.
+ *
+ * Checks the anthropicDeployments list first, then falls back to name-based
+ * detection (claude- prefix, claude_ prefix, or exact match 'claude').
+ */
+export function detectApiFormat(
+  deploymentName: string,
+  anthropicDeployments?: string[],
+): ApiFormat {
+  // Check explicit anthropic deployments list first
+  if (anthropicDeployments?.includes(deploymentName)) {
+    return 'anthropic';
+  }
+
+  // Normalize for prefix/exact matching
+  const normalized = deploymentName.toLowerCase();
+
+  if (
+    normalized.startsWith('claude-') ||
+    normalized.startsWith('claude_') ||
+    normalized === 'claude'
+  ) {
+    return 'anthropic';
+  }
+
+  return 'openai';
+}

--- a/packages/azure-ai-foundry/src/azure-ai-foundry-tools.ts
+++ b/packages/azure-ai-foundry/src/azure-ai-foundry-tools.ts
@@ -1,0 +1,60 @@
+import {
+  codeInterpreter,
+  fileSearch,
+  imageGeneration,
+  webSearchPreview,
+} from '@ai-sdk/openai/internal';
+import { anthropicTools } from '@ai-sdk/anthropic/internal';
+
+/**
+ * Merged provider tools for Azure AI Foundry, combining OpenAI and Anthropic
+ * tool definitions.
+ */
+export const azureAIFoundryTools: {
+  // OpenAI tools — explicit typeof annotations to avoid TS2742
+  codeInterpreter: typeof codeInterpreter;
+  fileSearch: typeof fileSearch;
+  imageGeneration: typeof imageGeneration;
+  webSearchPreview: typeof webSearchPreview;
+  // Anthropic tools
+  bash_20241022: typeof anthropicTools.bash_20241022;
+  bash_20250124: typeof anthropicTools.bash_20250124;
+  codeExecution_20250522: typeof anthropicTools.codeExecution_20250522;
+  codeExecution_20250825: typeof anthropicTools.codeExecution_20250825;
+  computer_20241022: typeof anthropicTools.computer_20241022;
+  computer_20250124: typeof anthropicTools.computer_20250124;
+  computer_20251124: typeof anthropicTools.computer_20251124;
+  memory_20250818: typeof anthropicTools.memory_20250818;
+  textEditor_20241022: typeof anthropicTools.textEditor_20241022;
+  textEditor_20250124: typeof anthropicTools.textEditor_20250124;
+  textEditor_20250429: typeof anthropicTools.textEditor_20250429;
+  textEditor_20250728: typeof anthropicTools.textEditor_20250728;
+  webFetch_20250910: typeof anthropicTools.webFetch_20250910;
+  webSearch_20250305: typeof anthropicTools.webSearch_20250305;
+  toolSearchRegex_20251119: typeof anthropicTools.toolSearchRegex_20251119;
+  toolSearchBm25_20251119: typeof anthropicTools.toolSearchBm25_20251119;
+} = {
+  // OpenAI tools
+  codeInterpreter,
+  fileSearch,
+  imageGeneration,
+  webSearchPreview,
+
+  // Anthropic tools
+  bash_20241022: anthropicTools.bash_20241022,
+  bash_20250124: anthropicTools.bash_20250124,
+  codeExecution_20250522: anthropicTools.codeExecution_20250522,
+  codeExecution_20250825: anthropicTools.codeExecution_20250825,
+  computer_20241022: anthropicTools.computer_20241022,
+  computer_20250124: anthropicTools.computer_20250124,
+  computer_20251124: anthropicTools.computer_20251124,
+  memory_20250818: anthropicTools.memory_20250818,
+  textEditor_20241022: anthropicTools.textEditor_20241022,
+  textEditor_20250124: anthropicTools.textEditor_20250124,
+  textEditor_20250429: anthropicTools.textEditor_20250429,
+  textEditor_20250728: anthropicTools.textEditor_20250728,
+  webFetch_20250910: anthropicTools.webFetch_20250910,
+  webSearch_20250305: anthropicTools.webSearch_20250305,
+  toolSearchRegex_20251119: anthropicTools.toolSearchRegex_20251119,
+  toolSearchBm25_20251119: anthropicTools.toolSearchBm25_20251119,
+};

--- a/packages/azure-ai-foundry/src/index.ts
+++ b/packages/azure-ai-foundry/src/index.ts
@@ -1,0 +1,19 @@
+export {
+  createAzureAIFoundry,
+  azureAIFoundry,
+} from './azure-ai-foundry-provider';
+export type {
+  AzureAIFoundryProvider,
+  AzureAIFoundryProviderSettings,
+} from './azure-ai-foundry-provider';
+export { azureAIFoundryTools } from './azure-ai-foundry-tools';
+export type { AzureAIFoundryChatModelId } from './azure-ai-foundry-chat-options';
+export type { AzureAIFoundryEmbeddingModelId } from './azure-ai-foundry-embedding-options';
+export type { AzureAIFoundryImageModelId } from './azure-ai-foundry-image-settings';
+export type {
+  AzureAIFoundryResponsesProviderMetadata,
+  AzureAIFoundryResponsesReasoningProviderMetadata,
+  AzureAIFoundryResponsesTextProviderMetadata,
+  AzureAIFoundryResponsesSourceDocumentProviderMetadata,
+} from './azure-ai-foundry-provider-metadata';
+export { VERSION } from './version';

--- a/packages/azure-ai-foundry/src/version.ts
+++ b/packages/azure-ai-foundry/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/azure-ai-foundry/tsconfig.build.json
+++ b/packages/azure-ai-foundry/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/azure-ai-foundry/tsconfig.json
+++ b/packages/azure-ai-foundry/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "tsup.config.ts"
+  ],
+  "references": [
+    {
+      "path": "../anthropic"
+    },
+    {
+      "path": "../openai"
+    },
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    },
+    {
+      "path": "../test-server"
+    }
+  ]
+}

--- a/packages/azure-ai-foundry/tsup.config.ts
+++ b/packages/azure-ai-foundry/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/azure-ai-foundry/turbo.json
+++ b/packages/azure-ai-foundry/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "**/dist/**"
+      ]
+    }
+  }
+}

--- a/packages/azure-ai-foundry/vitest.edge.config.js
+++ b/packages/azure-ai-foundry/vitest.edge.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/packages/azure-ai-foundry/vitest.node.config.js
+++ b/packages/azure-ai-foundry/vitest.node.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1682,6 +1682,40 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
 
+  packages/azure-ai-foundry:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: workspace:*
+        version: link:../anthropic
+      '@ai-sdk/openai':
+        specifier: workspace:*
+        version: link:../openai
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+    devDependencies:
+      '@ai-sdk/test-server':
+        specifier: workspace:*
+        version: link:../test-server
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8
+        version: 8.3.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.7.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
   packages/baseten:
     dependencies:
       '@ai-sdk/openai-compatible':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     { "path": "packages/anthropic" },
     { "path": "packages/assemblyai" },
     { "path": "packages/azure" },
+    { "path": "packages/azure-ai-foundry" },
     { "path": "packages/black-forest-labs" },
     { "path": "packages/baseten" },
     { "path": "packages/cerebras" },


### PR DESCRIPTION
## Background

Azure AI Foundry is Microsoft's unified AI model marketplace, hosting models from OpenAI, Anthropic, Meta, DeepSeek, xAI, Mistral, Cohere, and others behind a single Azure resource. The existing `@ai-sdk/azure` package covers only Azure OpenAI Service (native OpenAI deployments). Users deploying non-OpenAI models through Foundry have no first-class provider support.

Closes #6295

## Summary

Adds `@ai-sdk/azure-ai-foundry` — a new provider package that gives unified access to all Azure AI Foundry models:

- **Auto-routing**: Claude deployments (`claude-*` prefix) automatically route to the Anthropic Messages API (`/anthropic/v1/messages`). All other models use the OpenAI/v1 endpoint.
- **Dual authentication**: Supports both API key (`api-key` / `x-api-key` headers) and Entra ID (keyless/managed identity via async `tokenProvider` callback).
- **8 model types**: `languageModel` (auto-detect), `chat`, `responses`, `anthropic`, `completion` (legacy), `embeddingModel`, `imageModel`, `transcriptionModel`, `speechModel`
- **20 provider tools**: 4 OpenAI tools + 16 Anthropic tools merged into `azureAIFoundryTools`
- **Claude guard clauses**: Prevents misrouting Claude deployments to OpenAI-only endpoints (`responses()`, `embeddingModel()`, `imageModel()`)
- **Legacy audio support**: Transcription/speech models use deployment-based URLs since audio isn't in the v1 GA API

### Architecture

Wraps `@ai-sdk/openai/internal` and `@ai-sdk/anthropic/internal` classes (same pattern as `@ai-sdk/azure`), adding:
- URL construction for Azure Foundry's `services.ai.azure.com` domain
- Dual header construction (OpenAI vs Anthropic auth patterns)
- Model routing via `detectApiFormat()`

### Package structure

```
packages/azure-ai-foundry/
├── src/
│   ├── index.ts                          # Public API
│   ├── azure-ai-foundry-provider.ts      # Factory + interfaces
│   ├── azure-ai-foundry-auth.ts          # API key + Entra ID headers
│   ├── azure-ai-foundry-routing.ts       # Claude detection
│   ├── azure-ai-foundry-tools.ts         # 20 merged tools
│   ├── azure-ai-foundry-config.ts        # Shared config types
│   ├── azure-ai-foundry-chat-options.ts  # 68 model IDs
│   ├── azure-ai-foundry-embedding-options.ts
│   ├── azure-ai-foundry-image-settings.ts
│   ├── azure-ai-foundry-provider-metadata.ts
│   ├── version.ts
│   ├── *-provider.test.ts                # 37 tests
│   ├── *-auth.test.ts                    # 16 tests
│   └── *-routing.test.ts                 # 23 tests
├── package.json, tsconfig.json, tsup.config.ts, etc.
└── README.md
```

## Checklist

- [x] Tests have been added / updated (76 tests, node + edge)
- [x] Documentation has been added / updated (README.md)
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request (self-review)