### PR TITLE
test(provider/amazon-bedrock): rewrite tests to use fixture-based pattern

### DIFF
--- a/packages/amazon-bedrock/src/__fixtures__/bedrock-reasoning.chunks.txt
+++ b/packages/amazon-bedrock/src/__fixtures__/bedrock-reasoning.chunks.txt
@@ -1,0 +1,26 @@
+{"messageStart":{"role":"assistant"}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":"Let me count the r"}}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":"'s in \""}}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":"strawberry\":"}}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":"\n\ns-t-r-a"}}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":"-w-b-e-r"}}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":"-r-y\n\nr"}}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":" appears at positions "}}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":"3, 8"}}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":", and 9.\n\nSo there"}}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":" are 3 r's."}}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":""}}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"reasoningContent":{"signature":"Ep0CCkgICxABGAIqQOWPB6/PmA5SW9jC6FvaNq3E+U9ev4FMWcFWuAho+VGLCtazKc5WDjQ5i0MuxsY0o5pKDSVWVKii8KJDusXH4eASDK7jyzuk8iij7fJNihoMxHO9haYzt48R36HVIjCb/EmIFrJLIXShqN6DN//T6vZBtO9qj1QhNWJa3CGm8VZoq80S2/Ok4U0aVaIDiZcqggHC2b8BHuv8BHZrmsR0wjU1ynansBGMdfjnG+iIv8R5lPpRmYGhSVwNybwP3aQZ6o8Dr48Rau8TJfdsArW+r7bvL7bPs4f5nnlp2vG7WkMzWwABHK3fdM44zZ1GZQaWyECNWR2GfY6dXiklo94vgpFTPuZ97mfiN3LY6uYyBwL8RkDaGAE="}}}}
+{"contentBlockStop":{"contentBlockIndex":0}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"text":"There"}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"text":" are **3** r's in \""}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"text":"strawberry\":"}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"text":"\n\n1"}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"text":". st"}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"text":"**"}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"text":"r**awbe"}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"text":"**r****"}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"text":"r**y"}}}
+{"contentBlockStop":{"contentBlockIndex":1}}
+{"messageStop":{"additionalModelResponseFields":{"delta":{"stop_sequence":null}},"stopReason":"end_turn"}}
+{"metadata":{"metrics":{"latencyMs":2281},"usage":{"inputTokens":51,"outputTokens":94,"serverToolUsage":{},"totalTokens":145}}}

--- a/packages/amazon-bedrock/src/__fixtures__/bedrock-reasoning.json
+++ b/packages/amazon-bedrock/src/__fixtures__/bedrock-reasoning.json
@@ -1,0 +1,34 @@
+{
+  "metrics": {
+    "latencyMs": 2202
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "reasoningContent": {
+            "reasoningText": {
+              "signature": "EvYBCkgICxABGAIqQA9E9VC377UnbjdfXCw4RwQaaIXsqocZKzI3WwWtXT/wBjzAkBOfIiVkP/mhvsPGb5oQW/2j+E1tZcNFoXIb26YSDBTSbDrbHwXJoAl3/hoMA/Qo4rIHvObP/yBrIjAT+l69mh9k7evFO+w+ransSD5YGq4hYrieOyJH3k/zHv8nBJwiz3Nlrb3jNFi2Ib0qXJH7BIK0hR85yYIoccReoJUpeLEMxeWbsO6f0EpOSMSi3YDLd1U9NAw7Itjeay1fEBPHwvawt2M4e/rn52SsuEz3p2DfOZm+N3bnL63rg0Cb9lFcp3k5kuU1h6hcGAE=",
+              "text": "Let me count the r's in \"strawberry\":\n\ns-t-r-a-w-b-e-r-r-y\n\nThere are 3 r's."
+            }
+          }
+        },
+        {
+          "text": "There are **3** r's in \"strawberry\":\n\n1. st**r**awbe**r****r**y"
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "cacheReadInputTokenCount": 0,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokenCount": 0,
+    "cacheWriteInputTokens": 0,
+    "inputTokens": 51,
+    "outputTokens": 78,
+    "serverToolUsage": {},
+    "totalTokens": 129
+  }
+}

