### PR TITLE
fix(deepinfra,fireworks,openai): fix unsafe providerMetadata check

### DIFF
--- a/.changeset/tricky-apes-promise.md
+++ b/.changeset/tricky-apes-promise.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/deepinfra': patch
+'@ai-sdk/fireworks': patch
+'@ai-sdk/openai': patch
+---
+
+fix(deepinfra,fireworks,openai): fix unsafe providerMetadata check

--- a/packages/deepinfra/src/deepinfra-image-model.ts
+++ b/packages/deepinfra/src/deepinfra-image-model.ts
@@ -70,7 +70,7 @@ export class DeepInfraImageModel implements ImageModelV3 {
             mask: mask != null ? await fileToBlob(mask) : undefined,
             n,
             size,
-            ...(providerOptions.deepinfra ?? {}),
+            ...(providerOptions?.deepinfra ?? {}),
           },
           { useArrayBrackets: false },
         ),
@@ -109,7 +109,7 @@ export class DeepInfraImageModel implements ImageModelV3 {
         ...(aspectRatio && { aspect_ratio: aspectRatio }),
         ...(splitSize && { width: splitSize[0], height: splitSize[1] }),
         ...(seed != null && { seed }),
-        ...(providerOptions.deepinfra ?? {}),
+        ...(providerOptions?.deepinfra ?? {}),
       },
       failedResponseHandler: createJsonErrorResponseHandler({
         errorSchema: deepInfraErrorSchema,

--- a/packages/fireworks/src/fireworks-image-model.ts
+++ b/packages/fireworks/src/fireworks-image-model.ts
@@ -175,7 +175,7 @@ export class FireworksImageModel implements ImageModelV3 {
         samples: n,
         ...(inputImage && { input_image: inputImage }),
         ...(splitSize && { width: splitSize[0], height: splitSize[1] }),
-        ...(providerOptions.fireworks ?? {}),
+        ...(providerOptions?.fireworks ?? {}),
       },
       failedResponseHandler: createStatusCodeErrorResponseHandler(),
       successfulResponseHandler: createBinaryResponseHandler(),

--- a/packages/openai/src/image/openai-image-model.ts
+++ b/packages/openai/src/image/openai-image-model.ts
@@ -105,7 +105,7 @@ export class OpenAIImageModel implements ImageModelV3 {
           mask: mask != null ? await fileToBlob(mask) : undefined,
           n,
           size,
-          ...(providerOptions.openai ?? {}),
+          ...(providerOptions?.openai ?? {}),
         }),
         failedResponseHandler: openaiFailedResponseHandler,
         successfulResponseHandler: createJsonResponseHandler(
@@ -164,7 +164,7 @@ export class OpenAIImageModel implements ImageModelV3 {
         prompt,
         n,
         size,
-        ...(providerOptions.openai ?? {}),
+        ...(providerOptions?.openai ?? {}),
         ...(!hasDefaultResponseFormat(this.modelId)
           ? { response_format: 'b64_json' }
           : {}),


### PR DESCRIPTION
## Background
I was using the Gateway OpenAI compat endpoint to generate an image and didn't send any `providerOptions`, and got this error:

```
InternalServerError: 500 Cannot read properties of undefined (reading 'openai')
```

This was because the AI SDK OpenAI package needed the providerOptions `openai` key to exist (unsafe access). The regular `generateImage` AI SDK + Gateway works without `providerOptions` because it sends an empty object for `providerOptions` when the user doesn't specify any.

## Summary
Made the check safer

## Manual Verification

## Checklist
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)