### PR TITLE
docs: clarify conservative API surfaces and document experimental feature use in project philosophies, improve discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,10 @@ export class MyError extends AISDKError {
 }
 ```
 
+## Project Philosophies
+
+For an overview of the project's key philosophies that guide decision making, see `contributing/project-philosophies.md`.
+
 ## Architecture
 
 ### Provider Pattern

--- a/architecture/provider-abstraction.md
+++ b/architecture/provider-abstraction.md
@@ -25,6 +25,8 @@ classDiagram
 
 ## Model-Type Details
 
+If you're unable to find any of the functions mentioned below in the codebase, they may only exist with an `experimental_` prefix. This means they're experimental, and stable versions will likely be implemented at a later point.
+
 ### Language Model (`LanguageModelV3`)
 
 Language models are used for text generation and structured generation workflows from prompt or message input.
@@ -32,12 +34,10 @@ Language models are used for text generation and structured generation workflows
 - **AI functions**
   - `generateText` - [`packages/ai/src/generate-text/generate-text.ts`](packages/ai/src/generate-text/generate-text.ts) - Generates a complete text result from a language model in a single call.
   - `streamText` - [`packages/ai/src/generate-text/stream-text.ts`](packages/ai/src/generate-text/stream-text.ts) - Streams language model output incrementally as it is produced.
-  - `generateObject` - [`packages/ai/src/generate-object/generate-object.ts`](packages/ai/src/generate-object/generate-object.ts) - Generates one structured object from a language model according to a schema.
-  - `streamObject` - [`packages/ai/src/generate-object/stream-object.ts`](packages/ai/src/generate-object/stream-object.ts) - Streams partial structured object output from a language model over time.
 - **Model specification**
   - `LanguageModelV3` - [`packages/provider/src/language-model/v3/language-model-v3.ts`](packages/provider/src/language-model/v3/language-model-v3.ts)
 - **Provider implementations (examples)**
-  - `OpenAILanguageModel`, `AnthropicLanguageModel`
+  - [`OpenAIChatLanguageModel`](packages/openai/src/chat/openai-chat-language-model.ts), [`AnthropicMessagesLanguageModel`](packages/anthropic/src/anthropic-messages-language-model.ts)
 
 ```mermaid
 classDiagram
@@ -63,7 +63,7 @@ Embedding models are used to convert text into numeric vectors for similarity an
 - **Model specification**
   - `EmbeddingModelV3` - [`packages/provider/src/embedding-model/v3/embedding-model-v3.ts`](packages/provider/src/embedding-model/v3/embedding-model-v3.ts)
 - **Provider implementations (examples)**
-  - `OpenAIEmbeddingModel`, `MistralEmbeddingModel`
+  - [`OpenAIEmbeddingModel`](packages/openai/src/embedding/openai-embedding-model.ts), [`MistralEmbeddingModel`](packages/mistral/src/mistral-embedding-model.ts)
 
 ```mermaid
 classDiagram
@@ -85,23 +85,20 @@ Image models are used to generate image outputs from text prompts.
 
 - **AI functions**
   - `generateImage` - [`packages/ai/src/generate-image/generate-image.ts`](packages/ai/src/generate-image/generate-image.ts) - Generates one or more images from prompt input.
-  - `experimental_generateImage` - [`packages/ai/src/generate-image/generate-image.ts`](packages/ai/src/generate-image/generate-image.ts) - Provides the deprecated experimental alias for `generateImage`.
 - **Model specification**
   - `ImageModelV3` - [`packages/provider/src/image-model/v3/image-model-v3.ts`](packages/provider/src/image-model/v3/image-model-v3.ts)
 - **Provider implementations (examples)**
-  - `OpenAIImageModel`, `GoogleImageModel`
+  - [`OpenAIImageModel`](packages/openai/src/image/openai-image-model.ts), [`GoogleGenerativeAIImageModel`](packages/google/src/google-generative-ai-image-model.ts)
 
 ```mermaid
 classDiagram
     class generateImage
-    class experimental_generateImage
     class ImageModelV3 {
       <<interface>>
     }
     class OpenAIImageModel
 
     generateImage ..> ImageModelV3 : uses
-    experimental_generateImage ..> ImageModelV3 : uses
     OpenAIImageModel ..|> ImageModelV3 : implements
 ```
 
@@ -114,7 +111,7 @@ Reranking models are used to reorder candidate documents by relevance to a query
 - **Model specification**
   - `RerankingModelV3` - [`packages/provider/src/reranking-model/v3/reranking-model-v3.ts`](packages/provider/src/reranking-model/v3/reranking-model-v3.ts)
 - **Provider implementations (examples)**
-  - `CohereRerankingModel`, `VertexRerankingModel`
+  - [`CohereRerankingModel`](packages/cohere/src/reranking/cohere-reranking-model.ts), [`BedrockRerankingModel`](packages/amazon-bedrock/src/reranking/bedrock-reranking-model.ts)
 
 ```mermaid
 classDiagram