--- a/packages/amazon-bedrock/src/__fixtures__/bedrock-text.chunks.txt
+++ b/packages/amazon-bedrock/src/__fixtures__/bedrock-text.chunks.txt
@@ -1,0 +1,16 @@
+{"messageStart":{"role":"assistant"}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"Let"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" me count the \""}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"r\"s in \""}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"strawberry\":\n\ns-t-"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"**"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"r**-a-w-b"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"-e-**"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"r**-**"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"r**-y\n\nThere"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" are **3"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"** r"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"'s in \"strawberry.\""}}}
+{"contentBlockStop":{"contentBlockIndex":0}}
+{"messageStop":{"additionalModelResponseFields":{"delta":{"stop_sequence":null}},"stopReason":"end_turn"}}
+{"metadata":{"metrics":{"latencyMs":2040},"usage":{"inputTokens":22,"outputTokens":55,"serverToolUsage":{},"totalTokens":77}}}

--- a/packages/amazon-bedrock/src/__fixtures__/bedrock-text.json
+++ b/packages/amazon-bedrock/src/__fixtures__/bedrock-text.json
@@ -1,0 +1,26 @@
+{
+  "metrics": {
+    "latencyMs": 1864
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "text": "Let me count the \"r\"s in \"strawberry\":\n\ns-t-**r**-a-w-b-e-**r**-**r**-y\n\nThere are **3** \"r\"s in \"strawberry.\""
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "cacheReadInputTokenCount": 0,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokenCount": 0,
+    "cacheWriteInputTokens": 0,
+    "inputTokens": 22,
+    "outputTokens": 57,
+    "serverToolUsage": {},
+    "totalTokens": 79
+  }
+}

