### PR TITLE
feat(provider/azure): add mcp in azure Responses tools

### DIFF
--- a/.changeset/perfect-toys-pull.md
+++ b/.changeset/perfect-toys-pull.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/openai': patch
+'@ai-sdk/azure': patch
+---
+
+add mcp in azure responses built in tools

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -538,6 +538,96 @@ The code interpreter tool can be configured with:
   Source Document Parts](#typed-providermetadata-in-source-document-parts).
 </Note>
 
+#### MCP Tool
+
+The Azure OpenAI responses API supports connecting to [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers through the `azure.tools.mcp` tool. This allows models to call tools exposed by remote MCP servers or service connectors.
+
+```ts
+import { azure } from '@ai-sdk/azure';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: azure('gpt-5'),
+  prompt: 'Search the web for the latest news about AI developments',
+  tools: {
+    mcp: azure.tools.mcp({
+      serverLabel: 'web-search',
+      serverUrl: 'https://mcp.exa.ai/mcp',
+      serverDescription: 'A web-search API for AI agents',
+    }),
+  },
+});
+```
+
+The MCP tool can be configured with:
+
+- **serverLabel** _string_ (required)
+
+  A label to identify the MCP server. This label is used in tool calls to distinguish between multiple MCP servers.
+
+- **serverUrl** _string_ (required if `connectorId` is not provided)
+
+  The URL for the MCP server. Either `serverUrl` or `connectorId` must be provided.
+
+- **connectorId** _string_ (required if `serverUrl` is not provided)
+
+  Identifier for a service connector. Either `serverUrl` or `connectorId` must be provided.
+
+- **serverDescription** _string_ (optional)
+
+  Optional description of the MCP server that helps the model understand its purpose.
+
+- **allowedTools** _string[] | object_ (optional)
+
+  Controls which tools from the MCP server are available. Can be:
+
+  - An array of tool names: `['tool1', 'tool2']`
+  - An object with filters:
+    ```ts
+    {
+      readOnly: true, // Only allow read-only tools
+      toolNames: ['tool1', 'tool2'] // Specific tool names
+    }
+    ```
+
+- **authorization** _string_ (optional)
+
+  OAuth access token for authenticating with the MCP server or connector.
+
+- **headers** _Record&lt;string, string&gt;_ (optional)
+
+  Optional HTTP headers to include in requests to the MCP server.
+
+- **requireApproval** _'always' | 'never' | object_ (optional)
+
+  Controls which MCP tool calls require user approval before execution. Can be:
+
+  - `'always'`: All MCP tool calls require approval
+  - `'never'`: No MCP tool calls require approval (default)
+  - An object with filters:
+    ```ts
+    {
+      never: {
+        toolNames: ['safe_tool', 'another_safe_tool']; // Skip approval for these tools
+      }
+    }
+    ```
+
+  When approval is required, the model will return a `tool-approval-request` content part that you can use to prompt the user for approval. See [Human in the Loop](/cookbook/next/human-in-the-loop) for more details on implementing approval workflows.
+
+<Note>
+  When `requireApproval` is not set, tool calls are approved by default. Be sure
+  to connect to only trusted MCP servers, who you trust to share your data with.
+</Note>
+
+<Note>
+  The Azure OpenAI MCP tool is different from the general MCP client approach
+  documented in [MCP Tools](/docs/ai-sdk-core/mcp-tools). The Azure OpenAI MCP
+  tool is a built-in provider-defined tool that allows Azure OpenAI models to
+  directly connect to MCP servers, while the general MCP client requires you to
+  convert MCP tools to AI SDK tools first.
+</Note>
+
 #### PDF support
 
 The Azure OpenAI provider supports reading PDF files.

--- a/examples/ai-functions/src/generate-text/azure/responses-mcp-tool.ts
+++ b/examples/ai-functions/src/generate-text/azure/responses-mcp-tool.ts
@@ -1,0 +1,25 @@
+import { azure } from '@ai-sdk/azure';
+import { generateText, stepCountIs } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: azure.responses('gpt-5-mini'),
+    prompt: 'Can you search the web for latest NYC mayoral election results?',
+    stopWhen: stepCountIs(20),
+    tools: {
+      mcp: azure.tools.mcp({
+        serverLabel: 'dmcp',
+        serverUrl: 'https://mcp.exa.ai/mcp',
+        serverDescription: 'A web-search API for AI agents',
+      }),
+    },
+  });
+
+  console.log('\nTOOL CALLS:\n');
+  console.dir(result.toolCalls, { depth: Infinity });
+  console.log('\nTOOL RESULTS:\n');
+  console.dir(result.toolResults, { depth: Infinity });
+  console.log('\nTEXT RESULT:\n');
+  console.log(result.text);
+});

