### PR TITLE
fix(ai): guard toolResultsStreamController against enqueue/close on closed controller

### DIFF
--- a/.changeset/fix-run-tools-controller-closed.md
+++ b/.changeset/fix-run-tools-controller-closed.md
@@ -1,0 +1,9 @@
+---
+'ai': patch
+---
+
+fix(ai): guard toolResultsStreamController in run-tools-transformation against enqueue/close on already-closed controller
+
+When the LLM model stream errors while tools are still executing asynchronously, the cancellation cascade closes `toolResultsStreamController` before pending tool promise callbacks fire. This causes an unhandled `TypeError [ERR_INVALID_STATE]: Invalid state: Controller is already closed` that crashes the Node.js process.
+
+Added `safeEnqueue`/`safeClose` wrappers with a closed-state flag and a `cancel()` handler on `toolResultsStream` to gracefully handle late-arriving tool results.

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -144,13 +144,41 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
   let toolResultsStreamController: ReadableStreamDefaultController<
     SingleRequestTextStreamPart<TOOLS>
   > | null = null;
+  let toolResultsStreamClosed = false;
   const toolResultsStream = new ReadableStream<
     SingleRequestTextStreamPart<TOOLS>
   >({
     start(controller) {
       toolResultsStreamController = controller;
     },
+    cancel() {
+      toolResultsStreamClosed = true;
+    },
   });
+
+  // Guard against enqueue/close on a controller that has already been closed.
+  // When the combined stream is cancelled (e.g. due to a generator stream error),
+  // the cancellation cascades asynchronously to toolResultsStream. Pending
+  // fire-and-forget tool execution promises may resolve/reject after the
+  // controller is closed, causing "Controller is already closed" crashes.
+  function safeEnqueue(chunk: SingleRequestTextStreamPart<TOOLS>) {
+    if (toolResultsStreamClosed) return;
+    try {
+      safeEnqueue(chunk);
+    } catch (e) {
+      toolResultsStreamClosed = true;
+    }
+  }
+
+  function safeClose() {
+    if (toolResultsStreamClosed) return;
+    try {
+      toolResultsStreamController!.close();
+      toolResultsStreamClosed = true;
+    } catch (e) {
+      toolResultsStreamClosed = true;
+    }
+  }
 
   // keep track of outstanding tool results for stream closing:
   const outstandingToolResults = new Set<string>();
@@ -173,10 +201,10 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
       // are received to ensure that the frontend receives tool results before a message
       // finish event arrives.
       if (finishChunk != null) {
-        toolResultsStreamController!.enqueue(finishChunk);
+        safeEnqueue(finishChunk);
       }
 
-      toolResultsStreamController!.close();
+      safeClose();
     }
   }
 
