### PR TITLE
feat(anthropic): spread message-level providerOptions.anthropic onto assistant messages

### DIFF
--- a/.changeset/spread-anthropic-provider-options.md
+++ b/.changeset/spread-anthropic-provider-options.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Spread message-level `providerOptions.anthropic` (excluding cache control keys) onto assistant messages, enabling custom fields like `reasoning_content` to pass through to the HTTP body.

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -1961,6 +1961,57 @@ describe('assistant messages', () => {
       `);
     });
   });
+
+  it('should spread message-level providerOptions.anthropic onto assistant message', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello' }],
+          providerOptions: {
+            anthropic: {
+              reasoning_content: 'I thought about it...',
+            },
+          },
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    const msg = result.prompt.messages[0] as any;
+    expect(msg.reasoning_content).toBe('I thought about it...');
+    expect(msg.content).toEqual([
+      { type: 'text', text: 'Hello', cache_control: undefined },
+    ]);
+  });
+
+  it('should exclude cacheControl and cache_control from spread', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello' }],
+          providerOptions: {
+            anthropic: {
+              cacheControl: { type: 'ephemeral' },
+              cache_control: { type: 'ephemeral' },
+              reasoning_content: 'thinking...',
+            },
+          },
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    const msg = result.prompt.messages[0] as any;
+    expect(msg.reasoning_content).toBe('thinking...');
+    expect(msg.cacheControl).toBeUndefined();
+    expect(msg.cache_control).toBeUndefined();
+  });
 });
 
 describe('cache control', () => {

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -992,7 +992,25 @@ export async function convertToAnthropicMessagesPrompt({
           }
         }
 
-        messages.push({ role: 'assistant', content: anthropicContent });
+        // Collect message-level providerOptions.anthropic (excluding cache
+        // control keys) and spread onto the message, mirroring how the
+        // openai-compatible provider handles providerOptions.openaiCompatible.
+        const extra: Record<string, unknown> = {};
+        for (const message of block.messages) {
+          const opts = message.providerOptions?.anthropic;
+          if (opts != null && typeof opts === 'object') {
+            for (const [k, v] of Object.entries(opts)) {
+              if (k === 'cacheControl' || k === 'cache_control') continue;
+              extra[k] = v;
+            }
+          }
+        }
+
+        messages.push({
+          role: 'assistant',
+          content: anthropicContent,
+          ...extra,
+        } as AnthropicAssistantMessage);
 
         break;
       }


### PR DESCRIPTION
## Background

When non-Claude models (e.g. kimi-k2.5) are used via `@ai-sdk/anthropic`, there is no way to pass custom fields like `reasoning_content` on assistant messages through to the HTTP body. The openai-compatible provider already supports this by spreading `providerOptions.openaiCompatible` onto messages, but the Anthropic provider only reads `providerOptions.anthropic` at the part level (for signatures, cache control, etc.), never at the message level.

## Summary

Collect message-level `providerOptions.anthropic` (excluding `cacheControl` / `cache_control`) and spread it onto the serialized assistant message object. This mirrors how the openai-compatible provider handles `providerOptions.openaiCompatible`.

Changes:
- `convert-to-anthropic-messages-prompt.ts`: After building the assistant content array, collect and spread extra fields from `providerOptions.anthropic` onto the message
- Added 2 test cases covering the spread behavior and cache control key exclusion

## Manual Verification

- Built `@ai-sdk/anthropic` successfully
- Tested with kimi-k2.5 via Anthropic SDK: `reasoning_content` now flows through to the HTTP body on assistant messages

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Downstream consumer: https://github.com/anomalyco/opencode/pull/14641