### PR TITLE
feat(ai, providers): add top-level dimensions option to embed/embedMany

### DIFF
--- a/.changeset/embed-dimensions.md
+++ b/.changeset/embed-dimensions.md
@@ -1,0 +1,13 @@
+---
+'@ai-sdk/provider': minor
+'ai': minor
+'@ai-sdk/openai': minor
+'@ai-sdk/openai-compatible': minor
+'@ai-sdk/google': minor
+'@ai-sdk/google-vertex': minor
+'@ai-sdk/cohere': minor
+'@ai-sdk/amazon-bedrock': minor
+'@ai-sdk/mistral': minor
+---
+
+Add top-level `dimensions` option to `embed()` and `embedMany()` for configuring output embedding dimensionality. Supported providers: OpenAI, OpenAI-compatible, Google, Google Vertex, Cohere, Amazon Bedrock. Providers that don't support dimensionality reduction (Mistral) throw `UnsupportedFunctionalityError` when `dimensions` is set. Provider-specific `providerOptions` take precedence over the top-level `dimensions` when both are specified.

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -49,6 +49,7 @@ const originalGenerateCallId = createIdGenerator({
 export async function embedMany({
   model: modelArg,
   values,
+  dimensions,
   maxParallelCalls = Infinity,
   maxRetries: maxRetriesArg,
   abortSignal,
@@ -68,6 +69,12 @@ export async function embedMany({
    * The values that should be embedded.
    */
   values: Array<string>;
+
+  /**
+   * The number of dimensions the resulting output embeddings should have.
+   * Only supported by some models and providers.
+   */
+  dimensions?: number;
 
   /**
    * Maximum number of retries per embedding model call. Set to 0 to disable retries.
@@ -194,6 +201,7 @@ export async function embedMany({
 
           const modelResponse = await model.doEmbed({
             values,
+            dimensions,
             abortSignal,
             headers: headersWithUserAgent,
             providerOptions,
@@ -306,6 +314,7 @@ export async function embedMany({
 
             const modelResponse = await model.doEmbed({
               values: chunk,
+              dimensions,
               abortSignal,
               headers: headersWithUserAgent,
               providerOptions,

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -41,6 +41,7 @@ const originalGenerateCallId = createIdGenerator({
 export async function embed({
   model: modelArg,
   value,
+  dimensions,
   providerOptions,
   maxRetries: maxRetriesArg,
   abortSignal,
@@ -59,6 +60,12 @@ export async function embed({
    * The value that should be embedded.
    */
   value: string;
+
+  /**
+   * The number of dimensions the resulting output embeddings should have.
+   * Only supported by some models and providers.
+   */
+  dimensions?: number;
 
   /**
    * Maximum number of retries per embedding model call. Set to 0 to disable retries.
@@ -172,6 +179,7 @@ export async function embed({
 
         const modelResponse = await model.doEmbed({
           values: [value],
+          dimensions,
           abortSignal,
           headers: headersWithUserAgent,
           providerOptions,

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.ts
@@ -45,6 +45,7 @@ export class BedrockEmbeddingModel implements EmbeddingModelV4 {
 
   async doEmbed({
     values,
+    dimensions,
     headers,
     abortSignal,
     providerOptions,
@@ -81,7 +82,8 @@ export class BedrockEmbeddingModel implements EmbeddingModelV4 {
           singleEmbeddingParams: {
             embeddingPurpose:
               bedrockOptions.embeddingPurpose ?? 'GENERIC_INDEX',
-            embeddingDimension: bedrockOptions.embeddingDimension ?? 1024,
+            embeddingDimension:
+              bedrockOptions.embeddingDimension ?? dimensions ?? 1024,
             text: {
               truncationMode: bedrockOptions.truncate ?? 'END',
               value: values[0],
@@ -95,11 +97,11 @@ export class BedrockEmbeddingModel implements EmbeddingModelV4 {
             input_type: bedrockOptions.inputType ?? 'search_query',
             texts: [values[0]],
             truncate: bedrockOptions.truncate,
-            output_dimension: bedrockOptions.outputDimension,
+            output_dimension: bedrockOptions.outputDimension ?? dimensions,
           }
         : {
             inputText: values[0],
-            dimensions: bedrockOptions.dimensions,
+            dimensions: bedrockOptions.dimensions ?? dimensions,
             normalize: bedrockOptions.normalize,
           };
 

--- a/packages/cohere/src/cohere-embedding-model.ts
+++ b/packages/cohere/src/cohere-embedding-model.ts
@@ -43,6 +43,7 @@ export class CohereEmbeddingModel implements EmbeddingModelV4 {
 
   async doEmbed({
     values,
+    dimensions,
     headers,
     abortSignal,
     providerOptions,
@@ -80,7 +81,7 @@ export class CohereEmbeddingModel implements EmbeddingModelV4 {
         texts: values,
         input_type: embeddingOptions?.inputType ?? 'search_query',
         truncate: embeddingOptions?.truncate,
-        output_dimension: embeddingOptions?.outputDimension,
+        output_dimension: embeddingOptions?.outputDimension ?? dimensions,
       },
       failedResponseHandler: cohereFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(

--- a/packages/google-vertex/src/google-vertex-embedding-model.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.ts
@@ -39,6 +39,7 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV4 {
 
   async doEmbed({
     values,
+    dimensions,
     headers,
     abortSignal,
     providerOptions,
@@ -90,7 +91,8 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV4 {
           title: googleOptions.title,
         })),
         parameters: {
-          outputDimensionality: googleOptions.outputDimensionality,
+          outputDimensionality:
+            googleOptions.outputDimensionality ?? dimensions,
           autoTruncate: googleOptions.autoTruncate,
         },
       },

--- a/packages/google/src/google-generative-ai-embedding-model.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.ts
@@ -47,6 +47,7 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV4 {
 
   async doEmbed({
     values,
+    dimensions,
     headers,
     abortSignal,
     providerOptions,
@@ -106,7 +107,8 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV4 {
           content: {
             parts,
           },
-          outputDimensionality: googleOptions?.outputDimensionality,
+          outputDimensionality:
+            googleOptions?.outputDimensionality ?? dimensions,
           taskType: googleOptions?.taskType,
         },
         failedResponseHandler: googleFailedResponseHandler,
@@ -146,7 +148,8 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV4 {
                   ? [...textPart, ...valueParts]
                   : [{ text: value }],
             },
-            outputDimensionality: googleOptions?.outputDimensionality,
+            outputDimensionality:
+              googleOptions?.outputDimensionality ?? dimensions,
             taskType: googleOptions?.taskType,
           };
         }),

--- a/packages/mistral/src/mistral-embedding-model.test.ts
+++ b/packages/mistral/src/mistral-embedding-model.test.ts
@@ -124,4 +124,13 @@ describe('doEmbed', () => {
       `ai-sdk/mistral/0.0.0-test`,
     );
   });
+
+  it('should throw UnsupportedFunctionalityError when dimensions is set', async () => {
+    await expect(
+      provider.embedding('mistral-embed').doEmbed({
+        values: testValues,
+        dimensions: 256,
+      }),
+    ).rejects.toThrow("'dimensions' functionality not supported.");
+  });
 });

--- a/packages/mistral/src/mistral-embedding-model.ts
+++ b/packages/mistral/src/mistral-embedding-model.ts
@@ -1,6 +1,7 @@
 import {
   EmbeddingModelV4,
   TooManyEmbeddingValuesForCallError,
+  UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -41,11 +42,18 @@ export class MistralEmbeddingModel implements EmbeddingModelV4 {
 
   async doEmbed({
     values,
+    dimensions,
     abortSignal,
     headers,
   }: Parameters<EmbeddingModelV4['doEmbed']>[0]): Promise<
     Awaited<ReturnType<EmbeddingModelV4['doEmbed']>>
   > {
+    if (dimensions != null) {
+      throw new UnsupportedFunctionalityError({
+        functionality: 'dimensions',
+      });
+    }
+
     if (values.length > this.maxEmbeddingsPerCall) {
       throw new TooManyEmbeddingValuesForCallError({
         provider: this.provider,

--- a/packages/openai/src/embedding/openai-embedding-model.test.ts
+++ b/packages/openai/src/embedding/openai-embedding-model.test.ts
@@ -130,6 +130,49 @@ describe('doEmbed', () => {
     `);
   });
 
+  it('should pass the top-level dimensions setting', async () => {
+    prepareJsonFixtureResponse('openai-embedding');
+
+    await provider.embedding('text-embedding-3-large').doEmbed({
+      values: testValues,
+      dimensions: 128,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "dimensions": 128,
+        "encoding_format": "float",
+        "input": [
+          "sunny day at the beach",
+          "rainy day in the city",
+        ],
+        "model": "text-embedding-3-large",
+      }
+    `);
+  });
+
+  it('should prefer providerOptions dimensions over top-level dimensions', async () => {
+    prepareJsonFixtureResponse('openai-embedding');
+
+    await provider.embedding('text-embedding-3-large').doEmbed({
+      values: testValues,
+      dimensions: 128,
+      providerOptions: { openai: { dimensions: 64 } },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "dimensions": 64,
+        "encoding_format": "float",
+        "input": [
+          "sunny day at the beach",
+          "rainy day in the city",
+        ],
+        "model": "text-embedding-3-large",
+      }
+    `);
+  });
+
   it('should pass headers', async () => {
     prepareJsonFixtureResponse('openai-embedding');
 

--- a/packages/openai/src/embedding/openai-embedding-model.ts
+++ b/packages/openai/src/embedding/openai-embedding-model.ts
@@ -35,6 +35,7 @@ export class OpenAIEmbeddingModel implements EmbeddingModelV4 {
 
   async doEmbed({
     values,
+    dimensions,
     headers,
     abortSignal,
     providerOptions,
@@ -72,7 +73,7 @@ export class OpenAIEmbeddingModel implements EmbeddingModelV4 {
         model: this.modelId,
         input: values,
         encoding_format: 'float',
-        dimensions: openaiOptions.dimensions,
+        dimensions: openaiOptions.dimensions ?? dimensions,
         user: openaiOptions.user,
       },
       failedResponseHandler: openaiFailedResponseHandler,

--- a/packages/provider/src/embedding-model/v3/embedding-model-v3-call-options.ts
+++ b/packages/provider/src/embedding-model/v3/embedding-model-v3-call-options.ts
@@ -12,6 +12,12 @@ export type EmbeddingModelV3CallOptions = {
   abortSignal?: AbortSignal;
 
   /**
+   * The number of dimensions the resulting output embeddings should have.
+   * Only supported by some models and providers.
+   */
+  dimensions?: number;
+
+  /**
    * Additional provider-specific options. They are passed through
    * to the provider from the AI SDK and enable provider-specific
    * functionality that can be fully encapsulated in the provider.


### PR DESCRIPTION
Adds a `dimensions` parameter to `embed()` and `embedMany()` that configures the output dimensionality of embedding models. This provides a unified API instead of requiring provider-specific `providerOptions`.

Supported providers: OpenAI, OpenAI-compatible, Google, Google Vertex, Cohere, Amazon Bedrock.

Providers that don't support dimensionality reduction throw `UnsupportedFunctionalityError` when `dimensions` is set.

Provider-specific `providerOptions` take precedence over the top-level `dimensions` when both are specified.

Closes #12613