### PR TITLE
refactor(provider/revai): migrate tests to fixture-based pattern

### DIFF
--- a/packages/revai/src/__fixtures__/revai-job-status.json
+++ b/packages/revai/src/__fixtures__/revai-job-status.json
@@ -1,0 +1,10 @@
+{
+  "id": "test-id",
+  "created_on": "2026-02-12T23:26:22.276Z",
+  "completed_on": "2026-02-12T23:26:26.971Z",
+  "name": "audio.mp3",
+  "status": "transcribed",
+  "duration_seconds": 2.51,
+  "type": "async",
+  "language": "en"
+}

--- a/packages/revai/src/__fixtures__/revai-job-submit.json
+++ b/packages/revai/src/__fixtures__/revai-job-submit.json
@@ -1,0 +1,8 @@
+{
+  "id": "test-id",
+  "created_on": "2026-02-12T23:26:22.276Z",
+  "name": "audio.mp3",
+  "status": "in_progress",
+  "type": "async",
+  "language": "en"
+}

--- a/packages/revai/src/__fixtures__/revai-transcript.json
+++ b/packages/revai/src/__fixtures__/revai-transcript.json
@@ -1,0 +1,68 @@
+{
+  "monologues": [
+    {
+      "speaker": 0,
+      "elements": [
+        {
+          "type": "text",
+          "value": "Hello",
+          "ts": 0.075,
+          "end_ts": 0.425,
+          "confidence": 0.96
+        },
+        {
+          "type": "punct",
+          "value": " "
+        },
+        {
+          "type": "text",
+          "value": "from",
+          "ts": 0.425,
+          "end_ts": 0.665,
+          "confidence": 0.98
+        },
+        {
+          "type": "punct",
+          "value": " "
+        },
+        {
+          "type": "text",
+          "value": "the",
+          "ts": 0.665,
+          "end_ts": 0.785,
+          "confidence": 0.98
+        },
+        {
+          "type": "punct",
+          "value": " "
+        },
+        {
+          "type": "text",
+          "value": "Sal",
+          "ts": 0.945,
+          "end_ts": 1.105,
+          "confidence": 0.64
+        },
+        {
+          "type": "punct",
+          "value": ","
+        },
+        {
+          "type": "punct",
+          "value": " "
+        },
+        {
+          "type": "text",
+          "value": "A-I-S-D-K",
+          "ts": 1.185,
+          "end_ts": 2.145,
+          "confidence": 0.96
+        },
+        {
+          "type": "punct",
+          "value": "."
+        }
+      ]
+    }
+  ]
+}

--- a/packages/revai/src/__snapshots__/revai-transcription-model.test.ts.snap
+++ b/packages/revai/src/__snapshots__/revai-transcription-model.test.ts.snap
@@ -1,0 +1,82 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`doGenerate > response headers > should include response data with timestamp, modelId and headers 1`] = `
+{
+  "body": {
+    "monologues": [
+      {
+        "elements": [
+          {
+            "confidence": 0.96,
+            "end_ts": 0.425,
+            "ts": 0.075,
+            "type": "text",
+            "value": "Hello",
+          },
+          {
+            "type": "punct",
+            "value": " ",
+          },
+          {
+            "confidence": 0.98,
+            "end_ts": 0.665,
+            "ts": 0.425,
+            "type": "text",
+            "value": "from",
+          },
+          {
+            "type": "punct",
+            "value": " ",
+          },
+          {
+            "confidence": 0.98,
+            "end_ts": 0.785,
+            "ts": 0.665,
+            "type": "text",
+            "value": "the",
+          },
+          {
+            "type": "punct",
+            "value": " ",
+          },
+          {
+            "confidence": 0.64,
+            "end_ts": 1.105,
+            "ts": 0.945,
+            "type": "text",
+            "value": "Sal",
+          },
+          {
+            "type": "punct",
+            "value": ",",
+          },
+          {
+            "type": "punct",
+            "value": " ",
+          },
+          {
+            "confidence": 0.96,
+            "end_ts": 2.145,
+            "ts": 1.185,
+            "type": "text",
+            "value": "A-I-S-D-K",
+          },
+          {
+            "type": "punct",
+            "value": ".",
+          },
+        ],
+        "speaker": 0,
+      },
+    ],
+  },
+  "headers": {
+    "content-length": "596",
+    "content-type": "application/json",
+    "x-ratelimit-remaining": "123",
+    "x-request-id": "test-request-id",
+  },
+  "modelId": "machine",
+  "timestamp": 1970-01-01T00:00:00.000Z,
+}
+`;

