### PR TITLE
chore(examples): remove obsolete useSearchGrounding in google examples

### DIFF
--- a/.changeset/strong-cameras-turn.md
+++ b/.changeset/strong-cameras-turn.md
@@ -1,0 +1,5 @@
+---
+'@example/ai-functions': patch
+---
+
+chore(examples): remove obsolete useSearchGrounding in google examples

--- a/examples/ai-functions/src/e2e/google-vertex.test.ts
+++ b/examples/ai-functions/src/e2e/google-vertex.test.ts
@@ -43,11 +43,14 @@ const createSearchGroundedModel = (
     model: vertex(modelId),
     middleware: defaultSettingsMiddleware({
       settings: {
-        providerOptions: {
-          google: {
-            useSearchGrounding: true,
+        tools: [
+          {
+            type: 'provider',
+            id: 'google.google_search',
+            name: 'google_search',
+            args: {},
           },
-        },
+        ],
       },
     }),
   }),

--- a/examples/ai-functions/src/e2e/google.test.ts
+++ b/examples/ai-functions/src/e2e/google.test.ts
@@ -32,7 +32,14 @@ const createSearchGroundedModel = (
       model,
       middleware: defaultSettingsMiddleware({
         settings: {
-          providerOptions: { google: { useSearchGrounding: true } },
+          tools: [
+            {
+              type: 'provider',
+              id: 'google.google_search',
+              name: 'google_search',
+              args: {},
+            },
+          ],
         },
       }),
     }),

--- a/examples/ai-functions/src/generate-text/google-vertex-grounding.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-grounding.ts
@@ -4,11 +4,9 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: vertex('gemini-1.5-pro'),
-    providerOptions: {
-      google: {
-        useSearchGrounding: true,
-      },
+    model: vertex('gemini-2.5-flash'),
+    tools: {
+      google_search: vertex.tools.googleSearch({}),
     },
     prompt:
       'List the top 5 San Francisco news from the past week.' +

--- a/examples/ai-functions/src/stream-text/google-vertex-grounding.ts
+++ b/examples/ai-functions/src/stream-text/google-vertex-grounding.ts
@@ -4,11 +4,9 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: vertex('gemini-1.5-pro'),
-    providerOptions: {
-      google: {
-        useSearchGrounding: true,
-      },
+    model: vertex('gemini-2.5-flash'),
+    tools: {
+      google_search: vertex.tools.googleSearch({}),
     },
     prompt:
       'List the top 5 San Francisco news from the past week.' +


### PR DESCRIPTION
## Background

`useSearchGrounding` is an obsolete provider option for the Google (and Vertex) providers that was deprecated a long time ago. v5 migration guides already include documentation how to migrate away from it, but several examples and e2e tests still referenced it.

## Summary

Replaced all `useSearchGrounding` providerOption usages with the current `googleSearch` tool API.

The only remaining `useSearchGrounding` reference is in the v5 migration guide, which is correct since it documents historical behavior.

## Manual Verification

N/A — example-only changes, verified via `pnpm type-check:full` and running the examples.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Fixes #12438
