### PR TITLE
feat: normalize and export provider specific model options type names for existing schemas

### DIFF
--- a/.changeset/witty-boats-brush.md
+++ b/.changeset/witty-boats-brush.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+'@example/ai-functions': patch
+'@ai-sdk/assemblyai': patch
+'@ai-sdk/gladia': patch
+'@ai-sdk/revai': patch
+'@ai-sdk/hume': patch
+'@ai-sdk/lmnt': patch
+---
+
+feat: normalize and export provider specific model options type names for existing schemas

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -769,6 +769,7 @@ You can pass them as an options argument:
 
 ```ts
 import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { type AmazonBedrockEmbeddingModelOptions } from '@ai-sdk/amazon-bedrock';
 import { embed } from 'ai';
 
 const model = bedrock.embedding('amazon.titan-embed-text-v2:0');
@@ -780,7 +781,7 @@ const { embedding } = await embed({
     bedrock: {
       dimensions: 512, // optional, number of dimensions for the embedding
       normalize: true, // optional, normalize the output embeddings
-    },
+    } satisfies AmazonBedrockEmbeddingModelOptions,
   },
 });
 ```
@@ -801,6 +802,7 @@ Amazon Nova embedding models support additional provider options:
 
 ```ts
 import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { type AmazonBedrockEmbeddingModelOptions } from '@ai-sdk/amazon-bedrock';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
@@ -811,7 +813,7 @@ const { embedding } = await embed({
       embeddingDimension: 1024, // optional, number of dimensions
       embeddingPurpose: 'TEXT_RETRIEVAL', // optional, purpose of embedding
       truncate: 'END', // optional, truncation behavior
-    },
+    } satisfies AmazonBedrockEmbeddingModelOptions,
   },
 });
 ```
@@ -836,6 +838,7 @@ Cohere embedding models on Bedrock require an `inputType` and support truncation
 
 ```ts
 import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { type AmazonBedrockEmbeddingModelOptions } from '@ai-sdk/amazon-bedrock';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
@@ -845,7 +848,7 @@ const { embedding } = await embed({
     bedrock: {
       inputType: 'search_document', // required for Cohere
       truncate: 'END', // optional, truncation behavior
-    },
+    } satisfies AmazonBedrockEmbeddingModelOptions,
   },
 });
 ```

--- a/content/providers/01-ai-sdk-providers/100-assemblyai.mdx
+++ b/content/providers/01-ai-sdk-providers/100-assemblyai.mdx
@@ -77,15 +77,20 @@ const model = assemblyai.transcription('best');
 
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the `contentSafety` option will enable content safety filtering.
 
-```ts highlight="6"
+```ts highlight="7"
 import { experimental_transcribe as transcribe } from 'ai';
 import { assemblyai } from '@ai-sdk/assemblyai';
+import { type AssemblyAITranscriptionModelOptions } from '@ai-sdk/assemblyai';
 import { readFile } from 'fs/promises';
 
 const result = await transcribe({
   model: assemblyai.transcription('best'),
   audio: await readFile('audio.mp3'),
-  providerOptions: { assemblyai: { contentSafety: true } },
+  providerOptions: {
+    assemblyai: {
+      contentSafety: true,
+    } satisfies AssemblyAITranscriptionModelOptions,
+  },
 });
 ```
 

--- a/content/providers/01-ai-sdk-providers/120-gladia.mdx
+++ b/content/providers/01-ai-sdk-providers/120-gladia.mdx
@@ -75,15 +75,20 @@ const model = gladia.transcription();
 
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the `summarize` option will enable summaries for sections of content.
 
-```ts highlight="6"
+```ts highlight="7"
 import { experimental_transcribe as transcribe } from 'ai';
 import { gladia } from '@ai-sdk/gladia';
+import { type GladiaTranscriptionModelOptions } from '@ai-sdk/gladia';
 import { readFile } from 'fs/promises';
 
 const result = await transcribe({
   model: gladia.transcription(),
   audio: await readFile('audio.mp3'),
-  providerOptions: { gladia: { summarization: true } },
+  providerOptions: {
+    gladia: {
+      summarization: true,
+    } satisfies GladiaTranscriptionModelOptions,
+  },
 });
 ```
 

