### PR TITLE
fix(ai): preserve caller-referenced tool calls in pruneMessages

### DIFF
--- a/.changeset/fix-prune-messages-caller-deps.md
+++ b/.changeset/fix-prune-messages-caller-deps.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix `pruneMessages` dropping tool calls referenced via provider-specific caller dependencies (e.g. Anthropic `code_execution` `caller.toolId`), causing "source tool not found" API errors.


### PR DESCRIPTION
## Background

When using Anthropic's `code_execution_20250825` with programmatic tool calling (`allowedCallers`), `convertToModelMessages` splits a multi-step assistant UIMessage into separate ModelMessages at step boundaries. A `server_tool_use` block ends up in one message, and the dependent `tool_use` (with `caller.toolId` pointing back to it) ends up in another.

`pruneMessages` builds `keptToolCallIds` by scanning the last N messages, then strips tool-call/result parts from older messages if their ID is not in the set. It did not follow `providerOptions.anthropic.caller.toolId` references, so the `server_tool_use` message was removed while the `tool_use` that references it was kept. Anthropic then rejects the request with `"source tool not found"`.

## Fix

After the initial `keptToolCallIds` scan, do a transitive pass over all messages: if a kept tool-call part has a `caller.toolId` in its `providerOptions`, add that referenced ID to the kept set. The loop repeats until no new IDs are added, handling multi-level dependencies.

## Test

Added a test with a `code_execution` server tool use and a programmatic `lookup` tool use that references it via `caller.toolId`. Verifies both tool-call IDs and their results survive pruning.

Fixes #12504