### PR TITLE
feat(devtools): add optional runId to devToolsMiddleware

### DIFF
--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -1,1 +1,4 @@
-export { devToolsMiddleware } from './middleware.js';
+export {
+  devToolsMiddleware,
+  type DevToolsMiddlewareOptions,
+} from './middleware.js';

--- a/packages/devtools/src/middleware.ts
+++ b/packages/devtools/src/middleware.ts
@@ -97,7 +97,14 @@ const generateRunId = (): string => {
  * });
  * ```
  */
-export const devToolsMiddleware = (): LanguageModelV3Middleware => {
+export interface DevToolsMiddlewareOptions {
+  /** Optional run ID to group related steps. Auto-generated if not provided. */
+  runId?: string;
+}
+
+export const devToolsMiddleware = (
+  options?: DevToolsMiddlewareOptions,
+): LanguageModelV3Middleware => {
   if (process.env.NODE_ENV === 'production') {
     throw new Error(
       '@ai-sdk/devtools should not be used in production. ' +
@@ -108,7 +115,7 @@ export const devToolsMiddleware = (): LanguageModelV3Middleware => {
   // Register signal handlers once for cleanup on process exit
   registerSignalHandlers();
 
-  const runId = generateRunId();
+  const runId = options?.runId ?? generateRunId();
   let runCreated = false;
   let stepCounter = 0;
 


### PR DESCRIPTION
Closes #12724

### Summary

Add optional `runId` parameter to `devToolsMiddleware()` to allow grouping related LLM calls across different middleware instances under the same run.

### Usage

```ts
const runId = `operation-${Date.now()}`;
const model1 = wrapLanguageModel({ middleware: devToolsMiddleware({ runId }), model: openai("gpt-4") });
const model2 = wrapLanguageModel({ middleware: devToolsMiddleware({ runId }), model: openai("gpt-4") });
// Both appear under the same run in DevTools
```

When `runId` is not provided, behavior is unchanged (auto-generated unique ID).

### Changes

- Added `DevToolsMiddlewareOptions` interface with optional `runId`
- Updated `devToolsMiddleware()` to accept options parameter
- Exported new type from package index