### PR TITLE
fix(google): infer type from enum values when not explicitly set

### DIFF
--- a/.changeset/fix-google-enum-missing-type.md
+++ b/.changeset/fix-google-enum-missing-type.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(google): infer `type` from enum values when not explicitly set
+
+Gemini requires `type` alongside `enum` in response schemas. When Zod v4's
+`z.enum()` generates `{ enum: ["foo", "bar"] }` without `type: "string"`, the
+Gemini API rejects it with "enum: only allowed for STRING type". Now infers the
+type from the enum values when not explicitly set.

--- a/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
@@ -604,6 +604,31 @@ it('should convert string enum properties', () => {
   });
 });
 
+it('should infer type "string" for enum without explicit type (Zod v4)', () => {
+  const schemaWithEnumNoType: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      value: {
+        enum: ['foo', 'bar'],
+      },
+    },
+    required: ['value'],
+    additionalProperties: false,
+    $schema: 'http://json-schema.org/draft-07/schema#',
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(schemaWithEnumNoType)).toEqual({
+    type: 'object',
+    properties: {
+      value: {
+        type: 'string',
+        enum: ['foo', 'bar'],
+      },
+    },
+    required: ['value'],
+  });
+});
+
 it('should convert nullable string enum', () => {
   const schemaWithEnumProperty: JSONSchema7 = {
     type: 'object',

--- a/packages/google/src/convert-json-schema-to-openapi-schema.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.ts
@@ -76,6 +76,18 @@ export function convertJSONSchemaToOpenAPISchema(
   // Handle enum
   if (enumValues !== undefined) {
     result.enum = enumValues;
+
+    // Gemini requires `type` alongside `enum`. When Zod v4 emits
+    // `{ enum: [...] }` without a `type`, infer it from the values.
+    if (result.type === undefined && enumValues.length > 0) {
+      if (enumValues.every(v => typeof v === 'string')) {
+        result.type = 'string';
+      } else if (enumValues.every(v => typeof v === 'number')) {
+        result.type = 'number';
+      } else if (enumValues.every(v => typeof v === 'boolean')) {
+        result.type = 'boolean';
+      }
+    }
   }
 
   if (properties != null) {


### PR DESCRIPTION
## Summary
Fixes #6872

Gemini requires `type` alongside `enum` in response schemas. When Zod v4's `z.enum()` generates `{ enum: ['foo', 'bar'] }` without `type: 'string'`, the Gemini API rejects it with:

```
GenerateContentRequest.generation_config.response_schema.properties[value].enum: only allowed for STRING type
```

## Root Cause

Zod v4's `z.enum()` generates JSON Schema `{ enum: ['foo', 'bar'] }` without an explicit `type` field (unlike Zod v3 which includes `type: 'string'`). The `convertJSONSchemaToOpenAPISchema` function passes this through as-is, but Gemini's schema validation requires `type` to be present when `enum` is used.

## Changes

- **`convert-json-schema-to-openapi-schema.ts`**: When `enum` values are present but `type` is not set, infer the type from the values:
  - All strings → `type: 'string'`
  - All numbers → `type: 'number'`
  - All booleans → `type: 'boolean'`
- **`convert-json-schema-to-openapi-schema.test.ts`**: Added test for enum without explicit type (Zod v4 pattern)