### PR TITLE
feat(provider/openai): add contextManagement option for server-side compaction

### DIFF
--- a/.changeset/openai-context-management-compaction.md
+++ b/.changeset/openai-context-management-compaction.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Added support for OpenAI server-side compaction via the `contextManagement` provider option for Responses models. This allows the API to automatically compact conversation history when approaching a specified token threshold, reducing context size without losing important information.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -235,6 +235,14 @@ The following provider options are available:
   `['message.output_text.logprobs']` for logprobs.
   Defaults to `undefined`.
 
+- **contextManagement** _Array&lt;object&gt;_
+  Server-side context management configuration. When set, OpenAI will automatically
+  compact conversation history when it approaches the specified token threshold.
+  Each entry should have a `type` of `'compaction'` and a `compact_threshold` number
+  specifying the token count at which compaction triggers.
+  Example: `[{ type: 'compaction', compact_threshold: 200000 }]`.
+  See [OpenAI Compaction Guide](https://platform.openai.com/docs/guides/compaction) for details.
+
 - **truncation** _string_
   The truncation strategy to use for the model response.
 

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1070,6 +1070,43 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send context_management with compaction provider option', async () => {
+        const { warnings } = await createModel('gpt-5').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              contextManagement: [
+                { type: 'compaction', compact_threshold: 200000 },
+              ],
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-5',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          context_management: [
+            { type: 'compaction', compact_threshold: 200000 },
+          ],
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
+      it('should not send context_management when not specified', async () => {
+        const { warnings } = await createModel('gpt-5').doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+          'context_management',
+        );
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should send truncation auto provider option', async () => {
         const { warnings } = await createModel('gpt-5').doGenerate({
           prompt: TEST_PROMPT,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -315,6 +315,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       safety_identifier: openaiOptions?.safetyIdentifier,
       top_logprobs: topLogprobs,
       truncation: openaiOptions?.truncation,
+      context_management: openaiOptions?.contextManagement,
 
       // model-specific settings:
       ...(isReasoningModel &&

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -270,6 +270,24 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
       textVerbosity: z.enum(['low', 'medium', 'high']).nullish(),
 
       /**
+       * Server-side context management configuration.
+       * When set, OpenAI will automatically compact conversation history
+       * when it approaches the specified token threshold.
+       *
+       * Example: `[{ type: 'compaction', compact_threshold: 200000 }]`
+       *
+       * @see https://platform.openai.com/docs/guides/compaction
+       */
+      contextManagement: z
+        .array(
+          z.object({
+            type: z.literal('compaction'),
+            compact_threshold: z.number(),
+          }),
+        )
+        .nullish(),
+
+      /**
        * Controls output truncation. 'auto' (default) performs truncation automatically;
        * 'disabled' turns truncation off.
        */


### PR DESCRIPTION
## Background

OpenAI's Responses API supports a `context_management` parameter that enables server-side compaction of conversation history. When the rendered token count crosses a configured threshold, the server automatically compacts the context, emitting an encrypted compaction item that carries forward key prior state using fewer tokens.

This is already documented at https://platform.openai.com/docs/guides/compaction but the AI SDK's OpenAI provider does not currently expose this option — the Zod schema uses `z.object()` which strips unknown keys, and `getArgs()` maps fields explicitly with no passthrough.

## Summary

Adds `contextManagement` as a new provider option for OpenAI Responses models, following the same pattern as the existing `truncation` option.

**Changes:**

- **Schema** (`openai-responses-options.ts`): Added `contextManagement` field to `openaiLanguageModelResponsesOptionsSchema` — typed as `z.array(z.object({ type: z.literal('compaction'), compact_threshold: z.number() })).nullish()`
- **Request mapping** (`openai-responses-language-model.ts`): Added `context_management: openaiOptions?.contextManagement` to `baseArgs` in `getArgs()`
- **Tests** (`openai-responses-language-model.test.ts`): Added 2 test cases — one verifying the option is sent correctly, one verifying it's omitted when not specified
- **Documentation** (`03-openai.mdx`): Added `contextManagement` provider option documentation entry

**Usage:**

```ts
import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
import { generateText } from 'ai';

const result = await generateText({
  model: openai('gpt-5'),
  providerOptions: {
    openai: {
      contextManagement: [
        { type: 'compaction', compact_threshold: 200000 },
      ],
    } satisfies OpenAILanguageModelResponsesOptions,
  },
  prompt: 'Hello!',
});
```

## Verification

<details>
<summary>All 213 tests pass</summary>

```
npx vitest run src/responses/openai-responses-language-model.test.ts

 ✓ src/responses/openai-responses-language-model.test.ts (213 tests) 727ms

 Test Files  1 passed (1)
      Tests  213 passed (213)
   Start at  ...
   Duration  1.43s
```

</details>

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features — run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes https://github.com/vercel/ai/issues/12486
