### PR TITLE
test(provider/google): add thoughtSignature cross-namespace regression tests

### DIFF
--- a/examples/ai-functions/src/generate-text/gateway-google-gemini-3-multiturn.ts
+++ b/examples/ai-functions/src/generate-text/gateway-google-gemini-3-multiturn.ts
@@ -1,0 +1,78 @@
+import type { GoogleLanguageModelOptions } from '@ai-sdk/google';
+import { generateText, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+const model = 'google/gemini-3-pro-preview';
+const firstUserMessage =
+  'Use the lookup_definition tool first for "eventual consistency", then answer in one sentence. USE THE GOOGLE PROVIDER!!';
+
+run(async () => {
+  const providerOptions = {
+    gateway: {
+      only: ['google'],
+    },
+    vertex: {
+      safetySettings: [
+        {
+          category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+          threshold: 'BLOCK_ONLY_HIGH',
+        },
+        {
+          category: 'HARM_CATEGORY_HATE_SPEECH',
+          threshold: 'BLOCK_ONLY_HIGH',
+        },
+      ],
+    } satisfies GoogleLanguageModelOptions,
+  };
+  const tools = {
+    lookup_definition: tool({
+      description: 'Returns a short definition for a systems concept.',
+      inputSchema: z.object({
+        term: z.string(),
+      }),
+      execute: async ({ term }) => ({
+        term,
+        definition:
+          'Eventual consistency means replicas may temporarily differ, but converge to the same value after propagation.',
+      }),
+    }),
+  };
+
+  const firstTurn = await generateText({
+    model,
+    prompt: firstUserMessage,
+    tools,
+    stopWhen: stepCountIs(10),
+    providerOptions,
+  });
+
+  console.log('Turn 1:', firstTurn.text);
+  console.log(
+    'Turn 1 provider metadata:',
+    JSON.stringify(firstTurn.providerMetadata, null, 2),
+  );
+  console.log();
+
+  const secondTurn = await generateText({
+    model,
+    messages: [
+      { role: 'user', content: firstUserMessage },
+      ...firstTurn.response.messages,
+      {
+        role: 'user',
+        content:
+          'Use the lookup_definition tool again, then give a concrete 2-line example involving an inventory update.',
+      },
+    ],
+    tools,
+    stopWhen: stepCountIs(10),
+    providerOptions,
+  });
+
+  console.log('Turn 2:', secondTurn.text);
+  console.log(
+    'Turn 2 provider metadata:',
+    JSON.stringify(secondTurn.providerMetadata, null, 2),
+  );
+});

--- a/examples/ai-functions/src/generate-text/gateway-google-thinking-roundtrip.ts
+++ b/examples/ai-functions/src/generate-text/gateway-google-thinking-roundtrip.ts
@@ -1,0 +1,49 @@
+import { gateway, generateText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: gateway('google/gemini-3-flash-preview'),
+    tools: {
+      weather: tool({
+        description: 'Get the current weather in a given location',
+        inputSchema: z.object({
+          location: z
+            .string()
+            .describe('The city and state, e.g. San Francisco, CA'),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temperature: 72,
+          unit: 'fahrenheit',
+        }),
+      }),
+    },
+    stopWhen: result => result.steps.length >= 3,
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  console.log('Text:', result.text);
+  console.log('Steps:', result.steps.length);
+
+  for (const step of result.steps) {
+    console.log('---');
+    console.log('Step finish reason:', step.finishReason);
+    for (const content of step.content) {
+      if (content.type === 'tool-call') {
+        console.log('Tool call:', content.toolName, content.input);
+        console.log(
+          'Provider metadata:',
+          JSON.stringify(content.providerMetadata),
+        );
+      }
+      if (content.type === 'reasoning') {
+        console.log(
+          'Reasoning metadata:',
+          JSON.stringify(content.providerMetadata),
+        );
+      }
+    }
+  }
+});

