### PR TITLE
chore(provider/gateway): automate model settings files update for v5

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -44,7 +44,7 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "tsx": "4.19.2",
+    "tsx": "^4.19.2",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -22,7 +22,8 @@
     "test:update": "pnpm test:node -u",
     "test:watch": "vitest --config vitest.node.config.js",
     "test:edge": "vitest --config vitest.edge.config.js --run",
-    "test:node": "vitest --config vitest.node.config.js --run"
+    "test:node": "vitest --config vitest.node.config.js --run",
+    "generate-model-settings": "tsx scripts/generate-model-settings.ts"
   },
   "exports": {
     "./package.json": "./package.json",
@@ -43,6 +44,7 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
+    "tsx": "4.19.2",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/gateway/scripts/generate-model-settings.ts
+++ b/packages/gateway/scripts/generate-model-settings.ts
@@ -1,20 +1,20 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as z4 from 'zod';
+import * as z from 'zod';
 
 const API_URL = 'https://ai-gateway.vercel.sh/v1/models';
 const OUTPUT_DIR = path.join(__dirname, '..', 'src');
 
-const modelSchema = z4.object({
-  id: z4.string(),
-  type: z4.string(),
+const modelSchema = z.object({
+  id: z.string(),
+  type: z.string(),
 });
 
-const modelsResponseSchema = z4.object({
-  data: z4.array(modelSchema),
+const modelsResponseSchema = z.object({
+  data: z.array(modelSchema),
 });
 
-type ModelsResponse = z4.infer<typeof modelsResponseSchema>;
+type ModelsResponse = z.infer<typeof modelsResponseSchema>;
 
 const MODALITY_CONFIG: Record<
   string,

--- a/packages/gateway/scripts/generate-model-settings.ts
+++ b/packages/gateway/scripts/generate-model-settings.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as z from 'zod';
+import fs from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
 
 const API_URL = 'https://ai-gateway.vercel.sh/v1/models';
 const OUTPUT_DIR = path.join(__dirname, '..', 'src');
@@ -112,4 +112,4 @@ async function main() {
   console.log('Model settings updated successfully');
 }
 
-main();
+main().catch(console.error);;

--- a/packages/gateway/scripts/generate-model-settings.ts
+++ b/packages/gateway/scripts/generate-model-settings.ts
@@ -1,0 +1,115 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as z4 from 'zod';
+
+const API_URL = 'https://ai-gateway.vercel.sh/v1/models';
+const OUTPUT_DIR = path.join(__dirname, '..', 'src');
+
+const modelSchema = z4.object({
+  id: z4.string(),
+  type: z4.string(),
+});
+
+const modelsResponseSchema = z4.object({
+  data: z4.array(modelSchema),
+});
+
+type ModelsResponse = z4.infer<typeof modelsResponseSchema>;
+
+const MODALITY_CONFIG: Record<
+  string,
+  { outputFile: string; typeName: string }
+> = {
+  language: {
+    outputFile: 'gateway-language-model-settings.ts',
+    typeName: 'GatewayModelId',
+  },
+  embedding: {
+    outputFile: 'gateway-embedding-model-settings.ts',
+    typeName: 'GatewayEmbeddingModelId',
+  },
+  image: {
+    outputFile: 'gateway-image-model-settings.ts',
+    typeName: 'GatewayImageModelId',
+  },
+};
+
+async function fetchModels(): Promise<ModelsResponse> {
+  console.log('Fetching models from', API_URL);
+
+  const response = await fetch(API_URL);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch models: HTTP ${response.status} from ${API_URL}`,
+    );
+  }
+
+  const data = await response.json();
+
+  return modelsResponseSchema.parse(data);
+}
+
+function generateTypeFile(modelIds: string[], typeName: string): string {
+  const sortedIds = [...modelIds].sort();
+
+  if (sortedIds.length === 0) {
+    return `export type ${typeName} = string & {};\n`;
+  }
+
+  const lines = [
+    `export type ${typeName} =`,
+    ...sortedIds.map(id => `  | '${id}'`),
+    '  | (string & {});',
+  ];
+
+  return lines.join('\n') + '\n';
+}
+
+function getModalityConfig(type: string): {
+  outputFile: string;
+  typeName: string;
+} {
+  if (MODALITY_CONFIG[type]) {
+    return MODALITY_CONFIG[type];
+  }
+  const capitalized = type.charAt(0).toUpperCase() + type.slice(1);
+  return {
+    outputFile: `gateway-${type}-model-settings.ts`,
+    typeName: `Gateway${capitalized}ModelId`,
+  };
+}
+
+async function main() {
+  const response = await fetchModels();
+
+  const modelsByType: Record<string, string[]> = {};
+
+  for (const model of response.data) {
+    if (model.type === 'video') continue;
+    if (!modelsByType[model.type]) {
+      modelsByType[model.type] = [];
+    }
+    modelsByType[model.type].push(model.id);
+  }
+
+  for (const [type, modelIds] of Object.entries(modelsByType)) {
+    const config = getModalityConfig(type);
+    const outputPath = path.join(OUTPUT_DIR, config.outputFile);
+
+    if (!fs.existsSync(outputPath)) {
+      throw new Error(
+        `Output file does not exist for type '${type}': ${config.outputFile}`,
+      );
+    }
+
+    const content = generateTypeFile(modelIds, config.typeName);
+    fs.writeFileSync(outputPath, content, 'utf-8');
+    console.log(
+      `Generated ${config.outputFile} with ${modelIds.length} models`,
+    );
+  }
+
+  console.log('Model settings updated successfully');
+}
+
+main();

--- a/packages/gateway/scripts/generate-model-settings.ts
+++ b/packages/gateway/scripts/generate-model-settings.ts
@@ -112,4 +112,4 @@ async function main() {
   console.log('Model settings updated successfully');
 }
 
-main().catch(console.error);;
+main().catch(console.error);

--- a/packages/gateway/tsconfig.json
+++ b/packages/gateway/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "src",
     "outDir": "dist"
   },
-  "exclude": ["dist", "build", "node_modules", "tsup.config.ts"],
+  "exclude": ["dist", "build", "node_modules", "scripts", "tsup.config.ts"],
   "references": [
     {
       "path": "../provider"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1995,7 +1995,7 @@ importers:
         specifier: ^8
         version: 8.3.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.19.2)(typescript@5.8.3)(yaml@2.7.0)
       tsx:
-        specifier: 4.19.2
+        specifier: ^4.19.2
         version: 4.19.2
       typescript:
         specifier: 5.8.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1993,7 +1993,10 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8
-        version: 8.3.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.7.0)
+        version: 8.3.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.19.2)(typescript@5.8.3)(yaml@2.7.0)
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
       typescript:
         specifier: 5.8.3
         version: 5.8.3


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

Gateway team has an action that automatically generates model settings files update for v6 and backports it, but the backported PR has to be manually shared and approved. In addition, we recently launched video generation (not supported in v5) that introduced additional complexity for this automated process. 

## Summary

<!-- What did you change? -->

Add a script to update model settings files for v5 specifically
Prerequisite to #12716 

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

- verified new script works in v5 

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
