### PR TITLE
feat (provider/alibaba): add video generation support

### DIFF
--- a/.changeset/healthy-needles-guess.md
+++ b/.changeset/healthy-needles-guess.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/alibaba': patch
+---
+
+feat (provider/alibaba): add video generation support

--- a/content/providers/01-ai-sdk-providers/32-alibaba.mdx
+++ b/content/providers/01-ai-sdk-providers/32-alibaba.mdx
@@ -53,6 +53,12 @@ You can use the following optional settings to customize the Alibaba provider in
   Use a different URL prefix for API calls, e.g. to use proxy servers or regional endpoints.
   The default prefix is `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`.
 
+- **videoBaseURL** _string_
+
+  Use a different URL prefix for video generation API calls. The video API uses the DashScope
+  native endpoint (not the OpenAI-compatible endpoint).
+  The default prefix is `https://dashscope-intl.aliyuncs.com`.
+
 - **apiKey** _string_
 
   API key that is being sent using the `Authorization` header. It defaults to
@@ -193,6 +199,155 @@ const { text, usage } = await generateText({
   ],
 });
 ```
+
+## Video Models
+
+You can create [Wan](https://www.alibabacloud.com/help/en/model-studio/use-video-generation) video models that call the Alibaba Cloud DashScope API
+using the `.video()` factory method. For more on video generation with the AI SDK see [generateVideo()](/docs/reference/ai-sdk-core/generate-video).
+
+Alibaba supports three video generation modes: text-to-video, image-to-video (first frame), and reference-to-video.
+
+### Text-to-Video
+
+Generate videos from text prompts:
+
+```ts
+import { alibaba, type AlibabaVideoProviderOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { video } = await generateVideo({
+  model: alibaba.video('wan2.6-t2v'),
+  prompt: 'A serene mountain lake at sunset with gentle ripples on the water.',
+  resolution: '1280x720',
+  duration: 5,
+  providerOptions: {
+    alibaba: {
+      promptExtend: true,
+      pollTimeoutMs: 600000, // 10 minutes
+    } satisfies AlibabaVideoProviderOptions,
+  },
+});
+```
+
+### Image-to-Video
+
+Generate videos from a first-frame image and optional text prompt:
+
+```ts
+import { alibaba, type AlibabaVideoProviderOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { video } = await generateVideo({
+  model: alibaba.video('wan2.6-i2v'),
+  prompt: {
+    image: 'https://example.com/landscape.jpg',
+    text: 'Camera slowly pans across the landscape',
+  },
+  duration: 5,
+  providerOptions: {
+    alibaba: {
+      pollTimeoutMs: 600000, // 10 minutes
+    } satisfies AlibabaVideoProviderOptions,
+  },
+});
+```
+
+### Reference-to-Video
+
+Generate videos using reference images and/or videos for character consistency. Use character identifiers
+(`character1`, `character2`, etc.) in your prompt to reference them:
+
+```ts
+import { alibaba, type AlibabaVideoProviderOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { video } = await generateVideo({
+  model: alibaba.video('wan2.6-r2v-flash'),
+  prompt: 'character1 walks through a beautiful garden and waves at the camera',
+  resolution: '1280x720',
+  duration: 5,
+  providerOptions: {
+    alibaba: {
+      referenceUrls: ['https://example.com/character-reference.jpg'],
+      pollTimeoutMs: 600000, // 10 minutes
+    } satisfies AlibabaVideoProviderOptions,
+  },
+});
+```
+
+### Video Provider Options
+
+The following provider options are available via `providerOptions.alibaba`:
+
+- **negativePrompt** _string_
+
+  A description of what to avoid in the generated video (max 500 characters).
+
+- **audioUrl** _string_
+
+  URL to an audio file for audio-video sync (WAV/MP3, 3-30 seconds, max 15MB).
+
+- **promptExtend** _boolean_
+
+  Enable prompt extension/rewriting for better generation quality. Defaults to `true`.
+
+- **shotType** `'single'` | `'multi'`
+
+  Shot type for video generation. `'multi'` enables multi-shot cinematic narrative (wan2.6 models only).
+
+- **watermark** _boolean_
+
+  Whether to add a watermark to the generated video. Defaults to `false`.
+
+- **audio** _boolean_
+
+  Whether to generate audio (for I2V and R2V models that support it).
+
+- **referenceUrls** _string[]_
+
+  Array of reference image/video URLs for reference-to-video mode. Supports 0-5 images and 0-3 videos, max 5 total.
+
+- **pollIntervalMs** _number_
+
+  Polling interval in milliseconds for checking task status. Defaults to 5000.
+
+- **pollTimeoutMs** _number_
+
+  Maximum wait time in milliseconds for video generation. Defaults to 600000 (10 minutes).
+
+<Note>
+  Video generation is an asynchronous process that can take several minutes.
+  Consider setting `pollTimeoutMs` to at least 10 minutes (600000ms) for
+  reliable operation.
+</Note>
+
+### Video Model Capabilities
+
+#### Text-to-Video
+
+| Model                | Audio | Resolution        | Duration |
+| -------------------- | ----- | ----------------- | -------- |
+| `wan2.6-t2v`         | Yes   | 720P, 1080P       | 2-15s    |
+| `wan2.5-t2v-preview` | Yes   | 480P, 720P, 1080P | 5s, 10s  |
+
+#### Image-to-Video (First Frame)
+
+| Model              | Audio    | Resolution  | Duration |
+| ------------------ | -------- | ----------- | -------- |
+| `wan2.6-i2v-flash` | Optional | 720P, 1080P | 2-15s    |
+| `wan2.6-i2v`       | Yes      | 720P, 1080P | 2-15s    |
+
+#### Reference-to-Video
+
+| Model              | Audio    | Resolution  | Duration |
+| ------------------ | -------- | ----------- | -------- |
+| `wan2.6-r2v-flash` | Optional | 720P, 1080P | 2-10s    |
+| `wan2.6-r2v`       | Yes      | 720P, 1080P | 2-10s    |
+
+<Note>
+  The tables above list models available in the Singapore International region.
+  You can also pass any available provider model ID as a string if needed.
+</Note>
 
 ## Model Capabilities
 

--- a/examples/ai-functions/src/generate-video/alibaba-wan2.5-t2v-preview.ts
+++ b/examples/ai-functions/src/generate-video/alibaba-wan2.5-t2v-preview.ts
@@ -13,7 +13,7 @@ run(async () => {
         prompt:
           'A bustling night market with colorful lanterns, steam rising from food stalls, and people walking through the crowd.',
         resolution: '1920x1080',
-        duration: 10,
+        duration: 5,
         providerOptions: {
           alibaba: {
             promptExtend: true,

--- a/examples/ai-functions/src/generate-video/alibaba-wan2.5-t2v-preview.ts
+++ b/examples/ai-functions/src/generate-video/alibaba-wan2.5-t2v-preview.ts
@@ -1,0 +1,27 @@
+import { type AlibabaVideoProviderOptions, alibaba } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../lib/present-video';
+import { run } from '../lib/run';
+import { withSpinner } from '../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating text-to-video with wan2.5-t2v-preview...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan2.5-t2v-preview'),
+        prompt:
+          'A bustling night market with colorful lanterns, steam rising from food stalls, and people walking through the crowd.',
+        resolution: '1920x1080',
+        duration: 10,
+        providerOptions: {
+          alibaba: {
+            promptExtend: true,
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoProviderOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba-wan2.6-i2v-flash.ts
+++ b/examples/ai-functions/src/generate-video/alibaba-wan2.6-i2v-flash.ts
@@ -1,0 +1,29 @@
+import { type AlibabaVideoProviderOptions, alibaba } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../lib/present-video';
+import { run } from '../lib/run';
+import { withSpinner } from '../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating image-to-video with wan2.6-i2v-flash...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan2.6-i2v-flash'),
+        prompt: {
+          image:
+            'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+          text: 'The cat waves hello and smiles',
+        },
+        duration: 5,
+        providerOptions: {
+          alibaba: {
+            audio: false,
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoProviderOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba-wan2.6-i2v.ts
+++ b/examples/ai-functions/src/generate-video/alibaba-wan2.6-i2v.ts
@@ -1,0 +1,28 @@
+import { type AlibabaVideoProviderOptions, alibaba } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../lib/present-video';
+import { run } from '../lib/run';
+import { withSpinner } from '../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating image-to-video with wan2.6-i2v...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan2.6-i2v'),
+        prompt: {
+          image:
+            'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+          text: 'The cat slowly turns its head and blinks',
+        },
+        duration: 5,
+        providerOptions: {
+          alibaba: {
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoProviderOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba-wan2.6-r2v-flash.ts
+++ b/examples/ai-functions/src/generate-video/alibaba-wan2.6-r2v-flash.ts
@@ -1,0 +1,27 @@
+import { type AlibabaVideoProviderOptions, alibaba } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../lib/present-video';
+import { run } from '../lib/run';
+import { withSpinner } from '../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating reference-to-video with wan2.6-r2v-flash...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan2.6-r2v-flash'),
+        prompt:
+          'character1 walks through a beautiful garden and waves at the camera',
+        resolution: '1280x720',
+        duration: 5,
+        providerOptions: {
+          alibaba: {
+            referenceUrls: ['https://example.com/reference-character.jpg'],
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoProviderOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba-wan2.6-r2v-flash.ts
+++ b/examples/ai-functions/src/generate-video/alibaba-wan2.6-r2v-flash.ts
@@ -11,12 +11,14 @@ run(async () => {
       generateVideo({
         model: alibaba.video('wan2.6-r2v-flash'),
         prompt:
-          'character1 walks through a beautiful garden and waves at the camera',
+          'comic cat walks through a beautiful garden and waves at the camera',
         resolution: '1280x720',
-        duration: 5,
+        duration: 3,
         providerOptions: {
           alibaba: {
-            referenceUrls: ['https://example.com/reference-character.jpg'],
+            referenceUrls: [
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+            ],
             pollTimeoutMs: 600000, // 10 minutes
           } satisfies AlibabaVideoProviderOptions,
         },

--- a/examples/ai-functions/src/generate-video/alibaba-wan2.6-r2v.ts
+++ b/examples/ai-functions/src/generate-video/alibaba-wan2.6-r2v.ts
@@ -1,0 +1,30 @@
+import { type AlibabaVideoProviderOptions, alibaba } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../lib/present-video';
+import { run } from '../lib/run';
+import { withSpinner } from '../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating reference-to-video with wan2.6-r2v...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan2.6-r2v'),
+        prompt: 'character1 and character2 have a conversation in a cozy cafe',
+        resolution: '1920x1080',
+        duration: 8,
+        providerOptions: {
+          alibaba: {
+            referenceUrls: [
+              'https://example.com/character1.jpg',
+              'https://example.com/character2.jpg',
+            ],
+            shotType: 'multi',
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoProviderOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba-wan2.6-r2v.ts
+++ b/examples/ai-functions/src/generate-video/alibaba-wan2.6-r2v.ts
@@ -10,16 +10,16 @@ run(async () => {
     () =>
       generateVideo({
         model: alibaba.video('wan2.6-r2v'),
-        prompt: 'character1 and character2 have a conversation in a cozy cafe',
+        prompt: 'comic cat and comic dog have a conversation in a cozy cafe',
         resolution: '1920x1080',
-        duration: 8,
+        duration: 4,
         providerOptions: {
           alibaba: {
             referenceUrls: [
-              'https://example.com/character1.jpg',
-              'https://example.com/character2.jpg',
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-dog.png',
             ],
-            shotType: 'multi',
+            shotType: 'single',
             pollTimeoutMs: 600000, // 10 minutes
           } satisfies AlibabaVideoProviderOptions,
         },

--- a/examples/ai-functions/src/generate-video/alibaba-wan2.6-t2v.ts
+++ b/examples/ai-functions/src/generate-video/alibaba-wan2.6-t2v.ts
@@ -1,0 +1,27 @@
+import { type AlibabaVideoProviderOptions, alibaba } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../lib/present-video';
+import { run } from '../lib/run';
+import { withSpinner } from '../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating text-to-video with wan2.6-t2v...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan2.6-t2v'),
+        prompt:
+          'A serene mountain lake at sunset with gentle ripples on the water and birds flying across the sky.',
+        resolution: '1280x720',
+        duration: 5,
+        providerOptions: {
+          alibaba: {
+            promptExtend: true,
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoProviderOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba-wan2.6-t2v.ts
+++ b/examples/ai-functions/src/generate-video/alibaba-wan2.6-t2v.ts
@@ -10,8 +10,7 @@ run(async () => {
     () =>
       generateVideo({
         model: alibaba.video('wan2.6-t2v'),
-        prompt:
-          'A serene mountain lake at sunset with gentle ripples on the water and birds flying across the sky.',
+        prompt: 'A chicken flying into the sunset in the style of 90s anime.',
         resolution: '1280x720',
         duration: 5,
         providerOptions: {

--- a/packages/alibaba/src/alibaba-chat-language-model.test.ts
+++ b/packages/alibaba/src/alibaba-chat-language-model.test.ts
@@ -1,10 +1,10 @@
-import { LanguageModelV3Prompt } from '@ai-sdk/provider';
-import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import fs from 'node:fs';
-import { createAlibaba } from './alibaba-provider';
-import { AlibabaUsage } from './convert-alibaba-usage';
 import { describe, it, expect, vi } from 'vitest';
+import { createAlibaba } from './alibaba-provider';
+import type { AlibabaUsage } from './convert-alibaba-usage';
 
 vi.mock('./version', () => ({
   VERSION: '0.0.0-test',

--- a/packages/alibaba/src/alibaba-chat-language-model.ts
+++ b/packages/alibaba/src/alibaba-chat-language-model.ts
@@ -1,39 +1,38 @@
 import {
+  getResponseMetadata,
+  mapOpenAICompatibleFinishReason,
+  prepareTools,
+} from '@ai-sdk/openai-compatible/internal';
+import {
   InvalidResponseDataError,
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  LanguageModelV3Content,
-  LanguageModelV3FinishReason,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamPart,
-  LanguageModelV3StreamResult,
-  SharedV3Warning,
+  type LanguageModelV3,
+  type LanguageModelV3CallOptions,
+  type LanguageModelV3Content,
+  type LanguageModelV3FinishReason,
+  type LanguageModelV3GenerateResult,
+  type LanguageModelV3StreamPart,
+  type LanguageModelV3StreamResult,
+  type SharedV3Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
   createEventSourceResponseHandler,
   createJsonResponseHandler,
-  FetchFunction,
   generateId,
   isParsableJson,
   parseProviderOptions,
-  ParseResult,
   postJsonToApi,
+  type ParseResult,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import {
-  getResponseMetadata,
-  mapOpenAICompatibleFinishReason,
-  prepareTools,
-} from '@ai-sdk/openai-compatible/internal';
-import { AlibabaConfig } from './alibaba-config';
-import {
-  AlibabaChatModelId,
   alibabaProviderOptions,
+  type AlibabaChatModelId,
 } from './alibaba-chat-options';
+import type { AlibabaConfig } from './alibaba-config';
 import { alibabaFailedResponseHandler } from './alibaba-provider';
-import { convertToAlibabaChatMessages } from './convert-to-alibaba-chat-messages';
 import { convertAlibabaUsage } from './convert-alibaba-usage';
+import { convertToAlibabaChatMessages } from './convert-to-alibaba-chat-messages';
 import { CacheControlValidator } from './get-cache-control';
 
 /**

--- a/packages/alibaba/src/alibaba-config.ts
+++ b/packages/alibaba/src/alibaba-config.ts
@@ -1,4 +1,4 @@
-import { FetchFunction } from '@ai-sdk/provider-utils';
+import type { FetchFunction } from '@ai-sdk/provider-utils';
 
 export interface AlibabaConfig {
   provider: string;

--- a/packages/alibaba/src/alibaba-provider.test.ts
+++ b/packages/alibaba/src/alibaba-provider.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { createAlibaba } from './alibaba-provider';
 import { loadApiKey } from '@ai-sdk/provider-utils';
 import { AlibabaLanguageModel } from './alibaba-chat-language-model';
+import { AlibabaVideoModel } from './alibaba-video-model';
 
 const AlibabaLanguageModelMock = AlibabaLanguageModel as unknown as Mock;
+const AlibabaVideoModelMock = AlibabaVideoModel as unknown as Mock;
 
 vi.mock('./alibaba-chat-language-model', () => {
   const mockConstructor = vi.fn().mockImplementation(function (
@@ -17,6 +19,21 @@ vi.mock('./alibaba-chat-language-model', () => {
   });
   return {
     AlibabaLanguageModel: mockConstructor,
+  };
+});
+
+vi.mock('./alibaba-video-model', () => {
+  const mockConstructor = vi.fn().mockImplementation(function (
+    this: any,
+    modelId: string,
+    settings: any,
+  ) {
+    this.provider = 'alibaba.video';
+    this.modelId = modelId;
+    this.settings = settings;
+  });
+  return {
+    AlibabaVideoModel: mockConstructor,
   };
 });
 
@@ -118,6 +135,87 @@ describe('AlibabaProvider', () => {
       const model = provider.languageModel(modelId);
 
       expect(model).toBeInstanceOf(AlibabaLanguageModel);
+    });
+  });
+
+  describe('video', () => {
+    it('should construct a video model with correct provider', () => {
+      const provider = createAlibaba();
+      const model = provider.video('wan2.6-t2v');
+
+      expect(model).toBeInstanceOf(AlibabaVideoModel);
+      const constructorCall = AlibabaVideoModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe('wan2.6-t2v');
+      expect(constructorCall[1].provider).toBe('alibaba.video');
+    });
+
+    it('should use default videoBaseURL', () => {
+      const provider = createAlibaba();
+      provider.video('wan2.6-t2v');
+
+      const constructorCall = AlibabaVideoModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe(
+        'https://dashscope-intl.aliyuncs.com',
+      );
+    });
+
+    it('should use custom videoBaseURL', () => {
+      const provider = createAlibaba({
+        videoBaseURL: 'https://dashscope.aliyuncs.com',
+      });
+      provider.video('wan2.6-t2v');
+
+      const constructorCall = AlibabaVideoModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe('https://dashscope.aliyuncs.com');
+    });
+
+    it('should pass custom fetch to video model', () => {
+      const customFetch = vi.fn();
+      const provider = createAlibaba({ fetch: customFetch });
+      provider.video('wan2.6-t2v');
+
+      const constructorCall = AlibabaVideoModelMock.mock.calls[0];
+      expect(constructorCall[1].fetch).toBe(customFetch);
+    });
+
+    it('should pass headers function to video model', () => {
+      const provider = createAlibaba({
+        apiKey: 'test-key',
+        headers: { 'X-Custom': 'value' },
+      });
+      provider.video('wan2.6-t2v');
+
+      const constructorCall = AlibabaVideoModelMock.mock.calls[0];
+      const headers = constructorCall[1].headers();
+
+      expect(headers).toMatchObject({
+        authorization: 'Bearer mock-api-key',
+        'x-custom': 'value',
+      });
+    });
+  });
+
+  describe('videoModel', () => {
+    it('should construct a video model with correct configuration', () => {
+      const provider = createAlibaba();
+      const model = provider.videoModel('wan2.6-i2v-flash');
+
+      expect(model).toBeInstanceOf(AlibabaVideoModel);
+      const constructorCall = AlibabaVideoModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe('wan2.6-i2v-flash');
+      expect(constructorCall[1].provider).toBe('alibaba.video');
+    });
+
+    it('should use the same videoBaseURL as video()', () => {
+      const provider = createAlibaba({
+        videoBaseURL: 'https://custom-video.example.com',
+      });
+      provider.videoModel('wan2.6-r2v');
+
+      const constructorCall = AlibabaVideoModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe(
+        'https://custom-video.example.com',
+      );
     });
   });
 });

--- a/packages/alibaba/src/alibaba-provider.ts
+++ b/packages/alibaba/src/alibaba-provider.ts
@@ -1,4 +1,5 @@
 import {
+  type Experimental_VideoModelV3,
   LanguageModelV3,
   NoSuchModelError,
   ProviderV3,
@@ -13,6 +14,8 @@ import {
 import { z } from 'zod/v4';
 import { AlibabaLanguageModel } from './alibaba-chat-language-model';
 import { AlibabaChatModelId } from './alibaba-chat-options';
+import { AlibabaVideoModel } from './alibaba-video-model';
+import type { AlibabaVideoModelId } from './alibaba-video-settings';
 import { VERSION } from './version';
 
 export type AlibabaErrorData = z.infer<typeof alibabaErrorDataSchema>;
@@ -42,6 +45,16 @@ export interface AlibabaProvider extends ProviderV3 {
    * Creates a chat model for text generation.
    */
   chatModel(modelId: AlibabaChatModelId): LanguageModelV3;
+
+  /**
+   * Creates a model for video generation.
+   */
+  video(modelId: AlibabaVideoModelId): Experimental_VideoModelV3;
+
+  /**
+   * Creates a model for video generation.
+   */
+  videoModel(modelId: AlibabaVideoModelId): Experimental_VideoModelV3;
 }
 
 export interface AlibabaProviderSettings {
@@ -50,6 +63,13 @@ export interface AlibabaProviderSettings {
    * The default prefix is `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`.
    */
   baseURL?: string;
+
+  /**
+   * Use a different URL prefix for video generation API calls.
+   * The video API uses the DashScope native endpoint (not the OpenAI-compatible endpoint).
+   * The default prefix is `https://dashscope-intl.aliyuncs.com`.
+   */
+  videoBaseURL?: string;
 
   /**
    * API key that is being sent using the `Authorization` header.
@@ -87,6 +107,10 @@ export function createAlibaba(
     withoutTrailingSlash(options.baseURL) ??
     'https://dashscope-intl.aliyuncs.com/compatible-mode/v1';
 
+  const videoBaseURL =
+    withoutTrailingSlash(options.videoBaseURL) ??
+    'https://dashscope-intl.aliyuncs.com';
+
   const getHeaders = () =>
     withUserAgentSuffix(
       {
@@ -109,6 +133,14 @@ export function createAlibaba(
       includeUsage: options.includeUsage ?? true,
     });
 
+  const createVideoModel = (modelId: AlibabaVideoModelId) =>
+    new AlibabaVideoModel(modelId, {
+      provider: 'alibaba.video',
+      baseURL: videoBaseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
   const provider = function (modelId: AlibabaChatModelId) {
     if (new.target) {
       throw new Error(
@@ -122,6 +154,8 @@ export function createAlibaba(
   provider.specificationVersion = 'v3' as const;
   provider.languageModel = createLanguageModel;
   provider.chatModel = createLanguageModel;
+  provider.video = createVideoModel;
+  provider.videoModel = createVideoModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });

--- a/packages/alibaba/src/alibaba-provider.ts
+++ b/packages/alibaba/src/alibaba-provider.ts
@@ -1,19 +1,19 @@
 import {
   type Experimental_VideoModelV3,
-  LanguageModelV3,
+  type LanguageModelV3,
   NoSuchModelError,
-  ProviderV3,
+  type ProviderV3,
 } from '@ai-sdk/provider';
 import {
   createJsonErrorResponseHandler,
-  FetchFunction,
+  type FetchFunction,
   loadApiKey,
   withoutTrailingSlash,
   withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { AlibabaLanguageModel } from './alibaba-chat-language-model';
-import { AlibabaChatModelId } from './alibaba-chat-options';
+import type { AlibabaChatModelId } from './alibaba-chat-options';
 import { AlibabaVideoModel } from './alibaba-video-model';
 import type { AlibabaVideoModelId } from './alibaba-video-settings';
 import { VERSION } from './version';

--- a/packages/alibaba/src/alibaba-video-model.test.ts
+++ b/packages/alibaba/src/alibaba-video-model.test.ts
@@ -111,7 +111,7 @@ describe('AlibabaVideoModel', () => {
       });
     });
 
-    it('should send size parameter for T2V resolution', async () => {
+    it('should send size parameter for T2V resolution (x converted to *)', async () => {
       const model = createModel();
 
       await model.doGenerate({
@@ -121,7 +121,7 @@ describe('AlibabaVideoModel', () => {
 
       const body = await server.calls[0].requestBodyJson;
       expect(body).toMatchObject({
-        parameters: { size: '1920x1080' },
+        parameters: { size: '1920*1080' },
       });
     });
 
@@ -344,7 +344,7 @@ describe('AlibabaVideoModel', () => {
       });
     });
 
-    it('should send size parameter for R2V resolution', async () => {
+    it('should send size parameter for R2V resolution (x converted to *)', async () => {
       const model = createModel({ modelId: 'wan2.6-r2v' });
 
       await model.doGenerate({
@@ -354,7 +354,7 @@ describe('AlibabaVideoModel', () => {
 
       const body = await server.calls[0].requestBodyJson;
       expect(body).toMatchObject({
-        parameters: { size: '1280x720' },
+        parameters: { size: '1280*720' },
       });
     });
 

--- a/packages/alibaba/src/alibaba-video-model.test.ts
+++ b/packages/alibaba/src/alibaba-video-model.test.ts
@@ -1,0 +1,685 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import { AlibabaVideoModel } from './alibaba-video-model';
+
+const prompt = 'A serene mountain lake at sunset with gentle ripples';
+
+const TEST_BASE_URL = 'https://dashscope-intl.aliyuncs.com';
+const CREATE_URL = `${TEST_BASE_URL}/api/v1/services/aigc/video-generation/video-synthesis`;
+const TASK_URL = `${TEST_BASE_URL}/api/v1/tasks/task-abc-123`;
+
+const createTaskResponse = {
+  output: {
+    task_status: 'PENDING',
+    task_id: 'task-abc-123',
+  },
+  request_id: 'req-001',
+};
+
+const succeededTaskResponse = {
+  output: {
+    task_id: 'task-abc-123',
+    task_status: 'SUCCEEDED',
+    video_url: 'https://dashscope-result.oss.aliyuncs.com/output/video-001.mp4',
+    submit_time: '2024-01-01 00:00:00.000',
+    scheduled_time: '2024-01-01 00:00:01.000',
+    end_time: '2024-01-01 00:01:00.000',
+    orig_prompt: prompt,
+    actual_prompt: 'An enhanced prompt with more cinematic details',
+  },
+  usage: {
+    duration: 5.0,
+    output_video_duration: 5,
+    SR: 1080,
+    size: '1920x1080',
+  },
+  request_id: 'req-002',
+};
+
+const defaultProviderOptions = {
+  alibaba: {
+    pollIntervalMs: 10, // Fast polling for tests
+    pollTimeoutMs: 5000,
+  },
+};
+
+const defaultOptions = {
+  prompt,
+  n: 1,
+  image: undefined,
+  aspectRatio: undefined,
+  resolution: undefined,
+  duration: undefined,
+  fps: undefined,
+  seed: undefined,
+  providerOptions: defaultProviderOptions,
+} as const;
+
+function createModel({
+  modelId = 'wan2.6-t2v',
+  headers,
+  currentDate,
+}: {
+  modelId?: string;
+  headers?: Record<string, string | undefined>;
+  currentDate?: () => Date;
+} = {}) {
+  return new AlibabaVideoModel(modelId, {
+    provider: 'alibaba.video',
+    baseURL: TEST_BASE_URL,
+    headers: headers ?? { Authorization: 'Bearer test-api-key' },
+    _internal: { currentDate },
+  });
+}
+
+describe('AlibabaVideoModel', () => {
+  const server = createTestServer({
+    [CREATE_URL]: {
+      response: { type: 'json-value', body: createTaskResponse },
+    },
+    [TASK_URL]: {
+      response: { type: 'json-value', body: succeededTaskResponse },
+    },
+  });
+
+  describe('constructor', () => {
+    it('should expose correct provider and model information', () => {
+      const model = createModel();
+
+      expect(model.provider).toBe('alibaba.video');
+      expect(model.modelId).toBe('wan2.6-t2v');
+      expect(model.specificationVersion).toBe('v3');
+      expect(model.maxVideosPerCall).toBe(1);
+    });
+
+    it('should accept custom model IDs', () => {
+      const model = createModel({ modelId: 'wan2.6-i2v-flash' });
+      expect(model.modelId).toBe('wan2.6-i2v-flash');
+    });
+  });
+
+  describe('doGenerate - text-to-video', () => {
+    it('should send correct request body for T2V', async () => {
+      const model = createModel();
+
+      await model.doGenerate({ ...defaultOptions });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'wan2.6-t2v',
+        input: { prompt },
+        parameters: {},
+      });
+    });
+
+    it('should send size parameter for T2V resolution', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1920x1080',
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        parameters: { size: '1920x1080' },
+      });
+    });
+
+    it('should send duration parameter', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        duration: 10,
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        parameters: { duration: 10 },
+      });
+    });
+
+    it('should send seed parameter', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        seed: 42,
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        parameters: { seed: 42 },
+      });
+    });
+
+    it('should send provider options (negativePrompt, promptExtend, shotType, watermark)', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          alibaba: {
+            negativePrompt: 'blurry, low quality',
+            promptExtend: true,
+            shotType: 'multi',
+            watermark: false,
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        input: {
+          prompt,
+          negative_prompt: 'blurry, low quality',
+        },
+        parameters: {
+          prompt_extend: true,
+          shot_type: 'multi',
+          watermark: false,
+        },
+      });
+    });
+
+    it('should send audioUrl in input', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          alibaba: {
+            audioUrl: 'https://example.com/audio.mp3',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        input: { prompt, audio_url: 'https://example.com/audio.mp3' },
+      });
+    });
+  });
+
+  describe('doGenerate - image-to-video', () => {
+    it('should send img_url from URL-based image for I2V model', async () => {
+      const model = createModel({ modelId: 'wan2.6-i2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        image: {
+          type: 'url',
+          url: 'https://example.com/image.jpg',
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        model: 'wan2.6-i2v',
+        input: {
+          prompt,
+          img_url: 'https://example.com/image.jpg',
+        },
+      });
+    });
+
+    it('should send img_url as base64 from file data', async () => {
+      const model = createModel({ modelId: 'wan2.6-i2v-flash' });
+      const imageData = new Uint8Array([137, 80, 78, 71]); // PNG magic bytes
+
+      await model.doGenerate({
+        ...defaultOptions,
+        image: {
+          type: 'file',
+          data: imageData,
+          mediaType: 'image/png',
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        model: 'wan2.6-i2v-flash',
+        input: {
+          img_url: 'iVBORw==', // base64 of the bytes
+        },
+      });
+    });
+
+    it('should map resolution to I2V format (WxH → "720P"/"1080P")', async () => {
+      const model = createModel({ modelId: 'wan2.6-i2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1920x1080',
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        parameters: { resolution: '1080P' },
+      });
+    });
+
+    it('should map 720p resolution for I2V', async () => {
+      const model = createModel({ modelId: 'wan2.6-i2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1280x720',
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        parameters: { resolution: '720P' },
+      });
+    });
+
+    it('should not send img_url for T2V model even if image provided', async () => {
+      const model = createModel({ modelId: 'wan2.6-t2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        image: {
+          type: 'url',
+          url: 'https://example.com/image.jpg',
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.input).not.toHaveProperty('img_url');
+    });
+
+    it('should send audio provider option for I2V', async () => {
+      const model = createModel({ modelId: 'wan2.6-i2v-flash' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          alibaba: {
+            audio: false,
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        parameters: { audio: false },
+      });
+    });
+  });
+
+  describe('doGenerate - reference-to-video', () => {
+    it('should send reference_urls for R2V model', async () => {
+      const model = createModel({ modelId: 'wan2.6-r2v-flash' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          alibaba: {
+            referenceUrls: [
+              'https://example.com/ref-image.jpg',
+              'https://example.com/ref-video.mp4',
+            ],
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        model: 'wan2.6-r2v-flash',
+        input: {
+          prompt,
+          reference_urls: [
+            'https://example.com/ref-image.jpg',
+            'https://example.com/ref-video.mp4',
+          ],
+        },
+      });
+    });
+
+    it('should send size parameter for R2V resolution', async () => {
+      const model = createModel({ modelId: 'wan2.6-r2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1280x720',
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        parameters: { size: '1280x720' },
+      });
+    });
+
+    it('should not send reference_urls for non-R2V model', async () => {
+      const model = createModel({ modelId: 'wan2.6-t2v' });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          alibaba: {
+            referenceUrls: ['https://example.com/ref.jpg'],
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.input).not.toHaveProperty('reference_urls');
+    });
+  });
+
+  describe('headers', () => {
+    it('should send X-DashScope-Async header on task creation', async () => {
+      const model = createModel();
+
+      await model.doGenerate({ ...defaultOptions });
+
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        'x-dashscope-async': 'enable',
+      });
+    });
+
+    it('should send Authorization header', async () => {
+      const model = createModel();
+
+      await model.doGenerate({ ...defaultOptions });
+
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        authorization: 'Bearer test-api-key',
+      });
+    });
+
+    it('should pass custom headers', async () => {
+      const model = createModel({
+        headers: {
+          Authorization: 'Bearer custom-key',
+          'X-Custom': 'value',
+        },
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        headers: { 'X-Request-Header': 'request-value' },
+      });
+
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        authorization: 'Bearer custom-key',
+        'x-custom': 'value',
+        'x-request-header': 'request-value',
+      });
+    });
+
+    it('should not send X-DashScope-Async header on polling requests', async () => {
+      const model = createModel();
+
+      await model.doGenerate({ ...defaultOptions });
+
+      // calls[0] = task creation, calls[1] = polling
+      expect(server.calls[1].requestHeaders).not.toHaveProperty(
+        'x-dashscope-async',
+      );
+    });
+  });
+
+  describe('warnings', () => {
+    it('should warn about unsupported aspectRatio', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        aspectRatio: '16:9',
+      });
+
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'aspectRatio',
+        }),
+      );
+    });
+
+    it('should warn about unsupported fps', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        fps: 30,
+      });
+
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'fps',
+        }),
+      );
+    });
+
+    it('should warn when n > 1', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        n: 3,
+      });
+
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'n',
+        }),
+      );
+    });
+
+    it('should not warn when n is 1', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        n: 1,
+      });
+
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ feature: 'n' }),
+      );
+    });
+
+    it('should return empty warnings for supported features', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(result.warnings).toStrictEqual([]);
+    });
+  });
+
+  describe('response', () => {
+    it('should return video with correct URL and media type', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(result.videos).toHaveLength(1);
+      expect(result.videos[0]).toStrictEqual({
+        type: 'url',
+        url: 'https://dashscope-result.oss.aliyuncs.com/output/video-001.mp4',
+        mediaType: 'video/mp4',
+      });
+    });
+
+    it('should include timestamp, modelId, and headers in response', async () => {
+      const testDate = new Date('2024-01-01T00:00:00Z');
+      const model = createModel({ currentDate: () => testDate });
+
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(result.response).toStrictEqual({
+        timestamp: testDate,
+        modelId: 'wan2.6-t2v',
+        headers: expect.any(Object),
+      });
+    });
+  });
+
+  describe('providerMetadata', () => {
+    it('should include taskId, videoUrl, actualPrompt, and usage', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(result.providerMetadata).toStrictEqual({
+        alibaba: {
+          taskId: 'task-abc-123',
+          videoUrl:
+            'https://dashscope-result.oss.aliyuncs.com/output/video-001.mp4',
+          actualPrompt: 'An enhanced prompt with more cinematic details',
+          usage: {
+            duration: 5.0,
+            outputVideoDuration: 5,
+            resolution: 1080,
+            size: '1920x1080',
+          },
+        },
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw when no task_id is returned', async () => {
+      server.urls[CREATE_URL].response = {
+        type: 'json-value',
+        body: { output: null, request_id: 'req-003' },
+      };
+
+      const model = createModel();
+
+      await expect(model.doGenerate({ ...defaultOptions })).rejects.toThrow(
+        'No task_id',
+      );
+
+      // Reset
+      server.urls[CREATE_URL].response = {
+        type: 'json-value',
+        body: createTaskResponse,
+      };
+    });
+
+    it('should throw when task status is FAILED', async () => {
+      server.urls[TASK_URL].response = {
+        type: 'json-value',
+        body: {
+          output: {
+            task_id: 'task-abc-123',
+            task_status: 'FAILED',
+            message: 'Content policy violation',
+          },
+          request_id: 'req-004',
+        },
+      };
+
+      const model = createModel();
+
+      await expect(model.doGenerate({ ...defaultOptions })).rejects.toThrow(
+        /failed/i,
+      );
+
+      // Reset
+      server.urls[TASK_URL].response = {
+        type: 'json-value',
+        body: succeededTaskResponse,
+      };
+    });
+
+    it('should throw when task status is CANCELED', async () => {
+      server.urls[TASK_URL].response = {
+        type: 'json-value',
+        body: {
+          output: {
+            task_id: 'task-abc-123',
+            task_status: 'CANCELED',
+          },
+          request_id: 'req-005',
+        },
+      };
+
+      const model = createModel();
+
+      await expect(model.doGenerate({ ...defaultOptions })).rejects.toThrow(
+        /canceled/i,
+      );
+
+      // Reset
+      server.urls[TASK_URL].response = {
+        type: 'json-value',
+        body: succeededTaskResponse,
+      };
+    });
+
+    it('should throw when no video URL in succeeded response', async () => {
+      server.urls[TASK_URL].response = {
+        type: 'json-value',
+        body: {
+          output: {
+            task_id: 'task-abc-123',
+            task_status: 'SUCCEEDED',
+            video_url: null,
+          },
+          request_id: 'req-006',
+        },
+      };
+
+      const model = createModel();
+
+      await expect(model.doGenerate({ ...defaultOptions })).rejects.toThrow(
+        'No video URL',
+      );
+
+      // Reset
+      server.urls[TASK_URL].response = {
+        type: 'json-value',
+        body: succeededTaskResponse,
+      };
+    });
+  });
+
+  describe('polling', () => {
+    it('should poll until SUCCEEDED status', async () => {
+      const originalResponse = server.urls[TASK_URL].response;
+
+      server.urls[TASK_URL].response = ({ callNumber }) => {
+        if (callNumber < 3) {
+          return {
+            type: 'json-value' as const,
+            body: {
+              output: {
+                task_id: 'task-abc-123',
+                task_status: callNumber === 1 ? 'PENDING' : 'RUNNING',
+              },
+              request_id: `req-poll-${callNumber}`,
+            },
+          };
+        }
+        return {
+          type: 'json-value' as const,
+          body: succeededTaskResponse,
+        };
+      };
+
+      const model = createModel();
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(result.videos).toHaveLength(1);
+
+      // Reset
+      server.urls[TASK_URL].response = originalResponse;
+    });
+  });
+});

--- a/packages/alibaba/src/alibaba-video-model.ts
+++ b/packages/alibaba/src/alibaba-video-model.ts
@@ -225,8 +225,9 @@ export class AlibabaVideoModel implements Experimental_VideoModelV3 {
         parameters.resolution =
           resolutionMap[options.resolution] || options.resolution;
       } else {
-        // T2V and R2V use "WIDTHxHEIGHT" format for the size parameter
-        parameters.size = options.resolution;
+        // T2V and R2V use "WIDTH*HEIGHT" format for the size parameter
+        // Convert "WIDTHxHEIGHT" (SDK standard) to "WIDTH*HEIGHT" (Alibaba API)
+        parameters.size = options.resolution.replace('x', '*');
       }
     }
 

--- a/packages/alibaba/src/alibaba-video-model.ts
+++ b/packages/alibaba/src/alibaba-video-model.ts
@@ -1,0 +1,397 @@
+import {
+  AISDKError,
+  type Experimental_VideoModelV3,
+  type SharedV3Warning,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertUint8ArrayToBase64,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  delay,
+  type FetchFunction,
+  getFromApi,
+  lazySchema,
+  parseProviderOptions,
+  postJsonToApi,
+  type Resolvable,
+  resolve,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import type { AlibabaVideoModelId } from './alibaba-video-settings';
+
+export type AlibabaVideoProviderOptions = {
+  /** Negative prompt to specify what to avoid (max 500 chars). */
+  negativePrompt?: string | null;
+  /** URL to audio file for audio-video sync (WAV/MP3, 3-30s, max 15MB). */
+  audioUrl?: string | null;
+  /** Enable prompt extension/rewriting for better generation. Defaults to true. */
+  promptExtend?: boolean | null;
+  /** Shot type: 'single' for single-shot or 'multi' for multi-shot narrative. */
+  shotType?: 'single' | 'multi' | null;
+  /** Whether to add watermark to generated video. Defaults to false. */
+  watermark?: boolean | null;
+  /** Enable audio generation (for I2V/R2V models). */
+  audio?: boolean | null;
+  /**
+   * Reference URLs for reference-to-video mode.
+   * Array of URLs to images (0-5) and/or videos (0-3), max 5 total.
+   * Use character identifiers (character1, character2) in prompts to reference them.
+   */
+  referenceUrls?: string[] | null;
+  /** Polling interval in milliseconds. Defaults to 5000 (5 seconds). */
+  pollIntervalMs?: number | null;
+  /** Maximum wait time in milliseconds for video generation. Defaults to 600000 (10 minutes). */
+  pollTimeoutMs?: number | null;
+  [key: string]: unknown;
+};
+
+const alibabaVideoProviderOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z
+      .object({
+        negativePrompt: z.string().nullish(),
+        audioUrl: z.string().nullish(),
+        promptExtend: z.boolean().nullish(),
+        shotType: z.enum(['single', 'multi']).nullish(),
+        watermark: z.boolean().nullish(),
+        audio: z.boolean().nullish(),
+        referenceUrls: z.array(z.string()).nullish(),
+        pollIntervalMs: z.number().positive().nullish(),
+        pollTimeoutMs: z.number().positive().nullish(),
+      })
+      .passthrough(),
+  ),
+);
+
+interface AlibabaVideoModelConfig {
+  provider: string;
+  baseURL: string;
+  headers: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+// DashScope native API error format (different from OpenAI-compatible endpoint)
+const alibabaVideoErrorSchema = z.object({
+  code: z.string().nullish(),
+  message: z.string(),
+  request_id: z.string().nullish(),
+});
+
+const alibabaVideoFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: alibabaVideoErrorSchema,
+  errorToMessage: data => data.message,
+});
+
+const alibabaVideoCreateTaskSchema = z.object({
+  output: z
+    .object({
+      task_status: z.string(),
+      task_id: z.string(),
+    })
+    .nullish(),
+  request_id: z.string().nullish(),
+});
+
+const alibabaVideoTaskStatusSchema = z.object({
+  output: z
+    .object({
+      task_id: z.string(),
+      task_status: z.string(),
+      video_url: z.string().nullish(),
+      submit_time: z.string().nullish(),
+      scheduled_time: z.string().nullish(),
+      end_time: z.string().nullish(),
+      orig_prompt: z.string().nullish(),
+      actual_prompt: z.string().nullish(),
+      code: z.string().nullish(),
+      message: z.string().nullish(),
+    })
+    .nullish(),
+  usage: z
+    .object({
+      duration: z.number().nullish(),
+      output_video_duration: z.number().nullish(),
+      SR: z.number().nullish(),
+      size: z.string().nullish(),
+    })
+    .nullish(),
+  request_id: z.string().nullish(),
+});
+
+type AlibabaVideoTaskStatusResponse = z.infer<
+  typeof alibabaVideoTaskStatusSchema
+>;
+
+function detectMode(modelId: string): 't2v' | 'i2v' | 'r2v' {
+  if (modelId.includes('-i2v')) return 'i2v';
+  if (modelId.includes('-r2v')) return 'r2v';
+  return 't2v';
+}
+
+export class AlibabaVideoModel implements Experimental_VideoModelV3 {
+  readonly specificationVersion = 'v3';
+  readonly maxVideosPerCall = 1;
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: AlibabaVideoModelId,
+    private readonly config: AlibabaVideoModelConfig,
+  ) {}
+
+  async doGenerate(
+    options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<Experimental_VideoModelV3['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV3Warning[] = [];
+    const mode = detectMode(this.modelId);
+
+    const alibabaOptions = (await parseProviderOptions({
+      provider: 'alibaba',
+      providerOptions: options.providerOptions,
+      schema: alibabaVideoProviderOptionsSchema,
+    })) as AlibabaVideoProviderOptions | undefined;
+
+    // Build input object
+    const input: Record<string, unknown> = {};
+
+    if (options.prompt != null) {
+      input.prompt = options.prompt;
+    }
+
+    if (alibabaOptions?.negativePrompt != null) {
+      input.negative_prompt = alibabaOptions.negativePrompt;
+    }
+
+    if (alibabaOptions?.audioUrl != null) {
+      input.audio_url = alibabaOptions.audioUrl;
+    }
+
+    // Handle image input for I2V mode
+    if (mode === 'i2v' && options.image != null) {
+      if (options.image.type === 'url') {
+        input.img_url = options.image.url;
+      } else {
+        const base64Data =
+          typeof options.image.data === 'string'
+            ? options.image.data
+            : convertUint8ArrayToBase64(options.image.data);
+        input.img_url = base64Data;
+      }
+    }
+
+    // Handle reference URLs for R2V mode
+    if (mode === 'r2v' && alibabaOptions?.referenceUrls != null) {
+      input.reference_urls = alibabaOptions.referenceUrls;
+    }
+
+    // Build parameters object
+    const parameters: Record<string, unknown> = {};
+
+    if (options.duration != null) {
+      parameters.duration = options.duration;
+    }
+
+    if (options.seed != null) {
+      parameters.seed = options.seed;
+    }
+
+    // Resolution / Size mapping
+    if (options.resolution != null) {
+      if (mode === 'i2v') {
+        // I2V uses "720P" / "1080P" format
+        const resolutionMap: Record<string, string> = {
+          '1280x720': '720P',
+          '720x1280': '720P',
+          '960x960': '720P',
+          '1088x832': '720P',
+          '832x1088': '720P',
+          '1920x1080': '1080P',
+          '1080x1920': '1080P',
+          '1440x1440': '1080P',
+          '1632x1248': '1080P',
+          '1248x1632': '1080P',
+          '832x480': '480P',
+          '480x832': '480P',
+          '624x624': '480P',
+        };
+        parameters.resolution =
+          resolutionMap[options.resolution] || options.resolution;
+      } else {
+        // T2V and R2V use "WIDTHxHEIGHT" format for the size parameter
+        parameters.size = options.resolution;
+      }
+    }
+
+    // Provider-specific parameters
+    if (alibabaOptions?.promptExtend != null) {
+      parameters.prompt_extend = alibabaOptions.promptExtend;
+    }
+    if (alibabaOptions?.shotType != null) {
+      parameters.shot_type = alibabaOptions.shotType;
+    }
+    if (alibabaOptions?.watermark != null) {
+      parameters.watermark = alibabaOptions.watermark;
+    }
+    if (alibabaOptions?.audio != null) {
+      parameters.audio = alibabaOptions.audio;
+    }
+
+    // Warn about unsupported standard options
+    if (options.aspectRatio) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'aspectRatio',
+        details:
+          'Alibaba video models use explicit size/resolution dimensions. Use the resolution option or providerOptions.alibaba for size control.',
+      });
+    }
+    if (options.fps) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'fps',
+        details: 'Alibaba video models do not support custom FPS.',
+      });
+    }
+    if (options.n != null && options.n > 1) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'n',
+        details:
+          'Alibaba video models only support generating 1 video per call.',
+      });
+    }
+
+    // Step 1: Create task
+    const { value: createResponse } = await postJsonToApi({
+      url: `${this.config.baseURL}/api/v1/services/aigc/video-generation/video-synthesis`,
+      headers: combineHeaders(
+        await resolve(this.config.headers),
+        options.headers,
+        {
+          'X-DashScope-Async': 'enable',
+        },
+      ),
+      body: {
+        model: this.modelId,
+        input,
+        parameters,
+      },
+      successfulResponseHandler: createJsonResponseHandler(
+        alibabaVideoCreateTaskSchema,
+      ),
+      failedResponseHandler: alibabaVideoFailedResponseHandler,
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const taskId = createResponse.output?.task_id;
+    if (!taskId) {
+      throw new AISDKError({
+        name: 'ALIBABA_VIDEO_GENERATION_ERROR',
+        message: `No task_id returned from Alibaba API. Response: ${JSON.stringify(createResponse)}`,
+      });
+    }
+
+    // Step 2: Poll for task completion
+    const pollIntervalMs = alibabaOptions?.pollIntervalMs ?? 5000;
+    const pollTimeoutMs = alibabaOptions?.pollTimeoutMs ?? 600000;
+    const startTime = Date.now();
+    let finalResponse: AlibabaVideoTaskStatusResponse | undefined;
+    let responseHeaders: Record<string, string> | undefined;
+
+    while (true) {
+      await delay(pollIntervalMs, { abortSignal: options.abortSignal });
+
+      if (Date.now() - startTime > pollTimeoutMs) {
+        throw new AISDKError({
+          name: 'ALIBABA_VIDEO_GENERATION_TIMEOUT',
+          message: `Video generation timed out after ${pollTimeoutMs}ms`,
+        });
+      }
+
+      const { value: statusResponse, responseHeaders: pollHeaders } =
+        await getFromApi({
+          url: `${this.config.baseURL}/api/v1/tasks/${taskId}`,
+          headers: combineHeaders(
+            await resolve(this.config.headers),
+            options.headers,
+          ),
+          successfulResponseHandler: createJsonResponseHandler(
+            alibabaVideoTaskStatusSchema,
+          ),
+          failedResponseHandler: alibabaVideoFailedResponseHandler,
+          abortSignal: options.abortSignal,
+          fetch: this.config.fetch,
+        });
+
+      responseHeaders = pollHeaders;
+      const taskStatus = statusResponse.output?.task_status;
+
+      if (taskStatus === 'SUCCEEDED') {
+        finalResponse = statusResponse;
+        break;
+      }
+
+      if (taskStatus === 'FAILED' || taskStatus === 'CANCELED') {
+        throw new AISDKError({
+          name: 'ALIBABA_VIDEO_GENERATION_FAILED',
+          message: `Video generation ${taskStatus.toLowerCase()}. Task ID: ${taskId}. ${statusResponse.output?.message ?? ''}`,
+        });
+      }
+
+      // Continue polling for PENDING, RUNNING, UNKNOWN statuses
+    }
+
+    const videoUrl = finalResponse?.output?.video_url;
+    if (!videoUrl) {
+      throw new AISDKError({
+        name: 'ALIBABA_VIDEO_GENERATION_ERROR',
+        message: `No video URL in response. Task ID: ${taskId}`,
+      });
+    }
+
+    return {
+      videos: [
+        {
+          type: 'url',
+          url: videoUrl,
+          mediaType: 'video/mp4',
+        },
+      ],
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+      },
+      providerMetadata: {
+        alibaba: {
+          taskId,
+          videoUrl,
+          ...(finalResponse?.output?.actual_prompt
+            ? { actualPrompt: finalResponse.output.actual_prompt }
+            : {}),
+          ...(finalResponse?.usage
+            ? {
+                usage: {
+                  duration: finalResponse.usage.duration,
+                  outputVideoDuration:
+                    finalResponse.usage.output_video_duration,
+                  resolution: finalResponse.usage.SR,
+                  size: finalResponse.usage.size,
+                },
+              }
+            : {}),
+        },
+      },
+    };
+  }
+}

