### PR TITLE
fix(vertex): add fallback for providerOptions key

### DIFF
--- a/.changeset/clean-books-peel.md
+++ b/.changeset/clean-books-peel.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(vertex): add fallback for providerOptions keyname

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -82,7 +82,11 @@ export function convertToGoogleGenerativeAIMessages(
           role: 'model',
           parts: content
             .map(part => {
-              const providerOpts = part.providerOptions?.[providerOptionsName];
+              const providerOpts =
+                part.providerOptions?.[providerOptionsName] ??
+                (providerOptionsName !== 'google'
+                  ? part.providerOptions?.google
+                  : undefined);
               const thoughtSignature =
                 providerOpts?.thoughtSignature != null
                   ? String(providerOpts.thoughtSignature)


### PR DESCRIPTION
## Background

multi step tool calls fail because the `thoughtSignature` gets lost due to a key mismatch in providerOptions. 
if the `thoughtSignature` is passed under the google key, the vertex provider silently drops it. the api then rejects the request and we see the errors as observed in #12351 

## Summary

fallback check to see if `vertex` key doesn't have a `thoughtSignature`, we check if it's passed within the google key

## Manual Verification

verified via the repro code given in the original issue, which is resolved after the fix

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #12351 