### PR TITLE
fix(anthropic): handle missing documentInfo in createCitationSource

### DIFF
--- a/.changeset/fix-citation-missing-document-info.md
+++ b/.changeset/fix-citation-missing-document-info.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): handle missing documentInfo in createCitationSource gracefully
+
+When `citationDocuments[citation.document_index]` returns `undefined` (e.g. document index out of bounds), the citation was silently dropped. Now provides fallback values (`text/plain` mediaType, `Unknown document` title) so citations are preserved.

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -83,17 +83,15 @@ function createCitationSource(
 
   const documentInfo = citationDocuments[citation.document_index];
 
-  if (!documentInfo) {
-    return;
-  }
-
   return {
     type: 'source' as const,
     sourceType: 'document' as const,
     id: generateId(),
-    mediaType: documentInfo.mediaType,
-    title: citation.document_title ?? documentInfo.title,
-    filename: documentInfo.filename,
+    mediaType: documentInfo ? documentInfo.mediaType : 'text/plain',
+    title:
+      citation.document_title ??
+      (documentInfo ? documentInfo.title : 'Unknown document'),
+    filename: documentInfo?.filename,
     providerMetadata: {
       anthropic:
         citation.type === 'page_location'


### PR DESCRIPTION
## Background

When using Anthropic's Citation API, the `createCitationSource` function silently drops citations when `citationDocuments[citation.document_index]` returns `undefined` (e.g. document index out of bounds or missing document entry). This causes citation metadata (cited text, page/char locations) to be lost, even though it is still valuable to the consumer.

## Summary

- Removed the early `return` when `documentInfo` is `undefined` in `createCitationSource`
- Instead, provide graceful fallback values:
  - `mediaType` → `'text/plain'`
  - `title` → `citation.document_title` if available, otherwise `'Unknown document'`
  - `filename` → `undefined` (via optional chaining)
- Added 3 regression tests (2 for `doGenerate`, 1 for `doStream`) covering the missing `documentInfo` scenario
- Added patch changeset

## Manual Verification

Discovered and verified via a real-world Anthropic API response where `document_index` referenced an entry not present in the `citationDocuments` array. The citation was silently dropped before the fix; after the fix, it is correctly returned with fallback values.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)