### PR TITLE
fix(release): resolve PR number from merge commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,13 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
+      - name: Find release PR number
+        if: steps.changesets.outputs.published == 'true'
+        id: release-pr
+        run: echo "number=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0].number')" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Notify released PRs and issues
         if: steps.changesets.outputs.published == 'true'
         run: |
@@ -78,4 +85,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
-          PULL_REQUEST_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
+          PULL_REQUEST_NUMBER: ${{ steps.release-pr.outputs.number }}


### PR DESCRIPTION
## Summary

- The "Notify released PRs and issues" step was failing because `changesets/action` only sets `pullRequestNumber` in version mode (when creating/updating the Version Packages PR), not in publish mode (when `published` is `true`)
- Added a new step that uses the GitHub API to look up the PR associated with `github.sha` (the merge commit of the Version Packages PR) to resolve the correct PR number

## Test plan

- [ ] Trigger a release and verify the notify step resolves the correct PR number