### PR TITLE
feat(provider/google): add support for gemini-3.1-flash-image-preview

### DIFF
--- a/.changeset/yellow-pugs-whisper.md
+++ b/.changeset/yellow-pugs-whisper.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/google': patch
+---
+
+feat(provider/google): add support for gemini-3.1-flash-image-preview

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -1049,6 +1049,7 @@ The following Zod features are known to not work with Google Generative AI:
 | Model                                 | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      | Google Search       | URL Context         |
 | ------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | `gemini-3.1-pro-preview`              | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-3.1-flash-image-preview`      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3-pro-preview`                | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3-pro-image-preview`          | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3-flash-preview`              | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
@@ -1277,10 +1278,11 @@ const { image } = await generateImage({
 
 #### Gemini Image Model Capabilities
 
-| Model                        | Image Generation    | Image Editing       | Aspect Ratios                                       |
-| ---------------------------- | ------------------- | ------------------- | --------------------------------------------------- |
-| `gemini-2.5-flash-image`     | <Check size={18} /> | <Check size={18} /> | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 |
-| `gemini-3-pro-image-preview` | <Check size={18} /> | <Check size={18} /> | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 |
+| Model                            | Image Generation    | Image Editing       | Aspect Ratios                                       |
+| -------------------------------- | ------------------- | ------------------- | --------------------------------------------------- |
+| `gemini-2.5-flash-image`         | <Check size={18} /> | <Check size={18} /> | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 |
+| `gemini-3-pro-image-preview`     | <Check size={18} /> | <Check size={18} /> | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 |
+| `gemini-3.1-flash-image-preview` | <Check size={18} /> | <Check size={18} /> | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 |
 
 <Note>
   `gemini-3-pro-image-preview` supports additional features including up to 14

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1093,10 +1093,11 @@ const { image } = await generateImage({
 
 ##### Gemini Image Model Capabilities
 
-| Model                        | Image Generation    | Image Editing       | Aspect Ratios                                       |
-| ---------------------------- | ------------------- | ------------------- | --------------------------------------------------- |
-| `gemini-3-pro-image-preview` | <Check size={18} /> | <Check size={18} /> | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 |
-| `gemini-2.5-flash-image`     | <Check size={18} /> | <Check size={18} /> | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 |
+| Model                            | Image Generation    | Image Editing       | Aspect Ratios                                       |
+| -------------------------------- | ------------------- | ------------------- | --------------------------------------------------- |
+| `gemini-3.1-flash-image-preview` | <Check size={18} /> | <Check size={18} /> | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 |
+| `gemini-3-pro-image-preview`     | <Check size={18} /> | <Check size={18} /> | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 |
+| `gemini-2.5-flash-image`         | <Check size={18} /> | <Check size={18} /> | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 |
 
 <Note>
   `gemini-3-pro-image-preview` supports additional features including up to 14

--- a/examples/ai-functions/src/generate-image/google/gemini-3-1-flash-image.ts
+++ b/examples/ai-functions/src/generate-image/google/gemini-3-1-flash-image.ts
@@ -1,0 +1,13 @@
+import { google } from '@ai-sdk/google';
+import { generateImage } from 'ai';
+import { run } from '../../lib/run';
+import { presentImages } from '../../lib/present-image';
+
+run(async () => {
+  const { images } = await generateImage({
+    model: google.image('gemini-3.1-flash-image-preview'),
+    prompt: 'A nano banana in a fancy restaurant',
+  });
+
+  presentImages(images);
+});

--- a/examples/ai-functions/src/generate-text/google/gemini-3-1-flash-image-output.ts
+++ b/examples/ai-functions/src/generate-text/google/gemini-3-1-flash-image-output.ts
@@ -1,0 +1,19 @@
+import { google } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import { presentImages } from '../../lib/present-image';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: google('gemini-3.1-flash-image-preview'),
+    prompt: 'Generate an image of a comic cat',
+  });
+
+  console.log(result.text);
+
+  for (const file of result.files) {
+    if (file.mediaType.startsWith('image/')) {
+      await presentImages([file]);
+    }
+  }
+});

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -57,6 +57,7 @@ export type GatewayModelId =
   | 'google/gemini-3-pro-image'
   | 'google/gemini-3-pro-preview'
   | 'google/gemini-3.1-pro-preview'
