### PR TITLE
fix(openai): send content: null instead of "" for tool-call-only assistant messages

### DIFF
--- a/.changeset/fix-tool-call-content-null.md
+++ b/.changeset/fix-tool-call-content-null.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): send content: null instead of content: "" for tool-call-only assistant messages

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
@@ -455,7 +455,7 @@ describe('tool calls', () => {
     expect(result.messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             type: 'function',
@@ -471,6 +471,77 @@ describe('tool calls', () => {
         role: 'tool',
         content: JSON.stringify({ oof: '321rab' }),
         tool_call_id: 'quux',
+      },
+    ]);
+  });
+
+  it('should send content as null for tool-call-only assistant messages', () => {
+    const result = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              input: { location: 'Seattle' },
+              toolCallId: 'call_1',
+              toolName: 'get_weather',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.messages).toEqual([
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            type: 'function',
+            id: 'call_1',
+            function: {
+              name: 'get_weather',
+              arguments: JSON.stringify({ location: 'Seattle' }),
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should preserve text content alongside tool calls', () => {
+    const result = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Let me check the weather.' },
+            {
+              type: 'tool-call',
+              input: { location: 'Seattle' },
+              toolCallId: 'call_1',
+              toolName: 'get_weather',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.messages).toEqual([
+      {
+        role: 'assistant',
+        content: 'Let me check the weather.',
+        tool_calls: [
+          {
+            type: 'function',
+            id: 'call_1',
+            function: {
+              name: 'get_weather',
+              arguments: JSON.stringify({ location: 'Seattle' }),
+            },
+          },
+        ],
       },
     ]);
   });

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -175,7 +175,7 @@ export function convertToOpenAIChatMessages({
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 


### PR DESCRIPTION
## Summary

- `convertToOpenAIChatMessages` now sends `content: null` instead of `content: ""` for assistant messages that only contain tool calls and no text content
- Per the [OpenAI API spec](https://platform.openai.com/docs/api-reference/chat/create), `content` on assistant messages is nullable — their examples show `content: null` when the assistant only makes tool calls
- The type definition (`ChatCompletionAssistantMessage`) already declared `content?: string | null`, so this aligns the runtime behavior with the type

## Motivation

Sending `content: ""` causes issues with OpenAI-compatible providers (e.g. Ollama) where the empty string is rendered differently by model templates. Specifically, with Ollama + qwen3-coder, the empty string in prior assistant messages causes the model to switch from structured `tool_calls` to text-based markup (`<function=name>`) on subsequent turns, breaking multi-turn tool calling.

Verified via curl testing that the same conversation with `content: null` keeps the model in structured tool-calling mode, while `content: ""` causes mode switching.

Also filed on the Ollama side: https://github.com/ollama/ollama/issues/14181

## Test plan

- [x] Updated existing test: tool-call-only assistant messages now expect `content: null`
- [x] Added test: tool-call-only assistant messages produce `content: null`
- [x] Added test: assistant messages with both text and tool calls preserve text in `content`
- [x] All 21 tests in `convert-to-openai-chat-messages.test.ts` pass

Fixes #12389