### PR TITLE
test(amazon-bedrock): add cache_control passthrough tests for bedrock-anthropic provider

### DIFF
--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -1406,6 +1406,21 @@ const result = await generateText({
 });
 ```
 
+You can also apply automatic (request-level) caching to the entire request by setting `cacheControl` in the top-level `providerOptions`:
+
+```ts
+import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: bedrockAnthropic('us.anthropic.claude-3-7-sonnet-20250219-v1:0'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+  providerOptions: {
+    anthropic: { cacheControl: { type: 'ephemeral' } },
+  },
+});
+```
+
 <Note>
   Cache control requires a minimum of 1024 tokens before the cache checkpoint.
   See the [Amazon Bedrock prompt caching

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -258,6 +258,55 @@ describe('bedrock-anthropic-provider', () => {
     expect(transformedBody).toHaveProperty('anthropic_version');
   });
 
+  it('should pass through cache_control in request body', () => {
+    const provider = createBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model-id');
+
+    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
+      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const config = constructorCall[1];
+
+    const transformedBody = config.transformRequestBody?.({
+      model: 'test-model-id',
+      messages: [{ role: 'user', content: 'Hello' }],
+      max_tokens: 1024,
+      cache_control: { type: 'ephemeral' },
+    });
+
+    expect(transformedBody).toHaveProperty('cache_control', {
+      type: 'ephemeral',
+    });
+  });
+
+  it('should pass through cache_control with ttl in request body', () => {
+    const provider = createBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model-id');
+
+    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
+      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const config = constructorCall[1];
+
+    const transformedBody = config.transformRequestBody?.({
+      model: 'test-model-id',
+      messages: [{ role: 'user', content: 'Hello' }],
+      max_tokens: 1024,
+      cache_control: { type: 'ephemeral', ttl: '1h' },
+    });
+
+    expect(transformedBody).toHaveProperty('cache_control', {
+      type: 'ephemeral',
+      ttl: '1h',
+    });
+  });
+
   it('should strip disable_parallel_tool_use from tool_choice', () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',


### PR DESCRIPTION
## Summary

Adds two unit tests and a documentation example for `cache_control` support in the `bedrockAnthropic` provider.

Closes #12832

## Background

PR #12743 added `cacheControl` provider option support to `@ai-sdk/anthropic`. The `bedrock-anthropic` sub-provider wraps `AnthropicMessagesLanguageModel` from `@ai-sdk/anthropic/internal`, and its `transformRequestBody` destructures `{ model, stream, tool_choice, tools, ...rest }` — passing `cache_control` through untouched via `...rest`.

**The feature already works.** These changes confirm and document it.

## Changes

### Tests (`packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts`)

Two new unit tests following the existing `transformRequestBody` test pattern:

1. **Basic `cache_control` passthrough** — verifies `{ type: 'ephemeral' }` is preserved in the transformed body
2. **`cache_control` with TTL passthrough** — verifies `{ type: 'ephemeral', ttl: '1h' }` is preserved unchanged

### Docs (`content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx`)

Adds a code example in the **Cache Control** section showing request-level (top-level) `cacheControl` usage with `bedrockAnthropic`, so users don't need to cross-reference the Anthropic provider docs to discover this feature.