### PR TITLE
test(provider/google): rewrite tests to use fixture-based pattern

### DIFF
--- a/packages/google/src/__snapshots__/google-generative-ai-embedding-model.test.ts.snap
+++ b/packages/google/src/__snapshots__/google-generative-ai-embedding-model.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`GoogleGenerativeAIEmbeddingModel > should expose the raw response 1`] = `
+exports[`GoogleGenerativeAIEmbeddingModel > should expose the raw response 2`] = `
 {
   "body": {
     "embeddings": [

--- a/packages/google/src/google-generative-ai-embedding-model.test.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.test.ts
@@ -62,7 +62,24 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
 
     const { embeddings } = await model.doEmbed({ values: testValues });
 
-    expect(embeddings).toStrictEqual(dummyEmbeddings);
+    expect(embeddings).toMatchInlineSnapshot(`
+      [
+        [
+          0.1,
+          0.2,
+          0.3,
+          0.4,
+          0.5,
+        ],
+        [
+          0.6,
+          0.7,
+          0.8,
+          0.9,
+          1,
+        ],
+      ]
+    `);
   });
 
   it('should expose the raw response', async () => {
@@ -74,14 +91,13 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
 
     const { response } = await model.doEmbed({ values: testValues });
 
-    expect(response?.headers).toStrictEqual({
-      // default headers:
-      'content-length': '80',
-      'content-type': 'application/json',
-
-      // custom header
-      'test-header': 'test-value',
-    });
+    expect(response?.headers).toMatchInlineSnapshot(`
+      {
+        "content-length": "80",
+        "content-type": "application/json",
+        "test-header": "test-value",
+      }
+    `);
     expect(response).toMatchSnapshot();
   });
 
@@ -90,12 +106,34 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
 
     await model.doEmbed({ values: testValues });
 
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      requests: testValues.map(value => ({
-        model: 'models/gemini-embedding-001',
-        content: { role: 'user', parts: [{ text: value }] },
-      })),
-    });
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "requests": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "sunny day at the beach",
+                },
+              ],
+              "role": "user",
+            },
+            "model": "models/gemini-embedding-001",
+          },
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "rainy day in the city",
+                },
+              ],
+              "role": "user",
+            },
+            "model": "models/gemini-embedding-001",
+          },
+        ],
+      }
+    `);
   });
 
   it('should pass the outputDimensionality setting', async () => {
@@ -108,13 +146,36 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
       },
     });
 
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      requests: testValues.map(value => ({
-        model: 'models/gemini-embedding-001',
-        content: { role: 'user', parts: [{ text: value }] },
-        outputDimensionality: 64,
-      })),
-    });
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "requests": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "sunny day at the beach",
+                },
+              ],
+              "role": "user",
+            },
+            "model": "models/gemini-embedding-001",
+            "outputDimensionality": 64,
+          },
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "rainy day in the city",
+                },
+              ],
+              "role": "user",
+            },
+            "model": "models/gemini-embedding-001",
+            "outputDimensionality": 64,
+          },
+        ],
+      }
+    `);
   });
 
   it('should pass the taskType setting', async () => {
@@ -125,13 +186,36 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
       providerOptions: { google: { taskType: 'SEMANTIC_SIMILARITY' } },
     });
 
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      requests: testValues.map(value => ({
-        model: 'models/gemini-embedding-001',
-        content: { role: 'user', parts: [{ text: value }] },
-        taskType: 'SEMANTIC_SIMILARITY',
-      })),
-    });
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "requests": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "sunny day at the beach",
+                },
+              ],
+              "role": "user",
+            },
+            "model": "models/gemini-embedding-001",
+            "taskType": "SEMANTIC_SIMILARITY",
+          },
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "rainy day in the city",
+                },
+              ],
+              "role": "user",
+            },
+            "model": "models/gemini-embedding-001",
+            "taskType": "SEMANTIC_SIMILARITY",
+          },
+        ],
+      }
+    `);
   });
 
   it('should pass headers', async () => {
@@ -151,12 +235,14 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
       },
     });
 
-    expect(server.calls[0].requestHeaders).toStrictEqual({
-      'x-goog-api-key': 'test-api-key',
-      'content-type': 'application/json',
-      'custom-provider-header': 'provider-header-value',
-      'custom-request-header': 'request-header-value',
-    });
+    expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+      {
+        "content-type": "application/json",
+        "custom-provider-header": "provider-header-value",
+        "custom-request-header": "request-header-value",
+        "x-goog-api-key": "test-api-key",
+      }
+    `);
     expect(server.calls[0].requestUserAgent).toContain(
       `ai-sdk/google/0.0.0-test`,
     );


### PR DESCRIPTION
## background

part of #12270 — normalizing provider tests to use recorded API fixtures

google provider tests had 21 `toStrictEqual` assertions in the language model tests and 6 in the embedding tests. these have been converted to `toMatchInlineSnapshot()` to follow the fixture-based pattern used across other providers. additionally, two standalone tests were missing per the fixture testing guidelines

## summary

- convert all 21 `toStrictEqual` → `toMatchInlineSnapshot()` in `google-generative-ai-language-model.test.ts`
- convert all 6 `toStrictEqual` → `toMatchInlineSnapshot()` in `google-generative-ai-embedding-model.test.ts`
- add standalone `doGenerate` response metadata test (id, timestamp, modelId)
- add standalone `doStream` response headers test

## verification

<details>
<summary>tests pass (239 total, 111 → 113 language model, 9 embedding)</summary>

```
 ✓ src/google-generative-ai-embedding-model.test.ts  (9 tests) 33ms
 ✓ src/google-generative-ai-language-model.test.ts  (113 tests) 140ms

 Test Files  10 passed (10)
      Tests  239 passed (239)
```

</details>

<details>
<summary>zero toStrictEqual remaining</summary>

```
$ grep -c toStrictEqual packages/google/src/google-generative-ai-language-model.test.ts
0
$ grep -c toStrictEqual packages/google/src/google-generative-ai-embedding-model.test.ts
0
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [ ] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

part of #12270