### PR TITLE
Backport: fix/unbounded download dos (#12445)

### DIFF
--- a/.changeset/fix-unbounded-download-dos.md
+++ b/.changeset/fix-unbounded-download-dos.md
@@ -1,0 +1,10 @@
+---
+'ai': patch
+'@ai-sdk/provider-utils': patch
+---
+
+security: prevent unbounded memory growth in download functions
+
+The `download()` and `downloadBlob()` functions now enforce a default 2 GiB size limit when downloading from user-provided URLs. Downloads that exceed this limit are aborted with a `DownloadError` instead of consuming unbounded memory and crashing the process. The `abortSignal` parameter is now passed through to `fetch()` in all download call sites.
+
+Added `download` option to `transcribe()` and `experimental_generateVideo()` for providing a custom download function. Use the new `createDownload({ maxBytes })` factory to configure download size limits.

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -54,21 +54,75 @@ const transcript = await transcribe({
 });
 ```
 
+### Download Size Limits
+
+When `audio` is a URL, the SDK downloads the file with a default **2 GiB** size limit.
+You can customize this using `createDownload`:
+
+```ts highlight="1,8"
+import { experimental_transcribe as transcribe, createDownload } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const transcript = await transcribe({
+  model: openai.transcription('whisper-1'),
+  audio: new URL('https://example.com/audio.mp3'),
+  download: createDownload({ maxBytes: 50 * 1024 * 1024 }), // 50 MB limit
+});
+```
+
+You can also provide a fully custom download function:
+
+```ts highlight="6-12"
+import { experimental_transcribe as transcribe } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const transcript = await transcribe({
+  model: openai.transcription('whisper-1'),
+  audio: new URL('https://example.com/audio.mp3'),
+  download: async ({ url }) => {
+    const res = await myAuthenticatedFetch(url);
+    return {
+      data: new Uint8Array(await res.arrayBuffer()),
+      mediaType: res.headers.get('content-type') ?? undefined,
+    };
+  },
+});
+```
+
+If a download exceeds the size limit, a `DownloadError` is thrown:
+
+```ts
+import { experimental_transcribe as transcribe, DownloadError } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+try {
+  await transcribe({
+    model: openai.transcription('whisper-1'),
+    audio: new URL('https://example.com/audio.mp3'),
+  });
+} catch (error) {
+  if (DownloadError.isInstance(error)) {
+    console.log('Download failed:', error.message);
+  }
+}
+```
+
 ### Abort Signals and Timeouts
 
 `transcribe` accepts an optional `abortSignal` parameter of
 type [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
 that you can use to abort the transcription process or set a timeout.
 
+This is particularly useful when combined with URL downloads to prevent long-running requests:
+
 ```ts highlight="8"
 import { openai } from '@ai-sdk/openai';
 import { experimental_transcribe as transcribe } from 'ai';
-import { readFile } from 'fs/promises';
 
 const transcript = await transcribe({
   model: openai.transcription('whisper-1'),
-  audio: await readFile('audio.mp3'),
-  abortSignal: AbortSignal.timeout(1000), // Abort after 1 second
+  audio: new URL('https://example.com/audio.mp3'),
+  abortSignal: AbortSignal.timeout(5000), // Abort after 5 seconds
 });
 ```
 

--- a/content/docs/07-reference/01-ai-sdk-core/11-transcribe.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/11-transcribe.mdx
@@ -69,6 +69,13 @@ console.log(transcript);
       isOptional: true,
       description: 'Additional HTTP headers for the request.',
     },
+    {
+      name: 'download',
+      type: '(options: { url: URL; abortSignal?: AbortSignal }) => Promise<{ data: Uint8Array; mediaType: string | undefined }>',
+      isOptional: true,
+      description:
+        'Custom download function for fetching audio from URLs. Use `createDownload()` from `ai` to create a download function with custom size limits, e.g. `createDownload({ maxBytes: 50 * 1024 * 1024 })`. Default: built-in download with 2 GiB limit.',
+    },
   ]}
 />
 

--- a/packages/ai/scripts/check-bundle-size.ts
+++ b/packages/ai/scripts/check-bundle-size.ts
@@ -3,7 +3,7 @@ import { writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 // Bundle size limits in bytes
-const LIMIT = 550 * 1024;
+const LIMIT = 560 * 1024;
 
 interface BundleResult {
   size: number;

--- a/packages/ai/src/util/download/create-download.ts
+++ b/packages/ai/src/util/download/create-download.ts
@@ -1,0 +1,13 @@
+import { download as internalDownload } from './download';
+
+/**
+ * Creates a download function with configurable options.
+ *
+ * @param options - Configuration options for the download function.
+ * @param options.maxBytes - Maximum allowed download size in bytes. Default: 2 GiB.
+ * @returns A download function that can be passed to `transcribe()` or `experimental_generateVideo()`.
+ */
+export function createDownload(options?: { maxBytes?: number }) {
+  return ({ url, abortSignal }: { url: URL; abortSignal?: AbortSignal }) =>
+    internalDownload({ url, maxBytes: options?.maxBytes, abortSignal });
+}

--- a/packages/ai/src/util/download/download.test.ts
+++ b/packages/ai/src/util/download/download.test.ts
@@ -1,10 +1,11 @@
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { download } from './download';
 import { DownloadError } from './download-error';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 const server = createTestServer({
   'http://example.com/file': {},
+  'http://example.com/large': {},
 });
 
 describe('download', () => {
@@ -64,6 +65,54 @@ describe('download', () => {
       expect.fail('Expected download to throw');
     } catch (error: unknown) {
       expect(error).toBeInstanceOf(DownloadError);
+    }
+  });
+
+  it('should abort when response exceeds default size limit', async () => {
+    // Create a response that claims to be larger than 2 GiB
+    server.urls['http://example.com/large'].response = {
+      type: 'binary',
+      headers: {
+        'content-type': 'application/octet-stream',
+        'content-length': `${3 * 1024 * 1024 * 1024}`,
+      },
+      body: Buffer.from(new Uint8Array(10)),
+    };
+
+    try {
+      await download({
+        url: new URL('http://example.com/large'),
+      });
+      expect.fail('Expected download to throw');
+    } catch (error: unknown) {
+      expect(DownloadError.isInstance(error)).toBe(true);
+      expect((error as DownloadError).message).toContain(
+        'exceeded maximum size',
+      );
+    }
+  });
+
+  it('should pass abortSignal to fetch', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    server.urls['http://example.com/file'].response = {
+      type: 'binary',
+      headers: {
+        'content-type': 'application/octet-stream',
+      },
+      body: Buffer.from(new Uint8Array([1, 2, 3])),
+    };
+
+    try {
+      await download({
+        url: new URL('http://example.com/file'),
+        abortSignal: controller.signal,
+      });
+      expect.fail('Expected download to throw');
+    } catch (error: unknown) {
+      // The fetch should be aborted, resulting in a DownloadError wrapping an AbortError
+      expect(DownloadError.isInstance(error)).toBe(true);
     }
   });
 });

--- a/packages/ai/src/util/download/download.ts
+++ b/packages/ai/src/util/download/download.ts
@@ -1,5 +1,9 @@
 import { DownloadError } from './download-error';
 import {
+  readResponseWithSizeLimit,
+  DEFAULT_MAX_DOWNLOAD_SIZE,
+} from '@ai-sdk/provider-utils';
+import {
   withUserAgentSuffix,
   getRuntimeEnvironmentUserAgent,
 } from '@ai-sdk/provider-utils';
@@ -9,11 +13,21 @@ import { VERSION } from '../../version';
  * Download a file from a URL.
  *
  * @param url - The URL to download from.
+ * @param maxBytes - Maximum allowed download size in bytes. Defaults to 100 MiB.
+ * @param abortSignal - An optional abort signal to cancel the download.
  * @returns The downloaded data and media type.
  *
- * @throws DownloadError if the download fails.
+ * @throws DownloadError if the download fails or exceeds maxBytes.
  */
-export const download = async ({ url }: { url: URL }) => {
+export const download = async ({
+  url,
+  maxBytes,
+  abortSignal,
+}: {
+  url: URL;
+  maxBytes?: number;
+  abortSignal?: AbortSignal;
+}) => {
   const urlText = url.toString();
   try {
     const response = await fetch(urlText, {
@@ -22,6 +36,7 @@ export const download = async ({ url }: { url: URL }) => {
         `ai-sdk/${VERSION}`,
         getRuntimeEnvironmentUserAgent(),
       ),
+      signal: abortSignal,
     });
 
     if (!response.ok) {
@@ -32,8 +47,14 @@ export const download = async ({ url }: { url: URL }) => {
       });
     }
 
+    const data = await readResponseWithSizeLimit({
+      response,
+      url: urlText,
+      maxBytes: maxBytes ?? DEFAULT_MAX_DOWNLOAD_SIZE,
+    });
+
     return {
-      data: new Uint8Array(await response.arrayBuffer()),
+      data,
       mediaType: response.headers.get('content-type') ?? undefined,
     };
   } catch (error) {

--- a/packages/ai/src/util/index.ts
+++ b/packages/ai/src/util/index.ts
@@ -1,6 +1,7 @@
 export type { AsyncIterableStream } from './async-iterable-stream';
 export { consumeStream } from './consume-stream';
 export { cosineSimilarity } from './cosine-similarity';
+export { createDownload } from './download/create-download';
 export { getTextFromDataUrl } from './data-url';
 export type { DeepPartial } from './deep-partial';
 export type { DownloadFunction as Experimental_DownloadFunction } from './download/download-function';

--- a/packages/provider-utils/src/download-error.ts
+++ b/packages/provider-utils/src/download-error.ts
@@ -1,0 +1,39 @@
+import { AISDKError } from '@ai-sdk/provider';
+
+const name = 'AI_DownloadError';
+const marker = `vercel.ai.error.${name}`;
+const symbol = Symbol.for(marker);
+
+export class DownloadError extends AISDKError {
+  private readonly [symbol] = true; // used in isInstance
+
+  readonly url: string;
+  readonly statusCode?: number;
+  readonly statusText?: string;
+
+  constructor({
+    url,
+    statusCode,
+    statusText,
+    cause,
+    message = cause == null
+      ? `Failed to download ${url}: ${statusCode} ${statusText}`
+      : `Failed to download ${url}: ${cause}`,
+  }: {
+    url: string;
+    statusCode?: number;
+    statusText?: string;
+    message?: string;
+    cause?: unknown;
+  }) {
+    super({ name, message, cause });
+
+    this.url = url;
+    this.statusCode = statusCode;
+    this.statusText = statusText;
+  }
+
+  static isInstance(error: unknown): error is DownloadError {
+    return AISDKError.hasMarker(error, marker);
+  }
+}

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -3,6 +3,11 @@ export { convertAsyncIteratorToReadableStream } from './convert-async-iterator-t
 export * from './delay';
 export { DelayedPromise } from './delayed-promise';
 export * from './extract-response-headers';
+export { DownloadError } from './download-error';
+export {
+  readResponseWithSizeLimit,
+  DEFAULT_MAX_DOWNLOAD_SIZE,
+} from './read-response-with-size-limit';
 export * from './fetch-function';
 export { createIdGenerator, generateId, type IdGenerator } from './generate-id';
 export * from './get-error-message';

--- a/packages/provider-utils/src/read-response-with-size-limit.test.ts
+++ b/packages/provider-utils/src/read-response-with-size-limit.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import { readResponseWithSizeLimit } from './read-response-with-size-limit';
+import { DownloadError } from './download-error';
+
+function createMockResponse({
+  body,
+  contentLength,
+}: {
+  body?: Uint8Array | null;
+  contentLength?: string;
+}): Response {
+  const headers = new Headers();
+  if (contentLength != null) {
+    headers.set('content-length', contentLength);
+  }
+
+  const stream =
+    body != null
+      ? new ReadableStream<Uint8Array>({
+          start(controller) {
+            // Send in small chunks to simulate streaming
+            const chunkSize = 4;
+            for (let i = 0; i < body.length; i += chunkSize) {
+              controller.enqueue(body.slice(i, i + chunkSize));
+            }
+            controller.close();
+          },
+        })
+      : null;
+
+  return {
+    headers,
+    body: stream,
+  } as unknown as Response;
+}
+
+describe('readResponseWithSizeLimit', () => {
+  it('should read response within limit successfully', async () => {
+    const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    const response = createMockResponse({
+      body: data,
+      contentLength: '8',
+    });
+
+    const result = await readResponseWithSizeLimit({
+      response,
+      url: 'http://example.com/file',
+      maxBytes: 100,
+    });
+
+    expect(result).toEqual(data);
+  });
+
+  it('should reject when Content-Length exceeds limit (early check)', async () => {
+    const response = createMockResponse({
+      body: new Uint8Array(10),
+      contentLength: '1000',
+    });
+
+    await expect(
+      readResponseWithSizeLimit({
+        response,
+        url: 'http://example.com/large',
+        maxBytes: 100,
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(DownloadError.isInstance(error)).toBe(true);
+      expect((error as DownloadError).message).toContain(
+        'Content-Length: 1000',
+      );
+      return true;
+    });
+  });
+
+  it('should abort when streamed bytes exceed limit', async () => {
+    // Body is larger than maxBytes, but Content-Length is not set
+    const largeBody = new Uint8Array(200);
+    largeBody.fill(42);
+
+    const response = createMockResponse({
+      body: largeBody,
+    });
+
+    await expect(
+      readResponseWithSizeLimit({
+        response,
+        url: 'http://example.com/streaming',
+        maxBytes: 50,
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(DownloadError.isInstance(error)).toBe(true);
+      expect((error as DownloadError).message).toContain(
+        'exceeded maximum size of 50 bytes',
+      );
+      return true;
+    });
+  });
+
+  it('should handle lying Content-Length (says small, sends large)', async () => {
+    const largeBody = new Uint8Array(200);
+    largeBody.fill(42);
+
+    const response = createMockResponse({
+      body: largeBody,
+      contentLength: '10', // Claims to be small
+    });
+
+    await expect(
+      readResponseWithSizeLimit({
+        response,
+        url: 'http://example.com/liar',
+        maxBytes: 50,
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(DownloadError.isInstance(error)).toBe(true);
+      expect((error as DownloadError).message).toContain(
+        'exceeded maximum size of 50 bytes',
+      );
+      return true;
+    });
+  });
+
+  it('should handle empty body (null)', async () => {
+    const response = createMockResponse({
+      body: null,
+    });
+
+    const result = await readResponseWithSizeLimit({
+      response,
+      url: 'http://example.com/empty',
+      maxBytes: 100,
+    });
+
+    expect(result).toEqual(new Uint8Array(0));
+  });
+
+  it('should handle empty body (zero-length)', async () => {
+    const response = createMockResponse({
+      body: new Uint8Array(0),
+    });
+
+    const result = await readResponseWithSizeLimit({
+      response,
+      url: 'http://example.com/empty',
+      maxBytes: 100,
+    });
+
+    expect(result).toEqual(new Uint8Array(0));
+  });
+
+  it('should respect custom maxBytes', async () => {
+    const data = new Uint8Array(10);
+    data.fill(1);
+
+    const response = createMockResponse({
+      body: data,
+      contentLength: '10',
+    });
+
+    const result = await readResponseWithSizeLimit({
+      response,
+      url: 'http://example.com/custom',
+      maxBytes: 10,
+    });
+
+    expect(result).toEqual(data);
+  });
+
+  it('should reject at exact boundary (maxBytes + 1)', async () => {
+    const data = new Uint8Array(11);
+    data.fill(1);
+
+    const response = createMockResponse({
+      body: data,
+    });
+
+    await expect(
+      readResponseWithSizeLimit({
+        response,
+        url: 'http://example.com/boundary',
+        maxBytes: 10,
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(DownloadError.isInstance(error)).toBe(true);
+      return true;
+    });
+  });
+});

--- a/packages/provider-utils/src/read-response-with-size-limit.ts
+++ b/packages/provider-utils/src/read-response-with-size-limit.ts
@@ -1,0 +1,97 @@
+import { DownloadError } from './download-error';
+
+/**
+ * Default maximum download size: 2 GiB.
+ *
+ * `fetch().arrayBuffer()` has ~2x peak memory overhead (undici buffers the
+ * body internally, then creates the JS ArrayBuffer), so very large downloads
+ * risk exceeding the default V8 heap limit on 64-bit systems and terminating
+ * the process with an out-of-memory error.
+ *
+ * Setting this limit converts an unrecoverable OOM crash into a catchable
+ * `DownloadError`.
+ */
+export const DEFAULT_MAX_DOWNLOAD_SIZE = 2 * 1024 * 1024 * 1024;
+
+/**
+ * Reads a fetch Response body with a size limit to prevent memory exhaustion.
+ *
+ * Checks the Content-Length header for early rejection, then reads the body
+ * incrementally via ReadableStream and aborts with a DownloadError when the
+ * limit is exceeded.
+ *
+ * @param response - The fetch Response to read.
+ * @param url - The URL being downloaded (used in error messages).
+ * @param maxBytes - Maximum allowed bytes. Defaults to DEFAULT_MAX_DOWNLOAD_SIZE.
+ * @returns A Uint8Array containing the response body.
+ * @throws DownloadError if the response exceeds maxBytes.
+ */
+export async function readResponseWithSizeLimit({
+  response,
+  url,
+  maxBytes = DEFAULT_MAX_DOWNLOAD_SIZE,
+}: {
+  response: Response;
+  url: string;
+  maxBytes?: number;
+}): Promise<Uint8Array> {
+  // Early rejection based on Content-Length header
+  const contentLength = response.headers.get('content-length');
+  if (contentLength != null) {
+    const length = parseInt(contentLength, 10);
+    if (!isNaN(length) && length > maxBytes) {
+      throw new DownloadError({
+        url,
+        message: `Download of ${url} exceeded maximum size of ${maxBytes} bytes (Content-Length: ${length}).`,
+      });
+    }
+  }
+
+  const body = response.body;
+
+  // Handle missing body (empty responses)
+  if (body == null) {
+    return new Uint8Array(0);
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        break;
+      }
+
+      totalBytes += value.length;
+
+      if (totalBytes > maxBytes) {
+        throw new DownloadError({
+          url,
+          message: `Download of ${url} exceeded maximum size of ${maxBytes} bytes.`,
+        });
+      }
+
+      chunks.push(value);
+    }
+  } finally {
+    try {
+      await reader.cancel();
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  // Concatenate chunks into a single Uint8Array
+  const result = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Backport of #12445 to `release-v5.0`
- Adds size-limited download via `readResponseWithSizeLimit` to prevent unbounded memory consumption (DoS)
- Adds `maxBytes` and `abortSignal` parameters to download functions
- Skipped generate-video and download-blob changes (files don't exist on v5.0)

## Test plan

- [x] Test changes against local POC