### PR TITLE
feat(provider/google): add support for new Google image model aspect ratios and sizes

### DIFF
--- a/.changeset/friendly-onions-film.md
+++ b/.changeset/friendly-onions-film.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(provider/google): add support for new Google image model aspect ratios

--- a/.changeset/friendly-onions-film.md
+++ b/.changeset/friendly-onions-film.md
@@ -2,4 +2,4 @@
 '@ai-sdk/google': patch
 ---
 
-feat(provider/google): add support for new Google image model aspect ratios
+feat(provider/google): add support for new Google image model aspect ratios and sizes

--- a/examples/ai-functions/src/generate-image/google/gemini-3-1-flash-image.ts
+++ b/examples/ai-functions/src/generate-image/google/gemini-3-1-flash-image.ts
@@ -1,4 +1,4 @@
-import { google } from '@ai-sdk/google';
+import { google, GoogleLanguageModelOptions } from '@ai-sdk/google';
 import { generateImage } from 'ai';
 import { run } from '../../lib/run';
 import { presentImages } from '../../lib/present-image';
@@ -7,6 +7,7 @@ run(async () => {
   const { images } = await generateImage({
     model: google.image('gemini-3.1-flash-image-preview'),
     prompt: 'A nano banana in a fancy restaurant',
+    aspectRatio: '4:1',
   });
 
   presentImages(images);

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -181,6 +181,10 @@ export const googleLanguageModelOptions = lazySchema(() =>
               '9:16',
               '16:9',
               '21:9',
+              '1:8',
+              '8:1',
+              '1:4',
+              '4:1',
             ])
             .optional(),
           imageSize: z.enum(['1K', '2K', '4K']).optional(),

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -187,7 +187,7 @@ export const googleLanguageModelOptions = lazySchema(() =>
               '4:1',
             ])
             .optional(),
-          imageSize: z.enum(['1K', '2K', '4K']).optional(),
+          imageSize: z.enum(['1K', '2K', '4K', '512']).optional(),
         })
         .optional(),
 


### PR DESCRIPTION
## Background

With the launch of Gemini 3.1 Image, a few new image aspect ratios and one new size were introduced.

Reference from the source: https://github.com/googleapis/python-genai/commit/8b2a4e04707c86e5f7d46e0483a88457fbf6d533

## Summary

Adds the new image aspect ratios.

## Manual Verification

Run the updated example.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
