### PR TITLE
feat(provider/xai): add missing image model IDs

### DIFF
--- a/.changeset/add-xai-image-model-ids.md
+++ b/.changeset/add-xai-image-model-ids.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Added `grok-imagine-image-pro` and `grok-2-image-1212` to XaiImageModelId type for better autocomplete support.

--- a/examples/ai-functions/src/generate-image/xai/imagine-image-pro.ts
+++ b/examples/ai-functions/src/generate-image/xai/imagine-image-pro.ts
@@ -1,0 +1,13 @@
+import { xai } from '@ai-sdk/xai';
+import { generateImage } from 'ai';
+import { presentImages } from '../../lib/present-image';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { image } = await generateImage({
+    model: xai.image('grok-imagine-image-pro'),
+    prompt: 'A salamander at dusk in a forest pond surrounded by fireflies.',
+  });
+
+  await presentImages([image]);
+});

--- a/packages/xai/src/xai-image-settings.ts
+++ b/packages/xai/src/xai-image-settings.ts
@@ -1,4 +1,6 @@
 export type XaiImageModelId =
   | 'grok-2-image'
+  | 'grok-2-image-1212'
   | 'grok-imagine-image'
+  | 'grok-imagine-image-pro'
   | (string & {});


### PR DESCRIPTION
## Summary

- Adds `grok-imagine-image-pro` and `grok-2-image-1212` to `XaiImageModelId` type for IDE autocomplete support
- Adds example for `grok-imagine-image-pro` image generation

All other model IDs from [#12808](https://github.com/vercel/ai/issues/12808) were already present in the appropriate type unions (`XaiChatModelId`, `XaiImageModelId`, `XaiVideoModelId`). The two missing entries were both image model IDs that hadn't been added to `XaiImageModelId`.

Verified against the [xAI models documentation](https://docs.x.ai/docs/models).

## Test plan
- [x] All 217 tests pass (`pnpm test` in packages/xai)
- [x] Build succeeds
- [x] TypeScript type check passes for `packages/xai` and `examples/ai-functions`

Closes #12808