### PR TITLE
feat(perplexity): export PerplexityLanguageModelOptions

### DIFF
--- a/.changeset/perfect-chicken-smile.md
+++ b/.changeset/perfect-chicken-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/perplexity': patch
+---
+
+feat(perplexity): export PerplexityLanguageModelOptions

--- a/content/providers/01-ai-sdk-providers/70-perplexity.mdx
+++ b/content/providers/01-ai-sdk-providers/70-perplexity.mdx
@@ -103,6 +103,12 @@ The Perplexity provider includes additional metadata in the response through `pr
 Additional configuration options are available through `providerOptions`.
 
 ```ts
+import {
+  perplexity,
+  type PerplexityLanguageModelOptions,
+} from '@ai-sdk/perplexity';
+import { generateText } from 'ai';
+
 const result = await generateText({
   model: perplexity('sonar-pro'),
   prompt: 'What are the latest developments in quantum computing?',
@@ -110,7 +116,7 @@ const result = await generateText({
     perplexity: {
       return_images: true, // Enable image responses (Tier-2 Perplexity users only)
       search_recency_filter: 'week', // Filter search results by recency
-    },
+    } satisfies PerplexityLanguageModelOptions,
   },
 });
 

--- a/examples/ai-functions/src/perplexity-options-types.test-d.ts
+++ b/examples/ai-functions/src/perplexity-options-types.test-d.ts
@@ -1,0 +1,13 @@
+import type { PerplexityLanguageModelOptions } from '@ai-sdk/perplexity';
+import { describe, expectTypeOf, it } from 'vitest';
+
+describe('@ai-sdk/perplexity', () => {
+  it('exports PerplexityLanguageModelOptions for `providerOptions.perplexity`', () => {
+    const options = {
+      return_images: true,
+      search_recency_filter: 'week',
+    } satisfies PerplexityLanguageModelOptions;
+
+    expectTypeOf(options).toMatchTypeOf<PerplexityLanguageModelOptions>();
+  });
+});

--- a/packages/perplexity/src/index.ts
+++ b/packages/perplexity/src/index.ts
@@ -3,4 +3,5 @@ export type {
   PerplexityProvider,
   PerplexityProviderSettings,
 } from './perplexity-provider';
+export type { PerplexityLanguageModelOptions } from './perplexity-language-model-options';
 export { VERSION } from './version';

--- a/packages/perplexity/src/perplexity-language-model-options.ts
+++ b/packages/perplexity/src/perplexity-language-model-options.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod/v4';
+
 // https://docs.perplexity.ai/models/model-cards
 export type PerplexityLanguageModelId =
   | 'sonar-deep-research'
@@ -6,3 +8,73 @@ export type PerplexityLanguageModelId =
   | 'sonar-pro'
   | 'sonar'
   | (string & {});
+
+/**
+ * Provider-specific language model options for Perplexity.
+ *
+ * Perplexity uses an OpenAI-compatible API and supports additional parameters.
+ * The AI SDK docs list the most common ones; any other Perplexity API parameters
+ * can also be passed through (and are allowed by this schema).
+ */
+export const perplexityLanguageModelOptions = z
+  .object({
+    /**
+     * Enable image responses.
+     *
+     * When set to `true`, the response may include relevant images.
+     * This feature is only available to Perplexity Tier-2 users and above.
+     */
+    return_images: z.boolean().optional(),
+
+    /**
+     * Filter search results by recency.
+     *
+     * Possible values: `hour`, `day`, `week`, `month`.
+     */
+    search_recency_filter: z.enum(['hour', 'day', 'week', 'month']).optional(),
+
+    /**
+     * Filter web search results to a list of domains.
+     *
+     * Perplexity supports excluding domains by prefixing them with `-`.
+     *
+     * @example ['wikipedia.org', 'nature.com', '-reddit.com']
+     */
+    search_domain_filter: z.array(z.string()).optional(),
+
+    /**
+     * Return related questions.
+     */
+    return_related_questions: z.boolean().optional(),
+
+    /**
+     * Advanced web search configuration.
+     */
+    web_search_options: z
+      .object({
+        /**
+         * Search context size (amount of context pulled from web results).
+         */
+        search_context_size: z.enum(['low', 'medium', 'high']).optional(),
+      })
+      .optional(),
+
+    /**
+     * Filter search results to those after a specific date.
+     *
+     * NOTE: Perplexity expects a string date; format depends on the API.
+     */
+    search_after_date_filter: z.string().optional(),
+
+    /**
+     * Filter search results to those before a specific date.
+     *
+     * NOTE: Perplexity expects a string date; format depends on the API.
+     */
+    search_before_date_filter: z.string().optional(),
+  })
+  .passthrough();
+
+export type PerplexityLanguageModelOptions = z.infer<
+  typeof perplexityLanguageModelOptions
+>;


### PR DESCRIPTION
## Summary

- Adds a typed `PerplexityLanguageModelOptions` (based on a Zod schema) for `providerOptions.perplexity`.
- Exports the type from `@ai-sdk/perplexity`.
- Updates Perplexity provider docs to show `satisfies PerplexityLanguageModelOptions`.

## Tests

- `pnpm prettier-check`
- `pnpm type-check:full`

Fixes #12463