### PR TITLE
fix(bedrock/groq): pass strict mode for tools

### DIFF
--- a/.changeset/hip-bikes-greet.md
+++ b/.changeset/hip-bikes-greet.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/groq': patch
+---
+
+fix(bedrock/groq): pass strict mode for tools

--- a/packages/amazon-bedrock/src/bedrock-api-types.ts
+++ b/packages/amazon-bedrock/src/bedrock-api-types.ts
@@ -80,6 +80,7 @@ export interface BedrockTool {
   toolSpec: {
     name: string;
     description?: string;
+    strict?: boolean;
     inputSchema: { json: JSONObject };
   };
 }

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.test.ts
@@ -1,7 +1,294 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { prepareTools } from './bedrock-prepare-tools';
 
+vi.mock('@ai-sdk/anthropic/internal', async importOriginal => {
+  const original =
+    await importOriginal<typeof import('@ai-sdk/anthropic/internal')>();
+  return {
+    ...original,
+    prepareTools: vi.fn().mockResolvedValue({
+      toolChoice: undefined,
+      toolWarnings: [],
+      betas: new Set<string>(),
+    }),
+  };
+});
+
+const NON_ANTHROPIC_MODEL = 'meta.llama3-70b-instruct-v1:0';
+const ANTHROPIC_MODEL = 'anthropic.claude-sonnet-4-5-20250929-v1:0';
+
 describe('prepareTools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return empty toolConfig when tools are undefined', async () => {
+    const result = await prepareTools({
+      tools: undefined,
+      modelId: ANTHROPIC_MODEL,
+    });
+
+    expect(result).toEqual({
+      toolConfig: {},
+      additionalTools: undefined,
+      betas: new Set(),
+      toolWarnings: [],
+    });
+  });
+
+  it('should return empty toolConfig when tools are empty', async () => {
+    const result = await prepareTools({
+      tools: [],
+      modelId: ANTHROPIC_MODEL,
+    });
+
+    expect(result).toEqual({
+      toolConfig: {},
+      additionalTools: undefined,
+      betas: new Set(),
+      toolWarnings: [],
+    });
+  });
+
+  it('should correctly prepare function tools', async () => {
+    const result = await prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'A test function',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+      modelId: ANTHROPIC_MODEL,
+    });
+
+    expect(result.toolConfig.tools).toEqual([
+      {
+        toolSpec: {
+          name: 'testFunction',
+          description: 'A test function',
+          inputSchema: {
+            json: { type: 'object', properties: {} },
+          },
+        },
+      },
+    ]);
+    expect(result.toolWarnings).toEqual([]);
+  });
+
+  describe('tool description handling', () => {
+    it('should exclude description when it is empty string', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: '',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+        modelId: ANTHROPIC_MODEL,
+      });
+
+      const toolSpec = (result.toolConfig.tools![0] as any).toolSpec;
+      expect(toolSpec).not.toHaveProperty('description');
+    });
+
+    it('should exclude description when it is whitespace-only', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: '   ',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+        modelId: ANTHROPIC_MODEL,
+      });
+
+      const toolSpec = (result.toolConfig.tools![0] as any).toolSpec;
+      expect(toolSpec).not.toHaveProperty('description');
+    });
+
+    it('should include description when it has content', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'Valid description',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+        modelId: ANTHROPIC_MODEL,
+      });
+
+      const toolSpec = (result.toolConfig.tools![0] as any).toolSpec;
+      expect(toolSpec.description).toBe('Valid description');
+    });
+  });
+
+  describe('unsupported provider-defined tools', () => {
+    it('should warn for provider-defined tools on non-anthropic models', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'some.custom_tool',
+            name: 'custom_tool',
+            args: {},
+          },
+        ],
+        modelId: NON_ANTHROPIC_MODEL,
+      });
+
+      expect(result.toolConfig).toEqual({});
+      expect(result.toolWarnings).toEqual([
+        { type: 'unsupported', feature: 'tool some.custom_tool' },
+      ]);
+    });
+
+    it('should warn and filter out web_search_20250305 tool', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'anthropic.web_search_20250305',
+            name: 'web_search',
+            args: {},
+          },
+        ],
+        modelId: ANTHROPIC_MODEL,
+      });
+
+      expect(result.toolConfig).toEqual({});
+      expect(result.toolWarnings).toEqual([
+        {
+          type: 'unsupported',
+          feature: 'web_search_20250305 tool',
+          details:
+            'The web_search_20250305 tool is not supported on Amazon Bedrock.',
+        },
+      ]);
+    });
+
+    it('should return empty toolConfig when all tools are filtered out', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'anthropic.web_search_20250305',
+            name: 'web_search',
+            args: {},
+          },
+        ],
+        modelId: ANTHROPIC_MODEL,
+      });
+
+      expect(result.toolConfig).toEqual({});
+    });
+  });
+
+  describe('tool choice', () => {
+    it('should handle tool choice "auto"', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'Test',
+            inputSchema: {},
+          },
+        ],
+        toolChoice: { type: 'auto' },
+        modelId: NON_ANTHROPIC_MODEL,
+      });
+
+      expect(result.toolConfig.toolChoice).toEqual({ auto: {} });
+    });
+
+    it('should handle tool choice "required"', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'Test',
+            inputSchema: {},
+          },
+        ],
+        toolChoice: { type: 'required' },
+        modelId: NON_ANTHROPIC_MODEL,
+      });
+
+      expect(result.toolConfig.toolChoice).toEqual({ any: {} });
+    });
+
+    it('should handle tool choice "none" by clearing tools', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'Test',
+            inputSchema: {},
+          },
+        ],
+        toolChoice: { type: 'none' },
+        modelId: NON_ANTHROPIC_MODEL,
+      });
+
+      expect(result.toolConfig).toEqual({});
+    });
+
+    it('should handle tool choice "tool"', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'Test',
+            inputSchema: {},
+          },
+        ],
+        toolChoice: { type: 'tool', toolName: 'testFunction' },
+        modelId: NON_ANTHROPIC_MODEL,
+      });
+
+      expect(result.toolConfig.toolChoice).toEqual({
+        tool: { name: 'testFunction' },
+      });
+    });
+
+    it('should filter function tools to only the named tool when tool choice is "tool"', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'getWeather',
+            description: 'Get weather',
+            inputSchema: { type: 'object' },
+          },
+          {
+            type: 'function',
+            name: 'getTime',
+            description: 'Get time',
+            inputSchema: { type: 'object' },
+          },
+        ],
+        toolChoice: { type: 'tool', toolName: 'getWeather' },
+        modelId: NON_ANTHROPIC_MODEL,
+      });
+
+      expect(result.toolConfig.tools).toHaveLength(1);
+      expect((result.toolConfig.tools![0] as any).toolSpec.name).toBe(
+        'getWeather',
+      );
+    });
+  });
+
   describe('strict mode for function tools', () => {
     it('should pass through strict mode when strict is true', async () => {
       const result = await prepareTools({
@@ -14,7 +301,7 @@ describe('prepareTools', () => {
             strict: true,
           },
         ],
-        modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+        modelId: ANTHROPIC_MODEL,
       });
 
       expect(result.toolConfig.tools).toEqual([
@@ -42,7 +329,7 @@ describe('prepareTools', () => {
             strict: false,
           },
         ],
-        modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+        modelId: ANTHROPIC_MODEL,
       });
 
       expect(result.toolConfig.tools).toEqual([
@@ -69,12 +356,11 @@ describe('prepareTools', () => {
             inputSchema: { type: 'object', properties: {} },
           },
         ],
-        modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+        modelId: ANTHROPIC_MODEL,
       });
 
       const toolSpec = (result.toolConfig.tools![0] as any).toolSpec;
       expect(toolSpec).not.toHaveProperty('strict');
-      expect(toolSpec.name).toBe('testFunction');
     });
 
     it('should pass through strict mode for multiple tools with different strict settings', async () => {
@@ -101,7 +387,7 @@ describe('prepareTools', () => {
             inputSchema: { type: 'object', properties: {} },
           },
         ],
-        modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+        modelId: ANTHROPIC_MODEL,
       });
 
       const tools = result.toolConfig.tools!;

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { prepareTools } from './bedrock-prepare-tools';
+
+describe('prepareTools', () => {
+  describe('strict mode for function tools', () => {
+    it('should pass through strict mode when strict is true', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+        modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+      });
+
+      expect(result.toolConfig.tools).toEqual([
+        {
+          toolSpec: {
+            name: 'testFunction',
+            description: 'A test function',
+            strict: true,
+            inputSchema: {
+              json: { type: 'object', properties: {} },
+            },
+          },
+        },
+      ]);
+    });
+
+    it('should pass through strict mode when strict is false', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: false,
+          },
+        ],
+        modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+      });
+
+      expect(result.toolConfig.tools).toEqual([
+        {
+          toolSpec: {
+            name: 'testFunction',
+            description: 'A test function',
+            strict: false,
+            inputSchema: {
+              json: { type: 'object', properties: {} },
+            },
+          },
+        },
+      ]);
+    });
+
+    it('should not include strict when strict is undefined', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+        modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+      });
+
+      const toolSpec = (result.toolConfig.tools![0] as any).toolSpec;
+      expect(toolSpec).not.toHaveProperty('strict');
+      expect(toolSpec.name).toBe('testFunction');
+    });
+
+    it('should pass through strict mode for multiple tools with different strict settings', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'strictTool',
+            description: 'A strict tool',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+          {
+            type: 'function',
+            name: 'nonStrictTool',
+            description: 'A non-strict tool',
+            inputSchema: { type: 'object', properties: {} },
+            strict: false,
+          },
+          {
+            type: 'function',
+            name: 'defaultTool',
+            description: 'A tool without strict setting',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+        modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+      });
+
+      const tools = result.toolConfig.tools!;
+      expect((tools[0] as any).toolSpec.strict).toBe(true);
+      expect((tools[1] as any).toolSpec.strict).toBe(false);
+      expect((tools[2] as any).toolSpec).not.toHaveProperty('strict');
+    });
+  });
+});

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -136,6 +136,7 @@ export async function prepareTools({
         ...(tool.description?.trim() !== ''
           ? { description: tool.description }
           : {}),
+        ...(tool.strict != null ? { strict: tool.strict } : {}),
         inputSchema: {
           json: tool.inputSchema as JSONObject,
         },

--- a/packages/groq/src/groq-prepare-tools.test.ts
+++ b/packages/groq/src/groq-prepare-tools.test.ts
@@ -147,6 +147,144 @@ describe('prepareTools', () => {
     });
   });
 
