### PR TITLE
fix(ai): handle missing usage data in retry logic

### DIFF
--- a/.changeset/fix-retry-error-usage.md
+++ b/.changeset/fix-retry-error-usage.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): handle missing usage data in retry logic. Prevents AI_RetryError crash when providers return incomplete or missing usage data.

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -386,9 +386,9 @@ export async function generateObject<
                     ),
 
                     // TODO rename telemetry attributes to inputTokens and outputTokens
-                    'ai.usage.promptTokens': result.usage.inputTokens.total,
+                    'ai.usage.promptTokens': result.usage?.inputTokens?.total,
                     'ai.usage.completionTokens':
-                      result.usage.outputTokens.total,
+                      result.usage?.outputTokens?.total,
 
                     // standardized gen-ai llm span attributes:
                     'gen_ai.response.finish_reasons': [
@@ -396,9 +396,10 @@ export async function generateObject<
                     ],
                     'gen_ai.response.id': responseData.id,
                     'gen_ai.response.model': responseData.modelId,
-                    'gen_ai.usage.input_tokens': result.usage.inputTokens.total,
+                    'gen_ai.usage.input_tokens':
+                      result.usage?.inputTokens?.total,
                     'gen_ai.usage.output_tokens':
-                      result.usage.outputTokens.total,
+                      result.usage?.outputTokens?.total,
                   },
                 }),
               );

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -856,24 +856,24 @@ export async function generateText<
                           result.providerMetadata,
                         ),
 
-                        'ai.usage.inputTokens': result.usage.inputTokens.total,
+                        'ai.usage.inputTokens': result.usage?.inputTokens?.total,
                         'ai.usage.inputTokenDetails.noCacheTokens':
-                          result.usage.inputTokens.noCache,
+                          result.usage?.inputTokens?.noCache,
                         'ai.usage.inputTokenDetails.cacheReadTokens':
-                          result.usage.inputTokens.cacheRead,
+                          result.usage?.inputTokens?.cacheRead,
                         'ai.usage.inputTokenDetails.cacheWriteTokens':
-                          result.usage.inputTokens.cacheWrite,
+                          result.usage?.inputTokens?.cacheWrite,
                         'ai.usage.outputTokens':
-                          result.usage.outputTokens.total,
+                          result.usage?.outputTokens?.total,
                         'ai.usage.outputTokenDetails.textTokens':
-                          result.usage.outputTokens.text,
+                          result.usage?.outputTokens?.text,
                         'ai.usage.outputTokenDetails.reasoningTokens':
-                          result.usage.outputTokens.reasoning,
-                        'ai.usage.totalTokens': usage.totalTokens,
+                          result.usage?.outputTokens?.reasoning,
+                        'ai.usage.totalTokens': usage?.totalTokens,
                         'ai.usage.reasoningTokens':
-                          result.usage.outputTokens.reasoning,
+                          result.usage?.outputTokens?.reasoning,
                         'ai.usage.cachedInputTokens':
-                          result.usage.inputTokens.cacheRead,
+                          result.usage?.inputTokens?.cacheRead,
 
                         // standardized gen-ai llm span attributes:
                         'gen_ai.response.finish_reasons': [
@@ -882,9 +882,9 @@ export async function generateText<
                         'gen_ai.response.id': responseData.id,
                         'gen_ai.response.model': responseData.modelId,
                         'gen_ai.usage.input_tokens':
-                          result.usage.inputTokens.total,
+                          result.usage?.inputTokens?.total,
                         'gen_ai.usage.output_tokens':
-                          result.usage.outputTokens.total,
+                          result.usage?.outputTokens?.total,
                       },
                     }),
                   );
@@ -1148,6 +1148,7 @@ export async function generateText<
               'ai.response.providerMetadata': JSON.stringify(
                 currentModelResponse.providerMetadata,
               ),
+
             },
           }),
         );

--- a/packages/ai/src/types/usage.ts
+++ b/packages/ai/src/types/usage.ts
@@ -91,25 +91,29 @@ export type EmbeddingModelUsage = {
 export function asLanguageModelUsage(
   usage: LanguageModelV4Usage,
 ): LanguageModelUsage {
+  if (usage == null) {
+    return createNullLanguageModelUsage();
+  }
+
   return {
-    inputTokens: usage.inputTokens.total,
+    inputTokens: usage.inputTokens?.total,
     inputTokenDetails: {
-      noCacheTokens: usage.inputTokens.noCache,
-      cacheReadTokens: usage.inputTokens.cacheRead,
-      cacheWriteTokens: usage.inputTokens.cacheWrite,
+      noCacheTokens: usage.inputTokens?.noCache,
+      cacheReadTokens: usage.inputTokens?.cacheRead,
+      cacheWriteTokens: usage.inputTokens?.cacheWrite,
     },
-    outputTokens: usage.outputTokens.total,
+    outputTokens: usage.outputTokens?.total,
     outputTokenDetails: {
-      textTokens: usage.outputTokens.text,
-      reasoningTokens: usage.outputTokens.reasoning,
+      textTokens: usage.outputTokens?.text,
+      reasoningTokens: usage.outputTokens?.reasoning,
     },
     totalTokens: addTokenCounts(
-      usage.inputTokens.total,
-      usage.outputTokens.total,
+      usage.inputTokens?.total,
+      usage.outputTokens?.total,
     ),
     raw: usage.raw,
-    reasoningTokens: usage.outputTokens.reasoning,
-    cachedInputTokens: usage.inputTokens.cacheRead,
+    reasoningTokens: usage.outputTokens?.reasoning,
+    cachedInputTokens: usage.inputTokens?.cacheRead,
   };
 }
 


### PR DESCRIPTION
Fixes #12477

## Problem
AI_RetryError crashes with 'Cannot read properties of undefined (reading input_tokens)' when provider returns missing usage data during streamText retry.

## Root Cause
Some providers (Moonshot Kimi, Ollama, local LLMs) don't always include usage data in responses. The retry logic accessed usage properties without null checking.

## Fix
- Added null guard in asLanguageModelUsage() to handle null/undefined usage input
- Added optional chaining on telemetry attribute accesses in generate-text.ts and generate-object.ts