### PR TITLE
feat(openai): support all OpenAI input_file types in chat and responses

### DIFF
--- a/.changeset/fix-openai-input-file-audio-filename.md
+++ b/.changeset/fix-openai-input-file-audio-filename.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): preserve file extension in default filenames and guard against silent audio routing on Responses path.
+
+- Default filename for `file` parts without an explicit `filename` now derives an extension from the MIME type (e.g. `part-0.pdf` instead of `part-0`). Applies to both chat completions and responses paths.
+- Audio file parts on the Responses API path now throw `UnsupportedFunctionalityError` instead of silently falling through to `input_file`, which would produce confusing API-level errors.

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
@@ -116,23 +116,36 @@ describe('user messages', () => {
   });
 
   describe('file parts', () => {
-    it('should throw for unsupported mime types', () => {
-      expect(() =>
-        convertToOpenAIChatMessages({
-          prompt: [
+    it('should handle unknown mime types as file parts', () => {
+      const result = convertToOpenAIChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                data: 'AAECAw==',
+                mediaType: 'application/something',
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
             {
-              role: 'user',
-              content: [
-                {
-                  type: 'file',
-                  data: 'AAECAw==',
-                  mediaType: 'application/something',
-                },
-              ],
+              type: 'file',
+              file: {
+                filename: 'part-0.something',
+                file_data: 'data:application/something;base64,AAECAw==',
+              },
             },
           ],
-        }),
-      ).toThrow('file part media type application/something');
+        },
+      ]);
     });
 
     it('should throw for URL data', () => {
@@ -379,10 +392,135 @@ describe('user messages', () => {
       ]);
     });
 
-    it('should throw error for unsupported file types', async () => {
-      const base64Data = 'AQIDBAU=';
+    it('should convert text/plain file parts with base64 data to file content', () => {
+      const result = convertToOpenAIChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'text/plain',
+                data: 'SGVsbG8=',
+                filename: 'hello.txt',
+              },
+            ],
+          },
+        ],
+      });
 
-      expect(() => {
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file: {
+                filename: 'hello.txt',
+                file_data: 'data:text/plain;base64,SGVsbG8=',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should use default filename for text/plain file parts when not provided', () => {
+      const result = convertToOpenAIChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'text/plain',
+                data: 'SGVsbG8=',
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file: {
+                filename: 'part-0.plain',
+                file_data: 'data:text/plain;base64,SGVsbG8=',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should convert text/plain file parts with file_id', () => {
+      const result = convertToOpenAIChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'text/plain',
+                data: 'file-txt-abc123',
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file: { file_id: 'file-txt-abc123' },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should convert application/json file parts to file content', () => {
+      const result = convertToOpenAIChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'application/json',
+                data: 'e30=',
+                filename: 'data.json',
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file: {
+                filename: 'data.json',
+                file_data: 'data:application/json;base64,e30=',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should throw for file parts with URLs (URLs not supported in chat completions)', () => {
+      expect(() =>
         convertToOpenAIChatMessages({
           prompt: [
             {
@@ -391,17 +529,16 @@ describe('user messages', () => {
                 {
                   type: 'file',
                   mediaType: 'text/plain',
-                  data: base64Data,
+                  data: new URL('https://example.com/file.txt'),
                 },
               ],
             },
           ],
-          systemMessageMode: 'system',
-        });
-      }).toThrow('file part media type text/plain');
+        }),
+      ).toThrow('file parts with URLs');
     });
 
-    it('should throw error for file URLs', async () => {
+    it('should throw error for file URLs (application/pdf)', async () => {
       expect(() => {
         convertToOpenAIChatMessages({
           prompt: [
@@ -418,7 +555,41 @@ describe('user messages', () => {
           ],
           systemMessageMode: 'system',
         });
-      }).toThrow('PDF file parts with URLs');
+      }).toThrow('file parts with URLs');
+    });
+
+    it('should convert text/javascript file parts to file content', () => {
+      const result = convertToOpenAIChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'text/javascript',
+                data: 'Y29uc29sZS5sb2coImhpIik=',
+                filename: 'app.js',
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file: {
+                filename: 'app.js',
+                file_data:
+                  'data:text/javascript;base64,Y29uc29sZS5sb2coImhpIik=',
+              },
+            },
+          ],
+        },
+      ]);
     });
   });
 });

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -4,14 +4,21 @@ import {
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { OpenAIChatPrompt } from './openai-chat-prompt';
-import { convertToBase64 } from '@ai-sdk/provider-utils';
+import { convertToBase64, mediaTypeToExtension } from '@ai-sdk/provider-utils';
+
+function isFileId(data: string, prefixes?: readonly string[]): boolean {
+  if (!prefixes) return false;
+  return prefixes.some(prefix => data.startsWith(prefix));
+}
 
 export function convertToOpenAIChatMessages({
   prompt,
   systemMessageMode = 'system',
+  fileIdPrefixes = ['file-'],
 }: {
   prompt: LanguageModelV4Prompt;
   systemMessageMode?: 'system' | 'developer' | 'remove';
+  fileIdPrefixes?: readonly string[];
 }): {
   messages: OpenAIChatPrompt;
   warnings: Array<SharedV4Warning>;
@@ -114,10 +121,16 @@ export function convertToOpenAIChatMessages({
                       });
                     }
                   }
