### PR TITLE
fix(react): prevent stale transport body in useChat

### DIFF
--- a/.changeset/fix-use-chat-stale-transport.md
+++ b/.changeset/fix-use-chat-stale-transport.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/react': patch
+---
+
+fix: useChat now reflects updated body/headers in transport without remounting
+
+- Wrapped transport with a ref-based proxy so Chat instance always uses current transport values
+- Prevents stale closure over initial body/headers when transport is recreated with new values


### PR DESCRIPTION
## Summary

Fixes #7819

When React state used in `DefaultChatTransport({ body: { ... } })` changes, the body sent to the API remains stale because `useChat` stores the `Chat` instance in a `useRef` and never updates its transport.

## Root Cause

1. `useChat` creates a `Chat` instance on first render and stores it in `chatRef`
2. The `Chat` constructor stores the transport as a `private readonly` property
3. On re-renders, `shouldRecreateChat` only checks `id` and `chat` — **not** transport
4. A new `DefaultChatTransport` is created each render with fresh body, but the old `Chat` instance keeps the stale transport

## Fix

Apply the same ref-based proxy pattern already used for callbacks (`onToolCall`, `onError`, etc.):

1. **`transportRef`** — updated on every render with the latest transport
2. **`transportProxy`** — stable object created once via `useMemo`, delegates `sendMessages` and `reconnectToStream` to `transportRef.current`
3. The proxy is passed to the `Chat` constructor instead of the original transport

This ensures the `Chat` instance always delegates to the latest transport (and thus the latest body/headers) without needing to recreate the entire Chat instance.

## Test

Added a regression test that:
1. Renders a component with `useChat` and `DefaultChatTransport({ body: { subagent } })`
2. Changes `subagent` state from `'agent-a'` to `'agent-b'`
3. Sends a message
4. Asserts the request body contains `{ subagent: 'agent-b' }` (not stale `'agent-a'`)

## Verification

- 2 consecutive clean test passes: 35/35 tests in `use-chat.ui.test.tsx`
- 0 TypeScript errors
- No changes to the `Chat` class or `HttpChatTransport` — fix is entirely in the React hook layer