### PR TITLE
fix(fireworks): export FireworksImageModelOptions

### DIFF
--- a/.changeset/pink-jeans-design.md
+++ b/.changeset/pink-jeans-design.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fireworks': patch
+---
+
+feat(fireworks): export FireworksImageModelOptions, FireworksFluxImageModelOptions, FireworksKontextImageModelOptions

--- a/examples/ai-functions/src/fireworks-image-options-types.test-d.ts
+++ b/examples/ai-functions/src/fireworks-image-options-types.test-d.ts
@@ -1,0 +1,40 @@
+import type {
+  FireworksImageModelOptions,
+  FireworksFluxImageModelOptions,
+  FireworksKontextImageModelOptions,
+} from '@ai-sdk/fireworks';
+import { describe, expectTypeOf, it } from 'vitest';
+
+describe('@ai-sdk/fireworks', () => {
+  it('exports FireworksFluxImageModelOptions for `providerOptions.fireworks`', () => {
+    const options = {
+      guidance_scale: 3.5,
+      num_inference_steps: 4,
+    } satisfies FireworksFluxImageModelOptions;
+
+    expectTypeOf(options).toMatchTypeOf<FireworksFluxImageModelOptions>();
+  });
+
+  it('exports FireworksKontextImageModelOptions for `providerOptions.fireworks`', () => {
+    const options = {
+      output_format: 'png',
+      safety_tolerance: 2,
+      prompt_upsampling: true,
+    } satisfies FireworksKontextImageModelOptions;
+
+    expectTypeOf(options).toMatchTypeOf<FireworksKontextImageModelOptions>();
+  });
+
+  it('exports FireworksImageModelOptions as a union type', () => {
+    const fluxOptions = {
+      guidance_scale: 7.0,
+    } satisfies FireworksImageModelOptions;
+
+    const kontextOptions = {
+      safety_tolerance: 3,
+    } satisfies FireworksImageModelOptions;
+
+    expectTypeOf(fluxOptions).toMatchTypeOf<FireworksImageModelOptions>();
+    expectTypeOf(kontextOptions).toMatchTypeOf<FireworksImageModelOptions>();
+  });
+});

--- a/packages/fireworks/src/fireworks-image-options.ts
+++ b/packages/fireworks/src/fireworks-image-options.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod/v4';
+
 // https://fireworks.ai/models?type=image
 export type FireworksImageModelId =
   | 'accounts/fireworks/models/flux-1-dev-fp8'
@@ -10,3 +12,97 @@ export type FireworksImageModelId =
   | 'accounts/fireworks/models/SSD-1B'
   | 'accounts/fireworks/models/stable-diffusion-xl-1024-v1-0'
   | (string & {});
+
+// https://docs.fireworks.ai/api-reference/generate-a-new-image-from-a-text-prompt
+/**
+ * Provider-specific image model options for Fireworks FLUX workflow models
+ * (e.g. flux-1-dev-fp8, flux-1-schnell-fp8).
+ *
+ * These options are passed through the `providerOptions.fireworks` parameter
+ * when calling image generation functions with FLUX text-to-image models.
+ */
+export const fireworksFluxImageModelOptions = z
+  .object({
+    /**
+     * Classifier-free guidance scale for the image diffusion process.
+     *
+     * Default value is 3.5.
+     */
+    guidance_scale: z.number().optional(),
+
+    /**
+     * Number of denoising steps for the image generation process.
+     *
+     * Default value is 4.
+     */
+    num_inference_steps: z.number().int().optional(),
+  })
+  .passthrough();
+
+export type FireworksFluxImageModelOptions = z.infer<
+  typeof fireworksFluxImageModelOptions
+>;
+
+// https://docs.fireworks.ai/api-reference/generate-or-edit-image-using-flux-kontext
+/**
+ * Provider-specific image model options for Fireworks Kontext models
+ * (e.g. flux-kontext-pro, flux-kontext-max).
+ *
+ * These options are passed through the `providerOptions.fireworks` parameter
+ * when calling image generation functions with Kontext models.
+ */
+export const fireworksKontextImageModelOptions = z
+  .object({
+    /**
+     * Output format for the generated image.
+     *
+     * Options: `jpeg`, `png`.
+     */
+    output_format: z.enum(['jpeg', 'png']).optional(),
+
+    /**
+     * Whether to perform upsampling on the prompt.
+     *
+     * If active, automatically modifies the prompt for more creative generation.
+     */
+    prompt_upsampling: z.boolean().optional(),
+
+    /**
+     * Tolerance level for input and output moderation.
+     *
+     * Between 0 and 6, 0 being most strict, 6 being least strict.
+     * Limit of 2 for Image to Image.
+     */
+    safety_tolerance: z.number().int().min(0).max(6).optional(),
+
+    /**
+     * URL to receive webhook notifications.
+     */
+    webhook_url: z.string().optional(),
+
+    /**
+     * Optional secret for webhook signature verification.
+     */
+    webhook_secret: z.string().optional(),
+  })
+  .passthrough();
+
+export type FireworksKontextImageModelOptions = z.infer<
+  typeof fireworksKontextImageModelOptions
+>;
+
+/**
+ * Provider-specific image model options for all Fireworks image models.
+ *
+ * This is a union of the options for the different Fireworks image model
+ * backends. Since different models support different parameters, use the
+ * more specific types ({@link FireworksFluxImageModelOptions} or
+ * {@link FireworksKontextImageModelOptions}) when you know which model
+ * you are targeting.
+ *
+ * All options use `.passthrough()` so additional model-specific parameters
+ * can be included.
+ */
+export type FireworksImageModelOptions =
+  | FireworksFluxImageModelOptions
+  | FireworksKontextImageModelOptions;

--- a/packages/fireworks/src/index.ts
+++ b/packages/fireworks/src/index.ts
@@ -10,7 +10,12 @@ export type {
   FireworksEmbeddingModelOptions as FireworksEmbeddingProviderOptions,
 } from './fireworks-embedding-options';
 export { FireworksImageModel } from './fireworks-image-model';
-export type { FireworksImageModelId } from './fireworks-image-options';
+export type {
+  FireworksImageModelId,
+  FireworksImageModelOptions,
+  FireworksFluxImageModelOptions,
+  FireworksKontextImageModelOptions,
+} from './fireworks-image-options';
 export { fireworks, createFireworks } from './fireworks-provider';
 export type {
   FireworksProvider,


### PR DESCRIPTION
Fixes #12439

This PR adds the missing image model options type exports for the Fireworks provider.

## Changes
- Defined `FireworksFluxImageModelOptions` for FLUX workflow models (guidance_scale, num_inference_steps)
- Defined `FireworksKontextImageModelOptions` for Kontext models (output_format, prompt_upsampling, safety_tolerance, webhook_url, webhook_secret)
- Defined `FireworksImageModelOptions` as a union of both specific types
- All schemas use `.passthrough()` to allow additional model-specific parameters
- Exported all three types from `@ai-sdk/fireworks`
- Added type tests and changeset

As noted in the issue, Fireworks uses different endpoints for different model families, so the types are split accordingly while also providing a combined union type.