### PR TITLE
feat(google): add videoMetadata support for file parts

### DIFF
--- a/.changeset/google-video-metadata.md
+++ b/.changeset/google-video-metadata.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Add videoMetadata support for file parts. Users can now pass videoMetadata (startOffset, endOffset, fps) via providerOptions on file parts to control video clipping and frame rate when using the Google Generative AI provider.

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -339,7 +339,8 @@ const result = await generateText({
 });
 ```
 
-You can also use YouTube URLs directly:
+You can also use YouTube URLs directly. Pass `videoMetadata` through
+`providerOptions` to clip a segment of the video or control the frame rate:
 
 ```ts
 import { google } from '@ai-sdk/google';
@@ -353,12 +354,21 @@ const result = await generateText({
       content: [
         {
           type: 'text',
-          text: 'Summarize this video',
+          text: 'Summarize this part of the video',
         },
         {
           type: 'file',
           data: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
           mediaType: 'video/mp4',
+          providerOptions: {
+            google: {
+              videoMetadata: {
+                startOffset: '60s',
+                endOffset: '600s',
+                fps: 1,
+              },
+            },
+          },
         },
       ],
     },

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -518,6 +518,119 @@ describe('user messages', () => {
     });
   });
 
+  it('should include videoMetadata alongside fileData for URL file parts', async () => {
+    const result = convertToGoogleMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: {
+              type: 'url' as const,
+              url: new URL('https://www.youtube.com/watch?v=example'),
+            },
+            mediaType: 'video/mp4',
+            providerOptions: {
+              google: {
+                videoMetadata: {
+                  startOffset: '60s',
+                  endOffset: '600s',
+                  fps: 1,
+                },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.contents[0].parts[0]).toEqual({
+      fileData: {
+        mimeType: 'video/mp4',
+        fileUri: 'https://www.youtube.com/watch?v=example',
+      },
+      videoMetadata: {
+        startOffset: '60s',
+        endOffset: '600s',
+        fps: 1,
+      },
+    });
+  });
+
+  it('should include videoMetadata alongside inlineData for data file parts', async () => {
+    const result = convertToGoogleMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: { type: 'data' as const, data: 'AAECAw==' },
+            mediaType: 'video/mp4',
+            providerOptions: {
+              google: {
+                videoMetadata: {
+                  startOffset: '10s',
+                  endOffset: '20s',
+                },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.contents[0].parts[0]).toEqual({
+      inlineData: {
+        mimeType: 'video/mp4',
+        data: 'AAECAw==',
+      },
+      videoMetadata: {
+        startOffset: '10s',
+        endOffset: '20s',
+      },
+    });
+  });
+
+  it('should resolve videoMetadata from the google namespace for Vertex', async () => {
+    const result = convertToGoogleMessages(
+      [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: {
+                type: 'url' as const,
+                url: new URL('https://storage.googleapis.com/bucket/video.mp4'),
+              },
+              mediaType: 'video/mp4',
+              providerOptions: {
+                google: {
+                  videoMetadata: {
+                    startOffset: '30s',
+                    endOffset: '90s',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+      { providerOptionsNames: ['googleVertex', 'vertex'] },
+    );
+
+    expect(result.contents[0].parts[0]).toEqual({
+      fileData: {
+        mimeType: 'video/mp4',
+        fileUri: 'https://storage.googleapis.com/bucket/video.mp4',
+      },
+      videoMetadata: {
+        startOffset: '30s',
+        endOffset: '90s',
+      },
+    });
+  });
+
   it('should convert file parts with provider reference to fileData', async () => {
     const result = convertToGoogleMessages([
       {

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -17,6 +17,7 @@ import type {
   GoogleContentPart,
   GoogleFunctionResponsePart,
   GooglePrompt,
+  GoogleVideoMetadata,
 } from './google-prompt';
 
 /**
@@ -281,6 +282,10 @@ export function convertToGoogleMessages(
             }
 
             case 'file': {
+              const videoMetadata = readProviderOpts(part)?.videoMetadata as
+                | GoogleVideoMetadata
+                | undefined;
+
               switch (part.data.type) {
                 case 'url': {
                   parts.push({
@@ -288,6 +293,7 @@ export function convertToGoogleMessages(
                       mimeType: resolveFullMediaType({ part }),
                       fileUri: part.data.url.toString(),
                     },
+                    ...(videoMetadata != null ? { videoMetadata } : {}),
                   });
                   break;
                 }
@@ -306,6 +312,7 @@ export function convertToGoogleMessages(
                         provider: 'google',
                       }),
                     },
+                    ...(videoMetadata != null ? { videoMetadata } : {}),
                   });
                   break;
                 }
@@ -319,6 +326,7 @@ export function convertToGoogleMessages(
                         new TextEncoder().encode(part.data.text),
                       ),
                     },
+                    ...(videoMetadata != null ? { videoMetadata } : {}),
                   });
                   break;
                 }
@@ -328,6 +336,7 @@ export function convertToGoogleMessages(
                       mimeType: resolveFullMediaType({ part }),
                       data: convertToBase64(part.data.data),
                     },
+                    ...(videoMetadata != null ? { videoMetadata } : {}),
                   });
                   break;
                 }

--- a/packages/google/src/google-prompt.ts
+++ b/packages/google/src/google-prompt.ts
@@ -20,10 +20,17 @@ export type GoogleContent = {
   parts: Array<GoogleContentPart>;
 };
 
+export type GoogleVideoMetadata = {
+  startOffset?: string;
+  endOffset?: string;
+  fps?: number;
+};
+
 export type GoogleContentPart =
   | { text: string; thought?: boolean; thoughtSignature?: string }
   | {
       inlineData: { mimeType: string; data: string };
+      videoMetadata?: GoogleVideoMetadata;
       thought?: boolean;
       thoughtSignature?: string;
     }
@@ -41,6 +48,7 @@ export type GoogleContentPart =
     }
   | {
       fileData: { mimeType: string; fileUri: string };
+      videoMetadata?: GoogleVideoMetadata;
       thought?: boolean;
       thoughtSignature?: string;
     }

--- a/packages/google/src/index.ts
+++ b/packages/google/src/index.ts
@@ -6,8 +6,11 @@ export type {
 } from './google-language-model-options';
 export type {
   GoogleProviderMetadata,
+  GoogleVideoMetadata,
   /** @deprecated Use `GoogleProviderMetadata` instead. */
   GoogleProviderMetadata as GoogleGenerativeAIProviderMetadata,
+  /** @deprecated Use `GoogleVideoMetadata` instead. */
+  GoogleVideoMetadata as GoogleGenerativeAIVideoMetadata,
 } from './google-prompt';
 export type {
   GoogleImageModelOptions,


### PR DESCRIPTION
## Background

Google Generative AI supports `videoMetadata` on file parts (`fileData`/`inlineData`) for specifying video clipping offsets and frame rate. Currently the AI SDK's Google provider has no way to pass this metadata through to the API.

Ref: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1beta1/Content

## Summary

- Added `GoogleGenerativeAIVideoMetadata` type (`startOffset`, `endOffset`, `fps`)
- Updated `GoogleGenerativeAIContentPart` union to allow `videoMetadata` on `fileData` and `inlineData` variants
- Extract `videoMetadata` from `providerOptions.google` on file parts in the message conversion, using the same Vertex/Google fallback pattern as `thoughtSignature`
- Added documentation example for video clipping with YouTube URLs

### Usage

```ts
const result = await generateText({
  model: google('gemini-2.5-flash'),
  messages: [
    {
      role: 'user',
      content: [
        { type: 'text', text: 'Summarize this part of the video' },
        {
          type: 'file',
          data: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
          mediaType: 'video/mp4',
          providerOptions: {
            google: {
              videoMetadata: {
                startOffset: '60s',
                endOffset: '600s',
                fps: 1,
              },
            },
          },
        },
      ],
    },
  ],
});
```

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

Closes #8748