### PR TITLE
fix(devtools): fix dev mode detection for repos in /src/ paths

### DIFF
--- a/.changeset/five-shirts-learn.md
+++ b/.changeset/five-shirts-learn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/devtools': patch
+---
+
+Fix dev mode detection to prevent false positives when repos are in paths containing '/src/'

--- a/packages/devtools/src/viewer/server.ts
+++ b/packages/devtools/src/viewer/server.ts
@@ -238,17 +238,13 @@ app.get('*', async c => {
 });
 
 export const startViewer = (port = 4983) => {
-  const isDev =
-    process.env.NODE_ENV === 'development' ||
-    !process.argv[1]?.includes('/dist/');
-
   const server = serve(
     {
       fetch: app.fetch,
       port,
     },
     () => {
-      if (isDev) {
+      if (isDevMode) {
         console.log(`🔍 AI SDK DevTools API running on port ${port}`);
         console.log(`   Open http://localhost:5173 for the dev UI`);
       } else {

--- a/packages/devtools/src/viewer/server.ts
+++ b/packages/devtools/src/viewer/server.ts
@@ -37,8 +37,9 @@ const broadcastToClients = (event: string, data: Record<string, unknown>) => {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Determine if we're running from source (tsx) or built (dist)
+// We're in dev mode if NOT running from the dist folder
 const isDevMode =
-  __dirname.includes('/src/') || process.env.NODE_ENV === 'development';
+  !__dirname.includes('/dist/') || process.env.NODE_ENV === 'development';
 const projectRoot = isDevMode
   ? path.resolve(__dirname, '../..')
   : path.resolve(__dirname, '../..');
@@ -239,7 +240,7 @@ app.get('*', async c => {
 export const startViewer = (port = 4983) => {
   const isDev =
     process.env.NODE_ENV === 'development' ||
-    process.argv[1]?.includes('/src/');
+    !process.argv[1]?.includes('/dist/');
 
   const server = serve(
     {


### PR DESCRIPTION
Fixes dev mode detection that was incorrectly triggering when repos were checked out under paths containing `/src/` (e.g., `~/src/my-project`).

Changed the check from looking for `/src/` in the path to checking for the absence of `/dist/`, which correctly identifies whether code is running from compiled output or source.