--- a/content/providers/01-ai-sdk-providers/140-lmnt.mdx
+++ b/content/providers/01-ai-sdk-providers/140-lmnt.mdx
@@ -91,9 +91,10 @@ const result = await generateSpeech({
 
 You can also pass additional provider-specific options using the `providerOptions` argument:
 
-```ts highlight="9-13"
+```ts highlight="10-14"
 import { experimental_generateSpeech as generateSpeech } from 'ai';
 import { lmnt } from '@ai-sdk/lmnt';
+import { type LMNTSpeechModelOptions } from '@ai-sdk/lmnt';
 
 const result = await generateSpeech({
   model: lmnt.speech('aurora'),
@@ -104,7 +105,7 @@ const result = await generateSpeech({
     lmnt: {
       conversational: true,
       speed: 1.2,
-    },
+    } satisfies LMNTSpeechModelOptions,
   },
 });
 ```

--- a/content/providers/01-ai-sdk-providers/150-hume.mdx
+++ b/content/providers/01-ai-sdk-providers/150-hume.mdx
@@ -125,6 +125,7 @@ You can pass additional provider-specific options using the `providerOptions` ar
 ```ts
 import { experimental_generateSpeech as generateSpeech } from 'ai';
 import { hume } from '@ai-sdk/hume';
+import { type HumeSpeechModelOptions } from '@ai-sdk/hume';
 
 const result = await generateSpeech({
   model: hume.speech(),
@@ -134,7 +135,7 @@ const result = await generateSpeech({
       context: {
         generationId: 'previous-generation-id',
       },
-    },
+    } satisfies HumeSpeechModelOptions,
   },
 });
 ```

--- a/content/providers/01-ai-sdk-providers/160-revai.mdx
+++ b/content/providers/01-ai-sdk-providers/160-revai.mdx
@@ -77,15 +77,18 @@ const model = revai.transcription('machine');
 
 You can also pass additional provider-specific options using the `providerOptions` argument. For example, supplying the input language in ISO-639-1 (e.g. `en`) format can sometimes improve transcription performance if known beforehand.
 
-```ts highlight="6"
+```ts highlight="7"
 import { experimental_transcribe as transcribe } from 'ai';
 import { revai } from '@ai-sdk/revai';
+import { type RevaiTranscriptionModelOptions } from '@ai-sdk/revai';
 import { readFile } from 'fs/promises';
 
 const result = await transcribe({
   model: revai.transcription('machine'),
   audio: await readFile('audio.mp3'),
-  providerOptions: { revai: { language: 'en' } },
+  providerOptions: {
+    revai: { language: 'en' } satisfies RevaiTranscriptionModelOptions,
+  },
 });
 ```
 

--- a/examples/ai-functions/src/embed/amazon-bedrock-cohere-dimensions.ts
+++ b/examples/ai-functions/src/embed/amazon-bedrock-cohere-dimensions.ts
@@ -1,4 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { type AmazonBedrockEmbeddingModelOptions } from '@ai-sdk/amazon-bedrock';
 import { embed } from 'ai';
 import { run } from '../lib/run';
 
@@ -10,7 +11,7 @@ run(async () => {
     providerOptions: {
       bedrock: {
         outputDimension: 256,
-      },
+      } satisfies AmazonBedrockEmbeddingModelOptions,
     },
   });
 

--- a/examples/ai-functions/src/embed/amazon-bedrock-cohere-input-type.ts
+++ b/examples/ai-functions/src/embed/amazon-bedrock-cohere-input-type.ts
@@ -1,4 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { type AmazonBedrockEmbeddingModelOptions } from '@ai-sdk/amazon-bedrock';
 import { embed } from 'ai';
 import { run } from '../lib/run';
 
@@ -11,7 +12,7 @@ run(async () => {
     providerOptions: {
       bedrock: {
         inputType: 'search_document',
-      },
+      } satisfies AmazonBedrockEmbeddingModelOptions,
     },
   });
 

--- a/examples/ai-functions/src/embed/amazon-bedrock-nova-options.ts
+++ b/examples/ai-functions/src/embed/amazon-bedrock-nova-options.ts
@@ -1,4 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { type AmazonBedrockEmbeddingModelOptions } from '@ai-sdk/amazon-bedrock';
 import { embed } from 'ai';
 import { run } from '../lib/run';
 
