### PR TITLE
fix(amazon-bedrock): export AmazonBedrockImageModelOptions

### DIFF
--- a/.changeset/grumpy-rocks-sparkle.md
+++ b/.changeset/grumpy-rocks-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+feat(amazon-bedrock): export AmazonBedrockImageModelOptions

--- a/examples/ai-functions/src/amazon-bedrock-image-options-types.test-d.ts
+++ b/examples/ai-functions/src/amazon-bedrock-image-options-types.test-d.ts
@@ -1,0 +1,15 @@
+import type { AmazonBedrockImageModelOptions } from '@ai-sdk/amazon-bedrock';
+import { describe, expectTypeOf, it } from 'vitest';
+
+describe('@ai-sdk/amazon-bedrock', () => {
+  it('exports AmazonBedrockImageModelOptions for `providerOptions.bedrock`', () => {
+    const options = {
+      quality: 'premium',
+      cfgScale: 7.5,
+      negativeText: 'blurry, distorted',
+      taskType: 'TEXT_IMAGE',
+    } satisfies AmazonBedrockImageModelOptions;
+
+    expectTypeOf(options).toMatchTypeOf<AmazonBedrockImageModelOptions>();
+  });
+});

--- a/packages/amazon-bedrock/src/bedrock-image-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-options.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod/v4';
+
+export type BedrockImageModelId = 'amazon.nova-canvas-v1:0' | (string & {});
+
+// https://docs.aws.amazon.com/nova/latest/userguide/image-gen-req-resp-structure.html
+export const modelMaxImagesPerCall: Record<BedrockImageModelId, number> = {
+  'amazon.nova-canvas-v1:0': 5,
+};
+
+/**
+ * Provider-specific image model options for Amazon Bedrock.
+ *
+ * These options are passed through the `providerOptions.bedrock` parameter
+ * when calling image generation functions.
+ */
+export const amazonBedrockImageModelOptions = z
+  .object({
+    /**
+     * Task type for image operations.
+     *
+     * - `TEXT_IMAGE`: Generate images from text prompts
+     * - `IMAGE_VARIATION`: Create variations of existing images
+     * - `INPAINTING`: Fill in masked areas of an image
+     * - `OUTPAINTING`: Extend an image beyond its original boundaries
+     * - `BACKGROUND_REMOVAL`: Remove background from an image
+     */
+    taskType: z
+      .enum([
+        'TEXT_IMAGE',
+        'IMAGE_VARIATION',
+        'INPAINTING',
+        'OUTPAINTING',
+        'BACKGROUND_REMOVAL',
+      ])
+      .optional(),
+
+    /**
+     * Image quality setting.
+     *
+     * Higher quality may take longer to generate.
+     */
+    quality: z.enum(['standard', 'premium']).optional(),
+
+    /**
+     * CFG (Classifier Free Guidance) scale.
+     *
+     * Controls how closely the generated image follows the prompt.
+     * Higher values mean stricter adherence to the prompt.
+     */
+    cfgScale: z.number().optional(),
+
+    /**
+     * Negative text prompt.
+     *
+     * Describes what you don't want to see in the generated image.
+     */
+    negativeText: z.string().optional(),
+
+    /**
+     * Style for the generated image.
+     *
+     * Only applicable for text-to-image generation.
+     */
+    style: z.string().optional(),
+
+    /**
+     * Mask prompt for inpainting and outpainting operations.
+     *
+     * Describes the area to be modified when a mask image is not provided.
+     */
+    maskPrompt: z.string().optional(),
+
+    /**
+     * Outpainting mode.
+     *
+     * Specifies how the image should be extended beyond its original boundaries.
+     */
+    outPaintingMode: z.enum(['DEFAULT', 'PRECISE']).optional(),
+
+    /**
+     * Similarity strength for image variation tasks.
+     *
+     * Controls how similar the generated variations are to the source image(s).
+     * Range: 0.0 (very different) to 1.0 (very similar).
+     */
+    similarityStrength: z.number().min(0).max(1).optional(),
+  })
+  .passthrough();
+
+export type AmazonBedrockImageModelOptions = z.infer<
+  typeof amazonBedrockImageModelOptions
+>;

--- a/packages/amazon-bedrock/src/bedrock-image-settings.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-settings.ts
@@ -1,6 +1,5 @@
-export type BedrockImageModelId = 'amazon.nova-canvas-v1:0' | (string & {});
-
-// https://docs.aws.amazon.com/nova/latest/userguide/image-gen-req-resp-structure.html
-export const modelMaxImagesPerCall: Record<BedrockImageModelId, number> = {
-  'amazon.nova-canvas-v1:0': 5,
-};
+export type {
+  BedrockImageModelId,
+  AmazonBedrockImageModelOptions,
+} from './bedrock-image-options';
+export { modelMaxImagesPerCall } from './bedrock-image-options';

--- a/packages/amazon-bedrock/src/index.ts
+++ b/packages/amazon-bedrock/src/index.ts
@@ -1,6 +1,7 @@
 export type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 
 export type { AmazonBedrockEmbeddingModelOptions } from './bedrock-embedding-options';
+export type { AmazonBedrockImageModelOptions } from './bedrock-image-options';
 export type {
   AmazonBedrockLanguageModelOptions,
   /** @deprecated Use `AmazonBedrockLanguageModelOptions` instead. */


### PR DESCRIPTION
Fixes #12435

This PR adds the missing `AmazonBedrockImageModelOptions` type export for the Amazon Bedrock provider's image model.

## Changes
- Created `bedrock-image-options.ts` with the `AmazonBedrockImageModelOptions` type definition
- Exported the type from `@ai-sdk/amazon-bedrock/index.ts`
- Added type tests to verify the export
- Updated `bedrock-image-settings.ts` to re-export from the new options file

The type includes all Bedrock-specific image generation options:
- `taskType` - operation mode (TEXT_IMAGE, IMAGE_VARIATION, INPAINTING, OUTPAINTING, BACKGROUND_REMOVAL)
- `quality` - image quality setting
- `cfgScale` - CFG scale for prompt adherence
- `negativeText` - negative prompting
- `style` - style parameter
- `maskPrompt` - mask prompt for inpainting/outpainting
- `outPaintingMode` - outpainting mode
- `similarityStrength` - variation similarity control

This follows the same pattern as other provider-specific options types in the SDK.