--- a/examples/ai-functions/src/generate-text/azure/responses-mcp-tool.ts
+++ b/examples/ai-functions/src/generate-text/azure/responses-mcp-tool.ts
@@ -1,17 +1,16 @@
 import { azure } from '@ai-sdk/azure';
-import { generateText, stepCountIs } from 'ai';
+import { generateText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: azure.responses('gpt-5-mini'),
-    prompt: 'Can you search the web for latest NYC mayoral election results?',
-    stopWhen: stepCountIs(20),
+    model: azure.responses('gpt-5.4-mini'),
+    prompt: 'Please summarize about vercel/ai.',
     tools: {
       mcp: azure.tools.mcp({
         serverLabel: 'dmcp',
-        serverUrl: 'https://mcp.exa.ai/mcp',
-        serverDescription: 'A web-search API for AI agents',
+        serverUrl: 'https://mcp.deepwiki.com/mcp',
+        serverDescription: 'A depepwiki MCP',
       }),
     },
   });

--- a/examples/ai-functions/src/stream-text/azure/tool-mcp.ts
+++ b/examples/ai-functions/src/stream-text/azure/tool-mcp.ts
@@ -1,0 +1,28 @@
+import { azure } from '@ai-sdk/azure';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+import { saveRawChunks } from '../../lib/save-raw-chunks';
+
+run(async () => {
+  const result = await streamText({
+    model: azure('gpt-5-mini'),
+    prompt: 'Can you search the web for latest NYC mayoral election results?',
+    tools: {
+      mcp: azure.tools.mcp({
+        serverLabel: 'dmcp',
+        serverUrl: 'https://mcp.exa.ai/mcp',
+        serverDescription: 'A web-search API for AI agents',
+      }),
+    },
+    includeRawChunks: true,
+  });
+
+  console.log('\n=== Basic Text Generation ===');
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+  console.log('\nTOOL CALLS:\n');
+  console.log(await result.toolCalls);
+  console.log('\nTOOL RESULTS:\n');
+  console.log(await result.toolResults);
+});

--- a/examples/ai-functions/src/stream-text/azure/tool-mcp.ts
+++ b/examples/ai-functions/src/stream-text/azure/tool-mcp.ts
@@ -5,13 +5,13 @@ import { saveRawChunks } from '../../lib/save-raw-chunks';
 
 run(async () => {
   const result = await streamText({
-    model: azure('gpt-5-mini'),
-    prompt: 'Can you search the web for latest NYC mayoral election results?',
+    model: azure('gpt-5.4-mini'),
+    prompt: 'Please summarize about vercel/ai.',
     tools: {
       mcp: azure.tools.mcp({
         serverLabel: 'dmcp',
-        serverUrl: 'https://mcp.exa.ai/mcp',
-        serverDescription: 'A web-search API for AI agents',
+        serverUrl: 'https://mcp.deepwiki.com/mcp',
+        serverDescription: 'A depepwiki MCP',
       }),
     },
     includeRawChunks: true,

--- a/packages/azure/src/azure-openai-tools.ts
+++ b/packages/azure/src/azure-openai-tools.ts
@@ -3,6 +3,7 @@ import {
   fileSearch,
   imageGeneration,
   webSearchPreview,
+  mcp,
 } from '@ai-sdk/openai/internal';
 
 export const azureOpenaiTools: {
@@ -10,9 +11,11 @@ export const azureOpenaiTools: {
   fileSearch: typeof fileSearch;
   imageGeneration: typeof imageGeneration;
   webSearchPreview: typeof webSearchPreview;
+  mcp: typeof mcp;
 } = {
   codeInterpreter,
   fileSearch,
   imageGeneration,
   webSearchPreview,
+  mcp,
 };

--- a/packages/openai/src/internal/index.ts
+++ b/packages/openai/src/internal/index.ts
@@ -17,3 +17,4 @@ export * from '../tool/code-interpreter';
 export * from '../tool/file-search';
 export * from '../tool/image-generation';
 export * from '../tool/web-search-preview';
+export * from '../tool/mcp';


### PR DESCRIPTION
## BackGround

The Azure OpenAI Responses API supports connecting models directly to MCP (Model Context Protocol) servers, enabling them to call external tools (e.g., web search or service connectors) via the `mcp` tool.

This PR aims to make the Azure Responses MCP capability available as a provider-defined tool in the AI SDK, allowing it to be used in a natural and consistent way.


## Summary

### Add MCP tool to Azure provider built-in tools

* Added `mcp` to `azureOpenaiTools` in `packages/azure/src/azure-openai-tools.ts`, enabling usage via `azure.tools.mcp(...)`.
* add document in azure provider page.

## Manual Verification

- `examples/ai-functions`
  - pnpm tsx src/generate-text/azure/responses-mcp-tool.ts
  - pnpm tsx src/stream-text/azure/tool-mcp.ts 

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work
N/A

## Related Issues
N/A