### PR TITLE
fix(provider/xai): correct usage token calculation for reasoning models

### DIFF
--- a/.changeset/swift-berries-confess.md
+++ b/.changeset/swift-berries-confess.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(provider/xai): correct usage token calculation for reasoning models

--- a/examples/ai-functions/src/generate-text/xai-usage-full.ts
+++ b/examples/ai-functions/src/generate-text/xai-usage-full.ts
@@ -1,0 +1,44 @@
+import { xai } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
+
+const models = [
+  'grok-4',
+  'grok-4-1-fast-reasoning',
+  'grok-4-1-fast-non-reasoning',
+  'grok-4-fast-reasoning',
+  'grok-4-fast-non-reasoning',
+  'grok-code-fast-1',
+  'grok-3',
+  'grok-3-fast',
+  'grok-3-mini',
+  'grok-3-mini-fast',
+];
+
+run(async () => {
+  for (const modelId of models) {
+    try {
+      const result = await generateText({
+        model: xai(modelId),
+        prompt: 'Say a single word.',
+      });
+
+      const body = result.response.body as Record<string, any>;
+      const raw = body.usage;
+      const sdk = result.usage;
+
+      console.log(`--- ${modelId} ---`);
+      console.log(
+        `raw: completion_tokens=${raw.completion_tokens}, reasoning_tokens=${raw.completion_tokens_details?.reasoning_tokens ?? 0}, total_tokens=${raw.total_tokens}`,
+      );
+      console.log(
+        `sdk: outputTokens=${sdk.outputTokens}, textTokens=${sdk.outputTokenDetails?.textTokens}, reasoningTokens=${sdk.outputTokenDetails?.reasoningTokens}, totalTokens=${sdk.totalTokens}`,
+      );
+      console.log();
+    } catch (e: any) {
+      console.log(`--- ${modelId} ---`);
+      console.log(`error: ${e.message?.slice(0, 80)}`);
+      console.log();
+    }
+  }
+});

--- a/examples/ai-functions/src/generate-text/xai-usage.ts
+++ b/examples/ai-functions/src/generate-text/xai-usage.ts
@@ -1,0 +1,16 @@
+import { xai } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: xai('grok-3-mini'),
+    prompt: 'Say a single word.',
+  });
+
+  console.log('text:', result.text);
+  console.log();
+  console.log('raw usage:', JSON.stringify(result.response.body, null, 2));
+  console.log();
+  console.log('sdk usage:', JSON.stringify(result.usage, null, 2));
+});

--- a/examples/ai-functions/src/stream-text/xai-usage-full.ts
+++ b/examples/ai-functions/src/stream-text/xai-usage-full.ts
@@ -1,0 +1,43 @@
+import { xai } from '@ai-sdk/xai';
+import { streamText } from 'ai';
+import { run } from '../lib/run';
+
+const models = [
+  'grok-4',
+  'grok-4-1-fast-reasoning',
+  'grok-4-1-fast-non-reasoning',
+  'grok-4-fast-reasoning',
+  'grok-4-fast-non-reasoning',
+  'grok-code-fast-1',
+  'grok-3',
+  'grok-3-fast',
+  'grok-3-mini',
+  'grok-3-mini-fast',
+];
+
+run(async () => {
+  for (const modelId of models) {
+    try {
+      const result = streamText({
+        model: xai(modelId),
+        prompt: 'Say a single word.',
+      });
+
+      for await (const textPart of result.textStream) {
+        void textPart;
+      }
+
+      const sdk = await result.usage;
+
+      console.log(`--- ${modelId} ---`);
+      console.log(
+        `sdk: outputTokens=${sdk.outputTokens}, textTokens=${sdk.outputTokenDetails?.textTokens}, reasoningTokens=${sdk.outputTokenDetails?.reasoningTokens}, totalTokens=${sdk.totalTokens}`,
+      );
+      console.log();
+    } catch (e: any) {
+      console.log(`--- ${modelId} ---`);
+      console.log(`error: ${e.message?.slice(0, 80)}`);
+      console.log();
+    }
+  }
+});

--- a/examples/ai-functions/src/stream-text/xai-usage.ts
+++ b/examples/ai-functions/src/stream-text/xai-usage.ts
@@ -1,0 +1,18 @@
+import { xai } from '@ai-sdk/xai';
+import { streamText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: xai('grok-3-mini'),
+    prompt: 'Say a single word.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log();
+  console.log('sdk usage:', JSON.stringify(await result.usage, null, 2));
+});