@@ -133,21 +130,21 @@ classDiagram
 Transcription models are used to convert audio input into text transcripts.
 
 - **AI functions**
-  - `experimental_transcribe` - [`packages/ai/src/transcribe/transcribe.ts`](packages/ai/src/transcribe/transcribe.ts) - Transcribes audio into text with segment and metadata support.
+  - `transcribe` - [`packages/ai/src/transcribe/transcribe.ts`](packages/ai/src/transcribe/transcribe.ts) - Transcribes audio into text with segment and metadata support.
 - **Model specification**
   - `TranscriptionModelV3` - [`packages/provider/src/transcription-model/v3/transcription-model-v3.ts`](packages/provider/src/transcription-model/v3/transcription-model-v3.ts)
 - **Provider implementations (examples)**
-  - `OpenAITranscriptionModel`, `DeepgramTranscriptionModel`
+  - [`OpenAITranscriptionModel`](packages/openai/src/transcription/openai-transcription-model.ts), [`DeepgramTranscriptionModel`](packages/deepgram/src/deepgram-transcription-model.ts)
 
 ```mermaid
 classDiagram
-    class experimental_transcribe
+    class transcribe
     class TranscriptionModelV3 {
       <<interface>>
     }
     class OpenAITranscriptionModel
 
-    experimental_transcribe ..> TranscriptionModelV3 : uses
+    transcribe ..> TranscriptionModelV3 : uses
     OpenAITranscriptionModel ..|> TranscriptionModelV3 : implements
 ```
 
@@ -156,21 +153,21 @@ classDiagram
 Speech models are used to synthesize audio from text input.
 
 - **AI functions**
-  - `experimental_generateSpeech` - [`packages/ai/src/generate-speech/generate-speech.ts`](packages/ai/src/generate-speech/generate-speech.ts) - Generates speech audio from text input.
+  - `generateSpeech` - [`packages/ai/src/generate-speech/generate-speech.ts`](packages/ai/src/generate-speech/generate-speech.ts) - Generates speech audio from text input.
 - **Model specification**
   - `SpeechModelV3` - [`packages/provider/src/speech-model/v3/speech-model-v3.ts`](packages/provider/src/speech-model/v3/speech-model-v3.ts)
 - **Provider implementations (examples)**
-  - `OpenAISpeechModel`, `ElevenLabsSpeechModel`
+  - [`OpenAISpeechModel`](packages/openai/src/speech/openai-speech-model.ts), [`ElevenLabsSpeechModel`](packages/elevenlabs/src/elevenlabs-speech-model.ts)
 
 ```mermaid
 classDiagram
-    class experimental_generateSpeech
+    class generateSpeech
     class SpeechModelV3 {
       <<interface>>
     }
     class OpenAISpeechModel
 
-    experimental_generateSpeech ..> SpeechModelV3 : uses
+    generateSpeech ..> SpeechModelV3 : uses
     OpenAISpeechModel ..|> SpeechModelV3 : implements
 ```
 
@@ -179,20 +176,20 @@ classDiagram
 Video models are used to generate video outputs from prompts.
 
 - **AI functions**
-  - `experimental_generateVideo` - [`packages/ai/src/generate-video/generate-video.ts`](packages/ai/src/generate-video/generate-video.ts) - Generates one or more videos from prompt input.
+  - `generateVideo` - [`packages/ai/src/generate-video/generate-video.ts`](packages/ai/src/generate-video/generate-video.ts) - Generates one or more videos from prompt input.
 - **Model specification**
   - `VideoModelV3` - [`packages/provider/src/video-model/v3/video-model-v3.ts`](packages/provider/src/video-model/v3/video-model-v3.ts)
 - **Provider implementations (examples)**
-  - `FalVideoModel`, `ReplicateVideoModel`
+  - [`FalVideoModel`](packages/fal/src/fal-video-model.ts), [`ReplicateVideoModel`](packages/replicate/src/replicate-video-model.ts)
 
 ```mermaid
 classDiagram
-    class experimental_generateVideo
+    class generateVideo
     class VideoModelV3 {
       <<interface>>
     }
     class FalVideoModel
 
-    experimental_generateVideo ..> VideoModelV3 : uses
+    generateVideo ..> VideoModelV3 : uses
     FalVideoModel ..|> VideoModelV3 : implements
 ```

