### PR TITLE
refactor(openai-compatible): deprecate normalized chat option shims

### DIFF
--- a/.changeset/brave-impalas-pull.md
+++ b/.changeset/brave-impalas-pull.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Refine OpenAI-compatible chat option handling by separating stable options from legacy normalized compatibility options.
+
+- Keep `user` as the stable normalized chat option.
+- Continue supporting `reasoningEffort`, `textVerbosity`, and `strictJsonSchema` for backwards compatibility.
+- Emit deprecation warnings when legacy normalized options are used and recommend provider-native fields.
+- Update provider docs to clarify the normalized compatibility layer and preferred provider-native configuration.

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -423,26 +423,12 @@ const { text } = await generateText({
 
 ## Chat Model Options
 
-The following provider options are available for chat models via `providerOptions`:
+The following provider option is available for chat models via `providerOptions`:
 
 - **user** _string_
 
   A unique identifier representing your end-user, which can help the provider to
   monitor and detect abuse.
-
-- **reasoningEffort** _string_
-
-  Reasoning effort for reasoning models. The exact values depend on the provider.
-
-- **textVerbosity** _string_
-
-  Controls the verbosity of the generated text. The exact values depend on the provider.
-
-- **strictJsonSchema** _boolean_
-
-  Whether to use strict JSON schema validation. When true, the model uses constrained
-  decoding to guarantee schema compliance. Only used when the provider supports
-  structured outputs and a schema is provided. Defaults to `true`.
 
 ```ts
 const { text } = await generateText({
@@ -456,6 +442,16 @@ const { text } = await generateText({
   },
 });
 ```
+
+### Legacy normalized options (deprecated)
+
+The following normalized chat options are still supported for compatibility, but are deprecated:
+
+- `reasoningEffort`
+- `textVerbosity`
+- `strictJsonSchema`
+
+Prefer provider-native fields directly in `providerOptions.providerName` for long-term compatibility.
 
 ## Provider-specific options
 

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -469,6 +469,38 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should keep normalized chat options for compatibility and emit deprecation warning', async () => {
+    prepareJsonResponse();
+
+    const result = await provider('grok-beta').doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        'test-provider': {
+          reasoningEffort: 'high',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "Hello",
+            "role": "user",
+          },
+        ],
+        "model": "grok-beta",
+        "reasoning_effort": "high",
+      }
+    `);
+
+    expect(result.warnings).toContainEqual({
+      type: 'other',
+      message:
+        "The normalized OpenAI-compatible chat options ('reasoningEffort', 'textVerbosity', 'strictJsonSchema') are deprecated. Use provider-native fields in providerOptions.test-provider instead.",
+    });
+  });
+
   it('should include provider-specific options', async () => {
     prepareJsonResponse();
 

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-options.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-options.ts
@@ -8,27 +8,34 @@ export const openaiCompatibleLanguageModelChatOptions = z.object({
    * monitor and detect abuse.
    */
   user: z.string().optional(),
+});
 
+/**
+ * Legacy normalized chat options kept for backwards compatibility.
+ *
+ * Prefer provider-native option names passed through `providerOptions[providerName]`.
+ */
+export const openaiCompatibleLanguageModelChatLegacyOptions = z.object({
   /**
-   * Reasoning effort for reasoning models. Defaults to `medium`.
+   * @deprecated Use provider-native request fields for reasoning configuration.
    */
   reasoningEffort: z.string().optional(),
 
   /**
-   * Controls the verbosity of the generated text. Defaults to `medium`.
+   * @deprecated Use provider-native request fields for verbosity configuration.
    */
   textVerbosity: z.string().optional(),
 
   /**
-   * Whether to use strict JSON schema validation.
-   * When true, the model uses constrained decoding to guarantee schema compliance.
-   * Only used when the provider supports structured outputs and a schema is provided.
-   *
-   * @default true
+   * @deprecated Use provider-native request fields for schema strictness configuration.
    */
   strictJsonSchema: z.boolean().optional(),
 });
 
 export type OpenAICompatibleLanguageModelChatOptions = z.infer<
   typeof openaiCompatibleLanguageModelChatOptions
+>;
+
+export type OpenAICompatibleLanguageModelChatLegacyOptions = z.infer<
+  typeof openaiCompatibleLanguageModelChatLegacyOptions
 >;


### PR DESCRIPTION
## Summary
- split OpenAI-compatible chat options into:
  - stable normalized options (`user`)
  - legacy normalized compatibility options (`reasoningEffort`, `textVerbosity`, `strictJsonSchema`)
- keep legacy normalized options functional for backwards compatibility
- emit deprecation warnings when legacy normalized options are used
- continue passing provider-native options through `providerOptions.<providerName>`
- update OpenAI-compatible provider docs to clarify preferred provider-native configuration

## Why
Issue #12461 highlights that OpenAI-compatible is an abstraction layer, so hard-coding provider-specific option names in the normalized model options is brittle. This change keeps compatibility while moving toward a cleaner contract.

## Details
- Added `openaiCompatibleLanguageModelChatLegacyOptions` for deprecated normalized option shims.
- Kept `openaiCompatibleLanguageModelChatOptions` focused on stable `user`.
- Updated request-arg building to:
  - parse both stable and legacy options from `openai-compatible`, `openaiCompatible`, and provider-name keys
  - warn when legacy normalized options are used
  - filter both stable and legacy keys from passthrough request fields to avoid duplicates
- Updated docs section for OpenAI-compatible chat options and deprecated legacy options.

## Tests
- `pnpm --filter @ai-sdk/openai-compatible exec vitest --config vitest.node.config.js --run src/chat/openai-compatible-chat-language-model.test.ts`
- `pnpm --filter @ai-sdk/openai-compatible exec eslint src/chat/openai-compatible-chat-options.ts src/chat/openai-compatible-chat-language-model.ts src/chat/openai-compatible-chat-language-model.test.ts`
- `pnpm --filter @ai-sdk/openai-compatible type-check`
- `pnpm exec prettier --check $(git diff --name-only)`

Closes #12461

## Attribution request
If this pull request is merged, I would be grateful if contributor credit could be included in the related changelog or release notes for implementing this fix (@g97iulio1609).