### PR TITLE
feat(ai): add onStepFinish callback to createUIMessageStream

### DIFF
--- a/.changeset/great-goats-double.md
+++ b/.changeset/great-goats-double.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add onStepFinish callback to createUIMessageStream

--- a/examples/next-openai/app/api/use-chat-human-in-the-loop/route.ts
+++ b/examples/next-openai/app/api/use-chat-human-in-the-loop/route.ts
@@ -43,12 +43,17 @@ export async function POST(req: Request) {
         model: openai('gpt-4o'),
         messages: await convertToModelMessages(processedMessages),
         tools,
-        stopWhen: stepCountIs(5),
+        stopWhen: stepCountIs(20),
       });
 
       writer.merge(
         result.toUIMessageStream({ originalMessages: processedMessages }),
       );
+    },
+    onStepFinish: ({ messages, responseMessage }) => {
+      console.log('--- Step finished ---');
+      console.log('Parts count:', responseMessage.parts.length);
+      console.log('Messages:', JSON.stringify(messages, null, 2));
     },
     onFinish: ({}) => {
       // save messages here

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
@@ -7,6 +7,7 @@ import { UIMessage } from '../ui/ui-messages';
 import { handleUIMessageStreamFinish } from './handle-ui-message-stream-finish';
 import { InferUIMessageChunk } from './ui-message-chunks';
 import { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
+import { UIMessageStreamOnStepFinishCallback } from './ui-message-stream-on-step-finish-callback';
 import { UIMessageStreamWriter } from './ui-message-stream-writer';
 
 /**
@@ -16,6 +17,7 @@ import { UIMessageStreamWriter } from './ui-message-stream-writer';
  * @param options.onError - A function that extracts an error message from an error. Defaults to `getErrorMessage`.
  * @param options.originalMessages - The original messages. If provided, persistence mode is assumed
  *   and a message ID is provided for the response message.
+ * @param options.onStepFinish - A callback that is called when each step finishes. Useful for persisting intermediate messages.
  * @param options.onFinish - A callback that is called when the stream finishes.
  * @param options.generateId - A function that generates a unique ID. Defaults to the built-in ID generator.
  *
@@ -25,6 +27,7 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
   execute,
   onError = getErrorMessage,
   originalMessages,
+  onStepFinish,
   onFinish,
   generateId = generateIdFunc,
 }: {
@@ -38,6 +41,11 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
    * and a message ID is provided for the response message.
    */
   originalMessages?: UI_MESSAGE[];
+
+  /**
+   * Callback that is called when each step finishes during multi-step agent runs.
+   */
+  onStepFinish?: UIMessageStreamOnStepFinishCallback<UI_MESSAGE>;
 
   onFinish?: UIMessageStreamOnFinishCallback<UI_MESSAGE>;
 
@@ -130,6 +138,7 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
     stream,
     messageId: generateId(),
     originalMessages,
+    onStepFinish,
     onFinish,
     onError,
   });

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.test.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.test.ts
@@ -426,4 +426,271 @@ describe('handleUIMessageStreamFinish', () => {
       expect(callArgs.responseMessage.id).toBe('msg-1');
     });
   });
