### PR TITLE
feat: add withFallback utility for model failover

### DIFF
--- a/packages/ai/src/util/index.ts
+++ b/packages/ai/src/util/index.ts
@@ -10,3 +10,4 @@ export { isDeepEqualData } from './is-deep-equal-data';
 export { parsePartialJson } from './parse-partial-json';
 export { SerialJobExecutor } from './serial-job-executor';
 export { simulateReadableStream } from './simulate-readable-stream';
+export { withFallback, type FallbackOptions } from './with-fallback';

--- a/packages/ai/src/util/with-fallback.test.ts
+++ b/packages/ai/src/util/with-fallback.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withFallback } from './with-fallback';
+import { MockLanguageModelV3 } from '../test/mock-language-model-v3';
+
+describe('withFallback', () => {
+  describe('doGenerate', () => {
+    it('should use the first model when it succeeds', async () => {
+      const primaryModel = new MockLanguageModelV3({
+        modelId: 'primary',
+        doGenerate: {
+          text: 'primary response',
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 5 },
+        },
+      });
+
+      const fallbackModel = new MockLanguageModelV3({
+        modelId: 'fallback',
+        doGenerate: {
+          text: 'fallback response',
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 5 },
+        },
+      });
+
+      const model = withFallback({
+        models: [primaryModel, fallbackModel],
+      });
+
+      const result = await model.doGenerate({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      });
+
+      expect(result.text).toBe('primary response');
+      expect(primaryModel.doGenerateCalls.length).toBe(1);
+      expect(fallbackModel.doGenerateCalls.length).toBe(0);
+    });
+
+    it('should fall back to second model when first fails', async () => {
+      const primaryModel = new MockLanguageModelV3({
+        modelId: 'primary',
+        doGenerate: async () => {
+          throw new Error('primary model failed');
+        },
+      });
+
+      const fallbackModel = new MockLanguageModelV3({
+        modelId: 'fallback',
+        doGenerate: {
+          text: 'fallback response',
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 5 },
+        },
+      });
+
+      const model = withFallback({
+        models: [primaryModel, fallbackModel],
+      });
+
+      const result = await model.doGenerate({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      });
+
+      expect(result.text).toBe('fallback response');
+    });
+
+    it('should throw when all models fail', async () => {
+      const model1 = new MockLanguageModelV3({
+        modelId: 'model1',
+        doGenerate: async () => {
+          throw new Error('model1 failed');
+        },
+      });
+
+      const model2 = new MockLanguageModelV3({
+        modelId: 'model2',
+        doGenerate: async () => {
+          throw new Error('model2 failed');
+        },
+      });
+
+      const model = withFallback({ models: [model1, model2] });
+
+      await expect(
+        model.doGenerate({
+          inputFormat: 'prompt',
+          mode: { type: 'regular' },
+          prompt: [
+            { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+          ],
+        }),
+      ).rejects.toThrow('model2 failed');
+    });
+
+    it('should call onModelFailure when a model fails', async () => {
+      const onModelFailure = vi.fn();
+
+      const primaryModel = new MockLanguageModelV3({
+        modelId: 'primary',
+        doGenerate: async () => {
+          throw new Error('primary failed');
+        },
+      });
+
+      const fallbackModel = new MockLanguageModelV3({
+        modelId: 'fallback',
+        doGenerate: {
+          text: 'fallback response',
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 5 },
+        },
+      });
+
+      const model = withFallback({
+        models: [primaryModel, fallbackModel],
+        onModelFailure,
+      });
+
+      await model.doGenerate({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      });
+
+      expect(onModelFailure).toHaveBeenCalledTimes(1);
+      expect(onModelFailure).toHaveBeenCalledWith({
+        model: primaryModel,
+        error: expect.any(Error),
+        modelIndex: 0,
+      });
+    });
+
+    it('should try three models in sequence', async () => {
+      const model1 = new MockLanguageModelV3({
+        modelId: 'model1',
+        doGenerate: async () => {
+          throw new Error('model1 failed');
+        },
+      });
+
+      const model2 = new MockLanguageModelV3({
+        modelId: 'model2',
+        doGenerate: async () => {
+          throw new Error('model2 failed');
+        },
+      });
+
+      const model3 = new MockLanguageModelV3({
+        modelId: 'model3',
+        doGenerate: {
+          text: 'model3 response',
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 5 },
+        },
+      });
+
+      const model = withFallback({ models: [model1, model2, model3] });
+
+      const result = await model.doGenerate({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      });
+
+      expect(result.text).toBe('model3 response');
+    });
+  });
+
+  describe('model properties', () => {
+    it('should use primary model provider', () => {
+      const model = withFallback({
+        models: [
+          new MockLanguageModelV3({ provider: 'openai', modelId: 'gpt-4' }),
+          new MockLanguageModelV3({
+            provider: 'anthropic',
+            modelId: 'claude',
+          }),
+        ],
+      });
+
+      expect(model.provider).toBe('openai');
+    });
+
+    it('should create composite modelId', () => {
+      const model = withFallback({
+        models: [
+          new MockLanguageModelV3({ modelId: 'gpt-4' }),
+          new MockLanguageModelV3({ modelId: 'claude' }),
+        ],
+      });
+
+      expect(model.modelId).toBe('fallback(gpt-4, claude)');
+    });
+
+    it('should have v3 specification version', () => {
+      const model = withFallback({
+        models: [new MockLanguageModelV3(), new MockLanguageModelV3()],
+      });
+
+      expect(model.specificationVersion).toBe('v3');
+    });
+  });
+
+  describe('doStream', () => {
+    it('should fall back on stream failure', async () => {
+      const primaryModel = new MockLanguageModelV3({
+        modelId: 'primary',
+        doStream: async () => {
+          throw new Error('stream failed');
+        },
+      });
+
+      const fallbackModel = new MockLanguageModelV3({
+        modelId: 'fallback',
+        doStream: {
+          stream: new ReadableStream({
+            start(controller) {
+              controller.enqueue({
+                type: 'text-delta',
+                textDelta: 'fallback',
+              });
+              controller.enqueue({
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 10, outputTokens: 5 },
+              });
+              controller.close();
+            },
+          }),
+        },
+      });
+
+      const model = withFallback({
+        models: [primaryModel, fallbackModel],
+      });
+
+      const result = await model.doStream({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      });
+
+      expect(result).toBeDefined();
+      expect(result.stream).toBeDefined();
+    });
+  });
+
+  describe('abort handling', () => {
+    it('should not catch abort errors', async () => {
+      const primaryModel = new MockLanguageModelV3({
+        modelId: 'primary',
+        doGenerate: async () => {
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          throw error;
+        },
+      });
+
+      const fallbackModel = new MockLanguageModelV3({
+        modelId: 'fallback',
+        doGenerate: {
+          text: 'should not reach',
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 5 },
+        },
+      });
+
+      const model = withFallback({
+        models: [primaryModel, fallbackModel],
+      });
+
+      await expect(
+        model.doGenerate({
+          inputFormat: 'prompt',
+          mode: { type: 'regular' },
+          prompt: [
+            { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+          ],
+        }),
+      ).rejects.toThrow('aborted');
+
+      // Fallback should NOT have been called
+      expect(fallbackModel.doGenerateCalls.length).toBe(0);
+    });
+  });
+});

