### PR TITLE
feat(provider/azure): custom tool in azure Responses tools

### DIFF
--- a/.changeset/clean-squids-swim.md
+++ b/.changeset/clean-squids-swim.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/openai': patch
+'@ai-sdk/azure': patch
+---
+
+add custom tool in azure responses tools

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -538,6 +538,84 @@ The code interpreter tool can be configured with:
   Source Document Parts](#typed-providermetadata-in-source-document-parts).
 </Note>
 
+#### Custom Tool
+
+The Azure OpenAI Responses API supports
+[custom tools](https://developers.openai.com/api/docs/guides/function-calling/#custom-tools)
+through the `azure.tools.customTool` tool.
+Custom tools return a raw string instead of JSON, optionally constrained to a grammar
+(regex or Lark syntax). This makes them useful for generating structured text like
+SQL queries, code snippets, or any output that must match a specific pattern.
+
+```ts
+import { azure } from '@ai-sdk/azure';
+import { generateText, stepCountIs } from 'ai';
+
+const result = await generateText({
+  model: azure.responses('gpt-5.2-codex'),
+  tools: {
+    write_sql: azure.tools.customTool({
+      name: 'write_sql',
+      description: 'Write a SQL SELECT query to answer the user question.',
+      format: {
+        type: 'grammar',
+        syntax: 'regex',
+        definition: 'SELECT .+',
+      },
+      execute: async input => {
+        // input is a raw string matching the grammar, e.g. "SELECT * FROM users WHERE age > 25"
+        const rows = await db.query(input);
+        return JSON.stringify(rows);
+      },
+    }),
+  },
+  toolChoice: 'required',
+  prompt: 'Write a SQL query to get all users older than 25.',
+  stopWhen: stepCountIs(3),
+});
+```
+
+Custom tools also work with `streamText`:
+
+```ts
+import { azure } from '@ai-sdk/azure';
+import { streamText } from 'ai';
+
+const result = streamText({
+  model: azure.responses('gpt-5.2-codex'),
+  tools: {
+    write_sql: azure.tools.customTool({
+      name: 'write_sql',
+      description: 'Write a SQL SELECT query to answer the user question.',
+      format: {
+        type: 'grammar',
+        syntax: 'regex',
+        definition: 'SELECT .+',
+      },
+    }),
+  },
+  toolChoice: 'required',
+  prompt: 'Write a SQL query to get all users older than 25.',
+});
+
+for await (const chunk of result.fullStream) {
+  if (chunk.type === 'tool-call') {
+    console.log(`Tool: ${chunk.toolName}`);
+    console.log(`Input: ${chunk.input}`);
+  }
+}
+```
+
+The custom tool can be configured with:
+
+- **name** _string_ (required) - The name of the custom tool. Used to identify the tool in tool calls.
+- **description** _string_ (optional) - A description of what the tool does, to help the model understand when to use it.
+- **format** _object_ (optional) - The output format constraint. Omit for unconstrained text output.
+  - **type** _'grammar' | 'text'_ - The format type. Use `'grammar'` for constrained output or `'text'` for explicit unconstrained text.
+  - **syntax** _'regex' | 'lark'_ - (grammar only) The grammar syntax. Use `'regex'` for regular expression patterns or `'lark'` for [Lark parser grammar](https://lark-parser.readthedocs.io/).
+  - **definition** _string_ - (grammar only) The grammar definition string (a regex pattern or Lark grammar).
+- **execute** _function_ (optional) - An async function that receives the raw string input and returns a string result. Enables multi-turn tool calling.
+
 #### PDF support
 
 The Azure OpenAI provider supports reading PDF files.

--- a/examples/ai-functions/src/generate-text/azure/responses-custom-tool.ts
+++ b/examples/ai-functions/src/generate-text/azure/responses-custom-tool.ts
@@ -1,0 +1,28 @@
+import { azure } from '@ai-sdk/azure';
+import { generateText, stepCountIs } from 'ai';
+import { run } from '../../lib/run';
+import { print } from '../../lib/print';
+
+run(async () => {
+  const result = await generateText({
+    model: azure.responses('gpt-5.3-codex'),
+    tools: {
+      write_sql: azure.tools.customTool({
+        name: 'write_sql',
+        description: 'Write a SQL SELECT query to answer the user question.',
+        format: {
+          type: 'grammar',
+          syntax: 'regex',
+          definition: 'SELECT .+',
+        },
+      }),
+    },
+    toolChoice: 'required',
+    prompt: 'Write a SQL query to get all users older than 25.',
+    stopWhen: stepCountIs(5),
+  });
+
+  print('Tool calls:', result.toolCalls);
+  print('Finish reason:', result.finishReason);
+  print('Usage:', result.usage);
+});

--- a/examples/ai-functions/src/generate-text/azure/responses-custom-tool.ts
+++ b/examples/ai-functions/src/generate-text/azure/responses-custom-tool.ts
@@ -8,7 +8,6 @@ run(async () => {
     model: azure.responses('gpt-5.3-codex'),
     tools: {
       write_sql: azure.tools.customTool({
-        name: 'write_sql',
         description: 'Write a SQL SELECT query to answer the user question.',
         format: {
           type: 'grammar',

--- a/examples/ai-functions/src/generate-text/azure/responses-custom-tool.ts
+++ b/examples/ai-functions/src/generate-text/azure/responses-custom-tool.ts
@@ -1,5 +1,5 @@
 import { azure } from '@ai-sdk/azure';
-import { generateText, stepCountIs } from 'ai';
+import { generateText } from 'ai';
 import { run } from '../../lib/run';
 import { print } from '../../lib/print';
 
@@ -18,7 +18,6 @@ run(async () => {
     },
     toolChoice: 'required',
     prompt: 'Write a SQL query to get all users older than 25.',
-    stopWhen: stepCountIs(5),
   });
 
   print('Tool calls:', result.toolCalls);

--- a/examples/ai-functions/src/stream-text/azure/responses-custom-tool.ts
+++ b/examples/ai-functions/src/stream-text/azure/responses-custom-tool.ts
@@ -1,0 +1,43 @@
+import { azure } from '@ai-sdk/azure';
+import { stepCountIs, streamText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: azure.responses('gpt-5.3-codex'),
+    tools: {
+      write_sql: azure.tools.customTool({
+        name: 'write_sql',
+        description: 'Write a SQL SELECT query to answer the user question.',
+        format: {
+          type: 'grammar',
+          syntax: 'regex',
+          definition: 'SELECT .+',
+        },
+      }),
+    },
+    toolChoice: 'required',
+    prompt: 'Write a SQL query to get all users older than 25.',
+    stopWhen: stepCountIs(5),
+  });
+
+  for await (const chunk of result.fullStream) {
+    switch (chunk.type) {
+      case 'tool-call': {
+        console.log(
+          `\x1b[32m\x1b[1mTool call:\x1b[22m ${chunk.toolName}\x1b[0m`,
+        );
+        console.log(`  Input: ${JSON.stringify(chunk.input)}`);
+        break;
+      }
+
+      case 'error':
+        console.error('Error:', chunk.error);
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Finish reason:', await result.finishReason);
+  console.log('Usage:', await result.usage);
+});

--- a/examples/ai-functions/src/stream-text/azure/responses-custom-tool.ts
+++ b/examples/ai-functions/src/stream-text/azure/responses-custom-tool.ts
@@ -7,7 +7,6 @@ run(async () => {
     model: azure.responses('gpt-5.3-codex'),
     tools: {
       write_sql: azure.tools.customTool({
-        name: 'write_sql',
         description: 'Write a SQL SELECT query to answer the user question.',
         format: {
           type: 'grammar',

--- a/examples/ai-functions/src/stream-text/azure/responses-custom-tool.ts
+++ b/examples/ai-functions/src/stream-text/azure/responses-custom-tool.ts
@@ -1,5 +1,5 @@
 import { azure } from '@ai-sdk/azure';
-import { stepCountIs, streamText } from 'ai';
+import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
@@ -17,7 +17,6 @@ run(async () => {
     },
     toolChoice: 'required',
     prompt: 'Write a SQL query to get all users older than 25.',
-    stopWhen: stepCountIs(5),
   });
 
   for await (const chunk of result.fullStream) {

--- a/packages/azure/src/azure-openai-tools.ts
+++ b/packages/azure/src/azure-openai-tools.ts
@@ -1,5 +1,6 @@
 import {
   codeInterpreter,
+  customTool,
   fileSearch,
   imageGeneration,
   webSearchPreview,
@@ -7,11 +8,13 @@ import {
 
 export const azureOpenaiTools: {
   codeInterpreter: typeof codeInterpreter;
+  customTool: typeof customTool;
   fileSearch: typeof fileSearch;
   imageGeneration: typeof imageGeneration;
   webSearchPreview: typeof webSearchPreview;
 } = {
   codeInterpreter,
+  customTool,
   fileSearch,
   imageGeneration,
   webSearchPreview,

--- a/packages/openai/src/internal/index.ts
+++ b/packages/openai/src/internal/index.ts
@@ -13,6 +13,7 @@ export * from '../speech/openai-speech-model-options';
 export * from '../responses/openai-responses-language-model';
 export * from '../responses/openai-responses-provider-metadata';
 export * from '../tool/apply-patch';
+export * from '../tool/custom';
 export * from '../tool/code-interpreter';
 export * from '../tool/file-search';
 export * from '../tool/image-generation';


### PR DESCRIPTION
## Background
Azure OpenAI’s Responses API supports **custom tools**, but `@ai-sdk/azure` did not expose them via `azure.tools.*`.
This PR makes custom tools available through the Azure provider and adds documentation and examples.

## Summary
* Expose the Custom Tool in `@ai-sdk/azure` as `azure.tools.customTool`.
* Re-export the internal `custom` tool from `@ai-sdk/openai/internal`.
* Add Azure provider documentation for Custom Tool usage, including grammar-constrained output.

## Manual Verification
- `examples/ai-functions`
  - pnpm tsx src/generate-text/azure/responses-custom-tool.ts 
  - pnpm tsx src/stream-text/azure/responses-custom-tool.ts 

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work
N/A

## Related Issues
N/A