### PR TITLE
fix(provider/xai): video model follow-up improvements

### DIFF
--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -948,6 +948,12 @@ const { videos } = await generateVideo({
 });
 ```
 
+<Note>
+  Video editing accepts input videos up to 8.7 seconds long. The `duration`,
+  `aspectRatio`, and `resolution` parameters are not supported for editing - the
+  output matches the input video's properties (capped at 720p).
+</Note>
+
 ### Chaining and Concurrent Edits
 
 The xAI-hosted video URL is available in `providerMetadata.xai.videoUrl`.
@@ -1035,9 +1041,9 @@ If you specify `aspectRatio`, it will override this and stretch the image to the
 desired ratio.
 
 For **video editing**, the output matches the input video's aspect ratio and
-resolution. Custom `aspectRatio` and `resolution` are not supported —
-the output resolution is capped at 720p (e.g., a 1080p input will be
-downsized to 720p).
+resolution. Custom `duration`, `aspectRatio`, and `resolution` are not
+supported - the output resolution is capped at 720p (e.g., a 1080p input
+will be downsized to 720p).
 
 ### Video Model Capabilities
 

--- a/examples/ai-functions/src/generate-video/xai-edit-warnings.ts
+++ b/examples/ai-functions/src/generate-video/xai-edit-warnings.ts
@@ -1,0 +1,35 @@
+import { type XaiVideoModelOptions, xai } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  console.log('Step 1: generating a source video...');
+  const source = await generateVideo({
+    model: xai.video('grok-imagine-video'),
+    prompt: 'A cat sitting on a windowsill.',
+    duration: 3,
+    providerOptions: {
+      xai: { pollTimeoutMs: 600000 } satisfies XaiVideoModelOptions,
+    },
+  });
+
+  const sourceUrl = source.providerMetadata?.xai?.videoUrl as string;
+  console.log('Source video URL:', sourceUrl);
+
+  console.log('\nStep 2: editing with unsupported params...');
+  const result = await generateVideo({
+    model: xai.video('grok-imagine-video'),
+    prompt: 'Add sunglasses to the cat',
+    duration: 10,
+    aspectRatio: '16:9',
+    resolution: '1280x720',
+    providerOptions: {
+      xai: {
+        videoUrl: sourceUrl,
+        pollTimeoutMs: 600000,
+      } satisfies XaiVideoModelOptions,
+    },
+  });
+
+  console.log('\nWarnings:', JSON.stringify(result.warnings, null, 2));
+});

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -261,6 +261,143 @@ describe('XaiVideoModel', () => {
       });
     });
 
+    it('should warn about duration in edit mode', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        duration: 10,
+        providerOptions: {
+          xai: {
+            videoUrl: 'https://example.com/source-video.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'duration',
+        }),
+      );
+    });
+
+    it('should warn about aspectRatio in edit mode', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        aspectRatio: '16:9',
+        providerOptions: {
+          xai: {
+            videoUrl: 'https://example.com/source-video.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'aspectRatio',
+        }),
+      );
+    });
+
+    it('should warn about resolution in edit mode', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1280x720',
+        providerOptions: {
+          xai: {
+            videoUrl: 'https://example.com/source-video.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'resolution',
+        }),
+      );
+    });
+
+    it('should not warn about duration outside edit mode', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        duration: 10,
+      });
+
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({
+          feature: 'duration',
+        }),
+      );
+    });
+
+    it('should not warn about aspectRatio outside edit mode', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        aspectRatio: '16:9',
+      });
+
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({
+          feature: 'aspectRatio',
+        }),
+      );
+    });
+
+    it('should not warn about resolution outside edit mode', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1280x720',
+      });
+
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({
+          feature: 'resolution',
+        }),
+      );
+    });
+
+    it('should omit duration, aspect_ratio, and resolution from body in edit mode', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        duration: 10,
+        aspectRatio: '16:9',
+        resolution: '1280x720',
+        providerOptions: {
+          xai: {
+            videoUrl: 'https://example.com/source-video.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).not.toHaveProperty('duration');
+      expect(body).not.toHaveProperty('aspect_ratio');
+      expect(body).not.toHaveProperty('resolution');
+    });
+
     it('should pass headers to requests', async () => {
       const model = createModel({
         headers: () => ({

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -62,6 +62,8 @@ export class XaiVideoModel implements Experimental_VideoModelV3 {
       schema: xaiVideoModelOptionsSchema,
     })) as XaiVideoModelOptions | undefined;
 
+    const isEdit = xaiOptions?.videoUrl != null;
+
     if (options.fps != null) {
       warnings.push({
         type: 'unsupported',
@@ -88,23 +90,49 @@ export class XaiVideoModel implements Experimental_VideoModelV3 {
       });
     }
 
+    if (isEdit && options.duration != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'duration',
+        details: 'xAI video editing does not support custom duration.',
+      });
+    }
+
+    if (isEdit && options.aspectRatio != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'aspectRatio',
+        details: 'xAI video editing does not support custom aspect ratio.',
+      });
+    }
+
+    if (
+      isEdit &&
+      (xaiOptions?.resolution != null || options.resolution != null)
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'resolution',
+        details: 'xAI video editing does not support custom resolution.',
+      });
+    }
+
     const body: Record<string, unknown> = {
       model: this.modelId,
       prompt: options.prompt,
     };
 
-    if (options.duration != null) {
+    if (!isEdit && options.duration != null) {
       body.duration = options.duration;
     }
 
-    if (options.aspectRatio != null) {
+    if (!isEdit && options.aspectRatio != null) {
       body.aspect_ratio = options.aspectRatio;
     }
 
-    // Resolution: prefer provider option (native format), then map SDK format
-    if (xaiOptions?.resolution != null) {
+    if (!isEdit && xaiOptions?.resolution != null) {
       body.resolution = xaiOptions.resolution;
-    } else if (options.resolution != null) {
+    } else if (!isEdit && options.resolution != null) {
       const mapped = RESOLUTION_MAP[options.resolution];
       if (mapped != null) {
         body.resolution = mapped;
@@ -140,7 +168,6 @@ export class XaiVideoModel implements Experimental_VideoModelV3 {
     }
 
     const baseURL = this.config.baseURL ?? 'https://api.x.ai/v1';
-    const isEdit = xaiOptions?.videoUrl != null;
 
     // Step 1: Create video generation/edit request
     const { value: createResponse } = await postJsonToApi({

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -15,7 +15,10 @@ import {
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { xaiFailedResponseHandler } from './xai-error';
-import { xaiVideoModelOptions } from './xai-video-options';
+import {
+  type XaiVideoModelOptions,
+  xaiVideoModelOptionsSchema,
+} from './xai-video-options';
 import type { XaiVideoModelId } from './xai-video-settings';
 
 interface XaiVideoModelConfig {
@@ -53,11 +56,11 @@ export class XaiVideoModel implements Experimental_VideoModelV3 {
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const warnings: SharedV3Warning[] = [];
 
-    const xaiOptions = await parseProviderOptions({
+    const xaiOptions = (await parseProviderOptions({
       provider: 'xai',
       providerOptions: options.providerOptions,
-      schema: xaiVideoModelOptions,
-    });
+      schema: xaiVideoModelOptionsSchema,
+    })) as XaiVideoModelOptions | undefined;
 
     if (options.fps != null) {
       warnings.push({

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -167,6 +167,21 @@ export class XaiVideoModel implements Experimental_VideoModelV3 {
       }
     }
 
+    if (xaiOptions != null) {
+      for (const [key, value] of Object.entries(xaiOptions)) {
+        if (
+          ![
+            'pollIntervalMs',
+            'pollTimeoutMs',
+            'resolution',
+            'videoUrl',
+          ].includes(key)
+        ) {
+          body[key] = value;
+        }
+      }
+    }
+
     const baseURL = this.config.baseURL ?? 'https://api.x.ai/v1';
 
     // Step 1: Create video generation/edit request

--- a/packages/xai/src/xai-video-options.ts
+++ b/packages/xai/src/xai-video-options.ts
@@ -1,10 +1,23 @@
+import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
-export const xaiVideoModelOptions = z.object({
-  pollIntervalMs: z.number().positive().optional(),
-  pollTimeoutMs: z.number().positive().optional(),
-  resolution: z.enum(['480p', '720p']).optional(),
-  videoUrl: z.string().optional(),
-});
+export type XaiVideoModelOptions = {
+  pollIntervalMs?: number | null;
+  pollTimeoutMs?: number | null;
+  resolution?: '480p' | '720p' | null;
+  videoUrl?: string | null;
+  [key: string]: unknown;
+};
 
-export type XaiVideoModelOptions = z.infer<typeof xaiVideoModelOptions>;
+export const xaiVideoModelOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z
+      .object({
+        pollIntervalMs: z.number().positive().nullish(),
+        pollTimeoutMs: z.number().positive().nullish(),
+        resolution: z.enum(['480p', '720p']).nullish(),
+        videoUrl: z.string().nullish(),
+      })
+      .passthrough(),
+  ),
+);


### PR DESCRIPTION
## background

follow-up to #12589 - aligning with existing video provider patterns and adding edit mode guardrails based on xai api docs

## summary

- wrap video options schema in `lazySchema(() => zodSchema(...))` with `.passthrough()` and `.nullish()` to match fal/google/klingai video providers
- forward unknown provider options to the api request body (matching fal/google/klingai passthrough pattern)
- add warnings when `duration`, `aspectRatio`, or `resolution` are passed in video edit mode (unsupported by xai api) and omit them from the request body
- document the 8.7s input video duration cap and editing constraints

## verification

<details>
<summary>tests</summary>

```
pnpm test

 ✓ src/xai-video-model.test.ts  (34 tests)

 Test Files  10 passed (10)
      Tests  217 passed (217)
