### PR TITLE
refactor(provider/fal): migrate transcription tests to fixture-based pattern

### DIFF
--- a/packages/fal/src/__fixtures__/fal-transcription-queue.json
+++ b/packages/fal/src/__fixtures__/fal-transcription-queue.json
@@ -1,0 +1,10 @@
+{
+  "status": "IN_QUEUE",
+  "request_id": "test-id",
+  "response_url": "https://queue.fal.run/fal-ai/wizper/requests/test-id/result",
+  "status_url": "https://queue.fal.run/fal-ai/wizper/requests/test-id",
+  "cancel_url": "https://queue.fal.run/fal-ai/wizper/requests/test-id/cancel",
+  "logs": null,
+  "metrics": {},
+  "queue_position": 4
+}

--- a/packages/fal/src/__fixtures__/fal-transcription-result.json
+++ b/packages/fal/src/__fixtures__/fal-transcription-result.json
@@ -1,0 +1,10 @@
+{
+  "text": "Hello from the Versal AISDK.",
+  "chunks": [
+    {
+      "timestamp": [0, 2.508],
+      "text": "Hello from the Versal AISDK."
+    }
+  ],
+  "languages": ["en"]
+}

--- a/packages/fal/src/__snapshots__/fal-transcription-model.test.ts.snap
+++ b/packages/fal/src/__snapshots__/fal-transcription-model.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`doGenerate > response headers > should include response data with timestamp, modelId and headers 1`] = `
+{
+  "body": {
+    "chunks": [
+      {
+        "text": "Hello from the Versal AISDK.",
+        "timestamp": [
+          0,
+          2.508,
+        ],
+      },
+    ],
+    "languages": [
+      "en",
+    ],
+    "text": "Hello from the Versal AISDK.",
+  },
+  "headers": {
+    "content-length": "131",
+    "content-type": "application/json",
+    "x-ratelimit-remaining": "123",
+    "x-request-id": "test-request-id",
+  },
+  "modelId": "wizper",
+  "timestamp": 1970-01-01T00:00:00.000Z,
+}
+`;

--- a/packages/fal/src/fal-transcription-model.test.ts
+++ b/packages/fal/src/fal-transcription-model.test.ts
@@ -2,8 +2,9 @@ import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { createFal } from './fal-provider';
 import { FalTranscriptionModel } from './fal-transcription-model';
 import { readFile } from 'node:fs/promises';
+import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 
 const audioData = await readFile(path.join(__dirname, 'transcript-test.mp3'));
 const provider = createFal({ apiKey: 'test-api-key' });
@@ -14,168 +15,128 @@ const server = createTestServer({
   'https://queue.fal.run/fal-ai/wizper/requests/test-id': {},
 });
 
