### PR TITLE
fix(openai): omit reasoning item id when store is false

### DIFF
--- a/.changeset/fix-openai-responses-reasoning-id-store-false.md
+++ b/.changeset/fix-openai-responses-reasoning-id-store-false.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Omit `id` field from reasoning items when `store: false` in the Responses API input. Azure OpenAI rejects requests containing reasoning item IDs when storage is disabled. The `encrypted_content` field is sufficient for multi-turn reasoning without server-side persistence.

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -959,7 +959,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1001,7 +1000,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [
                 {
@@ -1043,7 +1041,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: null,
               summary: [
                 {
@@ -1086,7 +1083,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [],
             },
@@ -1123,7 +1119,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [],
             },
@@ -1168,7 +1163,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1230,7 +1224,6 @@ describe('convertToOpenAIResponsesInput', () => {
             [
               {
                 "encrypted_content": "encrypted_content_001",
-                "id": "reasoning_001",
                 "summary": [
                   {
                     "text": "First reasoning step",
@@ -1285,7 +1278,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1296,7 +1288,6 @@ describe('convertToOpenAIResponsesInput', () => {
             },
             {
               type: 'reasoning',
-              id: 'reasoning_002',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1485,7 +1476,6 @@ describe('convertToOpenAIResponsesInput', () => {
             },
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1508,7 +1498,6 @@ describe('convertToOpenAIResponsesInput', () => {
             },
             {
               type: 'reasoning',
-              id: 'reasoning_002',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1656,7 +1645,6 @@ describe('convertToOpenAIResponsesInput', () => {
             // First reasoning block (2 parts merged)
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [
                 {
@@ -1685,7 +1673,6 @@ describe('convertToOpenAIResponsesInput', () => {
             // Second reasoning block (3 parts merged)
             {
               type: 'reasoning',
-              id: 'reasoning_002',
               encrypted_content: 'encrypted_content_002',
               summary: [
                 {

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -411,7 +411,6 @@ export async function convertToOpenAIResponsesInput({
                   if (reasoningMessage === undefined) {
                     reasoningMessages[reasoningId] = {
                       type: 'reasoning',
-                      id: reasoningId,
                       encrypted_content:
                         providerOptions?.reasoningEncryptedContent,
                       summary: summaryParts,


### PR DESCRIPTION
## Problem

When using the OpenAI Responses API with `store: false`, reasoning items in the input still include an `id` field. Azure OpenAI rejects requests containing reasoning item IDs when storage is disabled, breaking multi-turn conversations with reasoning models on Azure.

## Root Cause

In `convert-to-openai-responses-input.ts`, the `store === false` branch (which correctly sends full reasoning content instead of `item_reference`) was still including `id: reasoningId` on the reasoning objects.

## Fix

Omit the `id` field from reasoning items when `store === false`. The `encrypted_content` field is what enables multi-turn reasoning without server-side persistence — the `id` is only meaningful for `item_reference` lookups (the `store === true` path), not for inline reasoning content.

## Tests

- Updated all existing `store: false` reasoning test expectations to not include `id`
- All 594 OpenAI package tests pass (2 consecutive clean runs)

Fixes #12687