### PR TITLE
fix(provider/anthropic): preserve streamObject deltas with thinking

### DIFF
--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -5887,6 +5887,67 @@ describe('AnthropicMessagesLanguageModel', () => {
       `);
     });
 
+    it('should emit json text deltas when json tool input is only on content_block_start', async () => {
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"message_start","message":{"id":"msg_01JsonToolInputOnly","type":"message","role":"assistant","content":[],"model":"claude-opus-4-6","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"output_tokens":1}}}\n\n`,
+          `data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Working..."}}\n\n`,
+          `data: {"type":"content_block_stop","index":0}\n\n`,
+          `data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_json_1","name":"json","input":{"greeting":"Hello","items":["apple","banana"]}}}\n\n`,
+          `data: {"type":"content_block_stop","index":1}\n\n`,
+          `data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":227}}\n\n`,
+          `data: {"type":"message_stop"}\n\n`,
+        ],
+      };
+
+      const { stream } = await provider('claude-opus-4-6').doStream({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              greeting: { type: 'string' },
+              items: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+            },
+            required: ['greeting', 'items'],
+            additionalProperties: false,
+          },
+        },
+        providerOptions: {
+          anthropic: {
+            structuredOutputMode: 'jsonTool',
+            thinking: { type: 'enabled', budgetTokens: 1024 },
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      const result = await convertReadableStreamToArray(stream);
+
+      expect(result).toContainEqual({ type: 'text-start', id: '1' });
+      expect(result).toContainEqual({
+        type: 'text-delta',
+        id: '1',
+        delta: '{"greeting":"Hello","items":["apple","banana"]}',
+      });
+      expect(result).toContainEqual({ type: 'text-end', id: '1' });
+
+      const finishPart = result.find(part => part.type === 'finish');
+      expect(finishPart).toBeDefined();
+      if (finishPart?.type !== 'finish') {
+        throw new Error('Expected finish part');
+      }
+      expect(finishPart.finishReason).toStrictEqual({
+        unified: 'stop',
+        raw: 'tool_use',
+      });
+    });
+
     it('should stream redacted reasoning', async () => {
       server.urls['https://api.anthropic.com/v1/messages'].response = {
         type: 'stream-chunks',

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -1300,6 +1300,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     let stopSequence: string | null = null;
     let container: AnthropicMessageMetadata['container'] | null = null;
     let isJsonResponseFromTool = false;
+    const jsonResponseToolStartInputByIndex: Record<number, string> = {};
 
     let blockType:
       | 'text'
@@ -1412,6 +1413,18 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                     isJsonResponseFromTool = true;
 
                     contentBlocks[value.index] = { type: 'text' };
+
+                    // In some Anthropic streams (e.g. with extended thinking),
+                    // the JSON tool input can be sent only on content_block_start
+                    // without any input_json_delta events.
+                    if (
+                      part.input != null &&
+                      typeof part.input === 'object' &&
+                      Object.keys(part.input).length > 0
+                    ) {
+                      jsonResponseToolStartInputByIndex[value.index] =
+                        JSON.stringify(part.input);
+                    }
 
                     controller.enqueue({
                       type: 'text-start',
@@ -1791,6 +1804,19 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
 
                 switch (contentBlock.type) {
                   case 'text': {
+                    const jsonResponseToolStartInput =
+                      jsonResponseToolStartInputByIndex[value.index];
+
+                    if (jsonResponseToolStartInput != null) {
+                      controller.enqueue({
+                        type: 'text-delta',
+                        id: String(value.index),
+                        delta: jsonResponseToolStartInput,
+                      });
+
+                      delete jsonResponseToolStartInputByIndex[value.index];
+                    }
+
                     controller.enqueue({
                       type: 'text-end',
                       id: String(value.index),
@@ -1945,6 +1971,8 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                     if (contentBlock?.type !== 'text') {
                       return; // exclude reasoning
                     }
+
+                    delete jsonResponseToolStartInputByIndex[value.index];
 
                     controller.enqueue({
                       type: 'text-delta',


### PR DESCRIPTION
## Summary
- emit `text-delta` for JSON tool outputs when Anthropic sends full JSON only in `content_block_start.input`
- keep existing `input_json_delta` behavior, but fall back to start-input emission when deltas are absent
- add regression coverage for `thinking + structured output (jsonTool)` streaming path

## Validation
- pnpm --filter @ai-sdk/anthropic exec vitest --config vitest.node.config.js --run src/anthropic-messages-language-model.test.ts
- pnpm --filter @ai-sdk/anthropic exec eslint src/anthropic-messages-language-model.ts src/anthropic-messages-language-model.test.ts
- pnpm --filter @ai-sdk/anthropic type-check
- repeated the same validation suite twice consecutively with zero failures

Closes #12427

## Attribution request
If this pull request is merged, I would be grateful if contributor credit could be included in the related changelog or release notes for implementing this fix (@g97iulio1609).