### PR TITLE
fix(deepinfra): export DeepInfraImageModelOptions

### DIFF
--- a/.changeset/olive-teachers-grin.md
+++ b/.changeset/olive-teachers-grin.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/deepinfra': patch
+---
+
+feat(deepinfra): export DeepInfraImageModelOptions

--- a/examples/ai-functions/src/deepinfra-image-options-types.test-d.ts
+++ b/examples/ai-functions/src/deepinfra-image-options-types.test-d.ts
@@ -1,0 +1,14 @@
+import type { DeepInfraImageModelOptions } from '@ai-sdk/deepinfra';
+import { describe, expectTypeOf, it } from 'vitest';
+
+describe('@ai-sdk/deepinfra', () => {
+  it('exports DeepInfraImageModelOptions for `providerOptions.deepinfra`', () => {
+    const options = {
+      guidance_scale: 7.5,
+      num_inference_steps: 25,
+      negative_prompt: 'blurry, distorted',
+    } satisfies DeepInfraImageModelOptions;
+
+    expectTypeOf(options).toMatchTypeOf<DeepInfraImageModelOptions>();
+  });
+});

--- a/packages/deepinfra/src/deepinfra-image-settings.ts
+++ b/packages/deepinfra/src/deepinfra-image-settings.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod/v4';
+
 // https://deepinfra.com/models/text-to-image
 export type DeepInfraImageModelId =
   | 'stabilityai/sd3.5'
@@ -10,3 +12,57 @@ export type DeepInfraImageModelId =
   | 'stabilityai/sd3.5-medium'
   | 'stabilityai/sdxl-turbo'
   | (string & {});
+
+/**
+ * Provider-specific image model options for DeepInfra.
+ *
+ * These options are passed through the `providerOptions.deepinfra` parameter
+ * when calling image generation functions. Available parameters vary by model;
+ * the schema uses `.passthrough()` to allow any additional model-specific fields.
+ */
+export const deepInfraImageModelOptions = z
+  .object({
+    /**
+     * Classifier-free guidance scale.
+     *
+     * Higher values mean the image follows the prompt more closely.
+     * Supported by FLUX-1-dev, FLUX-1-schnell, and Stable Diffusion models.
+     */
+    guidance_scale: z.number().optional(),
+
+    /**
+     * Number of denoising steps for the image generation process.
+     *
+     * More steps generally produce higher quality images but take longer.
+     * Supported by FLUX-1-dev, FLUX-1-schnell, and Stable Diffusion models.
+     */
+    num_inference_steps: z.number().int().optional(),
+
+    /**
+     * Negative prompt describing what to avoid in the generated image.
+     *
+     * Supported by Stable Diffusion models.
+     */
+    negative_prompt: z.string().optional(),
+
+    /**
+     * Whether to perform upsampling on the prompt.
+     *
+     * If active, automatically modifies the prompt for more creative generation.
+     * Supported by FLUX-1.1-pro and FLUX-pro models.
+     */
+    prompt_upsampling: z.boolean().optional(),
+
+    /**
+     * Tolerance level for input and output moderation.
+     *
+     * Between 0 and 6, 0 being most strict, 6 being least strict.
+     * Supported by FLUX-1.1-pro and FLUX-pro models.
+     */
+    safety_tolerance: z.number().int().min(0).max(6).optional(),
+  })
+  .passthrough();
+
+export type DeepInfraImageModelOptions = z.infer<
+  typeof deepInfraImageModelOptions
+>;

--- a/packages/deepinfra/src/index.ts
+++ b/packages/deepinfra/src/index.ts
@@ -3,5 +3,6 @@ export type {
   DeepInfraProvider,
   DeepInfraProviderSettings,
 } from './deepinfra-provider';
+export type { DeepInfraImageModelOptions } from './deepinfra-image-settings';
 export type { OpenAICompatibleErrorData as DeepInfraErrorData } from '@ai-sdk/openai-compatible';
 export { VERSION } from './version';


### PR DESCRIPTION
Fixes #12460

This PR adds the missing `DeepInfraImageModelOptions` type export for the DeepInfra provider's image models.

## Changes
- Defined `DeepInfraImageModelOptions` (with a Zod schema) in `packages/deepinfra/src/deepinfra-image-settings.ts`
- Exported the type from `@ai-sdk/deepinfra`
- Added a d.ts type test to verify the export
- Added a changeset

The type covers common DeepInfra image generation parameters:
- `guidance_scale` — classifier-free guidance (FLUX-1-dev, FLUX-1-schnell, SD models)
- `num_inference_steps` — denoising steps (FLUX-1-dev, FLUX-1-schnell, SD models)
- `negative_prompt` — negative prompting (Stable Diffusion models)
- `prompt_upsampling` — automatic prompt enhancement (FLUX-1.1-pro, FLUX-pro)
- `safety_tolerance` — moderation tolerance level 0–6 (FLUX-1.1-pro, FLUX-pro)

Uses `.passthrough()` to allow any additional model-specific parameters.