### PR TITLE
fix(openai): send content: null instead of empty string for tool-call-only assistant messages

### DIFF
--- a/.changeset/fix-content-empty-string-null.md
+++ b/.changeset/fix-content-empty-string-null.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): send content: null instead of empty string for tool-call-only assistant messages. This fixes issues with OpenAI-compatible providers that behave differently with content: "" vs content: null.

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
@@ -455,7 +455,7 @@ describe('tool calls', () => {
     expect(result.messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             type: 'function',

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -175,7 +175,7 @@ export function convertToOpenAIChatMessages({
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 


### PR DESCRIPTION
Fixes #12389

## Problem
convertToOpenAIChatMessages sends content: "" for assistant messages with only tool calls. Per OpenAI spec, it should be content: null.

## Impact
OpenAI-compatible providers (Ollama, etc.) switch from structured tool_calls to text markup when they see content: "" in history.

## Fix
Changed content: text to content: text || null - sends null when no text content exists.