@@ -238,7 +266,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
         case 'tool-approval-request': {
           const toolCall = toolCallsByToolCallId.get(chunk.toolCallId);
           if (toolCall == null) {
-            toolResultsStreamController!.enqueue({
+            safeEnqueue({
               type: 'error',
               error: new ToolCallNotFoundForApprovalError({
                 toolCallId: chunk.toolCallId,
@@ -271,7 +299,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
             controller.enqueue(toolCall);
 
             if (toolCall.invalid) {
-              toolResultsStreamController!.enqueue({
+              safeEnqueue({
                 type: 'tool-error',
                 toolCallId: toolCall.toolCallId,
                 toolName: toolCall.toolName,
@@ -309,7 +337,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                 experimental_context,
               })
             ) {
-              toolResultsStreamController!.enqueue({
+              safeEnqueue({
                 type: 'tool-approval-request',
                 approvalId: generateId(),
                 toolCall,
@@ -340,14 +368,14 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                 onToolCallStart,
                 onToolCallFinish,
                 onPreliminaryToolResult: result => {
-                  toolResultsStreamController!.enqueue(result);
+                  safeEnqueue(result);
                 },
               })
                 .then(result => {
-                  toolResultsStreamController!.enqueue(result);
+                  safeEnqueue(result);
                 })
                 .catch(error => {
-                  toolResultsStreamController!.enqueue({
+                  safeEnqueue({
                     type: 'error',
                     error,
                   });
@@ -358,7 +386,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                 });
             }
           } catch (error) {
-            toolResultsStreamController!.enqueue({ type: 'error', error });
+            safeEnqueue({ type: 'error', error });
           }
 
           break;
@@ -368,7 +396,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
           const toolName = chunk.toolName as keyof TOOLS & string;
 
           if (chunk.isError) {
-            toolResultsStreamController!.enqueue({
+            safeEnqueue({
               type: 'tool-error',
               toolCallId: chunk.toolCallId,
               toolName,


### PR DESCRIPTION
## Summary

Fixes a race condition in `run-tools-transformation.ts` where `toolResultsStreamController.enqueue()` is called on a closed controller, causing an unhandled `TypeError [ERR_INVALID_STATE]: Invalid state: Controller is already closed` that crashes the Node.js process.

Relates to #7518, #6974

## Root Cause

Tool executions are fire-and-forget promises whose `.then()`/`.catch()`/`.finally()` callbacks call `toolResultsStreamController.enqueue()` without checking if the controller is still open. When the LLM model stream errors (network failure, API 5xx, connection drop) while tools are still executing, `terminate()` asynchronously cascades a cancel to `toolResultsStreamController`, closing it before pending tool callbacks fire.

```
1. streamText() calls LLM → emits tool-call chunks → tools start executing async
2. LLM model stream errors (network failure, API 5xx mid-stream)
3. generatorStream.pipeTo() rejects → Promise.all rejects → combined stream errors
4. stitchableStream.processPull() catches error → calls terminate()
5. terminate() cancels inner stream readers → toolResultsStreamController is closed
6. Pending tool .then()/.catch() callbacks fire → enqueue() on closed controller → CRASH
```

The crash is intermittent — it depends on tool execution timing relative to the async cancel cascade (single fast tool: no crash; multiple/slow tools: crash).

## Fix

Adds `safeEnqueue`/`safeClose` wrappers around all `toolResultsStreamController.enqueue()` and `.close()` calls, with a `toolResultsStreamClosed` flag and a `cancel()` handler on `toolResultsStream`. This pattern already exists in the codebase for `stitchableStream`.

## Reproduction

Self-contained script (no API keys needed):

```js
const { streamText, tool, stepCountIs } = require('ai')
const { z } = require('zod')

function createCrashingModel() {
  return {
    specificationVersion: 'v3',
    provider: 'mock',
    modelId: 'mock',
    get supportedUrls() { return async () => ({}) },
    doGenerate: async () => { throw new Error('not implemented') },
    doStream: async () => ({
      stream: new ReadableStream({
        start(controller) {
          controller.enqueue({ type: 'response-metadata', id: 'resp-1', modelId: 'mock', timestamp: new Date() })
          controller.enqueue({ type: 'tool-call', toolCallId: 'call_1', toolName: 'slow_tool_a', input: '{"q":"a"}' })
          controller.enqueue({ type: 'tool-call', toolCallId: 'call_2', toolName: 'slow_tool_b', input: '{"q":"b"}' })
          setTimeout(() => controller.error(new Error('simulated LLM stream error')), 50)
        },
      }),
    }),
  }
}

async function main() {
  let crashed = false
  process.on('unhandledRejection', (err) => {
    if (err?.message?.includes('Controller is already closed')) { crashed = true; console.error('CRASH:', err.message) }
  })

  const result = streamText({
    model: createCrashingModel(),
    messages: [{ role: 'user', content: 'test' }],
    tools: {
      slow_tool_a: tool({ description: 'A', parameters: z.object({ q: z.string() }), execute: () => new Promise(r => setTimeout(() => r({ ok: true }), 2000)) }),
      slow_tool_b: tool({ description: 'B', parameters: z.object({ q: z.string() }), execute: () => new Promise(r => setTimeout(() => r({ ok: true }), 3000)) }),
    },
    toolChoice: 'auto',
    stopWhen: stepCountIs(10),
    onError: () => {},
  })

  try { for await (const _ of result.fullStream) {} } catch {}
  await new Promise(r => setTimeout(r, 4000))
  console.log(crashed ? 'Bug reproduced' : 'Race did not trigger')
}

main()
```

## Test Plan

- Added test case: "should not crash when generator stream errors while tools are executing"
- The test creates a stream that errors while a slow tool is executing, waits for the tool to complete, and verifies no unhandled rejection occurs