### PR TITLE
feat(devtools): migrate devtools off middleware

### DIFF
--- a/packages/ai/src/generate-text/callback-events.ts
+++ b/packages/ai/src/generate-text/callback-events.ts
@@ -293,6 +293,15 @@ export type OnToolCallFinishEvent<TOOLS extends ToolSet = ToolSet> = {
 );
 
 /**
+ * Event passed to the telemetry handler's `onChunk` callback (streamText only).
+ *
+ * for observing the raw model-level stream
+ */
+export interface OnChunkEvent {
+  readonly chunk: { readonly type: string; readonly [key: string]: unknown };
+}
+
+/**
  * Event passed to the `onStepFinish` callback.
  *
  * Called when a step (LLM call) completes.

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -51,8 +51,12 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   stepNumber?: number;
   model?: { provider: string; modelId: string };
   onPreliminaryToolResult?: (result: TypedToolResult<TOOLS>) => void;
-  onToolCallStart?: GenerateTextOnToolCallStartCallback<TOOLS>;
-  onToolCallFinish?: GenerateTextOnToolCallFinishCallback<TOOLS>;
+  onToolCallStart?:
+    | GenerateTextOnToolCallStartCallback<TOOLS>
+    | Array<GenerateTextOnToolCallStartCallback<TOOLS> | undefined | null>;
+  onToolCallFinish?:
+    | GenerateTextOnToolCallFinishCallback<TOOLS>
+    | Array<GenerateTextOnToolCallFinishCallback<TOOLS> | undefined | null>;
 }): Promise<ToolOutput<TOOLS> | undefined> {
   const { toolName, toolCallId, input } = toolCall;
   const tool = tools?.[toolName];

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -64,3 +64,7 @@ export type {
   TypedToolResult,
 } from './tool-result';
 export type { ToolSet } from './tool-set';
+export {
+  type TelemetryHandler,
+  bindTelemetryHandler,
+} from './telemetry-handler';

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -137,8 +137,12 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
   generateId: IdGenerator;
   stepNumber?: number;
   model?: { provider: string; modelId: string };
-  onToolCallStart?: StreamTextOnToolCallStartCallback<TOOLS>;
-  onToolCallFinish?: StreamTextOnToolCallFinishCallback<TOOLS>;
+  onToolCallStart?:
+    | StreamTextOnToolCallStartCallback<TOOLS>
+    | Array<StreamTextOnToolCallStartCallback<TOOLS> | undefined | null>;
+  onToolCallFinish?:
+    | StreamTextOnToolCallFinishCallback<TOOLS>
+    | Array<StreamTextOnToolCallFinishCallback<TOOLS> | undefined | null>;
 }): ReadableStream<SingleRequestTextStreamPart<TOOLS>> {
   // tool results stream
   let toolResultsStreamController: ReadableStreamDefaultController<

--- a/packages/ai/src/generate-text/telemetry-handler.ts
+++ b/packages/ai/src/generate-text/telemetry-handler.ts
@@ -1,0 +1,142 @@
+import type {
+  OnChunkEvent,
+  OnFinishEvent,
+  OnStartEvent,
+  OnStepFinishEvent,
+  OnStepStartEvent,
+  OnToolCallFinishEvent,
+  OnToolCallStartEvent,
+} from './callback-events';
+import type { Output } from './output';
+import type { ToolSet } from './tool-set';
+
+/**
+ * Interface for telemetry handlers.
+ *
+ * Implement this interface to create custom telemetry integrations
+ * (e.g., OpenTelemetry, logging, analytics).
+ */
+export interface TelemetryHandler<
+  TOOLS extends ToolSet = ToolSet,
+  OUTPUT extends Output = Output,
+> {
+  onStart?(event: OnStartEvent<TOOLS, OUTPUT>): PromiseLike<void> | void;
+  onStepStart?(
+    event: OnStepStartEvent<TOOLS, OUTPUT>,
+  ): PromiseLike<void> | void;
+  onChunk?(event: OnChunkEvent): PromiseLike<void> | void;
+  onToolCallStart?(
+    event: OnToolCallStartEvent<TOOLS>,
+  ): PromiseLike<void> | void;
+  onToolCallFinish?(
+    event: OnToolCallFinishEvent<TOOLS>,
+  ): PromiseLike<void> | void;
+  onStepFinish?(event: OnStepFinishEvent<TOOLS>): PromiseLike<void> | void;
+  onFinish?(event: OnFinishEvent<TOOLS>): PromiseLike<void> | void;
+}
+
+/**
+ * Wraps a telemetry handler implementation with bound methods.
+ * Use this when creating handlers to ensure methods work correctly
+ * when passed as callbacks.
+ */
+export function bindTelemetryHandler<
+  TOOLS extends ToolSet = ToolSet,
+  OUTPUT extends Output = Output,
+>(impl: TelemetryHandler<TOOLS, OUTPUT>): TelemetryHandler<TOOLS, OUTPUT> {
+  return {
+    onStart: impl.onStart?.bind(impl),
+    onStepStart: impl.onStepStart?.bind(impl),
+    onChunk: impl.onChunk?.bind(impl),
+    onToolCallStart: impl.onToolCallStart?.bind(impl),
+    onToolCallFinish: impl.onToolCallFinish?.bind(impl),
+    onStepFinish: impl.onStepFinish?.bind(impl),
+    onFinish: impl.onFinish?.bind(impl),
+  };
+}
+
+export interface ExpandedTelemetryListeners<
+  TOOLS extends ToolSet = ToolSet,
+  OUTPUT extends Output = Output,
+> {
+  onStart: ((event: OnStartEvent<TOOLS, OUTPUT>) => Promise<void>) | undefined;
+  onStepStart:
+    | ((event: OnStepStartEvent<TOOLS, OUTPUT>) => Promise<void>)
+    | undefined;
+  onChunk: ((event: OnChunkEvent) => Promise<void>) | undefined;
+  onToolCallStart:
+    | ((event: OnToolCallStartEvent<TOOLS>) => Promise<void>)
+    | undefined;
+  onToolCallFinish:
+    | ((event: OnToolCallFinishEvent<TOOLS>) => Promise<void>)
+    | undefined;
+  onStepFinish:
+    | ((event: OnStepFinishEvent<TOOLS>) => Promise<void>)
+    | undefined;
+  onFinish: ((event: OnFinishEvent<TOOLS>) => Promise<void>) | undefined;
+}
+
+/**
+ * Expands an array of telemetry handlers into individual listener functions.
+ * Each returned listener fans out to all handlers that implement that event.
+ *
+ * The generic parameters allow the returned listeners to be typed for the
+ * specific TOOLS/OUTPUT used at the call site. This is safe because
+ * TelemetryHandler<ToolSet> methods accept the base ToolSet events,
+ * and specific TOOLS events (where TOOLS extends ToolSet) are structurally
+ * compatible — a handler that processes ToolSet events can process any
+ * subtype's events.
+ */
+export function expandHandlers<
+  TOOLS extends ToolSet = ToolSet,
+  OUTPUT extends Output = Output,
+>(
+  handlers: TelemetryHandler | Array<TelemetryHandler> | undefined,
+): ExpandedTelemetryListeners<TOOLS, OUTPUT> {
+  if (handlers == null) {
+    return {
+      onStart: undefined,
+      onStepStart: undefined,
+      onChunk: undefined,
+      onToolCallStart: undefined,
+      onToolCallFinish: undefined,
+      onStepFinish: undefined,
+      onFinish: undefined,
+    };
+  }
+
+  // Safe cast: TelemetryHandler<ToolSet> can handle events for any
+  // TOOLS extends ToolSet, since the event types only add specificity
+  // to tool-related fields that the base handler reads as ToolSet.
+  const arr = (Array.isArray(handlers)
+    ? handlers
+    : [handlers]) as unknown as Array<TelemetryHandler<TOOLS, OUTPUT>>;
+
+  function createFanOut<E>(
+    extract: (
+      h: TelemetryHandler<TOOLS, OUTPUT>,
+    ) => ((event: E) => PromiseLike<void> | void) | undefined,
+  ): ((event: E) => Promise<void>) | undefined {
+    const fns = arr.map(extract).filter(Boolean) as Array<
+      (event: E) => PromiseLike<void> | void
+    >;
+    if (fns.length === 0) return undefined;
+    return async (event: E) => {
+      for (const fn of fns) {
+        try {
+          await fn(event);
+        } catch (_ignored) {}
+      }
+    };
+  }
+
+  return {
+    onStart: createFanOut(h => h.onStart),
+    onStepStart: createFanOut(h => h.onStepStart),
+    onChunk: createFanOut(h => h.onChunk),
+    onToolCallStart: createFanOut(h => h.onToolCallStart),
+    onToolCallFinish: createFanOut(h => h.onToolCallFinish),
+    onStepFinish: createFanOut(h => h.onStepFinish),
+    onFinish: createFanOut(h => h.onFinish),
+  };
+}

