### PR TITLE
feat (provider/gateway): add SSE support for video generation with heartbeat keep-alive

### DIFF
--- a/.changeset/popular-carpets-teach.md
+++ b/.changeset/popular-carpets-teach.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): add SSE support for video generation with heartbeat keep-alive

--- a/packages/gateway/src/gateway-video-model.test.ts
+++ b/packages/gateway/src/gateway-video-model.test.ts
@@ -87,13 +87,15 @@ describe('GatewayVideoModel', () => {
       >;
       providerMetadata?: Record<string, unknown>;
     } = {}) {
+      const ssePayload = {
+        type: 'result',
+        videos,
+        ...(warnings && { warnings }),
+        ...(providerMetadata && { providerMetadata }),
+      };
       server.urls['https://api.test.com/video-model'].response = {
-        type: 'json-value',
-        body: {
-          videos,
-          ...(warnings && { warnings }),
-          ...(providerMetadata && { providerMetadata }),
-        },
+        type: 'stream-chunks',
+        chunks: [`data: ${JSON.stringify(ssePayload)}\n\n`],
       };
     }
 


### PR DESCRIPTION
## Background

Video generation requests can take a long time to complete, and HTTP connections may timeout during processing. Server-Sent Events (SSE) with heartbeat keep-alive messages provide a way to maintain the connection while the video is being generated.

## Changes

Added SSE support for video generation in the gateway provider with heartbeat keep-alive functionality. The implementation:

- Sets `accept: 'text/event-stream'` header in video generation requests
- Parses SSE events using `parseJsonEventStream` with a discriminated union schema for result and error events
- Properly handles SSE error events by throwing `APICallError` with structured error data

## Manual Verification

Ran example video scripts against a gateway server supporting SSE format response.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

## Related Issues