-                } else if (part.mediaType === 'application/pdf') {
+                } else {
+                  // Handles application/pdf and all other non-image, non-audio
+                  // file types (text/plain, application/json, text/javascript,
+                  // etc.) via the file content type. OpenAI will validate
+                  // whether the specific MIME type is supported.
+                  // Note: Chat Completions API does not support file_url,
+                  // so URL data still throws.
                   if (part.data instanceof URL) {
                     throw new UnsupportedFunctionalityError({
-                      functionality: 'PDF file parts with URLs',
+                      functionality: 'file parts with URLs',
                     });
                   }
 
@@ -125,17 +138,15 @@ export function convertToOpenAIChatMessages({
                     type: 'file',
                     file:
                       typeof part.data === 'string' &&
-                      part.data.startsWith('file-')
+                      isFileId(part.data, fileIdPrefixes)
                         ? { file_id: part.data }
                         : {
-                            filename: part.filename ?? `part-${index}.pdf`,
-                            file_data: `data:application/pdf;base64,${convertToBase64(part.data)}`,
+                            filename:
+                              part.filename ??
+                              `part-${index}.${mediaTypeToExtension(part.mediaType)}`,
+                            file_data: `data:${part.mediaType};base64,${convertToBase64(part.data)}`,
                           },
                   };
-                } else {
-                  throw new UnsupportedFunctionalityError({
-                    functionality: `file part media type ${part.mediaType}`,
-                  });
                 }
               }
             }

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -47,6 +47,7 @@ type OpenAIChatConfig = {
   headers: () => Record<string, string | undefined>;
   url: (options: { modelId: string; path: string }) => string;
   fetch?: FetchFunction;
+  fileIdPrefixes?: readonly string[];
 };
 
 export class OpenAIChatLanguageModel implements LanguageModelV4 {
@@ -117,6 +118,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
           (isReasoningModel
             ? 'developer'
             : modelCapabilities.systemMessageMode),
+        fileIdPrefixes: this.config.fileIdPrefixes,
       },
     );
 

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -174,6 +174,7 @@ export function createOpenAI(
       url: ({ path }) => `${baseURL}${path}`,
       headers: getHeaders,
       fetch: options.fetch,
+      fileIdPrefixes: ['file-'],
     });
 
   const createCompletionModel = (modelId: OpenAICompletionModelId) =>

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -419,9 +419,180 @@ describe('convertToOpenAIResponsesInput', () => {
       ]);
     });
 
