### PR TITLE
fix(anthropic): convert oneOf to anyOf in tool and output_format schemas

### DIFF
--- a/.changeset/fix-anthropic-oneof-to-anyof.md
+++ b/.changeset/fix-anthropic-oneof-to-anyof.md
@@ -1,0 +1,20 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): convert oneOf to anyOf in tool and output_format schemas
+
+The Anthropic API rejects schemas that contain `oneOf`
+(`output_format.schema: Schema type 'oneOf' is not supported`).
+Zod's `z.discriminatedUnion()` produces `oneOf` when serialised to JSON
+Schema, which caused failures when using discriminated unions as tool
+`inputSchema` or as an `output_format` schema with structured output.
+
+Adds a `replaceOneOfWithAnyOf` helper that recursively rewrites every
+`oneOf` keyword to `anyOf` before the schema is sent to the API. The
+conversion is applied to:
+
+- function tool `input_schema` (in `prepareTools`)
+- native `output_format.schema` (structured output path)
+
+Fixes #12876

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -48,6 +48,7 @@ import {
   AnthropicMessagesUsage,
   convertAnthropicMessagesUsage,
 } from './convert-anthropic-messages-usage';
+import { replaceOneOfWithAnyOf } from './convert-anthropic-schema';
 import { convertToAnthropicMessagesPrompt } from './convert-to-anthropic-messages-prompt';
 import { CacheControlValidator } from './get-cache-control';
 import { mapAnthropicStopReason } from './map-anthropic-stop-reason';
@@ -372,6 +373,16 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       ...(anthropicOptions?.cacheControl && {
         cache_control: anthropicOptions.cacheControl,
       }),
