### PR TITLE
fix(ai): onStepFinish type for AgentUIStream methods

### DIFF
--- a/.changeset/orange-dragons-clean.md
+++ b/.changeset/orange-dragons-clean.md
@@ -1,0 +1,6 @@
+---
+'ai': patch
+---
+
+fix(ai): use `UIMessageStreamOnStepFinishCallback` type for `onStepFinish` in `createAgentUIStream` and related methods
+feat(ai): add `onStepFinish` callback to `DefaultStreamTextResult.toUIMessageStream` and related methods

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -3445,6 +3445,12 @@ To see `streamText` in action, check out [these examples](#examples).
               description: 'The original messages.',
             },
             {
+              name: 'onStepFinish',
+              type: '(options: { messages: UIMessage[]; isContinuation: boolean; responseMessage: UIMessage; }) => PromiseLike<void> | void',
+              isOptional: true,
+              description: 'Callback function called after each step completes during streaming. Useful for persisting intermediate UI messages during multi-step agent runs.',
+            },
+            {
               name: 'onFinish',
               type: '(options: { messages: UIMessage[]; isContinuation: boolean; responseMessage: UIMessage; isAborted: boolean; }) => void',
               isOptional: true,

--- a/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
@@ -87,18 +87,11 @@ export async function* streamAgent(
         'Optional transformations to apply to the agent output stream (experimental).',
     },
     {
-      name: 'onStepFinish',
-      type: 'ToolLoopAgentOnStepFinishCallback',
-      isRequired: false,
-      description:
-        'Callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage or logging intermediate steps.',
-    },
-    {
       name: '...UIMessageStreamOptions',
       type: 'UIMessageStreamOptions',
       isRequired: false,
       description:
-        'Additional options to control the output stream, such as including sources or usage data.',
+        'Additional options to control the output stream, such as including sources, usage data, or callbacks.',
     },
   ]}
 />