```

</details>

<details>
<summary>edit mode warnings</summary>

```
pnpm tsx src/generate-video/xai-edit-warnings.ts

Step 1: generating a source video...
Source video URL: https://vidgen.x.ai/xai-vidgen-bucket/xai-video-f6a9cbbf-252d-4049-81f3-a07192d5f7cd.mp4

Step 2: editing with unsupported params...
AI SDK Warning (xai.video / grok-imagine-video): The feature "duration" is not supported. xAI video editing does not support custom duration.
AI SDK Warning (xai.video / grok-imagine-video): The feature "aspectRatio" is not supported. xAI video editing does not support custom aspect ratio.
AI SDK Warning (xai.video / grok-imagine-video): The feature "resolution" is not supported. xAI video editing does not support custom resolution.

Warnings: [
  {
    "type": "unsupported",
    "feature": "duration",
    "details": "xAI video editing does not support custom duration."
  },
  {
    "type": "unsupported",
    "feature": "aspectRatio",
    "details": "xAI video editing does not support custom aspect ratio."
  },
  {
    "type": "unsupported",
    "feature": "resolution",
    "details": "xAI video editing does not support custom resolution."
  }
]
```

</details>

<details>
<summary>passthrough forwarding</summary>

```
pnpm tsx src/generate-video/xai-passthrough-test.ts

Videos: 1
Warnings: []
```

unknown provider option `someNewApiParam` passed validation and was forwarded to the api without error

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [x] documentation has been added / updated (for bug fixes / features)
- [ ] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)