### PR TITLE
feat(amazon-bedrock): export AmazonBedrockImageModelOptions

### DIFF
--- a/.changeset/amber-moons-listen.md
+++ b/.changeset/amber-moons-listen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+feat(amazon-bedrock): export AmazonBedrockImageModelOptions

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -992,7 +992,10 @@ const { image } = await generateImage({
 You can also pass the `providerOptions` object to the `generateImage` function to customize the generation behavior:
 
 ```ts
-import { bedrock } from '@ai-sdk/amazon-bedrock';
+import {
+  bedrock,
+  type AmazonBedrockImageModelOptions,
+} from '@ai-sdk/amazon-bedrock';
 import { generateImage } from 'ai';
 
 const { image } = await generateImage({
@@ -1006,7 +1009,7 @@ const { image } = await generateImage({
       negativeText: 'blurry, low quality',
       cfgScale: 7.5,
       style: 'PHOTOREALISM',
-    },
+    } satisfies AmazonBedrockImageModelOptions,
   },
 });
 ```

--- a/examples/ai-functions/src/bedrock-image-options-types.test-d.ts
+++ b/examples/ai-functions/src/bedrock-image-options-types.test-d.ts
@@ -1,0 +1,15 @@
+import type { AmazonBedrockImageModelOptions } from '@ai-sdk/amazon-bedrock';
+import { describe, expectTypeOf, it } from 'vitest';
+
+describe('@ai-sdk/amazon-bedrock', () => {
+  it('exports AmazonBedrockImageModelOptions for `providerOptions.bedrock`', () => {
+    const options = {
+      quality: 'premium',
+      negativeText: 'blurry, low quality',
+      cfgScale: 7.5,
+      style: 'PHOTOREALISM',
+    } satisfies AmazonBedrockImageModelOptions;
+
+    expectTypeOf(options).toMatchTypeOf<AmazonBedrockImageModelOptions>();
+  });
+});

--- a/packages/amazon-bedrock/src/bedrock-image-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-options.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod/v4';
+
+export type BedrockImageModelId = 'amazon.nova-canvas-v1:0' | (string & {});
+
+// https://docs.aws.amazon.com/nova/latest/userguide/image-gen-req-resp-structure.html
+export const modelMaxImagesPerCall: Record<BedrockImageModelId, number> = {
+  'amazon.nova-canvas-v1:0': 5,
+};
+
+/**
+ * Provider-specific image model options for Amazon Bedrock (Nova Canvas).
+ *
+ * These options can be passed in the `providerOptions.bedrock` field of
+ * `generateImage` to customize image generation, editing, and variation
+ * behavior.
+ *
+ * @see https://docs.aws.amazon.com/nova/latest/userguide/image-gen-req-resp-structure.html
+ */
+export const amazonBedrockImageModelOptions = z
+  .object({
+    /**
+     * The quality level for image generation.
+     */
+    quality: z.enum(['standard', 'premium']).optional(),
+
+    /**
+     * Text describing what you don't want in the generated image.
+     */
+    negativeText: z.string().optional(),
+
+    /**
+     * Controls how closely the generated image adheres to the prompt.
+     * Higher values result in images more closely aligned to the prompt.
+     */
+    cfgScale: z.number().optional(),
+
+    /**
+     * Predefined visual style for image generation.
+     *
+     * See the Amazon Bedrock documentation for a current list of supported
+     * styles (e.g. `PHOTOREALISM`).
+     */
+    style: z.string().optional(),
+
+    /**
+     * The task type to use for image generation with files.
+     * Inferred automatically when not specified:
+     * - `INPAINTING` when a mask is provided
+     * - `IMAGE_VARIATION` when files are provided without a mask
+     */
+    taskType: z
+      .enum([
+        'TEXT_IMAGE',
+        'INPAINTING',
+        'OUTPAINTING',
+        'BACKGROUND_REMOVAL',
+        'IMAGE_VARIATION',
+      ])
+      .optional(),
+
+    /**
+     * A text prompt describing the mask area for inpainting or outpainting.
+     * Used as an alternative to providing a mask image.
+     */
+    maskPrompt: z.string().optional(),
+
+    /**
+     * The outpainting mode to use.
+     */
+    outPaintingMode: z.string().optional(),
+
+    /**
+     * Controls how similar the generated variation is to the original image(s).
+     * Values closer to 1.0 produce images more similar to the input.
+     */
+    similarityStrength: z.number().optional(),
+  })
+  .passthrough();
+
+export type AmazonBedrockImageModelOptions = z.infer<
+  typeof amazonBedrockImageModelOptions
+>;

--- a/packages/amazon-bedrock/src/bedrock-image-settings.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-settings.ts
@@ -1,6 +1,5 @@
-export type BedrockImageModelId = 'amazon.nova-canvas-v1:0' | (string & {});
-
-// https://docs.aws.amazon.com/nova/latest/userguide/image-gen-req-resp-structure.html
-export const modelMaxImagesPerCall: Record<BedrockImageModelId, number> = {
-  'amazon.nova-canvas-v1:0': 5,
-};
+export type {
+  BedrockImageModelId,
+  AmazonBedrockImageModelOptions,
+} from './bedrock-image-options';
+export { modelMaxImagesPerCall } from './bedrock-image-options';

--- a/packages/amazon-bedrock/src/index.ts
+++ b/packages/amazon-bedrock/src/index.ts
@@ -16,4 +16,5 @@ export type {
   /** @deprecated Use `AmazonBedrockRerankingModelOptions` instead. */
   AmazonBedrockRerankingModelOptions as BedrockRerankingOptions,
 } from './reranking/bedrock-reranking-options';
+export type { AmazonBedrockImageModelOptions } from './bedrock-image-options';
 export { VERSION } from './version';


### PR DESCRIPTION
Adds and exports a typed AmazonBedrockImageModelOptions helper type for providerOptions.bedrock when using Amazon Bedrock image models (Nova Canvas).

- Adds Zod schema + exported type
- Exports from package index
- Updates provider docs with `satisfies AmazonBedrockImageModelOptions`
- Includes a small d.ts type test and a changeset

Fixes #12435
