### PR TITLE
fix(provider/openai-compatible): support additional audio formats and video

### DIFF
--- a/.changeset/audio-video-format-support.md
+++ b/.changeset/audio-video-format-support.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+fix(provider/openai-compatible): support additional audio formats and video
+
+Audio formats beyond wav/mp3 and all video formats are now passed as data URIs
+via image_url instead of being rejected, allowing downstream backends to handle
+them natively. Audio file URLs are also now supported via image_url.

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -181,38 +181,193 @@ describe('user messages', () => {
     ]);
   });
 
-  it('should throw error for audio parts with URLs', async () => {
-    expect(() =>
-      convertToOpenAICompatibleChatMessages([
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'file',
-              data: new URL('https://example.com/audio.wav'),
-              mediaType: 'audio/wav',
-            },
-          ],
-        },
-      ]),
-    ).toThrow("'audio file parts with URLs' functionality not supported");
+  it('should convert audio URLs to image_url', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new URL('https://example.com/audio.wav'),
+            mediaType: 'audio/wav',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/audio.wav' },
+          },
+        ],
+      },
+    ]);
   });
 
-  it('should throw error for unsupported audio format', async () => {
-    expect(() =>
-      convertToOpenAICompatibleChatMessages([
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'file',
-              data: new Uint8Array([0, 1, 2, 3]),
-              mediaType: 'audio/ogg',
-            },
-          ],
-        },
-      ]),
-    ).toThrow("'audio media type audio/ogg' functionality not supported");
+  it('should convert audio URLs with non-wav/mp3 format to image_url', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new URL('https://example.com/audio.ogg'),
+            mediaType: 'audio/ogg',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/audio.ogg' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert messages with audio/mpga parts to mp3 format', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'audio/mpga',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'input_audio',
+            input_audio: { data: 'AAECAw==', format: 'mp3' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert audio/ogg parts to image_url with data URI', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'audio/ogg',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:audio/ogg;base64,AAECAw==' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert audio/flac parts to image_url with data URI', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'audio/flac',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:audio/flac;base64,AAECAw==' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert audio/webm parts to image_url with data URI', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'audio/webm',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:audio/webm;base64,AAECAw==' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert unknown audio formats to image_url with data URI', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'audio/xyz',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:audio/xyz;base64,AAECAw==' },
+          },
+        ],
+      },
+    ]);
   });
 
   it('should convert messages with PDF parts', async () => {
@@ -379,6 +534,93 @@ describe('user messages', () => {
     ]);
   });
 
+  it('should convert messages with video/mp4 parts', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'video/mp4',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'data:video/mp4;base64,AAECAw==',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert messages with video/webm parts', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'video/webm',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'data:video/webm;base64,AAECAw==',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should handle URL-based video parts', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new URL('https://example.com/video.mp4'),
+            mediaType: 'video/mp4',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/video.mp4',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should throw error for unsupported file types', async () => {
     expect(() =>
       convertToOpenAICompatibleChatMessages([
@@ -388,12 +630,14 @@ describe('user messages', () => {
             {
               type: 'file',
               data: new Uint8Array([0, 1, 2, 3]),
-              mediaType: 'video/mp4',
+              mediaType: 'application/zip',
             },
           ],
         },
       ]),
-    ).toThrow("'file part media type video/mp4' functionality not supported");
+    ).toThrow(
+      "'file part media type application/zip' functionality not supported",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #12723

The `openai-compatible` provider threw `UnsupportedFunctionalityError` for audio formats beyond wav/mp3, audio file URLs, and all video formats. Since this provider is generic (used for Gemini, Vertex, etc.), it should delegate format validation to the downstream backend rather than rejecting upfront.

**Key insight:** `input_audio.format` only accepts `wav` and `mp3` in both the OpenAI API and Gemini's OAI-compatible endpoint ([confirmed here](https://discuss.ai.google.dev/t/more-audio-file-type-support-in-openai-compatible-api/77438)). Using `image_url` with data URIs (`data:audio/ogg;base64,...`) lets the backend parse the MIME type and handle it natively — same pattern already used for images.

### Changes

- Add `audio/mpga` as mp3 alias in `getAudioFormat`
- Audio with non-wav/mp3 formats → `image_url` with base64 data URI (previously threw error)
- Audio file URLs → `image_url` with URL (previously threw error)
- Video → `image_url` with data URI or URL (previously threw error)
- Unsupported types like `application/zip` still throw `UnsupportedFunctionalityError`

## Test plan

- [x] `pnpm test:node` in `packages/openai-compatible` — 184 tests pass
- [x] Existing `audio/wav`, `audio/mp3`, `audio/mpeg` tests unchanged (still use `input_audio`)
- [x] `audio/ogg`, `audio/flac`, `audio/webm` → expect `image_url` with data URI
- [x] New tests: `audio/mpga` → `input_audio`, audio URLs → `image_url`, unknown `audio/xyz` → `image_url`
- [x] Video tests: `video/mp4`, `video/webm`, video URL → `image_url`
- [x] `application/zip` still throws error