### PR TITLE
fix(docs): document originalMessages requirement for tool approval in createUIMessageStream

### DIFF
--- a/content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx
@@ -57,6 +57,39 @@ const stream = createUIMessageStream({
 });
 ```
 
+### With Tool Approval
+
+When using tools with `needsApproval: true`, you must pass `originalMessages` to both `createUIMessageStream` and `toUIMessageStream` for the `onFinish` callback to work correctly:
+
+```tsx
+const stream = createUIMessageStream({
+  originalMessages: messages, // Required for onFinish with tool approval
+  execute: async ({ writer }) => {
+    const result = streamText({
+      model: __MODEL__,
+      messages: convertToModelMessages(messages),
+      tools: myTools,
+    });
+
+    writer.merge(
+      result.toUIMessageStream({
+        originalMessages: messages, // Also required here
+      }),
+    );
+  },
+  onFinish: async ({ messages }) => {
+    // Save messages to database — works correctly with tool approval
+    await saveMessages(messages);
+  },
+});
+```
+
+<Note>
+  Without `originalMessages` on `createUIMessageStream`, the `onFinish`
+  callback will fail with a "No tool invocation found" error when processing
+  approved tool results.
+</Note>
+
 ## API Signature
 
 ### Parameters
@@ -103,7 +136,7 @@ const stream = createUIMessageStream({
       name: 'originalMessages',
       type: 'UIMessage[] | undefined',
       description:
-        'The original messages. If provided, persistence mode is assumed and a message ID is provided for the response message.',
+        'The original messages. If provided, persistence mode is assumed and a message ID is provided for the response message. **Required** when using `onFinish` with tools that have `needsApproval: true` — the finish handler needs the original messages to locate tool invocation parts. When using `writer.merge(result.toUIMessageStream())`, pass `originalMessages` to **both** `createUIMessageStream` and `toUIMessageStream`.',
     },
     {
       name: 'onFinish',


### PR DESCRIPTION
## Background

When using `createUIMessageStream` with tools that have `needsApproval: true`, the `onFinish` callback fails with `No tool invocation found for tool call ID` if `originalMessages` is not passed to `createUIMessageStream`.

## Summary

- Updated `originalMessages` parameter description to mention the tool approval requirement
- Added a new example section showing correct usage with tool approval
- Added a warning `<Note>` about the error

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added — N/A (docs only)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #12622