### PR TITLE
feat(ai): decouple otel from generateText

### DIFF
--- a/.changeset/lazy-cougars-smoke.md
+++ b/.changeset/lazy-cougars-smoke.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add experimental callbacks in generateText

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -331,13 +331,14 @@ export async function POST(request: Request) {
 
 ### Track Step Progress
 
-Use `onStepFinish` to track each step's progress, including token usage:
+Use `onStepFinish` to track each step's progress, including token usage.
+The callback receives a `stepNumber` (zero-based) to identify which step just completed:
 
 ```ts
 const result = await myAgent.generate({
   prompt: 'Research and summarize the latest AI trends',
-  onStepFinish: async ({ usage, finishReason, toolCalls }) => {
-    console.log('Step completed:', {
+  onStepFinish: async ({ stepNumber, usage, finishReason, toolCalls }) => {
+    console.log(`Step ${stepNumber} completed:`, {
       inputTokens: usage.inputTokens,
       outputTokens: usage.outputTokens,
       finishReason,
@@ -352,18 +353,18 @@ You can also define `onStepFinish` in the constructor for agent-wide tracking. W
 ```ts
 const agent = new ToolLoopAgent({
   model: __MODEL__,
-  onStepFinish: async ({ usage }) => {
+  onStepFinish: async ({ stepNumber, usage }) => {
     // Agent-wide logging
-    console.log('Agent step:', usage.totalTokens);
+    console.log(`Agent step ${stepNumber}:`, usage.totalTokens);
   },
 });
 
 // Method-level callback runs after constructor callback
 const result = await agent.generate({
   prompt: 'Hello',
-  onStepFinish: async ({ usage }) => {
+  onStepFinish: async ({ stepNumber, usage }) => {
     // Per-call tracking (e.g., for billing)
-    await trackUsage(usage);
+    await trackUsage(stepNumber, usage);
   },
 });
 ```

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -105,6 +105,60 @@ const result = await generateText({
 });
 ```
 
+### Lifecycle callbacks (experimental)
+
+<Note type="warning">
+  Experimental callbacks are subject to breaking changes in incremental package
+  releases.
+</Note>
+
+`generateText` provides several experimental lifecycle callbacks that let you hook into different phases of the generation process.
+These are useful for logging, observability, debugging, and custom telemetry.
+Errors thrown inside these callbacks are silently caught and do not break the generation flow.
+
+```tsx
+import { generateText } from 'ai';
+__PROVIDER_IMPORT__;
+
+const result = await generateText({
+  model: __MODEL__,
+  prompt: 'What is the weather in San Francisco?',
+  tools: {
+    // ... your tools
+  },
+
+  experimental_onStart({ model, settings, functionId }) {
+    console.log('Generation started', { model, functionId });
+  },
+
+  experimental_onStepStart({ stepNumber, model, promptMessages }) {
+    console.log(`Step ${stepNumber} starting`, { model: model.modelId });
+  },
+
+  experimental_onToolCallStart({ toolName, toolCallId, input }) {
+    console.log(`Tool call starting: ${toolName}`, { toolCallId });
+  },
+
+  experimental_onToolCallFinish({ toolName, durationMs, error }) {
+    console.log(`Tool call finished: ${toolName} (${durationMs}ms)`, {
+      success: !error,
+    });
+  },
+
+  onStepFinish({ stepNumber, finishReason, usage }) {
+    console.log(`Step ${stepNumber} finished`, { finishReason, usage });
+  },
+});
+```
+
+The available lifecycle callbacks are:
+
+- **`experimental_onStart`**: Called once when the `generateText` operation begins, before any LLM calls. Receives model info, prompt, settings, and telemetry metadata.
+- **`experimental_onStepStart`**: Called before each step (LLM call). Receives the step number, model, prompt messages being sent, tools, and prior steps.
+- **`experimental_onToolCallStart`**: Called right before a tool's `execute` function runs. Receives the tool name, call ID, and input.
+- **`experimental_onToolCallFinish`**: Called right after a tool's `execute` function completes or errors. Receives the tool name, call ID, input, output (or undefined on error), error (or undefined on success), and `durationMs`.
+- **`onStepFinish`**: Called after each step finishes. Now also includes `stepNumber` (zero-based index of the completed step).
+
 ## `streamText`
 
 Depending on your model and prompt, it can take a large language model (LLM) up to a minute to finish generating its response. This delay can be unacceptable for interactive use cases such as chatbots or real-time applications, where users expect immediate responses.

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -304,16 +304,58 @@ is triggered when a step is finished,
 i.e. all text deltas, tool calls, and tool results for the step are available.
 When you have multiple steps, the callback is triggered for each step.
 
-```tsx highlight="5-7"
+The callback receives a `stepNumber` (zero-based) to identify which step just completed:
+
+```tsx highlight="5-8"
 import { generateText } from 'ai';
 
 const result = await generateText({
   // ...
-  onStepFinish({ text, toolCalls, toolResults, finishReason, usage }) {
+  onStepFinish({
+    stepNumber,
+    text,
+    toolCalls,
+    toolResults,
+    finishReason,
+    usage,
+  }) {
+    console.log(`Step ${stepNumber} finished (${finishReason})`);
     // your own logic, e.g. for saving the chat history or recording usage
   },
 });
 ```
+
+### Tool execution lifecycle callbacks
+
+You can use `experimental_onToolCallStart` and `experimental_onToolCallFinish` to observe tool execution.
+These callbacks are called right before and after each tool's `execute` function, giving you
+visibility into tool execution timing, inputs, outputs, and errors:
+
+```tsx highlight="5-14"
+import { generateText } from 'ai';
+
+const result = await generateText({
+  // ... model, tools, prompt
+  experimental_onToolCallStart({ toolName, toolCallId, input }) {
+    console.log(`Calling tool: ${toolName}`, { toolCallId, input });
+  },
+  experimental_onToolCallFinish({
+    toolName,
+    toolCallId,
+    output,
+    error,
+    durationMs,
+  }) {
+    if (error) {
+      console.error(`Tool ${toolName} failed after ${durationMs}ms:`, error);
+    } else {
+      console.log(`Tool ${toolName} completed in ${durationMs}ms`, { output });
+    }
+  },
+});
+```
+
+Errors thrown inside these callbacks are silently caught and do not break the generation flow.
 
 ### `prepareStep` callback
 

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -862,14 +862,192 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'experimental_onStart',
+      type: '(event: OnStartEvent) => PromiseLike<void> | void',
+      isOptional: true,
+      description:
+        'Callback that is called when the generateText operation begins, before any LLM calls are made. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
+      properties: [
+        {
+          type: 'OnStartEvent',
+          parameters: [
+            {
+              name: 'model',
+              type: '{ provider: string; modelId: string }',
+              description: 'The model being used for the generation.',
+            },
+            {
+              name: 'system',
+              type: 'string | SystemModelMessage | SystemModelMessage[] | undefined',
+              description: 'The system prompt.',
+            },
+            {
+              name: 'prompt',
+              type: 'string | Array<ModelMessage> | undefined',
+              description: 'The input prompt.',
+            },
+            {
+              name: 'messages',
+              type: 'Array<ModelMessage> | undefined',
+              description: 'The input messages.',
+            },
+            {
+              name: 'settings',
+              type: 'object',
+              description:
+                'The call settings (maxOutputTokens, temperature, topP, topK, presencePenalty, frequencyPenalty, stopSequences, seed, maxRetries).',
+            },
+            {
+              name: 'functionId',
+              type: 'string | undefined',
+              description: 'The telemetry function ID, if set.',
+            },
+            {
+              name: 'metadata',
+              type: 'Record<string, unknown> | undefined',
+              description: 'The telemetry metadata, if set.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'experimental_onStepStart',
+      type: '(event: OnStepStartEvent) => PromiseLike<void> | void',
+      isOptional: true,
+      description:
+        'Callback that is called when a step (LLM call) begins, before the provider is called. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
+      properties: [
+        {
+          type: 'OnStepStartEvent',
+          parameters: [
+            {
+              name: 'stepNumber',
+              type: 'number',
+              description:
+                'The zero-based index of the step that is about to start.',
+            },
+            {
+              name: 'model',
+              type: '{ provider: string; modelId: string }',
+              description: 'The model being used for this step.',
+            },
+            {
+              name: 'promptMessages',
+              type: 'LanguageModelV3Prompt',
+              description:
+                'The prompt messages that will be sent to the provider for this step.',
+            },
+            {
+              name: 'tools',
+              type: 'Record<string, unknown> | undefined',
+              description: 'The tools available for this step.',
+            },
+            {
+              name: 'toolChoice',
+              type: 'LanguageModelV3ToolChoice | undefined',
+              description: 'The tool choice setting for this step.',
+            },
+            {
+              name: 'steps',
+              type: 'Array<StepResult<TOOLS>>',
+              description: 'The steps that have been completed so far.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'experimental_onToolCallStart',
+      type: '(event: OnToolCallStartEvent) => PromiseLike<void> | void',
+      isOptional: true,
+      description:
+        "Callback that is called right before a tool's execute function runs. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).",
+      properties: [
+        {
+          type: 'OnToolCallStartEvent',
+          parameters: [
+            {
+              name: 'toolName',
+              type: 'string',
+              description: 'The name of the tool being called.',
+            },
+            {
+              name: 'toolCallId',
+              type: 'string',
+              description: 'The unique ID of the tool call.',
+            },
+            {
+              name: 'input',
+              type: 'unknown',
+              description: 'The input parameters for the tool call.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'experimental_onToolCallFinish',
+      type: '(event: OnToolCallFinishEvent) => PromiseLike<void> | void',
+      isOptional: true,
+      description:
+        "Callback that is called right after a tool's execute function completes (or errors). Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).",
+      properties: [
+        {
+          type: 'OnToolCallFinishEvent',
+          parameters: [
+            {
+              name: 'toolName',
+              type: 'string',
+              description: 'The name of the tool that was called.',
+            },
+            {
+              name: 'toolCallId',
+              type: 'string',
+              description: 'The unique ID of the tool call.',
+            },
+            {
+              name: 'input',
+              type: 'unknown',
+              description: 'The input parameters that were passed to the tool.',
+            },
+            {
+              name: 'output',
+              type: 'unknown | undefined',
+              description:
+                'The output returned by the tool. Undefined if the tool errored.',
+            },
+            {
+              name: 'error',
+              type: 'unknown | undefined',
+              description:
+                'The error thrown by the tool, if any. Undefined on success.',
+            },
+            {
+              name: 'durationMs',
+              type: 'number',
+              description:
+                'The wall-clock duration of the tool execution in milliseconds.',
+            },
+          ],
+        },
+      ],
+    },
+    {
       name: 'onStepFinish',
-      type: '(result: OnStepFinishResult) => Promise<void> | void',
+      type: '(event: OnStepFinishEvent) => Promise<void> | void',
       isOptional: true,
       description: 'Callback that is called when a step is finished.',
       properties: [
         {
-          type: 'OnStepFinishResult',
+          type: 'OnStepFinishEvent',
           parameters: [
+            {
+              name: 'stepNumber',
+              type: 'number',
+              description:
+                'The zero-based index of the step that just finished.',
+            },
             {
               name: 'finishReason',
               type: '"stop" | "length" | "content-filter" | "tool-calls" | "error" | "other"',

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -280,7 +280,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
 
 exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callbacks > onStepFinish should be called for each step 1`] = `
 [
-  DefaultStepResult {
+  {
     "content": [
       {
         "input": {
@@ -304,9 +304,14 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
         "type": "tool-result",
       },
     ],
+    "dynamicToolCalls": [],
+    "dynamicToolResults": [],
+    "files": [],
     "finishReason": "tool-calls",
     "providerMetadata": undefined,
     "rawFinishReason": undefined,
+    "reasoning": [],
+    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -346,6 +351,59 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
+    "sources": [],
+    "staticToolCalls": [
+      {
+        "input": {
+          "value": "value",
+        },
+        "providerExecuted": undefined,
+        "providerMetadata": undefined,
+        "title": "Tool One",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-call",
+      },
+    ],
+    "staticToolResults": [
+      {
+        "dynamic": false,
+        "input": {
+          "value": "value",
+        },
+        "output": "result1",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-result",
+      },
+    ],
+    "stepNumber": 0,
+    "text": "",
+    "toolCalls": [
+      {
+        "input": {
+          "value": "value",
+        },
+        "providerExecuted": undefined,
+        "providerMetadata": undefined,
+        "title": "Tool One",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-call",
+      },
+    ],
+    "toolResults": [
+      {
+        "dynamic": false,
+        "input": {
+          "value": "value",
+        },
+        "output": "result1",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-result",
+      },
+    ],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokenDetails": {
@@ -365,16 +423,21 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
     },
     "warnings": [],
   },
-  DefaultStepResult {
+  {
     "content": [
       {
         "text": "Hello, world!",
         "type": "text",
       },
     ],
+    "dynamicToolCalls": [],
+    "dynamicToolResults": [],
+    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
     "rawFinishReason": "stop",
+    "reasoning": [],
+    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -426,6 +489,13 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
+    "sources": [],
+    "staticToolCalls": [],
+    "staticToolResults": [],
+    "stepNumber": 1,
+    "text": "Hello, world!",
+    "toolCalls": [],
+    "toolResults": [],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokenDetails": {
@@ -664,7 +734,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
 
 exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with prepareStep > onStepFinish should be called for each step 1`] = `
 [
-  DefaultStepResult {
+  {
     "content": [
       {
         "input": {
@@ -688,9 +758,14 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
         "type": "tool-result",
       },
     ],
+    "dynamicToolCalls": [],
+    "dynamicToolResults": [],
+    "files": [],
     "finishReason": "tool-calls",
     "providerMetadata": undefined,
     "rawFinishReason": undefined,
+    "reasoning": [],
+    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -730,6 +805,59 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
+    "sources": [],
+    "staticToolCalls": [
+      {
+        "input": {
+          "value": "value",
+        },
+        "providerExecuted": undefined,
+        "providerMetadata": undefined,
+        "title": undefined,
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-call",
+      },
+    ],
+    "staticToolResults": [
+      {
+        "dynamic": false,
+        "input": {
+          "value": "value",
+        },
+        "output": "result1",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-result",
+      },
+    ],
+    "stepNumber": 0,
+    "text": "",
+    "toolCalls": [
+      {
+        "input": {
+          "value": "value",
+        },
+        "providerExecuted": undefined,
+        "providerMetadata": undefined,
+        "title": undefined,
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-call",
+      },
+    ],
+    "toolResults": [
+      {
+        "dynamic": false,
+        "input": {
+          "value": "value",
+        },
+        "output": "result1",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-result",
+      },
+    ],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokenDetails": {
@@ -749,16 +877,21 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     },
     "warnings": [],
   },
-  DefaultStepResult {
+  {
     "content": [
       {
         "text": "Hello, world!",
         "type": "text",
       },
     ],
+    "dynamicToolCalls": [],
+    "dynamicToolResults": [],
+    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
     "rawFinishReason": "stop",
+    "reasoning": [],
+    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -810,6 +943,13 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
+    "sources": [],
+    "staticToolCalls": [],
+    "staticToolResults": [],
+    "stepNumber": 1,
+    "text": "Hello, world!",
+    "toolCalls": [],
+    "toolResults": [],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokenDetails": {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -135,7 +135,7 @@ export type GenerateTextOnStartCallback = (event: {
  *
  * @param event - The event that is passed to the callback.
  */
-export type GenerateTextOnStepStartCallback = (event: {
+export type GenerateTextOnStepStartCallback<TOOLS extends ToolSet> = (event: {
   readonly stepNumber: number;
 
   readonly model: {
@@ -148,6 +148,8 @@ export type GenerateTextOnStepStartCallback = (event: {
   readonly tools: Record<string, unknown> | undefined;
 
   readonly toolChoice: LanguageModelV3ToolChoice | undefined;
+
+  readonly steps: ReadonlyArray<StepResult<TOOLS>>;
 }) => PromiseLike<void> | void;
 
 /**
@@ -360,7 +362,7 @@ export async function generateText<
      * Callback that is called when a step (LLM call) begins,
      * before the provider is called.
      */
-    experimental_onStepStart?: GenerateTextOnStepStartCallback;
+    experimental_onStepStart?: GenerateTextOnStepStartCallback<NoInfer<TOOLS>>;
 
     /**
      * Callback that is called when each step (LLM call) is finished, including intermediate steps.
@@ -660,6 +662,7 @@ export async function generateText<
                 promptMessages,
                 tools: tools as Record<string, unknown> | undefined,
                 toolChoice: stepToolChoice,
+                steps: [...steps],
               });
             } catch (_ignored) {
               // Errors in callbacks should not break the generation flow.

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -155,10 +155,12 @@ export type GenerateTextOnStepStartCallback<TOOLS extends ToolSet> = (event: {
 /**
  * Callback that is set using the `onStepFinish` option.
  *
- * @param stepResult - The result of the step.
+ * @param event - The step result along with the step number.
  */
 export type GenerateTextOnStepFinishCallback<TOOLS extends ToolSet> = (
-  stepResult: StepResult<TOOLS>,
+  event: StepResult<TOOLS> & {
+    readonly stepNumber: number;
+  },
 ) => Promise<void> | void;
 
 /**
@@ -976,8 +978,30 @@ export async function generateText<
               model: stepModel.modelId,
             });
 
+            const stepNumber = steps.length;
             steps.push(currentStepResult);
-            await onStepFinish?.(currentStepResult);
+            await onStepFinish?.({
+              finishReason: currentStepResult.finishReason,
+              rawFinishReason: currentStepResult.rawFinishReason,
+              usage: currentStepResult.usage,
+              content: currentStepResult.content,
+              text: currentStepResult.text,
+              reasoningText: currentStepResult.reasoningText,
+              reasoning: currentStepResult.reasoning,
+              files: currentStepResult.files,
+              sources: currentStepResult.sources,
+              toolCalls: currentStepResult.toolCalls,
+              staticToolCalls: currentStepResult.staticToolCalls,
+              dynamicToolCalls: currentStepResult.dynamicToolCalls,
+              toolResults: currentStepResult.toolResults,
+              staticToolResults: currentStepResult.staticToolResults,
+              dynamicToolResults: currentStepResult.dynamicToolResults,
+              request: currentStepResult.request,
+              response: currentStepResult.response,
+              warnings: currentStepResult.warnings,
+              providerMetadata: currentStepResult.providerMetadata,
+              stepNumber,
+            });
           } finally {
             if (stepTimeoutId != null) {
               clearTimeout(stepTimeoutId);

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -4,6 +4,8 @@ export {
   type GenerateTextOnStartCallback,
   type GenerateTextOnStepStartCallback,
   type GenerateTextOnStepFinishCallback,
+  type GenerateTextOnToolCallStartCallback,
+  type GenerateTextOnToolCallFinishCallback,
 } from './generate-text';
 export type { ContentPart } from './content-part';
 export type { GenerateTextResult } from './generate-text-result';

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -2,6 +2,7 @@ export {
   generateText,
   type GenerateTextOnFinishCallback,
   type GenerateTextOnStartCallback,
+  type GenerateTextOnStepStartCallback,
   type GenerateTextOnStepFinishCallback,
 } from './generate-text';
 export type { ContentPart } from './content-part';

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -1,6 +1,7 @@
 export {
   generateText,
   type GenerateTextOnFinishCallback,
+  type GenerateTextOnStartCallback,
   type GenerateTextOnStepFinishCallback,
 } from './generate-text';
 export type { ContentPart } from './content-part';

--- a/packages/ai/src/telemetry/otel-handler.test.ts
+++ b/packages/ai/src/telemetry/otel-handler.test.ts
@@ -1,0 +1,715 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MockTracer } from '../test/mock-tracer';
+import { createOtelHandler } from './otel-handler';
+import { TelemetryHandler } from './telemetry-handler';
+import { LanguageModelUsage } from '../types/usage';
+
+const testUsage: LanguageModelUsage = {
+  inputTokens: 10,
+  inputTokenDetails: {
+    noCacheTokens: 8,
+    cacheReadTokens: 2,
+    cacheWriteTokens: undefined,
+  },
+  outputTokens: 20,
+  outputTokenDetails: {
+    textTokens: 15,
+    reasoningTokens: 5,
+  },
+  totalTokens: 30,
+};
+
+const testResponse = {
+  id: 'resp-1',
+  modelId: 'mock-model-id',
+  timestamp: new Date(0),
+};
+
+const testModel = {
+  provider: 'mock-provider',
+  modelId: 'mock-model-id',
+};
+
+const testSettings = {
+  maxOutputTokens: 100,
+  temperature: 0.7,
+  topP: undefined,
+  topK: undefined,
+  presencePenalty: undefined,
+  frequencyPenalty: undefined,
+  stopSequences: undefined,
+  seed: undefined,
+  maxRetries: 2,
+};
+
+describe('createOtelHandler', () => {
+  let tracer: MockTracer;
+  let handler: TelemetryHandler;
+
+  beforeEach(() => {
+    tracer = new MockTracer();
+    handler = createOtelHandler({
+      telemetry: {
+        isEnabled: true,
+        tracer,
+      },
+    });
+  });
+
+  it('should create root span on onStart', async () => {
+    await handler.onStart({
+      model: testModel,
+      system: 'You are helpful.',
+      prompt: 'Hello',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    expect(tracer.spans).toHaveLength(1);
+    expect(tracer.spans[0].name).toBe('ai.generateText');
+    expect(tracer.spans[0].attributes['ai.model.provider']).toBe(
+      'mock-provider',
+    );
+    expect(tracer.spans[0].attributes['ai.model.id']).toBe('mock-model-id');
+    expect(tracer.spans[0].attributes['ai.settings.maxRetries']).toBe(2);
+    expect(tracer.spans[0].attributes['ai.settings.maxOutputTokens']).toBe(100);
+    expect(tracer.spans[0].attributes['ai.prompt']).toBe(
+      JSON.stringify({
+        system: 'You are helpful.',
+        prompt: 'Hello',
+        messages: undefined,
+      }),
+    );
+    expect(tracer.spans[0].attributes['operation.name']).toBe(
+      'ai.generateText',
+    );
+    expect(tracer.spans[0].attributes['ai.operationId']).toBe(
+      'ai.generateText',
+    );
+  });
+
+  it('should include functionId in operation name', async () => {
+    const handlerWithFunctionId = createOtelHandler({
+      telemetry: {
+        isEnabled: true,
+        tracer,
+        functionId: 'my-function',
+      },
+    });
+
+    await handlerWithFunctionId.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: testSettings,
+      functionId: 'my-function',
+      metadata: undefined,
+    });
+
+    expect(tracer.spans[0].attributes['operation.name']).toBe(
+      'ai.generateText my-function',
+    );
+    expect(tracer.spans[0].attributes['ai.telemetry.functionId']).toBe(
+      'my-function',
+    );
+    expect(tracer.spans[0].attributes['resource.name']).toBe('my-function');
+  });
+
+  it('should include metadata as telemetry attributes', async () => {
+    const handlerWithMetadata = createOtelHandler({
+      telemetry: {
+        isEnabled: true,
+        tracer,
+        metadata: { env: 'test', version: '1.0' },
+      },
+    });
+
+    await handlerWithMetadata.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: { env: 'test', version: '1.0' },
+    });
+
+    expect(tracer.spans[0].attributes['ai.telemetry.metadata.env']).toBe(
+      'test',
+    );
+    expect(tracer.spans[0].attributes['ai.telemetry.metadata.version']).toBe(
+      '1.0',
+    );
+  });
+
+  it('should create step span on onStepStart', async () => {
+    await handler.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    await handler.onStepStart({
+      stepNumber: 0,
+      model: testModel,
+      promptMessages: [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ],
+      tools: undefined,
+      toolChoice: undefined,
+    });
+
+    expect(tracer.spans).toHaveLength(2);
+    expect(tracer.spans[1].name).toBe('ai.generateText.doGenerate');
+    expect(tracer.spans[1].attributes['ai.model.provider']).toBe(
+      'mock-provider',
+    );
+    expect(tracer.spans[1].attributes['ai.operationId']).toBe(
+      'ai.generateText.doGenerate',
+    );
+    expect(tracer.spans[1].attributes['gen_ai.system']).toBe('mock-provider');
+    expect(tracer.spans[1].attributes['gen_ai.request.model']).toBe(
+      'mock-model-id',
+    );
+    expect(tracer.spans[1].attributes['ai.prompt.messages']).toBe(
+      '[{"role":"user","content":[{"type":"text","text":"test"}]}]',
+    );
+  });
+
+  it('should set response attributes on step span in onStepFinish', async () => {
+    await handler.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    await handler.onStepStart({
+      stepNumber: 0,
+      model: testModel,
+      promptMessages: [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ],
+      tools: undefined,
+      toolChoice: undefined,
+    });
+
+    await handler.onStepFinish({
+      stepNumber: 0,
+      finishReason: 'stop',
+      text: 'Hello world',
+      reasoningText: undefined,
+      toolCalls: [],
+      usage: testUsage,
+      response: testResponse,
+      providerMetadata: undefined,
+    });
+
+    const stepSpan = tracer.spans[1];
+    expect(stepSpan.attributes['ai.response.finishReason']).toBe('stop');
+    expect(stepSpan.attributes['ai.response.text']).toBe('Hello world');
+    expect(stepSpan.attributes['ai.response.id']).toBe('resp-1');
+    expect(stepSpan.attributes['ai.response.model']).toBe('mock-model-id');
+    expect(stepSpan.attributes['ai.response.timestamp']).toBe(
+      '1970-01-01T00:00:00.000Z',
+    );
+    expect(stepSpan.attributes['ai.usage.promptTokens']).toBe(10);
+    expect(stepSpan.attributes['ai.usage.completionTokens']).toBe(20);
+    expect(stepSpan.attributes['ai.usage.inputTokens']).toBe(10);
+    expect(stepSpan.attributes['ai.usage.outputTokens']).toBe(20);
+    expect(stepSpan.attributes['ai.usage.totalTokens']).toBe(30);
+    expect(stepSpan.attributes['ai.usage.reasoningTokens']).toBe(5);
+    expect(stepSpan.attributes['ai.usage.cachedInputTokens']).toBe(2);
+    expect(stepSpan.attributes['gen_ai.response.finish_reasons']).toEqual([
+      'stop',
+    ]);
+    expect(stepSpan.attributes['gen_ai.usage.input_tokens']).toBe(10);
+    expect(stepSpan.attributes['gen_ai.usage.output_tokens']).toBe(20);
+  });
+
+  it('should set final attributes on root span in onFinish', async () => {
+    await handler.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    await handler.onStepStart({
+      stepNumber: 0,
+      model: testModel,
+      promptMessages: [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ],
+      tools: undefined,
+      toolChoice: undefined,
+    });
+
+    await handler.onStepFinish({
+      stepNumber: 0,
+      finishReason: 'stop',
+      text: 'Hello world',
+      reasoningText: undefined,
+      toolCalls: [],
+      usage: testUsage,
+      response: testResponse,
+      providerMetadata: undefined,
+    });
+
+    await handler.onFinish({
+      finishReason: 'stop',
+      text: 'Hello world',
+      reasoningText: undefined,
+      toolCalls: [],
+      usage: testUsage,
+      totalUsage: testUsage,
+      response: testResponse,
+      providerMetadata: undefined,
+    });
+
+    const rootSpan = tracer.spans[0];
+    expect(rootSpan.attributes['ai.response.finishReason']).toBe('stop');
+    expect(rootSpan.attributes['ai.response.text']).toBe('Hello world');
+    expect(rootSpan.attributes['ai.usage.promptTokens']).toBe(10);
+    expect(rootSpan.attributes['ai.usage.completionTokens']).toBe(20);
+    expect(rootSpan.attributes['ai.usage.totalTokens']).toBe(30);
+    expect(rootSpan.attributes['ai.usage.reasoningTokens']).toBe(5);
+    expect(rootSpan.attributes['ai.usage.cachedInputTokens']).toBe(2);
+  });
+
+  it('should create tool call span on onToolCallStart', async () => {
+    await handler.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    await handler.onStepStart({
+      stepNumber: 0,
+      model: testModel,
+      promptMessages: [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ],
+      tools: undefined,
+      toolChoice: undefined,
+    });
+
+    await handler.onToolCallStart({
+      toolName: 'weather',
+      toolCallId: 'call-1',
+      input: { city: 'Berlin' },
+    });
+
+    expect(tracer.spans).toHaveLength(3);
+    const toolSpan = tracer.spans[2];
+    expect(toolSpan.name).toBe('ai.toolCall');
+    expect(toolSpan.attributes['ai.toolCall.name']).toBe('weather');
+    expect(toolSpan.attributes['ai.toolCall.id']).toBe('call-1');
+    expect(toolSpan.attributes['ai.toolCall.args']).toBe('{"city":"Berlin"}');
+    expect(toolSpan.attributes['ai.operationId']).toBe('ai.toolCall');
+  });
+
+  it('should set result on tool call span in onToolCallFinish', async () => {
+    await handler.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    await handler.onStepStart({
+      stepNumber: 0,
+      model: testModel,
+      promptMessages: [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ],
+      tools: undefined,
+      toolChoice: undefined,
+    });
+
+    await handler.onToolCallStart({
+      toolName: 'weather',
+      toolCallId: 'call-1',
+      input: { city: 'Berlin' },
+    });
+
+    await handler.onToolCallFinish({
+      toolName: 'weather',
+      toolCallId: 'call-1',
+      input: { city: 'Berlin' },
+      output: { temp: 20 },
+      error: undefined,
+      durationMs: 100,
+    });
+
+    const toolSpan = tracer.spans[2];
+    expect(toolSpan.attributes['ai.toolCall.result']).toBe('{"temp":20}');
+  });
+
+  it('should record error on tool call span when tool fails', async () => {
+    await handler.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    await handler.onStepStart({
+      stepNumber: 0,
+      model: testModel,
+      promptMessages: [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ],
+      tools: undefined,
+      toolChoice: undefined,
+    });
+
+    await handler.onToolCallStart({
+      toolName: 'weather',
+      toolCallId: 'call-1',
+      input: { city: 'Berlin' },
+    });
+
+    const error = new Error('API timeout');
+    await handler.onToolCallFinish({
+      toolName: 'weather',
+      toolCallId: 'call-1',
+      input: { city: 'Berlin' },
+      output: undefined,
+      error,
+      durationMs: 5000,
+    });
+
+    const toolSpan = tracer.spans[2];
+    expect(toolSpan.status).toEqual({
+      code: 2,
+      message: 'API timeout',
+    });
+    expect(toolSpan.events).toHaveLength(1);
+    expect(toolSpan.events[0].name).toBe('exception');
+  });
+
+  it('should not record telemetry data when not enabled', async () => {
+    const disabledHandler = createOtelHandler({
+      telemetry: {
+        isEnabled: false,
+        tracer,
+      },
+    });
+
+    await disabledHandler.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    expect(tracer.spans).toHaveLength(0);
+  });
+
+  it('should not record inputs when recordInputs is false', async () => {
+    const noInputHandler = createOtelHandler({
+      telemetry: {
+        isEnabled: true,
+        tracer,
+        recordInputs: false,
+      },
+    });
+
+    await noInputHandler.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    expect(tracer.spans[0].attributes['ai.prompt']).toBeUndefined();
+    expect(tracer.spans[0].attributes['ai.model.provider']).toBe(
+      'mock-provider',
+    );
+  });
+
+  it('should not record outputs when recordOutputs is false', async () => {
+    const noOutputHandler = createOtelHandler({
+      telemetry: {
+        isEnabled: true,
+        tracer,
+        recordOutputs: false,
+      },
+    });
+
+    await noOutputHandler.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    await noOutputHandler.onStepStart({
+      stepNumber: 0,
+      model: testModel,
+      promptMessages: [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ],
+      tools: undefined,
+      toolChoice: undefined,
+    });
+
+    await noOutputHandler.onStepFinish({
+      stepNumber: 0,
+      finishReason: 'stop',
+      text: 'secret output',
+      reasoningText: 'secret reasoning',
+      toolCalls: [],
+      usage: testUsage,
+      response: testResponse,
+      providerMetadata: undefined,
+    });
+
+    const stepSpan = tracer.spans[1];
+    expect(stepSpan.attributes['ai.response.text']).toBeUndefined();
+    expect(stepSpan.attributes['ai.response.reasoning']).toBeUndefined();
+    expect(stepSpan.attributes['ai.response.finishReason']).toBe('stop');
+  });
+
+  it('should handle full lifecycle with tool calls', async () => {
+    await handler.onStart({
+      model: testModel,
+      system: 'You are helpful.',
+      prompt: 'What is the weather?',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    await handler.onStepStart({
+      stepNumber: 0,
+      model: testModel,
+      promptMessages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'What is the weather?' }],
+        },
+      ],
+      tools: { weather: { type: 'function' } },
+      toolChoice: { type: 'auto' },
+    });
+
+    await handler.onToolCallStart({
+      toolName: 'weather',
+      toolCallId: 'call-1',
+      input: { city: 'Berlin' },
+    });
+
+    await handler.onToolCallFinish({
+      toolName: 'weather',
+      toolCallId: 'call-1',
+      input: { city: 'Berlin' },
+      output: 'Sunny, 20°C',
+      error: undefined,
+      durationMs: 50,
+    });
+
+    await handler.onStepFinish({
+      stepNumber: 0,
+      finishReason: 'tool-calls',
+      text: '',
+      reasoningText: undefined,
+      toolCalls: [
+        {
+          toolName: 'weather',
+          toolCallId: 'call-1',
+          input: { city: 'Berlin' },
+        },
+      ],
+      usage: testUsage,
+      response: testResponse,
+      providerMetadata: undefined,
+    });
+
+    await handler.onStepStart({
+      stepNumber: 1,
+      model: testModel,
+      promptMessages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'What is the weather?' }],
+        },
+      ],
+      tools: undefined,
+      toolChoice: undefined,
+    });
+
+    await handler.onStepFinish({
+      stepNumber: 1,
+      finishReason: 'stop',
+      text: 'It is sunny in Berlin.',
+      reasoningText: undefined,
+      toolCalls: [],
+      usage: testUsage,
+      response: testResponse,
+      providerMetadata: undefined,
+    });
+
+    await handler.onFinish({
+      finishReason: 'stop',
+      text: 'It is sunny in Berlin.',
+      reasoningText: undefined,
+      toolCalls: [],
+      usage: testUsage,
+      totalUsage: {
+        ...testUsage,
+        inputTokens: 20,
+        outputTokens: 40,
+        totalTokens: 60,
+      },
+      response: testResponse,
+      providerMetadata: undefined,
+    });
+
+    expect(tracer.spans).toHaveLength(4);
+    expect(tracer.spans.map(s => s.name)).toEqual([
+      'ai.generateText',
+      'ai.generateText.doGenerate',
+      'ai.toolCall',
+      'ai.generateText.doGenerate',
+    ]);
+
+    const rootSpan = tracer.spans[0];
+    expect(rootSpan.attributes['ai.response.text']).toBe(
+      'It is sunny in Berlin.',
+    );
+    expect(rootSpan.attributes['ai.usage.promptTokens']).toBe(20);
+    expect(rootSpan.attributes['ai.usage.completionTokens']).toBe(40);
+
+    const toolSpan = tracer.spans[2];
+    expect(toolSpan.attributes['ai.toolCall.name']).toBe('weather');
+    expect(toolSpan.attributes['ai.toolCall.result']).toBe('"Sunny, 20°C"');
+  });
+
+  it('should handle onStepFinish with tool calls in attributes', async () => {
+    await handler.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: testSettings,
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    await handler.onStepStart({
+      stepNumber: 0,
+      model: testModel,
+      promptMessages: [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ],
+      tools: undefined,
+      toolChoice: undefined,
+    });
+
+    await handler.onStepFinish({
+      stepNumber: 0,
+      finishReason: 'tool-calls',
+      text: '',
+      reasoningText: undefined,
+      toolCalls: [
+        {
+          toolName: 'tool1',
+          toolCallId: 'call-1',
+          input: { value: 'test' },
+        },
+      ],
+      usage: testUsage,
+      response: testResponse,
+      providerMetadata: undefined,
+    });
+
+    const stepSpan = tracer.spans[1];
+    expect(stepSpan.attributes['ai.response.toolCalls']).toBe(
+      JSON.stringify([
+        { toolCallId: 'call-1', toolName: 'tool1', input: { value: 'test' } },
+      ]),
+    );
+    expect(stepSpan.attributes['ai.response.finishReason']).toBe('tool-calls');
+  });
+
+  it('should propagate gen_ai request settings to step span', async () => {
+    const handlerWithSettings = createOtelHandler({
+      telemetry: { isEnabled: true, tracer },
+    });
+
+    await handlerWithSettings.onStart({
+      model: testModel,
+      system: undefined,
+      prompt: 'test',
+      messages: undefined,
+      settings: {
+        ...testSettings,
+        temperature: 0.5,
+        frequencyPenalty: 0.3,
+        presencePenalty: 0.1,
+        topP: 0.9,
+        topK: 40,
+        stopSequences: ['END'],
+        seed: 42,
+      },
+      functionId: undefined,
+      metadata: undefined,
+    });
+
+    await handlerWithSettings.onStepStart({
+      stepNumber: 0,
+      model: testModel,
+      promptMessages: [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ],
+      tools: undefined,
+      toolChoice: undefined,
+    });
+
+    const stepSpan = tracer.spans[1];
+    expect(stepSpan.attributes['gen_ai.request.temperature']).toBe(0.5);
+    expect(stepSpan.attributes['gen_ai.request.frequency_penalty']).toBe(0.3);
+    expect(stepSpan.attributes['gen_ai.request.presence_penalty']).toBe(0.1);
+    expect(stepSpan.attributes['gen_ai.request.top_p']).toBe(0.9);
+    expect(stepSpan.attributes['gen_ai.request.top_k']).toBe(40);
+    expect(stepSpan.attributes['gen_ai.request.stop_sequences']).toEqual([
+      'END',
+    ]);
+    expect(stepSpan.attributes['ai.settings.seed']).toBe(42);
+  });
+});

--- a/packages/ai/src/telemetry/otel-handler.ts
+++ b/packages/ai/src/telemetry/otel-handler.ts
@@ -1,0 +1,306 @@
+import { Span, context, trace } from '@opentelemetry/api';
+import { assembleOperationName } from './assemble-operation-name';
+import { getTracer } from './get-tracer';
+import { recordErrorOnSpan } from './record-span';
+import { selectTelemetryAttributes } from './select-telemetry-attributes';
+import { stringifyForTelemetry } from './stringify-for-telemetry';
+import { TelemetryHandler, TelemetryOnStartEvent } from './telemetry-handler';
+import { TelemetrySettings } from './telemetry-settings';
+
+export function createOtelHandler({
+  telemetry,
+}: {
+  telemetry: TelemetrySettings;
+}): TelemetryHandler {
+  const tracer = getTracer(telemetry);
+
+  let rootSpan: Span | undefined;
+  let rootCtx = context.active();
+
+  const stepSpans = new Map<number, Span>();
+  const stepContexts = new Map<number, typeof rootCtx>();
+  const toolCallSpans = new Map<string, Span>();
+
+  let currentStepNumber = -1;
+
+  let storedSettings: TelemetryOnStartEvent['settings'] | undefined;
+
+  return {
+    async onStart(event) {
+      storedSettings = event.settings;
+
+      const attributes = await selectTelemetryAttributes({
+        telemetry,
+        attributes: {
+          ...assembleOperationName({
+            operationId: 'ai.generateText',
+            telemetry,
+          }),
+          'ai.model.provider': event.model.provider,
+          'ai.model.id': event.model.modelId,
+
+          'ai.settings.maxOutputTokens': event.settings.maxOutputTokens,
+          'ai.settings.topP': event.settings.topP,
+          'ai.settings.topK': event.settings.topK,
+          'ai.settings.presencePenalty': event.settings.presencePenalty,
+          'ai.settings.frequencyPenalty': event.settings.frequencyPenalty,
+          'ai.settings.stopSequences': event.settings.stopSequences,
+          'ai.settings.seed': event.settings.seed,
+          'ai.settings.maxRetries': event.settings.maxRetries,
+
+          ...Object.entries(telemetry?.metadata ?? {}).reduce(
+            (attrs, [key, value]) => {
+              attrs[`ai.telemetry.metadata.${key}`] =
+                value as import('@opentelemetry/api').AttributeValue;
+              return attrs;
+            },
+            {} as import('@opentelemetry/api').Attributes,
+          ),
+
+          'ai.prompt': {
+            input: () =>
+              JSON.stringify({
+                system: event.system,
+                prompt: event.prompt,
+                messages: event.messages,
+              }),
+          },
+        },
+      });
+
+      rootSpan = tracer.startSpan('ai.generateText', { attributes });
+      rootCtx = trace.setSpan(context.active(), rootSpan);
+    },
+
+    async onStepStart(event) {
+      currentStepNumber = event.stepNumber;
+
+      const attributes = await selectTelemetryAttributes({
+        telemetry,
+        attributes: {
+          ...assembleOperationName({
+            operationId: 'ai.generateText.doGenerate',
+            telemetry,
+          }),
+          'ai.model.provider': event.model.provider,
+          'ai.model.id': event.model.modelId,
+
+          'ai.settings.maxOutputTokens': storedSettings?.maxOutputTokens,
+          'ai.settings.topP': storedSettings?.topP,
+          'ai.settings.topK': storedSettings?.topK,
+          'ai.settings.presencePenalty': storedSettings?.presencePenalty,
+          'ai.settings.frequencyPenalty': storedSettings?.frequencyPenalty,
+          'ai.settings.stopSequences': storedSettings?.stopSequences,
+          'ai.settings.seed': storedSettings?.seed,
+          'ai.settings.maxRetries': storedSettings?.maxRetries,
+
+          ...Object.entries(telemetry?.metadata ?? {}).reduce(
+            (attrs, [key, value]) => {
+              attrs[`ai.telemetry.metadata.${key}`] =
+                value as import('@opentelemetry/api').AttributeValue;
+              return attrs;
+            },
+            {} as import('@opentelemetry/api').Attributes,
+          ),
+
+          'ai.prompt.messages': {
+            input: () => stringifyForTelemetry(event.promptMessages),
+          },
+          'ai.prompt.tools': {
+            input: () => {
+              if (event.tools == null) return undefined;
+              return Object.values(event.tools).map(tool =>
+                JSON.stringify(tool),
+              );
+            },
+          },
+          'ai.prompt.toolChoice': {
+            input: () =>
+              event.toolChoice != null
+                ? JSON.stringify(event.toolChoice)
+                : undefined,
+          },
+
+          'gen_ai.system': event.model.provider,
+          'gen_ai.request.model': event.model.modelId,
+          'gen_ai.request.frequency_penalty': storedSettings?.frequencyPenalty,
+          'gen_ai.request.max_tokens': storedSettings?.maxOutputTokens,
+          'gen_ai.request.presence_penalty': storedSettings?.presencePenalty,
+          'gen_ai.request.stop_sequences': storedSettings?.stopSequences,
+          'gen_ai.request.temperature':
+            storedSettings?.temperature ?? undefined,
+          'gen_ai.request.top_k': storedSettings?.topK,
+          'gen_ai.request.top_p': storedSettings?.topP,
+        },
+      });
+
+      const stepSpan = tracer.startSpan(
+        'ai.generateText.doGenerate',
+        { attributes },
+        rootCtx,
+      );
+      const stepCtx = trace.setSpan(rootCtx, stepSpan);
+
+      stepSpans.set(event.stepNumber, stepSpan);
+      stepContexts.set(event.stepNumber, stepCtx);
+    },
+
+    async onStepFinish(event) {
+      const stepSpan = stepSpans.get(event.stepNumber);
+      if (stepSpan == null) return;
+
+      const toolCallsForTelemetry =
+        event.toolCalls.length === 0
+          ? undefined
+          : JSON.stringify(
+              event.toolCalls.map(tc => ({
+                toolCallId: tc.toolCallId,
+                toolName: tc.toolName,
+                input: tc.input,
+              })),
+            );
+
+      stepSpan.setAttributes(
+        await selectTelemetryAttributes({
+          telemetry,
+          attributes: {
+            'ai.response.finishReason': event.finishReason,
+            'ai.response.text': { output: () => event.text || undefined },
+            'ai.response.reasoning': {
+              output: () => event.reasoningText,
+            },
+            'ai.response.toolCalls': {
+              output: () => toolCallsForTelemetry,
+            },
+            'ai.response.id': event.response.id,
+            'ai.response.model': event.response.modelId,
+            'ai.response.timestamp': event.response.timestamp.toISOString(),
+            'ai.response.providerMetadata': JSON.stringify(
+              event.providerMetadata,
+            ),
+
+            'ai.usage.promptTokens': event.usage.inputTokens,
+            'ai.usage.completionTokens': event.usage.outputTokens,
+            'ai.usage.inputTokens': event.usage.inputTokens,
+            'ai.usage.outputTokens': event.usage.outputTokens,
+            'ai.usage.totalTokens': event.usage.totalTokens,
+            'ai.usage.reasoningTokens':
+              event.usage.outputTokenDetails?.reasoningTokens,
+            'ai.usage.cachedInputTokens':
+              event.usage.inputTokenDetails?.cacheReadTokens,
+
+            'gen_ai.response.finish_reasons': [event.finishReason],
+            'gen_ai.response.id': event.response.id,
+            'gen_ai.response.model': event.response.modelId,
+            'gen_ai.usage.input_tokens': event.usage.inputTokens,
+            'gen_ai.usage.output_tokens': event.usage.outputTokens,
+          },
+        }),
+      );
+
+      stepSpan.end();
+      stepSpans.delete(event.stepNumber);
+      stepContexts.delete(event.stepNumber);
+    },
+
+    async onToolCallStart(event) {
+      const parentCtx = stepContexts.get(currentStepNumber) ?? rootCtx;
+
+      const attributes = await selectTelemetryAttributes({
+        telemetry,
+        attributes: {
+          ...assembleOperationName({
+            operationId: 'ai.toolCall',
+            telemetry,
+          }),
+          'ai.toolCall.name': event.toolName,
+          'ai.toolCall.id': event.toolCallId,
+          'ai.toolCall.args': {
+            output: () => JSON.stringify(event.input),
+          },
+        },
+      });
+
+      const toolSpan = tracer.startSpan(
+        'ai.toolCall',
+        { attributes },
+        parentCtx,
+      );
+      toolCallSpans.set(event.toolCallId, toolSpan);
+    },
+
+    async onToolCallFinish(event) {
+      const toolSpan = toolCallSpans.get(event.toolCallId);
+      if (toolSpan == null) return;
+
+      if (event.error != null) {
+        recordErrorOnSpan(toolSpan, event.error);
+      } else {
+        try {
+          toolSpan.setAttributes(
+            await selectTelemetryAttributes({
+              telemetry,
+              attributes: {
+                'ai.toolCall.result': {
+                  output: () => JSON.stringify(event.output),
+                },
+              },
+            }),
+          );
+        } catch (_ignored) {
+          // JSON.stringify may fail for non-serializable results
+        }
+      }
+
+      toolSpan.end();
+      toolCallSpans.delete(event.toolCallId);
+    },
+
+    async onFinish(event) {
+      if (rootSpan == null) return;
+
+      const toolCallsForTelemetry =
+        event.toolCalls.length === 0
+          ? undefined
+          : JSON.stringify(
+              event.toolCalls.map(tc => ({
+                toolCallId: tc.toolCallId,
+                toolName: tc.toolName,
+                input: tc.input,
+              })),
+            );
+
+      rootSpan.setAttributes(
+        await selectTelemetryAttributes({
+          telemetry,
+          attributes: {
+            'ai.response.finishReason': event.finishReason,
+            'ai.response.text': { output: () => event.text || undefined },
+            'ai.response.reasoning': {
+              output: () => event.reasoningText,
+            },
+            'ai.response.toolCalls': {
+              output: () => toolCallsForTelemetry,
+            },
+            'ai.response.providerMetadata': JSON.stringify(
+              event.providerMetadata,
+            ),
+
+            'ai.usage.promptTokens': event.totalUsage.inputTokens,
+            'ai.usage.completionTokens': event.totalUsage.outputTokens,
+            'ai.usage.inputTokens': event.totalUsage.inputTokens,
+            'ai.usage.outputTokens': event.totalUsage.outputTokens,
+            'ai.usage.totalTokens': event.totalUsage.totalTokens,
+            'ai.usage.reasoningTokens':
+              event.totalUsage.outputTokenDetails?.reasoningTokens,
+            'ai.usage.cachedInputTokens':
+              event.totalUsage.inputTokenDetails?.cacheReadTokens,
+          },
+        }),
+      );
+
+      rootSpan.end();
+      rootSpan = undefined;
+    },
+  };
+}

--- a/packages/ai/src/telemetry/telemetry-handler.ts
+++ b/packages/ai/src/telemetry/telemetry-handler.ts
@@ -1,0 +1,100 @@
+import {
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3Prompt,
+  LanguageModelV3ToolChoice,
+} from '@ai-sdk/provider';
+import { FinishReason, ProviderMetadata } from '../types';
+import { LanguageModelResponseMetadata } from '../types/language-model-response-metadata';
+import { LanguageModelUsage } from '../types/usage';
+
+type ModelInfo = Readonly<Pick<LanguageModelV3, 'provider' | 'modelId'>>;
+
+export type TelemetryOnStartEvent = {
+  readonly model: ModelInfo;
+  readonly system: unknown;
+  readonly prompt: unknown;
+  readonly messages: unknown;
+  readonly settings: Readonly<
+    Pick<
+      LanguageModelV3CallOptions,
+      | 'maxOutputTokens'
+      | 'temperature'
+      | 'topP'
+      | 'topK'
+      | 'presencePenalty'
+      | 'frequencyPenalty'
+      | 'stopSequences'
+      | 'seed'
+    >
+  > & { readonly maxRetries: number };
+  readonly functionId: string | undefined;
+  readonly metadata: Record<string, unknown> | undefined;
+};
+
+export type TelemetryOnStepStartEvent = {
+  readonly stepNumber: number;
+  readonly model: ModelInfo;
+  readonly promptMessages: LanguageModelV3Prompt;
+  readonly tools: Record<string, unknown> | undefined;
+  readonly toolChoice: LanguageModelV3ToolChoice | undefined;
+};
+
+export type TelemetryOnStepFinishEvent = {
+  readonly stepNumber: number;
+  readonly finishReason: FinishReason;
+  readonly text: string;
+  readonly reasoningText: string | undefined;
+  readonly toolCalls: ReadonlyArray<{
+    readonly toolName: string;
+    readonly toolCallId: string;
+    readonly input: unknown;
+  }>;
+  readonly usage: LanguageModelUsage;
+  readonly response: LanguageModelResponseMetadata;
+  readonly providerMetadata: ProviderMetadata | undefined;
+};
+
+export type TelemetryOnToolCallStartEvent = {
+  readonly toolName: string;
+  readonly toolCallId: string;
+  readonly input: unknown;
+};
+
+export type TelemetryOnToolCallFinishEvent = {
+  readonly toolName: string;
+  readonly toolCallId: string;
+  readonly input: unknown;
+  readonly output: unknown | undefined;
+  readonly error: unknown | undefined;
+  readonly durationMs: number;
+};
+
+export type TelemetryOnFinishEvent = {
+  readonly finishReason: FinishReason;
+  readonly text: string;
+  readonly reasoningText: string | undefined;
+  readonly toolCalls: ReadonlyArray<{
+    readonly toolName: string;
+    readonly toolCallId: string;
+    readonly input: unknown;
+  }>;
+  readonly usage: LanguageModelUsage;
+  readonly totalUsage: LanguageModelUsage;
+  readonly response: LanguageModelResponseMetadata;
+  readonly providerMetadata: ProviderMetadata | undefined;
+};
+
+/**
+ * Generic telemetry handler contract. Any telemetry adapter (OTEL, diagnostics
+ * channel, etc.) implements this interface to receive lifecycle events from
+ * core SDK functions like generateText and streamText.
+ */
+export type TelemetryHandler = {
+  onStart: (event: TelemetryOnStartEvent) => Promise<void>;
+  onStepStart: (event: TelemetryOnStepStartEvent) => Promise<void>;
+  onStepFinish: (event: TelemetryOnStepFinishEvent) => Promise<void>;
+  onToolCallStart: (event: TelemetryOnToolCallStartEvent) => Promise<void>;
+  onToolCallFinish: (event: TelemetryOnToolCallFinishEvent) => Promise<void>;
+  onFinish: (event: TelemetryOnFinishEvent) => Promise<void>;
+};


### PR DESCRIPTION
## Background

follow up to the PR #12654 

this will help decouple the integration with otel from the core functions

## Summary

- add an otel handler that listens to every event callback and populates spans accordingly
- add a telemetry handler layer that will enable provider handlers to receive lifecycle events

## Manual Verification

_will add later_

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)