+
+  describe('onStepFinish callback', () => {
+    it('should call onStepFinish when finish-step chunk is encountered', async () => {
+      const onStepFinishCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-step-1' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Step 1 text' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ];
+
+      const originalMessages: UIMessage[] = [
+        {
+          id: 'user-msg-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-step-1',
+        originalMessages,
+        onError: mockErrorHandler,
+        onStepFinish: onStepFinishCallback,
+      });
+
+      const result = await convertReadableStreamToArray(resultStream);
+
+      expect(result).toEqual(inputChunks);
+      expect(onStepFinishCallback).toHaveBeenCalledTimes(1);
+
+      const callArgs = onStepFinishCallback.mock.calls[0][0];
+      expect(callArgs.isContinuation).toBe(false);
+      expect(callArgs.responseMessage.id).toBe('msg-step-1');
+      expect(callArgs.responseMessage.role).toBe('assistant');
+      expect(callArgs.messages).toHaveLength(2);
+      expect(callArgs.messages[0]).toEqual(originalMessages[0]);
+      expect(callArgs.messages[1].id).toBe('msg-step-1');
+    });
+
+    it('should call onStepFinish multiple times for multiple steps', async () => {
+      const onStepFinishCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-multi-step' },
+        // Step 1
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Step 1' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        // Step 2
+        { type: 'start-step' },
+        { type: 'text-start', id: 'text-2' },
+        { type: 'text-delta', id: 'text-2', delta: 'Step 2' },
+        { type: 'text-end', id: 'text-2' },
+        { type: 'finish-step' },
+        // Step 3
+        { type: 'start-step' },
+        { type: 'text-start', id: 'text-3' },
+        { type: 'text-delta', id: 'text-3', delta: 'Step 3' },
+        { type: 'text-end', id: 'text-3' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-multi-step',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onStepFinish: onStepFinishCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onStepFinishCallback).toHaveBeenCalledTimes(3);
+
+      // Verify each step has the correct accumulated content
+      const step1Args = onStepFinishCallback.mock.calls[0][0];
+      expect(step1Args.responseMessage.parts).toHaveLength(1);
+
+      const step2Args = onStepFinishCallback.mock.calls[1][0];
+      expect(step2Args.responseMessage.parts).toHaveLength(3); // step-start + 2 text parts
+
+      const step3Args = onStepFinishCallback.mock.calls[2][0];
+      expect(step3Args.responseMessage.parts).toHaveLength(5); // 2 step-starts + 3 text parts
+    });
+
+    it('should call both onStepFinish and onFinish when both are provided', async () => {
+      const onStepFinishCallback = vi.fn();
+      const onFinishCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-both' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-both',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onStepFinish: onStepFinishCallback,
+        onFinish: onFinishCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onStepFinishCallback).toHaveBeenCalledTimes(1);
+      expect(onFinishCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle onStepFinish errors by logging and continuing', async () => {
+      const onStepFinishCallback = vi
+        .fn()
+        .mockRejectedValue(new Error('DB error'));
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-error' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Step 1' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'start-step' },
+        { type: 'text-start', id: 'text-2' },
+        { type: 'text-delta', id: 'text-2', delta: 'Step 2' },
+        { type: 'text-end', id: 'text-2' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-error',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onStepFinish: onStepFinishCallback,
+      });
+
+      // Stream should complete without throwing
+      const result = await convertReadableStreamToArray(resultStream);
+
+      expect(result).toEqual(inputChunks);
+      // Both steps should have been attempted
+      expect(onStepFinishCallback).toHaveBeenCalledTimes(2);
+      // Error should have been logged twice
+      expect(mockErrorHandler).toHaveBeenCalledTimes(2);
+      expect(mockErrorHandler).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('should handle continuation scenario with onStepFinish', async () => {
+      const onStepFinishCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'assistant-msg-1' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: ' continued' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ];
+
+      const originalMessages: UIMessage[] = [
+        {
+          id: 'user-msg-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Continue this' }],
+        },
+        {
+          id: 'assistant-msg-1',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'This is' }],
+        },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-999',
+        originalMessages,
+        onError: mockErrorHandler,
+        onStepFinish: onStepFinishCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onStepFinishCallback).toHaveBeenCalledTimes(1);
+
+      const callArgs = onStepFinishCallback.mock.calls[0][0];
+      expect(callArgs.isContinuation).toBe(true);
+      expect(callArgs.responseMessage.id).toBe('assistant-msg-1');
+      expect(callArgs.messages).toHaveLength(2);
+    });
+
+    it('should provide deep-cloned messages in onStepFinish to prevent mutation', async () => {
+      const onStepFinishCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-clone' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-clone',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onStepFinish: onStepFinishCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      // Get the response message from the first call
+      const firstCallMessage =
+        onStepFinishCallback.mock.calls[0][0].responseMessage;
+
+      // Mutate the response message
+      firstCallMessage.parts.push({ type: 'text', text: 'Mutated!' });
+
+      // The mutation should not affect future state
+      // (This test validates that structuredClone is being used)
+      expect(firstCallMessage.parts).toHaveLength(2);
+    });
+
+    it('should not process stream when neither onFinish nor onStepFinish is provided', async () => {
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-passthrough' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Test' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-passthrough',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        // Neither onFinish nor onStepFinish provided
+      });
+
+      const result = await convertReadableStreamToArray(resultStream);
+
+      expect(result).toEqual(inputChunks);
+      expect(mockErrorHandler).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/ai/src/ui-message-stream/index.ts
+++ b/packages/ai/src/ui-message-stream/index.ts
@@ -10,4 +10,5 @@ export {
 } from './ui-message-chunks';
 export { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
 export type { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
+export type { UIMessageStreamOnStepFinishCallback } from './ui-message-stream-on-step-finish-callback';
 export type { UIMessageStreamWriter } from './ui-message-stream-writer';

--- a/packages/ai/src/ui-message-stream/ui-message-stream-on-step-finish-callback.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-on-step-finish-callback.ts
@@ -1,0 +1,25 @@
+import { UIMessage } from '../ui/ui-messages';
+
+/**
+ * Callback that is called when a step finishes during streaming.
+ * This is useful for persisting intermediate UI messages during multi-step agent runs.
+ */
+export type UIMessageStreamOnStepFinishCallback<UI_MESSAGE extends UIMessage> =
+  (event: {
+    /**
+     * The updated list of UI messages at the end of this step.
+     */
+    messages: UI_MESSAGE[];
+
+    /**
+     * Indicates whether the response message is a continuation of the last original message,
+     * or if a new message was created.
+     */
+    isContinuation: boolean;
+
+    /**
+     * The message that was sent to the client as a response
+     * (including the original message if it was extended).
+     */
+    responseMessage: UI_MESSAGE;
+  }) => PromiseLike<void> | void;


### PR DESCRIPTION
## Background

we expose `onFinish` callback for createUIMessageStream() but not `onStepFInish`, which is inconsistent with the pattern.

also reported in #12383 

## Summary

added the callback to the function + new type added

## Manual Verification

- verified by running `localhost:3000/use-chat-human-in-the-loop`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

the callback might need to be added for `createAgentUIStreamResponse`

## Related Issues

fixes #12383 