### PR TITLE
fix(openai): add changeset and tests for per-image usage metadata

### DIFF
--- a/.changeset/image-model-usage-tokens.md
+++ b/.changeset/image-model-usage-tokens.md
@@ -1,5 +1,0 @@
----
-'@ai-sdk/openai': patch
----
-
-Add inputTokens and outputTokens to per-image provider metadata for image generation models. This enables downstream consumers like AI Gateway to compute token-based costs for gpt-image-1 on the v2 specification path.

--- a/.changeset/image-model-usage-tokens.md
+++ b/.changeset/image-model-usage-tokens.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Add inputTokens and outputTokens to per-image provider metadata for image generation models. This enables downstream consumers like AI Gateway to compute token-based costs for gpt-image-1 on the v2 specification path.

--- a/.changeset/proud-flies-impress.md
+++ b/.changeset/proud-flies-impress.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): add changeset and tests for per-image usage metadata

--- a/packages/openai/src/image/openai-image-model.test.ts
+++ b/packages/openai/src/image/openai-image-model.test.ts
@@ -520,6 +520,8 @@ describe('doGenerate', () => {
         {
           imageTokens: 7,
           textTokens: 5,
+          inputTokens: 12,
+          outputTokens: 0,
         },
       ],
     });
@@ -558,9 +560,52 @@ describe('doGenerate', () => {
 
     expect(result.providerMetadata?.openai).toMatchObject({
       images: [
-        { imageTokens: 64, textTokens: 9 },
-        { imageTokens: 64, textTokens: 9 },
-        { imageTokens: 66, textTokens: 10 },
+        { imageTokens: 64, textTokens: 9, inputTokens: 10, outputTokens: 300 },
+        { imageTokens: 64, textTokens: 9, inputTokens: 10, outputTokens: 300 },
+        { imageTokens: 66, textTokens: 10, inputTokens: 10, outputTokens: 300 },
+      ],
+    });
+  });
+
+  it('should include inputTokens and outputTokens in per-image provider metadata', async () => {
+    server.urls['https://api.openai.com/v1/images/generations'].response = {
+      type: 'json-value',
+      body: {
+        created: 1733837122,
+        data: [
+          {
+            b64_json: 'base64-image-1',
+          },
+        ],
+        usage: {
+          input_tokens: 27,
+          output_tokens: 1056,
+          total_tokens: 1083,
+          input_tokens_details: {
+            image_tokens: 0,
+            text_tokens: 27,
+          },
+        },
+      },
+    };
+
+    const result = await provider.image('gpt-image-1').doGenerate({
+      prompt,
+      n: 1,
+      size: '1024x1024',
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {},
+    });
+
+    expect(result.providerMetadata?.openai).toMatchObject({
+      images: [
+        {
+          imageTokens: 0,
+          textTokens: 27,
+          inputTokens: 27,
+          outputTokens: 1056,
+        },
       ],
     });
   });


### PR DESCRIPTION
## Summary
Follow-up to #12730:
- Adds a `@ai-sdk/openai` patch changeset for the per-image `inputTokens`/`outputTokens` metadata change
- Updates existing tests to assert on the new `inputTokens`/`outputTokens` fields
- Adds a new test verifying single-image usage metadata (text-only generation with gpt-image-1 token counts)

## Test plan
- [x] All 18 image model tests pass