### PR TITLE
feat: add GitHub Tools to tools registry

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -483,4 +483,37 @@ console.log(text);`,
     websiteUrl: 'https://github.com/vercel/bash-tool',
     npmUrl: 'https://www.npmjs.com/package/bash-tool',
   },
+  {
+  slug: 'github-tools',
+  name: 'GitHub Tools',
+  description:
+    'GitHub tools and agents for the Vercel AI SDK, wrap GitHub API as AI SDK tools ready to plug into any agent',
+  packageName: '@github-tools/sdk',
+  tags: ['github', 'code', 'repository'],
+  apiKeyEnvName: 'GITHUB_TOKEN',
+  installCommand: {
+    pnpm: 'pnpm add @github-tools/sdk',
+    npm: 'npm install @github-tools/sdk',
+    yarn: 'yarn add @github-tools/sdk',
+    bun: 'bun add @github-tools/sdk',
+  },
+  codeExample: `import { generateText } from 'ai'
+import { createGithubTools } from '@github-tools/sdk'
+
+const githubTools = createGithubTools({
+  // Choose a preset like "repo-explorer", "code-review", etc.
+  preset: 'repo-explorer',
+})
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4.6',
+  tools: githubTools,
+  prompt: 'List the open issues in this repository and summarize the most important ones.',
+})
+
+console.log(text)`,
+  docsUrl: 'https://github-tools.com/installation',
+  websiteUrl: 'https://github-tools.com',
+  npmUrl: 'https://www.npmjs.com/package/@github-tools/sdk',
+},
 ];

--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -515,5 +515,5 @@ console.log(text)`,
   docsUrl: 'https://github-tools.com/installation',
   websiteUrl: 'https://github-tools.com',
   npmUrl: 'https://www.npmjs.com/package/@github-tools/sdk',
-},
+  },
 ];

--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -484,20 +484,20 @@ console.log(text);`,
     npmUrl: 'https://www.npmjs.com/package/bash-tool',
   },
   {
-  slug: 'github-tools',
-  name: 'GitHub Tools',
-  description:
-    'GitHub tools and agents for the Vercel AI SDK, wrap GitHub API as AI SDK tools ready to plug into any agent',
-  packageName: '@github-tools/sdk',
-  tags: ['github', 'code', 'repository'],
-  apiKeyEnvName: 'GITHUB_TOKEN',
-  installCommand: {
-    pnpm: 'pnpm add @github-tools/sdk',
-    npm: 'npm install @github-tools/sdk',
-    yarn: 'yarn add @github-tools/sdk',
-    bun: 'bun add @github-tools/sdk',
-  },
-  codeExample: `import { generateText } from 'ai'
+    slug: 'github-tools',
+    name: 'GitHub Tools',
+    description:
+      'GitHub tools and agents for the Vercel AI SDK, wrap GitHub API as AI SDK tools ready to plug into any agent',
+    packageName: '@github-tools/sdk',
+    tags: ['github', 'code', 'repository'],
+    apiKeyEnvName: 'GITHUB_TOKEN',
+    installCommand: {
+      pnpm: 'pnpm add @github-tools/sdk',
+      npm: 'npm install @github-tools/sdk',
+      yarn: 'yarn add @github-tools/sdk',
+      bun: 'bun add @github-tools/sdk',
+    },
+    codeExample: `import { generateText } from 'ai'
 import { createGithubTools } from '@github-tools/sdk'
 
 const githubTools = createGithubTools({
@@ -512,8 +512,8 @@ const { text } = await generateText({
 })
 
 console.log(text)`,
-  docsUrl: 'https://github-tools.com/installation',
-  websiteUrl: 'https://github-tools.com',
-  npmUrl: 'https://www.npmjs.com/package/@github-tools/sdk',
+    docsUrl: 'https://github-tools.com/installation',
+    websiteUrl: 'https://github-tools.com',
+    npmUrl: 'https://www.npmjs.com/package/@github-tools/sdk',
   },
 ];


### PR DESCRIPTION
<img width="2400" height="1256" alt="image" src="https://github.com/user-attachments/assets/78ea8778-9f1f-44a9-83f5-b99e466060dc" />

## Background

GitHub Tools is an SDK that exposes GitHub operations as AI-callable tools for ‎`generateText`, ‎`streamText`, and agent loops. Adding it to the tools registry makes it easier for developers to discover and integrate it in the same way as other official tools.

## Summary

- Added a new ‎`github-tools` entry to ‎`ai/content/tools-registry/registry.ts`.

- Registered the ‎`@github-tools/sdk` package with install commands for pnpm, npm, yarn, and bun.

- Declared ‎`GITHUB_TOKEN` as the environment variable used by the SDK.

- Added tags, documentation links, and an example showing ‎`createGithubTools` used with ‎`generateText`.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
