### PR TITLE
refactor(provider/amazon-bedrock): finish fixture migration for doGenerate tests

### DIFF
--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -4,10 +4,6 @@ import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
 import { beforeEach, describe, expect, vi, it } from 'vitest';
 import { injectFetchHeaders } from './inject-fetch-headers';
-import {
-  BedrockReasoningContentBlock,
-  BedrockRedactedReasoningContentBlock,
-} from './bedrock-api-types';
 import { anthropicTools, prepareTools } from '@ai-sdk/anthropic/internal';
 import { z } from 'zod/v4';
 import fs from 'node:fs';
@@ -3009,62 +3005,6 @@ describe('doStream', () => {
 });
 
 describe('doGenerate', () => {
-  function prepareJsonResponse({
-    content = [{ type: 'text', text: 'Hello, World!' }],
-    usage = {
-      inputTokens: 4,
-      outputTokens: 34,
-      totalTokens: 38,
-      cacheReadInputTokens: undefined,
-      cacheWriteInputTokens: undefined,
-    },
-    stopReason = 'stop_sequence',
-    trace,
-  }: {
-    content?: Array<
-      | { type: 'text'; text: string }
-      | { type: 'thinking'; thinking: string; signature: string }
-      | { type: 'tool_use'; id: string; name: string; input: unknown }
-      | BedrockReasoningContentBlock
-      | BedrockRedactedReasoningContentBlock
-    >;
-    toolCalls?: Array<{
-      id?: string;
-      name: string;
-      args: Record<string, unknown>;
-    }>;
-    usage?: {
-      inputTokens: number;
-      outputTokens: number;
-      totalTokens: number;
-      cacheReadInputTokens?: number;
-      cacheWriteInputTokens?: number;
-    };
-    stopReason?: string;
-    trace?: typeof mockTrace;
-    reasoningContent?:
-      | BedrockReasoningContentBlock
-      | BedrockRedactedReasoningContentBlock
-      | Array<
-          BedrockReasoningContentBlock | BedrockRedactedReasoningContentBlock
-        >;
-  }) {
-    server.urls[generateUrl].response = {
-      type: 'json-value',
-      body: {
-        output: {
-          message: {
-            role: 'assistant',
-            content,
-          },
-        },
-        usage,
-        stopReason,
-        ...(trace ? { trace } : {}),
-      },
-    };
-  }
-
   describe('text', () => {
     beforeEach(() => {
       prepareJsonFixtureResponse('bedrock-text');

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -3159,7 +3159,19 @@ describe('doGenerate', () => {
   });
 
   it('should extract finish reason', async () => {
-    prepareJsonResponse({ stopReason: 'stop_sequence' });
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello, World!' }],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
+        stopReason: 'stop_sequence',
+      },
+    };
 
     const { finishReason } = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -3174,7 +3186,19 @@ describe('doGenerate', () => {
   });
 
   it('should support unknown finish reason', async () => {
-    prepareJsonResponse({ stopReason: 'eos' });
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello, World!' }],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
+        stopReason: 'eos',
+      },
+    };
 
     const { finishReason } = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -3266,7 +3290,20 @@ describe('doGenerate', () => {
   });
 
   it('should include trace information in providerMetadata', async () => {
-    prepareJsonResponse({ trace: mockTrace });
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello, World!' }],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
+        stopReason: 'stop_sequence',
+        trace: mockTrace,
+      },
+    };
 
     const result = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -3914,16 +3951,25 @@ describe('doGenerate', () => {
   });
 
   it('should include cache token usage in providerMetadata', async () => {
-    prepareJsonResponse({
-      content: [{ type: 'text', text: 'Testing' }],
-      usage: {
-        inputTokens: 4,
-        outputTokens: 34,
-        totalTokens: 38,
-        cacheReadInputTokens: 2,
-        cacheWriteInputTokens: 3,
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Testing' }],
+          },
+        },
+        usage: {
+          inputTokens: 4,
+          outputTokens: 34,
+          totalTokens: 38,
+          cacheReadInputTokens: 2,
+          cacheWriteInputTokens: 3,
+        },
+        stopReason: 'stop_sequence',
       },
-    });
+    };
 
     const response = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -4244,22 +4290,29 @@ describe('doGenerate', () => {
   });
 
   it('should extract reasoning text with signature', async () => {
-    const reasoningText = 'I need to think about this problem carefully...';
-    const signature = 'abc123signature';
-
-    prepareJsonResponse({
-      content: [
-        {
-          reasoningContent: {
-            reasoningText: {
-              text: reasoningText,
-              signature,
-            },
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                reasoningContent: {
+                  reasoningText: {
+                    text: 'I need to think about this problem carefully...',
+                    signature: 'abc123signature',
+                  },
+                },
+              },
+              { type: 'text', text: 'The answer is 42.' },
+            ],
           },
         },
-        { type: 'text', text: 'The answer is 42.' },
-      ],
-    });
+        usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
+        stopReason: 'stop_sequence',
+      },
+    };
 
     const result = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -4285,20 +4338,28 @@ describe('doGenerate', () => {
   });
 
   it('should extract reasoning text without signature', async () => {
-    const reasoningText = 'I need to think about this problem carefully...';
-
-    prepareJsonResponse({
-      content: [
-        {
-          reasoningContent: {
-            reasoningText: {
-              text: reasoningText,
-            },
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                reasoningContent: {
+                  reasoningText: {
+                    text: 'I need to think about this problem carefully...',
+                  },
+                },
+              },
+              { type: 'text', text: 'The answer is 42.' },
+            ],
           },
         },
-        { type: 'text', text: 'The answer is 42.' },
-      ],
-    });
+        usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
+        stopReason: 'stop_sequence',
+      },
+    };
 
     const result = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -4319,18 +4380,28 @@ describe('doGenerate', () => {
   });
 
   it('should extract redacted reasoning', async () => {
-    prepareJsonResponse({
-      content: [
-        {
-          reasoningContent: {
-            redactedReasoning: {
-              data: 'redacted-reasoning-data',
-            },
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                reasoningContent: {
+                  redactedReasoning: {
+                    data: 'redacted-reasoning-data',
+                  },
+                },
+              },
+              { type: 'text', text: 'The answer is 42.' },
+            ],
           },
         },
-        { type: 'text', text: 'The answer is 42.' },
-      ],
-    });
+        usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
+        stopReason: 'stop_sequence',
+      },
+    };
 
     const result = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -4356,26 +4427,36 @@ describe('doGenerate', () => {
   });
 
   it('should handle multiple reasoning blocks', async () => {
-    prepareJsonResponse({
-      content: [
-        {
-          reasoningContent: {
-            reasoningText: {
-              text: 'First reasoning block',
-              signature: 'sig1',
-            },
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                reasoningContent: {
+                  reasoningText: {
+                    text: 'First reasoning block',
+                    signature: 'sig1',
+                  },
+                },
+              },
+              {
+                reasoningContent: {
+                  redactedReasoning: {
+                    data: 'redacted-data',
+                  },
+                },
+              },
+              { type: 'text', text: 'The answer is 42.' },
+            ],
           },
         },
-        {
-          reasoningContent: {
-            redactedReasoning: {
-              data: 'redacted-data',
-            },
-          },
-        },
-        { type: 'text', text: 'The answer is 42.' },
-      ],
-    });
+        usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
+        stopReason: 'stop_sequence',
+      },
+    };
 
     const result = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -4485,20 +4566,32 @@ describe('doGenerate', () => {
   });
 
   it('should handle JSON response format with schema', async () => {
-    prepareJsonResponse({
-      content: [
-        {
-          toolUse: {
-            toolUseId: 'json-tool-id',
-            name: 'json',
-            input: {
-              recipe: { name: 'Lasagna', ingredients: ['pasta', 'cheese'] },
-            },
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                toolUse: {
+                  toolUseId: 'json-tool-id',
+                  name: 'json',
+                  input: {
+                    recipe: {
+                      name: 'Lasagna',
+                      ingredients: ['pasta', 'cheese'],
+                    },
+                  },
+                },
+              },
+            ],
           },
-        } as any,
-      ],
-      stopReason: 'tool_use',
-    });
+        },
+        usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
+        stopReason: 'tool_use',
+      },
+    };
 
     const result = await model.doGenerate({
       prompt: [

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -3189,7 +3189,7 @@ describe('doGenerate', () => {
   });
 
   it('should pass the model and the messages', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -3220,7 +3220,7 @@ describe('doGenerate', () => {
   });
 
   it('should pass settings', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -3241,7 +3241,7 @@ describe('doGenerate', () => {
   });
 
   it('should support guardrails', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -3493,7 +3493,7 @@ describe('doGenerate', () => {
   });
 
   it('should pass tools and tool choice correctly', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     await model.doGenerate({
       tools: [
@@ -3542,7 +3542,7 @@ describe('doGenerate', () => {
   });
 
   it('should omit empty tool descriptions to avoid Bedrock validation errors', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     await model.doGenerate({
       tools: [
@@ -3835,7 +3835,7 @@ describe('doGenerate', () => {
   });
 
   it('should properly combine headers from all sources', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     const optionsHeaders = {
       'options-header': 'options-value',
@@ -3872,7 +3872,7 @@ describe('doGenerate', () => {
   });
 
   it('should work with partial headers', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     const model = new BedrockChatLanguageModel(modelId, {
       baseUrl: () => baseUrl,
@@ -3898,9 +3898,7 @@ describe('doGenerate', () => {
   });
 
   it('should include providerOptions in the request for generate calls', async () => {
-    prepareJsonResponse({
-      content: [{ type: 'text', text: 'Test generation' }],
-    });
+    prepareJsonFixtureResponse('bedrock-text');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -3911,7 +3909,6 @@ describe('doGenerate', () => {
       },
     });
 
-    // Verify that the outgoing request body includes "foo" at its top level.
     const body = await server.calls[0].requestBodyJson;
     expect(body).toMatchObject({ foo: 'bar' });
   });
@@ -4074,7 +4071,7 @@ describe('doGenerate', () => {
   });
 
   it('should handle system messages with cache points', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     await model.doGenerate({
       prompt: [
@@ -4094,7 +4091,7 @@ describe('doGenerate', () => {
   });
 
   it('should transform reasoningConfig to thinking in additionalModelRequestFields', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -4129,7 +4126,7 @@ describe('doGenerate', () => {
   });
 
   it('merges user additionalModelRequestFields with derived thinking (generate)', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -4223,7 +4220,7 @@ describe('doGenerate', () => {
   });
 
   it('should pass maxReasoningEffort as output_config.effort for Anthropic models (generate)', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -4413,7 +4410,7 @@ describe('doGenerate', () => {
   });
 
   it('should omit toolConfig and filter tool content when conversation has tool calls but no active tools', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     const conversationWithToolCalls: LanguageModelV3Prompt = [
       {
@@ -4702,7 +4699,7 @@ describe('doGenerate', () => {
   });
 
   it('should handle unsupported response format types', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     const result = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -4721,7 +4718,7 @@ describe('doGenerate', () => {
   });
 
   it('should omit toolConfig when conversation has tool calls but toolChoice is none', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     const conversationWithToolCalls: LanguageModelV3Prompt = [
       {
@@ -4783,7 +4780,7 @@ describe('doGenerate', () => {
   });
 
   it('should clamp temperature above 1 to 1 and add warning', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     const result = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -4805,7 +4802,7 @@ describe('doGenerate', () => {
   });
 
   it('should clamp temperature below 0 to 0 and add warning', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     const result = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -4827,7 +4824,7 @@ describe('doGenerate', () => {
   });
 
   it('should not clamp valid temperature between 0 and 1', async () => {
-    prepareJsonResponse({});
+    prepareJsonFixtureResponse('bedrock-text');
 
     const result = await model.doGenerate({
       prompt: TEST_PROMPT,

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -3158,54 +3158,6 @@ describe('doGenerate', () => {
     });
   });
 
-  it('should extract text response', async () => {
-    prepareJsonResponse({ content: [{ type: 'text', text: 'Hello, World!' }] });
-
-    const result = await model.doGenerate({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(result.content).toMatchInlineSnapshot(`
-      [
-        {
-          "text": "Hello, World!",
-          "type": "text",
-        },
-      ]
-    `);
-  });
-
-  it('should extract usage', async () => {
-    prepareJsonResponse({
-      usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
-    });
-
-    const { usage } = await model.doGenerate({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(usage).toMatchInlineSnapshot(`
-      {
-        "inputTokens": {
-          "cacheRead": 0,
-          "cacheWrite": 0,
-          "noCache": 4,
-          "total": 4,
-        },
-        "outputTokens": {
-          "reasoning": undefined,
-          "text": 34,
-          "total": 34,
-        },
-        "raw": {
-          "inputTokens": 4,
-          "outputTokens": 34,
-          "totalTokens": 38,
-        },
-      }
-    `);
-  });
-
   it('should extract finish reason', async () => {
     prepareJsonResponse({ stopReason: 'stop_sequence' });
 


### PR DESCRIPTION
## background

amazon-bedrock was partially migrated to the fixture-based test pattern - doStream and some doGenerate tests already used `prepareJsonFixtureResponse` / `prepareChunksFixtureResponse`, but the doGenerate section still had an inline `prepareJsonResponse` helper used by ~29 tests

## summary

- remove 2 duplicate tests (`should extract text response` and `should extract usage`) that were identical to existing fixture-based tests in the `describe('text')` block
- replace `prepareJsonResponse({})` calls with `prepareJsonFixtureResponse('bedrock-text')` for tests that only check request body/headers
- replace `prepareJsonResponse({...specific fields...})` calls with direct `server.urls[generateUrl].response` assignment for tests that need specific response content
- delete the `prepareJsonResponse` helper function and unused `BedrockReasoningContentBlock` / `BedrockRedactedReasoningContentBlock` imports

no new fixtures were needed - all existing fixtures were already recorded from real API calls

## verification

- `grep -c prepareJsonResponse` returns 0
- test count: 103 → 101 (2 duplicates removed)
- 290/290 tests pass

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [ ] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)