### PR TITLE
feat(provider/google-vertex): allow using Gemini image models with `generateImage`

### DIFF
--- a/.changeset/gentle-cats-stare.md
+++ b/.changeset/gentle-cats-stare.md
@@ -1,6 +1,5 @@
 ---
 '@ai-sdk/google-vertex': patch
-'@example/ai-functions': patch
 '@ai-sdk/google': patch
 ---
 

--- a/.changeset/gentle-cats-stare.md
+++ b/.changeset/gentle-cats-stare.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/google-vertex': patch
+'@example/ai-functions': patch
+'@ai-sdk/google': patch
+---
+
+feat(provider/google-vertex): allow using Gemini image models with `generateImage`

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1097,7 +1097,7 @@ const { image } = await generateImage({
 <Note>
   `gemini-3-pro-image-preview` supports additional features including up to 14
   reference images for editing (6 objects, 5 humans), resolution options (1K,
-  2K, 4K via `providerOptions.google.imageConfig.imageSize`), and Google Search
+  2K, 4K via `providerOptions.vertex.imageConfig.imageSize`), and Google Search
   grounding.
 </Note>
 

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -838,8 +838,11 @@ The following optional provider options are available for Google Vertex AI embed
 
 ### Image Models
 
-You can create [Imagen](https://cloud.google.com/vertex-ai/generative-ai/docs/image/overview) models that call the [Imagen on Vertex AI API](https://cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images)
-using the `.image()` factory method. For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
+You can create image models using the `.image()` factory method. The Google Vertex provider supports both [Imagen](https://cloud.google.com/vertex-ai/generative-ai/docs/image/overview) and [Gemini image models](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-image). For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
+
+#### Imagen Models
+
+[Imagen models](https://cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images) generate images using the Imagen on Vertex AI API.
 
 ```ts
 import { vertex } from '@ai-sdk/google-vertex';
@@ -910,7 +913,7 @@ console.log(
 );
 ```
 
-#### Image Editing
+##### Image Editing
 
 Google Vertex Imagen models support image editing through inpainting, outpainting, and other edit modes. Pass input images via `prompt.images` and optionally a mask via `prompt.mask`.
 
@@ -919,7 +922,7 @@ Google Vertex Imagen models support image editing through inpainting, outpaintin
   `imagen-4.0-generate-001` model does not currently support editing operations.
 </Note>
 
-##### Inpainting (Insert Objects)
+###### Inpainting (Insert Objects)
 
 Insert or replace objects in specific areas using a mask:
 
@@ -951,7 +954,7 @@ const { images } = await generateImage({
 });
 ```
 
-##### Outpainting (Extend Image)
+###### Outpainting (Extend Image)
 
 Extend an image beyond its original boundaries:
 
@@ -982,7 +985,7 @@ const { images } = await generateImage({
 });
 ```
 
-##### Edit Provider Options
+###### Edit Provider Options
 
 The following options are available under `providerOptions.vertex.edit`:
 
@@ -1013,7 +1016,7 @@ The following options are available under `providerOptions.vertex.edit`:
   image editing.
 </Note>
 
-#### Model Capabilities
+##### Imagen Model Capabilities
 
 | Model                           | Aspect Ratios             |
 | ------------------------------- | ------------------------- |
@@ -1023,6 +1026,80 @@ The following options are available under `providerOptions.vertex.edit`:
 | `imagen-4.0-generate-001`       | 1:1, 3:4, 4:3, 9:16, 16:9 |
 | `imagen-4.0-fast-generate-001`  | 1:1, 3:4, 4:3, 9:16, 16:9 |
 | `imagen-4.0-ultra-generate-001` | 1:1, 3:4, 4:3, 9:16, 16:9 |
+
+#### Gemini Image Models
+
+[Gemini image models](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-image) (e.g. `gemini-2.5-flash-image`) are multimodal output language models that can be used with `generateImage()` for a simpler image generation experience. Internally, the provider calls the language model API with `responseModalities: ['IMAGE']`.
+
+```ts
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateImage } from 'ai';
+
+const { image } = await generateImage({
+  model: vertex.image('gemini-2.5-flash-image'),
+  prompt: 'A photorealistic image of a cat wearing a wizard hat',
+  aspectRatio: '1:1',
+});
+```
+
+Gemini image models also support image editing by providing input images:
+
+```ts
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateImage } from 'ai';
+import fs from 'node:fs';
+
+const sourceImage = fs.readFileSync('./cat.png');
+
+const { image } = await generateImage({
+  model: vertex.image('gemini-2.5-flash-image'),
+  prompt: {
+    text: 'Add a small wizard hat to this cat',
+    images: [sourceImage],
+  },
+});
+```
+
+You can also use URLs (including `gs://` Cloud Storage URIs) for input images:
+
+```ts
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateImage } from 'ai';
+
+const { image } = await generateImage({
+  model: vertex.image('gemini-2.5-flash-image'),
+  prompt: {
+    text: 'Add a small wizard hat to this cat',
+    images: ['https://example.com/cat.png'],
+  },
+});
+```
+
+<Note>
+  Gemini image models do not support the `size` or `n` parameters. Use
+  `aspectRatio` instead of `size`. Mask-based inpainting is also not supported.
+</Note>
+
+<Note>
+  Gemini image models are multimodal output models that can generate both text
+  and images. For more advanced use cases where you need both text and image
+  outputs, or want more control over the generation process, you can use them
+  directly with `generateText()`.
+</Note>
+
+##### Gemini Image Model Capabilities
+
+| Model                        | Image Generation    | Image Editing       | Aspect Ratios                                       |
+| ---------------------------- | ------------------- | ------------------- | --------------------------------------------------- |
+| `gemini-3-pro-image-preview` | <Check size={18} /> | <Check size={18} /> | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 |
+| `gemini-2.5-flash-image`     | <Check size={18} /> | <Check size={18} /> | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 |
+
+<Note>
+  `gemini-3-pro-image-preview` supports additional features including up to 14
+  reference images for editing (6 objects, 5 humans), resolution options (1K,
+  2K, 4K via `providerOptions.google.imageConfig.imageSize`), and Google Search
+  grounding.
+</Note>
 
 ### Video Models
 

--- a/examples/ai-functions/src/generate-image/google-vertex-gemini-editing.ts
+++ b/examples/ai-functions/src/generate-image/google-vertex-gemini-editing.ts
@@ -1,0 +1,36 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateImage } from 'ai';
+import fs from 'node:fs';
+import { presentImages } from '../lib/present-image';
+import { run } from '../lib/run';
+
+run(async () => {
+  console.log('Generating base cat image...');
+  const baseResult = await generateImage({
+    model: vertex.image('gemini-2.5-flash-image'),
+    prompt:
+      'A photorealistic picture of a fluffy ginger cat sitting on a wooden table',
+  });
+
+  const timestamp = Date.now();
+
+  fs.mkdirSync('output', { recursive: true });
+
+  const baseImage = baseResult.image;
+  await fs.promises.writeFile(
+    `output/cat-base-${timestamp}.png`,
+    baseImage.uint8Array,
+  );
+  console.log(`Saved base image: output/cat-base-${timestamp}.png`);
+
+  console.log('Adding wizard hat...');
+  const editResult = await generateImage({
+    model: vertex.image('gemini-2.5-flash-image'),
+    prompt: {
+      text: 'Add a small wizard hat to this cat. Keep everything else the same.',
+      images: [baseImage.uint8Array],
+    },
+  });
+
+  presentImages(editResult.images);
+});

--- a/examples/ai-functions/src/generate-image/google-vertex-gemini-image.ts
+++ b/examples/ai-functions/src/generate-image/google-vertex-gemini-image.ts
@@ -1,0 +1,21 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateImage } from 'ai';
+import { presentImages } from '../lib/present-image';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateImage({
+    model: vertex.image('gemini-2.5-flash-image'),
+    prompt:
+      'Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme',
+    aspectRatio: '1:1',
+  });
+
+  presentImages(result.images);
+
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(result.providerMetadata, null, 2),
+  );
+  console.log('Token usage:', result.usage);
+});