@@ -12,7 +13,7 @@ run(async () => {
         embeddingDimension: 256,
         embeddingPurpose: 'TEXT_RETRIEVAL',
         truncate: 'END',
-      },
+      } satisfies AmazonBedrockEmbeddingModelOptions,
     },
   });
 

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.ts
@@ -14,7 +14,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import {
   BedrockEmbeddingModelId,
-  bedrockEmbeddingProviderOptions,
+  amazonBedrockEmbeddingModelOptionsSchema,
 } from './bedrock-embedding-options';
 import { BedrockErrorSchema } from './bedrock-error';
 import { z } from 'zod/v4';
@@ -63,7 +63,7 @@ export class BedrockEmbeddingModel implements EmbeddingModelV3 {
       (await parseProviderOptions({
         provider: 'bedrock',
         providerOptions,
-        schema: bedrockEmbeddingProviderOptions,
+        schema: amazonBedrockEmbeddingModelOptionsSchema,
       })) ?? {};
 
     // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html

--- a/packages/amazon-bedrock/src/bedrock-embedding-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-options.ts
@@ -7,7 +7,7 @@ export type BedrockEmbeddingModelId =
   | 'cohere.embed-multilingual-v3'
   | (string & {});
 
-export const bedrockEmbeddingProviderOptions = z.object({
+export const amazonBedrockEmbeddingModelOptionsSchema = z.object({
   /**
    * The number of dimensions the resulting output embeddings should have (defaults to 1024).
    * Only supported in amazon.titan-embed-text-v2:0.
@@ -72,3 +72,7 @@ export const bedrockEmbeddingProviderOptions = z.object({
     .union([z.literal(256), z.literal(512), z.literal(1024), z.literal(1536)])
     .optional(),
 });
+
+export type AmazonBedrockEmbeddingModelOptions = z.infer<
+  typeof amazonBedrockEmbeddingModelOptionsSchema
+>;

--- a/packages/amazon-bedrock/src/index.ts
+++ b/packages/amazon-bedrock/src/index.ts
@@ -1,5 +1,6 @@
 export type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 
+export type { AmazonBedrockEmbeddingModelOptions } from './bedrock-embedding-options';
 export type {
   AmazonBedrockLanguageModelOptions,
   /** @deprecated Use `AmazonBedrockLanguageModelOptions` instead. */

--- a/packages/assemblyai/src/assemblyai-transcription-model.ts
+++ b/packages/assemblyai/src/assemblyai-transcription-model.ts
@@ -14,7 +14,7 @@ import { AssemblyAITranscriptionModelId } from './assemblyai-transcription-setti
 import { AssemblyAITranscriptionAPITypes } from './assemblyai-api-types';
 
 // https://www.assemblyai.com/docs/api-reference/transcripts/submit
-const assemblyaiProviderOptionsSchema = z.object({
+const assemblyaiTranscriptionModelOptionsSchema = z.object({
   /**
    * End time of the audio in milliseconds.
    */
@@ -161,8 +161,8 @@ const assemblyaiProviderOptionsSchema = z.object({
   wordBoost: z.array(z.string()).nullish(),
 });
 
-export type AssemblyAITranscriptionCallOptions = z.infer<
-  typeof assemblyaiProviderOptionsSchema
+export type AssemblyAITranscriptionModelOptions = z.infer<
+  typeof assemblyaiTranscriptionModelOptionsSchema
 >;
 
 interface AssemblyAITranscriptionModelConfig extends AssemblyAIConfig {
@@ -197,7 +197,7 @@ export class AssemblyAITranscriptionModel implements TranscriptionModelV3 {
     const assemblyaiOptions = await parseProviderOptions({
       provider: 'assemblyai',
       providerOptions,
-      schema: assemblyaiProviderOptionsSchema,
+      schema: assemblyaiTranscriptionModelOptionsSchema,
     });
 
     const body: Omit<AssemblyAITranscriptionAPITypes, 'audio_url'> = {

--- a/packages/assemblyai/src/index.ts
+++ b/packages/assemblyai/src/index.ts
@@ -3,4 +3,5 @@ export type {
   AssemblyAIProvider,
   AssemblyAIProviderSettings,
 } from './assemblyai-provider';
+export type { AssemblyAITranscriptionModelOptions } from './assemblyai-transcription-model';
 export { VERSION } from './version';

--- a/packages/gladia/src/gladia-transcription-model.ts
+++ b/packages/gladia/src/gladia-transcription-model.ts
@@ -20,7 +20,7 @@ import { gladiaFailedResponseHandler } from './gladia-error';
 import { GladiaTranscriptionInitiateAPITypes } from './gladia-api-types';
 
 // https://docs.gladia.io/api-reference/v2/pre-recorded/init
-const gladiaProviderOptionsSchema = z.object({
+const gladiaTranscriptionModelOptionsSchema = z.object({
   /**
    * Optional context prompt to guide the transcription.
    */
@@ -323,8 +323,8 @@ const gladiaProviderOptionsSchema = z.object({
   punctuationEnhanced: z.boolean().nullish(),
 });
 
-export type GladiaTranscriptionCallOptions = z.infer<
-  typeof gladiaProviderOptionsSchema
+export type GladiaTranscriptionModelOptions = z.infer<
+  typeof gladiaTranscriptionModelOptionsSchema
 >;
 
 interface GladiaTranscriptionModelConfig extends GladiaConfig {
@@ -354,7 +354,7 @@ export class GladiaTranscriptionModel implements TranscriptionModelV3 {
     const gladiaOptions = await parseProviderOptions({
       provider: 'gladia',
       providerOptions,
-      schema: gladiaProviderOptionsSchema,
+      schema: gladiaTranscriptionModelOptionsSchema,
     });
 
     const body: Omit<GladiaTranscriptionInitiateAPITypes, 'audio_url'> = {};

--- a/packages/gladia/src/index.ts
+++ b/packages/gladia/src/index.ts
@@ -1,3 +1,4 @@
 export { createGladia, gladia } from './gladia-provider';
 export type { GladiaProvider, GladiaProviderSettings } from './gladia-provider';
+export type { GladiaTranscriptionModelOptions } from './gladia-transcription-model';
 export { VERSION } from './version';

--- a/packages/hume/src/hume-speech-model.ts
+++ b/packages/hume/src/hume-speech-model.ts
@@ -11,7 +11,7 @@ import { humeFailedResponseHandler } from './hume-error';
 import { HumeSpeechAPITypes } from './hume-api-types';
 
 // https://dev.hume.ai/reference/text-to-speech-tts/synthesize-file
-const humeSpeechCallOptionsSchema = z.object({
+const humeSpeechModelOptionsSchema = z.object({
   /**
    * Context for the speech synthesis request.
    * Can be either a generationId for retrieving a previous generation,
@@ -82,7 +82,9 @@ const humeSpeechCallOptionsSchema = z.object({
     .nullish(),
 });
 
-export type HumeSpeechCallOptions = z.infer<typeof humeSpeechCallOptionsSchema>;
+export type HumeSpeechModelOptions = z.infer<
+  typeof humeSpeechModelOptionsSchema
+>;
 
 interface HumeSpeechModelConfig extends HumeConfig {
   _internal?: {
@@ -117,7 +119,7 @@ export class HumeSpeechModel implements SpeechModelV3 {
     const humeOptions = await parseProviderOptions({
       provider: 'hume',
       providerOptions,
-      schema: humeSpeechCallOptionsSchema,
+      schema: humeSpeechModelOptionsSchema,
     });
 
     // Create request body

--- a/packages/hume/src/index.ts
+++ b/packages/hume/src/index.ts
@@ -1,3 +1,4 @@
 export { createHume, hume } from './hume-provider';
 export type { HumeProvider, HumeProviderSettings } from './hume-provider';
+export type { HumeSpeechModelOptions } from './hume-speech-model';
 export { VERSION } from './version';

--- a/packages/lmnt/src/index.ts
+++ b/packages/lmnt/src/index.ts
@@ -1,3 +1,4 @@
 export { createLMNT, lmnt } from './lmnt-provider';
 export type { LMNTProvider, LMNTProviderSettings } from './lmnt-provider';
+export type { LMNTSpeechModelOptions } from './lmnt-speech-model';
 export { VERSION } from './version';

--- a/packages/lmnt/src/lmnt-speech-model.ts
+++ b/packages/lmnt/src/lmnt-speech-model.ts
@@ -12,7 +12,7 @@ import { LMNTSpeechModelId } from './lmnt-speech-options';
 import { LMNTSpeechAPITypes } from './lmnt-api-types';
 
 // https://docs.lmnt.com/api-reference/speech/synthesize-speech-bytes
-const lmntSpeechCallOptionsSchema = z.object({
+const lmntSpeechModelOptionsSchema = z.object({
   /**
    * The model to use for speech synthesis e.g. 'aurora' or 'blizzard'.
    * @default 'aurora'
@@ -75,7 +75,9 @@ const lmntSpeechCallOptionsSchema = z.object({
   temperature: z.number().min(0).nullish().default(1),
 });
 
-export type LMNTSpeechCallOptions = z.infer<typeof lmntSpeechCallOptionsSchema>;
+export type LMNTSpeechModelOptions = z.infer<
+  typeof lmntSpeechModelOptionsSchema
+>;
 
 interface LMNTSpeechModelConfig extends LMNTConfig {
   _internal?: {
@@ -109,7 +111,7 @@ export class LMNTSpeechModel implements SpeechModelV3 {
     const lmntOptions = await parseProviderOptions({
       provider: 'lmnt',
       providerOptions,
-      schema: lmntSpeechCallOptionsSchema,
+      schema: lmntSpeechModelOptionsSchema,
     });
 
     // Create request body

--- a/packages/revai/src/index.ts
+++ b/packages/revai/src/index.ts
@@ -1,3 +1,4 @@
 export { createRevai, revai } from './revai-provider';
 export type { RevaiProvider, RevaiProviderSettings } from './revai-provider';
+export type { RevaiTranscriptionModelOptions } from './revai-transcription-model';
 export { VERSION } from './version';

--- a/packages/revai/src/revai-transcription-model.ts
+++ b/packages/revai/src/revai-transcription-model.ts
@@ -20,7 +20,7 @@ import { RevaiTranscriptionModelId } from './revai-transcription-options';
 import { RevaiTranscriptionAPITypes } from './revai-api-types';
 
 // https://docs.rev.ai/api/asynchronous/reference/#operation/SubmitTranscriptionJob
-const revaiProviderOptionsSchema = z.object({
+const revaiTranscriptionModelOptionsSchema = z.object({
   /**
    * Optional metadata string to associate with the transcription job.
    */
@@ -210,8 +210,8 @@ const revaiProviderOptionsSchema = z.object({
   forced_alignment: z.boolean().nullish().default(false),
 });
 
-export type RevaiTranscriptionCallOptions = z.infer<
-  typeof revaiProviderOptionsSchema
+export type RevaiTranscriptionModelOptions = z.infer<
+  typeof revaiTranscriptionModelOptionsSchema
 >;
 
 interface RevaiTranscriptionModelConfig extends RevaiConfig {
@@ -243,7 +243,7 @@ export class RevaiTranscriptionModel implements TranscriptionModelV3 {
     const revaiOptions = await parseProviderOptions({
       provider: 'revai',
       providerOptions,
-      schema: revaiProviderOptionsSchema,
+      schema: revaiTranscriptionModelOptionsSchema,
     });
 
     // Create form data with base fields


### PR DESCRIPTION
## Background

Follow-up to #12443: six providers still had internal providerOptions schemas that weren't renamed to the normalized naming convention or exported. This PR addresses those remaining gaps tracked in #12269.

## Summary

Renames and exports provider-specific model options types for 6 providers that already had Zod schemas internally but weren't following the normalized naming convention:

- `@ai-sdk/amazon-bedrock`: `AmazonBedrockEmbeddingModelOptions`
- `@ai-sdk/lmnt`: `LMNTSpeechModelOptions`
- `@ai-sdk/hume`: `HumeSpeechModelOptions`
- `@ai-sdk/revai`: `RevaiTranscriptionModelOptions`
- `@ai-sdk/assemblyai`: `AssemblyAITranscriptionModelOptions`
- `@ai-sdk/gladia`: `GladiaTranscriptionModelOptions`

Also updates documentation code snippets and examples to use `satisfies` with the newly exported types.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Other categories of providers from #12269 still need attention:
- Providers using raw passthrough without schemas (e.g. elevenlabs, fal, sarvam)
- Providers extending OpenAI-compatible that inherit options
- Providers without embedding providerOptions support

These will require separate follow up issues for consideration.

## Related Issues

Fixes #12269
