### PR TITLE
fix(ai): include generated files in OTEL response attributes

### DIFF
--- a/.changeset/include-files-in-otel.md
+++ b/.changeset/include-files-in-otel.md
@@ -1,5 +1,0 @@
----
-'ai': patch
----
-
-Include generated files in OpenTelemetry `ai.response.files` span attribute for generateText and streamText

--- a/.changeset/include-files-in-otel.md
+++ b/.changeset/include-files-in-otel.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Include generated files in OpenTelemetry `ai.response.files` span attribute for generateText and streamText

--- a/.changeset/sixty-countries-sparkle.md
+++ b/.changeset/sixty-countries-sparkle.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): include generated files in OTEL response attributes

--- a/packages/ai/src/telemetry/open-telemetry-integration.test.ts
+++ b/packages/ai/src/telemetry/open-telemetry-integration.test.ts
@@ -681,6 +681,43 @@ describe('OpenTelemetryIntegration', () => {
       expect(parsed[0].toolName).toBe('myTool');
     });
 
+    it('includes files when present', () => {
+      otelIntegration.onStart!(makeOnStartEvent());
+      otelIntegration.onStepStart!(makeStepStartEvent());
+      otelIntegration.onStepFinish!(
+        makeStepFinishEvent({
+          files: [
+            {
+              mediaType: 'image/png',
+              base64: 'iVBORw0KGgo=',
+            },
+          ],
+        }),
+      );
+
+      const stepSpan = tracer.spans[1];
+      const setAttrsCall = getSetAttributesArg(stepSpan);
+      expect(setAttrsCall['ai.response.files']).toBeDefined();
+      const parsed = JSON.parse(setAttrsCall['ai.response.files'] as string);
+      expect(parsed).toEqual([
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          data: 'iVBORw0KGgo=',
+        },
+      ]);
+    });
+
+    it('does not include files when empty', () => {
+      otelIntegration.onStart!(makeOnStartEvent());
+      otelIntegration.onStepStart!(makeStepStartEvent());
+      otelIntegration.onStepFinish!(makeStepFinishEvent({ files: [] }));
+
+      const stepSpan = tracer.spans[1];
+      const setAttrsCall = getSetAttributesArg(stepSpan);
+      expect(setAttrsCall['ai.response.files']).toBeUndefined();
+    });
+
     it('does nothing without prior step span', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepFinish!(makeStepFinishEvent());
@@ -744,6 +781,34 @@ describe('OpenTelemetryIntegration', () => {
       const rootSpan = tracer.spans[0];
       const setAttrsCall = getSetAttributesArg(rootSpan);
       expect(setAttrsCall['ai.response.finishReason']).toBe('stop');
+    });
+
+    it('includes files in root span when present', () => {
+      otelIntegration.onStart!(makeOnStartEvent());
+      otelIntegration.onStepStart!(makeStepStartEvent());
+      otelIntegration.onStepFinish!(makeStepFinishEvent());
+      otelIntegration.onFinish!(
+        makeFinishEvent({
+          files: [
+            {
+              mediaType: 'image/png',
+              base64: 'iVBORw0KGgo=',
+            },
+          ],
+        }),
+      );
+
+      const rootSpan = tracer.spans[0];
+      const setAttrsCall = getSetAttributesArg(rootSpan);
+      expect(setAttrsCall['ai.response.files']).toBeDefined();
+      const parsed = JSON.parse(setAttrsCall['ai.response.files'] as string);
+      expect(parsed).toEqual([
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          data: 'iVBORw0KGgo=',
+        },
+      ]);
     });
 
     it('cleans up call state after finishing', () => {

--- a/packages/ai/src/telemetry/open-telemetry-integration.ts
+++ b/packages/ai/src/telemetry/open-telemetry-integration.ts
@@ -382,6 +382,18 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
                 )
               : undefined,
         },
+        'ai.response.files': {
+          output: () =>
+            event.files.length > 0
+              ? JSON.stringify(
+                  event.files.map(file => ({
+                    type: 'file',
+                    mediaType: file.mediaType,
+                    data: file.base64,
+                  })),
+                )
+              : undefined,
+        },
         'ai.response.id': event.response.id,
         'ai.response.model': event.response.modelId,
         'ai.response.timestamp': event.response.timestamp.toISOString(),
@@ -447,6 +459,18 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
                     toolCallId: toolCall.toolCallId,
                     toolName: toolCall.toolName,
                     input: toolCall.input,
+                  })),
+                )
+              : undefined,
+        },
+        'ai.response.files': {
+          output: () =>
+            event.files.length > 0
+              ? JSON.stringify(
+                  event.files.map(file => ({
+                    type: 'file',
+                    mediaType: file.mediaType,
+                    data: file.base64,
                   })),
                 )
               : undefined,


### PR DESCRIPTION
## Background

When models generate file outputs (e.g. Gemini image generation), the OpenTelemetry spans for `generateText` and `streamText` don't include these files. The spans emit `ai.response.text`, `ai.response.reasoning`, and `ai.response.toolCalls`, but there is no `ai.response.files` attribute. This means downstream telemetry consumers have no visibility into generated file outputs.

## Summary

- Added `ai.response.files` as an output attribute to both `onStepFinish` (step span) and `onFinish` (root span) in `OpenTelemetryIntegration`
- Files are serialized as a JSON array of `{ type, mediaType, data }` objects, where `data` is the base64-encoded content
- The attribute is omitted when no files are present
- Respects `recordOutputs: false` since it uses the `output` selector

## Manual Verification

- Ran `vitest run packages/ai/src/telemetry/open-telemetry-integration.test.ts` — all 62 tests pass (59 existing + 3 new)

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)