--- a/contributing/project-philosophies.md
+++ b/contributing/project-philosophies.md
@@ -31,7 +31,7 @@
 
   - Keep response schemas minimal (no unused properties).
   - Keep schemas flexible enough to handle provider API changes without unnecessary breakages.
-  - Use minimal exports, especially from the `@ai-sdk/provider` package, which is responsible for the spec. Usage of the TypeScript primitives `Params` and `ReturnType` is encouraged in consuming code over having direct exports of the underlying types.
+  - Use minimal package exports, especially from the `@ai-sdk/provider` package, which is responsible for the spec. Usage of the TypeScript primitives `Params` and `ReturnType` is encouraged in consuming code over having direct exports of the underlying types.
 
 - **Beware premature abstraction.** Provider APIs evolve quickly. Avoid adding generic parameters or abstractions that translate differently across providers.
 
@@ -39,7 +39,7 @@
   - When unsure or provider-specific, prefer `providerOptions`.
   - There can be significant pressure to abstract based on one provider. Resist it.
 
-- **Use `Experimental_` prefixes to explore new features outside of major releases.** When a new feature needs to be explored but a stable abstraction isn't yet justified, use code structures explicitly marked as experimental (e.g. `Experimental_*` prefix for types, `experimental_*` prefix for functions). This allows iteration without committing to a stable API contract.
+- **Use `Experimental_` prefixes to explore new features outside of major releases.** When a new feature needs to be explored outside of a major release cycle, use code structures explicitly marked as experimental (e.g. `Experimental_*` prefix for types, `experimental_*` prefix for functions). This allows iteration without committing to a stable API contract.
 
   - It is acceptable for `@ai-sdk/provider` to export `Experimental_*` types for this purpose. These types may have breaking changes outside of major releases.
   - Non-experimental types must NEVER include references to experimental types (e.g., do not add a reference to something like `Experimental_VideoModelV3` to `ProviderV3`).

--- a/contributing/project-philosophies.md
+++ b/contributing/project-philosophies.md
@@ -39,6 +39,13 @@
   - When unsure or provider-specific, prefer `providerOptions`.
   - There can be significant pressure to abstract based on one provider. Resist it.
 
+- **Use `Experimental_` prefixes to explore new features outside of major releases.** When a new feature needs to be explored but a stable abstraction isn't yet justified, use code structures explicitly marked as experimental (e.g. `Experimental_*` prefix for types, `experimental_*` prefix for functions). This allows iteration without committing to a stable API contract.
+
+  - It is acceptable for `@ai-sdk/provider` to export `Experimental_*` types for this purpose. These types may have breaking changes outside of major releases.
+  - Non-experimental types must NEVER include references to experimental types (e.g., do not add a reference to something like `Experimental_VideoModelV3` to `ProviderV3`).
+  - Experimental features must remain fully isolated until they are promoted to stable.
+  - Adding a new experimental feature requires broad consensus between the maintainers. Use it with caution. Do not use experimental code as a way out when you're unsure about stability.
+
 - **Clear, accurate naming.** When in doubt, prefer longer, more explicit names that are unambiguous and correct (e.g. `.languageModel(id)` over `.chat(id)`).
   - Optimize for clarity for both developers and coding agents, not brevity.
 

--- a/contributing/project-philosophies.md
+++ b/contributing/project-philosophies.md
@@ -31,6 +31,7 @@
 
   - Keep response schemas minimal (no unused properties).
   - Keep schemas flexible enough to handle provider API changes without unnecessary breakages.
+  - Use minimal exports, especially from the `@ai-sdk/provider` package, which is responsible for the spec. Usage of the TypeScript primitives `Params` and `ReturnType` is encouraged in consuming code over having direct exports of the underlying types.
 
 - **Beware premature abstraction.** Provider APIs evolve quickly. Avoid adding generic parameters or abstractions that translate differently across providers.
 

--- a/contributing/provider-architecture.md
+++ b/contributing/provider-architecture.md
@@ -25,3 +25,5 @@ graph LR
     class OPENAI provider
     class OPENAI_API external
 ```
+
+See the [provider abstraction architecture doc](../architecture/provider-abstraction.md) for a more in-depth guide.


### PR DESCRIPTION
## Background

Follow up to #12693, #12850

- Emphasizes to keep package exports minimal, especially for `@ai-sdk/provider`
- Explains use of experimental features in project philosophies
- Addresses follow up feedback that was left on #12850
- Makes project philosophies discoverable in `AGENTS.md`
- Links new provider abstraction doc from older provider architecture docs
    - Alternatively, we could consider removing that older doc entirely - unless we see value in having a shorter overview available (maybe still valuable, and less context use?)

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