--- a/examples/ai-functions/src/generate-text/google-thinking-roundtrip.ts
+++ b/examples/ai-functions/src/generate-text/google-thinking-roundtrip.ts
@@ -1,0 +1,47 @@
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  const google = createGoogleGenerativeAI();
+  const model = google('gemini-3-flash-preview');
+
+  const result = await generateText({
+    model,
+    tools: {
+      weather: tool({
+        description: 'Get the current weather in a given location',
+        inputSchema: z.object({
+          location: z
+            .string()
+            .describe('The city and state, e.g. San Francisco, CA'),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temperature: 72,
+          unit: 'fahrenheit',
+        }),
+      }),
+    },
+    stopWhen: result => result.steps.length >= 3,
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  console.log('Text:', result.text);
+  console.log('Steps:', result.steps.length);
+
+  for (const step of result.steps) {
+    console.log('---');
+    console.log('Step finish reason:', step.finishReason);
+    for (const content of step.content) {
+      if (content.type === 'tool-call') {
+        console.log('Tool call:', content.toolName, content.input);
+        console.log(
+          'Provider metadata:',
+          JSON.stringify(content.providerMetadata),
+        );
+      }
+    }
+  }
+});

--- a/examples/ai-functions/src/stream-text/gateway-google-gemini-3-multiturn.ts
+++ b/examples/ai-functions/src/stream-text/gateway-google-gemini-3-multiturn.ts
@@ -1,0 +1,89 @@
+import type { GoogleLanguageModelOptions } from '@ai-sdk/google';
+import { stepCountIs, streamText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+const model = 'google/gemini-3-flash';
+const firstUserMessage =
+  'Use the lookup_definition tool first for "eventual consistency", then answer in one sentence.';
+
+run(async () => {
+  const providerOptions = {
+    gateway: {
+      only: ['google'],
+    },
+    vertex: {
+      safetySettings: [
+        {
+          category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+          threshold: 'BLOCK_ONLY_HIGH',
+        },
+        {
+          category: 'HARM_CATEGORY_HATE_SPEECH',
+          threshold: 'BLOCK_ONLY_HIGH',
+        },
+      ],
+    } satisfies GoogleLanguageModelOptions,
+  };
+  const tools = {
+    lookup_definition: tool({
+      description: 'Returns a short definition for a systems concept.',
+      inputSchema: z.object({
+        term: z.string(),
+      }),
+      execute: async ({ term }) => ({
+        term,
+        definition:
+          'Eventual consistency means replicas may temporarily differ, but converge to the same value after propagation.',
+      }),
+    }),
+  };
+
+  const firstTurn = streamText({
+    model,
+    prompt: firstUserMessage,
+    tools,
+    stopWhen: stepCountIs(10),
+    providerOptions,
+  });
+
+  let firstTurnText = '';
+  process.stdout.write('Turn 1: ');
+  for await (const textPart of firstTurn.textStream) {
+    firstTurnText += textPart;
+    process.stdout.write(textPart);
+  }
+  process.stdout.write('\n');
+  console.log(
+    'Turn 1 provider metadata:',
+    JSON.stringify(await firstTurn.providerMetadata, null, 2),
+  );
+  console.log();
+  const firstTurnResponse = await firstTurn.response;
+
+  const secondTurn = streamText({
+    model,
+    messages: [
+      { role: 'user', content: firstUserMessage },
+      ...firstTurnResponse.messages,
+      {
+        role: 'user',
+        content:
+          'Use the lookup_definition tool again, then give a concrete 2-line example involving an inventory update.',
+      },
+    ],
+    tools,
+    stopWhen: stepCountIs(10),
+    providerOptions,
+  });
+
+  process.stdout.write('Turn 2: ');
+  for await (const textPart of secondTurn.textStream) {
+    process.stdout.write(textPart);
+  }
+  process.stdout.write('\n');
+  console.log(
+    'Turn 2 provider metadata:',
+    JSON.stringify(await secondTurn.providerMetadata, null, 2),
+  );
+});

--- a/examples/ai-functions/src/stream-text/gateway-google-thinking-roundtrip.ts
+++ b/examples/ai-functions/src/stream-text/gateway-google-thinking-roundtrip.ts
@@ -1,0 +1,58 @@
+import { gateway, streamText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: gateway('google/gemini-3-flash-preview'),
+    tools: {
+      weather: tool({
+        description: 'Get the current weather in a given location',
+        inputSchema: z.object({
+          location: z
+            .string()
+            .describe('The city and state, e.g. San Francisco, CA'),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temperature: 72,
+          unit: 'fahrenheit',
+        }),
+      }),
+    },
+    stopWhen: result => result.steps.length >= 3,
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  for await (const chunk of result.fullStream) {
+    switch (chunk.type) {
+      case 'text-delta':
+        process.stdout.write(chunk.text);
+        break;
+      case 'reasoning-delta':
+        break;
+      case 'tool-call':
+        console.log('Tool call:', chunk.toolName, chunk.input);
+        break;
+      case 'tool-result':
+        console.log('Tool result:', JSON.stringify(chunk.output));
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Steps:', (await result.steps).length);
+
+  for (const step of await result.steps) {
+    console.log('---');
+    console.log('Step finish reason:', step.finishReason);
+    for (const content of step.content) {
+      if (content.type === 'tool-call') {
+        console.log(
+          'Provider metadata:',
+          JSON.stringify(content.providerMetadata),
+        );
+      }
+    }
+  }
+});

--- a/examples/ai-functions/src/stream-text/google-thinking-roundtrip.ts
+++ b/examples/ai-functions/src/stream-text/google-thinking-roundtrip.ts
@@ -1,0 +1,62 @@
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  const google = createGoogleGenerativeAI();
+  const model = google('gemini-3-flash-preview');
+
+  const result = streamText({
+    model,
+    tools: {
+      weather: tool({
+        description: 'Get the current weather in a given location',
+        inputSchema: z.object({
+          location: z
+            .string()
+            .describe('The city and state, e.g. San Francisco, CA'),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temperature: 72,
+          unit: 'fahrenheit',
+        }),
+      }),
+    },
+    stopWhen: result => result.steps.length >= 3,
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  for await (const chunk of result.fullStream) {
+    switch (chunk.type) {
+      case 'text-delta':
+        process.stdout.write(chunk.text);
+        break;
+      case 'reasoning-delta':
+        break;
+      case 'tool-call':
+        console.log('Tool call:', chunk.toolName, chunk.input);
+        break;
+      case 'tool-result':
+        console.log('Tool result:', JSON.stringify(chunk.output));
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Steps:', (await result.steps).length);
+
+  for (const step of await result.steps) {
+    console.log('---');
+    console.log('Step finish reason:', step.finishReason);
+    for (const content of step.content) {
+      if (content.type === 'tool-call') {
+        console.log(
+          'Provider metadata:',
+          JSON.stringify(content.providerMetadata),
+        );
+      }
+    }
+  }
+});


### PR DESCRIPTION
## background

follow-up to #12403 - customers reported issues with gemini models on ai gateway when switching between google and vertex providers. the `thoughtSignature` metadata was stored under different namespace keys (`google` vs `vertex`), causing failures on multi-turn tool call conversations. adding regression tests and examples to prevent future breakage

## summary

- add unit tests verifying `thoughtSignature` is correctly included in the API request body for multi-turn tool call conversations
- cover both google and vertex (cross-namespace) providers in `doGenerate` and `doStream`
- add cross-namespace multi-turn test in conversion layer (vertex providerOptionsName resolving google-namespaced thoughtSignature through full tool call flow)
- add 4 example scripts exercising thinking roundtrip with gemini-3-flash-preview:
  - `generate-text/google-thinking-roundtrip.ts` (direct google)
  - `generate-text/gateway-google-thinking-roundtrip.ts` (via gateway)
  - `stream-text/google-thinking-roundtrip.ts` (direct google)
  - `stream-text/gateway-google-thinking-roundtrip.ts` (via gateway)

## verification

<details>
<summary>all google package tests pass (260 tests)</summary>

```
 ✓ src/convert-to-google-generative-ai-messages.test.ts  (19 tests) 9ms
 ✓ src/google-generative-ai-language-model.test.ts  (117 tests) 127ms
 ...
 Test Files  10 passed (10)
      Tests  260 passed (260)
```
</details>

<details>
<summary>all 4 examples complete multi-step tool calls with thoughtSignature</summary>

```
# direct google generateText
Text: The current temperature in San Francisco is 72°F.
Steps: 2
Provider metadata: {"google":{"thoughtSignature":"ErwDCrkDAb4+9v..."}}

# gateway generateText (routes to vertex)
Text: The weather in San Francisco is 72°F.
Steps: 2
Provider metadata: {"vertex":{"thoughtSignature":"CvMBAY89a1+ttw..."}}

# direct google streamText
Tool call: weather { location: 'San Francisco, CA' }
Steps: 2
Provider metadata: {"google":{"thoughtSignature":"EjQKMgG+Pvb7MP..."}}

# gateway streamText (routes to vertex)
Tool call: weather { location: 'San Francisco, CA' }
Steps: 2
Provider metadata: {"vertex":{"thoughtSignature":"CiQBjz1rX23pak..."}}
```
</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [ ] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

follow-up to #12403