--- a/packages/revai/src/revai-transcription-model.test.ts
+++ b/packages/revai/src/revai-transcription-model.test.ts
@@ -2,8 +2,9 @@ import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { RevaiTranscriptionModel } from './revai-transcription-model';
 import { createRevai } from './revai-provider';
 import { readFile } from 'node:fs/promises';
+import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('./version', () => ({
   VERSION: '0.0.0-test',
@@ -19,264 +20,137 @@ const server = createTestServer({
   'https://api.rev.ai/speechtotext/v1/jobs/test-id/transcript': {},
 });
 
-describe('doGenerate', () => {
-  function prepareJsonResponse({
+function prepareJsonFixtureResponse(headers?: Record<string, string>) {
+  server.urls['https://api.rev.ai/speechtotext/v1/jobs'].response = {
+    type: 'json-value',
     headers,
-  }: {
-    headers?: Record<string, string>;
-  } = {}) {
-    server.urls['https://api.rev.ai/speechtotext/v1/jobs'].response = {
-      type: 'json-value',
-      headers,
-      body: {
-        id: 'test-id',
-        status: 'in_progress',
-        language: 'en',
-        created_on: '2018-05-05T23:23:22.29Z',
-        transcriber: 'machine',
-      },
-    };
-    server.urls['https://api.rev.ai/speechtotext/v1/jobs/test-id'].response = {
-      type: 'json-value',
-      headers,
-      body: {
-        id: 'test-id',
-        status: 'transcribed',
-        language: 'en',
-        created_on: '2018-05-05T23:23:22.29Z',
-        transcriber: 'machine',
-      },
-    };
-    server.urls[
-      'https://api.rev.ai/speechtotext/v1/jobs/test-id/transcript'
-    ].response = {
-      type: 'json-value',
-      headers,
-      body: {
-        monologues: [
-          {
-            speaker: 1,
-            elements: [
-              {
-                type: 'text',
-                value: 'Hello',
-                ts: 0.5,
-                end_ts: 1.5,
-                confidence: 1,
-              },
-              {
-                type: 'punct',
-                value: ' ',
-              },
-              {
-                type: 'text',
-                value: 'World',
-                ts: 1.75,
-                end_ts: 2.85,
-                confidence: 0.8,
-              },
-              {
-                type: 'punct',
-                value: '.',
-              },
-            ],
-          },
-          {
-            speaker: 2,
-            elements: [
-              {
-                type: 'text',
-                value: 'monologues',
-                ts: 3,
-                end_ts: 3.5,
-                confidence: 1,
-              },
-              {
-                type: 'punct',
-                value: ' ',
-              },
-              {
-                type: 'text',
-                value: 'are',
-                ts: 3.6,
-                end_ts: 3.9,
-                confidence: 1,
-              },
-              {
-                type: 'punct',
-                value: ' ',
-              },
-              {
-                type: 'text',
-                value: 'a',
-                ts: 4,
-                end_ts: 4.3,
-                confidence: 1,
-              },
-              {
-                type: 'punct',
-                value: ' ',
-              },
-              {
-                type: 'text',
-                value: 'block',
-                ts: 4.5,
-                end_ts: 5.5,
-                confidence: 1,
-              },
-              {
-                type: 'punct',
-                value: ' ',
-              },
-              {
-                type: 'text',
-                value: 'of',
-                ts: 5.75,
-                end_ts: 6.14,
-                confidence: 1,
-              },
-              {
-                type: 'punct',
-                value: ' ',
-              },
-              {
-                type: 'unknown',
-                value: '<inaudible>',
-              },
-              {
-                type: 'punct',
-                value: ' ',
-              },
-              {
-                type: 'text',
-                value: 'text',
-                ts: 6.5,
-                end_ts: 7.78,
-                confidence: 1,
-              },
-              {
-                type: 'punct',
-                value: '.',
-              },
-            ],
-          },
-        ],
-      },
-    };
-  }
+    body: JSON.parse(
+      fs.readFileSync(`src/__fixtures__/revai-job-submit.json`, 'utf8'),
+    ),
+  };
+  server.urls['https://api.rev.ai/speechtotext/v1/jobs/test-id'].response = {
+    type: 'json-value',
+    headers,
+    body: JSON.parse(
+      fs.readFileSync(`src/__fixtures__/revai-job-status.json`, 'utf8'),
+    ),
+  };
+  server.urls[
+    'https://api.rev.ai/speechtotext/v1/jobs/test-id/transcript'
+  ].response = {
+    type: 'json-value',
+    headers,
+    body: JSON.parse(
+      fs.readFileSync(`src/__fixtures__/revai-transcript.json`, 'utf8'),
+    ),
+  };
+}
 
-  it('should pass the model', async () => {
-    prepareJsonResponse();
+describe('doGenerate', () => {
+  describe('transcription', () => {
+    beforeEach(() => prepareJsonFixtureResponse());
 
-    await model.doGenerate({
-      audio: audioData,
-      mediaType: 'audio/wav',
+    it('should pass the model', async () => {
+      await model.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+      });
+
+      expect(await server.calls[0].requestBodyMultipart).toMatchObject({
+        media: expect.any(File),
+        config: '{"transcriber":"machine"}',
+      });
     });
 
-    expect(await server.calls[0].requestBodyMultipart).toMatchObject({
-      media: expect.any(File),
-      config: '{"transcriber":"machine"}',
+    it('should pass headers', async () => {
+      const provider = createRevai({
+        apiKey: 'test-api-key',
+        headers: {
+          'Custom-Provider-Header': 'provider-header-value',
+        },
+      });
+
+      await provider.transcription('machine').doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+        headers: {
+          'Custom-Request-Header': 'request-header-value',
+        },
+      });
+
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        authorization: 'Bearer test-api-key',
+        'content-type': expect.stringMatching(
+          /^multipart\/form-data; boundary=----formdata-undici-\d+$/,
+        ),
+        'custom-provider-header': 'provider-header-value',
+        'custom-request-header': 'request-header-value',
+      });
+
+      expect(server.calls[0].requestUserAgent).toContain(
+        `ai-sdk/revai/0.0.0-test`,
+      );
+    });
+
+    it('should extract the transcription text', async () => {
+      const result = await model.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+      });
+
+      expect(result.text).toMatchInlineSnapshot(
+        `"Hello from the Sal, A-I-S-D-K."`,
+      );
     });
   });
 
-  it('should pass headers', async () => {
-    prepareJsonResponse();
-
-    const provider = createRevai({
-      apiKey: 'test-api-key',
-      headers: {
-        'Custom-Provider-Header': 'provider-header-value',
-      },
-    });
-
-    await provider.transcription('machine').doGenerate({
-      audio: audioData,
-      mediaType: 'audio/wav',
-      headers: {
-        'Custom-Request-Header': 'request-header-value',
-      },
-    });
-
-    expect(server.calls[0].requestHeaders).toMatchObject({
-      authorization: 'Bearer test-api-key',
-      'content-type': expect.stringMatching(
-        /^multipart\/form-data; boundary=----formdata-undici-\d+$/,
-      ),
-      'custom-provider-header': 'provider-header-value',
-      'custom-request-header': 'request-header-value',
-    });
-
-    expect(server.calls[0].requestUserAgent).toContain(
-      `ai-sdk/revai/0.0.0-test`,
-    );
-  });
-
-  it('should extract the transcription text', async () => {
-    prepareJsonResponse();
-
-    const result = await model.doGenerate({
-      audio: audioData,
-      mediaType: 'audio/wav',
-    });
-
-    expect(result.text).toBe(
-      'Hello World. monologues are a block of <inaudible> text.',
-    );
-  });
-
-  it('should include response data with timestamp, modelId and headers', async () => {
-    prepareJsonResponse({
-      headers: {
+  describe('response headers', () => {
+    it('should include response data with timestamp, modelId and headers', async () => {
+      prepareJsonFixtureResponse({
         'x-request-id': 'test-request-id',
         'x-ratelimit-remaining': '123',
-      },
-    });
+      });
 
-    const testDate = new Date(0);
-    const customModel = new RevaiTranscriptionModel('machine', {
-      provider: 'test-provider',
-      url: ({ path }) => `https://api.rev.ai${path}`,
-      headers: () => ({}),
-      _internal: {
-        currentDate: () => testDate,
-      },
-    });
+      const testDate = new Date(0);
+      const customModel = new RevaiTranscriptionModel('machine', {
+        provider: 'test-provider',
+        url: ({ path }) => `https://api.rev.ai${path}`,
+        headers: () => ({}),
+        _internal: {
+          currentDate: () => testDate,
+        },
+      });
 
-    const result = await customModel.doGenerate({
-      audio: audioData,
-      mediaType: 'audio/wav',
-    });
+      const result = await customModel.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+      });
 
-    expect(result.response).toMatchObject({
-      timestamp: testDate,
-      modelId: 'machine',
-      headers: {
-        'content-type': 'application/json',
-        'x-request-id': 'test-request-id',
-        'x-ratelimit-remaining': '123',
-      },
+      expect(result.response).toMatchSnapshot();
     });
   });
 
-  it('should use real date when no custom date provider is specified', async () => {
-    prepareJsonResponse();
+  describe('response metadata', () => {
+    it('should use real date when no custom date provider is specified', async () => {
+      prepareJsonFixtureResponse();
 
-    const testDate = new Date(0);
-    const customModel = new RevaiTranscriptionModel('machine', {
-      provider: 'test-provider',
-      url: ({ path }) => `https://api.rev.ai${path}`,
-      headers: () => ({}),
-      _internal: {
-        currentDate: () => testDate,
-      },
+      const testDate = new Date(0);
+      const customModel = new RevaiTranscriptionModel('machine', {
+        provider: 'test-provider',
+        url: ({ path }) => `https://api.rev.ai${path}`,
+        headers: () => ({}),
+        _internal: {
+          currentDate: () => testDate,
+        },
+      });
+
+      const result = await customModel.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+      });
+
+      expect(result.response.timestamp.getTime()).toEqual(testDate.getTime());
+      expect(result.response.modelId).toBe('machine');
     });
-
-    const result = await customModel.doGenerate({
-      audio: audioData,
-      mediaType: 'audio/wav',
-    });
-
-    expect(result.response.timestamp.getTime()).toEqual(testDate.getTime());
-    expect(result.response.modelId).toBe('machine');
   });
 });


### PR DESCRIPTION
## background

revai tests used an inline `prepareJsonResponse` helper that constructed fake response data directly in the test file - this makes tests harder to maintain and doesn't reflect real API responses

## summary

- record 3 real API response fixtures from rev.ai (job submit, job status, transcript)
- replace `prepareJsonResponse` with `prepareJsonFixtureResponse` that reads from fixture files
- organize tests into describe blocks (`transcription`, `response headers`, `response metadata`)
- use `toMatchSnapshot()` for response assertions

## verification

<details>
<summary>tests pass</summary>

```
 ✓ src/revai-error.test.ts  (1 test) 2ms
 ✓ src/revai-transcription-model.test.ts  (5 tests) 38ms

 Test Files  2 passed (2)
      Tests  6 passed (6)
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)