### PR TITLE
feat(provider/openai): add `gpt-5.3-codex`

### DIFF
--- a/.changeset/silver-camels-rule.md
+++ b/.changeset/silver-camels-rule.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/gateway': patch
+'@ai-sdk/openai': patch
+---
+
+feat(provider/openai): add `gpt-5.3-codex`

--- a/content/providers/03-community-providers/13-codex-cli.mdx
+++ b/content/providers/03-community-providers/13-codex-cli.mdx
@@ -91,7 +91,7 @@ const model = codexCli('gpt-5.2-codex');
 
 **Current Generation Models:**
 
-- **gpt-5.2-codex**: Latest agentic coding model
+- **gpt-5.3-codex**: Latest agentic coding model
 - **gpt-5.2**: Latest general purpose model
 - **gpt-5.1-codex-max**: Flagship model with deep reasoning (supports `xhigh` reasoning)
 - **gpt-5.1-codex-mini**: Lightweight, faster variant
@@ -135,6 +135,7 @@ const model = codexCli('gpt-5.1-codex-max', {
 
 | Model                | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
 | -------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gpt-5.3-codex`      | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 | `gpt-5.2-codex`      | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 | `gpt-5.2`            | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 | `gpt-5.1-codex-max`  | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |

--- a/content/providers/03-community-providers/46-codex-app-server.mdx
+++ b/content/providers/03-community-providers/46-codex-app-server.mdx
@@ -184,6 +184,7 @@ const result = await streamText({
 
 | Model                | Image Input         | Object Generation   | Tool Streaming      | Mid-Execution       |
 | -------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gpt-5.3-codex`      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gpt-5.2-codex`      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gpt-5.1-codex-max`  | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gpt-5.1-codex-mini` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -126,6 +126,7 @@ export type GatewayModelId =
   | 'openai/gpt-5.2-chat'
   | 'openai/gpt-5.2-codex'
   | 'openai/gpt-5.2-pro'
+  | 'openai/gpt-5.3-codex'
   | 'openai/gpt-oss-120b'
   | 'openai/gpt-oss-20b'
   | 'openai/gpt-oss-safeguard-20b'

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -42,6 +42,8 @@ export const openaiResponsesReasoningModelIds = [
   'gpt-5.2',
   'gpt-5.2-chat-latest',
   'gpt-5.2-pro',
+  'gpt-5.2-codex',
+  'gpt-5.3-codex',
 ] as const;
 
 export const openaiResponsesModelIds = [
@@ -110,6 +112,8 @@ export type OpenAIResponsesModelId =
   | 'gpt-5.2'
   | 'gpt-5.2-chat-latest'
   | 'gpt-5.2-pro'
+  | 'gpt-5.2-codex'
+  | 'gpt-5.3-codex'
   | 'gpt-5-2025-08-07'
   | 'gpt-5-chat-latest'
   | 'gpt-5-codex'


### PR DESCRIPTION
## Background

OpenAI released `gpt-5.3-codex` in the API: https://x.com/OpenAIDevs/status/2026379092661289260?s=20

This PR adds support for it.

## Summary

Adds `gpt-5.3-codex` to the OpenAI and Gateway provider model lists. Also adds `gpt-5.2-codex` to the OpenAI model list, which was previously missing. Docs referencing `gpt-5.2-codex` were updated as well to include `gpt-5.3-codex`.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
