### PR TITLE
Backport pr 12407 to release v5.0

### DIFF
--- a/.changeset/friendly-chefs-perform.md
+++ b/.changeset/friendly-chefs-perform.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix (provider/gateway): added custom error class and message for client side timeouts

--- a/examples/ai-core/package.json
+++ b/examples/ai-core/package.json
@@ -9,6 +9,7 @@
     "@ai-sdk/assemblyai": "workspace:*",
     "@ai-sdk/azure": "workspace:*",
     "@ai-sdk/baseten": "workspace:*",
+    "@ai-sdk/black-forest-labs": "workspace:*",
     "@ai-sdk/cerebras": "workspace:*",
     "@ai-sdk/cohere": "workspace:*",
     "@ai-sdk/deepgram": "workspace:*",
@@ -49,6 +50,7 @@
     "mathjs": "14.0.0",
     "sharp": "^0.33.5",
     "terminal-image": "^2.0.0",
+    "undici": "^7.21.0",
     "zod": "3.25.76",
     "valibot": "^1.0.0-rc.0 || ^1.0.0"
   },

--- a/examples/ai-core/src/generate-image/gateway-timeout.ts
+++ b/examples/ai-core/src/generate-image/gateway-timeout.ts
@@ -1,0 +1,87 @@
+/**
+ * Example demonstrating Gateway timeout error handling for image generation
+ *
+ * This example uses undici with an extremely short timeout (1ms) to trigger
+ * a timeout error. The Gateway SDK will catch this and provide a helpful
+ * error message with troubleshooting guidance.
+ *
+ * Prerequisites:
+ * - Set AI_GATEWAY_API_KEY environment variable
+ *   (See .env.example for setup instructions)
+ *
+ * Run: pnpm tsx src/generate-image/gateway-timeout.ts
+ */
+import { createGateway, generateImage } from 'ai';
+import { Agent, fetch as undiciFetch } from 'undici';
+import { run } from '../lib/run';
+
+run(async () => {
+  try {
+    // Create an undici Agent with very short timeouts
+    // bodyTimeout applies to receiving the entire response body
+    const agent = new Agent({
+      headersTimeout: 1, // 1ms - will timeout waiting for headers
+      bodyTimeout: 1, // 1ms - will timeout reading response body
+    });
+
+    // Create custom fetch using undici with the configured agent
+    const customFetch = (
+      url: string | URL | Request,
+      options?: RequestInit,
+    ): Promise<Response> => {
+      return undiciFetch(url as Parameters<typeof undiciFetch>[0], {
+        ...(options as any),
+        dispatcher: agent,
+      }) as Promise<Response>;
+    };
+
+    // Create gateway provider with custom fetch
+    const gateway = createGateway({
+      fetch: customFetch,
+    });
+
+    console.log('Making image generation request with 1ms timeout...');
+    console.log(
+      'This should timeout immediately and show the timeout error handling.\n',
+    );
+
+    const { image } = await generateImage({
+      model: gateway.imageModel('black-forest-labs/flux-1.1-pro'),
+      prompt: 'A serene mountain landscape at sunset',
+    });
+
+    console.log('Success! Image generated:');
+    console.log('Base64 length:', image.base64.length);
+    console.log('Media type:', image.mediaType);
+  } catch (error) {
+    console.error(
+      '╔════════════════════════════════════════════════════════════════╗',
+    );
+    console.error(
+      '║                    TIMEOUT ERROR CAUGHT                        ║',
+    );
+    console.error(
+      '╚════════════════════════════════════════════════════════════════╝\n',
+    );
+    console.error('Error Name:', (error as Error).name);
+    console.error('Error Type:', (error as any).type);
+    console.error('Status Code:', (error as any).statusCode);
+    console.error('Error Code:', (error as any).code);
+    console.error('\nError Message:');
+    console.error('─'.repeat(70));
+    console.error((error as Error).message);
+    console.error('─'.repeat(70));
+
+    // Log the cause to see the original undici error
+    if ((error as any).cause) {
+      console.error('\n📋 Original Error (cause):');
+      console.error('  Name:', ((error as any).cause as Error).name);
+      console.error('  Code:', ((error as any).cause as any).code);
+      console.error('  Message:', ((error as any).cause as Error).message);
+      console.error(
+        '  Constructor:',
+        ((error as any).cause as Error).constructor.name,
+      );
+    }
+  }
+});

