### PR TITLE
feat(mcp): expose serializable data from the server tools

### DIFF
--- a/.changeset/six-kids-burn.md
+++ b/.changeset/six-kids-burn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+feat(mcp): expose serializable data from the server tools

--- a/examples/mcp/src/tool-definitions/client.ts
+++ b/examples/mcp/src/tool-definitions/client.ts
@@ -1,0 +1,39 @@
+import { createMCPClient } from '@ai-sdk/mcp';
+import { openai } from '@ai-sdk/openai';
+import { generateText, stepCountIs } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const mcpClient = await createMCPClient({
+    transport: {
+      type: 'sse',
+      url: 'http://localhost:8085/sse',
+    },
+  });
+
+  const definitions = await mcpClient.listTools();
+  console.log(`Definitions: ${JSON.stringify(definitions, null, 2)}`);
+
+  // Create executable tools
+  const tools = mcpClient.toolsFromDefinitions(definitions);
+
+  const { text: answer, steps } = await generateText({
+    model: openai('gpt-4o-mini'),
+    tools,
+    stopWhen: stepCountIs(20),
+    onStepFinish: async ({ toolResults }) => {
+      if (toolResults.length > 0) {
+        console.log('Tool results:', JSON.stringify(toolResults, null, 2));
+      }
+    },
+    prompt:
+      'Please greet Alice, then tell me the current time, and finally add 42 + 58.',
+  });
+
+  console.log(`\nFinal answer: ${answer}`);
+  console.log(`Total steps: ${steps.length}`);
+
+  await mcpClient.close();
+}
+
+main().catch(console.error);

--- a/examples/mcp/src/tool-definitions/server.ts
+++ b/examples/mcp/src/tool-definitions/server.ts
@@ -1,0 +1,63 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import 'dotenv/config';
+import express from 'express';
+import { z } from 'zod';
+
+const mcpServer = new McpServer({
+  name: 'tool-caching-example-server',
+  version: '1.0.0',
+});
+
+mcpServer.tool(
+  'add',
+  'Add two numbers together',
+  {
+    a: z.number().describe('First number'),
+    b: z.number().describe('Second number'),
+  },
+  async ({ a, b }) => {
+    return {
+      content: [{ type: 'text', text: `${a} + ${b} = ${a + b}` }],
+    };
+  },
+);
+
+mcpServer.tool('get-current-time', 'Get the current time', async () => {
+  return {
+    content: [
+      { type: 'text', text: `Current time: ${new Date().toISOString()}` },
+    ],
+  };
+});
+
+mcpServer.tool(
+  'greet',
+  'Greet a person by name',
+  {
+    name: z.string().describe('Name of the person to greet'),
+  },
+  async ({ name }) => {
+    return {
+      content: [{ type: 'text', text: `Hello, ${name}! Nice to meet you.` }],
+    };
+  },
+);
+
+let transport: SSEServerTransport;
+
+const app = express();
+
+app.get('/sse', async (req, res) => {
+  transport = new SSEServerTransport('/messages', res);
+  await mcpServer.connect(transport);
+});
+
+app.post('/messages', async (req, res) => {
+  await transport.handlePostMessage(req, res);
+});
+
+const PORT = 8085;
+app.listen(PORT, () => {
+  console.log(`Tool caching example MCP server listening on port ${PORT}`);
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -16,6 +16,7 @@ export { ElicitationRequestSchema, ElicitResultSchema } from './tool/types';
 export type {
   ElicitationRequest,
   ElicitResult,
+  ListToolsResult,
   ClientCapabilities as MCPClientCapabilities,
 } from './tool/types';
 export { auth, UnauthorizedError } from './tool/oauth';


### PR DESCRIPTION
## Background

we needed a way to expose just the serializable data received from server tools

## Summary

- we already had the logic for obtaining the data and converting the tools to executable tools. we refactored the `tools()` functions to call the `toolsFromDefinitions()` function which creates AI SDK tools from tool definitions.
- make `listTools()` public

## Manual Verification

verified via running existing cli examples + `examples/mcp/src/tool-definitions/client.ts`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] na ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)