### PR TITLE
chore: use `presentImages` in single image generation example that wasn't using it yet

### DIFF
--- a/.changeset/nervous-penguins-boil.md
+++ b/.changeset/nervous-penguins-boil.md
@@ -1,0 +1,5 @@
+---
+'@example/ai-functions': patch
+---
+
+chore: use `presentImages` in single image generation example that wasn't using it yet

--- a/examples/ai-functions/src/registry/generate-image.ts
+++ b/examples/ai-functions/src/registry/generate-image.ts
@@ -1,6 +1,6 @@
 import { generateImage } from 'ai';
-import fs from 'node:fs';
 import { myImageModels } from './setup-registry';
+import { presentImages } from '../lib/present-image';
 import { run } from '../lib/run';
 
 run(async () => {
@@ -9,7 +9,5 @@ run(async () => {
     prompt: 'The Loch Ness Monster getting a manicure',
   });
 
-  const filename = `image-${Date.now()}.png`;
-  fs.writeFileSync(filename, image.uint8Array);
-  console.log(`Image saved to ${filename}`);
+  await presentImages([image]);
 });


### PR DESCRIPTION
## Background

The `registry/generate-image.ts` example was the only image-generating example in `ai-functions` that manually wrote images with `fs.writeFileSync` instead of using the shared `presentImages` helper.

## Summary

Replaced the manual `fs.writeFileSync` + `console.log` with a call to `presentImages([image])`, matching other image generation examples.

## Manual Verification

N/A

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