-    it('should throw error for unsupported file types', async () => {
+    it('should convert text/plain file parts with base64 data to input_file', async () => {
       const base64Data = 'AQIDBAU=';
 
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'text/plain',
+                data: base64Data,
+              },
+            ],
+          },
+        ],
+        toolNameMapping: testToolNameMapping,
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_file',
+              filename: 'part-0.plain',
+              file_data: 'data:text/plain;base64,AQIDBAU=',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should convert text/plain file parts with URL to input_file with file_url', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'text/plain',
+                data: new URL('https://example.com/file.txt'),
+              },
+            ],
+          },
+        ],
+        toolNameMapping: testToolNameMapping,
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_file',
+              file_url: 'https://example.com/file.txt',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should convert text/plain file parts with file_id to input_file with file_id', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'text/plain',
+                data: 'file-text-abc123',
+              },
+            ],
+          },
+        ],
+        toolNameMapping: testToolNameMapping,
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        fileIdPrefixes: ['file-'],
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_file',
+              file_id: 'file-text-abc123',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should convert application/json file parts with base64 data to input_file', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'application/json',
+                data: 'e30=',
+                filename: 'data.json',
+              },
+            ],
+          },
+        ],
+        toolNameMapping: testToolNameMapping,
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_file',
+              filename: 'data.json',
+              file_data: 'data:application/json;base64,e30=',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should convert text/javascript file parts to input_file', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'text/javascript',
+                data: 'Y29uc29sZS5sb2coImhpIik=',
+                filename: 'app.js',
+              },
+            ],
+          },
+        ],
+        toolNameMapping: testToolNameMapping,
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_file',
+              filename: 'app.js',
+              file_data: 'data:text/javascript;base64,Y29uc29sZS5sb2coImhpIik=',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should throw for audio file parts on the Responses API', async () => {
       await expect(
         convertToOpenAIResponsesInput({
           prompt: [
@@ -430,8 +601,8 @@ describe('convertToOpenAIResponsesInput', () => {
               content: [
                 {
                   type: 'file',
-                  mediaType: 'text/plain',
-                  data: base64Data,
+                  mediaType: 'audio/mp3',
+                  data: 'AAECAw==',
                 },
               ],
             },
@@ -441,7 +612,9 @@ describe('convertToOpenAIResponsesInput', () => {
           providerOptionsName: 'openai',
           store: true,
         }),
-      ).rejects.toThrow('file part media type text/plain');
+      ).rejects.toThrow(
+        'audio file parts with media type audio/mp3 on the Responses API',
+      );
     });
 
     it('should convert PDF file parts with URL to input_file with file_url', async () => {

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -7,6 +7,7 @@ import {
 import {
   convertToBase64,
   isNonNullable,
+  mediaTypeToExtension,
   parseJSON,
   parseProviderOptions,
   ToolNameMapping,
@@ -132,7 +133,18 @@ export async function convertToOpenAIResponsesInput({
                     detail:
                       part.providerOptions?.[providerOptionsName]?.imageDetail,
                   };
-                } else if (part.mediaType === 'application/pdf') {
+                } else if (part.mediaType.startsWith('audio/')) {
+                  // Audio files are not supported as input_file on the
+                  // Responses API. Silently routing them would produce
+                  // confusing API errors; throw a clear SDK-level error.
+                  throw new UnsupportedFunctionalityError({
+                    functionality: `audio file parts with media type ${part.mediaType} on the Responses API`,
+                  });
+                } else {
+                  // Handles application/pdf and all other non-image, non-audio
+                  // file types (text/plain, application/json, text/javascript,
+                  // etc.) via the input_file content type. OpenAI will validate
+                  // whether the specific MIME type is supported.
                   if (part.data instanceof URL) {
                     return {
                       type: 'input_file',
@@ -145,14 +157,12 @@ export async function convertToOpenAIResponsesInput({
                     isFileId(part.data, fileIdPrefixes)
                       ? { file_id: part.data }
                       : {
-                          filename: part.filename ?? `part-${index}.pdf`,
-                          file_data: `data:application/pdf;base64,${convertToBase64(part.data)}`,
+                          filename:
+                            part.filename ??
+                            `part-${index}.${mediaTypeToExtension(part.mediaType)}`,
+                          file_data: `data:${part.mediaType};base64,${convertToBase64(part.data)}`,
                         }),
                   };
-                } else {
-                  throw new UnsupportedFunctionalityError({
-                    functionality: `file part media type ${part.mediaType}`,
-                  });
                 }
               }
             }


### PR DESCRIPTION
Fixes #12842

## Summary

Currently the OpenAI provider throws `UnsupportedFunctionalityError` for any file MIME type that isn't `image/*` or `application/pdf` (responses path) or `image/*`, `audio/wav`, `audio/mp3`, or `application/pdf` (chat completions path).

OpenAI's API actually supports a wide range of file types via the `input_file` content type (responses) and `file` content type (chat completions), including text, code, JSON, HTML, markdown, and many more.

This PR removes the restrictive MIME type checks and routes all non-image (and non-audio in chat completions) file types through the generic file upload path, letting the OpenAI API handle validation.

### Changes

**Responses path** (`convert-to-openai-responses-input.ts`):
- Merged the `application/pdf` branch into a generic fallback for all non-image types
- Supports URL (`file_url`), file ID, and base64 data URI with correct MIME type
- Removed `UnsupportedFunctionalityError` for unknown file types

**Chat completions path** (`convert-to-openai-chat-messages.ts`):
- Merged the `application/pdf` branch into a generic fallback for all non-image, non-audio types
- File URLs still throw (Chat Completions API does not support `file_url`)
- Supports file ID and base64 data URI with correct MIME type

### Testing

Added tests for `text/plain`, `application/json`, and `text/javascript` file types covering base64 data, URLs (responses only), file IDs, and default filename handling.