--- a/packages/ai/src/telemetry/telemetry-settings.ts
+++ b/packages/ai/src/telemetry/telemetry-settings.ts
@@ -1,4 +1,5 @@
 import { AttributeValue, Tracer } from '@opentelemetry/api';
+import type { TelemetryHandler } from '../generate-text/telemetry-handler';
 
 /**
  * Telemetry configuration.
@@ -41,4 +42,10 @@ export type TelemetrySettings = {
    * A custom tracer to use for the telemetry data.
    */
   tracer?: Tracer;
+
+  /**
+   * Telemetry handlers that receive lifecycle events (start, step, tool call, finish).
+   * Use this to integrate custom telemetry, logging, or devtools.
+   */
+  handlers?: TelemetryHandler | Array<TelemetryHandler>;
 };

--- a/packages/ai/src/util/notify.ts
+++ b/packages/ai/src/util/notify.ts
@@ -8,9 +8,10 @@ export type Listener<EVENT> = (event: EVENT) => PromiseLike<void> | void;
  */
 export async function notify<EVENT>(options: {
   event: EVENT;
-  callbacks?: Listener<EVENT> | Array<Listener<EVENT>>;
+  callbacks?: Listener<EVENT> | Array<Listener<EVENT> | undefined | null>;
 }): Promise<void> {
   for (const callback of asArray(options.callbacks)) {
+    if (callback == null) continue;
     try {
       await callback(options.event);
     } catch (_ignored) {}

--- a/packages/devtools/examples/basic/index.ts
+++ b/packages/devtools/examples/basic/index.ts
@@ -1,18 +1,20 @@
-import { gateway, stepCountIs, streamText, wrapLanguageModel } from 'ai';
+import { gateway, stepCountIs, streamText } from 'ai';
 import { tools } from './tools';
-import { devToolsMiddleware } from '../../src';
+import { devToolsHandler } from '../../src';
 import { print } from './utils';
 import 'dotenv/config';
 
 const result = streamText({
-  model: wrapLanguageModel({
-    middleware: devToolsMiddleware(),
-    model: gateway('anthropic/claude-haiku-4.5'),
-  }),
+  model: gateway('anthropic/claude-haiku-4.5'),
   system: 'Always call the weather before recommending plans.',
-  prompt: 'Whats the weather in SF and London in C?',
+  prompt: 'Whats the weather in NYC and BOSTON in C?',
   tools,
+  includeRawChunks: true,
   stopWhen: stepCountIs(5),
+  experimental_telemetry: {
+    isEnabled: true,
+    handlers: [devToolsHandler()],
+  },
   providerOptions: {
     anthropic: {
       thinking: {

--- a/packages/devtools/src/db.ts
+++ b/packages/devtools/src/db.ts
@@ -38,6 +38,17 @@ export interface Run {
   started_at: string;
 }
 
+export interface ToolCallTiming {
+  toolCallId: string;
+  toolName: string;
+  started_at: string;
+  duration_ms: number;
+  args: unknown;
+  output: unknown;
+  error: unknown;
+  success: boolean;
+}
+
 export interface Step {
   id: string;
   run_id: string;
@@ -55,6 +66,7 @@ export interface Step {
   raw_response: string | null;
   raw_chunks: string | null;
   provider_options: string | null;
+  tool_calls: string | null;
 }
 
 export interface StepResult {
@@ -65,6 +77,7 @@ export interface StepResult {
   raw_request?: string | null;
   raw_response?: string | null;
   raw_chunks?: string | null;
+  tool_calls?: string | null;
 }
 
 interface Database {
@@ -172,6 +185,7 @@ export const createStep = async (
     | 'raw_request'
     | 'raw_response'
     | 'raw_chunks'
+    | 'tool_calls'
   >,
 ): Promise<void> => {
   const db = getDb();
@@ -184,6 +198,7 @@ export const createStep = async (
     raw_request: null,
     raw_response: null,
     raw_chunks: null,
+    tool_calls: null,
   };
   db.steps.push(newStep);
   saveDb(db);
@@ -204,6 +219,7 @@ export const updateStepResult = async (
     step.raw_request = result.raw_request ?? null;
     step.raw_response = result.raw_response ?? null;
     step.raw_chunks = result.raw_chunks ?? null;
+    step.tool_calls = result.tool_calls ?? null;
     saveDb(db);
     notifyServer('step-update');
   }

--- a/packages/devtools/src/handler.ts
+++ b/packages/devtools/src/handler.ts
@@ -1,0 +1,169 @@
+import type { TelemetryHandler } from 'ai';
+import {
+  createRun,
+  createStep,
+  updateStepResult,
+  notifyServerAsync,
+} from './db.js';
+
+const generateId = () => crypto.randomUUID();
+
+const generateRunId = (): string => {
+  const now = new Date();
+  const timestamp = now
+    .toISOString()
+    .replace(/[-:T.Z]/g, '')
+    .slice(0, 17);
+  const uniqueId = crypto.randomUUID().slice(0, 8);
+  return `${timestamp}-${uniqueId}`;
+};
+
+/**
+ * Convert a ToolSet (Record<string, Tool>) to the array format
+ * the viewer expects: [{ name, description, parameters }].
+ */
+function toolSetToArray(
+  tools: Record<string, unknown> | undefined,
+):
+  | Array<{ name: string; description?: string; parameters?: unknown }>
+  | undefined {
+  if (!tools) return undefined;
+  return Object.entries(tools).map(([name, tool]) => {
+    const t = tool as Record<string, unknown>;
+    const schema = t.inputSchema as Record<string, unknown> | undefined;
+    return {
+      name,
+      description: t.description as string | undefined,
+      parameters: schema?.jsonSchema ?? schema,
+    };
+  });
+}
+
+export function devToolsHandler(): TelemetryHandler {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      '@ai-sdk/devtools should not be used in production. ' +
+        'Remove devToolsHandler from your telemetry configuration for production builds.',
+    );
+  }
+
+  const runId = generateRunId();
+  let runCreated = false;
+  let stepCounter = 0;
+  const stepIds = new Map<number, string>();
+  const stepStartTimes = new Map<number, number>();
+  const stepStreamChunks = new Map<number, unknown[]>();
+  const stepRawChunks = new Map<number, unknown[]>();
+  let currentStepNumber = 0;
+
+  let callSettings: Record<string, unknown> = {};
+
+  const ensureRunCreated = async () => {
+    if (!runCreated) {
+      await createRun(runId);
+      runCreated = true;
+    }
+  };
+
+  return {
+    async onStart(event) {
+      callSettings = {
+        maxOutputTokens: event.maxOutputTokens,
+        temperature: event.temperature,
+        topP: event.topP,
+        topK: event.topK,
+        presencePenalty: event.presencePenalty,
+        frequencyPenalty: event.frequencyPenalty,
+        seed: event.seed,
+      };
+    },
+
+    async onStepStart(event) {
+      await ensureRunCreated();
+      stepCounter++;
+      const stepId = generateId();
+      const stepNumber = event.stepNumber;
+      stepIds.set(stepNumber, stepId);
+      stepStartTimes.set(stepNumber, Date.now());
+      stepStreamChunks.set(stepNumber, []);
+      stepRawChunks.set(stepNumber, []);
+      currentStepNumber = stepNumber;
+
+      await createStep({
+        id: stepId,
+        run_id: runId,
+        step_number: stepCounter,
+        type: 'stream',
+        model_id: event.model.modelId,
+        provider: event.model.provider,
+        started_at: new Date().toISOString(),
+        input: JSON.stringify({
+          prompt: event.messages,
+          system: event.system,
+          tools: toolSetToArray(
+            event.tools as Record<string, unknown> | undefined,
+          ),
+          toolChoice: event.toolChoice,
+          ...callSettings,
+        }),
+        provider_options: event.providerOptions
+          ? JSON.stringify(event.providerOptions)
+          : null,
+      });
+    },
+
+    onChunk(event: { chunk: { type: string; rawValue?: unknown } }) {
+      if (event.chunk.type === 'raw') {
+        const rawChunks = stepRawChunks.get(currentStepNumber);
+        if (rawChunks) {
+          rawChunks.push(event.chunk.rawValue);
+        }
+      } else {
+        const streamChunks = stepStreamChunks.get(currentStepNumber);
+        if (streamChunks) {
+          streamChunks.push(event.chunk);
+        }
+      }
+    },
+
+    async onStepFinish(event) {
+      const stepId = stepIds.get(event.stepNumber);
+      if (!stepId) return;
+
+      const startTime = stepStartTimes.get(event.stepNumber);
+      const durationMs = startTime ? Date.now() - startTime : 0;
+
+      const streamChunks = stepStreamChunks.get(event.stepNumber);
+      const rawChunks = stepRawChunks.get(event.stepNumber);
+
+      await updateStepResult(stepId, {
+        duration_ms: durationMs,
+        output: JSON.stringify({
+          content: event.content,
+          finishReason: event.finishReason,
+          response: event.response,
+        }),
+        usage: event.usage ? JSON.stringify(event.usage) : null,
+        error: null,
+        raw_request: event.request?.body
+          ? JSON.stringify(event.request.body)
+          : null,
+        raw_response:
+          streamChunks && streamChunks.length > 0
+            ? JSON.stringify(streamChunks)
+            : null,
+        raw_chunks:
+          rawChunks && rawChunks.length > 0 ? JSON.stringify(rawChunks) : null,
+      });
+
+      stepIds.delete(event.stepNumber);
+      stepStartTimes.delete(event.stepNumber);
+      stepStreamChunks.delete(event.stepNumber);
+      stepRawChunks.delete(event.stepNumber);
+    },
+
+    async onFinish() {
+      await notifyServerAsync('run');
+    },
+  };
+}

--- a/packages/devtools/src/handler.ts
+++ b/packages/devtools/src/handler.ts
@@ -152,7 +152,7 @@ export function devToolsHandler(): TelemetryHandler {
           ? new Date(startTime).toISOString()
           : new Date().toISOString(),
         duration_ms: durationMs,
-        args: toolCall.args,
+        args: toolCall.input ?? toolCall.args,
         output: event.success ? event.output : null,
         error: event.success ? null : event.error,
         success: event.success,

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -1,1 +1,2 @@
 export { devToolsMiddleware } from './middleware.js';
+export { devToolsHandler } from './handler.js';

--- a/packages/devtools/src/viewer/client/app.tsx
+++ b/packages/devtools/src/viewer/client/app.tsx
@@ -65,6 +65,7 @@ interface Step {
   raw_response: string | null;
   raw_chunks: string | null;
   provider_options: string | null;
+  tool_calls: string | null;
 }
 
 interface RunDetail {

--- a/packages/devtools/src/viewer/client/app.tsx
+++ b/packages/devtools/src/viewer/client/app.tsx
@@ -14,6 +14,8 @@ import {
   Brain,
   Loader2,
   BarChart3,
+  GanttChart,
+  List,
 } from 'lucide-react';
 import { AISDKLogo } from '@/components/icons';
 import { Button } from '@/components/ui/button';
@@ -37,6 +39,9 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { buildTraceTree, type Span } from '@/lib/trace-builder';
+import { SpanTimeline } from '@/components/span-timeline';
+import { SpanDetail } from '@/components/span-detail';
 
 interface Run {
   id: string;
@@ -278,11 +283,19 @@ function getStepSummary(output: any, error: string | null): StepSummary {
   return { type: 'response', icon: 'message', label: 'Response' };
 }
 
+type ViewMode = 'steps' | 'spans';
+
 function App() {
   const [runs, setRuns] = useState<Run[]>([]);
   const [selectedRun, setSelectedRun] = useState<RunDetail | null>(null);
   const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
+  const [viewMode, setViewMode] = useState<ViewMode>('steps');
+  const [selectedSpan, setSelectedSpan] = useState<Span | null>(null);
+
+  const traceTree = selectedRun
+    ? buildTraceTree(selectedRun.run, selectedRun.steps)
+    : null;
 
   const fetchRuns = async () => {
     try {
@@ -361,8 +374,8 @@ function App() {
     const res = await fetch(`/api/runs/${runId}`);
     const data = await res.json();
     setSelectedRun(data);
-    // Start with all steps collapsed
     setExpandedSteps(new Set());
+    setSelectedSpan(null);
   };
 
   const toggleStep = (stepId: string) => {
@@ -644,246 +657,291 @@ function App() {
                     <span>
                       {new Date(selectedRun.run.started_at).toLocaleString()}
                     </span>
+                    <span className="px-3 text-muted-foreground/30">·</span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2.5 text-[11px] gap-1.5"
+                      onClick={() => {
+                        setViewMode(viewMode === 'steps' ? 'spans' : 'steps');
+                        setSelectedSpan(null);
+                      }}
+                    >
+                      {viewMode === 'steps' ? (
+                        <>
+                          <GanttChart className="size-3" />
+                          View Spans
+                        </>
+                      ) : (
+                        <>
+                          <List className="size-3" />
+                          View Steps
+                        </>
+                      )}
+                    </Button>
                   </div>
                 </div>
 
-                {/* Steps */}
-                <div className="flex flex-col gap-3">
-                  {selectedRun.steps.map((step, index) => {
-                    const isExpanded = expandedSteps.has(step.id);
-                    const isLastStep = index === selectedRun.steps.length - 1;
-                    const isActiveStep =
-                      isLastStep && selectedRun.run.isInProgress;
-                    const input = parseJson(step.input);
-                    const output = parseJson(step.output);
-                    const usage = parseJson(step.usage);
+                {/* Span View */}
+                {viewMode === 'spans' && traceTree ? (
+                  <div className="flex gap-0 h-[calc(100vh-160px)]">
+                    <div className={selectedSpan ? 'flex-1 min-w-0' : 'w-full'}>
+                      <SpanTimeline
+                        root={traceTree}
+                        selectedSpanId={selectedSpan?.id ?? null}
+                        onSelectSpan={setSelectedSpan}
+                      />
+                    </div>
+                    {selectedSpan && (
+                      <div className="w-[420px] shrink-0">
+                        <SpanDetail
+                          span={selectedSpan}
+                          onClose={() => setSelectedSpan(null)}
+                        />
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  /* Steps View */
+                  <div className="flex flex-col gap-3">
+                    {selectedRun.steps.map((step, index) => {
+                      const isExpanded = expandedSteps.has(step.id);
+                      const isLastStep = index === selectedRun.steps.length - 1;
+                      const isActiveStep =
+                        isLastStep && selectedRun.run.isInProgress;
+                      const input = parseJson(step.input);
+                      const output = parseJson(step.output);
+                      const usage = parseJson(step.usage);
 
-                    // Get tool results from next step's input
-                    const nextStep = selectedRun.steps[index + 1];
-                    const nextInput = nextStep
-                      ? parseJson(nextStep.input)
-                      : null;
-                    const toolResults =
-                      nextInput?.prompt
-                        ?.filter((msg: any) => msg.role === 'tool')
-                        ?.flatMap((msg: any) => msg.content) ?? [];
+                      // Get tool results from next step's input
+                      const nextStep = selectedRun.steps[index + 1];
+                      const nextInput = nextStep
+                        ? parseJson(nextStep.input)
+                        : null;
+                      const toolResults =
+                        nextInput?.prompt
+                          ?.filter((msg: any) => msg.role === 'tool')
+                          ?.flatMap((msg: any) => msg.content) ?? [];
 
-                    const summary = getStepSummary(output, step.error);
-                    const isFirstStep = index === 0;
-                    const inputSummary = getStepInputSummary(
-                      input,
-                      isFirstStep,
-                    );
+                      const summary = getStepSummary(output, step.error);
+                      const isFirstStep = index === 0;
+                      const inputSummary = getStepInputSummary(
+                        input,
+                        isFirstStep,
+                      );
 
-                    return (
-                      <Collapsible
-                        key={step.id}
-                        open={isExpanded}
-                        onOpenChange={() => toggleStep(step.id)}
-                      >
-                        <Card
-                          className={`overflow-hidden py-0 gap-0 ${isActiveStep ? 'ring-2 ring-blue-500/50 ring-offset-1 ring-offset-background' : ''}`}
+                      return (
+                        <Collapsible
+                          key={step.id}
+                          open={isExpanded}
+                          onOpenChange={() => toggleStep(step.id)}
                         >
-                          {/* Step Header */}
-                          <CollapsibleTrigger asChild>
-                            <button
-                              className={`w-full flex items-center justify-between px-4 py-3 text-left transition-colors hover:bg-accent/50 ${
-                                isExpanded ? 'border-b border-border' : ''
-                              }`}
-                            >
-                              <div className="flex items-center gap-3">
-                                <span className="text-xs text-muted-foreground font-mono w-4">
-                                  {step.step_number}
-                                </span>
-                                <div className="flex items-center gap-2">
-                                  {/* Input side */}
-                                  {inputSummary && (
-                                    <>
-                                      {inputSummary.type === 'user' ? (
-                                        <MessageSquare className="size-3.5 text-muted-foreground" />
-                                      ) : (
-                                        <Wrench className="size-3.5 text-muted-foreground" />
-                                      )}
-                                      {inputSummary.fullText ||
-                                      inputSummary.toolDetails ? (
-                                        <Tooltip>
-                                          <TooltipTrigger asChild>
-                                            <span
-                                              className={`text-sm text-muted-foreground ${inputSummary.type === 'tool' ? 'font-mono' : ''}`}
+                          <Card
+                            className={`overflow-hidden py-0 gap-0 ${isActiveStep ? 'ring-2 ring-blue-500/50 ring-offset-1 ring-offset-background' : ''}`}
+                          >
+                            {/* Step Header */}
+                            <CollapsibleTrigger asChild>
+                              <button
+                                className={`w-full flex items-center justify-between px-4 py-3 text-left transition-colors hover:bg-accent/50 ${
+                                  isExpanded ? 'border-b border-border' : ''
+                                }`}
+                              >
+                                <div className="flex items-center gap-3">
+                                  <span className="text-xs text-muted-foreground font-mono w-4">
+                                    {step.step_number}
+                                  </span>
+                                  <div className="flex items-center gap-2">
+                                    {/* Input side */}
+                                    {inputSummary && (
+                                      <>
+                                        {inputSummary.type === 'user' ? (
+                                          <MessageSquare className="size-3.5 text-muted-foreground" />
+                                        ) : (
+                                          <Wrench className="size-3.5 text-muted-foreground" />
+                                        )}
+                                        {inputSummary.fullText ||
+                                        inputSummary.toolDetails ? (
+                                          <Tooltip>
+                                            <TooltipTrigger asChild>
+                                              <span
+                                                className={`text-sm text-muted-foreground ${inputSummary.type === 'tool' ? 'font-mono' : ''}`}
+                                              >
+                                                {inputSummary.label}
+                                              </span>
+                                            </TooltipTrigger>
+                                            <TooltipContent
+                                              side="bottom"
+                                              className="max-w-sm max-h-40 overflow-hidden"
                                             >
-                                              {inputSummary.label}
-                                            </span>
-                                          </TooltipTrigger>
-                                          <TooltipContent
-                                            side="bottom"
-                                            className="max-w-sm max-h-40 overflow-hidden"
+                                              <span className="line-clamp-6">
+                                                {inputSummary.fullText ||
+                                                  inputSummary.toolDetails}
+                                              </span>
+                                            </TooltipContent>
+                                          </Tooltip>
+                                        ) : (
+                                          <span
+                                            className={`text-sm text-muted-foreground ${inputSummary.type === 'tool' ? 'font-mono' : ''}`}
                                           >
-                                            <span className="line-clamp-6">
-                                              {inputSummary.fullText ||
-                                                inputSummary.toolDetails}
-                                            </span>
-                                          </TooltipContent>
-                                        </Tooltip>
-                                      ) : (
-                                        <span
-                                          className={`text-sm text-muted-foreground ${inputSummary.type === 'tool' ? 'font-mono' : ''}`}
-                                        >
-                                          {inputSummary.label}
+                                            {inputSummary.label}
+                                          </span>
+                                        )}
+                                        <span className="text-muted-foreground/50 mx-1">
+                                          →
                                         </span>
-                                      )}
-                                      <span className="text-muted-foreground/50 mx-1">
-                                        →
+                                      </>
+                                    )}
+
+                                    {/* Output side */}
+                                    {summary.icon === 'wrench' && (
+                                      <Wrench className="size-3.5 text-muted-foreground" />
+                                    )}
+                                    {summary.icon === 'message' && (
+                                      <MessageSquare className="size-3.5 text-muted-foreground" />
+                                    )}
+                                    {summary.icon === 'alert' && (
+                                      <AlertCircle className="size-3.5 text-destructive" />
+                                    )}
+
+                                    {summary.toolDetails ? (
+                                      <Tooltip>
+                                        <TooltipTrigger asChild>
+                                          <span className="text-sm font-medium font-mono">
+                                            {summary.label}
+                                          </span>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                          {summary.toolDetails}
+                                        </TooltipContent>
+                                      </Tooltip>
+                                    ) : (
+                                      <span
+                                        className={`text-sm font-medium ${
+                                          summary.icon === 'wrench'
+                                            ? 'font-mono'
+                                            : ''
+                                        }`}
+                                      >
+                                        {summary.label}
                                       </span>
-                                    </>
-                                  )}
+                                    )}
+                                  </div>
+                                </div>
 
-                                  {/* Output side */}
-                                  {summary.icon === 'wrench' && (
-                                    <Wrench className="size-3.5 text-muted-foreground" />
+                                <div className="flex items-center gap-4">
+                                  {isActiveStep ? (
+                                    <span className="text-[11px] text-blue-400 font-medium flex items-center gap-1.5">
+                                      <Loader2 className="size-3 animate-spin" />
+                                      streaming
+                                    </span>
+                                  ) : (
+                                    <span className="text-[11px] text-muted-foreground font-mono">
+                                      {formatDuration(step.duration_ms)}
+                                    </span>
                                   )}
-                                  {summary.icon === 'message' && (
-                                    <MessageSquare className="size-3.5 text-muted-foreground" />
-                                  )}
-                                  {summary.icon === 'alert' && (
-                                    <AlertCircle className="size-3.5 text-destructive" />
-                                  )}
-
-                                  {summary.toolDetails ? (
+                                  {usage && (
                                     <Tooltip>
                                       <TooltipTrigger asChild>
-                                        <span className="text-sm font-medium font-mono">
-                                          {summary.label}
+                                        <span className="text-[11px] font-mono text-muted-foreground cursor-help">
+                                          {formatInputTokens(
+                                            getInputTokenBreakdown(
+                                              usage.inputTokens,
+                                            ),
+                                          )}{' '}
+                                          <span className="text-muted-foreground/50">
+                                            →
+                                          </span>{' '}
+                                          {formatOutputTokens(
+                                            getOutputTokenBreakdown(
+                                              usage.outputTokens,
+                                            ),
+                                          )}
                                         </span>
                                       </TooltipTrigger>
                                       <TooltipContent>
-                                        {summary.toolDetails}
+                                        <TokenBreakdownTooltip
+                                          input={getInputTokenBreakdown(
+                                            usage.inputTokens,
+                                          )}
+                                          output={getOutputTokenBreakdown(
+                                            usage.outputTokens,
+                                          )}
+                                          raw={usage.raw}
+                                        />
                                       </TooltipContent>
                                     </Tooltip>
+                                  )}
+                                  <ChevronDown
+                                    className={`size-4 text-muted-foreground transition-transform ${
+                                      isExpanded ? 'rotate-180' : ''
+                                    }`}
+                                  />
+                                </div>
+                              </button>
+                            </CollapsibleTrigger>
+
+                            {/* Step Content */}
+                            <CollapsibleContent>
+                              {/* Config Bar */}
+                              <StepConfigBar
+                                modelId={step.model_id}
+                                provider={step.provider}
+                                input={input}
+                                providerOptions={parseJson(
+                                  step.provider_options,
+                                )}
+                                usage={usage}
+                              />
+
+                              {/* Two Panel Layout */}
+                              <div className="grid grid-cols-2 divide-x divide-border">
+                                {/* INPUT Panel */}
+                                <div className="bg-card/50">
+                                  <InputPanel input={input} />
+                                </div>
+
+                                {/* OUTPUT Panel */}
+                                <div className="p-4 bg-background min-h-full">
+                                  <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+                                    Output
+                                  </h3>
+
+                                  {step.error ? (
+                                    <div className="p-3 rounded-md bg-destructive/10 border border-destructive/30 text-sm text-destructive-foreground font-mono">
+                                      {step.error}
+                                    </div>
+                                  ) : output ? (
+                                    <OutputDisplay
+                                      output={output}
+                                      toolResults={toolResults}
+                                    />
+                                  ) : isActiveStep ? (
+                                    <div className="flex items-center gap-2 text-sm text-blue-400">
+                                      <Loader2 className="size-4 animate-spin" />
+                                      <span>Waiting for response...</span>
+                                    </div>
                                   ) : (
-                                    <span
-                                      className={`text-sm font-medium ${
-                                        summary.icon === 'wrench'
-                                          ? 'font-mono'
-                                          : ''
-                                      }`}
-                                    >
-                                      {summary.label}
-                                    </span>
+                                    <p className="text-sm text-muted-foreground">
+                                      No output
+                                    </p>
                                   )}
                                 </div>
                               </div>
 
-                              <div className="flex items-center gap-4">
-                                {isActiveStep ? (
-                                  <span className="text-[11px] text-blue-400 font-medium flex items-center gap-1.5">
-                                    <Loader2 className="size-3 animate-spin" />
-                                    streaming
-                                  </span>
-                                ) : (
-                                  <span className="text-[11px] text-muted-foreground font-mono">
-                                    {formatDuration(step.duration_ms)}
-                                  </span>
-                                )}
-                                {usage && (
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <span className="text-[11px] font-mono text-muted-foreground cursor-help">
-                                        {formatInputTokens(
-                                          getInputTokenBreakdown(
-                                            usage.inputTokens,
-                                          ),
-                                        )}{' '}
-                                        <span className="text-muted-foreground/50">
-                                          →
-                                        </span>{' '}
-                                        {formatOutputTokens(
-                                          getOutputTokenBreakdown(
-                                            usage.outputTokens,
-                                          ),
-                                        )}
-                                      </span>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      <TokenBreakdownTooltip
-                                        input={getInputTokenBreakdown(
-                                          usage.inputTokens,
-                                        )}
-                                        output={getOutputTokenBreakdown(
-                                          usage.outputTokens,
-                                        )}
-                                        raw={usage.raw}
-                                      />
-                                    </TooltipContent>
-                                  </Tooltip>
-                                )}
-                                <ChevronDown
-                                  className={`size-4 text-muted-foreground transition-transform ${
-                                    isExpanded ? 'rotate-180' : ''
-                                  }`}
-                                />
-                              </div>
-                            </button>
-                          </CollapsibleTrigger>
-
-                          {/* Step Content */}
-                          <CollapsibleContent>
-                            {/* Config Bar */}
-                            <StepConfigBar
-                              modelId={step.model_id}
-                              provider={step.provider}
-                              input={input}
-                              providerOptions={parseJson(step.provider_options)}
-                              usage={usage}
-                            />
-
-                            {/* Two Panel Layout */}
-                            <div className="grid grid-cols-2 divide-x divide-border">
-                              {/* INPUT Panel */}
-                              <div className="bg-card/50">
-                                <InputPanel input={input} />
-                              </div>
-
-                              {/* OUTPUT Panel */}
-                              <div className="p-4 bg-background min-h-full">
-                                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-                                  Output
-                                </h3>
-
-                                {step.error ? (
-                                  <div className="p-3 rounded-md bg-destructive/10 border border-destructive/30 text-sm text-destructive-foreground font-mono">
-                                    {step.error}
-                                  </div>
-                                ) : output ? (
-                                  <OutputDisplay
-                                    output={output}
-                                    toolResults={toolResults}
-                                  />
-                                ) : isActiveStep ? (
-                                  <div className="flex items-center gap-2 text-sm text-blue-400">
-                                    <Loader2 className="size-4 animate-spin" />
-                                    <span>Waiting for response...</span>
-                                  </div>
-                                ) : (
-                                  <p className="text-sm text-muted-foreground">
-                                    No output
-                                  </p>
-                                )}
-                              </div>
-                            </div>
-
-                            {/* Raw Data Toggle */}
-                            <RawDataSection
-                              rawRequest={step.raw_request}
-                              rawResponse={step.raw_response}
-                              rawChunks={step.raw_chunks}
-                              isStream={step.type === 'stream'}
-                            />
-                          </CollapsibleContent>
-                        </Card>
-                      </Collapsible>
-                    );
-                  })}
-                </div>
+                              {/* Raw Data Toggle */}
+                              <RawDataSection
+                                rawRequest={step.raw_request}
+                                rawResponse={step.raw_response}
+                                rawChunks={step.raw_chunks}
+                                isStream={step.type === 'stream'}
+                              />
+                            </CollapsibleContent>
+                          </Card>
+                        </Collapsible>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
             )}
           </ScrollArea>

--- a/packages/devtools/src/viewer/client/components/span-detail.tsx
+++ b/packages/devtools/src/viewer/client/components/span-detail.tsx
@@ -1,0 +1,564 @@
+import React, { useState } from 'react';
+import {
+  X,
+  Copy,
+  Check,
+  ChevronRight,
+  Wrench,
+  MessageSquare,
+  Brain,
+  Layers,
+  Sparkles,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { Span, SpanType } from '@/lib/trace-builder';
+
+const TYPE_LABELS: Record<SpanType, string> = {
+  run: 'Run',
+  step: 'Step',
+  'tool-call': 'Tool Call',
+  reasoning: 'Thinking',
+  text: 'Text',
+};
+
+const TYPE_COLORS: Record<SpanType, { badge: string; icon: string }> = {
+  run: {
+    badge: 'bg-blue-500/15 text-blue-400 border-blue-500/30',
+    icon: 'text-blue-400',
+  },
+  step: {
+    badge: 'bg-blue-500/15 text-blue-400 border-blue-500/30',
+    icon: 'text-blue-400',
+  },
+  'tool-call': {
+    badge: 'bg-purple/15 text-purple border-purple/30',
+    icon: 'text-purple',
+  },
+  reasoning: {
+    badge: 'bg-amber-500/15 text-amber-500 border-amber-500/30',
+    icon: 'text-amber-500',
+  },
+  text: {
+    badge: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30',
+    icon: 'text-emerald-400',
+  },
+};
+
+const TYPE_ICONS: Record<SpanType, React.ReactNode> = {
+  run: <Layers className="size-4" />,
+  step: <Sparkles className="size-4" />,
+  'tool-call': <Wrench className="size-4" />,
+  reasoning: <Brain className="size-4" />,
+  text: <MessageSquare className="size-4" />,
+};
+
+function formatDuration(ms: number): string {
+  if (ms < 1) return '0.00s';
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+interface SpanDetailProps {
+  span: Span;
+  onClose: () => void;
+}
+
+export function SpanDetail({ span, onClose }: SpanDetailProps) {
+  const colors = TYPE_COLORS[span.type];
+
+  return (
+    <div className="flex flex-col h-full border-l border-border bg-card">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className={colors.icon}>{TYPE_ICONS[span.type]}</span>
+          <span className="text-sm font-medium text-foreground truncate">
+            {span.label}
+          </span>
+          <Badge
+            variant="outline"
+            className={`text-[10px] h-5 shrink-0 ${colors.badge}`}
+          >
+            {TYPE_LABELS[span.type]}
+          </Badge>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-1 rounded-md hover:bg-accent transition-colors shrink-0 ml-2"
+        >
+          <X className="size-4 text-muted-foreground" />
+        </button>
+      </div>
+
+      {/* Timing bar */}
+      <div className="flex items-center gap-4 px-4 py-2 border-b border-border bg-muted/20 text-[11px] text-muted-foreground shrink-0">
+        <span>
+          Duration:{' '}
+          <span className="text-foreground font-mono">
+            {formatDuration(span.durationMs)}
+          </span>
+        </span>
+        {span.metadata.usage != null && (
+          <TokenSummary usage={span.metadata.usage} />
+        )}
+        {span.metadata.modelId && (
+          <span>
+            Model:{' '}
+            <span className="text-foreground font-mono">
+              {span.metadata.modelId}
+            </span>
+          </span>
+        )}
+        {span.metadata.provider && (
+          <span className="px-1.5 py-0.5 rounded bg-sidebar-primary/10 text-sidebar-primary text-[10px] font-medium">
+            {span.metadata.provider}
+          </span>
+        )}
+      </div>
+
+      {/* Content */}
+      <ScrollArea className="flex-1">
+        <div className="p-4 space-y-4">
+          {span.type === 'run' && <RunDetail span={span} />}
+          {span.type === 'step' && <StepDetail span={span} />}
+          {span.type === 'tool-call' && <ToolCallDetail span={span} />}
+          {span.type === 'reasoning' && <ContentDetail span={span} />}
+          {span.type === 'text' && <ContentDetail span={span} />}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+function RunDetail({ span }: { span: Span }) {
+  const usage = span.metadata.usage as Record<string, unknown> | null;
+
+  return (
+    <div className="space-y-4">
+      <Section title="Overview">
+        <div className="grid grid-cols-2 gap-3">
+          <StatCard label="Steps" value={String(span.children.length)} />
+          <StatCard label="Duration" value={formatDuration(span.durationMs)} />
+          {usage && (
+            <>
+              <StatCard
+                label="Input Tokens"
+                value={String(
+                  typeof usage.inputTokens === 'number'
+                    ? usage.inputTokens
+                    : ((usage.inputTokens as Record<string, number>)?.total ??
+                        0),
+                )}
+              />
+              <StatCard
+                label="Output Tokens"
+                value={String(
+                  typeof usage.outputTokens === 'number'
+                    ? usage.outputTokens
+                    : ((usage.outputTokens as Record<string, number>)?.total ??
+                        0),
+                )}
+              />
+            </>
+          )}
+        </div>
+      </Section>
+
+      <Section title="Steps">
+        <div className="space-y-2">
+          {span.children.map(child => (
+            <div
+              key={child.id}
+              className="flex items-center gap-2 px-3 py-2 rounded-md border border-border bg-background text-xs"
+            >
+              <span className={TYPE_COLORS[child.type].icon}>
+                {TYPE_ICONS[child.type]}
+              </span>
+              <span className="font-mono truncate">{child.label}</span>
+              <span className="ml-auto font-mono text-muted-foreground">
+                {formatDuration(child.durationMs)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+function StepDetail({ span }: { span: Span }) {
+  const {
+    input,
+    output,
+    usage,
+    rawRequest,
+    rawResponse,
+    rawChunks,
+    providerOptions,
+  } = span.metadata;
+
+  const parsedInput = input as Record<string, unknown> | null;
+  const parsedOutput = output as Record<string, unknown> | null;
+
+  const messages = (parsedInput?.prompt ?? []) as Array<
+    Record<string, unknown>
+  >;
+  const toolCount = (parsedInput?.tools as unknown[])?.length ?? 0;
+
+  const params: { label: string; value: string }[] = [];
+  if (parsedInput?.temperature != null)
+    params.push({ label: 'temp', value: String(parsedInput.temperature) });
+  if (parsedInput?.maxOutputTokens != null)
+    params.push({
+      label: 'max tokens',
+      value: String(parsedInput.maxOutputTokens),
+    });
+  if (parsedInput?.topP != null)
+    params.push({ label: 'topP', value: String(parsedInput.topP) });
+  if (parsedInput?.topK != null)
+    params.push({ label: 'topK', value: String(parsedInput.topK) });
+
+  return (
+    <div className="space-y-4">
+      {/* Config */}
+      {(params.length > 0 || toolCount > 0) && (
+        <Section title="Configuration">
+          <div className="flex flex-wrap gap-2 text-[11px]">
+            {params.map((p, i) => (
+              <span
+                key={i}
+                className="px-2 py-1 rounded bg-muted/50 text-muted-foreground"
+              >
+                {p.label}: <span className="text-foreground">{p.value}</span>
+              </span>
+            ))}
+            {toolCount > 0 && (
+              <span className="px-2 py-1 rounded bg-muted/50 text-muted-foreground">
+                <Wrench className="size-3 inline mr-1" />
+                {toolCount} tools
+              </span>
+            )}
+          </div>
+        </Section>
+      )}
+
+      {/* Input messages */}
+      {messages.length > 0 && (
+        <Section title={`Input (${messages.length} messages)`}>
+          <div className="space-y-2 max-h-[300px] overflow-y-auto">
+            {messages.map((msg, i) => (
+              <MessagePreview key={i} message={msg} index={i + 1} />
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* Output */}
+      {parsedOutput != null && (
+        <Section title="Output">
+          <DetailJsonBlock data={parsedOutput} />
+        </Section>
+      )}
+
+      {/* Usage */}
+      {usage != null && (
+        <Section title="Usage">
+          <DetailJsonBlock data={usage} />
+        </Section>
+      )}
+
+      {/* Provider options */}
+      {providerOptions != null && (
+        <CollapsibleSection title="Provider Options">
+          <DetailJsonBlock data={providerOptions} />
+        </CollapsibleSection>
+      )}
+
+      {/* Raw request/response */}
+      {(rawRequest != null || rawResponse != null) && (
+        <CollapsibleSection title="Request / Response">
+          <div className="space-y-3">
+            {rawRequest != null && (
+              <div>
+                <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mb-1">
+                  Request
+                </div>
+                <div className="max-h-[300px] overflow-auto rounded-md border border-border">
+                  <DetailJsonBlock data={rawRequest} />
+                </div>
+              </div>
+            )}
+            {rawResponse != null && (
+              <div>
+                <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mb-1">
+                  Response
+                </div>
+                <div className="max-h-[300px] overflow-auto rounded-md border border-border">
+                  <DetailJsonBlock data={rawResponse} />
+                </div>
+              </div>
+            )}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {rawChunks != null && (
+        <CollapsibleSection title="Raw Provider Chunks">
+          <div className="max-h-[300px] overflow-auto rounded-md border border-border">
+            <DetailJsonBlock data={rawChunks} />
+          </div>
+        </CollapsibleSection>
+      )}
+    </div>
+  );
+}
+
+function ToolCallDetail({ span }: { span: Span }) {
+  const { args, output, error, success, toolCallId } = span.metadata;
+  const parsedArgs = typeof args === 'string' ? safeParseJson(args) : args;
+  const parsedOutput =
+    typeof output === 'string' ? safeParseJson(output) : output;
+
+  return (
+    <div className="space-y-4">
+      {/* Status */}
+      <div className="flex items-center gap-2">
+        {success === false ? (
+          <Badge variant="destructive" className="text-[10px] h-5">
+            Failed
+          </Badge>
+        ) : (
+          <Badge
+            variant="secondary"
+            className="text-[10px] h-5 bg-success/15 text-success border-success/30"
+          >
+            Success
+          </Badge>
+        )}
+        {toolCallId && (
+          <span className="text-[10px] font-mono text-muted-foreground">
+            {toolCallId}
+          </span>
+        )}
+      </div>
+
+      {/* Input */}
+      <Section title="Input">
+        {parsedArgs ? (
+          <DetailJsonBlock data={parsedArgs} />
+        ) : (
+          <p className="text-xs text-muted-foreground">No arguments</p>
+        )}
+      </Section>
+
+      {/* Output */}
+      <Section title="Output">
+        {error ? (
+          <div className="p-3 rounded-md bg-destructive/10 border border-destructive/30 text-sm text-destructive-foreground font-mono">
+            {typeof error === 'string' ? error : JSON.stringify(error, null, 2)}
+          </div>
+        ) : parsedOutput ? (
+          <DetailJsonBlock data={parsedOutput} />
+        ) : (
+          <p className="text-xs text-muted-foreground">No output</p>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function ContentDetail({ span }: { span: Span }) {
+  const [copied, setCopied] = useState(false);
+  const content = (span.metadata.content ?? '') as string;
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(content);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="space-y-4">
+      <Section title="Content">
+        <div className="relative group">
+          <button
+            onClick={handleCopy}
+            className="absolute top-1.5 right-1.5 p-1.5 rounded-md border border-border bg-background opacity-0 group-hover:opacity-100 transition-opacity z-10"
+            title="Copy to clipboard"
+          >
+            {copied ? (
+              <Check className="size-3 text-success" />
+            ) : (
+              <Copy className="size-3 text-muted-foreground" />
+            )}
+          </button>
+          <div className="text-xs text-foreground/80 leading-relaxed whitespace-pre-wrap bg-background rounded-md border border-border p-3 max-h-[500px] overflow-y-auto">
+            {content || 'Empty'}
+          </div>
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+/* --- Shared sub-components --- */
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h4 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+        {title}
+      </h4>
+      {children}
+    </div>
+  );
+}
+
+function CollapsibleSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border border-border rounded-md overflow-hidden">
+      <button
+        className="w-full flex items-center gap-2 px-3 py-2 text-[11px] text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+        onClick={() => setOpen(!open)}
+      >
+        <ChevronRight
+          className={`size-3 transition-transform ${open ? 'rotate-90' : ''}`}
+        />
+        <span className="font-medium uppercase tracking-wider">{title}</span>
+      </button>
+      {open && <div className="p-3 border-t border-border">{children}</div>}
+    </div>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-background p-3">
+      <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mb-1">
+        {label}
+      </div>
+      <div className="text-lg font-semibold font-mono">{value}</div>
+    </div>
+  );
+}
+
+function TokenSummary({ usage }: { usage: unknown }) {
+  if (!usage || typeof usage !== 'object') return null;
+  const u = usage as Record<string, unknown>;
+  const inp = u.inputTokens;
+  const out = u.outputTokens;
+  const inputTotal =
+    typeof inp === 'number'
+      ? inp
+      : ((inp as Record<string, number>)?.total ?? 0);
+  const outputTotal =
+    typeof out === 'number'
+      ? out
+      : ((out as Record<string, number>)?.total ?? 0);
+  if (inputTotal === 0 && outputTotal === 0) return null;
+  return (
+    <span className="font-mono">
+      {inputTotal} <span className="text-muted-foreground/50">→</span>{' '}
+      {outputTotal} tokens
+    </span>
+  );
+}
+
+function MessagePreview({
+  message,
+  index,
+}: {
+  message: Record<string, unknown>;
+  index: number;
+}) {
+  const role = message.role as string;
+  const content = message.content;
+
+  const roleLabels: Record<string, string> = {
+    user: 'User',
+    assistant: 'Assistant',
+    system: 'System',
+    tool: 'Tool',
+  };
+
+  let text = '';
+  if (typeof content === 'string') {
+    text = content;
+  } else if (Array.isArray(content)) {
+    text = content
+      .filter((p: Record<string, unknown>) => p.type === 'text')
+      .map((p: Record<string, unknown>) => p.text)
+      .join('');
+  }
+
+  return (
+    <div className="rounded-md border border-border/50 bg-background/50 p-2.5 space-y-1">
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] font-mono text-muted-foreground/50">
+          {index}
+        </span>
+        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          {roleLabels[role] || role}
+        </span>
+      </div>
+      {text && (
+        <div className="text-xs text-foreground/90 line-clamp-3">{text}</div>
+      )}
+    </div>
+  );
+}
+
+function DetailJsonBlock({ data }: { data: unknown }) {
+  const [copied, setCopied] = useState(false);
+  const jsonString = JSON.stringify(data, null, 2);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(jsonString);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="relative group">
+      <button
+        onClick={handleCopy}
+        className="absolute top-1.5 right-1.5 p-1.5 rounded-md border border-border bg-background opacity-0 group-hover:opacity-100 transition-opacity z-10"
+        title="Copy to clipboard"
+      >
+        {copied ? (
+          <Check className="size-3 text-success" />
+        ) : (
+          <Copy className="size-3 text-muted-foreground" />
+        )}
+      </button>
+      <pre className="font-mono text-xs text-muted-foreground whitespace-pre-wrap wrap-break-words bg-background rounded p-2">
+        {jsonString}
+      </pre>
+    </div>
+  );
+}
+
+function safeParseJson(value: unknown): unknown {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+  return value;
+}

--- a/packages/devtools/src/viewer/client/components/span-timeline.tsx
+++ b/packages/devtools/src/viewer/client/components/span-timeline.tsx
@@ -1,0 +1,290 @@
+import React, { useState, useMemo } from 'react';
+import {
+  ChevronRight,
+  ChevronDown,
+  Wrench,
+  MessageSquare,
+  Brain,
+  Layers,
+  Sparkles,
+} from 'lucide-react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { Span, SpanType } from '@/lib/trace-builder';
+import { flattenSpans } from '@/lib/trace-builder';
+
+const SPAN_COLORS: Record<
+  SpanType,
+  { bar: string; bg: string; text: string; border: string }
+> = {
+  run: {
+    bar: 'bg-blue-500',
+    bg: 'bg-blue-500/10',
+    text: 'text-blue-400',
+    border: 'border-blue-500/30',
+  },
+  step: {
+    bar: 'bg-blue-500',
+    bg: 'bg-blue-500/10',
+    text: 'text-blue-400',
+    border: 'border-blue-500/30',
+  },
+  'tool-call': {
+    bar: 'bg-purple',
+    bg: 'bg-purple/10',
+    text: 'text-purple',
+    border: 'border-purple/30',
+  },
+  reasoning: {
+    bar: 'bg-amber-500',
+    bg: 'bg-amber-500/10',
+    text: 'text-amber-500',
+    border: 'border-amber-500/30',
+  },
+  text: {
+    bar: 'bg-emerald-500',
+    bg: 'bg-emerald-500/10',
+    text: 'text-emerald-400',
+    border: 'border-emerald-500/30',
+  },
+};
+
+const SPAN_ICONS: Record<SpanType, React.ReactNode> = {
+  run: <Layers className="size-3.5" />,
+  step: <Sparkles className="size-3.5" />,
+  'tool-call': <Wrench className="size-3.5" />,
+  reasoning: <Brain className="size-3.5" />,
+  text: <MessageSquare className="size-3.5" />,
+};
+
+function formatDuration(ms: number): string {
+  if (ms < 1) return '0.00s';
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function formatTokens(usage: unknown): string | null {
+  if (!usage || typeof usage !== 'object') return null;
+  const u = usage as Record<string, unknown>;
+  const inp = u.inputTokens;
+  const out = u.outputTokens;
+  const inputTotal =
+    typeof inp === 'number'
+      ? inp
+      : ((inp as Record<string, number>)?.total ?? 0);
+  const outputTotal =
+    typeof out === 'number'
+      ? out
+      : ((out as Record<string, number>)?.total ?? 0);
+  if (inputTotal === 0 && outputTotal === 0) return null;
+  return `${inputTotal} → ${outputTotal}`;
+}
+
+interface SpanTimelineProps {
+  root: Span;
+  selectedSpanId: string | null;
+  onSelectSpan: (span: Span) => void;
+}
+
+export function SpanTimeline({
+  root,
+  selectedSpanId,
+  onSelectSpan,
+}: SpanTimelineProps) {
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
+
+  const toggleCollapse = (id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setCollapsedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const flatRows = useMemo(
+    () => flattenSpans(root, collapsedIds),
+    [root, collapsedIds],
+  );
+
+  const totalDurationMs = root.durationMs || 1;
+
+  const timeMarkers = useMemo(() => {
+    const markers: number[] = [];
+    const count = 6;
+    for (let i = 0; i <= count; i++) {
+      markers.push((i / count) * totalDurationMs);
+    }
+    return markers;
+  }, [totalDurationMs]);
+
+  const LABEL_WIDTH = 340;
+
+  return (
+    <div className="flex flex-col h-full border border-border rounded-lg overflow-hidden bg-card">
+      {/* Time axis header */}
+      <div className="flex border-b border-border bg-muted/20 shrink-0">
+        <div
+          className="shrink-0 px-4 py-2 border-r border-border text-[10px] font-medium uppercase tracking-wider text-muted-foreground flex items-center"
+          style={{ width: LABEL_WIDTH }}
+        >
+          Span
+        </div>
+        <div className="flex-1 relative py-2 px-2">
+          <div className="flex justify-between">
+            {timeMarkers.map((ms, i) => (
+              <span
+                key={i}
+                className="text-[10px] font-mono text-muted-foreground/60"
+              >
+                {formatDuration(ms)}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Span rows */}
+      <ScrollArea className="flex-1">
+        <div className="min-w-0">
+          {flatRows.map(({ span, depth }) => {
+            const hasChildren = span.children.length > 0;
+            const isCollapsed = collapsedIds.has(span.id);
+            const isSelected = selectedSpanId === span.id;
+            const colors = SPAN_COLORS[span.type];
+            const icon = SPAN_ICONS[span.type];
+
+            const leftPct =
+              totalDurationMs > 0 ? (span.startMs / totalDurationMs) * 100 : 0;
+            const widthPct =
+              totalDurationMs > 0
+                ? Math.max((span.durationMs / totalDurationMs) * 100, 0.5)
+                : 0;
+
+            const tokenStr =
+              span.type === 'step' || span.type === 'run'
+                ? formatTokens(span.metadata.usage)
+                : null;
+
+            return (
+              <div
+                key={span.id}
+                className={`flex border-b border-border/50 cursor-pointer transition-colors group ${
+                  isSelected ? 'bg-accent' : 'hover:bg-accent/50'
+                }`}
+                onClick={() => onSelectSpan(span)}
+              >
+                {/* Label column */}
+                <div
+                  className="shrink-0 flex items-center gap-1.5 px-3 py-2 border-r border-border min-w-0"
+                  style={{
+                    width: LABEL_WIDTH,
+                    paddingLeft: `${12 + depth * 20}px`,
+                  }}
+                >
+                  {/* Collapse toggle */}
+                  {hasChildren ? (
+                    <button
+                      className="shrink-0 p-0.5 rounded hover:bg-accent transition-colors"
+                      onClick={e => toggleCollapse(span.id, e)}
+                    >
+                      {isCollapsed ? (
+                        <ChevronRight className={`size-3 ${colors.text}`} />
+                      ) : (
+                        <ChevronDown className={`size-3 ${colors.text}`} />
+                      )}
+                    </button>
+                  ) : (
+                    <span className="w-4 shrink-0" />
+                  )}
+
+                  {/* Icon */}
+                  <span className={`shrink-0 ${colors.text}`}>{icon}</span>
+
+                  {/* Label */}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        className={`text-xs truncate ${
+                          span.type === 'step' || span.type === 'tool-call'
+                            ? 'font-mono'
+                            : ''
+                        } ${
+                          span.type === 'run'
+                            ? 'font-medium text-foreground'
+                            : 'text-foreground/90'
+                        }`}
+                      >
+                        {span.label}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="right" className="max-w-xs">
+                      <div className="text-xs">
+                        <div className="font-medium">{span.label}</div>
+                        <div className="text-muted-foreground mt-0.5">
+                          {formatDuration(span.durationMs)}
+                          {tokenStr && ` · ${tokenStr} tokens`}
+                        </div>
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+
+                  {/* Duration + tokens */}
+                  <span className="ml-auto shrink-0 flex items-center gap-2 text-[10px] font-mono text-muted-foreground">
+                    {formatDuration(span.durationMs)}
+                    {tokenStr && (
+                      <span className="text-muted-foreground/60">
+                        {tokenStr}
+                      </span>
+                    )}
+                  </span>
+                </div>
+
+                {/* Bar column */}
+                <div className="flex-1 relative flex items-center px-2 min-h-[36px]">
+                  {/* Grid lines */}
+                  {timeMarkers.slice(1, -1).map((_, i) => (
+                    <div
+                      key={i}
+                      className="absolute top-0 bottom-0 border-l border-border/30"
+                      style={{
+                        left: `${((i + 1) / (timeMarkers.length - 1)) * 100}%`,
+                      }}
+                    />
+                  ))}
+
+                  {/* Span bar */}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div
+                        className={`absolute h-5 rounded-sm ${colors.bar} opacity-80 group-hover:opacity-100 transition-opacity`}
+                        style={{
+                          left: `${leftPct}%`,
+                          width: `${widthPct}%`,
+                          minWidth: '4px',
+                        }}
+                      />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <div className="text-xs font-mono">
+                        {formatDuration(span.durationMs)}
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/packages/devtools/src/viewer/client/lib/trace-builder.ts
+++ b/packages/devtools/src/viewer/client/lib/trace-builder.ts
@@ -1,0 +1,313 @@
+export type SpanType = 'run' | 'step' | 'tool-call' | 'reasoning' | 'text';
+
+export interface Span {
+  id: string;
+  parentId: string | null;
+  type: SpanType;
+  label: string;
+  startMs: number;
+  durationMs: number;
+  children: Span[];
+  metadata: SpanMetadata;
+}
+
+export interface SpanMetadata {
+  modelId?: string;
+  provider?: string | null;
+  usage?: unknown;
+  input?: unknown;
+  output?: unknown;
+  error?: unknown;
+  args?: unknown;
+  toolCallId?: string;
+  toolName?: string;
+  success?: boolean;
+  stepNumber?: number;
+  finishReason?: unknown;
+  rawRequest?: unknown;
+  rawResponse?: unknown;
+  rawChunks?: unknown;
+  providerOptions?: unknown;
+  content?: string;
+  stepRef?: Step;
+}
+
+interface Step {
+  id: string;
+  run_id: string;
+  step_number: number;
+  type: 'generate' | 'stream';
+  model_id: string;
+  provider: string | null;
+  started_at: string;
+  duration_ms: number | null;
+  input: string;
+  output: string | null;
+  usage: string | null;
+  error: string | null;
+  raw_request: string | null;
+  raw_response: string | null;
+  raw_chunks: string | null;
+  provider_options: string | null;
+  tool_calls: string | null;
+}
+
+interface Run {
+  id: string;
+  started_at: string;
+}
+
+interface ToolCallTiming {
+  toolCallId: string;
+  toolName: string;
+  started_at: string;
+  duration_ms: number;
+  args: unknown;
+  output: unknown;
+  error: unknown;
+  success: boolean;
+}
+
+function safeParseJson(str: string | null): unknown {
+  if (!str) return null;
+  try {
+    return JSON.parse(str);
+  } catch {
+    return null;
+  }
+}
+
+export function buildTraceTree(run: Run, steps: Step[]): Span {
+  const runStartMs = new Date(run.started_at).getTime();
+  const totalDurationMs = steps.reduce(
+    (sum, s) => sum + (s.duration_ms ?? 0),
+    0,
+  );
+
+  const rootSpan: Span = {
+    id: run.id,
+    parentId: null,
+    type: 'run',
+    label: getRunLabel(steps),
+    startMs: 0,
+    durationMs: totalDurationMs,
+    children: [],
+    metadata: {
+      usage: getAggregateUsage(steps),
+    },
+  };
+
+  for (const step of steps) {
+    const stepStartMs = new Date(step.started_at).getTime() - runStartMs;
+    const stepDurationMs = step.duration_ms ?? 0;
+    const output = safeParseJson(step.output) as Record<string, unknown> | null;
+    const contentParts = (output?.content ?? []) as Array<
+      Record<string, unknown>
+    >;
+
+    const stepSpan: Span = {
+      id: step.id,
+      parentId: run.id,
+      type: 'step',
+      label: `${step.model_id}:doGenerate`,
+      startMs: stepStartMs,
+      durationMs: stepDurationMs,
+      children: [],
+      metadata: {
+        modelId: step.model_id,
+        provider: step.provider,
+        usage: safeParseJson(step.usage),
+        input: safeParseJson(step.input),
+        output,
+        error: step.error,
+        stepNumber: step.step_number,
+        finishReason: output?.finishReason,
+        rawRequest: safeParseJson(step.raw_request),
+        rawResponse: safeParseJson(step.raw_response),
+        rawChunks: safeParseJson(step.raw_chunks),
+        providerOptions: safeParseJson(step.provider_options),
+        stepRef: step,
+      },
+    };
+
+    const toolCallTimings = safeParseJson(step.tool_calls) as
+      | ToolCallTiming[]
+      | null;
+    const toolTimingMap = new Map<string, ToolCallTiming>();
+    if (toolCallTimings) {
+      for (const tc of toolCallTimings) {
+        toolTimingMap.set(tc.toolCallId, tc);
+      }
+    }
+
+    let childOffsetMs = 0;
+
+    for (const part of contentParts) {
+      const partType = part.type as string;
+
+      if (partType === 'reasoning' || partType === 'thinking') {
+        const text = (part.text ?? part.reasoning ?? '') as string;
+        if (!text) continue;
+        const estimatedDuration = estimatePartDuration(
+          'reasoning',
+          contentParts,
+          stepDurationMs,
+          toolTimingMap,
+        );
+        stepSpan.children.push({
+          id: `${step.id}-reasoning-${childOffsetMs}`,
+          parentId: step.id,
+          type: 'reasoning',
+          label: 'Thinking',
+          startMs: stepStartMs + childOffsetMs,
+          durationMs: estimatedDuration,
+          children: [],
+          metadata: { content: text },
+        });
+        childOffsetMs += estimatedDuration;
+      } else if (partType === 'text') {
+        const text = (part.text ?? '') as string;
+        if (!text) continue;
+        const estimatedDuration = estimatePartDuration(
+          'text',
+          contentParts,
+          stepDurationMs,
+          toolTimingMap,
+        );
+        stepSpan.children.push({
+          id: `${step.id}-text-${childOffsetMs}`,
+          parentId: step.id,
+          type: 'text',
+          label: 'Text',
+          startMs: stepStartMs + childOffsetMs,
+          durationMs: estimatedDuration,
+          children: [],
+          metadata: { content: text },
+        });
+        childOffsetMs += estimatedDuration;
+      } else if (partType === 'tool-call') {
+        const toolCallId = part.toolCallId as string;
+        const toolName = part.toolName as string;
+        const timing = toolTimingMap.get(toolCallId);
+
+        const tcStartMs = timing
+          ? new Date(timing.started_at).getTime() - runStartMs
+          : stepStartMs + childOffsetMs;
+        const tcDurationMs = timing?.duration_ms ?? 0;
+
+        stepSpan.children.push({
+          id: `${step.id}-tc-${toolCallId}`,
+          parentId: step.id,
+          type: 'tool-call',
+          label: toolName,
+          startMs: tcStartMs,
+          durationMs: tcDurationMs,
+          children: [],
+          metadata: {
+            toolCallId,
+            toolName,
+            args: timing?.args ?? part.args,
+            output: timing?.output,
+            error: timing?.error,
+            success: timing?.success,
+          },
+        });
+        if (!timing) {
+          childOffsetMs += tcDurationMs;
+        }
+      }
+    }
+
+    rootSpan.children.push(stepSpan);
+  }
+
+  rootSpan.children.sort((a, b) => a.startMs - b.startMs);
+  return rootSpan;
+}
+
+function getRunLabel(steps: Step[]): string {
+  const firstStep = steps[0];
+  if (!firstStep) return 'Empty run';
+  const input = safeParseJson(firstStep.input) as Record<
+    string,
+    unknown
+  > | null;
+  const prompt = input?.prompt as Array<Record<string, unknown>> | undefined;
+  if (!prompt) return 'Run';
+  const userMsg = [...prompt].reverse().find(m => m.role === 'user');
+  if (!userMsg) return 'Run';
+  const content = userMsg.content;
+  if (typeof content === 'string') {
+    return content.length > 60 ? content.slice(0, 60) + '...' : content;
+  }
+  if (Array.isArray(content)) {
+    const textPart = content.find(
+      (p: Record<string, unknown>) => p.type === 'text',
+    ) as Record<string, unknown> | undefined;
+    const text = (textPart?.text ?? '') as string;
+    return text.length > 60 ? text.slice(0, 60) + '...' : text || 'Run';
+  }
+  return 'Run';
+}
+
+function getAggregateUsage(steps: Step[]): unknown {
+  let inputTotal = 0;
+  let outputTotal = 0;
+  for (const step of steps) {
+    const usage = safeParseJson(step.usage) as Record<string, unknown> | null;
+    if (!usage) continue;
+    const inp = usage.inputTokens;
+    const out = usage.outputTokens;
+    inputTotal +=
+      typeof inp === 'number'
+        ? inp
+        : ((inp as Record<string, number>)?.total ?? 0);
+    outputTotal +=
+      typeof out === 'number'
+        ? out
+        : ((out as Record<string, number>)?.total ?? 0);
+  }
+  return { inputTokens: inputTotal, outputTokens: outputTotal };
+}
+
+/**
+ * Estimates duration for non-tool content parts by splitting the remaining
+ * step time (after subtracting known tool call durations) proportionally.
+ */
+function estimatePartDuration(
+  _partType: 'reasoning' | 'text',
+  contentParts: Array<Record<string, unknown>>,
+  stepDurationMs: number,
+  toolTimingMap: Map<string, ToolCallTiming>,
+): number {
+  let toolDurationMs = 0;
+  for (const [, tc] of toolTimingMap) {
+    toolDurationMs += tc.duration_ms;
+  }
+  const remainingMs = Math.max(0, stepDurationMs - toolDurationMs);
+
+  const nonToolParts = contentParts.filter(p => {
+    const t = p.type as string;
+    return t === 'text' || t === 'reasoning' || t === 'thinking';
+  });
+  const count = Math.max(1, nonToolParts.length);
+  return Math.round(remainingMs / count);
+}
+
+/** Flatten a span tree into a list for rendering rows. */
+export function flattenSpans(
+  root: Span,
+  collapsedIds: Set<string>,
+  depth: number = 0,
+): Array<{ span: Span; depth: number }> {
+  const result: Array<{ span: Span; depth: number }> = [];
+  result.push({ span: root, depth });
+
+  if (!collapsedIds.has(root.id)) {
+    for (const child of root.children) {
+      result.push(...flattenSpans(child, collapsedIds, depth + 1));
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Background

our devtools setup currently uses middleware to extract event info

this needed to change since we now expose all the callbacks that will be needed by devtools, and it doesn't need to wrap with a middleware

## Summary

- use the telemetry interface for using callback info
- add a trace viewer (for o11y)

## Manual Verification

verified by running the `localhost:5173` devtools viewer

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)