### PR TITLE
fix(openai-compatible): support audio URLs, non-wav/mp3 audio, and video media types

### DIFF
--- a/.changeset/fix-openai-compatible-media-types.md
+++ b/.changeset/fix-openai-compatible-media-types.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Support audio URLs, non-wav/mp3 audio formats (e.g. ogg, flac, aac), and video media types in the OpenAI-compatible provider. Previously these threw `UnsupportedFunctionalityError`; they are now passed through as `image_url` parts with data URLs, which is the standard inline media format used by Gemini and other OpenAI-compatible providers.

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -181,38 +181,112 @@ describe('user messages', () => {
     ]);
   });
 
-  it('should throw error for audio parts with URLs', async () => {
-    expect(() =>
-      convertToOpenAICompatibleChatMessages([
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'file',
-              data: new URL('https://example.com/audio.wav'),
-              mediaType: 'audio/wav',
-            },
-          ],
-        },
-      ]),
-    ).toThrow("'audio file parts with URLs' functionality not supported");
+  it('should convert audio parts with URLs using image_url fallback', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new URL('https://example.com/audio.wav'),
+            mediaType: 'audio/wav',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/audio.wav' },
+          },
+        ],
+      },
+    ]);
   });
 
-  it('should throw error for unsupported audio format', async () => {
-    expect(() =>
-      convertToOpenAICompatibleChatMessages([
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'file',
-              data: new Uint8Array([0, 1, 2, 3]),
-              mediaType: 'audio/ogg',
-            },
-          ],
-        },
-      ]),
-    ).toThrow("'audio media type audio/ogg' functionality not supported");
+  it('should convert unsupported audio formats using image_url fallback', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'audio/ogg',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:audio/ogg;base64,AAECAw==' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert video parts using image_url format', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'video/mp4',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:video/mp4;base64,AAECAw==' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert video parts with URLs using image_url format', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new URL('https://example.com/video.webm'),
+            mediaType: 'video/webm',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/video.webm' },
+          },
+        ],
+      },
+    ]);
   });
 
   it('should convert messages with PDF parts', async () => {
@@ -418,12 +492,14 @@ describe('user messages', () => {
             {
               type: 'file',
               data: new Uint8Array([0, 1, 2, 3]),
-              mediaType: 'video/mp4',
+              mediaType: 'application/octet-stream',
             },
           ],
         },
       ]),
-    ).toThrow("'file part media type video/mp4' functionality not supported");
+    ).toThrow(
+      "'file part media type application/octet-stream' functionality not supported",
+    );
   });
 });
 

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -77,24 +77,42 @@ export function convertToOpenAICompatibleChatMessages(
                 }
 
                 if (part.mediaType.startsWith('audio/')) {
-                  if (part.data instanceof URL) {
-                    throw new UnsupportedFunctionalityError({
-                      functionality: 'audio file parts with URLs',
-                    });
-                  }
-
                   const format = getAudioFormat(part.mediaType);
-                  if (format === null) {
-                    throw new UnsupportedFunctionalityError({
-                      functionality: `audio media type ${part.mediaType}`,
-                    });
+
+                  if (format !== null && !(part.data instanceof URL)) {
+                    return {
+                      type: 'input_audio',
+                      input_audio: {
+                        data: convertToBase64(part.data),
+                        format,
+                      },
+                      ...partMetadata,
+                    };
                   }
 
+                  // For unsupported audio formats or URL-based audio,
+                  // pass through as image_url (the generic OpenAI-compatible
+                  // inline media format used by Gemini and other providers).
                   return {
-                    type: 'input_audio',
-                    input_audio: {
-                      data: convertToBase64(part.data),
-                      format,
+                    type: 'image_url',
+                    image_url: {
+                      url:
+                        part.data instanceof URL
+                          ? part.data.toString()
+                          : `data:${part.mediaType};base64,${convertToBase64(part.data)}`,
+                    },
+                    ...partMetadata,
+                  };
+                }
+
+                if (part.mediaType.startsWith('video/')) {
+                  return {
+                    type: 'image_url',
+                    image_url: {
+                      url:
+                        part.data instanceof URL
+                          ? part.data.toString()
+                          : `data:${part.mediaType};base64,${convertToBase64(part.data)}`,
                     },
                     ...partMetadata,
                   };


### PR DESCRIPTION
## Problem

The OpenAI-compatible provider throws `UnsupportedFunctionalityError` for:

1. **Audio file parts with URLs** — `'audio file parts with URLs' functionality not supported`
2. **Non-wav/mp3 audio formats** (e.g. `audio/ogg`, `audio/flac`, `audio/aac`) — `'audio media type audio/ogg' functionality not supported`
3. **All video media types** (e.g. `video/mp4`, `video/webm`) — `'file part media type video/mp4' functionality not supported`

This prevents using Gemini, Vertex AI, and other providers that accept these formats through the OpenAI-compatible endpoint.

## Solution

- For **known audio formats** (`wav`, `mp3`, `mpeg`) with inline data: continue using the `input_audio` format for native OpenAI compatibility
- For **all other audio/video formats** or **URL-based audio**: pass through as `image_url` parts with data URLs, which is the standard inline media format used by Gemini and other OpenAI-compatible providers

This is a non-breaking change — existing `input_audio` behavior for wav/mp3 is preserved. Only previously-throwing code paths now work.

## Tests

- Updated 2 existing tests that expected throws → now expect valid output
- Added 2 new tests: video inline data, video URL
- All 178 tests pass (2 consecutive clean runs)

Fixes #12723