--- a/examples/ai-core/src/generate-image/gateway-timeout.ts
+++ b/examples/ai-core/src/generate-image/gateway-timeout.ts
@@ -11,7 +11,7 @@
  *
  * Run: pnpm tsx src/generate-image/gateway-timeout.ts
  */
-import { createGateway, generateImage } from 'ai';
+import { createGateway, experimental_generateImage } from 'ai';
 import { Agent, fetch as undiciFetch } from 'undici';
 import { run } from '../lib/run';
 
@@ -45,7 +45,7 @@ run(async () => {
       'This should timeout immediately and show the timeout error handling.\n',
     );
 
-    const { image } = await generateImage({
+    const { image } = await experimental_generateImage({
       model: gateway.imageModel('black-forest-labs/flux-1.1-pro'),
       prompt: 'A serene mountain landscape at sunset',
     });

--- a/examples/ai-core/src/generate-image/gateway-timeout.ts
+++ b/examples/ai-core/src/generate-image/gateway-timeout.ts
@@ -1,87 +1,30 @@
-/**
- * Example demonstrating Gateway timeout error handling for image generation
- *
- * This example uses undici with an extremely short timeout (1ms) to trigger
- * a timeout error. The Gateway SDK will catch this and provide a helpful
- * error message with troubleshooting guidance.
- *
- * Prerequisites:
- * - Set AI_GATEWAY_API_KEY environment variable
- *   (See .env.example for setup instructions)
- *
- * Run: pnpm tsx src/generate-image/gateway-timeout.ts
- */
 import { createGateway, experimental_generateImage } from 'ai';
 import { Agent, fetch as undiciFetch } from 'undici';
 import { run } from '../lib/run';
 
 run(async () => {
   try {
-    // Create an undici Agent with very short timeouts
-    // bodyTimeout applies to receiving the entire response body
-    const agent = new Agent({
-      headersTimeout: 1, // 1ms - will timeout waiting for headers
-      bodyTimeout: 1, // 1ms - will timeout reading response body
-    });
-
-    // Create custom fetch using undici with the configured agent
-    const customFetch = (
-      url: string | URL | Request,
-      options?: RequestInit,
-    ): Promise<Response> => {
-      return undiciFetch(url as Parameters<typeof undiciFetch>[0], {
-        ...(options as any),
-        dispatcher: agent,
-      }) as Promise<Response>;
-    };
-
-    // Create gateway provider with custom fetch
     const gateway = createGateway({
-      fetch: customFetch,
+      fetch: (
+        url: string | URL | Request,
+        options?: RequestInit,
+      ): Promise<Response> => {
+        // @ts-expect-error - undici types are outdated and don't include dispatcher option
+        return undiciFetch(url as Parameters<typeof undiciFetch>[0], {
+          ...options,
+          dispatcher: new Agent({
+            headersTimeout: 1,
+            bodyTimeout: 1,
+          }),
+        }) as Promise<Response>;
+      },
     });
 
-    console.log('Making image generation request with 1ms timeout...');
-    console.log(
-      'This should timeout immediately and show the timeout error handling.\n',
-    );
-
-    const { image } = await experimental_generateImage({
-      model: gateway.imageModel('black-forest-labs/flux-1.1-pro'),
+    await experimental_generateImage({
+      model: gateway.imageModel('bfl/flux-pro-1.1'),
       prompt: 'A serene mountain landscape at sunset',
     });
-
-    console.log('Success! Image generated:');
-    console.log('Base64 length:', image.base64.length);
-    console.log('Media type:', image.mediaType);
   } catch (error) {
-    console.error(
-      '╔════════════════════════════════════════════════════════════════╗',
-    );
-    console.error(
-      '║                    TIMEOUT ERROR CAUGHT                        ║',
-    );
-    console.error(
-      '╚════════════════════════════════════════════════════════════════╝\n',
-    );
-    console.error('Error Name:', (error as Error).name);
-    console.error('Error Type:', (error as any).type);
-    console.error('Status Code:', (error as any).statusCode);
-    console.error('Error Code:', (error as any).code);
-    console.error('\nError Message:');
-    console.error('─'.repeat(70));
-    console.error((error as Error).message);
-    console.error('─'.repeat(70));
-
-    // Log the cause to see the original undici error
-    if ((error as any).cause) {
-      console.error('\n📋 Original Error (cause):');
-      console.error('  Name:', ((error as any).cause as Error).name);
-      console.error('  Code:', ((error as any).cause as any).code);
-      console.error('  Message:', ((error as any).cause as Error).message);
-      console.error(
-        '  Constructor:',
-        ((error as any).cause as Error).constructor.name,
-      );
-    }
+    console.log(error);
   }
 });

--- a/examples/ai-core/src/generate-text/gateway-timeout.ts
+++ b/examples/ai-core/src/generate-text/gateway-timeout.ts
@@ -1,0 +1,89 @@
+/**
+ * Example demonstrating Gateway timeout error handling
+ *
+ * This example uses undici with an extremely short timeout (1ms) to trigger
+ * a timeout error. The Gateway SDK will catch this and provide a helpful
+ * error message with troubleshooting guidance.
+ *
+ * Prerequisites:
+ * - Set AI_GATEWAY_API_KEY environment variable
+ *   (See .env.example for setup instructions)
+ *
+ * Run: pnpm tsx src/generate-text/gateway-timeout.ts
+ */
+import { createGateway, generateText } from 'ai';
+import { Agent, fetch as undiciFetch } from 'undici';
+import { run } from '../lib/run';
+
+run(async () => {
+  try {
+    // Create an undici Agent with very short timeouts
+    // bodyTimeout applies to receiving the entire response body
+    const agent = new Agent({
+      headersTimeout: 1, // 1ms - will timeout waiting for headers
+      bodyTimeout: 1, // 1ms - will timeout reading response body
+    });
+
+    // Create custom fetch using undici with the configured agent
+    const customFetch = (
+      url: string | URL | Request,
+      options?: RequestInit,
+    ): Promise<Response> => {
+      return undiciFetch(url as Parameters<typeof undiciFetch>[0], {
+        ...(options as any),
+        dispatcher: agent,
+      }) as Promise<Response>;
+    };
+
+    // Create gateway provider with custom fetch
+    const gateway = createGateway({
+      fetch: customFetch,
+    });
+
+    console.log('Making request with 1ms timeout...');
+    console.log(
+      'This should timeout immediately and show the timeout error handling.\n',
+    );
+
+    const { text, usage } = await generateText({
+      model: gateway('anthropic/claude-3.5-sonnet'),
+      prompt:
+        'Write a detailed essay about the history of artificial intelligence, covering major milestones from the 1950s to present day.',
+    });
+
+    console.log('Success! Response received:');
+    console.log(text);
+    console.log();
+    console.log('Usage:', usage);
+  } catch (error) {
+    console.error(
+      '╔════════════════════════════════════════════════════════════════╗',
+    );
+    console.error(
+      '║                    TIMEOUT ERROR CAUGHT                        ║',
+    );
+    console.error(
+      '╚════════════════════════════════════════════════════════════════╝\n',
+    );
+    console.error('Error Name:', (error as Error).name);
+    console.error('Error Type:', (error as any).type);
+    console.error('Status Code:', (error as any).statusCode);
+    console.error('Error Code:', (error as any).code);
+    console.error('\nError Message:');
+    console.error('─'.repeat(70));
+    console.error((error as Error).message);
+    console.error('─'.repeat(70));
+
+    // Log the cause to see the original undici error
+    if ((error as any).cause) {
+      console.error('\n📋 Original Error (cause):');
+      console.error('  Name:', ((error as any).cause as Error).name);
+      console.error('  Code:', ((error as any).cause as any).code);
+      console.error('  Message:', ((error as any).cause as Error).message);
+      console.error(
+        '  Constructor:',
+        ((error as any).cause as Error).constructor.name,
+      );
+    }
+  }
+});

--- a/examples/ai-core/src/generate-text/gateway-timeout.ts
+++ b/examples/ai-core/src/generate-text/gateway-timeout.ts
@@ -1,89 +1,31 @@
-/**
- * Example demonstrating Gateway timeout error handling
- *
- * This example uses undici with an extremely short timeout (1ms) to trigger
- * a timeout error. The Gateway SDK will catch this and provide a helpful
- * error message with troubleshooting guidance.
- *
- * Prerequisites:
- * - Set AI_GATEWAY_API_KEY environment variable
- *   (See .env.example for setup instructions)
- *
- * Run: pnpm tsx src/generate-text/gateway-timeout.ts
- */
 import { createGateway, generateText } from 'ai';
 import { Agent, fetch as undiciFetch } from 'undici';
 import { run } from '../lib/run';
 
 run(async () => {
   try {
-    // Create an undici Agent with very short timeouts
-    // bodyTimeout applies to receiving the entire response body
-    const agent = new Agent({
-      headersTimeout: 1, // 1ms - will timeout waiting for headers
-      bodyTimeout: 1, // 1ms - will timeout reading response body
-    });
-
-    // Create custom fetch using undici with the configured agent
-    const customFetch = (
-      url: string | URL | Request,
-      options?: RequestInit,
-    ): Promise<Response> => {
-      return undiciFetch(url as Parameters<typeof undiciFetch>[0], {
-        ...(options as any),
-        dispatcher: agent,
-      }) as Promise<Response>;
-    };
-
-    // Create gateway provider with custom fetch
     const gateway = createGateway({
-      fetch: customFetch,
+      fetch: (
+        url: string | URL | Request,
+        options?: RequestInit,
+      ): Promise<Response> => {
+        // @ts-expect-error - undici types are outdated and don't include dispatcher option
+        return undiciFetch(url as Parameters<typeof undiciFetch>[0], {
+          ...options,
+          dispatcher: new Agent({
+            headersTimeout: 1,
+            bodyTimeout: 1,
+          }),
+        }) as Promise<Response>;
+      },
     });
 
-    console.log('Making request with 1ms timeout...');
-    console.log(
-      'This should timeout immediately and show the timeout error handling.\n',
-    );
-
-    const { text, usage } = await generateText({
-      model: gateway('anthropic/claude-3.5-sonnet'),
+    await generateText({
+      model: gateway('anthropic/claude-sonnet-4.5'),
       prompt:
         'Write a detailed essay about the history of artificial intelligence, covering major milestones from the 1950s to present day.',
     });
-
-    console.log('Success! Response received:');
-    console.log(text);
-    console.log();
-    console.log('Usage:', usage);
   } catch (error) {
-    console.error(
-      '╔════════════════════════════════════════════════════════════════╗',
-    );
-    console.error(
-      '║                    TIMEOUT ERROR CAUGHT                        ║',
-    );
-    console.error(
-      '╚════════════════════════════════════════════════════════════════╝\n',
-    );
-    console.error('Error Name:', (error as Error).name);
-    console.error('Error Type:', (error as any).type);
-    console.error('Status Code:', (error as any).statusCode);
-    console.error('Error Code:', (error as any).code);
-    console.error('\nError Message:');
-    console.error('─'.repeat(70));
-    console.error((error as Error).message);
-    console.error('─'.repeat(70));
-
-    // Log the cause to see the original undici error
-    if ((error as any).cause) {
-      console.error('\n📋 Original Error (cause):');
-      console.error('  Name:', ((error as any).cause as Error).name);
-      console.error('  Code:', ((error as any).cause as any).code);
-      console.error('  Message:', ((error as any).cause as Error).message);
-      console.error(
-        '  Constructor:',
-        ((error as any).cause as Error).constructor.name,
-      );
-    }
+    console.log(error);
   }
 });

--- a/examples/ai-core/src/stream-text/gateway-timeout.ts
+++ b/examples/ai-core/src/stream-text/gateway-timeout.ts
@@ -1,0 +1,91 @@
+/**
+ * Example demonstrating Gateway timeout error handling for streaming text
+ *
+ * This example uses undici with an extremely short timeout (1ms) to trigger
+ * a timeout error. The Gateway SDK will catch this and provide a helpful
+ * error message with troubleshooting guidance.
+ *
+ * Prerequisites:
+ * - Set AI_GATEWAY_API_KEY environment variable
+ *   (See .env.example for setup instructions)
+ *
+ * Run: pnpm tsx src/stream-text/gateway-timeout.ts
+ */
+import { createGateway, streamText } from 'ai';
+import { Agent, fetch as undiciFetch } from 'undici';
+import { run } from '../lib/run';
+
+run(async () => {
+  try {
+    // Create an undici Agent with very short timeouts
+    // bodyTimeout applies to receiving the entire response body
+    const agent = new Agent({
+      headersTimeout: 1, // 1ms - will timeout waiting for headers
+      bodyTimeout: 1, // 1ms - will timeout reading response body
+    });
+
+    // Create custom fetch using undici with the configured agent
+    const customFetch = (
+      url: string | URL | Request,
+      options?: RequestInit,
+    ): Promise<Response> => {
+      return undiciFetch(url as Parameters<typeof undiciFetch>[0], {
+        ...(options as any),
+        dispatcher: agent,
+      }) as Promise<Response>;
+    };
+
+    // Create gateway provider with custom fetch
+    const gateway = createGateway({
+      fetch: customFetch,
+    });
+
+    console.log('Making streaming request with 1ms timeout...');
+    console.log(
+      'This should timeout immediately and show the timeout error handling.\n',
+    );
+
+    const result = streamText({
+      model: gateway('anthropic/claude-3.5-sonnet'),
+      prompt:
+        'Write a detailed essay about the history of artificial intelligence, covering major milestones from the 1950s to present day.',
+    });
+
+    console.log('Success! Streaming response:');
+    for await (const chunk of result.textStream) {
+      process.stdout.write(chunk);
+    }
+    console.log();
+    console.log('\nUsage:', await result.usage);
+  } catch (error) {
+    console.error(
+      '╔════════════════════════════════════════════════════════════════╗',
+    );
+    console.error(
+      '║                    TIMEOUT ERROR CAUGHT                        ║',
+    );
+    console.error(
+      '╚════════════════════════════════════════════════════════════════╝\n',
+    );
+    console.error('Error Name:', (error as Error).name);
+    console.error('Error Type:', (error as any).type);
+    console.error('Status Code:', (error as any).statusCode);
+    console.error('Error Code:', (error as any).code);
+    console.error('\nError Message:');
+    console.error('─'.repeat(70));
+    console.error((error as Error).message);
+    console.error('─'.repeat(70));
+
+    // Log the cause to see the original undici error
+    if ((error as any).cause) {
+      console.error('\n📋 Original Error (cause):');
+      console.error('  Name:', ((error as any).cause as Error).name);
+      console.error('  Code:', ((error as any).cause as any).code);
+      console.error('  Message:', ((error as any).cause as Error).message);
+      console.error(
+        '  Constructor:',
+        ((error as any).cause as Error).constructor.name,
+      );
+    }
+  }
+});

--- a/examples/ai-core/src/stream-text/gateway-timeout.ts
+++ b/examples/ai-core/src/stream-text/gateway-timeout.ts
@@ -17,8 +17,9 @@ import { run } from '../lib/run';
 
 run(async () => {
   try {
-    // Create an undici Agent with very short timeouts
-    // bodyTimeout applies to receiving the entire response body
+    // Create an undici Agent with extremely short timeouts
+    // Using 1ms to ensure timeout before response arrives
+    // For streaming, bodyTimeout will trigger while reading the stream
     const agent = new Agent({
       headersTimeout: 1, // 1ms - will timeout waiting for headers
       bodyTimeout: 1, // 1ms - will timeout reading response body

--- a/packages/gateway/src/errors/as-gateway-error.test.ts
+++ b/packages/gateway/src/errors/as-gateway-error.test.ts
@@ -1,0 +1,171 @@
+import { APICallError } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { asGatewayError } from './as-gateway-error';
+import {
+  GatewayError,
+  GatewayTimeoutError,
+  GatewayResponseError,
+} from './index';
+
+describe('asGatewayError', () => {
+  describe('timeout error detection', () => {
+    it('should detect error with UND_ERR_HEADERS_TIMEOUT code', async () => {
+      const error = Object.assign(new Error('Request timeout'), {
+        code: 'UND_ERR_HEADERS_TIMEOUT',
+      });
+
+      const result = await asGatewayError(error);
+
+      expect(GatewayTimeoutError.isInstance(result)).toBe(true);
+      expect(result.message).toContain('Request timeout');
+    });
+
+    it('should detect error with UND_ERR_BODY_TIMEOUT code', async () => {
+      const error = Object.assign(new Error('Body timeout'), {
+        code: 'UND_ERR_BODY_TIMEOUT',
+      });
+
+      const result = await asGatewayError(error);
+
+      expect(GatewayTimeoutError.isInstance(result)).toBe(true);
+    });
+
+    it('should detect error with UND_ERR_CONNECT_TIMEOUT code', async () => {
+      const error = Object.assign(new Error('Connect timeout'), {
+        code: 'UND_ERR_CONNECT_TIMEOUT',
+      });
+
+      const result = await asGatewayError(error);
+
+      expect(GatewayTimeoutError.isInstance(result)).toBe(true);
+    });
+  });
+
+  describe('non-timeout errors', () => {
+    it('should not treat network errors as timeout errors', async () => {
+      const error = new Error('Network error');
+
+      const result = await asGatewayError(error);
+
+      expect(GatewayTimeoutError.isInstance(result)).toBe(false);
+      expect(GatewayResponseError.isInstance(result)).toBe(true);
+      expect(result.message).toContain('Gateway request failed: Network error');
+    });
+
+    it('should not treat connection errors as timeout errors', async () => {
+      const error = Object.assign(new Error('Connection refused'), {
+        code: 'ECONNREFUSED',
+      });
+
+      const result = await asGatewayError(error);
+
+      expect(GatewayTimeoutError.isInstance(result)).toBe(false);
+      expect(GatewayResponseError.isInstance(result)).toBe(true);
+    });
+
+    it('should pass through existing GatewayError instances', async () => {
+      const existingError = GatewayTimeoutError.createTimeoutError({
+        originalMessage: 'existing timeout',
+      });
+
+      const result = await asGatewayError(existingError);
+
+      expect(result).toBe(existingError);
+    });
+
+    it('should handle non-Error objects', async () => {
+      const error = { message: 'timeout occurred' };
+
+      const result = await asGatewayError(error);
+
+      // Non-Error objects won't be detected as timeout errors
+      expect(GatewayTimeoutError.isInstance(result)).toBe(false);
+      expect(GatewayResponseError.isInstance(result)).toBe(true);
+    });
+
+    it('should handle null', async () => {
+      const result = await asGatewayError(null);
+
+      expect(GatewayTimeoutError.isInstance(result)).toBe(false);
+      expect(GatewayResponseError.isInstance(result)).toBe(true);
+    });
+
+    it('should handle undefined', async () => {
+      const result = await asGatewayError(undefined);
+
+      expect(GatewayTimeoutError.isInstance(result)).toBe(false);
+      expect(GatewayResponseError.isInstance(result)).toBe(true);
+    });
+  });
+
+  describe('error properties', () => {
+    it('should preserve the original error as cause', async () => {
+      const originalError = Object.assign(new Error('timeout error'), {
+        code: 'UND_ERR_HEADERS_TIMEOUT',
+      });
+
+      const result = await asGatewayError(originalError);
+
+      expect(result.cause).toBe(originalError);
+    });
+
+    it('should set correct status code for timeout errors', async () => {
+      const error = Object.assign(new Error('timeout'), {
+        code: 'UND_ERR_HEADERS_TIMEOUT',
+      });
+
+      const result = await asGatewayError(error);
+
+      expect(result.statusCode).toBe(408);
+    });
+
+    it('should have correct error type', async () => {
+      const error = Object.assign(new Error('timeout'), {
+        code: 'UND_ERR_HEADERS_TIMEOUT',
+      });
+
+      const result = await asGatewayError(error);
+
+      expect(result.type).toBe('timeout_error');
+    });
+  });
+
+  describe('APICallError with timeout cause', () => {
+    it('should detect timeout when APICallError has UND_ERR_HEADERS_TIMEOUT in cause', async () => {
+      const timeoutError = Object.assign(new Error('Request timeout'), {
+        code: 'UND_ERR_HEADERS_TIMEOUT',
+      });
+
+      const apiCallError = new APICallError({
+        message: 'Cannot connect to API: Request timeout',
+        url: 'https://example.com',
+        requestBodyValues: {},
+        cause: timeoutError,
+      });
+
+      const result = await asGatewayError(apiCallError);
+
+      expect(GatewayTimeoutError.isInstance(result)).toBe(true);
+      expect(result.message).toContain('Gateway request timed out');
+    });
+
+    it('should not treat APICallError as timeout if cause is not timeout-related', async () => {
+      const networkError = new Error('Network connection failed');
+
+      const apiCallError = new APICallError({
+        message: 'Cannot connect to API: Network connection failed',
+        url: 'https://example.com',
+        requestBodyValues: {},
+        cause: networkError,
+        statusCode: 500,
+        responseBody: JSON.stringify({
+          error: { message: 'Internal error', type: 'internal_error' },
+        }),
+      });
+
+      const result = await asGatewayError(apiCallError);
+
+      expect(GatewayTimeoutError.isInstance(result)).toBe(false);
+    });
+  });
+});

--- a/packages/gateway/src/errors/as-gateway-error.ts
+++ b/packages/gateway/src/errors/as-gateway-error.ts
@@ -1,8 +1,32 @@
 import { APICallError } from '@ai-sdk/provider';
 import { extractApiCallResponse, GatewayError } from '.';
 import { createGatewayErrorFromResponse } from './create-gateway-error';
+import { GatewayTimeoutError } from './gateway-timeout-error';
 
-export function asGatewayError(
+/**
+ * Checks if an error is a timeout error from undici.
+ * Only checks undici-specific error codes to avoid false positives.
+ */
+function isTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  // Check for undici-specific timeout error codes
+  const errorCode = (error as any).code;
+  if (typeof errorCode === 'string') {
+    const undiciTimeoutCodes = [
+      'UND_ERR_HEADERS_TIMEOUT',
+      'UND_ERR_BODY_TIMEOUT',
+      'UND_ERR_CONNECT_TIMEOUT',
+    ];
+    return undiciTimeoutCodes.includes(errorCode);
+  }
+
+  return false;
+}
+
+export async function asGatewayError(
   error: unknown,
   authMethod?: 'api-key' | 'oidc',
 ) {
@@ -10,8 +34,25 @@ export function asGatewayError(
     return error;
   }
 
+  // Check if this is a timeout error (or has a timeout error in the cause chain)
+  if (isTimeoutError(error)) {
+    return GatewayTimeoutError.createTimeoutError({
+      originalMessage: error instanceof Error ? error.message : 'Unknown error',
+      cause: error,
+    });
+  }
+
+  // Check if this is an APICallError caused by a timeout
   if (APICallError.isInstance(error)) {
-    return createGatewayErrorFromResponse({
+    // Check if the cause is a timeout error
+    if (error.cause && isTimeoutError(error.cause)) {
+      return GatewayTimeoutError.createTimeoutError({
+        originalMessage: error.message,
+        cause: error,
+      });
+    }
+
+    return await createGatewayErrorFromResponse({
       response: extractApiCallResponse(error),
       statusCode: error.statusCode ?? 500,
       defaultMessage: 'Gateway request failed',
@@ -20,7 +61,7 @@ export function asGatewayError(
     });
   }
 
-  return createGatewayErrorFromResponse({
+  return await createGatewayErrorFromResponse({
     response: {},
     statusCode: 500,
     defaultMessage:

--- a/packages/gateway/src/errors/gateway-timeout-error.ts
+++ b/packages/gateway/src/errors/gateway-timeout-error.ts
@@ -1,0 +1,59 @@
+import { GatewayError } from './gateway-error';
+
+const name = 'GatewayTimeoutError';
+const marker = `vercel.ai.gateway.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * Client request timed out before receiving a response.
+ */
+export class GatewayTimeoutError extends GatewayError {
+  private readonly [symbol] = true; // used in isInstance
+
+  readonly name = name;
+  readonly type = 'timeout_error';
+
+  constructor({
+    message = 'Request timed out',
+    statusCode = 408,
+    cause,
+    generationId,
+  }: {
+    message?: string;
+    statusCode?: number;
+    cause?: unknown;
+    generationId?: string;
+  } = {}) {
+    super({ message, statusCode, cause, generationId });
+  }
+
+  static isInstance(error: unknown): error is GatewayTimeoutError {
+    return GatewayError.hasMarker(error) && symbol in error;
+  }
+
+  /**
+   * Creates a helpful timeout error message with troubleshooting guidance
+   */
+  static createTimeoutError({
+    originalMessage,
+    statusCode = 408,
+    cause,
+    generationId,
+  }: {
+    originalMessage: string;
+    statusCode?: number;
+    cause?: unknown;
+    generationId?: string;
+  }): GatewayTimeoutError {
+    const message = `Gateway request timed out: ${originalMessage}
+
+    This is a client-side timeout. To resolve this, increase your timeout configuration: https://vercel.com/docs/ai-gateway/capabilities/video-generation#extending-timeouts-for-node.js`;
+
+    return new GatewayTimeoutError({
+      message,
+      statusCode,
+      cause,
+      generationId,
+    });
+  }
+}

--- a/packages/gateway/src/errors/gateway-timeout-error.ts
+++ b/packages/gateway/src/errors/gateway-timeout-error.ts
@@ -17,14 +17,12 @@ export class GatewayTimeoutError extends GatewayError {
     message = 'Request timed out',
     statusCode = 408,
     cause,
-    generationId,
   }: {
     message?: string;
     statusCode?: number;
     cause?: unknown;
-    generationId?: string;
   } = {}) {
-    super({ message, statusCode, cause, generationId });
+    super({ message, statusCode, cause });
   }
 
   static isInstance(error: unknown): error is GatewayTimeoutError {
@@ -38,12 +36,10 @@ export class GatewayTimeoutError extends GatewayError {
     originalMessage,
     statusCode = 408,
     cause,
-    generationId,
   }: {
     originalMessage: string;
     statusCode?: number;
     cause?: unknown;
-    generationId?: string;
   }): GatewayTimeoutError {
     const message = `Gateway request timed out: ${originalMessage}
 
@@ -53,7 +49,6 @@ export class GatewayTimeoutError extends GatewayError {
       message,
       statusCode,
       cause,
-      generationId,
     });
   }
 }

--- a/packages/gateway/src/errors/index.ts
+++ b/packages/gateway/src/errors/index.ts
@@ -14,3 +14,4 @@ export {
 } from './gateway-model-not-found-error';
 export { GatewayRateLimitError } from './gateway-rate-limit-error';
 export { GatewayResponseError } from './gateway-response-error';
+export { GatewayTimeoutError } from './gateway-timeout-error';

--- a/packages/gateway/src/gateway-image-model.ts
+++ b/packages/gateway/src/gateway-image-model.ts
@@ -95,7 +95,7 @@ export class GatewayImageModel implements ImageModelV2 {
         }),
       };
     } catch (error) {
-      throw asGatewayError(error, await parseAuthMethod(resolvedHeaders));
+      throw await asGatewayError(error, await parseAuthMethod(resolvedHeaders));
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       terminal-image:
         specifier: ^2.0.0
         version: 2.0.0
+      undici:
+        specifier: ^7.21.0
+        version: 7.21.0
       valibot:
         specifier: ^1.0.0-rc.0 || ^1.0.0
         version: 1.1.0(typescript@5.8.3)
@@ -17959,8 +17962,8 @@ packages:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
 
-  undici@7.16.0:
-    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
+  undici@7.21.0:
+    resolution: {integrity: sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==}
     engines: {node: '>=20.18.1'}
 
   unenv@1.10.0:
@@ -27813,7 +27816,7 @@ snapshots:
       jsonlines: 0.1.1
       ms: 2.1.3
       tar-stream: 3.1.7
-      undici: 7.16.0
+      undici: 7.21.0
       zod: 3.24.4
 
   '@vitejs/plugin-basic-ssl@2.1.0(vite@7.1.5(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.30.2)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))':
@@ -38512,7 +38515,7 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.0
 
-  undici@7.16.0: {}
+  undici@7.21.0: {}
 
   unenv@1.10.0:
     dependencies:


### PR DESCRIPTION
## Background

This is a manual backport of [12407](https://github.com/vercel/ai/pull/12407) to the release-v5.0 branch. 

## Summary

Client side timeouts were confusing to the user, so we wanted to improve the error message to link to the docs and explain how to modify fetch and undci header timeouts.

## Manual Verification

`pnpm tsx src/generate-text/gateway-timeout.ts`

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
