### PR TITLE
feat(ci): run prettier fix when the check fails

### DIFF
--- a/.github/workflows/prettier-autofix.yml
+++ b/.github/workflows/prettier-autofix.yml
@@ -1,0 +1,134 @@
+name: Prettier Autofix
+
+on:
+  check_run:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  autofix:
+    name: Autofix Prettier
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Only run when:
+    # 1. The Prettier check failed
+    # 2. It's associated with a PR
+    # 3. The PR does NOT have auto-merge enabled (that's handled by prettier-on-automerge.yml)
+    if: |
+      github.event.check_run.name == 'Prettier' &&
+      github.event.check_run.conclusion == 'failure' &&
+      github.event.check_run.pull_requests[0] != null &&
+      github.event.check_run.pull_requests[0].auto_merge == null
+
+    steps:
+      - name: Create access token for GitHub App
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8 }}
+
+      - name: Get PR details
+        id: pr-details
+        run: |
+          PR_NUMBER="${{ github.event.check_run.pull_requests[0].number }}"
+          HEAD_SHA="${{ github.event.check_run.pull_requests[0].head.sha }}"
+          HEAD_REF="${{ github.event.check_run.pull_requests[0].head.ref }}"
+          HEAD_REPO="${{ github.event.check_run.pull_requests[0].head.repo.full_name }}"
+
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+          echo "repo_full_name=$HEAD_REPO" >> "$GITHUB_OUTPUT"
+
+          # Check if this is a same-repo PR or a fork
+          if [[ "$HEAD_REPO" == "${{ github.repository }}" ]]; then
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+            echo "PR is from the same repository"
+          else
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+            echo "PR is from a fork: $HEAD_REPO"
+          fi
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # For fork PRs: post a comment with instructions
+      - name: Post comment for fork PRs
+        if: steps.pr-details.outputs.is_fork == 'true'
+        run: |
+          gh pr comment ${{ steps.pr-details.outputs.number }} --body "$(cat <<'EOF'
+          The prettier check failed on this PR. 
+
+          Please run the following command locally and push the changes:
+
+          ```bash
+          pnpm prettier-fix
+          ```
+
+          Then commit and push the changes to your branch.
+          EOF
+          )"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # For same-repo PRs: fix and push automatically
+      - name: Get GitHub App User ID
+        if: steps.pr-details.outputs.is_fork == 'false'
+        id: app-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git user for GitHub App
+        if: steps.pr-details.outputs.is_fork == 'false'
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.app-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
+      - name: Checkout Repository
+        if: steps.pr-details.outputs.is_fork == 'false'
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ steps.pr-details.outputs.sha }}
+
+      - name: Setup pnpm
+        if: steps.pr-details.outputs.is_fork == 'false'
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: steps.pr-details.outputs.is_fork == 'false'
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.pr-details.outputs.is_fork == 'false'
+        run: pnpm install
+
+      - name: Run Prettier
+        if: steps.pr-details.outputs.is_fork == 'false'
+        run: pnpm prettier-fix
+
+      - name: Check for changes
+        if: steps.pr-details.outputs.is_fork == 'false'
+        id: git-check
+        run: |
+          git add -A
+          if git diff --staged --quiet; then
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
+            echo "No changes detected"
+          else
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changes detected"
+          fi
+
+      - name: Commit and push changes
+        if: steps.pr-details.outputs.is_fork == 'false' && steps.git-check.outputs.has-changes == 'true'
+        run: |
+          git commit -m "style: prettier"
+          git push origin HEAD:${{ steps.pr-details.outputs.ref }}


### PR DESCRIPTION
## Background

manually telling people to run prettier-fix increases the turnaround time to how quickly we respond to community prs

eg: https://github.com/vercel/ai/pull/12324#pullrequestreview-3776037970

## Summary

new github workflow that triggers when the prettier check fails in CI and then:
- runs `pnpm prettier-fix` and commits the changes if the repo is `vercel/ai`
- comments to tell the contributor to run `pnpm prettier-fix` when the pr is on a fork