### PR TITLE
fix(provider-utils): include type: 'object' in default tool schema

### DIFF
--- a/.changeset/fix-no-schema-missing-type-object.md
+++ b/.changeset/fix-no-schema-missing-type-object.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Include `type: 'object'` in the default JSON Schema generated for tools without parameters. Providers like DeepSeek that strictly validate JSON Schema reject schemas missing the `type` field.

--- a/packages/provider-utils/src/schema.ts
+++ b/packages/provider-utils/src/schema.ts
@@ -133,7 +133,11 @@ export function asSchema<OBJECT>(
   schema: FlexibleSchema<OBJECT> | undefined,
 ): Schema<OBJECT> {
   return schema == null
-    ? jsonSchema({ properties: {}, additionalProperties: false })
+    ? jsonSchema({
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      })
     : isSchema(schema)
       ? schema
       : '~standard' in schema


### PR DESCRIPTION
## Problem

When a tool is defined without parameters (or with `parameters: undefined`), `asSchema()` generates a default JSON Schema:

```json
{"properties": {}, "additionalProperties": false}
```

This is missing `"type": "object"`, which causes providers that strictly validate JSON Schema (like DeepSeek) to reject all tool calls with:

> Invalid schema for function 'functionName': schema must be a JSON Schema of 'type: "object"', got 'type: null'.

## Fix

One-line change in `asSchema()` to include `type: 'object'` in the default schema:

```json
{"type": "object", "properties": {}, "additionalProperties": false}
```

## Tests

- All 403 provider-utils tests pass
- All 1979 ai package tests pass (2 consecutive clean runs)
- All 176 openai-compatible tests pass
- All 23 deepseek tests pass

Fixes #7924