+
+      // structured output:
+      ...(useStructuredOutput &&
+        responseFormat?.type === 'json' &&
+        responseFormat.schema != null && {
+          output_format: {
+            type: 'json_schema',
+            schema: replaceOneOfWithAnyOf(responseFormat.schema),
+          },
+        }),
 
       // mcp servers:
       ...(anthropicOptions?.mcpServers &&

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -9,6 +9,7 @@ import { textEditor_20250728ArgsSchema } from './tool/text-editor_20250728';
 import { webSearch_20250305ArgsSchema } from './tool/web-search_20250305';
 import { webFetch_20250910ArgsSchema } from './tool/web-fetch-20250910';
 import { validateTypes } from '@ai-sdk/provider-utils';
+import { replaceOneOfWithAnyOf } from './convert-anthropic-schema';
 
 export interface AnthropicToolOptions {
   deferLoading?: boolean;
@@ -70,7 +71,7 @@ export async function prepareTools({
         anthropicTools.push({
           name: tool.name,
           description: tool.description,
-          input_schema: tool.inputSchema,
+          input_schema: replaceOneOfWithAnyOf(tool.inputSchema),
           cache_control: cacheControl,
           ...(supportsStructuredOutput === true && tool.strict != null
             ? { strict: tool.strict }

--- a/packages/anthropic/src/convert-anthropic-schema.test.ts
+++ b/packages/anthropic/src/convert-anthropic-schema.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { replaceOneOfWithAnyOf } from './convert-anthropic-schema';
+
+describe('replaceOneOfWithAnyOf', () => {
+  it('should return primitives unchanged', () => {
+    expect(replaceOneOfWithAnyOf(null)).toBeNull();
+    expect(replaceOneOfWithAnyOf(undefined)).toBeUndefined();
+    expect(replaceOneOfWithAnyOf('string')).toBe('string');
+    expect(replaceOneOfWithAnyOf(42)).toBe(42);
+  });
+
+  it('should replace top-level oneOf with anyOf', () => {
+    const schema = {
+      oneOf: [
+        { type: 'object', properties: { brand: { const: 'BMW' } } },
+        { type: 'object', properties: { brand: { const: 'Mercedes' } } },
+      ],
+    };
+    expect(replaceOneOfWithAnyOf(schema)).toEqual({
+      anyOf: [
+        { type: 'object', properties: { brand: { const: 'BMW' } } },
+        { type: 'object', properties: { brand: { const: 'Mercedes' } } },
+      ],
+    });
+  });
+
+  it('should recursively replace nested oneOf', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        cars: {
+          oneOf: [
+            { type: 'object', properties: { brand: { const: 'BMW' } } },
+            { type: 'object', properties: { brand: { const: 'Mercedes' } } },
+          ],
+        },
+      },
+    };
+    expect(replaceOneOfWithAnyOf(schema)).toEqual({
+      type: 'object',
+      properties: {
+        cars: {
+          anyOf: [
+            { type: 'object', properties: { brand: { const: 'BMW' } } },
+            { type: 'object', properties: { brand: { const: 'Mercedes' } } },
+          ],
+        },
+      },
+    });
+  });
+
+  it('should leave anyOf unchanged', () => {
+    const schema = {
+      anyOf: [{ type: 'string' }, { type: 'number' }],
+    };
+    expect(replaceOneOfWithAnyOf(schema)).toEqual(schema);
+  });
+
+  it('should handle arrays', () => {
+    const schema = [{ oneOf: [{ type: 'string' }] }, { type: 'number' }];
+    expect(replaceOneOfWithAnyOf(schema)).toEqual([
+      { anyOf: [{ type: 'string' }] },
+      { type: 'number' },
+    ]);
+  });
+
+  it('should recurse into allOf sub-schemas', () => {
+    const schema = {
+      allOf: [
+        {
+          oneOf: [{ type: 'string' }, { type: 'number' }],
+        },
+      ],
+    };
+    expect(replaceOneOfWithAnyOf(schema)).toEqual({
+      allOf: [
+        {
+          anyOf: [{ type: 'string' }, { type: 'number' }],
+        },
+      ],
+    });
+  });
+
+  it('should recurse into anyOf sub-schemas', () => {
+    const schema = {
+      anyOf: [
+        {
+          oneOf: [{ type: 'string' }, { type: 'number' }],
+        },
+        { type: 'boolean' },
+      ],
+    };
+    expect(replaceOneOfWithAnyOf(schema)).toEqual({
+      anyOf: [
+        {
+          anyOf: [{ type: 'string' }, { type: 'number' }],
+        },
+        { type: 'boolean' },
+      ],
+    });
+  });
+
+  it('should handle typical Zod discriminatedUnion schema', () => {
+    // Simulates what z.object({ cars: z.discriminatedUnion('brand', [...]) })
+    // produces in JSON Schema when serialised.
+    const schema = {
+      type: 'object',
+      properties: {
+        cars: {
+          oneOf: [
+            {
+              type: 'object',
+              properties: {
+                brand: { type: 'string', const: 'BMW' },
+              },
+              required: ['brand'],
+            },
+            {
+              type: 'object',
+              properties: {
+                brand: { type: 'string', const: 'Mercedes' },
+              },
+              required: ['brand'],
+            },
+          ],
+        },
+      },
+      required: ['cars'],
+    };
+
+    const result = replaceOneOfWithAnyOf(schema) as Record<string, unknown>;
+    const cars = (result.properties as Record<string, unknown>).cars as Record<
+      string,
+      unknown
+    >;
+
+    expect(cars).toHaveProperty('anyOf');
+    expect(cars).not.toHaveProperty('oneOf');
+    expect((cars.anyOf as unknown[]).length).toBe(2);
+  });
+});

--- a/packages/anthropic/src/convert-anthropic-schema.ts
+++ b/packages/anthropic/src/convert-anthropic-schema.ts
@@ -14,13 +14,13 @@
  * mutually exclusive by design — the practical runtime behaviour is
  * identical and Anthropic only supports `anyOf`.
  */
-export function replaceOneOfWithAnyOf(schema: unknown): unknown {
+export function replaceOneOfWithAnyOf<T>(schema: T): T {
   if (schema == null || typeof schema !== 'object') {
     return schema;
   }
 
   if (Array.isArray(schema)) {
-    return schema.map(item => replaceOneOfWithAnyOf(item));
+    return schema.map(item => replaceOneOfWithAnyOf(item)) as T;
   }
 
   const result: Record<string, unknown> = {};
@@ -36,5 +36,5 @@ export function replaceOneOfWithAnyOf(schema: unknown): unknown {
     }
   }
 
-  return result;
+  return result as T;
 }

--- a/packages/anthropic/src/convert-anthropic-schema.ts
+++ b/packages/anthropic/src/convert-anthropic-schema.ts
@@ -1,0 +1,40 @@
+/**
+ * Recursively replaces all `oneOf` keywords with `anyOf` in a JSON Schema
+ * object tree.
+ *
+ * The Anthropic API rejects schemas containing `oneOf`
+ * (`output_format.schema: Schema type 'oneOf' is not supported`) but
+ * supports `anyOf` for the same use-cases.  Zod's `z.discriminatedUnion()`
+ * generates `oneOf` when serialised to JSON Schema, causing failures when
+ * that schema is passed to Anthropic as a tool `input_schema` or as an
+ * `output_format.schema`.
+ *
+ * Semantically `oneOf` (exactly-one-of) and `anyOf` (at-least-one-of)
+ * differ, but for the discriminated union case — where the variants are
+ * mutually exclusive by design — the practical runtime behaviour is
+ * identical and Anthropic only supports `anyOf`.
+ */
+export function replaceOneOfWithAnyOf(schema: unknown): unknown {
+  if (schema == null || typeof schema !== 'object') {
+    return schema;
+  }
+
+  if (Array.isArray(schema)) {
+    return schema.map(item => replaceOneOfWithAnyOf(item));
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(
+    schema as Record<string, unknown>,
+  )) {
+    if (key === 'oneOf') {
+      // Convert oneOf → anyOf and recurse into the sub-schemas.
+      result.anyOf = replaceOneOfWithAnyOf(value);
+    } else {
+      result[key] = replaceOneOfWithAnyOf(value);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Fixes #12876

Using `z.discriminatedUnion()` (or any other Zod construct that produces `oneOf` in JSON Schema) with the Anthropic provider fails with:

```
output_format.schema: Schema type 'oneOf' is not supported
```

## Root Cause

The Anthropic API supports `anyOf` but not `oneOf` in JSON schemas. Zod's `z.discriminatedUnion()` serialises to `oneOf` in JSON Schema 7. The SDK was passing this schema verbatim to the API without any conversion.

The same problem affects two code paths:
1. **Tool `input_schema`** — when a function tool's `inputSchema` contains `oneOf`
2. **Native structured output** — `output_format.schema` when `supportsStructuredOutput` is true (e.g. claude-haiku-4-5, claude-sonnet-4-5, etc.)

## Fix

Added a `replaceOneOfWithAnyOf` helper (`convert-anthropic-schema.ts`) that recursively walks a JSON Schema object tree and rewrites every `oneOf` keyword to `anyOf`. Applied in:

- `anthropic-prepare-tools.ts`: wraps `tool.inputSchema` before assigning to `input_schema`
- `anthropic-messages-language-model.ts`: wraps `responseFormat.schema` before assigning to `output_format.schema`

Semantically `oneOf` (exactly-one) and `anyOf` (at-least-one) differ, but discriminated unions are mutually exclusive by design so the runtime behaviour is identical, and Anthropic only supports `anyOf`.

## Tests

- New `convert-anthropic-schema.test.ts` with 8 unit tests covering primitives, top-level, nested, arrays, `allOf`/`anyOf` recursion, and the full Zod `discriminatedUnion` schema shape
- New `prepareTools` test that verifies `oneOf` → `anyOf` conversion in tool `input_schema`