### PR TITLE
feat(provider/azure):apply_patch in azure Responses tools

### DIFF
--- a/.changeset/poor-kangaroos-shake.md
+++ b/.changeset/poor-kangaroos-shake.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/azure': patch
+---
+
+add apply-patch in azure tools

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -538,6 +538,36 @@ The code interpreter tool can be configured with:
   Source Document Parts](#typed-providermetadata-in-source-document-parts).
 </Note>
 
+#### Apply Patch Tool
+
+The Azure OpenAI Responses API supports the apply patch tool for GPT-5.1 models through the `azure.tools.applyPatch` tool.
+The apply patch tool lets the model create, update, and delete files in your codebase using structured diffs.
+Instead of just suggesting edits, the model emits patch operations that your application applies and reports back on,
+enabling iterative, multi-step code editing workflows.
+
+```ts
+import { azure } from '@ai-sdk/azure';
+import { generateText, stepCountIs } from 'ai';
+
+const result = await generateText({
+  model: azure('gpt-5.1'),
+  tools: {
+    apply_patch: azure.tools.applyPatch({
+      execute: async ({ callId, operation }) => {
+        // ... your implementation for applying the diffs.
+      },
+    }),
+  },
+  prompt: 'Create a python file that calculates the factorial of a number',
+  stopWhen: stepCountIs(5),
+});
+```
+
+Your execute function must return:
+
+- **status** _'completed' | 'failed'_ - Whether the patch was applied successfully
+- **output** _string_ (optional) - Human-readable log text (e.g., results or error messages)
+
 #### PDF support
 
 The Azure OpenAI provider supports reading PDF files.

--- a/examples/ai-functions/src/generate-text/azure/responses-apply-patch.ts
+++ b/examples/ai-functions/src/generate-text/azure/responses-apply-patch.ts
@@ -1,0 +1,35 @@
+import { azure } from '@ai-sdk/azure';
+import { generateText, stepCountIs } from 'ai';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { createApplyPatchExecutor } from '../../lib/apply-patch-file-editor';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const workspaceRoot = path.join(__dirname, '../output');
+  await fs.mkdir(workspaceRoot, { recursive: true });
+
+  const result = await generateText({
+    model: azure.responses('gpt-5.1'),
+    tools: {
+      apply_patch: azure.tools.applyPatch({
+        execute: createApplyPatchExecutor(workspaceRoot),
+      }),
+    },
+    prompt: `Create a markdown file with a shopping checklist of 5 entries.`,
+    stopWhen: stepCountIs(5),
+  });
+
+  console.log('\n=== Result ===');
+  console.log('Text:', result.text);
+  console.log('\nFiles saved in:', workspaceRoot);
+
+  // List created files
+  const files = await fs.readdir(workspaceRoot);
+  for (const file of files) {
+    const filePath = path.join(workspaceRoot, file);
+    const content = await fs.readFile(filePath, 'utf8');
+    console.log(`\n=== ${file} ===`);
+    console.log(content);
+  }
+});

--- a/examples/ai-functions/src/generate-text/azure/responses-apply-patch.ts
+++ b/examples/ai-functions/src/generate-text/azure/responses-apply-patch.ts
@@ -1,5 +1,5 @@
 import { azure } from '@ai-sdk/azure';
-import { generateText, stepCountIs } from 'ai';
+import { generateText } from 'ai';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { createApplyPatchExecutor } from '../../lib/apply-patch-file-editor';
@@ -17,7 +17,6 @@ run(async () => {
       }),
     },
     prompt: `Create a markdown file with a shopping checklist of 5 entries.`,
-    stopWhen: stepCountIs(5),
   });
 
   console.log('\n=== Result ===');

