### PR TITLE
docs(contribting): correct provider method names for v3 spec and clarity

### DIFF
--- a/contributing/providers.md
+++ b/contributing/providers.md
@@ -25,7 +25,4 @@ If a provider has multiple implementations for the same model type, add a qualif
 
 ## Provider Method Names
 
-For the Provider v2 interface, we require fully specified names with a "Model" suffix,
-e.g. `languageModel(id)` or `imageModel(id)`.
-However, for DX reasons it is very useful to have shorter alias names,
-e.g. `.chat(id)` or `.image(id)`.
+For the Provider v3 interface, we require fully specified names with a "Model" suffix, e.g. `languageModel(id)` or `imageModel(id)`. These help with clarity for both developers and agents.


### PR DESCRIPTION
## Background

The contributing docs were outdated, referring to v2 provider spec.

## Summary

Updated to v3 spec requirements. Also included a note to focus on clarity for developers and agents - higher priority than brevity.

## Manual Verification

N/A

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Project philosophies will be holistically documented in a future contributing doc.

## Related Issues

N/A