### PR TITLE
fix: prevent orphaned tool_use blocks from needsApproval tools

### DIFF
--- a/packages/ai/src/prompt/__snapshots__/convert-to-language-model-prompt.validation.test.ts.snap
+++ b/packages/ai/src/prompt/__snapshots__/convert-to-language-model-prompt.validation.test.ts.snap
@@ -21,26 +21,7 @@ exports[`tool validation > should pass validation for provider-executed tools (d
 ]
 `;
 
-exports[`tool validation > should pass validation for tool-approval-response 1`] = `
-[
-  {
-    "content": [
-      {
-        "input": {
-          "action": "delete_db",
-        },
-        "providerExecuted": undefined,
-        "providerOptions": undefined,
-        "toolCallId": "call_to_approve",
-        "toolName": "dangerous_action",
-        "type": "tool-call",
-      },
-    ],
-    "providerOptions": undefined,
-    "role": "assistant",
-  },
-]
-`;
+exports[`tool validation > should pass validation for tool-approval-response 1`] = `[]`;
 
 exports[`tool validation > should preserve provider-executed tool-approval-response 1`] = `
 [


### PR DESCRIPTION
## Summary

Fixes #10980. Also related to #12709.

When a `needsApproval` tool is approved but not yet executed, `convertToModelMessages` produces a `tool-call` without a matching `tool-result`. Providers like Anthropic reject these orphaned `tool_use` blocks with:

> `tool_use` ids were found without `tool_result` blocks immediately after

Three interacting gaps in the tool approval pipeline:

### Fix 1: `ignoreIncompleteToolCalls` filter (`convert-to-model-messages.ts`)

Added `approval-requested` to the filter. A tool awaiting user decision is incomplete — same as `input-streaming` or `input-available`. This also addresses #12709 where sending a new user message while a tool is in `approval-requested` state causes errors.

### Fix 2: `approval-responded` switch case (`convert-to-model-messages.ts`)

The switch statement at line 281 had no `approval-responded` case — it fell through silently, producing no `tool-result`. Now:
- `approved: false` → emits a denied `tool-result` (same pattern as `output-denied`)
- `approved: true` → no result (execution handled by `streamText`'s `collectToolApprovals`)

### Fix 3: Strip unresolved approved tool-calls (`convert-to-language-model-prompt.ts`)

For code paths that don't use `streamText` (e.g., `generateText`, custom code), approved tool-calls may never get executed. The validation already exempted these from `MissingToolResultsError`, but still sent them to the provider. Now tracks `unresolvedApprovedToolCallIds` and strips them from assistant messages before serialization.

## How it works end-to-end

**With `streamText` (normal flow):**
1. `convertToModelMessages` → `tool-call` + `tool-approval-response` (no result)
2. `collectToolApprovals` → finds approval, executes tool
3. Tool result appended to `responseMessages`
4. `convertToLanguageModelPrompt` → tool-call has matching result → kept
5. Provider sees matched `tool_use` + `tool_result` ✓

**Without `streamText` (custom code / `generateText`):**
1. `convertToModelMessages` → `tool-call` + `tool-approval-response` (no result)
2. No execution happens
3. `convertToLanguageModelPrompt` → tool-call has no result → stripped
4. Provider doesn't see orphaned `tool_use` ✓

## Test plan

- [x] `ignoreIncompleteToolCalls` filters `approval-requested` parts
- [x] `approval-responded` + `approved: false` produces denied `tool-result`
- [x] `approval-responded` + `approved: true` emits `tool-approval-response` but no `tool-result`
- [x] Approved tool-call with no result is stripped from assistant message
- [x] Approved tool-call WITH result is preserved
- [x] Existing tests updated for new behavior (denied approvals now produce results)
- [x] `collect-tool-approvals.test` passes (no regressions)
- [x] All 1113 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)