### PR TITLE
fix(ai): Don't create duplicate tool parts when models call non-existent tools

### DIFF
--- a/.changeset/quiet-tables-relate.md
+++ b/.changeset/quiet-tables-relate.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): Don't create duplicate tool parts when models call non-existent tools


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

When a model calls a tool that doesn't exist in the tools object (e.g. a hallucinated tool name), processUIMessageStream creates two message parts for the same toolCallId — one static (tool-{toolName}) and one dynamic (dynamic-tool). This causes downstream failures when the conversation is continued, since the model API rejects requests containing two tool results for the same tool call ID.

## Summary

Fixes a bug in `processUIMessageStream` where a model calling a non-existent tool produces two UI message parts for the same `toolCallId` — one static (`tool-{toolName}`) and one dynamic (`dynamic-tool`). This happens because `tool-input-start` creates a static part (when `dynamic` is undefined for an unknown tool), but the subsequent `tool-input-error` arrives with `dynamic: true` and only searches for a `dynamic-tool` part, missing the existing static one and creating a duplicate. The fix checks for an existing part by `toolCallId` before branching on `chunk.dynamic`, so the error updates the existing part in place instead of creating a second one.

## Manual Verification

Manually verified against my own application. After the fix, I got a single tool part like:

```
            {
                "type": "tool-dashboard-page-create-dashboard",
                "state": "output-error",
                "rawInput":
                {
                    "name": "Staging Monitoring"
                },
                "errorText": "Model tried to call unavailable tool 'dashboard-page-create-dashboard'. Available tools: ....",
                "toolCallId": "toolu_015E6Kd6cwSMkw7SFpsa7w88",
                "callProviderMetadata":
                {
                    "anthropic":
                    {
                        "caller":
                        {
                            "type": "direct"
                        }
                    }
                }
            },
```
## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #12772 