--- a/examples/ai-functions/src/stream-text/azure/responses-apply-patch.ts
+++ b/examples/ai-functions/src/stream-text/azure/responses-apply-patch.ts
@@ -1,0 +1,60 @@
+import { azure } from '@ai-sdk/azure';
+import { stepCountIs, streamText } from 'ai';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { createApplyPatchExecutor } from '../../lib/apply-patch-file-editor';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const workspaceRoot = path.join(__dirname, '../output');
+  await fs.mkdir(workspaceRoot, { recursive: true });
+
+  const result = await streamText({
+    model: azure.responses('gpt-5.1'),
+    prompt: `Create a markdown file with a shopping checklist of 5 entries.`,
+    tools: {
+      apply_patch: azure.tools.applyPatch({
+        execute: createApplyPatchExecutor(workspaceRoot),
+      }),
+    },
+    stopWhen: stepCountIs(5),
+  });
+
+  process.stdout.write('\n=== Model Response (Streaming) ===\n');
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text-delta': {
+        process.stdout.write(part.text);
+        break;
+      }
+      case 'tool-call': {
+        process.stdout.write(
+          `\n\nTool call: '${part.toolName}'\nInput: ${JSON.stringify(part.input, null, 2)}\n`,
+        );
+        break;
+      }
+      case 'tool-result': {
+        process.stdout.write(
+          `\nTool result: '${part.toolName}'\nOutput: ${JSON.stringify(part.output, null, 2)}\n`,
+        );
+        break;
+      }
+      case 'error': {
+        console.error('\n\nError:', part.error);
+        break;
+      }
+    }
+  }
+  process.stdout.write('\n\n');
+
+  console.log('Files saved in:', workspaceRoot);
+
+  // List created files
+  const files = await fs.readdir(workspaceRoot);
+  for (const file of files) {
+    const filePath = path.join(workspaceRoot, file);
+    const content = await fs.readFile(filePath, 'utf8');
+    console.log(`\n=== ${file} ===`);
+    console.log(content);
+  }
+});

--- a/examples/ai-functions/src/stream-text/azure/responses-apply-patch.ts
+++ b/examples/ai-functions/src/stream-text/azure/responses-apply-patch.ts
@@ -1,5 +1,5 @@
 import { azure } from '@ai-sdk/azure';
-import { stepCountIs, streamText } from 'ai';
+import { streamText } from 'ai';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { createApplyPatchExecutor } from '../../lib/apply-patch-file-editor';
@@ -17,7 +17,6 @@ run(async () => {
         execute: createApplyPatchExecutor(workspaceRoot),
       }),
     },
-    stopWhen: stepCountIs(5),
   });
 
   process.stdout.write('\n=== Model Response (Streaming) ===\n');

--- a/packages/azure/src/azure-openai-tools.ts
+++ b/packages/azure/src/azure-openai-tools.ts
@@ -1,4 +1,5 @@
 import {
+  applyPatch,
   codeInterpreter,
   fileSearch,
   imageGeneration,
@@ -6,11 +7,13 @@ import {
 } from '@ai-sdk/openai/internal';
 
 export const azureOpenaiTools: {
+  applyPatch: typeof applyPatch;
   codeInterpreter: typeof codeInterpreter;
   fileSearch: typeof fileSearch;
   imageGeneration: typeof imageGeneration;
   webSearchPreview: typeof webSearchPreview;
 } = {
+  applyPatch,
   codeInterpreter,
   fileSearch,
   imageGeneration,


### PR DESCRIPTION
## Background

Azure OpenAI’s Responses API supports the **Apply Patch** tool, but `@ai-sdk/azure` did not expose it via `azure.tools.*`.
This PR makes the tool available from the Azure provider and adds documentation and examples.


## Summary

- Expose the Apply Patch tool in `@ai-sdk/azure` as `azure.tools.applyPatch`.
- Add Azure provider documentation for the Apply Patch tool, including the expected `execute` return shape.

## Manual Verification

- `examples/ai-functions`
  - pnpm tsx src/generate-text/azure/responses-apply-patch.ts 
  - pnpm tsx src/stream-text/azure/responses-apply-patch.ts 

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work
N/A

## Related Issues
N/A