### PR TITLE
fix(ai): propagate AbortError from tool execution instead of swallowing it

### DIFF
--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -1,4 +1,8 @@
-import { executeTool, ModelMessage } from '@ai-sdk/provider-utils';
+import {
+  executeTool,
+  isAbortError,
+  ModelMessage,
+} from '@ai-sdk/provider-utils';
 import { Tracer } from '@opentelemetry/api';
 import { notify } from '../util/notify';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
@@ -121,6 +125,10 @@ export async function executeToolCall<TOOLS extends ToolSet>({
           }
         }
       } catch (error) {
+        if (isAbortError(error)) {
+          throw error; // propagate abort errors instead of converting to tool-error
+        }
+
         const durationMs = now() - startTime;
 
         await notify({


### PR DESCRIPTION
## Summary

When an `AbortSignal` fires during tool execution in `generateText()`'s multi-step loop, the `AbortError` was being caught by the `executeToolCall` catch block and converted to a `tool-error` result. This caused `generateText()` to return normally with `finishReason: 'unknown'` instead of throwing, giving callers no indication the generation was aborted.

## Root Cause

In `packages/ai/src/generate-text/execute-tool-call.ts`, the catch block that handles tool execution errors converts any thrown error into a `TypedToolError` result. Without a special case for abort errors, `AbortError` instances were silently swallowed.

## Fix

Re-throw `AbortError` immediately in the `executeToolCall` catch block (before converting other errors to `tool-error` results), consistent with how the retry utility already handles abort errors.

## Checklist

- [x] Existing tests pass
- [x] ESLint passes

Fixes #12878