--- a/packages/xai/src/__snapshots__/xai-chat-language-model.test.ts.snap
+++ b/packages/xai/src/__snapshots__/xai-chat-language-model.test.ts.snap
@@ -97,8 +97,8 @@ Response: I'll go with "Hello" as it's a common greeting and keeps it simple.",
     },
     "outputTokens": {
       "reasoning": 228,
-      "text": -227,
-      "total": 1,
+      "text": 1,
+      "total": 229,
     },
     "raw": {
       "completion_tokens": 1,
@@ -235,8 +235,8 @@ I should call this function to advance the user's request.",
     },
     "outputTokens": {
       "reasoning": 189,
-      "text": -163,
-      "total": 26,
+      "text": 26,
+      "total": 215,
     },
     "raw": {
       "completion_tokens": 26,
@@ -333,8 +333,8 @@ exports[`XaiChatLanguageModel > doStream > text > should stream text content 1`]
       },
       "outputTokens": {
         "reasoning": 290,
-        "text": -289,
-        "total": 1,
+        "text": 1,
+        "total": 291,
       },
       "raw": {
         "completion_tokens": 1,
@@ -438,8 +438,8 @@ exports[`XaiChatLanguageModel > doStream > tool call > should stream tool call c
       },
       "outputTokens": {
         "reasoning": 196,
-        "text": -170,
-        "total": 26,
+        "text": 26,
+        "total": 222,
       },
       "raw": {
         "completion_tokens": 26,

--- a/packages/xai/src/convert-xai-chat-usage.ts
+++ b/packages/xai/src/convert-xai-chat-usage.ts
@@ -14,8 +14,8 @@ export function convertXaiChatUsage(usage: XaiChatUsage): LanguageModelV3Usage {
       cacheWrite: undefined,
     },
     outputTokens: {
-      total: usage.completion_tokens,
-      text: usage.completion_tokens - reasoningTokens,
+      total: usage.completion_tokens + reasoningTokens,
+      text: usage.completion_tokens,
       reasoning: reasoningTokens,
     },
     raw: usage,

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -107,8 +107,8 @@ describe('XaiChatLanguageModel', () => {
           },
           "outputTokens": {
             "reasoning": 228,
-            "text": -227,
-            "total": 1,
+            "text": 1,
+            "total": 229,
           },
           "raw": {
             "completion_tokens": 1,
@@ -1218,8 +1218,8 @@ describe('XaiChatLanguageModel', () => {
           },
           "outputTokens": {
             "reasoning": 228,
-            "text": -227,
-            "total": 1,
+            "text": 1,
+            "total": 229,
           },
           "raw": {
             "completion_tokens": 1,
@@ -1358,8 +1358,8 @@ describe('XaiChatLanguageModel', () => {
               },
               "outputTokens": {
                 "reasoning": 10,
-                "text": 10,
-                "total": 20,
+                "text": 20,
+                "total": 30,
               },
               "raw": {
                 "completion_tokens": 20,


### PR DESCRIPTION
## background

follow-up to #11536 — xAI's API reports `completion_tokens` as text-only, with `reasoning_tokens` separate in `completion_tokens_details` (unlike OpenAI which includes reasoning in `completion_tokens`). per [xAI docs](https://docs.x.ai/docs/key-information/consumption-and-rate-limits): "reasoning token consumption will be counted separately from completion_tokens, but will be counted in the total_tokens"

this results in negative `textTokens` and underreported `outputTokens` for all reasoning models (grok-4, grok-3-mini, grok-3-mini-fast, grok-code-fast-1, etc.)

## summary

- change `outputTokens.total` from `completion_tokens` to `completion_tokens + reasoningTokens`
- change `outputTokens.text` from `completion_tokens - reasoningTokens` to `completion_tokens`
- rewrite unit tests with real xAI API token values

## verification

<details>
<summary>before (negative tokens)</summary>

```
--- grok-3-mini ---
raw: completion_tokens=2, reasoning_tokens=317, total_tokens=331
sdk: outputTokens=2, textTokens=-315, reasoningTokens=317, totalTokens=14
```

</details>

<details>
<summary>after (correct)</summary>

```
--- grok-3-mini ---
raw: completion_tokens=1, reasoning_tokens=386, total_tokens=399
sdk: outputTokens=387, textTokens=1, reasoningTokens=386, totalTokens=399
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)