### PR TITLE
feat(examples): add gpt-5.3-codex stream and generate examples

### DIFF
--- a/examples/ai-functions/src/generate-text/openai/gpt-5-3-codex.ts
+++ b/examples/ai-functions/src/generate-text/openai/gpt-5-3-codex.ts
@@ -1,0 +1,17 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+import { print } from '../../lib/print';
+
+run(async () => {
+  const result = await generateText({
+    model: openai('gpt-5.3-codex'),
+    prompt: 'Write a JavaScript function that returns the sum of two numbers.',
+    maxRetries: 0,
+  });
+
+  print('Text:', result.text);
+  print('Usage:', result.usage);
+  print('Finish reason:', result.finishReason);
+  print('Raw finish reason:', result.rawFinishReason);
+});

--- a/examples/ai-functions/src/stream-text/openai/gpt-5-3-codex.ts
+++ b/examples/ai-functions/src/stream-text/openai/gpt-5-3-codex.ts
@@ -1,0 +1,20 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+import { print } from '../../lib/print';
+
+run(async () => {
+  const result = streamText({
+    model: openai('gpt-5.3-codex'),
+    prompt: 'Write a JavaScript function that returns the sum of two numbers.',
+    maxRetries: 0,
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  process.stdout.write('\n');
+  print('Usage:', await result.usage);
+  print('Finish reason:', await result.finishReason);
+});


### PR DESCRIPTION
## Background

a new model `gpt-5.3-codex` was added in https://github.com/vercel/ai/pull/12814
we should have ai-functions coverage examples for both `generateText` and `streamText`

## Summary

- add `generate-text` example for `gpt-5.3-codex`
  - `examples/ai-functions/src/generate-text/openai/gpt-5-3-codex.ts`
- add `stream-text` example for `gpt-5.3-codex`
  - `examples/ai-functions/src/stream-text/openai/gpt-5-3-codex.ts`

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
