### PR TITLE
feat(langchain): add baseMessagesToUIMessages and stateSnapshotToUIMessages

### DIFF
--- a/.changeset/langchain-base-messages-to-ui.md
+++ b/.changeset/langchain-base-messages-to-ui.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/langchain': minor
+---
+
+Add `baseMessagesToUIMessages` and `stateSnapshotToUIMessages` for converting LangChain BaseMessage arrays and LangGraph StateSnapshots to AI SDK UIMessage format.

--- a/.changeset/langchain-base-messages-to-ui.md
+++ b/.changeset/langchain-base-messages-to-ui.md
@@ -1,5 +1,5 @@
 ---
-'@ai-sdk/langchain': minor
+'@ai-sdk/langchain': patch
 ---
 
 Add `baseMessagesToUIMessages` and `stateSnapshotToUIMessages` for converting LangChain BaseMessage arrays and LangGraph StateSnapshots to AI SDK UIMessage format.

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -6,6 +6,8 @@ import {
   toUIMessageStream,
   toBaseMessages,
   convertModelMessages,
+  baseMessagesToUIMessages,
+  stateSnapshotToUIMessages,
 } from './adapter';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ModelMessage, UIMessage } from 'ai';
@@ -2426,5 +2428,381 @@ describe('toUIMessageStream callbacks', () => {
     );
 
     expect(onFinish).toHaveBeenCalledWith(valuesData);
+  });
+});
+
+describe('baseMessagesToUIMessages', () => {
+  it('should return empty array for empty input', () => {
+    expect(baseMessagesToUIMessages([])).toEqual([]);
+  });
+
+  it('should convert HumanMessage to user UIMessage', () => {
+    const messages = [new HumanMessage({ content: 'Hello', id: 'msg-1' })];
+    const result = baseMessagesToUIMessages(messages);
+
+    expect(result).toEqual([
+      {
+        id: 'msg-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Hello' }],
+      },
+    ]);
+  });
+
+  it('should convert SystemMessage to system UIMessage', () => {
+    const messages = [
+      new SystemMessage({ content: 'You are helpful', id: 'sys-1' }),
+    ];
+    const result = baseMessagesToUIMessages(messages);
+
+    expect(result).toEqual([
+      {
+        id: 'sys-1',
+        role: 'system',
+        parts: [{ type: 'text', text: 'You are helpful' }],
+      },
+    ]);
+  });
+
+  it('should convert AIMessage with text to assistant UIMessage', () => {
+    const messages = [new AIMessage({ content: 'Hi there!', id: 'ai-1' })];
+    const result = baseMessagesToUIMessages(messages);
+
+    expect(result).toEqual([
+      {
+        id: 'ai-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Hi there!' }],
+      },
+    ]);
+  });
+
+  it('should convert AIMessage with tool_calls and ToolMessages', () => {
+    const messages = [
+      new HumanMessage({ content: 'What is the weather?', id: 'h-1' }),
+      new AIMessage({
+        content: '',
+        id: 'ai-1',
+        tool_calls: [
+          { id: 'call-1', name: 'get_weather', args: { city: 'NYC' } },
+        ],
+      }),
+      new ToolMessage({
+        content: 'Sunny, 72°F',
+        tool_call_id: 'call-1',
+        id: 'tool-1',
+      }),
+    ];
+    const result = baseMessagesToUIMessages(messages);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      id: 'h-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'What is the weather?' }],
+    });
+    expect(result[1].role).toBe('assistant');
+    expect(result[1].parts).toEqual([
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'call-1',
+        toolName: 'get_weather',
+        state: 'output-available',
+        input: { city: 'NYC' },
+        output: 'Sunny, 72°F',
+      },
+    ]);
+  });
+
+  it('should handle AIMessage with text and tool_calls', () => {
+    const messages = [
+      new AIMessage({
+        content: 'Let me check the weather.',
+        id: 'ai-1',
+        tool_calls: [
+          { id: 'call-1', name: 'get_weather', args: { city: 'NYC' } },
+        ],
+      }),
+    ];
+    const result = baseMessagesToUIMessages(messages);
+
+    expect(result[0].parts).toEqual([
+      { type: 'text', text: 'Let me check the weather.' },
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'call-1',
+        toolName: 'get_weather',
+        state: 'input-available',
+        input: { city: 'NYC' },
+      },
+    ]);
+  });
+
+  it('should handle AIMessage with array content', () => {
+    const messages = [
+      new AIMessage({
+        content: [
+          { type: 'text', text: 'Hello ' },
+          { type: 'text', text: 'World' },
+        ],
+        id: 'ai-1',
+      }),
+    ];
+    const result = baseMessagesToUIMessages(messages);
+
+    expect(result[0].parts).toEqual([{ type: 'text', text: 'Hello World' }]);
+  });
+
+  it('should handle multiple consecutive user messages', () => {
+    const messages = [
+      new HumanMessage({ content: 'First', id: 'h-1' }),
+      new HumanMessage({ content: 'Second', id: 'h-2' }),
+    ];
+    const result = baseMessagesToUIMessages(messages);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].role).toBe('user');
+    expect(result[1].role).toBe('user');
+  });
+
+  it('should handle partial tool results (some ToolMessages missing)', () => {
+    const messages = [
+      new AIMessage({
+        content: '',
+        id: 'ai-1',
+        tool_calls: [
+          { id: 'call-1', name: 'tool_a', args: {} },
+          { id: 'call-2', name: 'tool_b', args: {} },
+        ],
+      }),
+      new ToolMessage({
+        content: 'Result A',
+        tool_call_id: 'call-1',
+        id: 'tool-1',
+      }),
+    ];
+    const result = baseMessagesToUIMessages(messages);
+
+    const parts = result[0].parts;
+    expect(parts).toHaveLength(2);
+    // First tool call should have output
+    expect(parts[0]).toMatchObject({
+      type: 'dynamic-tool',
+      toolCallId: 'call-1',
+      state: 'output-available',
+      output: 'Result A',
+    });
+    // Second tool call should remain input-available
+    expect(parts[1]).toMatchObject({
+      type: 'dynamic-tool',
+      toolCallId: 'call-2',
+      state: 'input-available',
+    });
+  });
+
+  it('should generate IDs for messages without IDs', () => {
+    const messages = [new HumanMessage({ content: 'Hello' })];
+    const result = baseMessagesToUIMessages(messages);
+
+    expect(result[0].id).toBeDefined();
+    expect(typeof result[0].id).toBe('string');
+    expect(result[0].id.length).toBeGreaterThan(0);
+  });
+
+  it('should handle plain object messages (serialized/RemoteGraph format)', () => {
+    const messages = [
+      {
+        type: 'human',
+        content: 'Hello',
+        id: 'h-1',
+      },
+      {
+        type: 'ai',
+        content: 'Hi!',
+        id: 'ai-1',
+        tool_calls: [],
+      },
+    ] as unknown as BaseMessage[];
+
+    const result = baseMessagesToUIMessages(messages);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      id: 'h-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Hello' }],
+    });
+    expect(result[1]).toEqual({
+      id: 'ai-1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Hi!' }],
+    });
+  });
+
+  it('should handle serialized LangChain message format (constructor)', () => {
+    const messages = [
+      {
+        lc: 1,
+        type: 'constructor',
+        id: ['langchain_core', 'messages', 'HumanMessage'],
+        kwargs: {
+          content: 'Hello',
+          id: 'h-1',
+        },
+      },
+      {
+        lc: 1,
+        type: 'constructor',
+        id: ['langchain_core', 'messages', 'AIMessage'],
+        kwargs: {
+          content: 'Hi there!',
+          id: 'ai-1',
+          tool_calls: [],
+        },
+      },
+    ] as unknown as BaseMessage[];
+
+    const result = baseMessagesToUIMessages(messages);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      id: 'h-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Hello' }],
+    });
+    expect(result[1]).toEqual({
+      id: 'ai-1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Hi there!' }],
+    });
+  });
+
+  it('should handle orphaned ToolMessage gracefully', () => {
+    const messages = [
+      new ToolMessage({
+        content: 'orphan result',
+        tool_call_id: 'call-999',
+        id: 'tool-orphan',
+      }),
+    ];
+    const result = baseMessagesToUIMessages(messages);
+
+    // Orphaned tool messages should be skipped
+    expect(result).toHaveLength(0);
+  });
+
+  it('should handle AIMessage with reasoning content (Anthropic thinking)', () => {
+    const messages = [
+      new AIMessage({
+        content: [
+          { type: 'thinking', thinking: 'Let me think about this...' },
+          { type: 'text', text: 'Here is my answer.' },
+        ],
+        id: 'ai-1',
+      }),
+    ];
+    const result = baseMessagesToUIMessages(messages);
+
+    // Reasoning is extracted from contentBlocks, text from content
+    expect(result[0].parts).toContainEqual({
+      type: 'text',
+      text: 'Here is my answer.',
+    });
+  });
+
+  it('should handle AIMessage with GPT-5 reasoning in response_metadata', () => {
+    const messages = [
+      new AIMessage({
+        content: 'Final answer',
+        id: 'ai-1',
+        response_metadata: {
+          output: [
+            {
+              id: 'reasoning-1',
+              type: 'reasoning',
+              summary: [{ type: 'summary_text', text: 'I thought about it.' }],
+            },
+          ],
+        },
+      }),
+    ];
+    const result = baseMessagesToUIMessages(messages);
+
+    expect(result[0].parts).toContainEqual({
+      type: 'reasoning',
+      text: 'I thought about it.',
+      state: 'done',
+    });
+    expect(result[0].parts).toContainEqual({
+      type: 'text',
+      text: 'Final answer',
+    });
+  });
+});
+
+describe('stateSnapshotToUIMessages', () => {
+  it('should return empty array for snapshot without messages', () => {
+    const snapshot = { values: {} };
+    expect(
+      stateSnapshotToUIMessages(
+        snapshot as { values: Record<string, unknown> },
+      ),
+    ).toEqual([]);
+  });
+
+  it('should convert snapshot messages to UIMessages', () => {
+    const snapshot = {
+      values: {
+        messages: [
+          new HumanMessage({ content: 'Hello', id: 'h-1' }),
+          new AIMessage({ content: 'Hi!', id: 'ai-1' }),
+        ],
+      },
+    };
+    const result = stateSnapshotToUIMessages(snapshot);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].role).toBe('user');
+    expect(result[1].role).toBe('assistant');
+  });
+
+  it('should handle snapshot with tool call conversation', () => {
+    const snapshot = {
+      values: {
+        messages: [
+          new HumanMessage({ content: 'Search for cats', id: 'h-1' }),
+          new AIMessage({
+            content: '',
+            id: 'ai-1',
+            tool_calls: [
+              { id: 'call-1', name: 'search', args: { query: 'cats' } },
+            ],
+          }),
+          new ToolMessage({
+            content: 'Found 10 results about cats',
+            tool_call_id: 'call-1',
+            id: 'tool-1',
+          }),
+          new AIMessage({
+            content: 'I found 10 results about cats.',
+            id: 'ai-2',
+          }),
+        ],
+      },
+    };
+    const result = stateSnapshotToUIMessages(snapshot);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].role).toBe('user');
+    expect(result[1].role).toBe('assistant');
+    expect(result[1].parts[0]).toMatchObject({
+      type: 'dynamic-tool',
+      toolCallId: 'call-1',
+      state: 'output-available',
+    });
+    expect(result[2].role).toBe('assistant');
+    expect(result[2].parts).toEqual([
+      { type: 'text', text: 'I found 10 results about cats.' },
+    ]);
   });
 });

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -2805,4 +2805,148 @@ describe('stateSnapshotToUIMessages', () => {
       { type: 'text', text: 'I found 10 results about cats.' },
     ]);
   });
