### PR TITLE
fix(amazon-bedrock): strip cross-region inference prefix before embedding model detection

### DIFF
--- a/packages/amazon-bedrock/src/bedrock-embedding-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.test.ts
@@ -24,7 +24,15 @@ const cohereV4EmbedUrl = `https://bedrock-runtime.us-east-1.amazonaws.com/model/
   'cohere.embed-v4:0',
 )}/invoke`;
 
-// Cross-region inference prepends a region prefix (e.g. "eu.") to the model ID.
+// Cross-region inference prepends a region prefix to the model ID.
+// AWS supports multiple prefix formats: 2-letter codes (us., eu., ap.),
+// multi-letter codes (apac., global.), and hyphenated codes (us-gov.).
+const crossRegionCohereModels = [
+  'eu.cohere.embed-v4:0',
+  'apac.cohere.embed-v4:0',
+  'global.cohere.embed-v4:0',
+  'us-gov.cohere.embed-v4:0',
+];
 const cohereEuCrossRegionEmbedUrl = `https://bedrock-runtime.us-east-1.amazonaws.com/model/${encodeURIComponent(
   'eu.cohere.embed-v4:0',
 )}/invoke`;
@@ -76,19 +84,20 @@ describe('doEmbed', () => {
         ),
       },
     },
-    [cohereEuCrossRegionEmbedUrl]: {
-      response: {
-        type: 'binary',
-        headers: {
-          'content-type': 'application/json',
+    ...Object.fromEntries(
+      crossRegionCohereModels.map(modelId => [
+        `https://bedrock-runtime.us-east-1.amazonaws.com/model/${encodeURIComponent(modelId)}/invoke`,
+        {
+          response: {
+            type: 'binary' as const,
+            headers: { 'content-type': 'application/json' },
+            body: Buffer.from(
+              JSON.stringify({ embeddings: { float: [mockEmbeddings[0]] } }),
+            ),
+          },
         },
-        body: Buffer.from(
-          JSON.stringify({
-            embeddings: { float: [mockEmbeddings[0]] },
-          }),
-        ),
-      },
-    },
+      ]),
+    ),
   });
 
   const model = new BedrockEmbeddingModel('amazon.titan-embed-text-v2:0', {
@@ -247,42 +256,37 @@ describe('doEmbed', () => {
     });
   });
 
