### PR TITLE
fix(langchain): register key mapping for HITL interrupt matching in dual streamMode

### DIFF
--- a/.changeset/hitl-interrupt-key-mapping.md
+++ b/.changeset/hitl-interrupt-key-mapping.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/langchain': patch
+---
+
+fix(langchain): register key mapping for tool calls emitted via messages mode for HITL interrupt matching

--- a/packages/langchain/src/__snapshots__/langgraph-hitl-request-1.json
+++ b/packages/langchain/src/__snapshots__/langgraph-hitl-request-1.json
@@ -480,24 +480,9 @@
     "id": "run-019b259a-5def-7000-8000-0a449f226de9"
   },
   {
-    "type": "tool-input-start",
-    "toolCallId": "hitl-delete_file-1234567890",
-    "toolName": "delete_file",
-    "dynamic": true
-  },
-  {
-    "type": "tool-input-available",
-    "toolCallId": "hitl-delete_file-1234567890",
-    "toolName": "delete_file",
-    "input": {
-      "filename": "report.pdf"
-    },
-    "dynamic": true
-  },
-  {
     "type": "tool-approval-request",
-    "approvalId": "hitl-delete_file-1234567890",
-    "toolCallId": "hitl-delete_file-1234567890"
+    "approvalId": "call_LOd3dMxgYxmNLWZVWXra9xWQ",
+    "toolCallId": "call_LOd3dMxgYxmNLWZVWXra9xWQ"
   },
   {
     "type": "finish-step"

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -1461,6 +1461,11 @@ export function processLangGraphEvent(
                     input: toolCall.args,
                     dynamic: true,
                   });
+                } else if (toolCall.id && emittedToolCalls.has(toolCall.id)) {
+                  // Register key mapping for tool calls already emitted via messages mode
+                  // so that __interrupt__ handling can match them by key
+                  const toolCallKey = `${toolCall.name}:${JSON.stringify(toolCall.args)}`;
+                  emittedToolCallsByKey.set(toolCallKey, toolCall.id);
                 }
               }
             }


### PR DESCRIPTION
## Background

When using `@ai-sdk/langchain` with `streamMode: ["messages", "values"]` for LangGraph HITL (Human-in-the-Loop) workflows, the `__interrupt__` handler fails to match tool calls that were already emitted via the `messages` stream mode.

In `processLangGraphEvent`, tool calls emitted through `messages` events are added to `emittedToolCalls` (Set) but **not** to `emittedToolCallsByKey` (Map). When the subsequent `values` event arrives with the same tool call, the values mode tool call loop skips it because `emittedToolCalls.has(toolCall.id)` is already true — but this also skips the `emittedToolCallsByKey.set()` registration. When the `__interrupt__` handler then tries `emittedToolCallsByKey.get(toolCallKey)`, it fails and falls back to generating a new ID like `hitl-delete_file-1234567890`.

This causes:
1. `tool-approval-request` gets a mismatched `toolCallId` (orphaned from the original tool call card in the UI)
2. Duplicate `tool-input-start` / `tool-input-available` events are emitted for the same tool call

## Summary

Added an `else if` branch in the values mode tool call loop to register the key mapping for tool calls that were already emitted via messages mode:

```typescript
} else if (toolCall.id && emittedToolCalls.has(toolCall.id)) {
  // Register key mapping for tool calls already emitted via messages mode
  // so that __interrupt__ handling can match them by key
  const toolCallKey = `${toolCall.name}:${JSON.stringify(toolCall.args)}`;
  emittedToolCallsByKey.set(toolCallKey, toolCall.id);
}
```

This is consistent with the existing key mapping pattern at L1292 (values finalization block).

**Changes:**
- `packages/langchain/src/utils.ts`: 5-line else-if branch addition
- `packages/langchain/src/adapter.test.ts`: 2 new test cases for the dual streamMode scenario
- Updated existing HITL snapshot to reflect correct tool call ID matching

## Manual Verification

Verified in a production application using `createReactAgent` + `interrupt()` + `streamMode: ["messages", "values"]`:
- Before fix: `tool-approval-request` gets fallback ID → orphaned approval card in UI
- After fix: `tool-approval-request` correctly references the original `toolCallId` → approval card connects to the existing tool call card

The existing HITL fixture test (`LANGGRAPH_RESPONSE_1`) also demonstrates the fix — the snapshot previously contained the fallback ID `hitl-delete_file-1234567890`, now correctly shows the original `call_LOd3dMxgYxmNLWZVWXra9xWQ`.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #12797

## Related PRs

- #11417 — fixes a different bug in the same code path (historical tool call re-emission)
- #11238 — original HITL interrupt support