### PR TITLE
fix(openai): include reasoning parts without itemId when encrypted_content is present

### DIFF
--- a/.changeset/fix-openai-responses-reasoning-no-item-id.md
+++ b/.changeset/fix-openai-responses-reasoning-no-item-id.md
@@ -1,0 +1,16 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): include reasoning parts without itemId when encrypted_content is present
+
+When `providerOptions.openai.itemId` is absent on a reasoning content part,
+the converter now uses `encrypted_content` as a fallback instead of silently
+skipping the part with a warning. The OpenAI Responses API accepts reasoning
+items without an `id` when `encrypted_content` is supplied, enabling
+multi-turn reasoning even when item IDs are stripped from provider options.
+
+Also makes the `id` field optional on the `OpenAIResponsesReasoning` type to
+reflect that the API does not require it.
+
+Fixes #12853

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -381,7 +381,7 @@ export type OpenAIResponsesTool =
 
 export type OpenAIResponsesReasoning = {
   type: 'reasoning';
-  id: string;
+  id?: string;
   encrypted_content?: string | null;
   summary: Array<{
     type: 'summary_text';


### PR DESCRIPTION
## Summary

When `providerOptions.openai.itemId` is absent on a reasoning content part, the `convertToOpenAIResponsesInput` converter previously skipped the part entirely with:

> "Non-OpenAI reasoning parts are not supported. Skipping reasoning part"

This breaks multi-turn conversations for users who remove `itemId` from their reasoning parts to avoid `Item with id 'rs_...' not found` errors from the OpenAI Responses API.

## Root Cause

The `reasoning` case in the converter required `providerOptions.openai.itemId` to be present before including the reasoning in the request. When absent, it fell to the generic warning path — even when `reasoningEncryptedContent` was available.

## Fix

The OpenAI Responses API accepts reasoning items without an `id` field when `encrypted_content` is supplied. With this change:

1. If `itemId` is absent but `reasoningEncryptedContent` is present → push a reasoning item with only `encrypted_content` (no `id`).
2. If neither is present → existing warning is still emitted (no behaviour change).
3. Makes `id` optional on `OpenAIResponsesReasoning` type to accurately reflect the API.

## Testing

Added two new test cases:
- ✅ Reasoning without `itemId` but with `encrypted_content` is included in output
- ✅ Reasoning without either `itemId` or `encrypted_content` still warns

Fixes #12853