--- a/packages/alibaba/src/alibaba-video-settings.ts
+++ b/packages/alibaba/src/alibaba-video-settings.ts
@@ -1,0 +1,11 @@
+export type AlibabaVideoModelId =
+  // Text-to-Video
+  | 'wan2.6-t2v'
+  | 'wan2.5-t2v-preview'
+  // Image-to-Video (first frame)
+  | 'wan2.6-i2v'
+  | 'wan2.6-i2v-flash'
+  // Reference-to-Video
+  | 'wan2.6-r2v'
+  | 'wan2.6-r2v-flash'
+  | (string & {});

--- a/packages/alibaba/src/alibaba-video-settings.ts
+++ b/packages/alibaba/src/alibaba-video-settings.ts
@@ -1,3 +1,4 @@
+// https://www.alibabacloud.com/help/en/model-studio/use-video-generation
 export type AlibabaVideoModelId =
   // Text-to-Video
   | 'wan2.6-t2v'

--- a/packages/alibaba/src/convert-alibaba-usage.ts
+++ b/packages/alibaba/src/convert-alibaba-usage.ts
@@ -1,5 +1,5 @@
-import { LanguageModelV3Usage } from '@ai-sdk/provider';
 import { convertOpenAICompatibleChatUsage } from '@ai-sdk/openai-compatible/internal';