--- a/packages/ai/src/util/with-fallback.ts
+++ b/packages/ai/src/util/with-fallback.ts
@@ -1,0 +1,115 @@
+import { LanguageModelV3 } from '@ai-sdk/provider';
+import { delay, isAbortError } from '@ai-sdk/provider-utils';
+import { LanguageModel } from '../types/language-model';
+import { resolveLanguageModel } from '../model/resolve-model';
+
+export type FallbackOptions = {
+  /**
+   * List of language models to try in order.
+   * Each model is attempted sequentially - if one fails, the next is tried.
+   * At least two models must be provided.
+   */
+  models: [LanguageModel, LanguageModel, ...LanguageModel[]];
+
+  /**
+   * Delay in milliseconds before retrying with the next model.
+   * @default 0
+   */
+  initialDelayInMs?: number;
+
+  /**
+   * Factor to multiply the delay by after each failed attempt.
+   * @default 1
+   */
+  backoffFactor?: number;
+
+  /**
+   * Called when a model fails and the next model will be tried.
+   */
+  onModelFailure?: (params: {
+    model: LanguageModelV3;
+    error: unknown;
+    modelIndex: number;
+  }) => void;
+};
+
+/**
+ * Creates a language model that tries multiple models in sequence.
+ * If the first model fails, it automatically falls back to the next model
+ * in the list. Supports optional exponential backoff between attempts.
+ *
+ * @example
+ * ```ts
+ * import { withFallback } from 'ai';
+ * import { openai } from '@ai-sdk/openai';
+ * import { anthropic } from '@ai-sdk/anthropic';
+ *
+ * const model = withFallback({
+ *   models: [openai('gpt-4o'), anthropic('claude-sonnet-4-20250514')],
+ * });
+ *
+ * const result = await generateText({ model, prompt: 'Hello' });
+ * ```
+ */
+export function withFallback(options: FallbackOptions): LanguageModelV3 {
+  const {
+    models,
+    initialDelayInMs = 0,
+    backoffFactor = 1,
+    onModelFailure,
+  } = options;
+
+  const resolvedModels = models.map(m => resolveLanguageModel(m));
+  const primaryModel = resolvedModels[0];
+
+  async function tryModels<T>(
+    operation: (model: LanguageModelV3) => PromiseLike<T>,
+  ): Promise<T> {
+    let currentDelay = initialDelayInMs;
+
+    for (let i = 0; i < resolvedModels.length; i++) {
+      try {
+        return await operation(resolvedModels[i]);
+      } catch (error) {
+        if (isAbortError(error)) {
+          throw error;
+        }
+
+        onModelFailure?.({
+          model: resolvedModels[i],
+          error,
+          modelIndex: i,
+        });
+
+        // If this was the last model, throw
+        if (i === resolvedModels.length - 1) {
+          throw error;
+        }
+
+        // Wait before trying next model
+        if (currentDelay > 0) {
+          await delay(currentDelay);
+          currentDelay *= backoffFactor;
+        }
+      }
+    }
+
+    // This should never be reached, but TypeScript needs it
+    throw new Error('All fallback models failed');
+  }
+
+  return {
+    specificationVersion: 'v3',
+    provider: primaryModel.provider,
+    modelId: `fallback(${resolvedModels.map(m => m.modelId).join(', ')})`,
+    supportedUrls: primaryModel.supportedUrls,
+
+    doGenerate(options) {
+      return tryModels(model => model.doGenerate(options));
+    },
+
+    doStream(options) {
+      return tryModels(model => model.doStream(options));
+    },
+  };
+}

