### PR TITLE
fix(provider-utils): RFC 9110 compliant User-Agent header format

### DIFF
--- a/.changeset/fix-user-agent-rfc-compliance.md
+++ b/.changeset/fix-user-agent-rfc-compliance.md
@@ -1,0 +1,13 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix(provider-utils): RFC 9110 compliant User-Agent header format
+
+The generated User-Agent header contained invalid product tokens per
+RFC 9110 §10.1.5. `ai-sdk/provider-utils/4.0.15` has a `/` in the
+product name, and `runtime/bun/1.3.9` has a nested `/` in the
+product-version. This caused Azure OpenAI to reject requests with 400.
+
+Now produces RFC-compliant tokens like `ai-sdk-provider-utils/4.0.15`
+and `runtime-bun/1.3.9`.

--- a/packages/provider-utils/src/get-from-api.test.ts
+++ b/packages/provider-utils/src/get-from-api.test.ts
@@ -60,7 +60,7 @@ describe('getFromApi', () => {
         method: 'GET',
         headers: {
           authorization: 'Bearer test',
-          'user-agent': 'ai-sdk/provider-utils/0.0.0-test runtime/test-env',
+          'user-agent': 'ai-sdk-provider-utils/0.0.0-test runtime/test-env',
         },
       }),
     );
@@ -148,7 +148,7 @@ describe('getFromApi', () => {
       expect.objectContaining({
         headers: {
           authorization: 'Bearer test',
-          'user-agent': 'ai-sdk/provider-utils/0.0.0-test runtime/test-env',
+          'user-agent': 'ai-sdk-provider-utils/0.0.0-test runtime/test-env',
         },
       }),
     );

--- a/packages/provider-utils/src/get-from-api.ts
+++ b/packages/provider-utils/src/get-from-api.ts
@@ -31,7 +31,7 @@ export const getFromApi = async <T>({
       method: 'GET',
       headers: withUserAgentSuffix(
         headers,
-        `ai-sdk/provider-utils/${VERSION}`,
+        `ai-sdk-provider-utils/${VERSION}`,
         getRuntimeEnvironmentUserAgent(),
       ),
       signal: abortSignal,

--- a/packages/provider-utils/src/get-runtime-environment-user-agent.test.ts
+++ b/packages/provider-utils/src/get-runtime-environment-user-agent.test.ts
@@ -26,6 +26,26 @@ describe('getRuntimeEnvironmentUserAgent', () => {
     ).toBe('runtime/test');
   });
 
+  it('should return RFC-compliant user agent for Bun', () => {
+    expect(
+      getRuntimeEnvironmentUserAgent({
+        navigator: {
+          userAgent: 'Bun/1.3.9',
+        },
+      }),
+    ).toBe('runtime-bun/1.3.9');
+  });
+
+  it('should return RFC-compliant user agent for Deno', () => {
+    expect(
+      getRuntimeEnvironmentUserAgent({
+        navigator: {
+          userAgent: 'Deno/2.1.0',
+        },
+      }),
+    ).toBe('runtime-deno/2.1.0');
+  });
+
   it('should return the correct user agent for Edge Runtime', () => {
     expect(
       getRuntimeEnvironmentUserAgent({
@@ -39,9 +59,9 @@ describe('getRuntimeEnvironmentUserAgent', () => {
       getRuntimeEnvironmentUserAgent({
         process: {
           versions: { node: 'test' },
-          version: 'test',
+          version: 'v22.0.0',
         },
       }),
-    ).toBe('runtime/node.js/test');
+    ).toBe('runtime-node/v22.0.0');
   });
 });

--- a/packages/provider-utils/src/get-runtime-environment-user-agent.ts
+++ b/packages/provider-utils/src/get-runtime-environment-user-agent.ts
@@ -8,12 +8,24 @@ export function getRuntimeEnvironmentUserAgent(
 
   // Cloudflare Workers / Deno / Bun / Node.js >= 21.1
   if (globalThisAny.navigator?.userAgent) {
-    return `runtime/${globalThisAny.navigator.userAgent.toLowerCase()}`;
+    const ua = globalThisAny.navigator.userAgent;
+
+    // navigator.userAgent may contain product/version (e.g. "Bun/1.3.9").
+    // RFC 9110 §10.1.5 only allows a single "/" between product and version,
+    // so "runtime/bun/1.3.9" is invalid. Split and restructure.
+    const slashIdx = ua.indexOf('/');
+    if (slashIdx !== -1) {
+      const product = ua.substring(0, slashIdx).toLowerCase();
+      const version = ua.substring(slashIdx + 1);
+      return `runtime-${product}/${version}`;
+    }
+
+    return `runtime/${ua.toLowerCase()}`;
   }
 
   // Nodes.js < 21.1
   if (globalThisAny.process?.versions?.node) {
-    return `runtime/node.js/${globalThisAny.process.version.substring(0)}`;
+    return `runtime-node/${globalThisAny.process.version.substring(0)}`;
   }
 
   if (globalThisAny.EdgeRuntime) {

--- a/packages/provider-utils/src/post-to-api.ts
+++ b/packages/provider-utils/src/post-to-api.ts
@@ -99,7 +99,7 @@ export const postToApi = async <T>({
       method: 'POST',
       headers: withUserAgentSuffix(
         headers,
-        `ai-sdk/provider-utils/${VERSION}`,
+        `ai-sdk-provider-utils/${VERSION}`,
         getRuntimeEnvironmentUserAgent(),
       ),
       body: body.content,


### PR DESCRIPTION
## Summary
Fixes #12799

The generated `User-Agent` header contained invalid product tokens per [RFC 9110 §10.1.5](https://www.rfc-editor.org/rfc/rfc9110#section-10.1.5), causing Azure OpenAI to reject all requests with HTTP 400 when running on Bun.

## Root Cause

Two violations:

1. **`ai-sdk/provider-utils/4.0.15`** — The product name `ai-sdk/provider-utils` contains a `/`, which is only allowed as the separator between product name and version. This makes `provider-utils/4.0.15` parse as an invalid product-version.

2. **`runtime/bun/1.3.9`** — Bun exposes `navigator.userAgent = 'Bun/1.3.9'`. Wrapping in `runtime/${...}` produces `runtime/bun/1.3.9` with a nested `/` in the product-version.

RFC 9110 defines:
```
product = token "/" product-version
token = 1*tchar
```

## Changes

- **`get-runtime-environment-user-agent.ts`**: Parse `navigator.userAgent` to split product/version (e.g. `Bun/1.3.9` → `runtime-bun/1.3.9`). Also fix Node.js path from `runtime/node.js/` to `runtime-node/`.
- **`post-to-api.ts`** + **`get-from-api.ts`**: Changed `ai-sdk/provider-utils/` → `ai-sdk-provider-utils/` (replace `/` with `-` in product name).
- Updated test expectations to match new format.

### Before / After

| Before (invalid) | After (RFC 9110 compliant) |
|---|---|
| `ai-sdk/provider-utils/4.0.15` | `ai-sdk-provider-utils/4.0.15` |
| `runtime/bun/1.3.9` | `runtime-bun/1.3.9` |
| `runtime/node.js/v22.0.0` | `runtime-node/v22.0.0` |