### PR TITLE
feat(google): map strict: true to Gemini VALIDATED function calling mode

### DIFF
--- a/.changeset/google-strict-validated-mode.md
+++ b/.changeset/google-strict-validated-mode.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(google): map `strict: true` tool option to Gemini VALIDATED function calling mode

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -449,6 +449,127 @@ it('should handle google maps tool', () => {
   expect(result.toolWarnings).toEqual([]);
 });
 
+it('should use VALIDATED mode when any function tool has strict: true and no toolChoice', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'strictTool',
+        description: 'A strict tool',
+        inputSchema: { type: 'object', properties: {} },
+        strict: true,
+      },
+      {
+        type: 'function',
+        name: 'normalTool',
+        description: 'A normal tool',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    ],
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'VALIDATED' },
+  });
+});
+
+it('should use VALIDATED mode with toolChoice auto when strict: true', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'strictTool',
+        description: 'A strict tool',
+        inputSchema: { type: 'object', properties: {} },
+        strict: true,
+      },
+    ],
+    toolChoice: { type: 'auto' },
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'VALIDATED' },
+  });
+});
+
+it('should use VALIDATED mode with toolChoice required when strict: true', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'strictTool',
+        description: 'A strict tool',
+        inputSchema: { type: 'object', properties: {} },
+        strict: true,
+      },
+    ],
+    toolChoice: { type: 'required' },
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'VALIDATED' },
+  });
+});
+
+it('should use VALIDATED mode with toolChoice tool when strict: true', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'strictTool',
+        description: 'A strict tool',
+        inputSchema: { type: 'object', properties: {} },
+        strict: true,
+      },
+    ],
+    toolChoice: { type: 'tool', toolName: 'strictTool' },
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: {
+      mode: 'VALIDATED',
+      allowedFunctionNames: ['strictTool'],
+    },
+  });
+});
+
+it('should not use VALIDATED mode when no tool has strict: true', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'normalTool',
+        description: 'A normal tool',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    ],
+    toolChoice: { type: 'auto' },
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'AUTO' },
+  });
+});
+
+it('should keep NONE mode even when strict: true is present', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'strictTool',
+        description: 'A strict tool',
+        inputSchema: { type: 'object', properties: {} },
+        strict: true,
+      },
+    ],
+    toolChoice: { type: 'none' },
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'NONE' },
+  });
+});
+
 it('should add warnings for google maps on unsupported models', () => {
   const result = prepareTools({
     tools: [


### PR DESCRIPTION
## Summary

When a function tool has `strict: true`, the Google provider now uses `VALIDATED` mode in `toolConfig.functionCallingConfig` instead of the default mode. This is the closest Gemini equivalent to OpenAI's per-tool `strict` mode, enforcing schema validation on the API side.

## Changes

- **`google-prepare-tools.ts`**: After building function declarations, detect if any tool has `strict: true`. If so, override the `functionCallingConfig.mode` to `VALIDATED` for `auto`, `required`, and `tool` toolChoice types. `NONE` mode is unchanged (strict is irrelevant when tools are disabled).
- **`google-prepare-tools.test.ts`**: 6 new test cases covering all toolChoice variants with `strict: true`.

## Context

Gemini's `VALIDATED` mode ([docs](https://ai.google.dev/gemini-api/docs/function-calling#validated-mode)) enforces that model output conforms to the provided function schema. This maps naturally to the AI SDK's `strict: true` option on function tools, which currently has no effect in the Google provider.

Fixes the gap where users setting `strict: true` on tools get schema enforcement with OpenAI but not with Google.

## Related Issues

fixes #12767 