### PR TITLE
fix(ai): simplify resume-stream status flash fix

### DIFF
--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -582,7 +582,9 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     trigger: 'submit-message' | 'resume-stream' | 'regenerate-message';
     messageId?: string;
   } & ChatRequestOptions) {
-    this.setStatus({ status: 'submitted', error: undefined });
+    if (trigger !== 'resume-stream') {
+      this.setStatus({ status: 'submitted', error: undefined });
+    }
 
     const lastMessage = this.lastMessage;
 
@@ -621,6 +623,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         }
 
         stream = reconnect;
+        this.setStatus({ status: 'submitted', error: undefined });
       } else {
         stream = await this.transport.sendMessages({
           chatId: this.id,


### PR DESCRIPTION
## Background

PR #12102 fixed a bug where `useChat` with `resume: true` would briefly flash status to `submitted` on page load when there is no active stream to resume (`ready → submitted → ready`).

However, the fix was more complex than necessary: it moved `reconnectToStream` out of the existing try-finally block, introduced a separate try-catch, a `resumeStream` closure variable with a non-null assertion (`resumeStream!`), and changed `onFinish` behavior (no longer called when there's nothing to resume).

## Summary

This PR replaces the #12102 implementation with a simpler approach ([net +3 lines changed in `chat.ts`](https://github.com/vercel/ai/pull/12679/changes/375b0aaf4bf2c5177240842c2f2e11c895edc299) vs +28/-13):

1. **Skip `setStatus('submitted')` for `resume-stream` triggers** — defer it until after `reconnectToStream` confirms there's an active stream
2. **Set `submitted` only after reconnect succeeds** — inside the existing try block, right after `stream = reconnect`

This keeps `reconnectToStream` inside the existing try-finally block, so:
- Errors are handled by the existing catch block (no duplicate try-catch)
- `onFinish` still fires in all cases (no behavior change vs pre-#12102)
- No `resumeStream` variable or non-null assertion needed

All tests from #12102 are preserved and pass.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Simplifies #12102