### PR TITLE
chore: remove obsolete Gemini models from examples

### DIFF
--- a/examples/ai-functions/src/e2e/google-vertex.test.ts
+++ b/examples/ai-functions/src/e2e/google-vertex.test.ts
@@ -95,11 +95,8 @@ const createModelsForRuntime = (
 ) => ({
   invalidModel: vertex('no-such-model'),
   languageModels: [
-    ...createModelVariants(vertex, 'gemini-2.0-flash-exp'),
-    ...createModelVariants(vertex, 'gemini-1.5-flash'),
-    // Gemini 2.0 and Pro models have low quota limits and may require billing enabled.
-    // ...createModelVariants(vertex, 'gemini-1.5-pro-001'),
-    // ...createModelVariants(vertex, 'gemini-1.0-pro-001'),
+    ...createModelVariants(vertex, 'gemini-2.5-flash-image'),
+    ...createModelVariants(vertex, 'gemini-2.5-flash'),
   ],
   embeddingModels: [
     createEmbeddingModelWithCapabilities(

--- a/examples/ai-functions/src/e2e/google.test.ts
+++ b/examples/ai-functions/src/e2e/google.test.ts
@@ -52,12 +52,12 @@ createFeatureTestSuite({
   models: {
     invalidModel: provider.chat('no-such-model'),
     languageModels: [
-      createSearchGroundedModel('gemini-1.5-flash-latest'),
-      createChatModel('gemini-1.5-flash-latest'),
+      createSearchGroundedModel('gemini-2.5-flash'),
+      createChatModel('gemini-2.5-flash'),
       // Gemini 2.0 and Pro models have low quota limits and may require billing enabled.
-      // createChatModel('gemini-2.0-flash-exp'),
-      // createSearchGroundedModel('gemini-2.0-flash-exp'),
-      // createChatModel('gemini-1.5-pro-latest'),
+      // createChatModel('gemini-2.5-flash-image'),
+      // createSearchGroundedModel('gemini-2.5-flash-image'),
+      // createChatModel('gemini-2.5-pro'),
       // createChatModel('gemini-1.0-pro'),
     ],
     embeddingModels: [

--- a/examples/ai-functions/src/e2e/raw-chunks.test.ts
+++ b/examples/ai-functions/src/e2e/raw-chunks.test.ts
@@ -11,7 +11,7 @@ describe('Raw Chunks E2E Tests', () => {
   const providers = [
     { name: 'OpenAI', model: openai('gpt-4o-mini') },
     { name: 'Anthropic', model: anthropic('claude-3-5-haiku-latest') },
-    { name: 'Google', model: google('gemini-1.5-flash') },
+    { name: 'Google', model: google('gemini-2.5-flash') },
   ];
 
   providers.forEach(({ name, model }) => {

--- a/examples/ai-functions/src/generate-object/google-enum.ts
+++ b/examples/ai-functions/src/generate-object/google-enum.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateObject({
-    model: google('gemini-1.5-pro-latest'),
+    model: google('gemini-2.5-pro'),
     output: 'enum',
     enum: ['action', 'comedy', 'drama', 'horror', 'sci-fi'],
     prompt:

--- a/examples/ai-functions/src/generate-object/google-gemini-files.ts
+++ b/examples/ai-functions/src/generate-object/google-gemini-files.ts
@@ -18,7 +18,7 @@ run(async () => {
   });
 
   const { object: summary } = await generateObject({
-    model: google('gemini-1.5-pro-latest'),
+    model: google('gemini-2.5-pro'),
     schema: z.object({
       title: z.string(),
       keyPoints: z.array(z.string()),

--- a/examples/ai-functions/src/generate-object/google-no-structured-output.ts
+++ b/examples/ai-functions/src/generate-object/google-no-structured-output.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateObject({
-    model: google('gemini-1.5-pro-latest'),
+    model: google('gemini-2.5-pro'),
     providerOptions: {
       google: {
         structuredOutputs: false,

--- a/examples/ai-functions/src/generate-object/google-pdf-url.ts
+++ b/examples/ai-functions/src/generate-object/google-pdf-url.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const { object: summary } = await generateObject({
-    model: google('gemini-1.5-pro-latest'),
+    model: google('gemini-2.5-pro'),
     schema: z.object({
       title: z.string(),
       authors: z.array(z.string()),

--- a/examples/ai-functions/src/generate-object/google-vertex.ts
+++ b/examples/ai-functions/src/generate-object/google-vertex.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateObject({
-    model: vertex('gemini-1.5-pro'),
+    model: vertex('gemini-2.5-pro'),
     schema: z.object({
       recipe: z.object({
         name: z.literal('Lasagna'),

--- a/examples/ai-functions/src/generate-text/google-audio.ts
+++ b/examples/ai-functions/src/generate-text/google-audio.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-1.5-flash'),
+    model: google('gemini-2.5-flash'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/google-chatbot-image-output.ts
+++ b/examples/ai-functions/src/generate-text/google-chatbot-image-output.ts
@@ -16,7 +16,7 @@ run(async () => {
     messages.push({ role: 'user', content: await terminal.question('You: ') });
 
     const result = await generateText({
-      model: google('gemini-2.0-flash-exp'),
+      model: google('gemini-2.5-flash-image'),
       providerOptions: {
         google: {
           responseModalities: ['TEXT', 'IMAGE'],

--- a/examples/ai-functions/src/generate-text/google-custom-fetch.ts
+++ b/examples/ai-functions/src/generate-text/google-custom-fetch.ts
@@ -16,7 +16,7 @@ const google = createGoogleGenerativeAI({
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-1.5-pro-latest'),
+    model: google('gemini-2.5-pro'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/generate-text/google-image-output.ts
+++ b/examples/ai-functions/src/generate-text/google-image-output.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-2.0-flash-exp'),
+    model: google('gemini-2.5-flash-image'),
     prompt: 'Generate an image of a comic cat',
   });
 

--- a/examples/ai-functions/src/generate-text/google-image-url.ts
+++ b/examples/ai-functions/src/generate-text/google-image-url.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-1.5-flash'),
+    model: google('gemini-2.5-flash'),
     maxOutputTokens: 512,
     messages: [
       {

--- a/examples/ai-functions/src/generate-text/google-image.ts
+++ b/examples/ai-functions/src/generate-text/google-image.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-1.5-flash'),
+    model: google('gemini-2.5-flash'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/google-multi-step.ts
+++ b/examples/ai-functions/src/generate-text/google-multi-step.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const { text } = await generateText({
-    model: google('gemini-1.5-pro'),
+    model: google('gemini-2.5-pro'),
     tools: {
       currentLocation: tool({
         description: 'Get the current location.',

--- a/examples/ai-functions/src/generate-text/google-pdf.ts
+++ b/examples/ai-functions/src/generate-text/google-pdf.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-1.5-flash'),
+    model: google('gemini-2.5-flash'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/google-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/google-tool-call.ts
@@ -6,7 +6,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-1.5-pro-latest'),
+    model: google('gemini-2.5-pro'),
     maxOutputTokens: 512,
     tools: {
       weather: weatherTool,

--- a/examples/ai-functions/src/generate-text/google-tool-choice.ts
+++ b/examples/ai-functions/src/generate-text/google-tool-choice.ts
@@ -6,7 +6,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-1.5-pro-latest'),
+    model: google('gemini-2.5-pro'),
     maxOutputTokens: 512,
     tools: {
       weather: weatherTool,

--- a/examples/ai-functions/src/generate-text/google-vertex-audio.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-audio.ts
@@ -6,7 +6,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: vertex('gemini-1.5-flash'),
+    model: vertex('gemini-2.5-flash'),
     providerOptions: {
       google: {
         audioTimestamp: true,

--- a/examples/ai-functions/src/generate-text/google-vertex-image-base64.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-image-base64.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: vertex('gemini-1.5-flash'),
+    model: vertex('gemini-2.5-flash'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/google-vertex-image-url.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-image-url.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: vertex('gemini-1.5-flash'),
+    model: vertex('gemini-2.5-flash'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/google-vertex-multi-step.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-multi-step.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const { text } = await generateText({
-    model: vertex('gemini-1.5-flash'),
+    model: vertex('gemini-2.5-flash'),
     tools: {
       currentLocation: tool({
         description: 'Get the current location.',

--- a/examples/ai-functions/src/generate-text/google-vertex-output-object.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-output-object.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const { output } = await generateText({
-    model: vertex('gemini-1.5-flash'),
+    model: vertex('gemini-2.5-flash'),
     output: Output.object({
       schema: z.object({
         name: z.string(),

--- a/examples/ai-functions/src/generate-text/google-vertex-pdf-url.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-pdf-url.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: vertex('gemini-1.5-flash'),
+    model: vertex('gemini-2.5-flash'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/google-vertex-pdf.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex-pdf.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: vertex('gemini-1.5-flash'),
+    model: vertex('gemini-2.5-flash'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/google-vertex.ts
+++ b/examples/ai-functions/src/generate-text/google-vertex.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: vertex('gemini-1.5-flash'),
+    model: vertex('gemini-2.5-flash'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/generate-text/google-youtube-url.ts
+++ b/examples/ai-functions/src/generate-text/google-youtube-url.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-1.5-flash'),
+    model: google('gemini-2.5-flash'),
     maxOutputTokens: 512,
     messages: [
       {

--- a/examples/ai-functions/src/stream-object/google-vertex.ts
+++ b/examples/ai-functions/src/stream-object/google-vertex.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = streamObject({
-    model: vertex('gemini-1.5-pro'),
+    model: vertex('gemini-2.5-pro'),
     schema: z.object({
       characters: z.array(
         z.object({

--- a/examples/ai-functions/src/stream-object/google.ts
+++ b/examples/ai-functions/src/stream-object/google.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = streamObject({
-    model: google('gemini-1.5-pro-002'),
+    model: google('gemini-2.5-pro'),
     schema: z.object({
       characters: z.array(
         z.object({

--- a/examples/ai-functions/src/stream-text/google-chatbot-image-output.ts
+++ b/examples/ai-functions/src/stream-text/google-chatbot-image-output.ts
@@ -16,7 +16,7 @@ run(async () => {
     messages.push({ role: 'user', content: await terminal.question('You: ') });
 
     const result = streamText({
-      model: google('gemini-2.0-flash-exp'),
+      model: google('gemini-2.5-flash-image'),
       messages,
     });
 

--- a/examples/ai-functions/src/stream-text/google-fullstream.ts
+++ b/examples/ai-functions/src/stream-text/google-fullstream.ts
@@ -6,7 +6,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: google('gemini-1.5-pro-latest'),
+    model: google('gemini-2.5-pro'),
     tools: {
       weather: weatherTool,
       cityAttractions: {

--- a/examples/ai-functions/src/stream-text/google-image-output.ts
+++ b/examples/ai-functions/src/stream-text/google-image-output.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: google('gemini-2.0-flash-exp'),
+    model: google('gemini-2.5-flash-image'),
     prompt: 'Generate an image of a comic cat',
   });
 

--- a/examples/ai-functions/src/stream-text/google-vertex-fullstream.ts
+++ b/examples/ai-functions/src/stream-text/google-vertex-fullstream.ts
@@ -6,7 +6,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: vertex('gemini-1.5-pro'),
+    model: vertex('gemini-2.5-pro'),
     tools: {
       weather: weatherTool,
       cityAttractions: {

--- a/examples/ai-functions/src/stream-text/google-youtube-url.ts
+++ b/examples/ai-functions/src/stream-text/google-youtube-url.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: google('gemini-1.5-pro-latest'),
+    model: google('gemini-2.5-pro'),
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/stream-text/google.ts
+++ b/examples/ai-functions/src/stream-text/google.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: google('gemini-1.5-pro-latest'),
+    model: google('gemini-2.5-pro'),
     system: 'You are a comedian. Only give funny answers.',
     prompt: 'Invent a new holiday and describe its traditions.',
   });


### PR DESCRIPTION
## Background

The Gemini 1.5 model family and `gemini-2.0-flash-exp` (which was Google's first multimodal image generation model) are no longer around.

## Summary

Updates all examples that use one of them to use an equivalent available model.

## Related PRs

#12494