### PR TITLE
fix(openai-compatible): decode base64 string data for text/* file parts

### DIFF
--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -303,7 +303,9 @@ describe('user messages', () => {
           { type: 'text', text: 'Summarize this document' },
           {
             type: 'file',
-            data: '# Hello World\n\nThis is **markdown** content.',
+            data: Buffer.from(
+              '# Hello World\n\nThis is **markdown** content.',
+            ).toString('base64'),
             mediaType: 'text/markdown',
           },
         ],
@@ -333,6 +335,33 @@ describe('user messages', () => {
           {
             type: 'file',
             data: encoder.encode('Plain text content'),
+            mediaType: 'text/plain',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Plain text content',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should decode base64 string data for text/* file parts', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: Buffer.from('Plain text content').toString('base64'),
             mediaType: 'text/plain',
           },
         ],

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -119,7 +119,7 @@ export function convertToOpenAICompatibleChatMessages(
                     part.data instanceof URL
                       ? part.data.toString()
                       : typeof part.data === 'string'
-                        ? part.data
+                        ? Buffer.from(part.data, 'base64').toString('utf-8')
                         : new TextDecoder().decode(part.data);
 
                   return {


### PR DESCRIPTION
## Problem

When a `FilePart` has a `string` `data` field and a `text/*` media type, the provider was passing the raw base64 string verbatim as the text content instead of decoding it.

Per the `LanguageModelV2DataContent` spec, when `data` is a `string` it is **base64-encoded**. So sending `Buffer.from('Hello').toString('base64')` (i.e. `'SGVsbG8='`) would result in the literal string `'SGVsbG8='` being sent to the API instead of `'Hello'`.

Fixes #12965

## Fix

Decode the base64 string with `Buffer.from(part.data, 'base64').toString('utf-8')` when `data` is a `string` for text/* media types.

Also updated the existing text/markdown test to use properly base64-encoded data (it was passing a plain text string directly, which violates the spec).