### PR TITLE
test(provider/cohere): add back usage and metadata standalone tests

### DIFF
--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -612,6 +612,54 @@ describe('doGenerate', () => {
         }
       `);
     });
+
+    it('should extract usage', async () => {
+      prepareJsonFixtureResponse('cohere-text');
+
+      const { usage } = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(usage).toMatchInlineSnapshot(`
+        {
+          "inputTokens": {
+            "cacheRead": undefined,
+            "cacheWrite": undefined,
+            "noCache": 507,
+            "total": 507,
+          },
+          "outputTokens": {
+            "reasoning": undefined,
+            "text": 10,
+            "total": 10,
+          },
+          "raw": {
+            "input_tokens": 507,
+            "output_tokens": 10,
+          },
+        }
+      `);
+    });
+
+    it('should send additional response information', async () => {
+      prepareJsonFixtureResponse('cohere-text');
+
+      const { response } = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect({
+        id: response?.id,
+        timestamp: response?.timestamp,
+        modelId: response?.modelId,
+      }).toMatchInlineSnapshot(`
+        {
+          "id": undefined,
+          "modelId": undefined,
+          "timestamp": undefined,
+        }
+      `);
+    });
   });
 });
 


### PR DESCRIPTION
## background

the fixture migration PR (#12374) removed `should extract usage` and `should send additional response information` standalone tests, which were subsumed by full-object snapshots. adding them back for explicit specificity

## summary

- add `should extract usage` standalone test using the text fixture
- add `should send additional response information` standalone test using the text fixture

## verification

<details>
<summary>tests pass</summary>

```
 ✓ src/cohere-chat-language-model.test.ts  (31 tests) 81ms

 Test Files  5 passed (5)
      Tests  62 passed (62)
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [ ] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)