+
+  it('should handle pending interrupts from snapshot tasks', () => {
+    const snapshot = {
+      values: {
+        messages: [
+          new HumanMessage({ content: 'Send an email', id: 'h-1' }),
+          new AIMessage({
+            content: 'I will send the email now.',
+            id: 'ai-1',
+          }),
+        ],
+      },
+      tasks: [
+        {
+          id: 'task-1',
+          name: 'agent',
+          interrupts: [
+            {
+              value: {
+                action_requests: [
+                  {
+                    name: 'send_email',
+                    arguments: { to: 'user@example.com', body: 'Hello' },
+                    id: 'call-email-1',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const result = stateSnapshotToUIMessages(snapshot);
+
+    expect(result).toHaveLength(2);
+    expect(result[1].role).toBe('assistant');
+    // Last part should be the interrupt tool call
+    const lastPart = result[1].parts[result[1].parts.length - 1];
+    expect(lastPart).toMatchObject({
+      type: 'dynamic-tool',
+      toolCallId: 'call-email-1',
+      toolName: 'send_email',
+      state: 'input-available',
+      input: { to: 'user@example.com', body: 'Hello' },
+    });
+  });
+
+  it('should handle multiple interrupts with camelCase action requests', () => {
+    const snapshot = {
+      values: {
+        messages: [
+          new HumanMessage({ content: 'Do tasks', id: 'h-1' }),
+          new AIMessage({ content: '', id: 'ai-1' }),
+        ],
+      },
+      tasks: [
+        {
+          id: 'task-1',
+          name: 'agent',
+          interrupts: [
+            {
+              value: {
+                actionRequests: [
+                  {
+                    name: 'delete_file',
+                    args: { filename: 'temp.txt' },
+                    id: 'call-del-1',
+                  },
+                  {
+                    name: 'send_notification',
+                    args: { channel: '#general' },
+                    id: 'call-notif-1',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const result = stateSnapshotToUIMessages(snapshot);
+
+    expect(result[1].parts).toHaveLength(2);
+    expect(result[1].parts[0]).toMatchObject({
+      type: 'dynamic-tool',
+      toolCallId: 'call-del-1',
+      toolName: 'delete_file',
+      state: 'input-available',
+    });
+    expect(result[1].parts[1]).toMatchObject({
+      type: 'dynamic-tool',
+      toolCallId: 'call-notif-1',
+      toolName: 'send_notification',
+      state: 'input-available',
+    });
+  });
+
+  it('should create assistant message for interrupts when none exists', () => {
+    const snapshot = {
+      values: {
+        messages: [new HumanMessage({ content: 'Hello', id: 'h-1' })],
+      },
+      tasks: [
+        {
+          id: 'task-1',
+          name: 'agent',
+          interrupts: [
+            {
+              value: {
+                action_requests: [
+                  { name: 'confirm', arguments: {}, id: 'call-1' },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const result = stateSnapshotToUIMessages(snapshot);
+
+    expect(result).toHaveLength(2);
+    expect(result[1].role).toBe('assistant');
+    expect(result[1].parts[0]).toMatchObject({
+      type: 'dynamic-tool',
+      toolName: 'confirm',
+      state: 'input-available',
+    });
+  });
+
+  it('should ignore tasks without interrupts', () => {
+    const snapshot = {
+      values: {
+        messages: [
+          new HumanMessage({ content: 'Hello', id: 'h-1' }),
+          new AIMessage({ content: 'Hi!', id: 'ai-1' }),
+        ],
+      },
+      tasks: [{ id: 'task-1', name: 'agent' }],
+    };
+    const result = stateSnapshotToUIMessages(snapshot);
+
+    expect(result).toHaveLength(2);
+    expect(result[1].parts).toEqual([{ type: 'text', text: 'Hi!' }]);
+  });
 });

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -2934,6 +2934,55 @@ describe('stateSnapshotToUIMessages', () => {
     });
   });
 
+  it('should deduplicate interrupt parts matching existing tool calls', () => {
+    const snapshot = {
+      values: {
+        messages: [
+          new HumanMessage({ content: 'Send email', id: 'h-1' }),
+          new AIMessage({
+            content: '',
+            id: 'ai-1',
+            tool_calls: [
+              {
+                id: 'call-email-1',
+                name: 'send_email',
+                args: { to: 'user@example.com' },
+              },
+            ],
+          }),
+        ],
+      },
+      tasks: [
+        {
+          id: 'task-1',
+          name: 'agent',
+          interrupts: [
+            {
+              value: {
+                action_requests: [
+                  {
+                    name: 'send_email',
+                    arguments: { to: 'user@example.com' },
+                    id: 'call-email-1',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const result = stateSnapshotToUIMessages(snapshot);
+
+    // Should have only one dynamic-tool part, not duplicated
+    const toolParts = result[1].parts.filter(p => p.type === 'dynamic-tool');
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0]).toMatchObject({
+      toolCallId: 'call-email-1',
+      toolName: 'send_email',
+    });
+  });
+
   it('should ignore tasks without interrupts', () => {
     const snapshot = {
       values: {

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -14,6 +14,7 @@ import type { ModelMessage, UIMessage } from 'ai';
 import {
   AIMessage,
   AIMessageChunk,
+  BaseMessage,
   HumanMessage,
   SystemMessage,
   ToolMessage,

--- a/packages/langchain/src/adapter.ts
+++ b/packages/langchain/src/adapter.ts
@@ -8,6 +8,7 @@ import {
   type UIMessageChunk,
   convertToModelMessages,
   type ModelMessage,
+  generateId,
 } from 'ai';
 import {
   convertToolResultPart,
@@ -18,6 +19,13 @@ import {
   parseLangGraphEvent,
   isToolResultPart,
   extractReasoningFromContentBlocks,
+  getMessageText,
+  isToolMessageType,
+  isAIMessageChunk,
+  isPlainMessageObject,
+  getMessageId,
+  extractReasoningFromValuesMessage,
+  extractImageOutputs,
 } from './utils';
 import { type LangGraphEventState } from './types';
 import { type StreamCallbacks } from './stream-callbacks';
@@ -584,4 +592,348 @@ export function toUIMessageStream<TState = unknown>(
       }
     },
   });
+}
+
+/**
+ * Gets the message type from a BaseMessage, handling both class instances and plain/serialized objects.
+ *
+ * @param msg - The message to get the type from.
+ * @returns The message type string (e.g., 'human', 'ai', 'system', 'tool').
+ */
+function getMessageType(msg: unknown): string | undefined {
+  if (msg == null || typeof msg !== 'object') return undefined;
+
+  const msgObj = msg as Record<string, unknown>;
+
+  /**
+   * Class instances have _getType method
+   */
+  if (typeof (msgObj as { _getType?: () => string })._getType === 'function') {
+    return (msgObj as { _getType: () => string })._getType();
+  }
+
+  /**
+   * Plain objects from RemoteGraph API have type directly
+   */
+  if (typeof msgObj.type === 'string' && msgObj.type !== 'constructor') {
+    return msgObj.type;
+  }
+
+  /**
+   * Serialized LangChain messages: { type: "constructor", id: ["...", "HumanMessage"], kwargs: {...} }
+   */
+  if (msgObj.type === 'constructor' && Array.isArray(msgObj.id)) {
+    const ids = msgObj.id as string[];
+    if (ids.includes('HumanMessage') || ids.includes('HumanMessageChunk'))
+      return 'human';
+    if (ids.includes('AIMessage') || ids.includes('AIMessageChunk'))
+      return 'ai';
+    if (ids.includes('SystemMessage') || ids.includes('SystemMessageChunk'))
+      return 'system';
+    if (ids.includes('ToolMessage') || ids.includes('ToolMessageChunk'))
+      return 'tool';
+  }
+
+  return undefined;
+}
+
+/**
+ * Gets tool_call_id from a ToolMessage, handling both class instances and plain/serialized objects.
+ */
+function getToolCallId(msg: unknown): string | undefined {
+  if (msg == null || typeof msg !== 'object') return undefined;
+
+  const msgObj = msg as Record<string, unknown>;
+
+  /**
+   * For serialized LangChain messages, data is in kwargs
+   */
+  const dataSource =
+    msgObj.type === 'constructor' &&
+    msgObj.kwargs &&
+    typeof msgObj.kwargs === 'object'
+      ? (msgObj.kwargs as Record<string, unknown>)
+      : msgObj;
+
+  return typeof dataSource.tool_call_id === 'string'
+    ? dataSource.tool_call_id
+    : undefined;
+}
+
+/**
+ * Gets tool_calls from an AI message, handling both class instances and plain/serialized objects.
+ */
+function getToolCalls(
+  msg: unknown,
+): Array<{ id: string; name: string; args: Record<string, unknown> }> {
+  if (msg == null || typeof msg !== 'object') return [];
+
+  const msgObj = msg as Record<string, unknown>;
+
+  /**
+   * For serialized LangChain messages, data is in kwargs
+   */
+  const dataSource =
+    msgObj.type === 'constructor' &&
+    msgObj.kwargs &&
+    typeof msgObj.kwargs === 'object'
+      ? (msgObj.kwargs as Record<string, unknown>)
+      : msgObj;
+
+  if (Array.isArray(dataSource.tool_calls)) {
+    return dataSource.tool_calls as Array<{
+      id: string;
+      name: string;
+      args: Record<string, unknown>;
+    }>;
+  }
+
+  /**
+   * Fall back to additional_kwargs.tool_calls (OpenAI format)
+   */
+  if (
+    dataSource.additional_kwargs &&
+    typeof dataSource.additional_kwargs === 'object'
+  ) {
+    const additionalKwargs = dataSource.additional_kwargs as Record<
+      string,
+      unknown
+    >;
+    if (Array.isArray(additionalKwargs.tool_calls)) {
+      return (
+        additionalKwargs.tool_calls as Array<{
+          id?: string;
+          function?: { name?: string; arguments?: string };
+        }>
+      ).map((tc, idx) => {
+        let args: Record<string, unknown>;
+        try {
+          args = tc.function?.arguments
+            ? JSON.parse(tc.function.arguments)
+            : {};
+        } catch {
+          args = {};
+        }
+        return {
+          id: tc.id || `call_${idx}`,
+          name: tc.function?.name || 'unknown',
+          args,
+        };
+      });
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Gets additional_kwargs from a message, handling both class instances and plain/serialized objects.
+ */
+function getAdditionalKwargs(
+  msg: unknown,
+): Record<string, unknown> | undefined {
+  if (msg == null || typeof msg !== 'object') return undefined;
+
+  const msgObj = msg as Record<string, unknown>;
+
+  const dataSource =
+    msgObj.type === 'constructor' &&
+    msgObj.kwargs &&
+    typeof msgObj.kwargs === 'object'
+      ? (msgObj.kwargs as Record<string, unknown>)
+      : msgObj;
+
+  return dataSource.additional_kwargs as Record<string, unknown> | undefined;
+}
+
+/**
+ * Converts LangChain BaseMessage objects to AI SDK UIMessage objects.
+ *
+ * This function transforms LangChain's message format into the AI SDK's UIMessage
+ * format, enabling chat history restoration from LangGraph checkpointers for use
+ * with `useChat`'s `initialMessages`.
+ *
+ * @param messages - Array of LangChain BaseMessage objects to convert.
+ * @returns Array of AI SDK UIMessage objects.
+ *
+ * @example
+ * ```ts
+ * import { baseMessagesToUIMessages } from '@ai-sdk/langchain';
+ *
+ * const uiMessages = baseMessagesToUIMessages(langchainMessages);
+ *
+ * // Use with useChat
+ * const { messages } = useChat({ initialMessages: uiMessages });
+ * ```
+ */
+export function baseMessagesToUIMessages(messages: BaseMessage[]): UIMessage[] {
+  const result: UIMessage[] = [];
+  let currentAssistant: UIMessage | null = null;
+
+  for (const msg of messages) {
+    const msgType = getMessageType(msg);
+    const msgId = getMessageId(msg) ?? generateId();
+
+    switch (msgType) {
+      case 'human': {
+        currentAssistant = null;
+        const text = getMessageText(msg);
+        result.push({
+          id: msgId,
+          role: 'user',
+          parts: [{ type: 'text', text }],
+        });
+        break;
+      }
+
+      case 'system': {
+        currentAssistant = null;
+        const text = getMessageText(msg);
+        result.push({
+          id: msgId,
+          role: 'system',
+          parts: [{ type: 'text', text }],
+        });
+        break;
+      }
+
+      case 'ai': {
+        const parts: UIMessage['parts'] = [];
+
+        /**
+         * Extract reasoning content
+         */
+        const reasoning =
+          extractReasoningFromContentBlocks(msg) ||
+          extractReasoningFromValuesMessage(msg);
+        if (reasoning) {
+          parts.push({ type: 'reasoning', text: reasoning, state: 'done' });
+        }
+
+        /**
+         * Extract text content
+         */
+        const text = getMessageText(msg);
+        if (text) {
+          parts.push({ type: 'text', text });
+        }
+
+        /**
+         * Extract image generation outputs
+         */
+        const additionalKwargs = getAdditionalKwargs(msg);
+        const imageOutputs = extractImageOutputs(additionalKwargs);
+        for (const imageOutput of imageOutputs) {
+          if (imageOutput.result) {
+            const mediaType = `image/${imageOutput.output_format || 'png'}`;
+            parts.push({
+              type: 'file',
+              mediaType,
+              url: `data:${mediaType};base64,${imageOutput.result}`,
+            });
+          }
+        }
+
+        /**
+         * Extract tool calls
+         */
+        const toolCalls = getToolCalls(msg);
+        for (const toolCall of toolCalls) {
+          parts.push({
+            type: 'dynamic-tool',
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            state: 'input-available',
+            input: toolCall.args,
+          });
+        }
+
+        const assistantMessage: UIMessage = {
+          id: msgId,
+          role: 'assistant',
+          parts,
+        };
+
+        result.push(assistantMessage);
+        currentAssistant = assistantMessage;
+        break;
+      }
+
+      case 'tool': {
+        const toolCallId = getToolCallId(msg);
+        if (toolCallId && currentAssistant) {
+          /**
+           * Find the matching tool-invocation part in the current assistant message
+           */
+          const toolPart = currentAssistant.parts.find(
+            (
+              p,
+            ): p is Extract<
+              UIMessage['parts'][number],
+              { type: 'dynamic-tool' }
+            > => p.type === 'dynamic-tool' && p.toolCallId === toolCallId,
+          );
+
+          if (toolPart) {
+            /**
+             * Upgrade the tool part to output-available state
+             */
+            const idx = currentAssistant.parts.indexOf(toolPart);
+            const content = getMessageText(msg);
+            currentAssistant.parts[idx] = {
+              type: 'dynamic-tool',
+              toolCallId: toolPart.toolCallId,
+              toolName: toolPart.toolName,
+              state: 'output-available',
+              input: toolPart.input,
+              output: content,
+            };
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Minimal type for LangGraph StateSnapshot.
+ * Uses inline type to avoid requiring `@langchain/langgraph` as a runtime dependency.
+ */
+interface StateSnapshotLike {
+  values: { messages?: BaseMessage[] } & Record<string, unknown>;
+  tasks?: Array<Record<string, unknown>>;
+}
+
+/**
+ * Converts a LangGraph StateSnapshot to AI SDK UIMessage objects.
+ *
+ * This function extracts the messages from a LangGraph state snapshot and converts
+ * them to AI SDK UIMessage format, enabling chat history restoration from
+ * LangGraph checkpointers.
+ *
+ * @param snapshot - A LangGraph StateSnapshot object.
+ * @returns Array of AI SDK UIMessage objects.
+ *
+ * @example
+ * ```ts
+ * import { stateSnapshotToUIMessages } from '@ai-sdk/langchain';
+ *
+ * const snapshot = await graph.getState(threadConfig);
+ * const uiMessages = stateSnapshotToUIMessages(snapshot);
+ *
+ * // Use with useChat
+ * const { messages } = useChat({ initialMessages: uiMessages });
+ * ```
+ */
+export function stateSnapshotToUIMessages(
+  snapshot: StateSnapshotLike,
+): UIMessage[] {
+  const messages = snapshot.values?.messages;
+  if (!Array.isArray(messages)) {
+    return [];
+  }
+  return baseMessagesToUIMessages(messages);
 }

--- a/packages/langchain/src/adapter.ts
+++ b/packages/langchain/src/adapter.ts
@@ -971,7 +971,25 @@ export function stateSnapshotToUIMessages(
       };
       uiMessages.push(lastAssistant);
     }
-    lastAssistant.parts.push(...interruptParts);
+    // Deduplicate: skip interrupt parts that already exist on the assistant
+    // (e.g., when the AI message's tool_calls match the interrupt's actionRequests)
+    const existingToolCallIds = new Set<string>();
+    const existingToolParts = new Set<string>();
+    for (const part of lastAssistant.parts) {
+      if (part.type === 'dynamic-tool') {
+        existingToolCallIds.add(part.toolCallId);
+        existingToolParts.add(`${part.toolName}:${JSON.stringify(part.input)}`);
+      }
+    }
+    for (const interruptPart of interruptParts) {
+      const toolCallKey = `${interruptPart.toolName}:${JSON.stringify(interruptPart.input)}`;
+      if (
+        !existingToolCallIds.has(interruptPart.toolCallId) &&
+        !existingToolParts.has(toolCallKey)
+      ) {
+        lastAssistant.parts.push(interruptPart);
+      }
+    }
   }
 
   return uiMessages;

--- a/packages/langchain/src/adapter.ts
+++ b/packages/langchain/src/adapter.ts
@@ -902,9 +902,30 @@ export function baseMessagesToUIMessages(messages: BaseMessage[]): UIMessage[] {
  * Minimal type for LangGraph StateSnapshot.
  * Uses inline type to avoid requiring `@langchain/langgraph` as a runtime dependency.
  */
+interface InterruptActionRequest {
+  name: string;
+  args?: Record<string, unknown>;
+  arguments?: Record<string, unknown>;
+  id?: string;
+}
+
+interface InterruptValue {
+  actionRequests?: InterruptActionRequest[];
+  action_requests?: InterruptActionRequest[];
+}
+
+interface PregelInterrupt {
+  value?: InterruptValue | unknown;
+}
+
+interface PregelTask {
+  interrupts?: PregelInterrupt[];
+  [key: string]: unknown;
+}
+
 interface StateSnapshotLike {
   values: { messages?: BaseMessage[] } & Record<string, unknown>;
-  tasks?: Array<Record<string, unknown>>;
+  tasks?: PregelTask[];
 }
 
 /**
@@ -935,5 +956,67 @@ export function stateSnapshotToUIMessages(
   if (!Array.isArray(messages)) {
     return [];
   }
-  return baseMessagesToUIMessages(messages);
+  const uiMessages = baseMessagesToUIMessages(messages);
+
+  // Extract pending interrupts from snapshot tasks
+  const interruptParts = extractInterruptParts(snapshot.tasks);
+  if (interruptParts.length > 0) {
+    // Find or create the last assistant message to attach interrupt parts
+    let lastAssistant = uiMessages.findLast(m => m.role === 'assistant');
+    if (!lastAssistant) {
+      lastAssistant = {
+        id: generateId(),
+        role: 'assistant' as const,
+        parts: [],
+      };
+      uiMessages.push(lastAssistant);
+    }
+    lastAssistant.parts.push(...interruptParts);
+  }
+
+  return uiMessages;
+}
+
+function extractInterruptParts(tasks?: PregelTask[]): Array<{
+  type: 'dynamic-tool';
+  toolCallId: string;
+  toolName: string;
+  state: 'input-available';
+  input: Record<string, unknown>;
+}> {
+  if (!Array.isArray(tasks)) return [];
+
+  const parts: Array<{
+    type: 'dynamic-tool';
+    toolCallId: string;
+    toolName: string;
+    state: 'input-available';
+    input: Record<string, unknown>;
+  }> = [];
+
+  for (const task of tasks) {
+    if (!Array.isArray(task.interrupts)) continue;
+
+    for (const interrupt of task.interrupts) {
+      if (!interrupt.value || typeof interrupt.value !== 'object') continue;
+
+      const interruptValue = interrupt.value as InterruptValue;
+      const actionRequests =
+        interruptValue.actionRequests ?? interruptValue.action_requests;
+
+      if (!Array.isArray(actionRequests)) continue;
+
+      for (const request of actionRequests) {
+        parts.push({
+          type: 'dynamic-tool',
+          toolCallId: request.id ?? generateId(),
+          toolName: request.name,
+          state: 'input-available',
+          input: request.args ?? request.arguments ?? {},
+        });
+      }
+    }
+  }
+
+  return parts;
 }

--- a/packages/langchain/src/index.ts
+++ b/packages/langchain/src/index.ts
@@ -2,6 +2,8 @@ export {
   toBaseMessages,
   toUIMessageStream,
   convertModelMessages,
+  baseMessagesToUIMessages,
+  stateSnapshotToUIMessages,
 } from './adapter';
 
 export {


### PR DESCRIPTION
Adds reverse conversion utilities for LangChain ↔ AI SDK message interop:

- `baseMessagesToUIMessages(messages)` — converts LangChain `BaseMessage[]` to AI SDK `UIMessage[]`
- `stateSnapshotToUIMessages(snapshot)` — converts a LangGraph `StateSnapshot` to `UIMessage[]`

This enables restoring chat history from LangGraph checkpointers for use with `useChat`'s `initialMessages`.

### Features
- Maps HumanMessage → user, AIMessage → assistant, SystemMessage → system
- Correlates ToolMessages back to their parent AIMessage's tool calls
- Handles reasoning content (Anthropic thinking, GPT-5 reasoning)
- Handles image generation outputs
- Works with both class instances and serialized/RemoteGraph plain objects
- Generates stable IDs from message metadata

Closes #12680