### PR TITLE
fix(openai): allow null/undefined type in streaming tool call deltas

### DIFF
--- a/.changeset/fix-openai-streaming-tool-call-null-type.md
+++ b/.changeset/fix-openai-streaming-tool-call-null-type.md
@@ -1,0 +1,12 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): allow null/undefined type in streaming tool call deltas
+
+Azure AI Foundry and Mistral deployed on Azure omit the `type` field in
+streaming tool_calls deltas. The chat stream parser now accepts a missing
+`type` field (treating it as `"function"`) instead of throwing
+`InvalidResponseDataError: Expected 'function' type.`
+
+Fixes #12770

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -2784,6 +2784,61 @@ describe('doStream', () => {
     `);
   });
 
+  it('should stream tool call with missing type field (Azure AI Foundry / Mistral)', async () => {
+    // Azure AI Foundry and Mistral omit the `type` field in streaming tool call deltas.
+    // The parser should accept null/undefined type as equivalent to "function".
+    server.urls['https://api.openai.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-azure-001","object":"chat.completion.chunk","created":1711357598,"model":"mistral-large",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"call_abc123","function":{"name":"test-tool","arguments":""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-azure-001","object":"chat.completion.chunk","created":1711357598,"model":"mistral-large",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"value\\""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-azure-001","object":"chat.completion.chunk","created":1711357598,"model":"mistral-large",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\\"hello\\"}"}}]},` +
+          `"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const chunks = await convertReadableStreamToArray(stream);
+    const toolInputStart = chunks.find(c => c.type === 'tool-input-start');
+    const toolCall = chunks.find(c => c.type === 'tool-call');
+
+    expect(toolInputStart).toMatchObject({
+      type: 'tool-input-start',
+      id: 'call_abc123',
+      toolName: 'test-tool',
+    });
+    expect(toolCall).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'call_abc123',
+      toolName: 'test-tool',
+      input: '{"value":"hello"}',
+    });
+  });
+
   it('should stream tool call that is sent in one chunk', async () => {
     server.urls['https://api.openai.com/v1/chat/completions'].response = {
       type: 'stream-chunks',

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -551,7 +551,10 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
 
                 // Tool call start. OpenAI returns all information except the arguments in the first chunk.
                 if (toolCalls[index] == null) {
-                  if (toolCallDelta.type !== 'function') {
+                  if (
+                    toolCallDelta.type != null &&
+                    toolCallDelta.type !== 'function'
+                  ) {
                     throw new InvalidResponseDataError({
                       data: toolCallDelta,
                       message: `Expected 'function' type.`,


### PR DESCRIPTION
## Summary

Fixes #12770

Azure AI Foundry and Mistral models deployed on Azure omit the `type` field in streaming `tool_calls` deltas. The OpenAI chat stream parser was throwing:

```
InvalidResponseDataError: Expected 'function' type.
```

## Root Cause

In `openai-chat-language-model.ts`, the parser checked `if (toolCallDelta.type !== 'function')` at the start of a new tool call. Azure / Mistral omit the `type` field entirely (it is `undefined`), so `undefined !== 'function'` triggered the error before even reading the function name or id.

## Fix

Changed the guard from:
```ts
if (toolCallDelta.type !== 'function') {
```
to:
```ts
if (toolCallDelta.type != null && toolCallDelta.type !== 'function') {
```

A missing `type` is now silently treated as `"function"` (the only valid value). An explicit non-`"function"` type still throws.

## Test

Added a new streaming test case that sends tool call deltas without a `type` field (matching Azure / Mistral behaviour) and verifies the tool call is parsed correctly.