### PR TITLE
fix(openai): omit reasoning item id when store is false

### DIFF
--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -959,7 +959,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1001,7 +1000,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [
                 {
@@ -1043,7 +1041,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: null,
               summary: [
                 {
@@ -1086,7 +1083,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [],
             },
@@ -1123,7 +1119,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [],
             },
@@ -1168,7 +1163,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1230,7 +1224,6 @@ describe('convertToOpenAIResponsesInput', () => {
             [
               {
                 "encrypted_content": "encrypted_content_001",
-                "id": "reasoning_001",
                 "summary": [
                   {
                     "text": "First reasoning step",
@@ -1285,7 +1278,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1296,7 +1288,6 @@ describe('convertToOpenAIResponsesInput', () => {
             },
             {
               type: 'reasoning',
-              id: 'reasoning_002',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1485,7 +1476,6 @@ describe('convertToOpenAIResponsesInput', () => {
             },
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1508,7 +1498,6 @@ describe('convertToOpenAIResponsesInput', () => {
             },
             {
               type: 'reasoning',
-              id: 'reasoning_002',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1656,7 +1645,6 @@ describe('convertToOpenAIResponsesInput', () => {
             // First reasoning block (2 parts merged)
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [
                 {
@@ -1685,7 +1673,6 @@ describe('convertToOpenAIResponsesInput', () => {
             // Second reasoning block (3 parts merged)
             {
               type: 'reasoning',
-              id: 'reasoning_002',
               encrypted_content: 'encrypted_content_002',
               summary: [
                 {

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -428,7 +428,6 @@ export async function convertToOpenAIResponsesInput({
                   if (reasoningMessage === undefined) {
                     reasoningMessages[reasoningId] = {
                       type: 'reasoning',
-                      id: reasoningId,
                       encrypted_content:
                         providerOptions?.reasoningEncryptedContent,
                       summary: summaryParts,


### PR DESCRIPTION
## Summary

Fixes #12687

Azure OpenAI rejects reasoning items that include an `id` field when `store` is disabled.

## Root Cause

In `convert-to-openai-responses-input.ts`, the `store: false` branch for reasoning messages was creating objects with `id: reasoningId`:

```typescript
reasoningMessages[reasoningId] = {
  type: 'reasoning',
  id: reasoningId,          // ← Azure rejects this when store=false
  encrypted_content: ...,
  summary: summaryParts,
};
```

The `store: true` branch correctly uses `item_reference` with `id` (line 384). But when `store` is false, the reasoning content should be sent inline without an `id` — the same pattern used for reasoning without an `itemId` (lines 450-454).

## Fix

Remove `id: reasoningId` from the reasoning message object created in the `store: false` path. The `reasoningId` is still used as the local tracking key in `reasoningMessages` for deduplication, but it is not sent to the API.

**594/594 OpenAI provider tests pass (2 consecutive clean runs).**