### PR TITLE
fix(ai): preserve caller tool dependency chains in pruneMessages

### DIFF
--- a/packages/ai/src/generate-text/prune-messages.test.ts
+++ b/packages/ai/src/generate-text/prune-messages.test.ts
@@ -940,16 +940,15 @@ describe('pruneMessages', () => {
         });
 
         // toolu_leaf (kept) -> srv_mid -> srv_root: all should be kept
-        const allToolCallIds = result.flatMap(m =>
-          typeof m.content === 'string'
-            ? []
-            : m.content
-                .filter(
-                  (p): p is { type: 'tool-call'; toolCallId: string } =>
-                    p.type === 'tool-call',
-                )
-                .map(p => p.toolCallId),
-        );
+        const allToolCallIds = result.flatMap(m => {
+          if (typeof m.content === 'string') {
+            return [];
+          }
+
+          return m.content
+            .map(part => (part.type === 'tool-call' ? part.toolCallId : null))
+            .filter((toolCallId): toolCallId is string => toolCallId != null);
+        });
         expect(allToolCallIds).toContain('srv_root');
         expect(allToolCallIds).toContain('srv_mid');
         expect(allToolCallIds).toContain('toolu_leaf');


### PR DESCRIPTION
## Summary
- trace transitive caller.toolId dependencies when computing retained tool-call IDs in pruneMessages
- prevent orphaned Anthropic programmatic tool caller references after pruning
- add regression tests for direct and transitive dependency chains plus backward-compatibility coverage

## Validation
- pnpm --filter ai exec vitest --config vitest.node.config.js --run src/generate-text/prune-messages.test.ts
- pnpm --filter ai exec eslint src/generate-text/prune-messages.ts src/generate-text/prune-messages.test.ts
- pnpm --filter ai type-check
- repeated the same validation suite twice consecutively with zero failures

Closes #12504

## Attribution request
If this pull request is merged, I would be grateful if contributor credit could be included in the related changelog or release notes for implementing this fix (@g97iulio1609).