### PR TITLE
fix (provider/google-vertex): pass mime type with i2v video generation

### DIFF
--- a/.changeset/witty-parrots-burn.md
+++ b/.changeset/witty-parrots-burn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+fix (provider/google-vertex): pass mime type with i2v video generation

--- a/examples/ai-functions/src/generate-video/vertex-veo-i2v-base64.ts
+++ b/examples/ai-functions/src/generate-video/vertex-veo-i2v-base64.ts
@@ -1,0 +1,32 @@
+import {
+  type GoogleVertexVideoProviderOptions,
+  vertex,
+} from '@ai-sdk/google-vertex';
+import { experimental_generateVideo } from 'ai';
+import fs from 'node:fs';
+import { presentVideos } from '../lib/present-video';
+import { run } from '../lib/run';
+import { withSpinner } from '../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating video from image (base64)...',
+    () =>
+      experimental_generateVideo({
+        model: vertex.video('veo-3.1-generate-001'),
+        prompt: {
+          image: fs.readFileSync('data/comic-cat.png'),
+          text: 'Animate this image with gentle motion',
+        },
+        aspectRatio: '16:9',
+        duration: 4,
+        providerOptions: {
+          vertex: {
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies GoogleVertexVideoProviderOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/packages/google-vertex/src/google-vertex-video-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-video-model.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
 import { GoogleVertexVideoModel } from './google-vertex-video-model';
-import { createVertex } from './google-vertex-provider';
 
 vi.mock('./version', () => ({
   VERSION: '0.0.0-test',
@@ -457,6 +456,7 @@ describe('GoogleVertexVideoModel', () => {
             prompt,
             image: {
               bytesBase64Encoded: 'base64-image-data',
+              mimeType: 'image/png',
             },
           },
         ],

--- a/packages/google-vertex/src/google-vertex-video-model.ts
+++ b/packages/google-vertex/src/google-vertex-video-model.ts
@@ -105,6 +105,7 @@ export class GoogleVertexVideoModel implements Experimental_VideoModelV3 {
 
         instance.image = {
           bytesBase64Encoded: base64Data,
+          mimeType: options.image.mediaType,
         };
       }
     }


### PR DESCRIPTION
## Background

When generating videos from images using the Google Vertex AI provider, the MIME type was not being passed along with the base64-encoded image data. This resulted in Vertex failing with an error re: missing mime type for media.

## Summary

This PR fixes the Google Vertex provider's image-to-video generation by properly passing the MIME type with the base64-encoded image data.

## Manual Verification

Tested the image-to-video generation functionality with a base64-encoded image and confirmed that the video is generated correctly with the MIME type properly passed to the API.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)