### PR TITLE
fix(docs): render MLflow video with <video> tag instead of markdown image

### DIFF
--- a/content/providers/05-observability/mlflow.mdx
+++ b/content/providers/05-observability/mlflow.mdx
@@ -5,7 +5,15 @@ description: Track, visualize, and debug Vercel AI SDK traces with MLflow Tracin
 
 # MLflow Observability
 
-![MLflow Tracing Vercel AI SDK](https://mlflow.org/docs/latest/images/llms/tracing/vercel-ai-tracing.mp4)
+<video
+  src="https://mlflow.org/docs/latest/images/llms/tracing/vercel-ai-tracing.mp4"
+  autoplay
+  muted
+  loop
+  controls
+  playsinline
+  aria-label="MLflow Tracing Vercel AI SDK"
+/>
 
 [MLflow Tracing](https://mlflow.org/docs/latest/genai/tracing) provides automatic tracing for applications built with the [Vercel AI SDK](https://ai-sdk.dev/) (the `ai` package) via OpenTelemetry, unlocking observability for TypeScript and JavaScript apps.
 


### PR DESCRIPTION
The `.mp4` URL on the [MLflow observability page](https://ai-sdk.dev/providers/observability/mlflow) is wrapped in markdown image syntax (`![...](....mp4)`), which browsers cannot render as a video — it shows a broken image icon instead.

This replaces it with an HTML `<video>` element (with `autoplay`, `muted`, `loop`, `controls`, and `playsinline` attributes), matching the pattern already used in the docs (e.g. the RAG chatbot guide).

Fixes #12472