### PR TITLE
feat(ai): increase bundle size limit

### DIFF
--- a/.changeset/sour-mirrors-clean.md
+++ b/.changeset/sour-mirrors-clean.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): increase bundle size limit

--- a/packages/ai/scripts/check-bundle-size.ts
+++ b/packages/ai/scripts/check-bundle-size.ts
@@ -3,7 +3,7 @@ import { writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 // Bundle size limits in bytes
-const LIMIT = 560 * 1024;
+const LIMIT = 570 * 1024;
 
 interface BundleResult {
   size: number;


### PR DESCRIPTION
## Background

the CI check was constantly failing for the logic change/addition in https://github.com/vercel/ai/actions/runs/22241057817/job/64344494686?pr=12717

## Summary

bumped limit from 560 to 570 KB

## Manual Verification

verified by running the check locally

## Checklist

- [ ] na ~~Tests have been added / updated (for bug fixes / features)~~
- [ ] ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)