### PR TITLE
feat(provider/xai): add logprobs and toplogprobs support for chat and responses

### DIFF
--- a/.changeset/blue-buttons-smile.md
+++ b/.changeset/blue-buttons-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+add support for `logprobs` and `topLogprobs` in xai chat and responses provider options

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -125,6 +125,14 @@ The following optional provider options are available for xAI chat models:
 
   Reasoning effort for reasoning models.
 
+- **logprobs** _boolean_
+
+  Return log probabilities for output tokens.
+
+- **topLogprobs** _number_
+
+  Number of most likely tokens to return per token position (0-8). When set, `logprobs` is automatically enabled.
+
 - **parallel_function_calling** _boolean_
 
   Whether to enable parallel function calling during tool use. When true, the model can call multiple functions in parallel. When false, the model will call functions sequentially. Defaults to `true`.
@@ -445,6 +453,14 @@ The following provider options are available:
 - **reasoningEffort** _'low' | 'medium' | 'high'_
 
   Control the reasoning effort for the model. Higher effort may produce more thorough results at the cost of increased latency and token usage.
+
+- **logprobs** _boolean_
+
+  Return log probabilities for output tokens.
+
+- **topLogprobs** _number_
+
+  Number of most likely tokens to return per token position (0-8). When set, `logprobs` is automatically enabled.
 
 - **include** _Array&lt;'file_search_call.results'&gt;_
 

--- a/examples/ai-functions/src/generate-text/xai/logprobs.ts
+++ b/examples/ai-functions/src/generate-text/xai/logprobs.ts
@@ -1,0 +1,21 @@
+import { xai, type XaiLanguageModelChatOptions } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: xai('grok-4-latest'),
+    prompt: 'write one short sentence about san francisco',
+    providerOptions: {
+      xai: {
+        logprobs: true,
+        topLogprobs: 3,
+      } satisfies XaiLanguageModelChatOptions,
+    },
+  });
+
+  console.log(result.text);
+  console.log();
+  console.log('warnings:', result.warnings);
+  console.log('usage:', result.usage);
+});

--- a/examples/ai-functions/src/generate-text/xai/logprobs.ts
+++ b/examples/ai-functions/src/generate-text/xai/logprobs.ts
@@ -1,16 +1,16 @@
-import { xai, type XaiLanguageModelChatOptions } from '@ai-sdk/xai';
+import { xai, type XaiLanguageModelResponsesOptions } from '@ai-sdk/xai';
 import { generateText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: xai('grok-4-latest'),
+    model: xai.responses('grok-4-latest'),
     prompt: 'write one short sentence about san francisco',
     providerOptions: {
       xai: {
         logprobs: true,
         topLogprobs: 3,
-      } satisfies XaiLanguageModelChatOptions,
+      } satisfies XaiLanguageModelResponsesOptions,
     },
   });
 

--- a/examples/ai-functions/src/stream-text/xai/logprobs.ts
+++ b/examples/ai-functions/src/stream-text/xai/logprobs.ts
@@ -1,0 +1,37 @@
+import { xai, type XaiLanguageModelChatOptions } from '@ai-sdk/xai';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: xai('grok-4-latest'),
+    prompt: 'write one short sentence about san francisco',
+    includeRawChunks: true,
+    providerOptions: {
+      xai: {
+        logprobs: true,
+        topLogprobs: 3,
+      } satisfies XaiLanguageModelChatOptions,
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'raw') {
+      console.log('raw:', JSON.stringify(part.rawValue));
+      continue;
+    }
+
+    if (part.type === 'text-delta') {
+      console.log('text:', part.text);
+      continue;
+    }
+
+    if (part.type === 'finish') {
+      console.log('finish:', part.finishReason);
+    }
+  }
+
+  console.log();
+  console.log('warnings:', await result.warnings);
+  console.log('usage:', await result.usage);
+});

