### PR TITLE
fix(openai-compatible): inject JSON schema instruction when structuredOutputs disabled

### DIFF
--- a/.changeset/fix-output-object-json-mode.md
+++ b/.changeset/fix-output-object-json-mode.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+fix(openai-compatible): inject JSON schema instruction when structuredOutputs is disabled. Improves reliability of generateText + Output.object() with OpenAI-compatible providers that don't support json_schema response format.

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -835,7 +835,7 @@ describe('doGenerate', () => {
       `);
     });
 
-    it('should forward json response format as "json_object" and omit schema when structuredOutputs are disabled', async () => {
+    it('should forward json response format as "json_object" and inject schema instruction when structuredOutputs are disabled', async () => {
       prepareJsonResponse({ content: '{"value":"Spark"}' });
 
       const model = new OpenAICompatibleChatLanguageModel('gpt-4o-2024-08-06', {
@@ -862,6 +862,12 @@ describe('doGenerate', () => {
       expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
         {
           "messages": [
+            {
+              "content": "JSON schema:
+        {"type":"object","properties":{"value":{"type":"string"}},"required":["value"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}
+        You MUST answer with a JSON object that matches the JSON schema above.",
+              "role": "system",
+            },
             {
               "content": "Hello",
               "role": "user",


### PR DESCRIPTION
Fixes #12491

## Problem
generateText + Output.object() had ~15% failure rate vs generateObject's 100% reliability with OpenAI-compatible providers.

## Root Cause
When supportsStructuredOutputs is false (default for openai-compatible), the provider sends response_format: json_object but silently drops the schema - giving the model no knowledge of what JSON structure to produce.

## Fix
In openai-compatible-chat-language-model.ts, when falling back to json_object mode, inject the JSON schema as a system instruction using injectJsonInstructionIntoMessages from @ai-sdk/provider-utils. This matches patterns used by other providers (e.g., Mistral).