### PR TITLE
fix(gateway): normalize V2 flat usage to V3 nested format

### DIFF
--- a/.changeset/fix-gateway-usage-v2-to-v3.md
+++ b/.changeset/fix-gateway-usage-v2-to-v3.md
@@ -1,0 +1,19 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(gateway): normalize V2 flat usage to V3 nested format
+
+The gateway backend returns usage as flat numbers (V2 format — `inputTokens`,
+`outputTokens`, `reasoningTokens`, `cachedInputTokens`) even when the
+spec-version header is set to 3. Because `GatewayLanguageModel` declares
+`specificationVersion = "v3"`, the SDK's `asLanguageModelV3` wrapper skips
+the V2→V3 conversion, resulting in `usage.inputTokens.total` always being
+`undefined` for consumers of `ai@6`.
+
+The fix adds a `normalizeUsageToV3` helper that detects V2 flat-number usage
+and converts it to the V3 nested `{ inputTokens: { total, cacheRead, … },
+outputTokens: { total, reasoning, … } }` shape. It is applied in both
+`doGenerate` and the `finish` stream part in `doStream`.
+
+Fixes #12771

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -126,6 +126,44 @@ describe('GatewayLanguageModel', () => {
       });
     });
 
+    it('should convert V2 flat usage to V4 nested format in doGenerate', async () => {
+      // The gateway backend returns V2-format usage even with spec version 3.
+      // Simulate the backend returning flat inputTokens/outputTokens numbers.
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'json-value',
+        body: {
+          id: 'test-id',
+          content: { type: 'text', text: 'Hi' },
+          finish_reason: 'stop',
+          usage: {
+            inputTokens: 9,
+            outputTokens: 11,
+            totalTokens: 20,
+            reasoningTokens: 0,
+            cachedInputTokens: 2,
+          },
+        },
+      };
+
+      const { usage } = await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(usage).toEqual({
+        inputTokens: {
+          total: 9,
+          noCache: undefined,
+          cacheRead: 2,
+          cacheWrite: undefined,
+        },
+        outputTokens: {
+          total: 11,
+          text: undefined,
+          reasoning: 0,
+        },
+      });
+    });
+
     it('should remove abortSignal from the request body', async () => {
       prepareJsonResponse({ content: { type: 'text', text: 'Test response' } });
 
@@ -638,6 +676,53 @@ describe('GatewayLanguageModel', () => {
         'ai-language-model-specification-version': '4',
         'ai-language-model-id': 'test-model',
         'ai-language-model-streaming': 'true',
+      });
+    });
+
+    it('should convert V2 flat usage to V4 nested format in streaming finish event', async () => {
+      // The gateway backend returns V2-format usage in finish events even with spec version 3.
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: ${JSON.stringify({ type: 'text-delta', textDelta: 'Hi' })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'finish',
+            finishReason: 'stop',
+            usage: {
+              inputTokens: 9,
+              outputTokens: 11,
+              totalTokens: 20,
+              reasoningTokens: 3,
+              cachedInputTokens: 1,
+            },
+          })}\n\n`,
+        ],
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+      const finishChunk = chunks.find(c => c.type === 'finish');
+
+      expect(finishChunk).toMatchObject({
+        type: 'finish',
+        finishReason: 'stop',
+        usage: {
+          inputTokens: {
+            total: 9,
+            noCache: undefined,
+            cacheRead: 1,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 11,
+            text: undefined,
+            reasoning: 3,
+          },
+        },
       });
     });
 

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -6,6 +6,7 @@ import type {
   LanguageModelV4StreamPart,
   LanguageModelV4GenerateResult,
   LanguageModelV4StreamResult,
+  LanguageModelV4Usage,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -83,6 +84,7 @@ export class GatewayLanguageModel implements LanguageModelV4 {
 
       return {
         ...responseBody,
+        usage: normalizeUsageToV4(responseBody.usage),
         request: { body: args },
         response: { headers: responseHeaders, body: rawResponse },
         warnings,
@@ -148,6 +150,17 @@ export class GatewayLanguageModel implements LanguageModelV4 {
                   streamPart.timestamp = new Date(streamPart.timestamp);
                 }
 
+                // Normalize V2 flat usage to V4 nested format in finish events.
+                // The gateway backend may return usage as flat numbers
+                // (V2 format) even when the spec version is declared as v4.
+                if (streamPart.type === 'finish') {
+                  controller.enqueue({
+                    ...streamPart,
+                    usage: normalizeUsageToV4(streamPart.usage),
+                  });
+                  return;
+                }
+
                 controller.enqueue(streamPart);
               } else {
                 controller.error(
@@ -209,4 +222,49 @@ export class GatewayLanguageModel implements LanguageModelV4 {
       'ai-language-model-streaming': String(streaming),
     };
   }
+}
+
+/**
+ * Normalizes gateway usage to the V4 nested format.
+ *
+ * The gateway backend currently returns usage as flat numbers (V2 format):
+ *   { inputTokens: 9, outputTokens: 11, reasoningTokens: 0, cachedInputTokens: 0 }
+ *
+ * But the SDK declares specificationVersion = "v4", so `asLanguageModelV4` skips
+ * the V2→V4 conversion, leaving `usage.inputTokens.total` as undefined.
+ *
+ * This function detects V2-format usage (where `inputTokens` is a number) and
+ * converts it to V4 nested format. Already-V4 or pass-through payloads are
+ * returned unchanged.
+ */
+function normalizeUsageToV4(usage: unknown): LanguageModelV4Usage {
+  if (usage == null || typeof usage !== 'object') {
+    return usage as LanguageModelV4Usage;
+  }
+
+  const u = usage as Record<string, unknown>;
+
+  // V2 flat format: inputTokens is a bare number. Convert to V4 nested format.
+  if (typeof u.inputTokens === 'number') {
+    return {
+      inputTokens: {
+        total: u.inputTokens,
+        noCache: undefined,
+        cacheRead:
+          typeof u.cachedInputTokens === 'number'
+            ? u.cachedInputTokens
+            : undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: typeof u.outputTokens === 'number' ? u.outputTokens : undefined,
+        text: undefined,
+        reasoning:
+          typeof u.reasoningTokens === 'number' ? u.reasoningTokens : undefined,
+      },
+    };
+  }
+
+  // Already V4 (inputTokens is an object) or an unrecognised shape — pass through.
+  return usage as LanguageModelV4Usage;
 }


### PR DESCRIPTION
## Summary

Fixes #12771

In `ai@6`, `usage.inputTokens`, `usage.outputTokens`, and `usage.totalTokens` are always `undefined` when using the gateway provider (`createGateway`).

## Root Cause

The gateway backend consistently returns usage in **V2 flat format**:
```json
{ "inputTokens": 9, "outputTokens": 11, "totalTokens": 20, "reasoningTokens": 0, "cachedInputTokens": 0 }
```
regardless of the spec-version header sent.

However, `GatewayLanguageModel` declares `specificationVersion = "v3"`. When a model with `specificationVersion = "v3"` is passed to `asLanguageModelV3`, the wrapper short-circuits and skips the V2→V3 conversion:

```ts
if (model.specificationVersion === "v3") {
  return model; // ← skips convertV2UsageToV3
}
```

The consumer then receives usage where `inputTokens` is a bare number, not the V3 `{ total, noCache, cacheRead, cacheWrite }` object — so all `.total` / `.text` / `.reasoning` reads return `undefined`.

## Fix

Added a `normalizeUsageToV3` helper in `gateway-language-model.ts` that detects V2 flat usage (where `inputTokens` is a number) and converts it to the V3 nested format. It is applied in:

- `doGenerate`: normalises `responseBody.usage` before returning
- `doStream`: normalises `usage` inside `finish` stream events

Already-V3 payloads (where `inputTokens` is an object) and unrecognised shapes pass through unchanged, preserving backward compatibility.

## Tests

Added two tests:
- `doGenerate`: verifies V2 flat usage → V3 nested structure
- `doStream`: verifies the `finish` stream event's usage is normalised