+import type { LanguageModelV3Usage } from '@ai-sdk/provider';
 
 export type AlibabaUsage = {
   prompt_tokens?: number | null;

--- a/packages/alibaba/src/convert-to-alibaba-chat-messages.ts
+++ b/packages/alibaba/src/convert-to-alibaba-chat-messages.ts
@@ -1,11 +1,11 @@
 import {
-  LanguageModelV3DataContent,
-  LanguageModelV3Prompt,
+  type LanguageModelV3DataContent,
+  type LanguageModelV3Prompt,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { convertToBase64 } from '@ai-sdk/provider-utils';
-import { AlibabaChatPrompt } from './alibaba-chat-prompt';
-import { CacheControlValidator } from './get-cache-control';
+import type { AlibabaChatPrompt } from './alibaba-chat-prompt';
+import type { CacheControlValidator } from './get-cache-control';
 
 function formatImageUrl({
   data,

--- a/packages/alibaba/src/get-cache-control.ts
+++ b/packages/alibaba/src/get-cache-control.ts
@@ -1,5 +1,8 @@
-import { SharedV3Warning, SharedV3ProviderMetadata } from '@ai-sdk/provider';
-import { AlibabaCacheControl } from './alibaba-chat-prompt';
+import type {
+  SharedV3ProviderMetadata,
+  SharedV3Warning,
+} from '@ai-sdk/provider';
+import type { AlibabaCacheControl } from './alibaba-chat-prompt';
 
 // Alibaba allows a maximum of 4 cache breakpoints per request
 const MAX_CACHE_BREAKPOINTS = 4;

--- a/packages/alibaba/src/index.ts
+++ b/packages/alibaba/src/index.ts
@@ -1,13 +1,14 @@
-export { createAlibaba, alibaba } from './alibaba-provider';
-export type {
-  AlibabaProvider,
-  AlibabaProviderSettings,
-} from './alibaba-provider';
 export type {
   AlibabaChatModelId,
   AlibabaProviderOptions,
 } from './alibaba-chat-options';
 export type { AlibabaCacheControl } from './alibaba-chat-prompt';
+export {
+  type AlibabaProvider,
+  type AlibabaProviderSettings,
+  alibaba,
+  createAlibaba,
+} from './alibaba-provider';
 export type { AlibabaVideoProviderOptions } from './alibaba-video-model';
 export type { AlibabaVideoModelId } from './alibaba-video-settings';
 export type { AlibabaUsage } from './convert-alibaba-usage';

--- a/packages/alibaba/src/index.ts
+++ b/packages/alibaba/src/index.ts
@@ -8,5 +8,7 @@ export type {
   AlibabaProviderOptions,
 } from './alibaba-chat-options';
 export type { AlibabaCacheControl } from './alibaba-chat-prompt';
+export type { AlibabaVideoProviderOptions } from './alibaba-video-model';
+export type { AlibabaVideoModelId } from './alibaba-video-settings';
 export type { AlibabaUsage } from './convert-alibaba-usage';
 export { VERSION } from './version';


### PR DESCRIPTION
## Background

The Alibaba Cloud DashScope API offers video generation capabilities through their Wan models, but these were not yet supported in the AI SDK. Adding this functionality allows developers to generate videos using text-to-video, image-to-video, and reference-to-video approaches with the Alibaba provider.

## Summary

Added video generation support to the Alibaba provider in AI SDK. This implementation:

- Adds the `.video()` factory method to create Alibaba video models
- Supports three video generation modes:
    - Text-to-video: Generate videos from text prompts
    - Image-to-video: Generate videos from a first-frame image
    - Reference-to-video: Generate videos with character consistency using reference images/videos
- Implements asynchronous task creation and polling for video generation
- Provides comprehensive provider options for customization (negative prompts, audio settings, etc.)
- Includes detailed documentation and examples for each video generation mode
- Adds capability tables showing supported resolutions and durations for each model

## Manual Verification

Tested the implementation against the Alibaba Cloud DashScope API with various models and parameters to ensure proper request formatting, response handling, and error management. Verified that the polling mechanism correctly handles task status updates and retrieves the final video URL.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)