### PR TITLE
fix(provider/openai): add chatgpt-image to default response format prefixes

### DIFF
--- a/packages/openai/src/image/openai-image-model.test.ts
+++ b/packages/openai/src/image/openai-image-model.test.ts
@@ -260,6 +260,33 @@ describe('doGenerate', () => {
     expect(requestBody).not.toHaveProperty('response_format');
   });
 
+  it('should not include response_format for chatgpt-image-latest', async () => {
+    prepareJsonFixtureResponse('openai-image');
+
+    const chatgptImageModel = provider.image('chatgpt-image-latest');
+    await chatgptImageModel.doGenerate({
+      prompt,
+      files: undefined,
+      mask: undefined,
+      n: 1,
+      size: '1024x1024',
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {},
+    });
+
+    const requestBody =
+      await server.calls[server.calls.length - 1].requestBodyJson;
+    expect(requestBody).toStrictEqual({
+      model: 'chatgpt-image-latest',
+      prompt,
+      n: 1,
+      size: '1024x1024',
+    });
+
+    expect(requestBody).not.toHaveProperty('response_format');
+  });
+
   it('should not include response_format for date-suffixed gpt-image model IDs (Azure deployment names)', async () => {
     prepareJsonFixtureResponse('openai-image');
 

--- a/packages/openai/src/image/openai-image-options.ts
+++ b/packages/openai/src/image/openai-image-options.ts
@@ -18,6 +18,7 @@ export const modelMaxImagesPerCall: Record<OpenAIImageModelId, number> = {
 };
 
 const defaultResponseFormatPrefixes = [
+  'chatgpt-image-',
   'gpt-image-1-mini',
   'gpt-image-1.5',
   'gpt-image-1',


### PR DESCRIPTION
## Summary

- Adds `chatgpt-image-` prefix to `defaultResponseFormatPrefixes` so `chatgpt-image-latest` (and future `chatgpt-image-*` models) no longer get `response_format: 'b64_json'` incorrectly sent in API requests
- Adds regression test

Flagged by the Vercel bot review on #12831 — out of scope for that PR since it's an OpenAI provider issue, not xAI.

## Test plan

- [x] New test verifying `chatgpt-image-latest` requests don't include `response_format`
- [x] All OpenAI image model tests pass (24 tests)