### PR TITLE
fix(ai): aggregate gateway cost across multiple generateImage calls

### DIFF
--- a/packages/ai/src/generate-image/generate-image.test.ts
+++ b/packages/ai/src/generate-image/generate-image.test.ts
@@ -1051,6 +1051,48 @@ describe('generateImage', () => {
       });
     });
 
+    it('should aggregate gateway cost across multiple calls', async () => {
+      let callCount = 0;
+
+      const result = await generateImage({
+        model: new MockImageModelV3({
+          maxImagesPerCall: 1,
+          doGenerate: async () => {
+            switch (callCount++) {
+              case 0:
+                return createMockResponse({
+                  images: [pngBase64],
+                  providerMetaData: {
+                    gateway: {
+                      images: [],
+                      cost: '0.02',
+                    },
+                  },
+                });
+              case 1:
+                return createMockResponse({
+                  images: [jpegBase64],
+                  providerMetaData: {
+                    gateway: {
+                      images: [],
+                      cost: '0.02',
+                    },
+                  },
+                });
+              default:
+                throw new Error('Unexpected call');
+            }
+          },
+        }),
+        prompt,
+        n: 2,
+      });
+
+      expect(result.providerMetadata.gateway).toStrictEqual({
+        cost: '0.04',
+      });
+    });
+
     it('should preserve null values in images array', async () => {
       const result = await generateImage({
         model: new MockImageModelV4({

--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -57,6 +57,17 @@ export type GenerateImagePrompt =
  *
  * @returns A result object that contains the generated images.
  */
+
+function sumCosts(cost1: unknown, cost2: unknown): number | string | undefined {
+  if (cost1 == null) return cost2 as number | string | undefined;
+  if (cost2 == null) return cost1 as number | string | undefined;
+  const n1 = typeof cost1 === 'string' ? parseFloat(cost1) : (cost1 as number);
+  const n2 = typeof cost2 === 'string' ? parseFloat(cost2) : (cost2 as number);
+  if (isNaN(n1) || isNaN(n2)) return cost2 as number | string;
+  const sum = n1 + n2;
+  return typeof cost1 === 'string' ? String(parseFloat(sum.toFixed(10))) : sum;
+}
+
 export async function generateImage({
   model: modelArg,
   prompt: promptArg,
@@ -228,6 +239,10 @@ export async function generateImage({
             providerMetadata[providerName] = {
               ...(currentEntry as object),
               ...metadata,
+              cost: sumCosts(
+                (currentEntry as { cost?: unknown }).cost,
+                (metadata as { cost?: unknown }).cost,
+              ),
             } as ImageModelV4ProviderMetadata[string];
           } else {
             providerMetadata[providerName] =


### PR DESCRIPTION
## Summary

Closes #12796

When `generateImage` is called with `n > maxImagesPerCall`, the SDK splits the request into multiple parallel calls. Usage tokens are correctly aggregated via `addImageModelUsage()`, but `providerMetadata.gateway` was merged with a plain object spread, so scalar fields like `cost` were overwritten by the last call's value.

**Example:** 4 calls each costing $0.02 would produce `providerMetadata.gateway.cost` = `'0.02'` instead of `'0.08'`.

## Root cause

In `generate-image.ts`, the gateway metadata aggregation loop used:

```ts
providerMetadata[providerName] = {
  ...(currentEntry as object),
  ...metadata,          // ← overwrites cost from previous calls
};
```

## Fix

Introduced a `sumCosts()` helper that parses and sums numeric/numeric-string cost values, then applies it explicitly after the spread:

```ts
providerMetadata[providerName] = {
  ...(currentEntry as object),
  ...metadata,
  cost: sumCosts(currentEntry.cost, metadata.cost),
};
```

Handles string costs (e.g. `'0.02'`), numeric costs, and cases where only one side has a value.

## Test plan

- Added new test: *"should aggregate gateway cost across multiple calls"*
- All 39 generate-image tests pass.