### PR TITLE
Backport: Add automatic caching for Anthropic (#12743)

### DIFF
--- a/.changeset/add-automatic-caching-anthropic.md
+++ b/.changeset/add-automatic-caching-anthropic.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Pass `cacheControl` provider option as top-level `cache_control` in Anthropic API request body to support automatic caching.

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -3006,14 +3006,14 @@ describe('AnthropicMessagesLanguageModel', () => {
     });
 
     it('should pass cache_control to request body', async () => {
-      prepareJsonFixtureResponse('anthropic-text');
+      prepareJsonResponse({});
 
       const result = await model.doGenerate({
         prompt: TEST_PROMPT,
         providerOptions: {
           anthropic: {
             cacheControl: { type: 'ephemeral' },
-          } satisfies AnthropicLanguageModelOptions,
+          } satisfies AnthropicProviderOptions,
         },
       });
 
@@ -3042,14 +3042,14 @@ describe('AnthropicMessagesLanguageModel', () => {
     });
 
     it('should pass cache_control with ttl to request body', async () => {
-      prepareJsonFixtureResponse('anthropic-text');
+      prepareJsonResponse({});
 
       const result = await model.doGenerate({
         prompt: TEST_PROMPT,
         providerOptions: {
           anthropic: {
             cacheControl: { type: 'ephemeral', ttl: '1h' },
-          } satisfies AnthropicLanguageModelOptions,
+          } satisfies AnthropicProviderOptions,
         },
       });
 

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -3005,6 +3005,79 @@ describe('AnthropicMessagesLanguageModel', () => {
       expect(result.warnings).toStrictEqual([]);
     });
 
+    it('should pass cache_control to request body', async () => {
+      prepareJsonFixtureResponse('anthropic-text');
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            cacheControl: { type: 'ephemeral' },
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "cache_control": {
+            "type": "ephemeral",
+          },
+          "max_tokens": 4096,
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "claude-3-haiku-20240307",
+        }
+      `);
+
+      expect(result.warnings).toStrictEqual([]);
+    });
+
+    it('should pass cache_control with ttl to request body', async () => {
+      prepareJsonFixtureResponse('anthropic-text');
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            cacheControl: { type: 'ephemeral', ttl: '1h' },
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "cache_control": {
+            "ttl": "1h",
+            "type": "ephemeral",
+          },
+          "max_tokens": 4096,
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "claude-3-haiku-20240307",
+        }
+      `);
+
+      expect(result.warnings).toStrictEqual([]);
+    });
+
     describe('context management', () => {
       it('should send context_management in request body', async () => {
         prepareJsonResponse({});

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -279,6 +279,9 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
       ...(anthropicOptions?.speed && {
         speed: anthropicOptions.speed,
       }),
+      ...(anthropicOptions?.cacheControl && {
+        cache_control: anthropicOptions.cacheControl,
+      }),
 
       // structured output:
       ...(useStructuredOutput &&


### PR DESCRIPTION
## Summary

Backport of #12743 to `release-v5.0`.

- Passes the `cacheControl` provider option as a top-level `cache_control` field in the Anthropic API request body to support [automatic caching](https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching#automatic-caching)
- Includes tests for both `{ type: 'ephemeral' }` and `{ type: 'ephemeral', ttl: '1h' }`
- Includes patch changeset for `@ai-sdk/anthropic`