### PR TITLE
fix(anthropic): ensure thinking blocks appear first in assistant messages with tool use

### DIFF
--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -992,7 +992,22 @@ export async function convertToAnthropicMessagesPrompt({
           }
         }
 
-        messages.push({ role: 'assistant', content: anthropicContent });
+        // Ensure thinking blocks come first in assistant messages as required by Anthropic API
+        // when extended thinking is enabled
+        const thinkingBlocks = anthropicContent.filter(
+          part => part.type === 'thinking' || part.type === 'redacted_thinking',
+        );
+        const nonThinkingBlocks = anthropicContent.filter(
+          part => part.type !== 'thinking' && part.type !== 'redacted_thinking',
+        );
+
+        // If there are thinking blocks, reorder content to place them first
+        const orderedContent =
+          thinkingBlocks.length > 0
+            ? [...thinkingBlocks, ...nonThinkingBlocks]
+            : anthropicContent;
+
+        messages.push({ role: 'assistant', content: orderedContent });
 
         break;
       }


### PR DESCRIPTION
## Summary

Fixes #7729

When extended thinking is enabled and assistant messages contain both thinking/redacted_thinking blocks and tool calls, the Anthropic API requires thinking blocks to appear first in the content array. Without this, the API returns:

```
Expected `thinking` or `redacted_thinking`, but found `tool_use`.
When `thinking` is enabled, a final assistant message must start with a thinking block.
```

## Changes

**`packages/anthropic/src/convert-to-anthropic-messages-prompt.ts`**
- Added content reordering logic before pushing assistant messages
- Separates thinking/redacted_thinking blocks from other content types
- Places thinking blocks at the beginning while preserving relative order of other content
- No-op when no thinking blocks are present (zero overhead for non-thinking scenarios)

**`packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts`**
- Added 4 test cases covering:
  - thinking block + tool_use reordering
  - redacted_thinking block + tool_use reordering  
  - No thinking blocks (order preserved)
  - Multiple thinking blocks (all placed first)

## Before/After

```
// Before: content order depends on input order
[text, tool_use, thinking] → API error ❌

// After: thinking blocks always first
[text, tool_use, thinking] → [thinking, text, tool_use] ✅
```

## Testing

All new tests pass. No changes to existing behavior for non-thinking scenarios.