### PR TITLE
feat(fireworks): add FireworksImageModelOptions type with providerOptions validation

### DIFF
--- a/.changeset/fireworks-image-model-options.md
+++ b/.changeset/fireworks-image-model-options.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fireworks': patch
+---
+
+Add `FireworksImageModelOptions` type and validate image generation provider options using Zod schema with `parseProviderOptions`.

--- a/examples/ai-functions/src/generate-image/fireworks.ts
+++ b/examples/ai-functions/src/generate-image/fireworks.ts
@@ -1,4 +1,5 @@
 import { fireworks } from '@ai-sdk/fireworks';
+import type { FireworksImageModelOptions } from '@ai-sdk/fireworks';
 import { generateImage } from 'ai';
 import { presentImages } from '../lib/present-image';
 import { run } from '../lib/run';
@@ -17,7 +18,7 @@ run(async () => {
         // https://fireworks.ai/models/fireworks/stable-diffusion-xl-1024-v1-0/playground
         cfg_scale: 10,
         steps: 30,
-      },
+      } satisfies FireworksImageModelOptions,
     },
   });
 

--- a/packages/fireworks/src/fireworks-image-model.test.ts
+++ b/packages/fireworks/src/fireworks-image-model.test.ts
@@ -64,7 +64,7 @@ describe('FireworksImageModel', () => {
         size: undefined,
         aspectRatio: '16:9',
         seed: 42,
-        providerOptions: { fireworks: { additional_param: 'value' } },
+        providerOptions: { fireworks: { cfg_scale: 10 } },
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -72,7 +72,7 @@ describe('FireworksImageModel', () => {
         aspect_ratio: '16:9',
         seed: 42,
         samples: 1,
-        additional_param: 'value',
+        cfg_scale: 10,
       });
     });
 

--- a/packages/fireworks/src/fireworks-image-options.ts
+++ b/packages/fireworks/src/fireworks-image-options.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod/v4';
+
 // https://fireworks.ai/models?type=image
 export type FireworksImageModelId =
   | 'accounts/fireworks/models/flux-1-dev-fp8'
@@ -10,3 +12,19 @@ export type FireworksImageModelId =
   | 'accounts/fireworks/models/SSD-1B'
   | 'accounts/fireworks/models/stable-diffusion-xl-1024-v1-0'
   | (string & {});
+
+// https://docs.fireworks.ai/api-reference/post-imagegeneration
+export const fireworksImageModelOptions = z.object({
+  cfg_scale: z.number().optional(),
+  steps: z.number().optional(),
+  negative_prompt: z.string().optional(),
+  strength: z.number().optional(),
+  scheduler: z.string().optional(),
+  safety_checker: z.boolean().optional(),
+  output_format: z.string().optional(),
+  safety_tolerance: z.number().optional(),
+});
+
+export type FireworksImageModelOptions = z.infer<
+  typeof fireworksImageModelOptions
+>;

--- a/packages/fireworks/src/index.ts
+++ b/packages/fireworks/src/index.ts
@@ -10,7 +10,10 @@ export type {
   FireworksEmbeddingModelOptions as FireworksEmbeddingProviderOptions,
 } from './fireworks-embedding-options';
 export { FireworksImageModel } from './fireworks-image-model';
-export type { FireworksImageModelId } from './fireworks-image-options';
+export type {
+  FireworksImageModelId,
+  FireworksImageModelOptions,
+} from './fireworks-image-options';
 export { fireworks, createFireworks } from './fireworks-provider';
 export type {
   FireworksProvider,


### PR DESCRIPTION
## Summary

Adds a proper `FireworksImageModelOptions` type definition for Fireworks image model provider options, backed by a Zod schema and validated at runtime using `parseProviderOptions`.

This addresses the lack of type safety for Fireworks image generation provider options. Previously, `providerOptions.fireworks` was spread directly into the request body without any validation.

### Changes

- **`packages/fireworks/src/fireworks-image-options.ts`**: Added Zod schema (`fireworksImageModelOptions`) defining all supported Fireworks image generation options (`cfg_scale`, `steps`, `negative_prompt`, `strength`, `scheduler`, `safety_checker`, `output_format`, `safety_tolerance`). Exported inferred `FireworksImageModelOptions` type.
- **`packages/fireworks/src/fireworks-image-model.ts`**: Integrated `parseProviderOptions` to validate provider options against the Zod schema at runtime, replacing unvalidated `...(providerOptions.fireworks ?? {})` spread. Provider options are now consumed via individual property assignments.
- **`packages/fireworks/src/fireworks-image-model.test.ts`**: Updated tests to use schema-defined options instead of arbitrary pass-through properties.
- **`packages/fireworks/src/index.ts`**: Exported `FireworksImageModelOptions` type.
- **`examples/ai-functions/src/generate-image/fireworks.ts`**: Updated example to import and use `satisfies FireworksImageModelOptions` for type-safe provider options.

### Verification

- Build passes (`pnpm turbo build --filter=@ai-sdk/fireworks`)
- Lint passes (`pnpm turbo lint --filter=@ai-sdk/fireworks`)
- All existing tests pass (33/33)

Closes #12439