### PR TITLE
docs(agents): document ai-functions examples folder layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,15 @@ Run these from within a package directory (e.g., `packages/ai`):
 
 ```bash
 cd examples/ai-functions
-pnpm tsx src/stream-text/openai.ts    # Run a specific example
+pnpm tsx src/stream-text/openai/basic.ts    # Run a specific example
 ```
+
+### AI Functions Example Layout
+
+- Place examples under `examples/ai-functions/src/<function>/<provider>/`
+- Use `basic.ts` for the provider entry example file
+- Place all other examples in the same provider folder using descriptive `kebab-case` file names
+- Do not create flat top-level provider files like `src/stream-text/openai.ts`
 
 ## Core APIs
 


### PR DESCRIPTION
## Background

the ai-functions examples were moved to provider folders with `basic.ts` entry files
`AGENTS.md` still showed the old flat path example and had no explicit layout guidance

## Summary

- update the running example command to `pnpm tsx src/stream-text/openai/basic.ts`
- add an `AI Functions Example Layout` section in `AGENTS.md`
- document the expected pattern `examples/ai-functions/src/<function>/<provider>/`
- document `basic.ts` as the provider entry file
- clarify that flat top-level provider files should not be created

## Manual Verification

- reviewed rendered markdown in `AGENTS.md`
- confirmed the paths match the current examples structure

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