--- a/packages/amazon-bedrock/src/__snapshots__/bedrock-chat-language-model.test.ts.snap
+++ b/packages/amazon-bedrock/src/__snapshots__/bedrock-chat-language-model.test.ts.snap
@@ -1,0 +1,391 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`doGenerate > reasoning > should extract reasoning and text response 1`] = `
+{
+  "content": [
+    {
+      "providerMetadata": {
+        "bedrock": {
+          "signature": "EvYBCkgICxABGAIqQA9E9VC377UnbjdfXCw4RwQaaIXsqocZKzI3WwWtXT/wBjzAkBOfIiVkP/mhvsPGb5oQW/2j+E1tZcNFoXIb26YSDBTSbDrbHwXJoAl3/hoMA/Qo4rIHvObP/yBrIjAT+l69mh9k7evFO+w+ransSD5YGq4hYrieOyJH3k/zHv8nBJwiz3Nlrb3jNFi2Ib0qXJH7BIK0hR85yYIoccReoJUpeLEMxeWbsO6f0EpOSMSi3YDLd1U9NAw7Itjeay1fEBPHwvawt2M4e/rn52SsuEz3p2DfOZm+N3bnL63rg0Cb9lFcp3k5kuU1h6hcGAE=",
+        },
+      },
+      "text": "Let me count the r's in "strawberry":
+
+s-t-r-a-w-b-e-r-r-y
+
+There are 3 r's.",
+      "type": "reasoning",
+    },
+    {
+      "text": "There are **3** r's in "strawberry":
+
+1. st**r**awbe**r****r**y",
+      "type": "text",
+    },
+  ],
+  "finishReason": {
+    "raw": "end_turn",
+    "unified": "stop",
+  },
+  "providerMetadata": {
+    "bedrock": {
+      "stopSequence": null,
+      "usage": {
+        "cacheWriteInputTokens": 0,
+      },
+    },
+  },
+  "response": {
+    "headers": {
+      "content-length": "865",
+      "content-type": "application/json",
+    },
+  },
+  "usage": {
+    "inputTokens": {
+      "cacheRead": 0,
+      "cacheWrite": 0,
+      "noCache": 51,
+      "total": 51,
+    },
+    "outputTokens": {
+      "reasoning": undefined,
+      "text": 78,
+      "total": 78,
+    },
+    "raw": {
+      "cacheReadInputTokens": 0,
+      "cacheWriteInputTokens": 0,
+      "inputTokens": 51,
+      "outputTokens": 78,
+      "totalTokens": 129,
+    },
+  },
+  "warnings": [],
+}
+`;
+
+exports[`doGenerate > text > should extract text response 1`] = `
+{
+  "content": [
+    {
+      "text": "Let me count the "r"s in "strawberry":
+
+s-t-**r**-a-w-b-e-**r**-**r**-y
+
+There are **3** "r"s in "strawberry."",
+      "type": "text",
+    },
+  ],
+  "finishReason": {
+    "raw": "end_turn",
+    "unified": "stop",
+  },
+  "providerMetadata": {
+    "bedrock": {
+      "stopSequence": null,
+      "usage": {
+        "cacheWriteInputTokens": 0,
+      },
+    },
+  },
+  "response": {
+    "headers": {
+      "content-length": "435",
+      "content-type": "application/json",
+    },
+  },
+  "usage": {
+    "inputTokens": {
+      "cacheRead": 0,
+      "cacheWrite": 0,
+      "noCache": 22,
+      "total": 22,
+    },
+    "outputTokens": {
+      "reasoning": undefined,
+      "text": 57,
+      "total": 57,
+    },
+    "raw": {
+      "cacheReadInputTokens": 0,
+      "cacheWriteInputTokens": 0,
+      "inputTokens": 22,
+      "outputTokens": 57,
+      "totalTokens": 79,
+    },
+  },
+  "warnings": [],
+}
+`;
+
+exports[`doStream > reasoning > should stream reasoning and text parts 1`] = `
+[
+  {
+    "type": "stream-start",
+    "warnings": [],
+  },
+  {
+    "id": "0",
+    "type": "reasoning-start",
+  },
+  {
+    "delta": "Let me count the r",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": "'s in "",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": "strawberry":",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": "
+
+s-t-r-a",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": "-w-b-e-r",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": "-r-y
+
+r",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " appears at positions ",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": "3, 8",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": ", and 9.
+
+So there",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": " are 3 r's.",
+    "id": "0",
+    "type": "reasoning-delta",
+  },
+  {
+    "delta": "",
+    "id": "0",
+    "providerMetadata": {
+      "bedrock": {
+        "signature": "Ep0CCkgICxABGAIqQOWPB6/PmA5SW9jC6FvaNq3E+U9ev4FMWcFWuAho+VGLCtazKc5WDjQ5i0MuxsY0o5pKDSVWVKii8KJDusXH4eASDK7jyzuk8iij7fJNihoMxHO9haYzt48R36HVIjCb/EmIFrJLIXShqN6DN//T6vZBtO9qj1QhNWJa3CGm8VZoq80S2/Ok4U0aVaIDiZcqggHC2b8BHuv8BHZrmsR0wjU1ynansBGMdfjnG+iIv8R5lPpRmYGhSVwNybwP3aQZ6o8Dr48Rau8TJfdsArW+r7bvL7bPs4f5nnlp2vG7WkMzWwABHK3fdM44zZ1GZQaWyECNWR2GfY6dXiklo94vgpFTPuZ97mfiN3LY6uYyBwL8RkDaGAE=",
+      },
+    },
+    "type": "reasoning-delta",
+  },
+  {
+    "id": "0",
+    "type": "reasoning-end",
+  },
+  {
+    "id": "1",
+    "type": "text-start",
+  },
+  {
+    "delta": "There",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": " are **3** r's in "",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": "strawberry":",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": "
+
+1",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": ". st",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": "**",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": "r**awbe",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": "**r****",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "delta": "r**y",
+    "id": "1",
+    "type": "text-delta",
+  },
+  {
+    "id": "1",
+    "type": "text-end",
+  },
+  {
+    "finishReason": {
+      "raw": "end_turn",
+      "unified": "stop",
+    },
+    "type": "finish",
+    "usage": {
+      "inputTokens": {
+        "cacheRead": 0,
+        "cacheWrite": 0,
+        "noCache": 51,
+        "total": 51,
+      },
+      "outputTokens": {
+        "reasoning": undefined,
+        "text": 94,
+        "total": 94,
+      },
+      "raw": {
+        "inputTokens": 51,
+        "outputTokens": 94,
+        "serverToolUsage": {},
+        "totalTokens": 145,
+      },
+    },
+  },
+]
+`;
+
+exports[`doStream > text > should stream text deltas 1`] = `
+[
+  {
+    "type": "stream-start",
+    "warnings": [],
+  },
+  {
+    "id": "0",
+    "type": "text-start",
+  },
+  {
+    "delta": "Let",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": " me count the "",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "r"s in "",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "strawberry":
+
+s-t-",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "**",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "r**-a-w-b",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "-e-**",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "r**-**",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "r**-y
+
+There",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": " are **3",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "** r",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "'s in "strawberry."",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "id": "0",
+    "type": "text-end",
+  },
+  {
+    "finishReason": {
+      "raw": "end_turn",
+      "unified": "stop",
+    },
+    "type": "finish",
+    "usage": {
+      "inputTokens": {
+        "cacheRead": 0,
+        "cacheWrite": 0,
+        "noCache": 22,
+        "total": 22,
+      },
+      "outputTokens": {
+        "reasoning": undefined,
+        "text": 55,
+        "total": 55,
+      },
+      "raw": {
+        "inputTokens": 22,
+        "outputTokens": 55,
+        "serverToolUsage": {},
+        "totalTokens": 77,
+      },
+    },
+  },
+]
+`;

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.test.ts
@@ -103,7 +103,15 @@ describe('doEmbed', () => {
     });
 
     expect(embeddings.length).toBe(1);
