### PR TITLE
feat(provider/amazon-bedrock): add performanceConfig, serviceTier, and cacheDetails to provider metadata

### DIFF
--- a/.changeset/thin-dogs-breathe.md
+++ b/.changeset/thin-dogs-breathe.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+feat(provider/amazon-bedrock): add performanceConfig, serviceTier, and cacheDetails to provider metadata

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -449,6 +449,21 @@ console.log(
 // }
 ```
 
+### Provider Metadata
+
+The following Bedrock-specific metadata may be returned in `providerMetadata.bedrock`:
+
+- **trace** _(optional)_
+  Guardrail tracing information (when tracing is enabled).
+- **performanceConfig** _(optional)_
+  Performance configuration, e.g. `{ latency: 'optimized' }`.
+- **serviceTier** _(optional)_
+  Service tier information, e.g. `{ type: 'on-demand' }`.
+- **usage** _(optional)_
+  Cache token usage details including `cacheWriteInputTokens` and `cacheDetails`.
+- **stopSequence** _string | null_
+  The stop sequence that triggered the stop, if any.
+
 ## Reasoning
 
 Amazon Bedrock supports model creator-specific reasoning features:

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -1486,6 +1486,143 @@ describe('doStream', () => {
     `);
   });
 
+  it('should include performanceConfig in providerMetadata', async () => {
+    setupMockEventStreamHandler();
+    server.urls[streamUrl].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { text: 'Hello' },
+          },
+        }) + '\n',
+        JSON.stringify({
+          metadata: {
+            usage: {
+              inputTokens: 4,
+              outputTokens: 34,
+            },
+            performanceConfig: { latency: 'optimized' },
+          },
+        }) + '\n',
+        JSON.stringify({
+          messageStop: { stopReason: 'end_turn' },
+        }) + '\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const parts = await convertReadableStreamToArray(stream);
+    const finish = parts.find(p => p.type === 'finish');
+    expect(finish?.providerMetadata).toMatchInlineSnapshot(`
+      {
+        "bedrock": {
+          "performanceConfig": {
+            "latency": "optimized",
+          },
+        },
+      }
+    `);
+  });
+
+  it('should include serviceTier in providerMetadata', async () => {
+    setupMockEventStreamHandler();
+    server.urls[streamUrl].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { text: 'Hello' },
+          },
+        }) + '\n',
+        JSON.stringify({
+          metadata: {
+            usage: {
+              inputTokens: 4,
+              outputTokens: 34,
+            },
+            serviceTier: { type: 'on-demand' },
+          },
+        }) + '\n',
+        JSON.stringify({
+          messageStop: { stopReason: 'end_turn' },
+        }) + '\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const parts = await convertReadableStreamToArray(stream);
+    const finish = parts.find(p => p.type === 'finish');
+    expect(finish?.providerMetadata).toMatchInlineSnapshot(`
+      {
+        "bedrock": {
+          "serviceTier": {
+            "type": "on-demand",
+          },
+        },
+      }
+    `);
+  });
+
+  it('should include cacheDetails in providerMetadata', async () => {
+    setupMockEventStreamHandler();
+    server.urls[streamUrl].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { text: 'Hello' },
+          },
+        }) + '\n',
+        JSON.stringify({
+          metadata: {
+            usage: {
+              inputTokens: 4,
+              outputTokens: 34,
+              cacheDetails: [{ inputTokens: 100, ttl: 'T5M' }],
+            },
+          },
+        }) + '\n',
+        JSON.stringify({
+          messageStop: { stopReason: 'end_turn' },
+        }) + '\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const parts = await convertReadableStreamToArray(stream);
+    const finish = parts.find(p => p.type === 'finish');
+    expect(finish?.providerMetadata).toMatchInlineSnapshot(`
+      {
+        "bedrock": {
+          "usage": {
+            "cacheDetails": [
+              {
+                "inputTokens": 100,
+                "ttl": "T5M",
+              },
+            ],
+          },
+        },
+      }
+    `);
+  });
+
   it('should handle system messages with cache points', async () => {
     setupMockEventStreamHandler();
     server.urls[streamUrl].response = {
@@ -3675,6 +3812,113 @@ describe('doGenerate', () => {
           "inputTokens": 4,
           "outputTokens": 34,
           "totalTokens": 38,
+        },
+      }
+    `);
+  });
+
+  it('should include performanceConfig in providerMetadata', async () => {
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+        },
+        usage: {
+          inputTokens: 4,
+          outputTokens: 34,
+          totalTokens: 38,
+        },
+        stopReason: 'end_turn',
+        performanceConfig: { latency: 'optimized' },
+      },
+    };
+
+    const response = await model.doGenerate({ prompt: TEST_PROMPT });
+
+    expect(response.providerMetadata).toMatchInlineSnapshot(`
+      {
+        "bedrock": {
+          "performanceConfig": {
+            "latency": "optimized",
+          },
+          "stopSequence": null,
+        },
+      }
+    `);
+  });
+
+  it('should include serviceTier in providerMetadata', async () => {
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+        },
+        usage: {
+          inputTokens: 4,
+          outputTokens: 34,
+          totalTokens: 38,
+        },
+        stopReason: 'end_turn',
+        serviceTier: { type: 'on-demand' },
+      },
+    };
+
+    const response = await model.doGenerate({ prompt: TEST_PROMPT });
+
+    expect(response.providerMetadata).toMatchInlineSnapshot(`
+      {
+        "bedrock": {
+          "serviceTier": {
+            "type": "on-demand",
+          },
+          "stopSequence": null,
+        },
+      }
+    `);
+  });
+
+  it('should include cacheDetails in providerMetadata', async () => {
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+        },
+        usage: {
+          inputTokens: 4,
+          outputTokens: 34,
+          totalTokens: 38,
+          cacheDetails: [{ inputTokens: 100, ttl: 'T5M' }],
+        },
+        stopReason: 'end_turn',
+      },
+    };
+
+    const response = await model.doGenerate({ prompt: TEST_PROMPT });
+
+    expect(response.providerMetadata).toMatchInlineSnapshot(`
+      {
+        "bedrock": {
+          "stopSequence": null,
+          "usage": {
+            "cacheDetails": [
+              {
+                "inputTokens": 100,
+                "ttl": "T5M",
+              },
+            ],
+          },
         },
       }
     `);

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -483,15 +483,32 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       response.additionalModelResponseFields?.delta?.stop_sequence ?? null;
 
     const providerMetadata =
-      response.trace || response.usage || isJsonResponseFromTool || stopSequence
+      response.trace ||
+      response.usage ||
+      response.performanceConfig ||
+      response.serviceTier ||
+      isJsonResponseFromTool ||
+      stopSequence
         ? {
             bedrock: {
               ...(response.trace && typeof response.trace === 'object'
                 ? { trace: response.trace as JSONObject }
                 : {}),
-              ...(response.usage?.cacheWriteInputTokens != null && {
+              ...(response.performanceConfig && {
+                performanceConfig: response.performanceConfig,
+              }),
+              ...(response.serviceTier && {
+                serviceTier: response.serviceTier,
+              }),
+              ...((response.usage?.cacheWriteInputTokens != null ||
+                response.usage?.cacheDetails != null) && {
                 usage: {
-                  cacheWriteInputTokens: response.usage.cacheWriteInputTokens,
+                  ...(response.usage.cacheWriteInputTokens != null && {
+                    cacheWriteInputTokens: response.usage.cacheWriteInputTokens,
+                  }),
+                  ...(response.usage.cacheDetails != null && {
+                    cacheDetails: response.usage.cacheDetails,
+                  }),
                 },
               }),
               ...(isJsonResponseFromTool && { isJsonResponseFromTool: true }),
@@ -631,11 +648,18 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
               }
 
               const cacheUsage =
-                value.metadata.usage?.cacheWriteInputTokens != null
+                value.metadata.usage?.cacheWriteInputTokens != null ||
+                value.metadata.usage?.cacheDetails != null
                   ? {
                       usage: {
-                        cacheWriteInputTokens:
-                          value.metadata.usage.cacheWriteInputTokens,
+                        ...(value.metadata.usage?.cacheWriteInputTokens !=
+                          null && {
+                          cacheWriteInputTokens:
+                            value.metadata.usage.cacheWriteInputTokens,
+                        }),
+                        ...(value.metadata.usage?.cacheDetails != null && {
+                          cacheDetails: value.metadata.usage.cacheDetails,
+                        }),
                       },
                     }
                   : undefined;
@@ -646,11 +670,22 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
                   }
                 : undefined;
 
-              if (cacheUsage || trace) {
+              if (
+                cacheUsage ||
+                trace ||
+                value.metadata.performanceConfig ||
+                value.metadata.serviceTier
+              ) {
                 providerMetadata = {
                   bedrock: {
                     ...cacheUsage,
                     ...trace,
+                    ...(value.metadata.performanceConfig && {
+                      performanceConfig: value.metadata.performanceConfig,
+                    }),
+                    ...(value.metadata.serviceTier && {
+                      serviceTier: value.metadata.serviceTier,
+                    }),
                   },
                 };
               }
@@ -955,12 +990,17 @@ const BedrockResponseSchema = z.object({
   additionalModelResponseFields:
     BedrockAdditionalModelResponseFieldsSchema.nullish(),
   trace: z.unknown().nullish(),
+  performanceConfig: z.object({ latency: z.string() }).nullish(),
+  serviceTier: z.object({ type: z.string() }).nullish(),
   usage: z.object({
     inputTokens: z.number(),
     outputTokens: z.number(),
     totalTokens: z.number(),
     cacheReadInputTokens: z.number().nullish(),
     cacheWriteInputTokens: z.number().nullish(),
+    cacheDetails: z
+      .array(z.object({ inputTokens: z.number(), ttl: z.string() }))
+      .nullish(),
   }),
 });
 
@@ -1015,10 +1055,15 @@ const BedrockStreamSchema = z.object({
   metadata: z
     .object({
       trace: z.unknown().nullish(),
+      performanceConfig: z.object({ latency: z.string() }).nullish(),
+      serviceTier: z.object({ type: z.string() }).nullish(),
       usage: z
         .object({
           cacheReadInputTokens: z.number().nullish(),
           cacheWriteInputTokens: z.number().nullish(),
+          cacheDetails: z
+            .array(z.object({ inputTokens: z.number(), ttl: z.string() }))
+            .nullish(),
           inputTokens: z.number(),
           outputTokens: z.number(),
         })


### PR DESCRIPTION
## background

the Bedrock Converse API returns `performanceConfig`, `serviceTier`, and `usage.cacheDetails` fields that the SDK currently drops silently. these are optional fields that appear with specific Bedrock configurations (performance tiers, prompt caching with TTL)

## summary

- add `performanceConfig` and `serviceTier` to `BedrockResponseSchema` and `BedrockStreamSchema`
- add `cacheDetails` to the `usage` object in both schemas
- surface all three fields in `providerMetadata.bedrock` for both `doGenerate` and `doStream`
- add provider metadata documentation section to Bedrock docs

## verification

<details>
<summary>tests pass</summary>

```
pnpm test

 ✓ src/bedrock-chat-language-model.test.ts  (99 tests) 190ms

 Test Files  14 passed (14)
      Tests  290 passed (290)
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [x] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)