### PR TITLE
fix: ai-provider-models workflow YAML parsing error

### DIFF
--- a/.github/workflows/ai-provider-models.yml
+++ b/.github/workflows/ai-provider-models.yml
@@ -15,10 +15,10 @@ jobs:
           app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8 }}
 
-      - name: Build issue body
-        id: body
+      - name: Create issue
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { provider, resultType, newModelIDs, obsoleteModelIDs } = context.payload.client_payload;
 
@@ -43,20 +43,10 @@ jobs:
               lines.push('');
             }
 
-            core.setOutput('content', lines.join('\n'));
-
-      - name: Create issue
-        uses: octokit/request-action@v2.x
-        with:
-          route: POST /repos/{owner}/{repo}/issues
-          owner: vercel
-          repo: ai
-          title: |
-            🤖 Provider model changes - ${{ env.PROVIDER }}
-          body: |
-            ${{ env.BODY }}
-          labels: '["maintenance"]'
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          PROVIDER: ${{ github.event.client_payload.provider }}
-          BODY: ${{ steps.body.outputs.content }}
+            await github.rest.issues.create({
+              owner: 'vercel',
+              repo: 'ai',
+              title: `🤖 Provider model changes - ${provider}`,
+              body: lines.join('\n'),
+              labels: ['maintenance'],
+            });


### PR DESCRIPTION
## Summary

- Fixes the `ai-provider-models` workflow failing with `unidentified alias "*Provider:**"` YAML parsing error
- Replaces the two-step approach (`actions/github-script` + `octokit/request-action`) with a single `actions/github-script` step that builds the body and creates the issue directly via `github.rest.issues.create()`
- Root cause: `octokit/request-action@v2.x` parses all `with:` input values as YAML, causing markdown `**Provider:**` to be misinterpreted as a YAML alias

Fixes: https://github.com/vercel/ai/actions/runs/22365606983/job/64730638388

## Test plan

- [ ] Re-run the `ai_provider_models` repository dispatch event and verify the issue is created successfully