### PR TITLE
fix(@ai-sdk/cerebras): remove deprecated model IDs

### DIFF
--- a/.changeset/remove-deprecated-cerebras-models.md
+++ b/.changeset/remove-deprecated-cerebras-models.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cerebras': patch
+---
+
+Remove deprecated model IDs (`llama-3.3-70b`, `qwen-3-32b`) from `CerebrasChatModelId` type.

--- a/packages/cerebras/src/cerebras-chat-options.ts
+++ b/packages/cerebras/src/cerebras-chat-options.ts
@@ -2,9 +2,7 @@
 export type CerebrasChatModelId =
   // production
   | 'llama3.1-8b'
-  | 'llama-3.3-70b'
   | 'gpt-oss-120b'
-  | 'qwen-3-32b'
   // preview
   | 'qwen-3-235b-a22b-instruct-2507'
   | 'qwen-3-235b-a22b-thinking-2507'


### PR DESCRIPTION
## Background

The `llama-3.3-70b` and `qwen-3-32b` models have been deprecated by Cerebras:
- https://inference-docs.cerebras.ai/models/llama-33-70b
- https://inference-docs.cerebras.ai/models/qwen-3-32b

## Summary

Remove deprecated model IDs (`llama-3.3-70b`, `qwen-3-32b`) from the `CerebrasChatModelId` type. These models are no longer available through the Cerebras inference API.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)