### PR TITLE
fix(xai): support frequencyPenalty, presencePenalty, stopSequences; add logprobs and cost metadata

### DIFF
--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -364,6 +364,7 @@ describe('XaiChatLanguageModel', () => {
       expect(request).toMatchInlineSnapshot(`
         {
           "body": {
+            "frequency_penalty": undefined,
             "logprobs": undefined,
             "max_completion_tokens": undefined,
             "messages": [
@@ -374,10 +375,12 @@ describe('XaiChatLanguageModel', () => {
             ],
             "model": "grok-3",
             "parallel_function_calling": undefined,
+            "presence_penalty": undefined,
             "reasoning_effort": undefined,
             "response_format": undefined,
             "search_parameters": undefined,
             "seed": undefined,
+            "stop": undefined,
             "temperature": undefined,
             "tool_choice": undefined,
             "tools": undefined,
@@ -897,6 +900,44 @@ describe('XaiChatLanguageModel', () => {
         }
       `);
     });
+
+    it('should pass frequencyPenalty, presencePenalty, stopSequences to the API', async () => {
+      prepareJsonFixtureResponse('xai-text');
+
+      const { request } = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.3,
+        stopSequences: ['STOP', '\n\n'],
+      });
+
+      expect(
+        (request.body as Record<string, unknown>)['frequency_penalty'],
+      ).toBe(0.5);
+      expect(
+        (request.body as Record<string, unknown>)['presence_penalty'],
+      ).toBe(0.3);
+      expect((request.body as Record<string, unknown>)['stop']).toEqual([
+        'STOP',
+        '\n\n',
+      ]);
+    });
+
+    it('should not warn when frequencyPenalty, presencePenalty, or stopSequences are set', async () => {
+      prepareJsonFixtureResponse('xai-text');
+
+      const { warnings } = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.3,
+        stopSequences: ['STOP'],
+      });
+
+      const unsupportedWarnings = warnings.filter(
+        w => w.type === 'unsupported',
+      );
+      expect(unsupportedWarnings).toEqual([]);
+    });
   });
 
   describe('doStream', () => {
@@ -1039,6 +1080,7 @@ describe('XaiChatLanguageModel', () => {
       expect(request).toMatchInlineSnapshot(`
         {
           "body": {
+            "frequency_penalty": undefined,
             "logprobs": undefined,
             "max_completion_tokens": undefined,
             "messages": [
@@ -1049,10 +1091,12 @@ describe('XaiChatLanguageModel', () => {
             ],
             "model": "grok-3",
             "parallel_function_calling": undefined,
+            "presence_penalty": undefined,
             "reasoning_effort": undefined,
             "response_format": undefined,
             "search_parameters": undefined,
             "seed": undefined,
+            "stop": undefined,
             "stream": true,
             "stream_options": {
               "include_usage": true,

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -94,17 +94,8 @@ export class XaiChatLanguageModel implements LanguageModelV4 {
       warnings.push({ type: 'unsupported', feature: 'topK' });
     }
 
-    if (frequencyPenalty != null) {
-      warnings.push({ type: 'unsupported', feature: 'frequencyPenalty' });
-    }
-
-    if (presencePenalty != null) {
-      warnings.push({ type: 'unsupported', feature: 'presencePenalty' });
-    }
-
-    if (stopSequences != null) {
-      warnings.push({ type: 'unsupported', feature: 'stopSequences' });
-    }
+    // frequencyPenalty, presencePenalty, stopSequences are supported by xAI chat completions
+    // (with caveats for reasoning models, but we pass them through regardless)
 
     // convert ai sdk messages to xai format
     const { messages, warnings: messageWarnings } =
@@ -136,6 +127,9 @@ export class XaiChatLanguageModel implements LanguageModelV4 {
       temperature,
       top_p: topP,
       seed,
+      frequency_penalty: frequencyPenalty,
+      presence_penalty: presencePenalty,
+      stop: stopSequences,
       reasoning_effort:
         options.reasoningEffort ??
         (isCustomReasoning(reasoning)


### PR DESCRIPTION
## Summary

Fixes #12826 (partial — high/medium priority items)

The xAI Chat Completions API supports `frequency_penalty`, `presence_penalty`, and `stop` parameters, but the AI SDK implementation was incorrectly emitting 'unsupported' warnings for them.

## Changes

### Bug fixes — parameters incorrectly marked as unsupported

- **`frequencyPenalty`**: Removed unsupported warning; now passed through as `frequency_penalty`
- **`presencePenalty`**: Removed unsupported warning; now passed through as `presence_penalty`
- **`stopSequences`**: Removed unsupported warning; now passed through as `stop`

### New features

- **`logprobs` / `topLogprobs`**: Added as xAI provider options to enable token log probability output (`logprobs: boolean`, `topLogprobs: 0-8`)
- **`cost_in_usd_ticks`**: Added to `xaiUsageSchema`; exposed as `providerMetadata.xai.costInUsdTicks` in both `doGenerate` and `doStream` results (10 billion ticks = $1)
- **`num_sources_used`**: Added to `xaiUsageSchema`; exposed as `providerMetadata.xai.numSourcesUsed`

## Usage

```ts
// frequencyPenalty/presencePenalty/stopSequences now work correctly
const result = await generateText({
  model: xai('grok-3'),
  prompt: 'Hello',
  frequencyPenalty: 0.5,
  presencePenalty: 0.3,
  stopSequences: ['END'],
});

// logprobs via provider options
const result2 = await generateText({
  model: xai('grok-3'),
  prompt: 'Hello',
  providerOptions: {
    xai: { logprobs: true, topLogprobs: 5 },
  },
});

// cost metadata
console.log(result.providerMetadata?.xai?.costInUsdTicks);
```