### PR TITLE
fix(xai): add support for response.function_call_arguments streaming events

### DIFF
--- a/.changeset/fix-xai-function-call-arguments.md
+++ b/.changeset/fix-xai-function-call-arguments.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Add support for `response.function_call_arguments.delta` and `response.function_call_arguments.done` streaming events in the xAI Responses API provider. Previously, xAI Grok models using function tools would fail with `AI_TypeValidationError` because these standard Responses API events were missing from the Zod schema and stream handler.

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -460,6 +460,19 @@ export const xaiResponsesChunkSchema = z.union([
     output_index: z.number(),
     input: z.string(),
   }),
+  // Function call arguments streaming events (standard function tools)
+  z.object({
+    type: z.literal('response.function_call_arguments.delta'),
+    item_id: z.string(),
+    output_index: z.number(),
+    delta: z.string(),
+  }),
+  z.object({
+    type: z.literal('response.function_call_arguments.done'),
+    item_id: z.string(),
+    output_index: z.number(),
+    arguments: z.string(),
+  }),
   z.object({
     type: z.literal('response.mcp_call.in_progress'),
     item_id: z.string(),

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -1891,6 +1891,116 @@ describe('XaiResponsesLanguageModel', () => {
         });
       });
 
+      it('should stream function tool call arguments', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast',
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            output_index: 0,
+            item: {
+              type: 'function_call',
+              id: 'fc_123',
+              call_id: 'call_123',
+              name: 'weather',
+              arguments: '',
+              status: 'in_progress',
+            },
+          }),
+          JSON.stringify({
+            type: 'response.function_call_arguments.delta',
+            item_id: 'fc_123',
+            output_index: 0,
+            delta: '{"location"',
+          }),
+          JSON.stringify({
+            type: 'response.function_call_arguments.delta',
+            item_id: 'fc_123',
+            output_index: 0,
+            delta: ':"sf"}',
+          }),
+          JSON.stringify({
+            type: 'response.function_call_arguments.done',
+            item_id: 'fc_123',
+            output_index: 0,
+            arguments: '{"location":"sf"}',
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            output_index: 0,
+            item: {
+              type: 'function_call',
+              id: 'fc_123',
+              call_id: 'call_123',
+              name: 'weather',
+              arguments: '{"location":"sf"}',
+              status: 'completed',
+            },
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'function',
+              name: 'weather',
+              description: 'get weather',
+              inputSchema: {
+                type: 'object',
+                properties: { location: { type: 'string' } },
+              },
+            },
+          ],
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        expect(parts).toContainEqual({
+          type: 'tool-input-start',
+          id: 'call_123',
+          toolName: 'weather',
+        });
+        expect(parts).toContainEqual({
+          type: 'tool-input-delta',
+          id: 'call_123',
+          delta: '{"location"',
+        });
+        expect(parts).toContainEqual({
+          type: 'tool-input-delta',
+          id: 'call_123',
+          delta: ':"sf"}',
+        });
+        expect(parts).toContainEqual({
+          type: 'tool-input-end',
+          id: 'call_123',
+        });
+        expect(parts).toContainEqual({
+          type: 'tool-call',
+          toolCallId: 'call_123',
+          toolName: 'weather',
+          input: '{"location":"sf"}',
+        });
+      });
+
       it('should stream file_search tool call and result', async () => {
         prepareStreamChunks([
           JSON.stringify({

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -450,6 +450,13 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
     const contentBlocks: Record<string, { type: 'text' }> = {};
     const seenToolCalls = new Set<string>();
 
+    // Track ongoing function calls by output_index so we can stream
+    // arguments via response.function_call_arguments.delta events.
+    const ongoingToolCalls: Record<
+      number,
+      { toolName: string; toolCallId: string } | undefined
+    > = {};
+
     const activeReasoning: Record<
       string,
       { encryptedContent?: string | null }
@@ -644,6 +651,24 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
               event.type === 'response.custom_tool_call_input.delta' ||
               event.type === 'response.custom_tool_call_input.done'
             ) {
+              return;
+            }
+
+            // Function call arguments streaming (standard function tools)
+            if (event.type === 'response.function_call_arguments.delta') {
+              const toolCall = ongoingToolCalls[event.output_index];
+              if (toolCall != null) {
+                controller.enqueue({
+                  type: 'tool-input-delta',
+                  id: toolCall.toolCallId,
+                  delta: event.delta,
+                });
+              }
+              return;
+            }
+            if (event.type === 'response.function_call_arguments.done') {
+              // Arguments are fully received; output_item.done will
+              // emit tool-input-end and tool-call with the final arguments.
               return;
             }
 
@@ -867,20 +892,21 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
                   }
                 }
               } else if (part.type === 'function_call') {
-                if (!seenToolCalls.has(part.call_id)) {
-                  seenToolCalls.add(part.call_id);
+                if (event.type === 'response.output_item.added') {
+                  // Track the call so function_call_arguments.delta events
+                  // can stream the arguments incrementally.
+                  ongoingToolCalls[event.output_index] = {
+                    toolName: part.name,
+                    toolCallId: part.call_id,
+                  };
 
                   controller.enqueue({
                     type: 'tool-input-start',
                     id: part.call_id,
                     toolName: part.name,
                   });
-
-                  controller.enqueue({
-                    type: 'tool-input-delta',
-                    id: part.call_id,
-                    delta: part.arguments,
-                  });
+                } else if (event.type === 'response.output_item.done') {
+                  ongoingToolCalls[event.output_index] = undefined;
 
                   controller.enqueue({
                     type: 'tool-input-end',


### PR DESCRIPTION
When using xAI Grok models (e.g. `grok-4-1-fast-reasoning`) with function tools via the Responses API, the model streams `response.function_call_arguments.delta` and `response.function_call_arguments.done` events — standard Responses API events also used by OpenAI. The `@ai-sdk/xai` provider's Zod schema did not include these event types, causing `AI_TypeValidationError` and breaking the entire stream whenever a function tool call was attempted.

**Summary**

- Added `response.function_call_arguments.delta` and `response.function_call_arguments.done` to `xaiResponsesChunkSchema` in `xai-responses-api.ts`
- Updated the stream handler in `xai-responses-language-model.ts` to:
  - Track ongoing tool calls by `output_index`
  - Emit `tool-input-start` on `response.output_item.added` for `function_call` items
  - Emit `tool-input-delta` for each `response.function_call_arguments.delta` event
  - Emit `tool-input-end` and `tool-call` on `response.output_item.done` (once arguments are fully received)
  - Skip `response.custom_tool_call_input.delta/done` events for `function_call` items (these are handled by the output_item events)
- Added unit test for function call argument streaming

**Manual Verification**

Built the patched `@ai-sdk/xai` locally and ran an e2e test against the real xAI API using `grok-4-1-fast-reasoning` with a function tool:

**Before fix** — `AI_TypeValidationError` on `response.function_call_arguments.done`:
```
AI_TypeValidationError: Type validation failed: Value: {
  "sequence_number":4,
  "type":"response.function_call_arguments.done",
  "arguments":"{}",
  "item_id":"fc_14f28817-...",
  "output_index":0
}
```

**After fix** — full streaming pipeline works:
```
tool-input-start:  PASS
tool-input-delta:  PASS
tool-call:         PASS
no errors:         PASS
```

**Checklist**

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes function tool calls failing with `AI_TypeValidationError` for xAI Grok models using the Responses API.