### PR TITLE
feat(anthropic): support for user_id through metadata

### DIFF
--- a/.changeset/little-flowers-return.md
+++ b/.changeset/little-flowers-return.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Adds support for user_id through the metadata option. This is used for safety purposes by anthropic, similiar to user id and safety identifiers in other providers.

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -141,6 +141,12 @@ The following optional provider options are available for Anthropic models:
   - `"jsonTool"`: Use a special `"json"` tool to specify the structured output format.
   - `"auto"`: Use `"outputFormat"` when supported, otherwise fall back to `"jsonTool"` (default).
 
+- `metadata` _object_
+
+  Optional. An object describing metadata about the request.
+
+  - `userId` _string_ - An external identifier for the user associated with the request. Should be a uuid, hash value, or other opaque identifier. Do not include identifying information such as name, email, or phone number. Max 256 characters.
+
 ### Structured Outputs and Tool Input Streaming
 
 Tool call streaming is enabled by default. You can opt out by setting the

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -1410,6 +1410,41 @@ describe('AnthropicMessagesLanguageModel', () => {
       });
     });
 
+    it('should pass metadata with user_id', async () => {
+      prepareJsonResponse({});
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            metadata: {
+              userId: 'test-user-id',
+            },
+          } satisfies AnthropicProviderOptions,
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        metadata: {
+          user_id: 'test-user-id',
+        },
+      });
+    });
+
+    it('should not send metadata when not provided', async () => {
+      prepareJsonResponse({});
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {} satisfies AnthropicProviderOptions,
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).not.toHaveProperty('metadata');
+    });
+
     it('should pass headers', async () => {
       prepareJsonResponse({ content: [] });
 
@@ -8041,6 +8076,29 @@ describe('AnthropicMessagesLanguageModel', () => {
 
         expect(await server.calls[0].requestBodyJson).toMatchObject({
           tool_choice: { type: 'auto', disable_parallel_tool_use: true },
+        });
+      });
+
+      it('should accept metadata with custom provider name key', async () => {
+        prepareCustomJsonResponse();
+
+        const customModel = createCustomModel('my-custom-anthropic');
+
+        await customModel.doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            'my-custom-anthropic': {
+              metadata: {
+                userId: 'custom-user-id',
+              },
+            },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          metadata: {
+            user_id: 'custom-user-id',
+          },
         });
       });
     });

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -354,6 +354,13 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
         speed: anthropicOptions.speed,
       }),
 
+      // metadata:
+      ...(anthropicOptions?.metadata && {
+        metadata: {
+          user_id: anthropicOptions.metadata.userId,
+        },
+      }),
+
       // structured output:
       ...(useStructuredOutput &&
         responseFormat?.type === 'json' &&

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -99,6 +99,24 @@ export const anthropicProviderOptions = z.object({
     .optional(),
 
   /**
+   * An object describing metadata about the request.
+   */
+  metadata: z
+    .object({
+      /**
+       * An external identifier for the user who is associated with the request.
+       *
+       * This should be a uuid, hash value, or other opaque identifier.
+       * Anthropic may use this id to help detect abuse. Do not include any
+       * identifying information such as name, email address, or phone number.
+       *
+       * Max length: 256 characters.
+       */
+      userId: z.string().optional(),
+    })
+    .optional(),
+
+  /**
    * Whether to disable parallel function calling during tool use. Default is false.
    * When set to true, Claude will use at most one tool per response.
    */


### PR DESCRIPTION
The metadata field could reasonably be expanded by anthropic to include more fields, but for now it supports user_id


> An external identifier for the user who is associated with the request.
> 
> This should be a uuid, hash value, or other opaque identifier. Anthropic may use this id to help detect abuse. Do not include any identifying information such as name, email address, or phone number.
> 
> maxLength256

https://platform.claude.com/docs/en/api/messages#metadata

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

## Summary

<!-- What did you change? -->

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->
anthropic may add more fields to the metadata object
## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
Fixes #12386