--- a/packages/google-vertex/src/google-vertex-image-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.test.ts
@@ -26,6 +26,7 @@ const server = createTestServer({
     {},
   'https://api.example.com/models/imagen-4.0-ultra-generate-preview-06-06:predict':
     {},
+  'https://api.example.com/models/gemini-2.5-flash-image:generateContent': {},
 });
 
 describe('GoogleVertexImageModel', () => {
@@ -921,6 +922,310 @@ describe('GoogleVertexImageModel', () => {
           }
         `);
       });
+    });
+  });
+});
+
+describe('GoogleVertexImageModel (Gemini)', () => {
+  const geminiModel = new GoogleVertexImageModel('gemini-2.5-flash-image', {
+    provider: 'google.vertex.image',
+    baseURL: 'https://api.example.com',
+    headers: { 'api-key': 'test-key' },
+  });
+
+  const TEST_URL_GEMINI_IMAGE =
+    'https://api.example.com/models/gemini-2.5-flash-image:generateContent';
+
+  function prepareGeminiJsonResponse({
+    images = [{ mimeType: 'image/png', data: 'base64-generated-image' }],
+    usage = {
+      promptTokenCount: 10,
+      candidatesTokenCount: 100,
+      totalTokenCount: 110,
+    },
+    headers,
+  }: {
+    images?: Array<{ mimeType: string; data: string }>;
+    usage?: {
+      promptTokenCount: number;
+      candidatesTokenCount: number;
+      totalTokenCount: number;
+    };
+    headers?: Record<string, string>;
+  } = {}) {
+    server.urls[TEST_URL_GEMINI_IMAGE].response = {
+      type: 'json-value',
+      headers,
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: images.map(img => ({
+                inlineData: {
+                  mimeType: img.mimeType,
+                  data: img.data,
+                },
+              })),
+              role: 'model',
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: usage,
+      },
+    };
+  }
+
+  describe('maxImagesPerCall', () => {
+    it('should return 10 for Gemini image models', () => {
+      expect(geminiModel.maxImagesPerCall).toBe(10);
+    });
+
+    it('should return 4 for Imagen models', () => {
+      const imagenModel = new GoogleVertexImageModel(
+        'imagen-3.0-generate-002',
+        {
+          provider: 'google.vertex.image',
+          baseURL: 'https://api.example.com',
+          headers: { 'api-key': 'test-key' },
+        },
+      );
+      expect(imagenModel.maxImagesPerCall).toBe(4);
+    });
+  });
+
+  describe('doGenerate', () => {
+    it('should extract the generated image', async () => {
+      prepareGeminiJsonResponse();
+
+      const result = await geminiModel.doGenerate({
+        prompt: 'A beautiful sunset',
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.images).toStrictEqual(['base64-generated-image']);
+    });
+
+    it('should send correct request body with responseModalities', async () => {
+      prepareGeminiJsonResponse();
+
+      await geminiModel.doGenerate({
+        prompt: 'A beautiful sunset',
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.generationConfig.responseModalities).toStrictEqual([
+        'IMAGE',
+      ]);
+      expect(requestBody.contents).toStrictEqual([
+        {
+          role: 'user',
+          parts: [{ text: 'A beautiful sunset' }],
+        },
+      ]);
+    });
+
+    it('should pass aspectRatio via imageConfig', async () => {
+      prepareGeminiJsonResponse();
+
+      await geminiModel.doGenerate({
+        prompt: 'A beautiful sunset',
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: '16:9',
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.generationConfig.imageConfig).toStrictEqual({
+        aspectRatio: '16:9',
+      });
+    });
+
+    it('should pass seed in generationConfig', async () => {
+      prepareGeminiJsonResponse();
+
+      await geminiModel.doGenerate({
+        prompt: 'A beautiful sunset',
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: 12345,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.generationConfig.seed).toBe(12345);
+    });
+
+    it('should include usage in response', async () => {
+      prepareGeminiJsonResponse({
+        usage: {
+          promptTokenCount: 20,
+          candidatesTokenCount: 200,
+          totalTokenCount: 220,
+        },
+      });
+
+      const result = await geminiModel.doGenerate({
+        prompt: 'A beautiful sunset',
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.usage).toStrictEqual({
+        inputTokens: 20,
+        outputTokens: 200,
+        totalTokens: 220,
+      });
+    });
+
+    it('should return warning for unsupported size option', async () => {
+      prepareGeminiJsonResponse();
+
+      const result = await geminiModel.doGenerate({
+        prompt: 'A beautiful sunset',
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: '1024x1024',
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'size',
+        details:
+          'This model does not support the `size` option. Use `aspectRatio` instead.',
+      });
+    });
+  });
+
+  describe('image editing', () => {
+    it('should include input images in request for editing', async () => {
+      prepareGeminiJsonResponse();
+
+      await geminiModel.doGenerate({
+        prompt: 'Add a hat to this cat',
+        files: [
+          {
+            type: 'file',
+            data: 'base64-source-image',
+            mediaType: 'image/png',
+          },
+        ],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.contents[0].parts).toHaveLength(2);
+      expect(requestBody.contents[0].parts[0]).toStrictEqual({
+        text: 'Add a hat to this cat',
+      });
+      expect(requestBody.contents[0].parts[1]).toStrictEqual({
+        inlineData: {
+          mimeType: 'image/png',
+          data: 'base64-source-image',
+        },
+      });
+    });
+
+    it('should handle URL-based input images', async () => {
+      prepareGeminiJsonResponse();
+
+      await geminiModel.doGenerate({
+        prompt: 'Add a hat to this cat',
+        files: [
+          {
+            type: 'url',
+            url: 'https://example.com/cat.png',
+          },
+        ],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.contents[0].parts[1]).toStrictEqual({
+        fileData: {
+          mimeType: 'image/jpeg',
+          fileUri: 'https://example.com/cat.png',
+        },
+      });
+    });
+  });
+
+  describe('unsupported options', () => {
+    it('should throw error when n > 1', async () => {
+      await expect(
+        geminiModel.doGenerate({
+          prompt: 'A beautiful sunset',
+          files: undefined,
+          mask: undefined,
+          n: 2,
+          size: undefined,
+          aspectRatio: undefined,
+          seed: undefined,
+          providerOptions: {},
+        }),
+      ).rejects.toThrow(
+        'Gemini image models do not support generating a set number of images per call.',
+      );
+    });
+
+    it('should throw error when mask is provided', async () => {
+      await expect(
+        geminiModel.doGenerate({
+          prompt: 'Edit this image',
+          files: undefined,
+          mask: {
+            type: 'file',
+            data: 'base64-mask-image',
+            mediaType: 'image/png',
+          },
+          n: 1,
+          size: undefined,
+          aspectRatio: undefined,
+          seed: undefined,
+          providerOptions: {},
+        }),
+      ).rejects.toThrow(
+        'Gemini image models do not support mask-based image editing.',
+      );
     });
   });
 });

--- a/packages/google-vertex/src/google-vertex-image-settings.ts
+++ b/packages/google-vertex/src/google-vertex-image-settings.ts
@@ -5,4 +5,6 @@ export type GoogleVertexImageModelId =
   | 'imagen-4.0-generate-001'
   | 'imagen-4.0-ultra-generate-001'
   | 'imagen-4.0-fast-generate-001'
+  | 'gemini-2.5-flash-image'
+  | 'gemini-3-pro-image-preview'
   | (string & {});

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -210,7 +210,10 @@ export function createVertex(
     new GoogleVertexEmbeddingModel(modelId, createConfig('embedding'));
 
   const createImageModel = (modelId: GoogleVertexImageModelId) =>
-    new GoogleVertexImageModel(modelId, createConfig('image'));
+    new GoogleVertexImageModel(modelId, {
+      ...createConfig('image'),
+      generateId: options.generateId ?? generateId,
+    });
 
   const createVideoModel = (modelId: GoogleVertexVideoModelId) =>
     new GoogleVertexVideoModel(modelId, {

--- a/packages/google/src/google-generative-ai-image-model.ts
+++ b/packages/google/src/google-generative-ai-image-model.ts
@@ -24,6 +24,7 @@ import {
   GoogleGenerativeAIImageSettings,
 } from './google-generative-ai-image-settings';
 import { GoogleGenerativeAILanguageModel } from './google-generative-ai-language-model';
+import type { GoogleLanguageModelOptions } from './google-generative-ai-options';
 
 interface GoogleGenerativeAIImageModelConfig {
   provider: string;
@@ -272,9 +273,18 @@ export class GoogleGenerativeAIImageModel implements ImageModelV3 {
       providerOptions: {
         google: {
           responseModalities: ['IMAGE'],
-          imageConfig: aspectRatio ? { aspectRatio } : undefined,
-          ...((providerOptions?.google as Record<string, unknown>) ?? {}),
-        },
+          imageConfig: aspectRatio
+            ? {
+                aspectRatio: aspectRatio as NonNullable<
+                  GoogleLanguageModelOptions['imageConfig']
+                >['aspectRatio'],
+              }
+            : undefined,
+          ...((providerOptions?.google as Omit<
+            GoogleLanguageModelOptions,
+            'responseModalities' | 'imageConfig'
+          >) ?? {}),
+        } satisfies GoogleLanguageModelOptions,
       },
       headers,
       abortSignal,


### PR DESCRIPTION
## Background

Follow-up to #12252 (which added Gemini image generation to the `google` provider). This wasn't yet wired up for the `google-vertex` provider.

## Summary

- Adds Gemini image model support to `google-vertex`'s `generateImage()`. When a `gemini-*` model ID is detected, the image model internally delegates to `GoogleGenerativeAILanguageModel` with `responseModalities: ['IMAGE']`, matching the approach used in the `google` provider. Existing Imagen model behavior is unchanged.
- Includes docs for this new `generateImage` capability for `google-vertex`
- Also improves provider options typing in both `google` and `google-vertex` image models to use `satisfies GoogleLanguageModelOptions`

## Manual Verification

Ran `google-vertex-gemini-image.ts` and `google-vertex-gemini-editing.ts` examples against Vertex AI with real credentials. Both image generation and image editing produce correct results.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Fixes #12452
