### PR TITLE
feat (provider/gateway): pass through project id when available for o11y

### DIFF
--- a/.changeset/fuzzy-eggs-play.md
+++ b/.changeset/fuzzy-eggs-play.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): pass through project id when available for o11y

--- a/packages/gateway/src/gateway-provider.test.ts
+++ b/packages/gateway/src/gateway-provider.test.ts
@@ -395,6 +395,7 @@ describe('GatewayProvider', () => {
         VERCEL_DEPLOYMENT_ID: 'test-deployment',
         VERCEL_ENV: 'test',
         VERCEL_REGION: 'iad1',
+        VERCEL_PROJECT_ID: 'prj_test123',
       };
       vi.mocked(getVercelRequestId).mockResolvedValue('test-request-id');
 
@@ -423,6 +424,7 @@ describe('GatewayProvider', () => {
           'ai-o11y-environment': 'test',
           'ai-o11y-region': 'iad1',
           'ai-o11y-request-id': 'test-request-id',
+          'ai-o11y-project-id': 'prj_test123',
         });
       } finally {
         process.env = originalEnv;

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -185,6 +185,10 @@ export function createGatewayProvider(
       settingValue: undefined,
       environmentVariableName: 'VERCEL_REGION',
     });
+    const projectId = loadOptionalSetting({
+      settingValue: undefined,
+      environmentVariableName: 'VERCEL_PROJECT_ID',
+    });
 
     return async () => {
       const requestId = await getVercelRequestId();
@@ -193,6 +197,7 @@ export function createGatewayProvider(
         ...(environment && { 'ai-o11y-environment': environment }),
         ...(region && { 'ai-o11y-region': region }),
         ...(requestId && { 'ai-o11y-request-id': requestId }),
+        ...(projectId && { 'ai-o11y-project-id': projectId }),
       };
     };
   };


### PR DESCRIPTION
## Background

The gateway provider needs to pass through Vercel project ID information for observability purposes when it's available in the environment.

## Changes

Added support for passing through the `VERCEL_PROJECT_ID` environment variable as the `ai-o11y-project-id` header in the gateway provider's observability headers. This enables better tracking and identification of requests by project when using the AI SDK gateway in Vercel deployments.

## Manual Verification

Tested that when `VERCEL_PROJECT_ID` is set in the environment, it gets properly included in the observability headers sent with gateway requests.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)