### PR TITLE
chore: set up AI provider models tracking

### DIFF
--- a/.github/workflows/ai-provider-models.yml
+++ b/.github/workflows/ai-provider-models.yml
@@ -1,0 +1,60 @@
+name: AI Provider Models
+
+on:
+  repository_dispatch:
+    types: [ai_provider_models]
+
+jobs:
+  create-issue:
+    name: 'Create Issue for Provider Model Changes'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8 }}
+
+      - name: Build issue body
+        id: body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { provider, resultType, newModelIDs, obsoleteModelIDs } = context.payload.client_payload;
+
+            const lines = [];
+            lines.push(`**Provider:** \`${provider}\``);
+            lines.push(`**Type:** ${resultType === 'new_provider' ? 'New provider' : 'Model list diff'}`);
+            lines.push('');
+
+            if (newModelIDs.length > 0) {
+              lines.push('### New models');
+              for (const id of newModelIDs) {
+                lines.push(`- \`${id}\``);
+              }
+              lines.push('');
+            }
+
+            if (obsoleteModelIDs.length > 0) {
+              lines.push('### Obsolete models');
+              for (const id of obsoleteModelIDs) {
+                lines.push(`- \`${id}\``);
+              }
+              lines.push('');
+            }
+
+            core.setOutput('content', lines.join('\n'));
+
+      - name: Create issue
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/{owner}/{repo}/issues
+          owner: vercel
+          repo: ai
+          title: |
+            🤖 Provider model changes - ${{ github.event.client_payload.provider }}
+          body: |
+            ${{ steps.body.outputs.content }}
+          labels: '["maintenance"]'
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

* Adds a workflow that listens to the `ai_provider_models` repository_dispatch event, which includes new and obsolete model IDs for a given provider.
* Opens an issue with this information.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

We should add a skill for how to add new model IDs, or remove obsolete model IDs.
Ideally, an agent should pick up work on these in the future.

## Related Issues

N/A