--- a/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
@@ -88,18 +88,11 @@ export async function POST(request: Request) {
         'Optional stream transforms to post-process text output—the same as in lower-level streaming APIs.',
     },
     {
-      name: 'onStepFinish',
-      type: 'ToolLoopAgentOnStepFinishCallback',
-      isRequired: false,
-      description:
-        'Callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage or logging intermediate steps.',
-    },
-    {
       name: '...UIMessageStreamOptions',
       type: 'UIMessageStreamOptions',
       isRequired: false,
       description:
-        'Other UI message output options—such as `sendSources` and more.',
+        'Additional options to control the output stream, such as including sources, usage data, or callbacks.',
     },
     {
       name: 'headers',

--- a/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
@@ -89,13 +89,6 @@ export async function handler(req, res) {
         'Optional stream text transformation(s) applied to agent output.',
     },
     {
-      name: 'onStepFinish',
-      type: 'ToolLoopAgentOnStepFinishCallback',
-      isRequired: false,
-      description:
-        'Callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage or logging intermediate steps.',
-    },
-    {
       name: '...UIMessageStreamResponseInit & UIMessageStreamOptions',
       type: 'object',
       isRequired: false,

--- a/content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx
@@ -106,6 +106,37 @@ const stream = createUIMessageStream({
         'The original messages. If provided, persistence mode is assumed and a message ID is provided for the response message.',
     },
     {
+      name: 'onStepFinish',
+      type: '(options: { messages: UIMessage[]; isContinuation: boolean; responseMessage: UIMessage; }) => PromiseLike<void> | void',
+      description:
+        'A callback function that is called when each step finishes during multi-step agent runs. Useful for persisting intermediate UI messages.',
+      properties: [
+        {
+          type: 'StepFinishOptions',
+          parameters: [
+            {
+              name: 'messages',
+              type: 'UIMessage[]',
+              description:
+                'The updated list of UI messages at the end of this step.',
+            },
+            {
+              name: 'isContinuation',
+              type: 'boolean',
+              description:
+                'Indicates whether the response message is a continuation of the last original message, or if a new message was created.',
+            },
+            {
+              name: 'responseMessage',
+              type: 'UIMessage',
+              description:
+                'The message that was sent to the client as a response (including the original message if it was extended).',
+            },
+          ],
+        },
+      ],
+    },
+    {
       name: 'onFinish',
       type: '(options: { messages: UIMessage[]; isContinuation: boolean; isAborted: boolean; responseMessage: UIMessage; finishReason?: FinishReason }) => PromiseLike<void> | void',
       description:

--- a/packages/ai/src/agent/create-agent-ui-stream-response.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.ts
@@ -7,7 +7,6 @@ import { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-str
 import { InferUITools, UIMessage } from '../ui/ui-messages';
 import { Agent } from './agent';
 import { createAgentUIStream } from './create-agent-ui-stream';
-import type { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-settings';
 
 /**
  * Runs the agent and returns a response object with a UI message stream.
@@ -18,7 +17,6 @@ import type { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-settin
  * @param timeout - Timeout in milliseconds. Optional.
  * @param options - The options for the agent. Optional.
  * @param experimental_transform - Stream transformations. Optional.
- * @param onStepFinish - Callback that is called when each step is finished. Optional.
  * @param headers - Additional headers for the response. Optional.
  * @param status - The status code for the response. Optional.
  * @param statusText - The status text for the response. Optional.
@@ -46,7 +44,6 @@ export async function createAgentUIStreamResponse<
   experimental_transform?:
     | StreamTextTransform<TOOLS>
     | Array<StreamTextTransform<TOOLS>>;
-  onStepFinish?: ToolLoopAgentOnStepFinishCallback<TOOLS>;
 } & UIMessageStreamResponseInit &
   UIMessageStreamOptions<
     UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>

--- a/packages/ai/src/agent/create-agent-ui-stream.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.ts
@@ -8,7 +8,6 @@ import { InferUITools, UIMessage } from '../ui/ui-messages';
 import { validateUIMessages } from '../ui/validate-ui-messages';
 import { AsyncIterableStream } from '../util/async-iterable-stream';
 import { Agent } from './agent';
-import type { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-settings';
 
 /**
  * Runs the agent and stream the output as a UI message stream.
@@ -19,7 +18,6 @@ import type { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-settin
  * @param timeout - Timeout in milliseconds. Optional.
  * @param options - The options for the agent.
  * @param experimental_transform - The stream transformations. Optional.
- * @param onStepFinish - Callback that is called when each step is finished. Optional.
  *
  * @returns The UI message stream.
  */
@@ -35,7 +33,6 @@ export async function createAgentUIStream<
   abortSignal,
   timeout,
   experimental_transform,
-  onStepFinish,
   ...uiMessageStreamOptions
 }: {
   agent: Agent<CALL_OPTIONS, TOOLS, OUTPUT>;
@@ -46,7 +43,6 @@ export async function createAgentUIStream<
   experimental_transform?:
     | StreamTextTransform<TOOLS>
     | Array<StreamTextTransform<TOOLS>>;
-  onStepFinish?: ToolLoopAgentOnStepFinishCallback<TOOLS>;
   // TODO `originalMessages` is part of this for bc, omit in v7
 } & UIMessageStreamOptions<
   UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
@@ -72,7 +68,6 @@ export async function createAgentUIStream<
     abortSignal,
     timeout,
     experimental_transform,
-    onStepFinish,
   });
 
   return result.toUIMessageStream({

--- a/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
+++ b/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
@@ -8,7 +8,6 @@ import { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-str
 import { InferUITools, UIMessage } from '../ui/ui-messages';
 import { Agent } from './agent';
 import { createAgentUIStream } from './create-agent-ui-stream';
-import type { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-settings';
 
 /**
  * Pipes the agent UI message stream to a Node.js ServerResponse object.
@@ -20,7 +19,6 @@ import type { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-settin
  * @param timeout - Timeout in milliseconds. Optional.
  * @param options - The options for the agent. Optional.
  * @param experimental_transform - Stream transformations. Optional.
- * @param onStepFinish - Callback that is called when each step is finished. Optional.
  * @param headers - Additional headers for the response. Optional.
  * @param status - The status code for the response. Optional.
  * @param statusText - The status text for the response. Optional.
@@ -48,7 +46,6 @@ export async function pipeAgentUIStreamToResponse<
   experimental_transform?:
     | StreamTextTransform<TOOLS>
     | Array<StreamTextTransform<TOOLS>>;
-  onStepFinish?: ToolLoopAgentOnStepFinishCallback<TOOLS>;
 } & UIMessageStreamResponseInit &
   UIMessageStreamOptions<
     UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -11,6 +11,7 @@ import { LanguageModelResponseMetadata } from '../types/language-model-response-
 import { LanguageModelUsage } from '../types/usage';
 import { InferUIMessageChunk } from '../ui-message-stream/ui-message-chunks';
 import { UIMessageStreamOnFinishCallback } from '../ui-message-stream/ui-message-stream-on-finish-callback';
+import { UIMessageStreamOnStepFinishCallback } from '../ui-message-stream/ui-message-stream-on-step-finish-callback';
 import { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-stream-response-init';
 import { InferUIMessageMetadata, UIMessage } from '../ui/ui-messages';
 import { AsyncIterableStream } from '../util/async-iterable-stream';
@@ -51,6 +52,8 @@ export type UIMessageStreamOptions<UI_MESSAGE extends UIMessage> = {
    * the original messages are provided and the last message is an assistant message).
    */
   generateMessageId?: IdGenerator;
+
+  onStepFinish?: UIMessageStreamOnStepFinishCallback<UI_MESSAGE>;
 
   onFinish?: UIMessageStreamOnFinishCallback<UI_MESSAGE>;
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2315,6 +2315,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
   toUIMessageStream<UI_MESSAGE extends UIMessage>({
     originalMessages,
     generateMessageId,
+    onStepFinish,
     onFinish,
     messageMetadata,
     sendReasoning = true,
@@ -2670,6 +2671,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
         stream: baseStream,
         messageId: responseMessageId ?? generateMessageId?.(),
         originalMessages,
+        onStepFinish,
         onFinish,
         onError,
       }),
@@ -2681,6 +2683,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
     {
       originalMessages,
       generateMessageId,
+      onStepFinish,
       onFinish,
       messageMetadata,
       sendReasoning,
@@ -2696,6 +2699,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
       stream: this.toUIMessageStream({
         originalMessages,
         generateMessageId,
+        onStepFinish,
         onFinish,
         messageMetadata,
         sendReasoning,
@@ -2719,6 +2723,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
   toUIMessageStreamResponse<UI_MESSAGE extends UIMessage>({
     originalMessages,
     generateMessageId,
+    onStepFinish,
     onFinish,
     messageMetadata,
     sendReasoning,
@@ -2733,6 +2738,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
       stream: this.toUIMessageStream({
         originalMessages,
         generateMessageId,
+        onStepFinish,
         onFinish,
         messageMetadata,
         sendReasoning,

--- a/packages/ai/src/ui/direct-chat-transport.ts
+++ b/packages/ai/src/ui/direct-chat-transport.ts
@@ -26,7 +26,7 @@ export type DirectChatTransportOptions<
    * Options to pass to the agent when calling it.
    */
   options?: CALL_OPTIONS;
-} & Omit<UIMessageStreamOptions<UI_MESSAGE>, 'onFinish'>;
+} & Omit<UIMessageStreamOptions<UI_MESSAGE>, 'onFinish' | 'onStepFinish'>;
 
 /**
  * A transport that directly communicates with an Agent in-process,
@@ -61,7 +61,7 @@ export class DirectChatTransport<
   private readonly agentOptions: CALL_OPTIONS | undefined;
   private readonly uiMessageStreamOptions: Omit<
     UIMessageStreamOptions<UI_MESSAGE>,
-    'onFinish'
+    'onFinish' | 'onStepFinish'
   >;
 
   constructor({


### PR DESCRIPTION
## Background

See #12841. Recently, `onStepFinish` callbacks where added in a few places, but the type for AgentUIStreams focussed on the "agent" part instead of the "UI stream" part.

## Summary

This changes the type of the `onStepFinish` callback from `ToolLoopAgentOnStepFinishCallback<TOOLS>` to
`UIMessageStreamOnStepFinishCallback<UI_MESSAGE>`
for methods which create a `UIMessageChunk` stream for an Agent, giving the implementation access to the generated`UIMessage` so far instead of just the raw parts.

This partly reverts #11980, which explicitly added the `onStepFinish` callback to the method signatures. Instead, `onStepFinish` is now added to the `UIMessageStreamOptions` type in the same way as `onFinish` already was, and is passed through via `options`.

Affected methods are:
- `createAgentUIStream()`
- `createAgentUIStreamResponse()`
- `pipeAgentUIStreamToResponse()`

For even more consistency, the `onStepFinish` callback is also added to:
- `DefaultStreamTextResult.toUIMessageStream()` (used by the methods above)
- `DefaultStreamTextResult.toUIMessageStreamResponse()`
- `DefaultStreamTextResult.pipeUIMessageStreamToResponse()`

Callers which want to receive the `ToolLoopAgentOnStepFinishCallback` can easily do that with the `onStepFinish` callback to the constructor of the `ToolLoopAgent` that they're passing to the methods above.

Fixes #12841.

## Manual Verification

Used `createAgentUIStream()` in a project, added a `onStepFinish` callback, logged the `responseMessage` and verified that it looks as expected.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues
Issues #12841 and #12383 describe the motivation to have the callback.
PRs #11980 and #12448 added implementations recently.
PR #12654 also touched callbacks afterwards.