--- a/packages/xai/src/__snapshots__/xai-chat-language-model.test.ts.snap
+++ b/packages/xai/src/__snapshots__/xai-chat-language-model.test.ts.snap
@@ -20,6 +20,7 @@ Response: I'll go with "Hello" as it's a common greeting and keeps it simple.",
   },
   "request": {
     "body": {
+      "logprobs": undefined,
       "max_completion_tokens": undefined,
       "messages": [
         {
@@ -36,6 +37,7 @@ Response: I'll go with "Hello" as it's a common greeting and keeps it simple.",
       "temperature": undefined,
       "tool_choice": undefined,
       "tools": undefined,
+      "top_logprobs": undefined,
       "top_p": undefined,
     },
   },
@@ -146,6 +148,7 @@ I should call this function to advance the user's request.",
   },
   "request": {
     "body": {
+      "logprobs": undefined,
       "max_completion_tokens": undefined,
       "messages": [
         {
@@ -162,6 +165,7 @@ I should call this function to advance the user's request.",
       "temperature": undefined,
       "tool_choice": undefined,
       "tools": undefined,
+      "top_logprobs": undefined,
       "top_p": undefined,
     },
   },

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -378,6 +378,55 @@ describe('XaiResponsesLanguageModel', () => {
           expect(requestBody.reasoning.effort).toBe('high');
         });
 
+        it('logprobs and topLogprobs', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                logprobs: true,
+                topLogprobs: 6,
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.logprobs).toBe(true);
+          expect(requestBody.top_logprobs).toBe(6);
+        });
+
+        it('topLogprobs enables logprobs', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                topLogprobs: 2,
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.logprobs).toBe(true);
+          expect(requestBody.top_logprobs).toBe(2);
+        });
+
         it('store:true', async () => {
           prepareJsonResponse({
             id: 'resp_123',

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -142,6 +142,11 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
     const baseArgs: Record<string, unknown> = {
       model: this.modelId,
       input,
+      logprobs:
+        options.logprobs === true || options.topLogprobs != null
+          ? true
+          : undefined,
+      top_logprobs: options.topLogprobs,
       max_output_tokens: maxOutputTokens,
       temperature,
       top_p: topP,

--- a/packages/xai/src/responses/xai-responses-options.ts
+++ b/packages/xai/src/responses/xai-responses-options.ts
@@ -17,6 +17,8 @@ export const xaiLanguageModelResponsesOptions = z.object({
    * Possible values are `low` (uses fewer reasoning tokens), `medium` and `high` (uses more reasoning tokens).
    */
   reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+  logprobs: z.boolean().optional(),
+  topLogprobs: z.number().int().min(0).max(8).optional(),
   /**
    * Whether to store the input message(s) and model response for later retrieval.
    * @default true

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -364,6 +364,7 @@ describe('XaiChatLanguageModel', () => {
       expect(request).toMatchInlineSnapshot(`
         {
           "body": {
+            "logprobs": undefined,
             "max_completion_tokens": undefined,
             "messages": [
               {
@@ -380,8 +381,64 @@ describe('XaiChatLanguageModel', () => {
             "temperature": undefined,
             "tool_choice": undefined,
             "tools": undefined,
+            "top_logprobs": undefined,
             "top_p": undefined,
           },
+        }
+      `);
+    });
+
+    it('should pass logprobs provider options', async () => {
+      prepareJsonFixtureResponse('xai-text');
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          xai: {
+            logprobs: true,
+            topLogprobs: 5,
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "logprobs": true,
+          "messages": [
+            {
+              "content": "Hello",
+              "role": "user",
+            },
+          ],
+          "model": "grok-beta",
+          "top_logprobs": 5,
+        }
+      `);
+    });
+
+    it('should enable logprobs when topLogprobs is set', async () => {
+      prepareJsonFixtureResponse('xai-text');
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          xai: {
+            topLogprobs: 3,
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "logprobs": true,
+          "messages": [
+            {
+              "content": "Hello",
+              "role": "user",
+            },
+          ],
+          "model": "grok-beta",
+          "top_logprobs": 3,
         }
       `);
     });
@@ -982,6 +1039,7 @@ describe('XaiChatLanguageModel', () => {
       expect(request).toMatchInlineSnapshot(`
         {
           "body": {
+            "logprobs": undefined,
             "max_completion_tokens": undefined,
             "messages": [
               {
@@ -1002,6 +1060,7 @@ describe('XaiChatLanguageModel', () => {
             "temperature": undefined,
             "tool_choice": undefined,
             "tools": undefined,
+            "top_logprobs": undefined,
             "top_p": undefined,
           },
         }

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -124,6 +124,11 @@ export class XaiChatLanguageModel implements LanguageModelV3 {
       model: this.modelId,
 
       // standard generation settings
+      logprobs:
+        options.logprobs === true || options.topLogprobs != null
+          ? true
+          : undefined,
+      top_logprobs: options.topLogprobs,
       max_completion_tokens: maxOutputTokens,
       temperature,
       top_p: topP,

--- a/packages/xai/src/xai-chat-options.ts
+++ b/packages/xai/src/xai-chat-options.ts
@@ -74,6 +74,8 @@ const searchSourceSchema = z.discriminatedUnion('type', [
 // xai-specific provider options
 export const xaiLanguageModelChatOptions = z.object({
   reasoningEffort: z.enum(['low', 'high']).optional(),
+  logprobs: z.boolean().optional(),
+  topLogprobs: z.number().int().min(0).max(8).optional(),
 
   /**
    * Whether to enable parallel function calling during tool use.


### PR DESCRIPTION
## background

xai supports `logprobs` and `top_logprobs` in both chat and responses requests
`@ai-sdk/xai` did not expose these options in provider options

## summary

- add `logprobs` and `topLogprobs` to xai chat provider options
- add `logprobs` and `topLogprobs` to xai responses provider options
- map `providerOptions.xai.logprobs` and `providerOptions.xai.topLogprobs` to request fields `logprobs` and `top_logprobs`
- auto-enable `logprobs` when `topLogprobs` is set
- add test coverage for chat and responses request forwarding
- update xai chat snapshots for new request fields
- add ai-functions examples for logprobs in stream-text and generate-text
- switch generate-text example to `xai.responses('grok-4-latest')` so the examples cover both chat and responses
- document `logprobs` and `topLogprobs` in xai chat and responses provider options docs

## manual verification

- `cd examples/ai-functions && pnpm tsx src/generate-text/xai/logprobs.ts`
- `cd examples/ai-functions && pnpm tsx src/stream-text/xai/logprobs.ts`

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [x] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] i have reviewed this pull request (self-review)

## related issues

related #12825
related #12826
related #12827
