### PR TITLE
fix(ai): trace caller.toolId dependencies in pruneMessages

### DIFF
--- a/.changeset/fix-prune-messages-caller.md
+++ b/.changeset/fix-prune-messages-caller.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): trace caller.toolId dependencies in pruneMessages. Prevents orphaned Anthropic caller references when pruning messages with code_execution programmatic tool calling.


### PR DESCRIPTION
Fixes #12504

## Problem
pruneMessages + convertToModelMessages orphan Anthropic caller references, causing 'source tool not found' API error with code_execution programmatic tool calling.

## Root Cause
pruneMessages builds keptToolCallIds but doesn't follow providerOptions.anthropic.caller.toolId references. When a tool-call references a server_tool_use via caller.toolId, the server_tool_use can be pruned while the referencing tool-call is kept.

## Fix
Added transitive caller.toolId dependency tracing in pruneMessages:
- Builds callerDeps map from toolCallId → caller.toolId
- Iteratively resolves until fixed-point (handles transitive chains)
- Terminates correctly even with circular references