### PR TITLE
fix(langchain): HITL interrupt uses original tool call ID from messages stream

### DIFF
--- a/.changeset/fix-langchain-hitl-toolcall-id.md
+++ b/.changeset/fix-langchain-hitl-toolcall-id.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/langchain': patch
+---
+
+fix(langchain): HITL interrupt now uses original tool call ID from messages stream mode
+
+When a tool call was already emitted via the `messages` stream mode, the
+values mode skipped the entire block including the key mapping registration.
+This caused the HITL interrupt handler to generate a fallback ID instead of
+reusing the original `toolCallId`, creating orphaned approval cards.

--- a/packages/langchain/src/__snapshots__/langgraph-hitl-request-1.json
+++ b/packages/langchain/src/__snapshots__/langgraph-hitl-request-1.json
@@ -480,24 +480,9 @@
     "id": "run-019b259a-5def-7000-8000-0a449f226de9"
   },
   {
-    "type": "tool-input-start",
-    "toolCallId": "hitl-delete_file-1234567890",
-    "toolName": "delete_file",
-    "dynamic": true
-  },
-  {
-    "type": "tool-input-available",
-    "toolCallId": "hitl-delete_file-1234567890",
-    "toolName": "delete_file",
-    "input": {
-      "filename": "report.pdf"
-    },
-    "dynamic": true
-  },
-  {
     "type": "tool-approval-request",
-    "approvalId": "hitl-delete_file-1234567890",
-    "toolCallId": "hitl-delete_file-1234567890"
+    "approvalId": "call_LOd3dMxgYxmNLWZVWXra9xWQ",
+    "toolCallId": "call_LOd3dMxgYxmNLWZVWXra9xWQ"
   },
   {
     "type": "finish-step"

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -1461,6 +1461,15 @@ export function processLangGraphEvent(
                     input: toolCall.args,
                     dynamic: true,
                   });
+                } else if (
+                  toolCall.id &&
+                  emittedToolCalls.has(toolCall.id)
+                ) {
+                  // Tool call was already emitted via messages mode — still
+                  // register the key mapping so the HITL interrupt handler can
+                  // match by name+args and use the original toolCallId.
+                  const toolCallKey = `${toolCall.name}:${JSON.stringify(toolCall.args)}`;
+                  emittedToolCallsByKey.set(toolCallKey, toolCall.id);
                 }
               }
             }


### PR DESCRIPTION
## Summary
Fixes #12797

When using `@ai-sdk/langchain` with `streamMode: ['messages', 'values']`, the HITL interrupt handler failed to match tool calls that were already emitted via the `messages` stream mode, generating a fallback ID instead of reusing the original `toolCallId`.

## Root Cause

In the values mode tool call processing loop (`utils.ts` ~L1437):
1. **Messages mode** emits the tool call and adds it to `emittedToolCalls` ✅
2. **Values mode** sees `emittedToolCalls.has(toolCall.id)` → `true` → **skips the entire block**, including `emittedToolCallsByKey.set()`  
3. **Interrupt handler** calls `emittedToolCallsByKey.get(toolCallKey)` → `undefined` → generates fallback `hitl-{name}-{timestamp}`

## Fix

Added an `else if` branch for already-emitted tool calls that registers the key mapping so the interrupt handler can still resolve the original ID:

```typescript
} else if (toolCall.id && emittedToolCalls.has(toolCall.id)) {
  const toolCallKey = \`${toolCall.name}:${JSON.stringify(toolCall.args)}\`;
  emittedToolCallsByKey.set(toolCallKey, toolCall.id);
}
```

## Impact

Before: `tool-approval-request` gets fallback ID `hitl-delete_file-1234567890` → orphaned approval card  
After: `tool-approval-request` uses original `call_LOd3dMxgYxmNLWZVWXra9xWQ` → correctly linked to tool call card

Also eliminates duplicate `tool-input-start`/`tool-input-available` events that were emitted for already-streamed tool calls.