### PR TITLE
fix(anthropic): keep tools array when toolChoice is 'none'

### DIFF
--- a/.changeset/fix-tool-choice-none.md
+++ b/.changeset/fix-tool-choice-none.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): keep tools array when toolChoice is 'none'. Previously, toolChoice 'none' stripped both tools and tool_choice from the request, causing empty responses with tool_use history.

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -460,7 +460,7 @@ export type AnthropicTool =
 export type AnthropicSpeed = 'fast' | 'standard';
 
 export type AnthropicToolChoice =
-  | { type: 'auto' | 'any'; disable_parallel_tool_use?: boolean }
+  | { type: 'auto' | 'any' | 'none'; disable_parallel_tool_use?: boolean }
   | { type: 'tool'; name: string; disable_parallel_tool_use?: boolean };
 
 export type AnthropicContainer = {

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -1197,8 +1197,14 @@ describe('prepareTools', () => {
       toolChoice: { type: 'none' },
       supportsStructuredOutput: true,
     });
-    expect(result.tools).toBeUndefined();
-    expect(result.toolChoice).toBeUndefined();
+    expect(result.tools).toEqual([
+      {
+        name: 'testFunction',
+        description: 'Test',
+        input_schema: {},
+      },
+    ]);
+    expect(result.toolChoice).toEqual({ type: 'none' });
   });
 
   it('should handle tool choice "tool"', async () => {

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -381,8 +381,12 @@ export async function prepareTools({
         betas,
       };
     case 'none':
-      // Anthropic does not support 'none' tool choice, so we remove the tools:
-      return { tools: undefined, toolChoice: undefined, toolWarnings, betas };
+      return {
+        tools: anthropicTools,
+        toolChoice: { type: 'none' },
+        toolWarnings,
+        betas,
+      };
     case 'tool':
       return {
         tools: anthropicTools,


### PR DESCRIPTION
Fixes #12378

## Problem
When toolChoice is 'none', the Anthropic provider strips both tools and tool_choice from the API request. This causes empty content response when conversation history contains tool_use/tool_result blocks.

## Fix
- Changed 'none' case to return tools array and toolChoice: { type: 'none' } instead of undefined for both
- Added 'none' to AnthropicToolChoice type union
- Updated tests