### PR TITLE
fix: pass abort signal to reconnectToStream so stop() works on resumed streams

### DIFF
--- a/packages/ai/src/ui/chat-transport.ts
+++ b/packages/ai/src/ui/chat-transport.ts
@@ -78,6 +78,8 @@ export interface ChatTransport<UI_MESSAGE extends UIMessage> {
     options: {
       /** Unique identifier for the chat session to reconnect to */
       chatId: string;
+      /** Signal to abort the request if needed */
+      abortSignal: AbortSignal | undefined;
     } & ChatRequestOptions,
   ) => Promise<ReadableStream<UIMessageChunk> | null>;
 }

--- a/packages/ai/src/ui/direct-chat-transport.test.ts
+++ b/packages/ai/src/ui/direct-chat-transport.test.ts
@@ -438,6 +438,7 @@ describe('DirectChatTransport', () => {
 
       const result = await transport.reconnectToStream({
         chatId: 'chat-1',
+        abortSignal: undefined,
       });
 
       expect(result).toBeNull();

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -219,9 +219,12 @@ export abstract class HttpChatTransport<UI_MESSAGE extends UIMessage>
     return this.processResponseStream(response.body);
   }
 
-  async reconnectToStream(
-    options: Parameters<ChatTransport<UI_MESSAGE>['reconnectToStream']>[0],
-  ): Promise<ReadableStream<UIMessageChunk> | null> {
+  async reconnectToStream({
+    abortSignal,
+    ...options
+  }: Parameters<
+    ChatTransport<UI_MESSAGE>['reconnectToStream']
+  >[0]): Promise<ReadableStream<UIMessageChunk> | null> {
     const resolvedBody = await resolve(this.body);
     const resolvedHeaders = await resolve(this.headers);
     const resolvedCredentials = await resolve(this.credentials);
@@ -258,6 +261,7 @@ export abstract class HttpChatTransport<UI_MESSAGE extends UIMessage>
         getRuntimeEnvironmentUserAgent(),
       ),
       credentials,
+      signal: abortSignal,
     });
 
     // no active stream found, so we do not resume


### PR DESCRIPTION
## Summary

- `Chat.stop()` calls `activeResponse.abortController.abort()`, but for the `resume-stream` path, `reconnectToStream` never received or forwarded the abort signal to `fetch()`. This meant `stop()` was a no-op on reconnected streams — the SSE connection stayed open until the server closed it naturally.
- Hoists the `AbortController` creation in `Chat.makeRequest` so the same controller is shared between the reconnect fetch and `activeResponse`, and threads `abortSignal` through the `ChatTransport` interface into `HttpChatTransport`'s `fetch()` call.