### PR TITLE
feat (provider/klingai): add kling v3.0 t2v and i2v support

### DIFF
--- a/.changeset/chilly-trains-doubt.md
+++ b/.changeset/chilly-trains-doubt.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/klingai': patch
+---
+
+feat (provider/klingai): add kling v3.0 t2v and i2v support

--- a/content/providers/01-ai-sdk-providers/85-klingai.mdx
+++ b/content/providers/01-ai-sdk-providers/85-klingai.mdx
@@ -5,7 +5,7 @@ description: Learn how to use the Kling AI provider for the AI SDK.
 
 # Kling AI Provider
 
-The [Kling AI](https://klingai.com/) provider contains support for Kling AI's video generation models, including text-to-video, image-to-video, and motion control.
+The [Kling AI](https://klingai.com/) provider contains support for Kling AI's video generation models, including text-to-video, image-to-video, motion control, and multi-shot video generation.
 
 ## Setup
 
@@ -132,6 +132,49 @@ const { videos } = await generateVideo({
 });
 ```
 
+### Multi-Shot Video Generation
+
+Generate videos with multiple storyboard shots, each with its own prompt and duration (Kling v3.0+):
+
+```ts
+import { klingai, type KlingAIVideoModelOptions } from '@ai-sdk/klingai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { videos } = await generateVideo({
+  model: klingai.video('kling-v3.0-t2v'),
+  prompt: '',
+  aspectRatio: '16:9',
+  duration: 10,
+  providerOptions: {
+    klingai: {
+      mode: 'pro',
+      multiShot: true,
+      shotType: 'customize',
+      multiPrompt: [
+        {
+          index: 1,
+          prompt: 'A sunrise over a calm ocean, warm golden light.',
+          duration: '4',
+        },
+        {
+          index: 2,
+          prompt: 'A flock of seagulls take flight from the beach.',
+          duration: '3',
+        },
+        {
+          index: 3,
+          prompt: 'Waves crash against rocky cliffs at sunset.',
+          duration: '3',
+        },
+      ],
+      sound: 'on',
+    } satisfies KlingAIVideoModelOptions,
+  },
+});
+```
+
+Multi-shot also works with image-to-video by combining a start frame image with per-shot prompts.
+
 ### Motion Control
 
 Generate video by transferring motion from a reference video to a character image:
@@ -194,6 +237,22 @@ The following provider options are available via `providerOptions.klingai`. Opti
 
   Camera movement control with a `type` preset (`'simple'`, `'down_back'`, `'forward_up'`, `'right_turn_forward'`, `'left_turn_forward'`) and optional `config` with `horizontal`, `vertical`, `pan`, `tilt`, `roll`, `zoom` values (range: [-10, 10]).
 
+- **multiShot** _boolean_
+
+  Enable multi-shot video generation (Kling v3.0+). When true, the video is split into up to 6 storyboard shots with individual prompts and durations.
+
+- **shotType** _'customize' | 'intelligence'_
+
+  Storyboard method for multi-shot generation. `'customize'` uses `multiPrompt` for user-defined shots. `'intelligence'` lets the model auto-segment based on the main prompt. Required when `multiShot` is true.
+
+- **multiPrompt** _Array&lt;\{index, prompt, duration\}&gt;_
+
+  Per-shot details for multi-shot generation. Each shot has an `index` (number), `prompt` (string, max 512 characters), and `duration` (string, in seconds). Shot durations must sum to the total duration. Required when `multiShot` is true and `shotType` is `'customize'`.
+
+- **voiceList** _Array&lt;\{voice_id: string\}&gt;_
+
+  Voice references for voice control (Kling v3.0+). Up to 2 voices. Reference via `<<<voice_1>>>` template syntax in the prompt. Requires `sound: 'on'`. Cannot coexist with `elementList` on the I2V endpoint.
+
 #### Image-to-Video Only Options
 
 - **imageTail** _string_
@@ -207,6 +266,10 @@ The following provider options are available via `providerOptions.klingai`. Opti
 - **dynamicMasks** _Array_
 
   Dynamic brush configurations for motion brush. Up to 6 groups, each with a `mask` (image URL or base64) and `trajectories` (array of `{x, y}` coordinates).
+
+- **elementList** _Array&lt;\{element_id: number\}&gt;_
+
+  Reference elements for element control (Kling v3.0+ I2V). Supports video character elements and multi-image elements. Up to 3 reference elements. Cannot coexist with `voiceList`.
 
 #### Motion Control Only Options
 
@@ -238,27 +301,29 @@ The following provider options are available via `providerOptions.klingai`. Opti
 
 #### Text-to-Video
 
-| Model                   | Description                                      |
-| ----------------------- | ------------------------------------------------ |
-| `kling-v2.6-t2v`        | Latest model, sound in pro mode                  |
-| `kling-v2.5-turbo-t2v`  | Optimized for speed, std and pro                 |
-| `kling-v2.1-master-t2v` | High-quality generation, pro only                |
-| `kling-v2-master-t2v`   | Master-quality generation                        |
-| `kling-v1.6-t2v`        | V1.6 generation, std and pro                     |
-| `kling-v1-t2v`          | Original V1 model, supports camera control (std) |
+| Model                   | Description                                           |
+| ----------------------- | ----------------------------------------------------- |
+| `kling-v3.0-t2v`        | Latest v3.0, multi-shot, voice control, sound (3-15s) |
+| `kling-v2.6-t2v`        | V2.6, sound in pro mode                               |
+| `kling-v2.5-turbo-t2v`  | Optimized for speed, std and pro                      |
+| `kling-v2.1-master-t2v` | High-quality generation, pro only                     |
+| `kling-v2-master-t2v`   | Master-quality generation                             |
+| `kling-v1.6-t2v`        | V1.6 generation, std and pro                          |
+| `kling-v1-t2v`          | Original V1 model, supports camera control (std)      |
 
 #### Image-to-Video
 
-| Model                   | Description                                              |
-| ----------------------- | -------------------------------------------------------- |
-| `kling-v2.6-i2v`        | Latest model, sound and end-frame in pro mode            |
-| `kling-v2.5-turbo-i2v`  | Optimized for speed, end-frame in pro                    |
-| `kling-v2.1-master-i2v` | High-quality generation, pro only                        |
-| `kling-v2.1-i2v`        | V2.1 generation, end-frame in pro                        |
-| `kling-v2-master-i2v`   | Master-quality generation                                |
-| `kling-v1.6-i2v`        | V1.6 generation, end-frame in pro                        |
-| `kling-v1.5-i2v`        | V1.5 generation, end-frame and motion brush in pro       |
-| `kling-v1-i2v`          | Original V1 model, end-frame and motion brush in std/pro |
+| Model                   | Description                                                   |
+| ----------------------- | ------------------------------------------------------------- |
+| `kling-v3.0-i2v`        | Latest v3.0, multi-shot, element/voice control, sound (3-15s) |
+| `kling-v2.6-i2v`        | V2.6, sound and end-frame in pro mode                         |
+| `kling-v2.5-turbo-i2v`  | Optimized for speed, end-frame in pro                         |
+| `kling-v2.1-master-i2v` | High-quality generation, pro only                             |
+| `kling-v2.1-i2v`        | V2.1 generation, end-frame in pro                             |
+| `kling-v2-master-i2v`   | Master-quality generation                                     |
+| `kling-v1.6-i2v`        | V1.6 generation, end-frame in pro                             |
+| `kling-v1.5-i2v`        | V1.5 generation, end-frame and motion brush in pro            |
+| `kling-v1-i2v`          | Original V1 model, end-frame and motion brush in std/pro      |
 
 #### Motion Control
 

--- a/examples/ai-functions/src/generate-video/klingai-i2v-multi-shot.ts
+++ b/examples/ai-functions/src/generate-video/klingai-i2v-multi-shot.ts
@@ -1,0 +1,44 @@
+import { type KlingAIVideoModelOptions, klingai } from '@ai-sdk/klingai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../lib/present-video';
+import { run } from '../lib/run';
+import { withSpinner } from '../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner(
+    'Generating KlingAI multi-shot image-to-video with kling-v3.0-i2v...',
+    () =>
+      generateVideo({
+        model: klingai.video('kling-v3.0-i2v'),
+        prompt: {
+          image:
+            'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+          text: '',
+        },
+        duration: 8,
+        providerOptions: {
+          klingai: {
+            mode: 'pro',
+            multiShot: true,
+            shotType: 'customize',
+            multiPrompt: [
+              {
+                index: 1,
+                prompt: 'The cat stretches and yawns lazily in the sunlight.',
+                duration: '4',
+              },
+              {
+                index: 2,
+                prompt: 'The cat pounces playfully on a toy mouse.',
+                duration: '4',
+              },
+            ],
+            sound: 'on',
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies KlingAIVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos(videos);
+});

--- a/examples/ai-functions/src/generate-video/klingai-t2v-multi-shot.ts
+++ b/examples/ai-functions/src/generate-video/klingai-t2v-multi-shot.ts
@@ -1,0 +1,49 @@
+import { type KlingAIVideoModelOptions, klingai } from '@ai-sdk/klingai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../lib/present-video';
+import { run } from '../lib/run';
+import { withSpinner } from '../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner(
+    'Generating KlingAI multi-shot text-to-video with kling-v3.0-t2v...',
+    () =>
+      generateVideo({
+        model: klingai.video('kling-v3.0-t2v'),
+        prompt: '',
+        aspectRatio: '16:9',
+        duration: 10,
+        providerOptions: {
+          klingai: {
+            mode: 'pro',
+            multiShot: true,
+            shotType: 'customize',
+            multiPrompt: [
+              {
+                index: 1,
+                prompt:
+                  'A sunrise over a calm ocean, warm golden light reflecting on the water.',
+                duration: '4',
+              },
+              {
+                index: 2,
+                prompt:
+                  'A flock of seagulls take flight from the beach, wings spread wide.',
+                duration: '3',
+              },
+              {
+                index: 3,
+                prompt:
+                  'Waves crash against rocky cliffs at sunset, mist rising.',
+                duration: '3',
+              },
+            ],
+            sound: 'on',
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies KlingAIVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos(videos);
+});

--- a/packages/klingai/src/klingai-video-model.test.ts
+++ b/packages/klingai/src/klingai-video-model.test.ts
@@ -657,6 +657,108 @@ describe('KlingAIVideoModel', () => {
       });
     });
 
+    it('should derive model_name kling-v3 for kling-v3.0-t2v', async () => {
+      const model = createBasicModel({ modelId: 'kling-v3.0-t2v' });
+
+      await model.doGenerate({ ...t2vDefaultOptions });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({ model_name: 'kling-v3' });
+    });
+
+    it('should send multi_shot and shot_type when provided', async () => {
+      const model = createBasicModel({ modelId: 'kling-v3.0-t2v' });
+
+      await model.doGenerate({
+        ...t2vDefaultOptions,
+        providerOptions: {
+          klingai: {
+            ...t2vProviderOptions.klingai,
+            multiShot: true,
+            shotType: 'customize',
+            multiPrompt: [
+              { index: 1, prompt: 'A sunrise over mountains', duration: '4' },
+              {
+                index: 2,
+                prompt: 'A bird flying across the sky',
+                duration: '3',
+              },
+            ],
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        multi_shot: true,
+        shot_type: 'customize',
+        multi_prompt: [
+          { index: 1, prompt: 'A sunrise over mountains', duration: '4' },
+          { index: 2, prompt: 'A bird flying across the sky', duration: '3' },
+        ],
+      });
+    });
+
+    it('should send multi_shot with intelligence shot_type', async () => {
+      const model = createBasicModel({ modelId: 'kling-v3.0-t2v' });
+
+      await model.doGenerate({
+        ...t2vDefaultOptions,
+        providerOptions: {
+          klingai: {
+            ...t2vProviderOptions.klingai,
+            multiShot: true,
+            shotType: 'intelligence',
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        multi_shot: true,
+        shot_type: 'intelligence',
+      });
+      expect(body).not.toHaveProperty('multi_prompt');
+    });
+
+    it('should send voice_list when provided for T2V', async () => {
+      const model = createBasicModel({ modelId: 'kling-v3.0-t2v' });
+
+      await model.doGenerate({
+        ...t2vDefaultOptions,
+        providerOptions: {
+          klingai: {
+            ...t2vProviderOptions.klingai,
+            voiceList: [{ voice_id: 'voice-abc' }],
+            sound: 'on',
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        voice_list: [{ voice_id: 'voice-abc' }],
+        sound: 'on',
+      });
+    });
+
+    it('should not send element_list for T2V', async () => {
+      const model = createBasicModel({ modelId: 'kling-v3.0-t2v' });
+
+      await model.doGenerate({
+        ...t2vDefaultOptions,
+        providerOptions: {
+          klingai: {
+            ...t2vProviderOptions.klingai,
+            elementList: [{ element_id: 101 }],
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).not.toHaveProperty('element_list');
+    });
+
     it('should warn when image is provided for T2V', async () => {
       const model = createBasicModel({ modelId: 'kling-v2.6-t2v' });
 
@@ -885,6 +987,84 @@ describe('KlingAIVideoModel', () => {
 
       const body = await server.calls[0].requestBodyJson;
       expect(body).toMatchObject({ dynamic_masks: dynamicMasks });
+    });
+
+    it('should derive model_name kling-v3 for kling-v3.0-i2v', async () => {
+      const model = createBasicModel({ modelId: 'kling-v3.0-i2v' });
+
+      await model.doGenerate({ ...i2vDefaultOptions });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({ model_name: 'kling-v3' });
+    });
+
+    it('should send multi_shot and multi_prompt for I2V', async () => {
+      const model = createBasicModel({ modelId: 'kling-v3.0-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        providerOptions: {
+          klingai: {
+            ...i2vProviderOptions.klingai,
+            multiShot: true,
+            shotType: 'customize',
+            multiPrompt: [
+              { index: 1, prompt: 'The cat stretches lazily', duration: '3' },
+              { index: 2, prompt: 'The cat pounces on a toy', duration: '2' },
+            ],
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        multi_shot: true,
+        shot_type: 'customize',
+        multi_prompt: [
+          { index: 1, prompt: 'The cat stretches lazily', duration: '3' },
+          { index: 2, prompt: 'The cat pounces on a toy', duration: '2' },
+        ],
+      });
+    });
+
+    it('should send element_list when provided for I2V', async () => {
+      const model = createBasicModel({ modelId: 'kling-v3.0-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        providerOptions: {
+          klingai: {
+            ...i2vProviderOptions.klingai,
+            elementList: [{ element_id: 101 }, { element_id: 202 }],
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        element_list: [{ element_id: 101 }, { element_id: 202 }],
+      });
+    });
+
+    it('should send voice_list when provided for I2V', async () => {
+      const model = createBasicModel({ modelId: 'kling-v3.0-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        providerOptions: {
+          klingai: {
+            ...i2vProviderOptions.klingai,
+            voiceList: [{ voice_id: 'voice-abc' }, { voice_id: 'voice-def' }],
+            sound: 'on',
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        voice_list: [{ voice_id: 'voice-abc' }, { voice_id: 'voice-def' }],
+        sound: 'on',
+      });
     });
 
     it('should send negative_prompt for I2V', async () => {

--- a/packages/klingai/src/klingai-video-settings.ts
+++ b/packages/klingai/src/klingai-video-settings.ts
@@ -6,6 +6,7 @@ export type KlingAIVideoModelId =
   | 'kling-v2.1-master-t2v'
   | 'kling-v2.5-turbo-t2v'
   | 'kling-v2.6-t2v'
+  | 'kling-v3.0-t2v'
   // Image-to-Video
   | 'kling-v1-i2v'
   | 'kling-v1.5-i2v'
@@ -15,6 +16,7 @@ export type KlingAIVideoModelId =
   | 'kling-v2.1-master-i2v'
   | 'kling-v2.5-turbo-i2v'
   | 'kling-v2.6-i2v'
+  | 'kling-v3.0-i2v'
   // Motion Control
   | 'kling-v2.6-motion-control'
   | (string & {});


### PR DESCRIPTION
## Background

Kling AI has released version 3.0 of their video generation models, which introduces new capabilities like multi-shot video generation and voice/element control. This PR adds support for these new features in the AI SDK.

## Summary

- Added support for Kling AI v3.0 models (`kling-v3.0-t2v` and `kling-v3.0-i2v`)
- Implemented multi-shot video generation capabilities for creating videos with multiple storyboard shots
- Added support for voice control in text-to-video and image-to-video generation
- Added element control support for image-to-video generation
- Updated documentation with examples and parameter descriptions
- Added example scripts demonstrating multi-shot video generation

## Manual Verification

Tested the new models and features by creating example scripts that demonstrate multi-shot video generation for both text-to-video and image-to-video. Verified that the API requests are properly formatted with the new parameters and that the generated videos contain the expected content.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)