### PR TITLE
fix(ai): prevent duplicate tool parts when model calls unavailable tool

### DIFF
--- a/.changeset/fix-duplicate-tool-parts.md
+++ b/.changeset/fix-duplicate-tool-parts.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fixed duplicate tool parts when model calls an unavailable tool. The `tool-input-start` chunk creates a static part without a `dynamic` flag, but the subsequent `tool-input-error` chunk arrives with `dynamic: true`, causing a second `dynamic-tool` part to be created with the same `toolCallId`. This led to providers like Amazon Bedrock rejecting the message for duplicate tool use IDs.

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -558,7 +558,12 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'tool-input-error': {
-              if (chunk.dynamic) {
+              const partialToolCall = state.partialToolCalls[chunk.toolCallId];
+              const dynamic = partialToolCall
+                ? partialToolCall.dynamic
+                : chunk.dynamic;
+
+              if (dynamic) {
                 updateDynamicToolPart({
                   toolCallId: chunk.toolCallId,
                   toolName: chunk.toolName,


### PR DESCRIPTION
## Summary

- Fixes a bug where calling an unavailable tool creates two UI parts with the same `toolCallId` — a static `tool-{name}` part and a `dynamic-tool` part
- The duplicate causes Bedrock (and potentially other providers) to reject the message with "duplicate Ids" when the message is sent back in conversation history
- Root cause: `tool-input-start` arrives without a `dynamic` flag (creating a static part), then `tool-input-error` arrives with `dynamic: true` (from `parseToolCall`'s `NoSuchToolError` handling) and creates a new dynamic part instead of updating the existing one
- Fix: check for an existing part before deciding which update function to call, preserving the original part type

### Reproduction

1. Configure an agent with a set of tools
2. Have the model call a tool name that isn't in the available tools (e.g., model hallucinates a tool name)
3. The resulting UI message will contain two parts with the same `toolCallId` — one `tool-{name}` and one `dynamic-tool`
4. On the next turn, `convertToModelMessages` converts both into `tool-call` content parts
5. The Bedrock provider's `groupIntoBlocks` merges them into one message, and Bedrock rejects it:
   ```
   The toolUse blocks at messages.54.content contain duplicate Ids: tooluse_Uel6zAsKe7Lve5LiXPGiyH
   ```