+  describe('strict mode for function tools', () => {
+    it('should pass through strict mode when strict is true', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+        modelId: 'gemma2-9b-it',
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'testFunction',
+            description: 'A test function',
+            parameters: { type: 'object', properties: {} },
+            strict: true,
+          },
+        },
+      ]);
+    });
+
+    it('should pass through strict mode when strict is false', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: false,
+          },
+        ],
+        modelId: 'gemma2-9b-it',
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'testFunction',
+            description: 'A test function',
+            parameters: { type: 'object', properties: {} },
+            strict: false,
+          },
+        },
+      ]);
+    });
+
+    it('should not include strict when strict is undefined', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+        modelId: 'gemma2-9b-it',
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'testFunction',
+            description: 'A test function',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      ]);
+    });
+
+    it('should pass through strict mode for multiple tools with different strict settings', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'strictTool',
+            description: 'A strict tool',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+          {
+            type: 'function',
+            name: 'nonStrictTool',
+            description: 'A non-strict tool',
+            inputSchema: { type: 'object', properties: {} },
+            strict: false,
+          },
+          {
+            type: 'function',
+            name: 'defaultTool',
+            description: 'A tool without strict setting',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+        modelId: 'gemma2-9b-it',
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'strictTool',
+            description: 'A strict tool',
+            parameters: { type: 'object', properties: {} },
+            strict: true,
+          },
+        },
+        {
+          type: 'function',
+          function: {
+            name: 'nonStrictTool',
+            description: 'A non-strict tool',
+            parameters: { type: 'object', properties: {} },
+            strict: false,
+          },
+        },
+        {
+          type: 'function',
+          function: {
+            name: 'defaultTool',
+            description: 'A tool without strict setting',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      ]);
+    });
+  });
+
   describe('browser search tool', () => {
     it('should handle browser search tool with supported model', () => {
       const result = prepareTools({

--- a/packages/groq/src/groq-prepare-tools.ts
+++ b/packages/groq/src/groq-prepare-tools.ts
@@ -27,6 +27,7 @@ export function prepareTools({
               name: string;
               description: string | undefined;
               parameters: unknown;
+              strict?: boolean;
             };
           }
         | {
@@ -57,6 +58,7 @@ export function prepareTools({
           name: string;
           description: string | undefined;
           parameters: unknown;
+          strict?: boolean;
         };
       }
     | {
@@ -91,6 +93,7 @@ export function prepareTools({
           name: tool.name,
           description: tool.description,
           parameters: tool.inputSchema,
+          ...(tool.strict != null ? { strict: tool.strict } : {}),
         },
       });
     }


### PR DESCRIPTION
## Background

#12766 

we were not passing the `strict: true` mode for tools for the bedrock and groq provider, which sometimes led to the models not adhering to the tool input schema

## Summary

modified the api to ensure strict mode is stored and ensure it's passed to the model tool spec

## Manual Verification

hard to verify via a cli example since behaviour can vary but ran the following example

<Details>
<summary> repro example </summary>

```ts
import { generateText, tool } from 'ai';
import { bedrock } from '@ai-sdk/amazon-bedrock';
import { z } from 'zod';
import { run } from '../../lib/run';

run(async () => {
  const result = await generateText({
  model: bedrock('openai.gpt-oss-120b-1:0'),
  tools: {
    getWeather: tool({
      description: 'Get weather by city and unit',
      inputSchema: z.object({
        city: z.string(),
        unit: z.enum(['celsius', 'fahrenheit']),
      }),
      strict: true,
    }),
  },
    prompt: 'What is the weather in Boston?',
  });

  console.log(JSON.stringify(result, null, 2));
});
```
</Details>

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #12766 