### PR TITLE
Update tigent.yml to clarify label usage

### DIFF
--- a/.github/tigent.yml
+++ b/.github/tigent.yml
@@ -44,9 +44,6 @@ prompt: |
   external — issue caused by something outside the ai sdk.
   resumability — resumable streams and recovery.
 
-  version labels (prs only):
-  major — breaking changes. minor — new features. backport — should be backported.
-
   workflow labels:
   type:batch — coordinated changes across packages.
   type:epic — large tracked initiatives.
@@ -58,3 +55,6 @@ prompt: |
   issues about useChat, useCompletion, hooks → ai/ui.
   docs-only prs → documentation.
   dependency updates → maintenance.
+
+  Important: do not apply these labels, they are for humans only.
+  major, minor, backport


### PR DESCRIPTION
see https://github.com/vercel/ai/pull/12673. @tigent shouldn't apply these labels, they are reserved for humans to control releases and backports. I really don't want to accidentally release a breaking change lol