### PR TITLE
fix(google): honor strict tools for Gemini function calling

### DIFF
--- a/.changeset/google-strict-validated-mode.md
+++ b/.changeset/google-strict-validated-mode.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(google): map `strict: true` tool option to Gemini VALIDATED function calling mode

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -449,6 +449,127 @@ it('should handle google maps tool', () => {
   expect(result.toolWarnings).toEqual([]);
 });
 
+it('should use VALIDATED mode when any function tool has strict: true and no toolChoice', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'strictTool',
+        description: 'A strict tool',
+        inputSchema: { type: 'object', properties: {} },
+        strict: true,
+      },
+      {
+        type: 'function',
+        name: 'normalTool',
+        description: 'A normal tool',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    ],
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'VALIDATED' },
+  });
+});
+
+it('should use VALIDATED mode with toolChoice auto when strict: true', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'strictTool',
+        description: 'A strict tool',
+        inputSchema: { type: 'object', properties: {} },
+        strict: true,
+      },
+    ],
+    toolChoice: { type: 'auto' },
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'VALIDATED' },
+  });
+});
+
+it('should use VALIDATED mode with toolChoice required when strict: true', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'strictTool',
+        description: 'A strict tool',
+        inputSchema: { type: 'object', properties: {} },
+        strict: true,
+      },
+    ],
+    toolChoice: { type: 'required' },
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'VALIDATED' },
+  });
+});
+
+it('should use VALIDATED mode with toolChoice tool when strict: true', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'strictTool',
+        description: 'A strict tool',
+        inputSchema: { type: 'object', properties: {} },
+        strict: true,
+      },
+    ],
+    toolChoice: { type: 'tool', toolName: 'strictTool' },
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: {
+      mode: 'VALIDATED',
+      allowedFunctionNames: ['strictTool'],
+    },
+  });
+});
+
+it('should not use VALIDATED mode when no tool has strict: true', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'normalTool',
+        description: 'A normal tool',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    ],
+    toolChoice: { type: 'auto' },
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'AUTO' },
+  });
+});
+
+it('should keep NONE mode even when strict: true is present', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'strictTool',
+        description: 'A strict tool',
+        inputSchema: { type: 'object', properties: {} },
+        strict: true,
+      },
+    ],
+    toolChoice: { type: 'none' },
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'NONE' },
+  });
+});
+
 it('should add warnings for google maps on unsupported models', () => {
   const result = prepareTools({
     tools: [

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -492,7 +492,7 @@ it('should use VALIDATED mode with toolChoice auto when strict: true', () => {
   });
 });
 
-it('should use VALIDATED mode with toolChoice required when strict: true', () => {
+it('should keep ANY mode with toolChoice required when strict: true (and add warning)', () => {
   const result = prepareTools({
     tools: [
       {
@@ -507,11 +507,19 @@ it('should use VALIDATED mode with toolChoice required when strict: true', () =>
     modelId: 'gemini-2.5-flash',
   });
   expect(result.toolConfig).toEqual({
-    functionCallingConfig: { mode: 'VALIDATED' },
+    functionCallingConfig: { mode: 'ANY' },
   });
+  expect(result.toolWarnings).toEqual([
+    {
+      type: 'unsupported',
+      feature: 'strict tools with toolChoice required',
+      details:
+        "Gemini's VALIDATED mode does not guarantee forced function calling; keeping ANY mode to preserve toolChoice required semantics.",
+    },
+  ]);
 });
 
-it('should use VALIDATED mode with toolChoice tool when strict: true', () => {
+it('should keep ANY mode with toolChoice tool when strict: true (and add warning)', () => {
   const result = prepareTools({
     tools: [
       {
@@ -527,10 +535,18 @@ it('should use VALIDATED mode with toolChoice tool when strict: true', () => {
   });
   expect(result.toolConfig).toEqual({
     functionCallingConfig: {
-      mode: 'VALIDATED',
+      mode: 'ANY',
       allowedFunctionNames: ['strictTool'],
     },
   });
+  expect(result.toolWarnings).toEqual([
+    {
+      type: 'unsupported',
+      feature: 'strict tools with toolChoice tool',
+      details:
+        "Gemini's VALIDATED mode does not guarantee forced function calling; keeping ANY mode to preserve toolChoice tool semantics.",
+    },
+  ]);
 });
 
 it('should not use VALIDATED mode when no tool has strict: true', () => {

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -250,27 +250,47 @@ export function prepareTools({
         toolConfig: { functionCallingConfig: { mode: 'NONE' } },
         toolWarnings,
       };
-    case 'required':
+    case 'required': {
+      if (hasStrictTool) {
+        toolWarnings.push({
+          type: 'unsupported',
+          feature: 'strict tools with toolChoice required',
+          details:
+            "Gemini's VALIDATED mode does not guarantee forced function calling; keeping ANY mode to preserve toolChoice required semantics.",
+        });
+      }
+
       return {
         tools: [{ functionDeclarations }],
         toolConfig: {
           functionCallingConfig: {
-            mode: hasStrictTool ? 'VALIDATED' : 'ANY',
+            mode: 'ANY',
           },
         },
         toolWarnings,
       };
-    case 'tool':
+    }
+    case 'tool': {
+      if (hasStrictTool) {
+        toolWarnings.push({
+          type: 'unsupported',
+          feature: 'strict tools with toolChoice tool',
+          details:
+            "Gemini's VALIDATED mode does not guarantee forced function calling; keeping ANY mode to preserve toolChoice tool semantics.",
+        });
+      }
+
       return {
         tools: [{ functionDeclarations }],
         toolConfig: {
           functionCallingConfig: {
-            mode: hasStrictTool ? 'VALIDATED' : 'ANY',
+            mode: 'ANY',
             allowedFunctionNames: [toolChoice.toolName],
           },
         },
         toolWarnings,
       };
+    }
     default: {
       const _exhaustiveCheck: never = type;
       throw new UnsupportedFunctionalityError({


### PR DESCRIPTION
Fixes #12767.

When any function tool has `strict: true`, map Gemini `functionCallingConfig.mode` to `VALIDATED` (closest equivalent to per-tool strict enforcement).

- Updates tool config mapping in `packages/google/src/google-prepare-tools.ts`
- Adds/updates coverage in `packages/google/src/google-prepare-tools.test.ts`