### PR TITLE
fix(provider/amazon-bedrock): extract response metadata from api headers

### DIFF
--- a/.changeset/bedrock-response-metadata.md
+++ b/.changeset/bedrock-response-metadata.md
@@ -1,5 +1,0 @@
----
-'@ai-sdk/amazon-bedrock': patch
----
-
-extract response metadata (id, timestamp, modelId) from bedrock api headers instead of falling back to sdk-generated defaults

--- a/.changeset/bedrock-response-metadata.md
+++ b/.changeset/bedrock-response-metadata.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+extract response metadata (id, timestamp, modelId) from bedrock api headers instead of falling back to sdk-generated defaults

--- a/.changeset/gentle-rules-help.md
+++ b/.changeset/gentle-rules-help.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(provider/amazon-bedrock): extract response metadata from api headers

--- a/packages/amazon-bedrock/src/__snapshots__/bedrock-chat-language-model.test.ts.snap
+++ b/packages/amazon-bedrock/src/__snapshots__/bedrock-chat-language-model.test.ts.snap
@@ -40,6 +40,9 @@ There are 3 r's.",
       "content-length": "865",
       "content-type": "application/json",
     },
+    "id": undefined,
+    "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+    "timestamp": undefined,
   },
   "usage": {
     "inputTokens": {
@@ -94,6 +97,9 @@ There are **3** "r"s in "strawberry."",
       "content-length": "435",
       "content-type": "application/json",
     },
+    "id": undefined,
+    "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+    "timestamp": undefined,
   },
   "usage": {
     "inputTokens": {
@@ -124,6 +130,12 @@ exports[`doStream > reasoning > should stream reasoning and text parts 1`] = `
   {
     "type": "stream-start",
     "warnings": [],
+  },
+  {
+    "id": undefined,
+    "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+    "timestamp": undefined,
+    "type": "response-metadata",
   },
   {
     "id": "0",
@@ -288,6 +300,12 @@ exports[`doStream > text > should stream text deltas 1`] = `
   {
     "type": "stream-start",
     "warnings": [],
+  },
+  {
+    "id": undefined,
+    "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+    "timestamp": undefined,
+    "type": "response-metadata",
   },
   {
     "id": "0",

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -325,6 +325,12 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
+        },
+        {
           "id": "0",
           "type": "text-start",
         },
@@ -440,6 +446,12 @@ describe('doStream', () => {
         {
           "type": "stream-start",
           "warnings": [],
+        },
+        {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
         },
         {
           "id": "tool-use-id",
@@ -587,6 +599,12 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
+        },
+        {
           "id": "tool-use-id-1",
           "toolName": "test-tool-1",
           "type": "tool-input-start",
@@ -689,6 +707,12 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
+        },
+        {
           "error": {
             "$fault": "server",
             "$metadata": {},
@@ -748,6 +772,12 @@ describe('doStream', () => {
         {
           "type": "stream-start",
           "warnings": [],
+        },
+        {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
         },
         {
           "error": {
@@ -811,6 +841,12 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
+        },
+        {
           "error": {
             "$fault": "server",
             "$metadata": {},
@@ -872,6 +908,12 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
+        },
+        {
           "error": {
             "$fault": "server",
             "$metadata": {},
@@ -921,6 +963,12 @@ describe('doStream', () => {
         {
           "type": "stream-start",
           "warnings": [],
+        },
+        {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
         },
         {
           "error": {
@@ -1059,6 +1107,12 @@ describe('doStream', () => {
         {
           "type": "stream-start",
           "warnings": [],
+        },
+        {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
         },
         {
           "id": "0",
@@ -1282,6 +1336,47 @@ describe('doStream', () => {
     });
   });
 
+  it('should extract response metadata', async () => {
+    setupMockEventStreamHandler();
+    server.urls[streamUrl].response = {
+      type: 'stream-chunks',
+      headers: {
+        'x-amzn-requestid': 'test-request-id',
+        date: 'Wed, 01 Jan 2025 00:00:00 GMT',
+      },
+      chunks: [
+        JSON.stringify({
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { text: 'Hello' },
+          },
+        }) + '\n',
+        JSON.stringify({
+          messageStop: {
+            stopReason: 'end_turn',
+          },
+        }) + '\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const parts = await convertReadableStreamToArray(stream);
+    const metadata = parts.find(p => p.type === 'response-metadata');
+
+    expect(metadata).toMatchInlineSnapshot(`
+      {
+        "id": "test-request-id",
+        "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+        "timestamp": 2025-01-01T00:00:00.000Z,
+        "type": "response-metadata",
+      }
+    `);
+  });
+
   it('should properly combine headers from all sources', async () => {
     setupMockEventStreamHandler();
     server.urls[streamUrl].response = {
@@ -1440,6 +1535,12 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
+        },
+        {
           "id": "0",
           "type": "text-start",
         },
@@ -1578,6 +1679,12 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
+        },
+        {
           "id": "0",
           "type": "reasoning-start",
         },
@@ -1674,6 +1781,12 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
+        },
+        {
           "delta": "",
           "id": "0",
           "providerMetadata": {
@@ -1746,6 +1859,12 @@ describe('doStream', () => {
         {
           "type": "stream-start",
           "warnings": [],
+        },
+        {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
         },
         {
           "rawValue": {
@@ -1911,6 +2030,12 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
+        },
+        {
           "id": "0",
           "type": "text-start",
         },
@@ -1981,6 +2106,12 @@ describe('doStream', () => {
         {
           "type": "stream-start",
           "warnings": [],
+        },
+        {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
         },
         {
           "id": "0",
@@ -2071,6 +2202,12 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
+        },
+        {
           "id": "0",
           "type": "text-start",
         },
@@ -2158,6 +2295,12 @@ describe('doStream', () => {
         {
           "type": "stream-start",
           "warnings": [],
+        },
+        {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
         },
         {
           "id": "0",
@@ -2266,6 +2409,12 @@ describe('doStream', () => {
         {
           "type": "stream-start",
           "warnings": [],
+        },
+        {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
         },
         {
           "id": "0",
@@ -2392,6 +2541,12 @@ describe('doStream', () => {
         {
           "type": "stream-start",
           "warnings": [],
+        },
+        {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
         },
         {
           "id": "0",
@@ -2553,6 +2708,12 @@ describe('doStream', () => {
         {
           "type": "stream-start",
           "warnings": [],
+        },
+        {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
         },
         {
           "id": "0",
@@ -2821,7 +2982,7 @@ describe('doGenerate', () => {
       }).toMatchInlineSnapshot(`
         {
           "id": undefined,
-          "modelId": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
           "timestamp": undefined,
         }
       `);
@@ -3204,6 +3365,42 @@ describe('doGenerate', () => {
       'content-type': 'application/json',
       'content-length': '164',
     });
+  });
+
+  it('should extract response metadata', async () => {
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      headers: {
+        'x-amzn-requestid': 'test-request-id',
+        date: 'Wed, 01 Jan 2025 00:00:00 GMT',
+      },
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ text: 'Testing' }],
+          },
+        },
+        usage: {
+          inputTokens: 4,
+          outputTokens: 34,
+          totalTokens: 38,
+        },
+        stopReason: 'end_turn',
+      },
+    };
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.response?.id).toMatchInlineSnapshot(`"test-request-id"`);
+    expect(result.response?.timestamp).toMatchInlineSnapshot(
+      `2025-01-01T00:00:00.000Z`,
+    );
+    expect(result.response?.modelId).toMatchInlineSnapshot(
+      `"anthropic.claude-3-haiku-20240307-v1:0"`,
+    );
   });
 
   it('should pass tools and tool choice correctly', async () => {


### PR DESCRIPTION
## background

the bedrock provider had a TODO comment (`// TODO add id, timestamp, etc`) and returned `undefined` for `response.id`, `response.timestamp`, and `response.modelId` in both `doGenerate` and `doStream` — falling back to SDK-generated defaults (random id, client-side timestamp) instead of real api values

## summary

- extract `response.id` from `x-amzn-requestid` header (AWS request UUID)
- extract `response.timestamp` from `date` header (server-side timestamp)
- set `response.modelId` from the configured model id
- emit `response-metadata` stream part in `doStream` so streaming responses get real metadata too

<details>
<summary>before (sdk-generated defaults)</summary>

```
Response ID: aitxt-mjz1fkFBSGAqsaoRzPcaQmyb    ← random
Response timestamp: 2026-02-11T15:59:45.333Z     ← client-side (has ms)
```
</details>

<details>
<summary>after (real api values)</summary>

```
Response ID: 520ad50e-06c1-4a77-b24e-4fdba4f5217f  ← AWS request ID
Response timestamp: 2026-02-11T16:02:25.000Z        ← server date header
```
</details>

## verification

<details>
<summary>generateText</summary>

```
Response ID: 520ad50e-06c1-4a77-b24e-4fdba4f5217f
Response model ID: us.anthropic.claude-opus-4-6-v1
Response timestamp: 2026-02-11T16:02:25.000Z
```
</details>

<details>
<summary>streamText</summary>

```
Response ID: e061d76e-c713-4455-b980-4c6c41ed3b8a
Response model ID: us.anthropic.claude-opus-4-6-v1
Response timestamp: 2026-02-11T16:07:14.000Z
```
</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)