### PR TITLE
fix(openai): export OpenAIImageModelOptions

### DIFF
--- a/.changeset/small-mice-argue.md
+++ b/.changeset/small-mice-argue.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): export OpenAIImageModelOptions

--- a/examples/ai-functions/src/openai-image-options-types.test-d.ts
+++ b/examples/ai-functions/src/openai-image-options-types.test-d.ts
@@ -1,0 +1,15 @@
+import type { OpenAIImageModelOptions } from '@ai-sdk/openai';
+import { describe, expectTypeOf, it } from 'vitest';
+
+describe('@ai-sdk/openai', () => {
+  it('exports OpenAIImageModelOptions for `providerOptions.openai`', () => {
+    const options = {
+      quality: 'high',
+      style: 'vivid',
+      output_format: 'webp',
+      background: 'transparent',
+    } satisfies OpenAIImageModelOptions;
+
+    expectTypeOf(options).toMatchTypeOf<OpenAIImageModelOptions>();
+  });
+});

--- a/packages/openai/src/image/openai-image-options.ts
+++ b/packages/openai/src/image/openai-image-options.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod/v4';
+
 export type OpenAIImageModelId =
   | 'dall-e-3'
   | 'dall-e-2'
@@ -26,3 +28,107 @@ export function hasDefaultResponseFormat(modelId: string): boolean {
     modelId.startsWith(prefix),
   );
 }
+
+/**
+ * Provider-specific image model options for OpenAI.
+ *
+ * These options are passed through the `providerOptions.openai` parameter
+ * when calling image generation functions.
+ */
+export const openAIImageModelOptions = z
+  .object({
+    /**
+     * The quality of the image that will be generated.
+     *
+     * - `standard`: Standard quality (DALL-E 2 & 3)
+     * - `low`, `medium`, `high`: Quality levels (gpt-image-1 only)
+     * - `auto`: Let the model choose (default for gpt-image-1)
+     */
+    quality: z.enum(['standard', 'low', 'medium', 'high', 'auto']).optional(),
+
+    /**
+     * The style of the generated images.
+     *
+     * - `vivid`: Hyper-real and dramatic images (default for DALL-E 3)
+     * - `natural`: More natural, less hyper-real looking images
+     *
+     * Only supported for DALL-E 3.
+     */
+    style: z.enum(['vivid', 'natural']).optional(),
+
+    /**
+     * Background transparency setting.
+     *
+     * - `transparent`: Generate images with transparent backgrounds
+     * - `opaque`: Generate images with opaque backgrounds
+     * - `auto`: Let the model decide (default)
+     *
+     * Only supported for gpt-image-1. When using `transparent`, the output
+     * format should be set to `png` (default) or `webp`.
+     */
+    background: z.enum(['transparent', 'opaque', 'auto']).optional(),
+
+    /**
+     * The format in which the generated images are returned.
+     *
+     * - `png`: PNG format (default for gpt-image-1)
+     * - `jpeg`: JPEG format
+     * - `webp`: WebP format
+     *
+     * Only supported for gpt-image-1.
+     */
+    output_format: z.enum(['png', 'jpeg', 'webp']).optional(),
+
+    /**
+     * The compression level (0-100%) for the generated images.
+     *
+     * Only supported for gpt-image-1 with `webp` or `jpeg` output formats.
+     * Defaults to 100.
+     */
+    output_compression: z.number().min(0).max(100).optional(),
+
+    /**
+     * Input fidelity level for image editing operations.
+     *
+     * - `high`: Higher fidelity to the input image
+     * - `low`: Lower fidelity, more creative freedom
+     *
+     * Only supported for gpt-image-1.
+     */
+    input_fidelity: z.enum(['high', 'low']).optional(),
+
+    /**
+     * The format in which the generated images are returned.
+     *
+     * - `url`: Return URLs to the generated images (valid for 60 minutes)
+     * - `b64_json`: Return base64-encoded JSON
+     *
+     * Only supported for DALL-E 2. gpt-image-1 always returns base64-encoded images.
+     */
+    response_format: z.enum(['url', 'b64_json']).optional(),
+
+    /**
+     * Edit the image in streaming mode.
+     *
+     * Defaults to false. Only supported for certain models.
+     * See the OpenAI Image generation guide for more information.
+     */
+    stream: z.boolean().optional(),
+
+    /**
+     * A unique identifier representing your end-user.
+     *
+     * This can help OpenAI to monitor and detect abuse.
+     */
+    user: z.string().optional(),
+
+    /**
+     * Number of partial images to return during streaming.
+     *
+     * Only applicable when stream is enabled.
+     */
+    partial_images: z.number().optional(),
+  })
+  .passthrough();
+
+export type OpenAIImageModelOptions = z.infer<typeof openAIImageModelOptions>;

--- a/packages/openai/src/image/openai-image-options.ts
+++ b/packages/openai/src/image/openai-image-options.ts
@@ -41,10 +41,13 @@ export const openAIImageModelOptions = z
      * The quality of the image that will be generated.
      *
      * - `standard`: Standard quality (DALL-E 2 & 3)
+     * - `hd`: High-definition quality (DALL-E 3 only)
      * - `low`, `medium`, `high`: Quality levels (gpt-image-1 only)
      * - `auto`: Let the model choose (default for gpt-image-1)
      */
-    quality: z.enum(['standard', 'low', 'medium', 'high', 'auto']).optional(),
+    quality: z
+      .enum(['standard', 'hd', 'low', 'medium', 'high', 'auto'])
+      .optional(),
 
     /**
      * The style of the generated images.

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -12,6 +12,7 @@ export type {
 } from './chat/openai-chat-options';
 export type { OpenAILanguageModelCompletionOptions } from './completion/openai-completion-options';
 export type { OpenAIEmbeddingModelOptions } from './embedding/openai-embedding-options';
+export type { OpenAIImageModelOptions } from './image/openai-image-options';
 export type { OpenAISpeechModelOptions } from './speech/openai-speech-options';
 export type { OpenAITranscriptionModelOptions } from './transcription/openai-transcription-options';
 export type {


### PR DESCRIPTION
Fixes #12437

This PR adds the missing `OpenAIImageModelOptions` type export for the OpenAI provider's image models.

## Changes
- Defined `OpenAIImageModelOptions` (with a Zod schema) in `packages/openai/src/image/openai-image-options.ts`
- Exported the type from `@ai-sdk/openai`
- Added a d.ts type test to verify the export
- Added a changeset