-describe('doGenerate', () => {
-  function prepareJsonResponse({
+function prepareJsonFixtureResponse(headers?: Record<string, string>) {
+  server.urls['https://queue.fal.run/fal-ai/wizper'].response = {
+    type: 'json-value',
     headers,
-  }: {
-    headers?: Record<string, string>;
-  } = {}) {
-    server.urls['https://queue.fal.run/fal-ai/wizper'].response = {
+    body: JSON.parse(
+      fs.readFileSync('src/__fixtures__/fal-transcription-queue.json', 'utf8'),
+    ),
+  };
+  server.urls['https://queue.fal.run/fal-ai/wizper/requests/test-id'].response =
+    {
       type: 'json-value',
       headers,
-      body: {
-        status: 'COMPLETED',
-        request_id: 'test-id',
-        response_url:
-          'https://queue.fal.run/fal-ai/wizper/requests/test-id/result',
-        status_url: 'https://queue.fal.run/fal-ai/wizper/requests/test-id',
-        cancel_url:
-          'https://queue.fal.run/fal-ai/wizper/requests/test-id/cancel',
-        logs: null,
-        metrics: {},
-        queue_position: 0,
-      },
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/__fixtures__/fal-transcription-result.json',
+          'utf8',
+        ),
+      ),
     };
-    server.urls[
-      'https://queue.fal.run/fal-ai/wizper/requests/test-id'
-    ].response = {
-      type: 'json-value',
-      headers,
-      body: {
-        text: 'Hello world!',
-        chunks: [
-          {
-            text: 'Hello',
-            timestamp: [0, 1],
-            speaker: 'speaker_1',
-          },
-          {
-            text: ' ',
-            timestamp: [1, 2],
-            speaker: 'speaker_1',
-          },
-          {
-            text: 'world!',
-            timestamp: [2, 3],
-            speaker: 'speaker_1',
-          },
-        ],
-        diarization_segments: [
-          {
-            speaker: 'speaker_1',
-            timestamp: [0, 3],
-          },
-        ],
-      },
-    };
-  }
+}
 
-  it('should pass the model', async () => {
-    prepareJsonResponse();
+describe('doGenerate', () => {
+  describe('transcription', () => {
+    beforeEach(() => prepareJsonFixtureResponse());
 
-    await model.doGenerate({
-      audio: audioData,
-      mediaType: 'audio/wav',
+    it('should pass the model', async () => {
+      await model.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        audio_url: expect.stringMatching(/^data:audio\//),
+        task: 'transcribe',
+        diarize: true,
+        chunk_level: 'word',
+      });
     });
 
-    expect(await server.calls[0].requestBodyJson).toMatchObject({
-      audio_url: expect.stringMatching(/^data:audio\//),
-      task: 'transcribe',
-      diarize: true,
-      chunk_level: 'word',
-    });
-  });
+    it('should pass headers', async () => {
+      const provider = createFal({
+        apiKey: 'test-api-key',
+        headers: {
+          'Custom-Provider-Header': 'provider-header-value',
+        },
+      });
 
-  it('should pass headers', async () => {
-    prepareJsonResponse();
+      await provider.transcription('wizper').doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+        headers: {
+          'Custom-Request-Header': 'request-header-value',
+        },
+      });
 
-    const provider = createFal({
-      apiKey: 'test-api-key',
-      headers: {
-        'Custom-Provider-Header': 'provider-header-value',
-      },
-    });
-
-    await provider.transcription('wizper').doGenerate({
-      audio: audioData,
-      mediaType: 'audio/wav',
-      headers: {
-        'Custom-Request-Header': 'request-header-value',
-      },
-    });
-
-    expect(server.calls[0].requestHeaders).toMatchObject({
-      authorization: 'Key test-api-key',
-      'content-type': 'application/json',
-      'custom-provider-header': 'provider-header-value',
-      'custom-request-header': 'request-header-value',
-    });
-  });
-
-  it('should extract the transcription text', async () => {
-    prepareJsonResponse();
-
-    const result = await model.doGenerate({
-      audio: audioData,
-      mediaType: 'audio/wav',
-    });
-
-    expect(result.text).toBe('Hello world!');
-  });
-
-  it('should include response data with timestamp, modelId and headers', async () => {
-    prepareJsonResponse({
-      headers: {
-        'x-request-id': 'test-request-id',
-        'x-ratelimit-remaining': '123',
-      },
-    });
-
-    const testDate = new Date(0);
-    const customModel = new FalTranscriptionModel('wizper', {
-      provider: 'test-provider',
-      url: ({ path }) => path,
-      headers: () => ({}),
-      _internal: {
-        currentDate: () => testDate,
-      },
-    });
-
-    const result = await customModel.doGenerate({
-      audio: audioData,
-      mediaType: 'audio/wav',
-    });
-
-    expect(result.response).toMatchObject({
-      timestamp: testDate,
-      modelId: 'wizper',
-      headers: {
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        authorization: 'Key test-api-key',
         'content-type': 'application/json',
-        'x-request-id': 'test-request-id',
-        'x-ratelimit-remaining': '123',
-      },
+        'custom-provider-header': 'provider-header-value',
+        'custom-request-header': 'request-header-value',
+      });
+    });
+
+    it('should extract the transcription text', async () => {
+      const result = await model.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+      });
+
+      expect(result.text).toMatchInlineSnapshot(
+        `"Hello from the Versal AISDK."`,
+      );
     });
   });
 
-  it('should use real date when no custom date provider is specified', async () => {
-    prepareJsonResponse();
+  describe('response headers', () => {
+    it('should include response data with timestamp, modelId and headers', async () => {
+      prepareJsonFixtureResponse({
+        'x-request-id': 'test-request-id',
+        'x-ratelimit-remaining': '123',
+      });
 
-    const testDate = new Date(0);
-    const customModel = new FalTranscriptionModel('wizper', {
-      provider: 'test-provider',
-      url: ({ path }) => path,
-      headers: () => ({}),
-      _internal: {
-        currentDate: () => testDate,
-      },
+      const testDate = new Date(0);
+      const customModel = new FalTranscriptionModel('wizper', {
+        provider: 'test-provider',
+        url: ({ path }) => path,
+        headers: () => ({}),
+        _internal: {
+          currentDate: () => testDate,
+        },
+      });
+
+      const result = await customModel.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+      });
+
+      expect(result.response).toMatchSnapshot();
     });
+  });
 
-    const result = await customModel.doGenerate({
-      audio: audioData,
-      mediaType: 'audio/wav',
+  describe('response metadata', () => {
+    it('should use real date when no custom date provider is specified', async () => {
+      prepareJsonFixtureResponse();
+
+      const testDate = new Date(0);
+      const customModel = new FalTranscriptionModel('wizper', {
+        provider: 'test-provider',
+        url: ({ path }) => path,
+        headers: () => ({}),
+        _internal: {
+          currentDate: () => testDate,
+        },
+      });
+
+      const result = await customModel.doGenerate({
+        audio: audioData,
+        mediaType: 'audio/wav',
+      });
+
+      expect(result.response.timestamp.getTime()).toEqual(testDate.getTime());
+      expect(result.response.modelId).toBe('wizper');
     });
-
-    expect(result.response.timestamp.getTime()).toEqual(testDate.getTime());
-    expect(result.response.modelId).toBe('wizper');
   });
 });


### PR DESCRIPTION
## background

fal transcription tests used an inline `prepareJsonResponse` helper that constructed fake response data directly in the test file - this makes tests harder to maintain and doesn't reflect real API responses

## summary

- record 2 real API response fixtures from fal wizper model (queue submit, transcription result)
- replace `prepareJsonResponse` with `prepareJsonFixtureResponse` that reads from fixture files
- organize tests into describe blocks (`transcription`, `response headers`, `response metadata`)
- use `toMatchSnapshot()` for response assertions

## verification

<details>
<summary>tests pass</summary>

```
 ✓ src/fal-error.test.ts  (1 test) 2ms
 ✓ src/fal-provider.test.ts  (5 tests) 5ms
 ✓ src/fal-speech-model.test.ts  (5 tests) 46ms
 ✓ src/fal-transcription-model.test.ts  (5 tests) 55ms
 ✓ src/fal-image-model.test.ts  (25 tests) 94ms
 ✓ src/fal-video-model.test.ts  (30 tests) 164ms

 Test Files  6 passed (6)
      Tests  71 passed (71)
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)