-    expect(embeddings[0]).toStrictEqual(mockEmbeddings[0]);
+    expect(embeddings[0]).toMatchInlineSnapshot(`
+      [
+        -0.09,
+        0.05,
+        -0.02,
+        0.01,
+        0.04,
+      ]
+    `);
 
     const body = await server.calls[0].requestBodyJson;
     expect(body).toEqual({
@@ -118,7 +126,7 @@ describe('doEmbed', () => {
       values: [testValues[0]],
     });
 
-    expect(usage?.tokens).toStrictEqual(8);
+    expect(usage?.tokens).toMatchInlineSnapshot(`8`);
   });
 
   it('should support Cohere embedding models', async () => {
@@ -133,7 +141,15 @@ describe('doEmbed', () => {
     });
 
     expect(embeddings.length).toBe(1);
-    expect(embeddings[0]).toStrictEqual(mockEmbeddings[0]);
+    expect(embeddings[0]).toMatchInlineSnapshot(`
+      [
+        -0.09,
+        0.05,
+        -0.02,
+        0.01,
+        0.04,
+      ]
+    `);
     expect(Number.isNaN(usage?.tokens)).toBe(true);
 
     const body = await server.calls[0].requestBodyJson;
@@ -157,7 +173,15 @@ describe('doEmbed', () => {
     });
 
     expect(embeddings.length).toBe(1);
-    expect(embeddings[0]).toStrictEqual(mockEmbeddings[0]);
+    expect(embeddings[0]).toMatchInlineSnapshot(`
+      [
+        -0.09,
+        0.05,
+        -0.02,
+        0.01,
+        0.04,
+      ]
+    `);
     expect(Number.isNaN(usage?.tokens)).toBe(true);
 
     const body = await server.calls[0].requestBodyJson;
@@ -186,7 +210,15 @@ describe('doEmbed', () => {
     });
 
     expect(embeddings.length).toBe(1);
-    expect(embeddings[0]).toStrictEqual(mockEmbeddings[0]);
+    expect(embeddings[0]).toMatchInlineSnapshot(`
+      [
+        -0.09,
+        0.05,
+        -0.02,
+        0.01,
+        0.04,
+      ]
+    `);
 
     const body = await server.calls[0].requestBodyJson;
     expect(body).toEqual({
@@ -298,7 +330,15 @@ describe('should support Nova embeddings', () => {
       values: [testValues[0]],
     });
 
-    expect(embeddings[0]).toStrictEqual(mockEmbeddings[0]);
+    expect(embeddings[0]).toMatchInlineSnapshot(`
+      [
+        -0.09,
+        0.05,
+        -0.02,
+        0.01,
+        0.04,
+      ]
+    `);
 
     const body = await server.calls[0].requestBodyJson;
     expect(body).toEqual({
@@ -324,7 +364,15 @@ describe('should support Nova embeddings', () => {
       },
     });
 
-    expect(embeddings[0]).toStrictEqual(mockEmbeddings[0]);
+    expect(embeddings[0]).toMatchInlineSnapshot(`
+      [
+        -0.09,
+        0.05,
+        -0.02,
+        0.01,
+        0.04,
+      ]
+    `);
 
     const body = await server.calls[0].requestBodyJson;
     expect(body).toEqual({

--- a/packages/amazon-bedrock/src/bedrock-image-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.test.ts
@@ -59,21 +59,23 @@ describe('doGenerate', () => {
       },
     });
 
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      taskType: 'TEXT_IMAGE',
-      textToImageParams: {
-        text: prompt,
-        negativeText: 'bad',
-      },
-      imageGenerationConfig: {
-        numberOfImages: 1,
-        seed: 1234,
-        quality: 'premium',
-        cfgScale: 1.2,
-        width: 1024,
-        height: 1024,
-      },
-    });
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "imageGenerationConfig": {
+          "cfgScale": 1.2,
+          "height": 1024,
+          "numberOfImages": 1,
+          "quality": "premium",
+          "seed": 1234,
+          "width": 1024,
+        },
+        "taskType": "TEXT_IMAGE",
+        "textToImageParams": {
+          "negativeText": "bad",
+          "text": "A cute baby sea otter",
+        },
+      }
+    `);
   });
 
   it('should properly combine headers from all sources', async () => {
@@ -157,7 +159,12 @@ describe('doGenerate', () => {
       providerOptions: {},
     });
 
-    expect(result.images).toStrictEqual(['base64-image-1', 'base64-image-2']);
+    expect(result.images).toMatchInlineSnapshot(`
+      [
+        "base64-image-1",
+        "base64-image-2",
+      ]
+    `);
   });
 
   it('should include response data with timestamp, modelId and headers', async () => {
@@ -182,14 +189,16 @@ describe('doGenerate', () => {
       providerOptions: {},
     });
 
-    expect(result.response).toStrictEqual({
-      timestamp: testDate,
-      modelId: 'amazon.nova-canvas-v1:0',
-      headers: {
-        'content-length': '46',
-        'content-type': 'application/json',
-      },
-    });
+    expect(result.response).toMatchInlineSnapshot(`
+      {
+        "headers": {
+          "content-length": "46",
+          "content-type": "application/json",
+        },
+        "modelId": "amazon.nova-canvas-v1:0",
+        "timestamp": 2024-03-15T12:00:00.000Z,
+      }
+    `);
   });
 
   it('should use real date when no custom date provider is specified', async () => {
@@ -236,22 +245,24 @@ describe('doGenerate', () => {
       },
     });
 
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      taskType: 'TEXT_IMAGE',
-      textToImageParams: {
-        text: prompt,
-        negativeText: 'bad',
-        style: 'PHOTOREALISM',
-      },
-      imageGenerationConfig: {
-        numberOfImages: 1,
-        seed: 1234,
-        quality: 'premium',
-        cfgScale: 1.2,
-        width: 1024,
-        height: 1024,
-      },
-    });
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "imageGenerationConfig": {
+          "cfgScale": 1.2,
+          "height": 1024,
+          "numberOfImages": 1,
+          "quality": "premium",
+          "seed": 1234,
+          "width": 1024,
+        },
+        "taskType": "TEXT_IMAGE",
+        "textToImageParams": {
+          "negativeText": "bad",
+          "style": "PHOTOREALISM",
+          "text": "A cute baby sea otter",
+        },
+      }
+    `);
   });
 
   it('should not include style parameter when not provided', async () => {
@@ -543,7 +554,11 @@ describe('Image Editing', () => {
       },
     });
 
-    expect(result.images).toStrictEqual(['edited-image-base64']);
+    expect(result.images).toMatchInlineSnapshot(`
+      [
+        "edited-image-base64",
+      ]
+    `);
   });
 
   it('should throw error for URL-based images', async () => {


### PR DESCRIPTION
## background

part of #12270 — migrating provider tests to the fixture-based pattern established in xai, azure, google, and openai-compatible

## summary

- record real text and reasoning fixtures from bedrock converse API using `us.anthropic.claude-opus-4-6-v1`
- add fixture-based `describe` blocks for doGenerate and doStream (text + reasoning scenarios)
- add snapshot file for full response parsing assertions
- add standalone fixture-based tests: response headers (doGenerate + doStream), usage extraction, response metadata
- add optional `headers` param to `prepareJsonFixtureResponse` and `prepareChunksFixtureResponse` helpers
- convert all `toStrictEqual` → `toMatchInlineSnapshot` across language model, embedding, and image model tests (14 total)
- follow-up: record real fixtures for invoke API (embeddings + images) in a separate PR

## verification

<details>
<summary>tests pass (276 → 284, +8 new fixture-based tests)</summary>

```
 ✓ src/bedrock-embedding-model.test.ts  (9 tests) 43ms
 ✓ src/bedrock-image-model.test.ts  (25 tests) 53ms
 ✓ src/bedrock-chat-language-model.test.ts  (93 tests) 203ms

 Test Files  14 passed (14)
      Tests  284 passed (284)
```

</details>

<details>
<summary>zero toStrictEqual remaining in package</summary>

```
$ grep -r 'toStrictEqual' packages/amazon-bedrock/src/
(no output)
```

</details>

<details>
<summary>new fixture files (recorded from real bedrock API)</summary>

```
packages/amazon-bedrock/src/__fixtures__/bedrock-text.json
packages/amazon-bedrock/src/__fixtures__/bedrock-text.chunks.txt
packages/amazon-bedrock/src/__fixtures__/bedrock-reasoning.json
packages/amazon-bedrock/src/__fixtures__/bedrock-reasoning.chunks.txt
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [ ] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

part of #12270