+  | 'google/gemini-3.1-flash-image-preview'
   | 'inception/mercury-coder-small'
   | 'kwaipilot/kat-coder-pro-v1'
   | 'meituan/longcat-flash-chat'

--- a/packages/google-vertex/src/google-vertex-image-settings.ts
+++ b/packages/google-vertex/src/google-vertex-image-settings.ts
@@ -7,4 +7,5 @@ export type GoogleVertexImageModelId =
   | 'imagen-4.0-fast-generate-001'
   | 'gemini-2.5-flash-image'
   | 'gemini-3-pro-image-preview'
+  | 'gemini-3.1-flash-image-preview'
   | (string & {});

--- a/packages/google-vertex/src/google-vertex-options.ts
+++ b/packages/google-vertex/src/google-vertex-options.ts
@@ -23,10 +23,11 @@ export type GoogleVertexModelId =
   | 'gemini-2.0-flash-lite-preview-02-05'
   | 'gemini-2.5-flash-lite-preview-09-2025'
   | 'gemini-2.5-flash-preview-09-2025'
-  | 'gemini-3.1-pro-preview'
   | 'gemini-3-pro-preview'
   | 'gemini-3-pro-image-preview'
   | 'gemini-3-flash-preview'
+  | 'gemini-3.1-pro-preview'
+  | 'gemini-3.1-flash-image-preview'
   // Experimental models
   | 'gemini-2.0-pro-exp-02-05'
   | 'gemini-2.0-flash-exp'

--- a/packages/google/src/google-generative-ai-image-settings.ts
+++ b/packages/google/src/google-generative-ai-image-settings.ts
@@ -6,6 +6,7 @@ export type GoogleGenerativeAIImageModelId =
   // Gemini image models (technically multimodal output language models, use :generateContent API)
   | 'gemini-2.5-flash-image'
   | 'gemini-3-pro-image-preview'
+  | 'gemini-3.1-flash-image-preview'
   | (string & {});
 
 export interface GoogleGenerativeAIImageSettings {

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -37,11 +37,12 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-2.5-flash-native-audio-preview-09-2025'
   | 'gemini-2.5-flash-native-audio-preview-12-2025'
   | 'gemini-2.5-computer-use-preview-10-2025'
-  | 'gemini-3.1-pro-preview'
-  | 'gemini-3.1-pro-preview-customtools'
   | 'gemini-3-pro-preview'
   | 'gemini-3-pro-image-preview'
   | 'gemini-3-flash-preview'
+  | 'gemini-3.1-pro-preview'
+  | 'gemini-3.1-pro-preview-customtools'
+  | 'gemini-3.1-flash-image-preview'
   // latest version
   // https://ai.google.dev/gemini-api/docs/models#latest
   | 'gemini-pro-latest'


### PR DESCRIPTION
## Background

Google released `gemini-3.1-flash-image-preview`, a new Gemini image model:

- https://blog.google/innovation-and-ai/technology/ai/nano-banana-2/
- https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-flash-image-preview

## Summary

Adds `gemini-3.1-flash-image-preview` to the model ID type unions in google, google-vertex, and gateway packages (both language model and image model ID lists). Updates documentation capability tables for both providers. Adds two `ai-functions` examples: one using `generateImage`, one using `generateText` with multimodal output.

## Manual Verification

Model ID additions are type-only changes. Examples can be verified by running:

```bash
aif examples/ai-functions/src/generate-image/google/gemini-3-1-flash-image.ts
aif examples/ai-functions/src/generate-text/google/gemini-3-1-flash-image-output.ts
```

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Fixes #12882
