### PR TITLE
feat(ai): stabilize include setting and flip defaults to false

### DIFF
--- a/.changeset/stabilize-include-option.md
+++ b/.changeset/stabilize-include-option.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Stabilize `include` setting: rename `experimental_include` to `include` and flip defaults to `false` for both `requestBody` and `responseBody`. This reduces memory usage by default when processing large payloads like images. To opt in to including bodies, set `include: { requestBody: true, responseBody: true }`.

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -644,11 +644,11 @@ To see `generateText` in action, check out [these examples](#examples).
         'Custom download function to control how URLs are fetched when they appear in prompts. By default, files are downloaded if the model does not support the URL for the given media type. Experimental feature. Return null to pass the URL directly to the model (when supported), or return downloaded content with data and media type.',
     },
     {
-      name: 'experimental_include',
+      name: 'include',
       type: '{ requestBody?: boolean; responseBody?: boolean }',
       isOptional: true,
       description:
-        'Controls inclusion of request and response bodies in step results. By default, bodies are included. When processing many large payloads (e.g., images), set requestBody and/or responseBody to false to reduce memory usage. Experimental feature.',
+        'Controls inclusion of request and response bodies in step results. By default, bodies are excluded to reduce memory usage. Set requestBody and/or responseBody to true to include them.',
       properties: [
         {
           type: 'Object',
@@ -658,14 +658,14 @@ To see `generateText` in action, check out [these examples](#examples).
               type: 'boolean',
               isOptional: true,
               description:
-                'Whether to include the request body in step results. The request body can be large when sending images or files. Default: true.',
+                'Whether to include the request body in step results. The request body can be large when sending images or files. Default: false.',
             },
             {
               name: 'responseBody',
               type: 'boolean',
               isOptional: true,
               description:
-                'Whether to include the response body in step results. Default: true.',
+                'Whether to include the response body in step results. Default: false.',
             },
           ],
         },

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -688,11 +688,11 @@ To see `streamText` in action, check out [these examples](#examples).
         'Custom download function to control how URLs are fetched when they appear in prompts. By default, files are downloaded if the model does not support the URL for the given media type. Experimental feature. Return null to pass the URL directly to the model (when supported), or return downloaded content with data and media type.',
     },
     {
-      name: 'experimental_include',
+      name: 'include',
       type: '{ requestBody?: boolean }',
       isOptional: true,
       description:
-        'Controls inclusion of request body in step results. By default, the body is included. When processing many large payloads (e.g., images), set requestBody to false to reduce memory usage. Experimental feature.',
+        'Controls inclusion of request body in step results. By default, the body is excluded to reduce memory usage. Set requestBody to true to include it.',
       properties: [
         {
           type: 'Object',
@@ -702,7 +702,7 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'boolean',
               isOptional: true,
               description:
-                'Whether to include the request body in step results. The request body can be large when sending images or files. Default: true.',
+                'Whether to include the request body in step results. The request body can be large when sending images or files. Default: false.',
             },
           ],
         },

--- a/content/docs/09-troubleshooting/70-high-memory-usage-with-images.mdx
+++ b/content/docs/09-troubleshooting/70-high-memory-usage-with-images.mdx
@@ -17,13 +17,13 @@ This is especially noticeable when using `experimental_download` to process imag
 
 ## Background
 
-By default, the AI SDK includes the full request and response bodies in the step results. When processing images, the request body contains the base64-encoded image data, which can be very large (a single image can be 1MB+ when base64 encoded). If you process many images and keep references to the results, this data accumulates in memory.
+By default, the AI SDK excludes request and response bodies from step results to reduce memory usage. However, if you explicitly opt in to including bodies via the `include` option, the request body will contain the base64-encoded image data, which can be very large (a single image can be 1MB+ when base64 encoded). If you process many images and keep references to the results, this data accumulates in memory.
 
-For example, processing 100 images of 500KB each would include ~50MB+ of request body data in memory.
+For example, processing 100 images of 500KB each with `include: { requestBody: true }` would include ~50MB+ of request body data in memory.
 
 ## Solution
 
-Use the `experimental_include` option to disable inclusion of request and/or response bodies:
+The default behavior already excludes bodies. If you have opted in to including bodies and are experiencing memory issues, either remove the `include` option or explicitly set the values to `false`:
 
 ```ts
 import { generateText } from 'ai';
@@ -40,67 +40,39 @@ const result = await generateText({
       ],
     },
   ],
-  // Disable inclusion of request body to reduce memory usage
-  experimental_include: {
-    requestBody: false,
-    responseBody: false,
-  },
+  // Bodies are excluded by default, but you can explicitly disable them:
+  // include: { requestBody: false, responseBody: false },
 });
 ```
 
 ### Options
 
-The `experimental_include` option accepts:
+The `include` option accepts:
 
-- `requestBody`: Set to `false` to exclude the request body from step results. This is where base64-encoded images are stored. Default: `true`. Available in both `generateText` and `streamText`.
-- `responseBody`: Set to `false` to exclude the response body from step results. Default: `true`. Only available in `generateText`.
+- `requestBody`: Set to `true` to include the request body in step results. This is where base64-encoded images are stored. Default: `false`. Available in both `generateText` and `streamText`.
+- `responseBody`: Set to `true` to include the response body in step results. Default: `false`. Only available in `generateText`.
 
 ### When to use
 
-- **Batch processing images**: When processing many images in a loop
-- **Long-running agents**: When an agent may process many images over its lifetime
-- **Memory-constrained environments**: When running in environments with limited memory
+If you need access to `result.request.body` or `result.response.body` for debugging or logging, you can enable inclusion:
+
+```ts
+const result = await generateText({
+  model: openai('gpt-4o'),
+  prompt: 'Hello',
+  include: { requestBody: true, responseBody: true },
+});
+```
+
+Be aware that enabling inclusion when processing many large payloads (e.g., images) can lead to high memory usage.
 
 ### Trade-offs
 
-When you disable body inclusion:
+When you enable body inclusion:
 
-- You won't have access to `result.request.body` or `result.response.body`
-- Debugging may be harder since you can't inspect the raw request/response
-- If you need the bodies for logging or debugging, consider extracting the data you need before the next iteration
-
-## Example: Processing multiple images
-
-```ts
-import { generateText } from 'ai';
-import { openai } from '@ai-sdk/openai';
-
-const imageUrls = [
-  /* array of image URLs */
-];
-const results = [];
-
-for (const imageUrl of imageUrls) {
-  const result = await generateText({
-    model: openai('gpt-4o'),
-    messages: [
-      {
-        role: 'user',
-        content: [
-          { type: 'text', text: 'Describe this image' },
-          { type: 'image', image: imageUrl },
-        ],
-      },
-    ],
-    experimental_include: {
-      requestBody: false,
-    },
-  });
-
-  // Only store the text result, not the full result object
-  results.push(result.text);
-}
-```
+- You will have access to `result.request.body` and `result.response.body`
+- Memory usage will increase, especially when processing images or large files
+- Consider extracting the data you need before the next iteration to avoid accumulating large objects in memory
 
 ## Learn more
 

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -17,7 +17,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
   "rawFinishReason": "stop",
   "reasoning": [],
   "reasoningText": undefined,
-  "request": {},
+  "request": {
+    "body": undefined,
+  },
   "response": {
     "body": undefined,
     "headers": {
@@ -99,7 +101,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       "finishReason": "tool-calls",
       "providerMetadata": undefined,
       "rawFinishReason": undefined,
-      "request": {},
+      "request": {
+        "body": undefined,
+      },
       "response": {
         "body": undefined,
         "headers": undefined,
@@ -167,7 +171,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       "finishReason": "stop",
       "providerMetadata": undefined,
       "rawFinishReason": "stop",
-      "request": {},
+      "request": {
+        "body": undefined,
+      },
       "response": {
         "body": undefined,
         "headers": {
@@ -307,7 +313,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
     "finishReason": "tool-calls",
     "providerMetadata": undefined,
     "rawFinishReason": undefined,
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "response": {
       "body": undefined,
       "headers": undefined,
@@ -375,7 +383,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
     "finishReason": "stop",
     "providerMetadata": undefined,
     "rawFinishReason": "stop",
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "response": {
       "body": undefined,
       "headers": {
@@ -521,7 +531,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
     "finishReason": "tool-calls",
     "providerMetadata": undefined,
     "rawFinishReason": undefined,
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "response": {
       "body": undefined,
       "headers": undefined,
@@ -589,7 +601,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
     "finishReason": "stop",
     "providerMetadata": undefined,
     "rawFinishReason": "stop",
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "response": {
       "body": undefined,
       "headers": {
@@ -691,7 +705,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     "finishReason": "tool-calls",
     "providerMetadata": undefined,
     "rawFinishReason": undefined,
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "response": {
       "body": undefined,
       "headers": undefined,
@@ -759,7 +775,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     "finishReason": "stop",
     "providerMetadata": undefined,
     "rawFinishReason": "stop",
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "response": {
       "body": undefined,
       "headers": {
@@ -905,7 +923,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     "finishReason": "tool-calls",
     "providerMetadata": undefined,
     "rawFinishReason": undefined,
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "response": {
       "body": undefined,
       "headers": undefined,
@@ -973,7 +993,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     "finishReason": "stop",
     "providerMetadata": undefined,
     "rawFinishReason": "stop",
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "response": {
       "body": undefined,
       "headers": {
@@ -1305,7 +1327,7 @@ exports[`generateText > result.files > should contain files 1`] = `
 
 exports[`generateText > result.response > should contain response body and headers 1`] = `
 {
-  "body": "test body",
+  "body": undefined,
   "headers": {
     "custom-response-header": "response-header-value",
   },
@@ -1329,7 +1351,7 @@ exports[`generateText > result.response > should contain response body and heade
 
 exports[`generateText > result.response > should contain response body and headers 2`] = `
 {
-  "body": "test body",
+  "body": undefined,
   "headers": {
     "custom-response-header": "response-header-value",
   },
@@ -1497,7 +1519,9 @@ exports[`generateText > result.steps > should add the reasoning from the model r
     "finishReason": "stop",
     "providerMetadata": undefined,
     "rawFinishReason": "stop",
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "response": {
       "body": undefined,
       "headers": undefined,
@@ -1589,7 +1613,9 @@ exports[`generateText > result.steps > should contain files 1`] = `
     "finishReason": "stop",
     "providerMetadata": undefined,
     "rawFinishReason": "stop",
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "response": {
       "body": undefined,
       "headers": undefined,
@@ -1679,7 +1705,9 @@ exports[`generateText > result.steps > should contain sources 1`] = `
     "finishReason": "stop",
     "providerMetadata": undefined,
     "rawFinishReason": "stop",
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "response": {
       "body": undefined,
       "headers": undefined,

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -402,7 +402,9 @@ exports[`streamText > result.fullStream > should send delayed asynchronous tool 
     "type": "start",
   },
   {
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "type": "start-step",
     "warnings": [],
   },
@@ -486,7 +488,9 @@ exports[`streamText > result.fullStream > should send tool calls 1`] = `
     "type": "start",
   },
   {
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "type": "start-step",
     "warnings": [],
   },
@@ -564,7 +568,9 @@ exports[`streamText > result.fullStream > should send tool results 1`] = `
     "type": "start",
   },
   {
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "type": "start-step",
     "warnings": [],
   },
@@ -1187,7 +1193,9 @@ exports[`streamText > tools with custom schema > should send tool calls 1`] = `
     "type": "start",
   },
   {
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "type": "start-step",
     "warnings": [],
   },

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -616,7 +616,7 @@ describe('generateText', () => {
   });
 
   describe('result.request', () => {
-    it('should contain request body by default', async () => {
+    it('should exclude request body by default', async () => {
       const result = await generateText({
         model: new MockLanguageModelV3({
           doGenerate: async ({}) => ({
@@ -628,30 +628,30 @@ describe('generateText', () => {
           }),
         }),
         prompt: 'prompt',
-      });
-
-      expect(result.request).toStrictEqual({
-        body: 'test body',
-      });
-    });
-
-    it('should exclude request body when retention.requestBody is false', async () => {
-      const result = await generateText({
-        model: new MockLanguageModelV3({
-          doGenerate: async ({}) => ({
-            ...dummyResponseValues,
-            content: [{ type: 'text', text: 'Hello, world!' }],
-            request: {
-              body: 'test body',
-            },
-          }),
-        }),
-        prompt: 'prompt',
-        experimental_include: { requestBody: false },
       });
 
       expect(result.request).toStrictEqual({
         body: undefined,
+      });
+    });
+
+    it('should include request body when include.requestBody is true', async () => {
+      const result = await generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: async ({}) => ({
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: 'Hello, world!' }],
+            request: {
+              body: 'test body',
+            },
+          }),
+        }),
+        prompt: 'prompt',
+        include: { requestBody: true },
+      });
+
+      expect(result.request).toStrictEqual({
+        body: 'test body',
       });
     });
   });
@@ -762,7 +762,9 @@ describe('generateText', () => {
           "rawFinishReason": "stop",
           "reasoning": [],
           "reasoningText": undefined,
-          "request": {},
+          "request": {
+            "body": undefined,
+          },
           "response": {
             "body": undefined,
             "headers": {
@@ -866,7 +868,9 @@ describe('generateText', () => {
               "finishReason": "stop",
               "providerMetadata": undefined,
               "rawFinishReason": "stop",
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "response": {
                 "body": undefined,
                 "headers": {
@@ -1377,7 +1381,9 @@ describe('generateText', () => {
                   "finishReason": "tool-calls",
                   "providerMetadata": undefined,
                   "rawFinishReason": undefined,
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "body": undefined,
                     "headers": undefined,
@@ -1445,7 +1451,9 @@ describe('generateText', () => {
                   "finishReason": "stop",
                   "providerMetadata": undefined,
                   "rawFinishReason": "stop",
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "body": undefined,
                     "headers": {
@@ -1586,7 +1594,9 @@ describe('generateText', () => {
                   "finishReason": "tool-calls",
                   "providerMetadata": undefined,
                   "rawFinishReason": undefined,
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "body": undefined,
                     "headers": undefined,
@@ -1654,7 +1664,9 @@ describe('generateText', () => {
                   "finishReason": "stop",
                   "providerMetadata": undefined,
                   "rawFinishReason": "stop",
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "body": undefined,
                     "headers": {
@@ -2030,7 +2042,9 @@ describe('generateText', () => {
                   "finishReason": "tool-calls",
                   "providerMetadata": undefined,
                   "rawFinishReason": undefined,
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "body": undefined,
                     "headers": undefined,
@@ -2120,7 +2134,9 @@ describe('generateText', () => {
                   "finishReason": "tool-calls",
                   "providerMetadata": undefined,
                   "rawFinishReason": undefined,
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "body": undefined,
                     "headers": undefined,
@@ -5456,7 +5472,9 @@ describe('generateText', () => {
               "finishReason": "tool-calls",
               "providerMetadata": undefined,
               "rawFinishReason": undefined,
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "response": {
                 "body": undefined,
                 "headers": undefined,

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -194,7 +194,7 @@ export async function generateText<
   experimental_repairToolCall: repairToolCall,
   experimental_download: download,
   experimental_context,
-  experimental_include: include,
+  include,
   _internal: { generateId = originalGenerateId } = {},
   onStepFinish,
   onFinish,
@@ -307,19 +307,19 @@ export async function generateText<
      * Disabling inclusion can help reduce memory usage when processing
      * large payloads like images.
      *
-     * By default, all data is included for backwards compatibility.
+     * By default, bodies are excluded to reduce memory usage.
      */
-    experimental_include?: {
+    include?: {
       /**
        * Whether to retain the request body in step results.
        * The request body can be large when sending images or files.
-       * @default true
+       * @default false
        */
       requestBody?: boolean;
 
       /**
        * Whether to retain the response body in step results.
-       * @default true
+       * @default false
        */
       responseBody?: boolean;
     };
@@ -823,7 +823,7 @@ export async function generateText<
             // Conditionally include request.body and response.body based on include settings.
             // Large payloads (e.g., base64-encoded images) can cause memory issues.
             const stepRequest: LanguageModelRequestMetadata =
-              (include?.requestBody ?? true)
+              (include?.requestBody ?? false)
                 ? (currentModelResponse.request ?? {})
                 : { ...currentModelResponse.request, body: undefined };
 
@@ -833,7 +833,7 @@ export async function generateText<
               messages: structuredClone(responseMessages),
               // Conditionally include response body:
               body:
-                (include?.responseBody ?? true)
+                (include?.responseBody ?? false)
                   ? currentModelResponse.response?.body
                   : undefined,
             };

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -484,7 +484,9 @@ describe('streamText', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -581,7 +583,9 @@ describe('streamText', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -811,7 +815,9 @@ describe('streamText', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -920,7 +926,9 @@ describe('streamText', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -1051,7 +1059,9 @@ describe('streamText', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -1291,7 +1301,9 @@ describe('streamText', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -1587,7 +1599,9 @@ describe('streamText', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -3978,7 +3992,9 @@ describe('streamText', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -4285,7 +4301,7 @@ describe('streamText', () => {
   });
 
   describe('result.request', () => {
-    it('should resolve with request information by default', async () => {
+    it('should exclude request body by default', async () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
@@ -4307,40 +4323,40 @@ describe('streamText', () => {
           request: { body: 'test body' },
         }),
         prompt: 'test-input',
-      });
-
-      expect(await result.request).toStrictEqual({
-        body: 'test body',
-      });
-    });
-
-    it('should exclude request body when retention.requestBody is false', async () => {
-      const result = streamText({
-        model: createTestModel({
-          stream: convertArrayToReadableStream([
-            {
-              type: 'response-metadata',
-              id: 'id-0',
-              modelId: 'mock-model-id',
-              timestamp: new Date(0),
-            },
-            { type: 'text-start', id: '1' },
-            { type: 'text-delta', id: '1', delta: 'Hello' },
-            { type: 'text-end', id: '1' },
-            {
-              type: 'finish',
-              finishReason: { unified: 'stop', raw: 'stop' },
-              usage: testUsage,
-            },
-          ]),
-          request: { body: 'test body' },
-        }),
-        prompt: 'test-input',
-        experimental_include: { requestBody: false },
       });
 
       expect(await result.request).toStrictEqual({
         body: undefined,
+      });
+    });
+
+    it('should include request body when include.requestBody is true', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'response-metadata',
+              id: 'id-0',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Hello' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+            },
+          ]),
+          request: { body: 'test body' },
+        }),
+        prompt: 'test-input',
+        include: { requestBody: true },
+      });
+
+      expect(await result.request).toStrictEqual({
+        body: 'test body',
       });
     });
   });
@@ -4519,7 +4535,9 @@ describe('streamText', () => {
             "finishReason": "stop",
             "providerMetadata": undefined,
             "rawFinishReason": "stop",
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "response": {
               "headers": undefined,
               "id": "id-0",
@@ -4653,7 +4671,9 @@ describe('streamText', () => {
             "finishReason": "stop",
             "providerMetadata": undefined,
             "rawFinishReason": "stop",
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "response": {
               "headers": undefined,
               "id": "id-0",
@@ -4732,7 +4752,9 @@ describe('streamText', () => {
             "finishReason": "stop",
             "providerMetadata": undefined,
             "rawFinishReason": "stop",
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "response": {
               "headers": undefined,
               "id": "id-0",
@@ -5154,7 +5176,9 @@ describe('streamText', () => {
           "rawFinishReason": "stop",
           "reasoning": [],
           "reasoningText": undefined,
-          "request": {},
+          "request": {
+            "body": undefined,
+          },
           "response": {
             "headers": {
               "call": "2",
@@ -5262,7 +5286,9 @@ describe('streamText', () => {
                 },
               },
               "rawFinishReason": "stop",
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "response": {
                 "headers": {
                   "call": "2",
@@ -5448,7 +5474,9 @@ describe('streamText', () => {
           "rawFinishReason": "stop",
           "reasoning": [],
           "reasoningText": undefined,
-          "request": {},
+          "request": {
+            "body": undefined,
+          },
           "response": {
             "headers": undefined,
             "id": "id-0",
@@ -5531,7 +5559,9 @@ describe('streamText', () => {
               "finishReason": "stop",
               "providerMetadata": undefined,
               "rawFinishReason": "stop",
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "response": {
                 "headers": undefined,
                 "id": "id-0",
@@ -5675,7 +5705,9 @@ describe('streamText', () => {
           "rawFinishReason": "stop",
           "reasoning": [],
           "reasoningText": undefined,
-          "request": {},
+          "request": {
+            "body": undefined,
+          },
           "response": {
             "headers": undefined,
             "id": "id-0",
@@ -5739,7 +5771,9 @@ describe('streamText', () => {
               "finishReason": "stop",
               "providerMetadata": undefined,
               "rawFinishReason": "stop",
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "response": {
                 "headers": undefined,
                 "id": "id-0",
@@ -6196,7 +6230,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -6267,7 +6303,9 @@ describe('streamText', () => {
                 },
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -6371,7 +6409,9 @@ describe('streamText', () => {
               "rawFinishReason": "stop",
               "reasoning": [],
               "reasoningText": undefined,
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "response": {
                 "headers": {
                   "call": "2",
@@ -6462,7 +6502,9 @@ describe('streamText', () => {
                   "finishReason": "tool-calls",
                   "providerMetadata": undefined,
                   "rawFinishReason": undefined,
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "headers": {
                       "call": "1",
@@ -6537,7 +6579,9 @@ describe('streamText', () => {
                   "finishReason": "stop",
                   "providerMetadata": undefined,
                   "rawFinishReason": "stop",
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "headers": {
                       "call": "2",
@@ -6688,7 +6732,9 @@ describe('streamText', () => {
                 "finishReason": "tool-calls",
                 "providerMetadata": undefined,
                 "rawFinishReason": undefined,
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "response": {
                   "headers": {
                     "call": "1",
@@ -6763,7 +6809,9 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "providerMetadata": undefined,
                 "rawFinishReason": "stop",
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "response": {
                   "headers": {
                     "call": "2",
@@ -6932,7 +6980,9 @@ describe('streamText', () => {
                 "finishReason": "tool-calls",
                 "providerMetadata": undefined,
                 "rawFinishReason": undefined,
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "response": {
                   "headers": {
                     "call": "1",
@@ -7007,7 +7057,9 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "providerMetadata": undefined,
                 "rawFinishReason": "stop",
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "response": {
                   "headers": {
                     "call": "2",
@@ -7511,7 +7563,9 @@ describe('streamText', () => {
                   "finishReason": "tool-calls",
                   "providerMetadata": undefined,
                   "rawFinishReason": undefined,
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "headers": {
                       "call": "1",
@@ -7581,7 +7635,9 @@ describe('streamText', () => {
                   "finishReason": "stop",
                   "providerMetadata": undefined,
                   "rawFinishReason": "stop",
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "headers": {
                       "call": "2",
@@ -7721,7 +7777,9 @@ describe('streamText', () => {
                   "finishReason": "tool-calls",
                   "providerMetadata": undefined,
                   "rawFinishReason": undefined,
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "headers": {
                       "call": "1",
@@ -7791,7 +7849,9 @@ describe('streamText', () => {
                   "finishReason": "stop",
                   "providerMetadata": undefined,
                   "rawFinishReason": "stop",
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "headers": {
                       "call": "2",
@@ -7984,7 +8044,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -8055,7 +8117,9 @@ describe('streamText', () => {
                 },
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -8159,7 +8223,9 @@ describe('streamText', () => {
               "rawFinishReason": "stop",
               "reasoning": [],
               "reasoningText": undefined,
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "response": {
                 "headers": {
                   "call": "2",
@@ -8250,7 +8316,9 @@ describe('streamText', () => {
                   "finishReason": "tool-calls",
                   "providerMetadata": undefined,
                   "rawFinishReason": undefined,
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "headers": {
                       "call": "1",
@@ -8325,7 +8393,9 @@ describe('streamText', () => {
                   "finishReason": "stop",
                   "providerMetadata": undefined,
                   "rawFinishReason": "stop",
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "headers": {
                       "call": "2",
@@ -8476,7 +8546,9 @@ describe('streamText', () => {
                 "finishReason": "tool-calls",
                 "providerMetadata": undefined,
                 "rawFinishReason": undefined,
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "response": {
                   "headers": {
                     "call": "1",
@@ -8551,7 +8623,9 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "providerMetadata": undefined,
                 "rawFinishReason": "stop",
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "response": {
                   "headers": {
                     "call": "2",
@@ -8716,7 +8790,9 @@ describe('streamText', () => {
                 "finishReason": "tool-calls",
                 "providerMetadata": undefined,
                 "rawFinishReason": undefined,
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "response": {
                   "headers": {
                     "call": "1",
@@ -8791,7 +8867,9 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "providerMetadata": undefined,
                 "rawFinishReason": "stop",
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "response": {
                   "headers": {
                     "call": "2",
@@ -9256,7 +9334,9 @@ describe('streamText', () => {
                   "finishReason": "tool-calls",
                   "providerMetadata": undefined,
                   "rawFinishReason": undefined,
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "headers": {
                       "call": "1",
@@ -9357,7 +9437,9 @@ describe('streamText', () => {
                   "finishReason": "tool-calls",
                   "providerMetadata": undefined,
                   "rawFinishReason": undefined,
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "headers": {
                       "call": "1",
@@ -9601,7 +9683,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -9870,7 +9954,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -11293,7 +11379,9 @@ describe('streamText', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -11402,7 +11490,9 @@ describe('streamText', () => {
             "finishReason": "stop",
             "providerMetadata": undefined,
             "rawFinishReason": "stop",
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "response": {
               "headers": undefined,
               "id": "id-0",
@@ -11894,7 +11984,9 @@ describe('streamText', () => {
               "finishReason": "stop",
               "providerMetadata": undefined,
               "rawFinishReason": "stop",
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "response": {
                 "headers": undefined,
                 "id": "id-0",
@@ -11982,6 +12074,7 @@ describe('streamText', () => {
             request: { body: 'test body' },
           }),
           prompt: 'test-input',
+          include: { requestBody: true },
           experimental_transform: upperCaseTransform,
         });
 
@@ -12123,7 +12216,9 @@ describe('streamText', () => {
             "rawFinishReason": "stop",
             "reasoning": [],
             "reasoningText": undefined,
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "response": {
               "headers": {
                 "call": "2",
@@ -12231,7 +12326,9 @@ describe('streamText', () => {
                   },
                 },
                 "rawFinishReason": "stop",
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "response": {
                   "headers": {
                     "call": "2",
@@ -12448,7 +12545,9 @@ describe('streamText', () => {
               },
             },
             "rawFinishReason": "stop",
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "response": {
               "headers": {
                 "call": "2",
@@ -12829,7 +12928,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -12934,7 +13035,9 @@ describe('streamText', () => {
             "finishReason": "stop",
             "providerMetadata": undefined,
             "rawFinishReason": undefined,
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "response": {
               "id": "response-id",
               "messages": [
@@ -13370,7 +13473,9 @@ describe('streamText', () => {
             "rawFinishReason": "stop",
             "reasoning": [],
             "reasoningText": undefined,
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "response": {
               "headers": undefined,
               "id": "id-0",
@@ -13404,7 +13509,9 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "providerMetadata": undefined,
                 "rawFinishReason": "stop",
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "response": {
                   "headers": undefined,
                   "id": "id-0",
@@ -14284,7 +14391,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -14490,7 +14599,9 @@ describe('streamText', () => {
               "finishReason": "stop",
               "providerMetadata": undefined,
               "rawFinishReason": "stop",
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "response": {
                 "headers": undefined,
                 "id": "id-0",
@@ -14636,7 +14747,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -14872,7 +14985,9 @@ describe('streamText', () => {
                   "finishReason": "tool-calls",
                   "providerMetadata": undefined,
                   "rawFinishReason": undefined,
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "response": {
                     "headers": undefined,
                     "id": "id-0",
@@ -14943,7 +15058,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -14998,7 +15115,9 @@ describe('streamText', () => {
                 },
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -15184,7 +15303,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -15433,7 +15554,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -15674,7 +15797,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -15913,7 +16038,9 @@ describe('streamText', () => {
               "finishReason": "stop",
               "providerMetadata": undefined,
               "rawFinishReason": "stop",
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "response": {
                 "headers": undefined,
                 "id": "id-0",
@@ -16062,7 +16189,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -17370,7 +17499,9 @@ describe('streamText', () => {
                   "type": "start",
                 },
                 {
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "type": "start-step",
                   "warnings": [],
                 },
@@ -17458,7 +17589,9 @@ describe('streamText', () => {
                   },
                 },
                 {
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "type": "start-step",
                   "warnings": [],
                 },
@@ -17521,7 +17654,9 @@ describe('streamText', () => {
                   },
                 },
                 {
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "type": "start-step",
                   "warnings": [],
                 },
@@ -17584,7 +17719,9 @@ describe('streamText', () => {
                   },
                 },
                 {
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "type": "start-step",
                   "warnings": [],
                 },
@@ -17647,7 +17784,9 @@ describe('streamText', () => {
                   },
                 },
                 {
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "type": "start-step",
                   "warnings": [],
                 },
@@ -18219,7 +18358,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -18455,7 +18596,9 @@ describe('streamText', () => {
                 "type": "start",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -18916,7 +19059,9 @@ describe('streamText', () => {
                 "type": "tool-result",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -19233,7 +19378,9 @@ describe('streamText', () => {
                 "type": "tool-result",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -19536,7 +19683,9 @@ describe('streamText', () => {
                 "type": "tool-output-denied",
               },
               {
-                "request": {},
+                "request": {
+                  "body": undefined,
+                },
                 "type": "start-step",
                 "warnings": [],
               },
@@ -19698,7 +19847,9 @@ describe('streamText', () => {
                   "type": "start",
                 },
                 {
-                  "request": {},
+                  "request": {
+                    "body": undefined,
+                  },
                   "type": "start-step",
                   "warnings": [],
                 },

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -286,7 +286,7 @@ export function streamText<
   onAbort,
   onStepFinish,
   experimental_context,
-  experimental_include: include,
+  include,
   _internal: { now = originalNow, generateId = originalGenerateId } = {},
   ...settings
 }: CallSettings &
@@ -435,13 +435,13 @@ export function streamText<
      * Disabling inclusion can help reduce memory usage when processing
      * large payloads like images.
      *
-     * By default, all data is included for backwards compatibility.
+     * By default, bodies are excluded to reduce memory usage.
      */
-    experimental_include?: {
+    include?: {
       /**
        * Whether to retain the request body in step results.
        * The request body can be large when sending images or files.
-       * @default true
+       * @default false
        */
       requestBody?: boolean;
     };
@@ -1474,7 +1474,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
             // Conditionally include request.body based on include settings.
             // Large payloads (e.g., base64-encoded images) can cause memory issues.
             const stepRequest: LanguageModelRequestMetadata =
-              (include?.requestBody ?? true)
+              (include?.requestBody ?? false)
                 ? (request ?? {})
                 : { ...request, body: undefined };
             const stepToolCalls: TypedToolCall<TOOLS>[] = [];

--- a/packages/ai/src/middleware/__snapshots__/simulate-streaming-middleware.test.ts.snap
+++ b/packages/ai/src/middleware/__snapshots__/simulate-streaming-middleware.test.ts.snap
@@ -6,7 +6,9 @@ exports[`simulateStreamingMiddleware > should handle empty text response 1`] = `
     "type": "start",
   },
   {
-    "request": {},
+    "request": {
+      "body": undefined,
+    },
     "type": "start-step",
     "warnings": [],
   },

--- a/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
@@ -292,7 +292,9 @@ describe('extractReasoningMiddleware', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -434,7 +436,9 @@ describe('extractReasoningMiddleware', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -584,7 +588,9 @@ describe('extractReasoningMiddleware', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -724,7 +730,9 @@ describe('extractReasoningMiddleware', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -823,7 +831,9 @@ describe('extractReasoningMiddleware', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },
@@ -953,7 +963,9 @@ describe('extractReasoningMiddleware', () => {
               "type": "start",
             },
             {
-              "request": {},
+              "request": {
+                "body": undefined,
+              },
               "type": "start-step",
               "warnings": [],
             },

--- a/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
+++ b/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
@@ -84,7 +84,9 @@ describe('simulateStreamingMiddleware', () => {
             "type": "start",
           },
           {
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "type": "start-step",
             "warnings": [],
           },
@@ -190,7 +192,9 @@ describe('simulateStreamingMiddleware', () => {
             "type": "start",
           },
           {
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "type": "start-step",
             "warnings": [],
           },
@@ -323,7 +327,9 @@ describe('simulateStreamingMiddleware', () => {
             "type": "start",
           },
           {
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "type": "start-step",
             "warnings": [],
           },
@@ -487,7 +493,9 @@ describe('simulateStreamingMiddleware', () => {
             "type": "start",
           },
           {
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "type": "start-step",
             "warnings": [],
           },
@@ -651,7 +659,9 @@ describe('simulateStreamingMiddleware', () => {
             "type": "start",
           },
           {
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "type": "start-step",
             "warnings": [],
           },
@@ -773,7 +783,9 @@ describe('simulateStreamingMiddleware', () => {
             "type": "start",
           },
           {
-            "request": {},
+            "request": {
+              "body": undefined,
+            },
             "type": "start-step",
             "warnings": [],
           },

--- a/packages/codemod/src/bin/codemod.ts
+++ b/packages/codemod/src/bin/codemod.ts
@@ -3,7 +3,13 @@
 import debug from 'debug';
 import { Command } from 'commander';
 import { transform } from '../lib/transform';
-import { upgrade, upgradeV4, upgradeV5, upgradeV6 } from '../lib/upgrade';
+import {
+  upgrade,
+  upgradeV4,
+  upgradeV5,
+  upgradeV6,
+  upgradeV7,
+} from '../lib/upgrade';
 import { TransformOptions } from '../lib/transform-options';
 
 const log = debug('codemod');
@@ -80,6 +86,17 @@ addTransformOptions(
     upgradeV6(options);
   } catch (err: any) {
     error(`Error applying v6 codemods: ${err}`);
+    process.exit(1);
+  }
+});
+
+addTransformOptions(
+  program.command('v7').description('Apply v7 codemods (v6 → v7 migration)'),
+).action((options: TransformOptions) => {
+  try {
+    upgradeV7(options);
+  } catch (err: any) {
+    error(`Error applying v7 codemods: ${err}`);
     process.exit(1);
   }
 });

--- a/packages/codemod/src/codemods/v7/rename-experimental-include.ts
+++ b/packages/codemod/src/codemods/v7/rename-experimental-include.ts
@@ -1,0 +1,43 @@
+import { createTransformer } from '../lib/create-transformer';
+
+export default createTransformer((fileInfo, api, options, context) => {
+  const { j, root } = context;
+
+  let hasChanges = false;
+
+  // AI methods that accept the include option
+  const aiMethods = ['generateText', 'streamText'];
+
+  // Find AI method calls and rename experimental_include to include
+  root.find(j.CallExpression).forEach(path => {
+    const { callee, arguments: args } = path.node;
+
+    // Check if this is an AI method call
+    if (
+      callee.type === 'Identifier' &&
+      aiMethods.includes(callee.name) &&
+      args.length > 0
+    ) {
+      const firstArg = args[0];
+
+      // The first argument should be an object with properties
+      if (firstArg.type === 'ObjectExpression') {
+        firstArg.properties.forEach(prop => {
+          const isPropertyType =
+            prop.type === 'Property' || prop.type === 'ObjectProperty';
+
+          if (isPropertyType && prop.key && prop.key.type === 'Identifier') {
+            if (prop.key.name === 'experimental_include') {
+              prop.key.name = 'include';
+              hasChanges = true;
+            }
+          }
+        });
+      }
+    }
+  });
+
+  if (hasChanges) {
+    context.hasChanges = true;
+  }
+});

--- a/packages/codemod/src/lib/upgrade.ts
+++ b/packages/codemod/src/lib/upgrade.ts
@@ -88,6 +88,7 @@ const bundle = [
   'v6/rename-vertex-provider-metadata-key',
   'v6/wrap-tomodeloutput-parameter',
   'v6/add-await-converttomodelmessages',
+  'v7/rename-experimental-include',
 ];
 
 const log = debug('codemod:upgrade');
@@ -97,6 +98,7 @@ const error = debug('codemod:upgrade:error');
 const v4Bundle = bundle.filter(codemod => codemod.startsWith('v4/'));
 const v5Bundle = bundle.filter(codemod => codemod.startsWith('v5/'));
 const v6Bundle = bundle.filter(codemod => codemod.startsWith('v6/'));
+const v7Bundle = bundle.filter(codemod => codemod.startsWith('v7/'));
 
 function runCodemods(
   codemods: string[],
@@ -156,6 +158,10 @@ export function upgradeV5(options: TransformOptions) {
 
 export function upgradeV6(options: TransformOptions) {
   runCodemods(v6Bundle, options, 'v6');
+}
+
+export function upgradeV7(options: TransformOptions) {
+  runCodemods(v7Bundle, options, 'v7');
 }
 
 export function upgrade(options: TransformOptions) {

--- a/packages/codemod/src/test/__testfixtures__/rename-experimental-include.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/rename-experimental-include.input.ts
@@ -1,0 +1,33 @@
+// @ts-nocheck
+import { generateText, streamText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+// Case 1: generateText with experimental_include
+const result1 = await generateText({
+  model: openai('gpt-4o'),
+  prompt: 'Hello',
+  experimental_include: {
+    requestBody: false,
+    responseBody: false,
+  },
+});
+
+// Case 2: streamText with experimental_include
+const result2 = streamText({
+  model: openai('gpt-4o'),
+  prompt: 'Hello',
+  experimental_include: {
+    requestBody: false,
+  },
+});
+
+// Case 3: generateText without experimental_include (should not change)
+const result3 = await generateText({
+  model: openai('gpt-4o'),
+  prompt: 'Hello',
+});
+
+// Case 4: Other function with experimental_include (should not change)
+const result4 = someOtherFunction({
+  experimental_include: { requestBody: false },
+});

--- a/packages/codemod/src/test/__testfixtures__/rename-experimental-include.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/rename-experimental-include.output.ts
@@ -1,0 +1,33 @@
+// @ts-nocheck
+import { generateText, streamText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+// Case 1: generateText with experimental_include
+const result1 = await generateText({
+  model: openai('gpt-4o'),
+  prompt: 'Hello',
+  include: {
+    requestBody: false,
+    responseBody: false,
+  },
+});
+
+// Case 2: streamText with experimental_include
+const result2 = streamText({
+  model: openai('gpt-4o'),
+  prompt: 'Hello',
+  include: {
+    requestBody: false,
+  },
+});
+
+// Case 3: generateText without experimental_include (should not change)
+const result3 = await generateText({
+  model: openai('gpt-4o'),
+  prompt: 'Hello',
+});
+
+// Case 4: Other function with experimental_include (should not change)
+const result4 = someOtherFunction({
+  experimental_include: { requestBody: false },
+});

--- a/packages/codemod/src/test/rename-experimental-include.test.ts
+++ b/packages/codemod/src/test/rename-experimental-include.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v7/rename-experimental-include';
+import { testTransform } from './test-utils';
+
+describe('rename-experimental-include', () => {
+  it('transforms experimental_include to include in generateText and streamText', () => {
+    testTransform(transformer, 'rename-experimental-include');
+  });
+});


### PR DESCRIPTION
## Summary

- Rename `experimental_include` to `include` in `generateText` and `streamText`, stabilizing the API (addresses #12130, #12131)
- Flip default values for `requestBody` and `responseBody` from `true` to `false`, reducing memory usage by default when processing large payloads like images
- Add v7 codemod (`rename-experimental-include`) to automatically migrate existing usage

## Test plan

- Updated existing tests and snapshots to reflect new defaults and renamed option
- Added codemod test with input/output fixtures