### PR TITLE
fix(openai): properly handle stream errors in Responses API

### DIFF
--- a/.changeset/fix-openai-responses-stream-error-handling.md
+++ b/.changeset/fix-openai-responses-stream-error-handling.md
@@ -1,0 +1,12 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): properly handle stream errors in Responses API
+
+- Wrap `error` events in `APICallError` with appropriate status codes and retryability instead of passing raw error objects
+- Add `response.failed` event handling to Zod schema and stream processor
+- Set `finishReason.unified` to `'error'` (was `'other'`) and `finishReason.raw` to the error code (was `undefined`) when stream errors occur
+- Add helper functions `mapErrorCodeToStatusCode()` and `isRetryableErrorCode()` for consistent error mapping
+
+Fixes #6534

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -459,6 +459,18 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
         }),
       }),
       z.object({
+        type: z.literal('response.failed'),
+        response: z.object({
+          error: z
+            .object({
+              code: z.string(),
+              message: z.string(),
+            })
+            .nullish(),
+          status: z.string().nullish(),
+        }),
+      }),
+      z.object({
         type: z.literal('response.created'),
         response: z.object({
           id: z.string(),


### PR DESCRIPTION
## Summary

Fixes #6534

The OpenAI Responses API stream error handling had three issues:

1. **`error` events were passed through as raw objects** instead of being wrapped in `APICallError`, making error handling inconsistent between streaming and non-streaming paths
2. **`response.failed` events were silently ignored** — the Zod schema didn't include this event type, so failures were dropped
3. **`finishReason` was set to `{unified: 'other', raw: undefined}`** instead of `{unified: 'error', raw: '<error_code>'}`, making it impossible for consumers to distinguish errors from other finish reasons

## Changes

### `openai-responses-language-model.ts`
- Wrap `error` stream events in `APICallError` with proper status codes and retryability flags
- Add `response.failed` event handler that produces `APICallError` with error details
- Set `finishReason` to `{unified: 'error', raw: errorCode}` for both event types
- Add `mapErrorCodeToStatusCode()` helper: maps OpenAI error codes to HTTP status codes
- Add `isRetryableErrorCode()` helper: identifies retryable errors (rate limits, server errors)
- Add `isResponseFailedChunk()` type guard

### `openai-responses-api.ts`
- Add `response.failed` event type to Zod schema with `error` and `status` fields

### Tests
- Updated snapshot to reflect proper `APICallError` wrapping and `finishReason: error`
- Added test verifying `finishReason` is `{unified: 'error', raw: 'insufficient_quota'}`
- Added test verifying `APICallError` properties (statusCode, isRetryable)

## Before/After

**Before:** Stream errors produced raw objects with `finishReason: 'other'` — consumers couldn't detect or handle errors properly.

**After:** Stream errors produce `APICallError` with `finishReason: 'error'` and the error code — consistent with the non-streaming error path.