-  it('should support cross-region inference prefix for Cohere embedding models', async () => {
-    const crossRegionModel = new BedrockEmbeddingModel('eu.cohere.embed-v4:0', {
-      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
-      headers: mockConfigHeaders,
-      fetch: fakeFetchWithAuth,
-    });
+  it.each(crossRegionCohereModels)(
+    'should support cross-region inference prefix for Cohere embedding models (%s)',
+    async modelId => {
+      const crossRegionModel = new BedrockEmbeddingModel(modelId, {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        headers: mockConfigHeaders,
+        fetch: fakeFetchWithAuth,
+      });
 
-    const { embeddings } = await crossRegionModel.doEmbed({
-      values: [testValues[0]],
-      providerOptions: {
-        bedrock: {
-          inputType: 'search_document',
-          outputDimension: 1024,
+      const { embeddings } = await crossRegionModel.doEmbed({
+        values: [testValues[0]],
+        providerOptions: {
+          bedrock: {
+            inputType: 'search_document',
+            outputDimension: 1024,
+          },
         },
-      },
-    });
+      });
 
-    expect(embeddings.length).toBe(1);
-    expect(embeddings[0]).toMatchInlineSnapshot(`
-      [
-        -0.09,
-        0.05,
-        -0.02,
-        0.01,
-        0.04,
-      ]
-    `);
+      expect(embeddings.length).toBe(1);
+      expect(embeddings[0]).toEqual([-0.09, 0.05, -0.02, 0.01, 0.04]);
 
-    const body = await server.calls[0].requestBodyJson;
-    expect(body).toEqual({
-      input_type: 'search_document',
-      texts: [testValues[0]],
-      truncate: undefined,
-      output_dimension: 1024,
-    });
-  });
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toEqual({
+        input_type: 'search_document',
+        texts: [testValues[0]],
+        truncate: undefined,
+        output_dimension: 1024,
+      });
+    },
+  );
 
   it('should properly combine headers from all sources', async () => {
     const optionsHeaders = {

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.ts
@@ -71,9 +71,14 @@ export class BedrockEmbeddingModel implements EmbeddingModelV3 {
     // Note: Different embedding model families expect different request/response
     // payloads (e.g. Titan vs Cohere vs Nova). We keep the public interface stable and
     // adapt here based on the modelId.
+    //
+    // Cross-region inference access points prepend a region prefix to the model ID
+    // (e.g. "eu.cohere.embed-v4:0", "us.amazon.nova-lite-v1:0"). Strip it before
+    // detecting the model family so that the correct request payload is used.
+    const baseModelId = this.modelId.replace(/^[a-z]{2,3}\./, '');
     const isNovaModel =
-      this.modelId.startsWith('amazon.nova-') && this.modelId.includes('embed');
-    const isCohereModel = this.modelId.startsWith('cohere.embed-');
+      baseModelId.startsWith('amazon.nova-') && baseModelId.includes('embed');
+    const isCohereModel = baseModelId.startsWith('cohere.embed-');
 
     const args = isNovaModel
       ? {

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.ts
@@ -73,9 +73,15 @@ export class BedrockEmbeddingModel implements EmbeddingModelV3 {
     // adapt here based on the modelId.
     //
     // Cross-region inference access points prepend a region prefix to the model ID
-    // (e.g. "eu.cohere.embed-v4:0", "us.amazon.nova-lite-v1:0"). Strip it before
-    // detecting the model family so that the correct request payload is used.
-    const baseModelId = this.modelId.replace(/^[a-z]{2,3}\./, '');
+    // (e.g. "eu.cohere.embed-v4:0", "apac.cohere.embed-v4:0", "us-gov.cohere.embed-v4:0",
+    // "global.amazon.nova-lite-v1:0"). All Bedrock model IDs have exactly one dot
+    // (provider.model-name), so a second dot indicates a cross-region prefix.
+    // Strip the prefix before detecting the model family.
+    const dotIndex = this.modelId.indexOf('.');
+    const baseModelId =
+      dotIndex !== -1 && this.modelId.indexOf('.', dotIndex + 1) !== -1
+        ? this.modelId.slice(dotIndex + 1)
+        : this.modelId;
     const isNovaModel =
       baseModelId.startsWith('amazon.nova-') && baseModelId.includes('embed');
     const isCohereModel = baseModelId.startsWith('cohere.embed-');


### PR DESCRIPTION
## Summary

AWS Bedrock cross-region inference access points prepend a region prefix to the model ID (e.g. `eu.cohere.embed-v4:0`, `us.amazon.nova-lite-v1:0`). The embedding model was comparing `this.modelId` directly against known model-family prefixes like `"cohere.embed-"` and `"amazon.nova-"`, so cross-region model IDs fell through to the default Titan handler and sent a malformed request body (`inputText` / `dimensions` / `normalize` instead of the Cohere-expected `texts` / `input_type` / `output_dimension`).

## Root cause

```ts
// Before — fails for eu.cohere.embed-v4:0
const isCohereModel = this.modelId.startsWith('cohere.embed-');
```

## Fix

Extract a `baseModelId` by stripping the optional cross-region region prefix (`/^[a-z]{2,3}\./`) and use it for model-family detection only. The **original** model ID is still used for the API URL so that cross-region routing continues to work.

```ts
const baseModelId = this.modelId.replace(/^[a-z]{2,3}\./, '');
const isCohereModel = baseModelId.startsWith('cohere.embed-');
```

## Changes

- `bedrock-embedding-model.ts`: Add `baseModelId` stripping; use it for `isNovaModel`/`isCohereModel` detection.
- `bedrock-embedding-model.test.ts`: Add a new test case using `eu.cohere.embed-v4:0` to verify the cross-region prefix is handled correctly and the right Cohere request body is sent.

Fixes #12773