### PR TITLE
fix(provider/anthropic): minor follow up to support no-op speed standard

### DIFF
--- a/.changeset/shaggy-steaks-float.md
+++ b/.changeset/shaggy-steaks-float.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(provider/anthropic): minor follow up to support no-op speed standard

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -198,7 +198,7 @@ console.log(usage); // token usage
 
 ### Fast Mode
 
-Anthropic supports a `speed` option for `claude-opus-4-6` that enables faster inference with approximately 2.5x faster output token speeds.
+Anthropic supports a [`speed` option](https://code.claude.com/docs/en/fast-mode) for `claude-opus-4-6` that enables faster inference with approximately 2.5x faster output token speeds.
 
 ```ts highlight="8-10"
 import { anthropic, AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -125,6 +125,10 @@ The following optional provider options are available for Anthropic models:
 
   Optional. See [Effort section](#effort) for more details.
 
+- `speed` _"fast" | "standard"_
+
+  Optional. See [Fast Mode section](#fast-mode) for more details.
+
 - `thinking` _object_
 
   Optional. See [Reasoning section](#reasoning) for more details.
@@ -191,6 +195,27 @@ const { text, usage } = await generateText({
 console.log(text); // resulting text
 console.log(usage); // token usage
 ```
+
+### Fast Mode
+
+Anthropic supports a `speed` option for `claude-opus-4-6` that enables faster inference with approximately 2.5x faster output token speeds.
+
+```ts highlight="8-10"
+import { anthropic, AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: anthropic('claude-opus-4-6'),
+  prompt: 'Write a short poem about the sea.',
+  providerOptions: {
+    anthropic: {
+      speed: 'fast',
+    } satisfies AnthropicLanguageModelOptions,
+  },
+});
+```
+
+The `speed` option accepts `'fast'` or `'standard'` (default behavior).
 
 ### Reasoning
 

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -439,6 +439,8 @@ export type AnthropicTool =
       name: string;
     };
 
+export type AnthropicSpeed = 'fast' | 'standard';
+
 export type AnthropicToolChoice =
   | { type: 'auto' | 'any'; disable_parallel_tool_use?: boolean }
   | { type: 'tool'; name: string; disable_parallel_tool_use?: boolean };

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -4127,6 +4127,47 @@ describe('AnthropicMessagesLanguageModel', () => {
       expect(result.warnings).toStrictEqual([]);
     });
 
+    it('should set speed=standard without fast-mode beta header', async () => {
+      prepareJsonFixtureResponse('anthropic-text');
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            speed: 'standard',
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "max_tokens": 4096,
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "claude-3-haiku-20240307",
+          "speed": "standard",
+        }
+      `);
+      expect(await server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+        {
+          "anthropic-version": "2023-06-01",
+          "content-type": "application/json",
+          "x-api-key": "test-api-key",
+        }
+      `);
+
+      expect(result.warnings).toStrictEqual([]);
+    });
+
     describe('context management', () => {
       it('should send context_management in request body', async () => {
         prepareJsonFixtureResponse('anthropic-text');

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -576,7 +576,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       betas.add('effort-2025-11-24');
     }
 
-    if (anthropicOptions?.speed) {
+    if (anthropicOptions?.speed === 'fast') {
       betas.add('fast-mode-2026-02-01');
     }
 

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -174,7 +174,7 @@ export const anthropicLanguageModelOptions = z.object({
    * Enable fast mode for faster inference (2.5x faster output token speeds).
    * Only supported with claude-opus-4-6.
    */
-  speed: z.literal('fast').optional(),
+  speed: z.enum(['fast', 'standard']).optional(),
 
   contextManagement: z
     .object({


### PR DESCRIPTION
## Background

Follow-up to #12353 which added `speed: 'fast'` support for Claude. A few things were missed: `'standard'` is also a valid value per the Anthropic spec, the `speed` field was missing from the API type definitions, and there was no documentation for the feature.

These are low-severity issues, but potentially could lead to problems for those that rely on `providerOptions` schema and may incorrectly reject the `'standard'` value.

## Summary

- Accept `'standard'` in addition to `'fast'` for the `speed` provider option (it's a no-op but required by the spec)
- Add `AnthropicSpeed` type to the API definitions
- Add a "Fast Mode" section to the Anthropic provider docs
- Add test for `speed: 'standard'` verifying no beta header is sent

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

N/A