--- a/packages/ai/src/util/with-fallback.ts
+++ b/packages/ai/src/util/with-fallback.ts
@@ -75,16 +75,16 @@ export function withFallback(options: FallbackOptions): LanguageModelV3 {
           throw error;
         }
 
+        // If this was the last model, throw without calling onModelFailure
+        if (i === resolvedModels.length - 1) {
+          throw error;
+        }
+
         onModelFailure?.({
           model: resolvedModels[i],
           error,
           modelIndex: i,
         });
-
-        // If this was the last model, throw
-        if (i === resolvedModels.length - 1) {
-          throw error;
-        }
 
         // Wait before trying next model
         if (currentDelay > 0) {


### PR DESCRIPTION
Adds a `withFallback()` utility that lets you chain multiple models together as a failover strategy. If the primary model fails (rate limits, outage, whatever), it automatically tries the next one in the list.

Usage looks like:

```ts
import { withFallback, generateText } from 'ai';
import { openai } from '@ai-sdk/openai';
import { anthropic } from '@ai-sdk/anthropic';

const model = withFallback({
  models: [openai('gpt-4o'), anthropic('claude-sonnet-4-20250514')],
  onModelFailure: ({ model, error }) => {
    console.log(`${model.modelId} failed, trying next...`);
  },
});

const result = await generateText({ model, prompt: 'Hello' });
```

It returns a standard `LanguageModelV3` so it works with `generateText`, `streamText`, and anything else that takes a model. Also supports optional backoff between retries via `initialDelayInMs` and `backoffFactor`.

The implementation properly re-throws abort errors without falling back (you wouldn't want to retry a user cancellation), and the last model's error is thrown if everything fails.

10 tests covering the main scenarios (success path, single/multi fallback, abort handling, stream fallback, onModelFailure callback).

Closes #2636