### PR TITLE
feat(ai): surface tool `_meta` on `DynamicToolUIPart`

### DIFF
--- a/.changeset/surface-tool-meta-on-dynamic-tool-ui-part.md
+++ b/.changeset/surface-tool-meta-on-dynamic-tool-ui-part.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+feat(ai): surface tool `_meta` on `DynamicToolUIPart`
+
+Added an optional `_meta` field to `DynamicToolUIPart` and threaded it through the UI message stream pipeline. MCP tools can declare metadata via `_meta` (e.g. `_meta.ui.resourceUri` for rendering tool-specific app UIs), and this metadata is now preserved end-to-end from the tool definition through to the frontend message parts.

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -199,6 +199,27 @@ const tools = await mcpClient.tools({
 
 This approach provides full TypeScript type safety and IDE autocompletion, letting you catch parameter mismatches during development. When you define `schemas`, the client only pulls the explicitly defined tools, keeping your application focused on the tools it needs
 
+### Tool Metadata in UI Streams
+
+MCP tool definitions can include `_meta` entries such as UI hints. When these
+tools are used with `streamText` and converted to `UIMessage` parts, the
+metadata is preserved on `dynamic-tool` parts as `part._meta`.
+
+```tsx
+message.parts.map(part => {
+  if (part.type !== 'dynamic-tool') {
+    return null;
+  }
+
+  return (
+    <div key={part.toolCallId}>
+      <div>{part.toolName}</div>
+      {part._meta?.ui && <pre>{JSON.stringify(part._meta.ui, null, 2)}</pre>}
+    </div>
+  );
+});
+```
+
 ### Typed Tool Outputs
 
 When MCP servers return `structuredContent` (per the [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content)), you can define an `outputSchema` to get typed tool results:

--- a/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
@@ -493,6 +493,9 @@ When using dynamic tools (tools with unknown types at compile time), the UI part
         return (
           <div key={index}>
             <h4>Tool: {part.toolName}</h4>
+            {part._meta?.ui?.resourceUri && (
+              <div>Resource URI: {part._meta.ui.resourceUri}</div>
+            )}
             {part.state === 'input-streaming' && (
               <pre>{JSON.stringify(part.input, null, 2)}</pre>
             )}
@@ -514,6 +517,10 @@ Dynamic tools are useful when integrating with:
 - MCP (Model Context Protocol) tools without schemas
 - User-defined functions loaded at runtime
 - External tool providers
+
+When present on the tool definition, metadata is available on
+`dynamic-tool` parts as `_meta`. This is especially useful for MCP tools that
+provide UI hints such as `resourceUri`.
 
 ## Tool call streaming
 

--- a/content/docs/04-ai-sdk-ui/50-stream-protocol.mdx
+++ b/content/docs/04-ai-sdk-ui/50-stream-protocol.mdx
@@ -291,10 +291,13 @@ Indicates the beginning of tool input streaming.
 
 Format: Server-Sent Event with JSON object
 
+Optional fields such as `title`, `dynamic`, `providerMetadata`, and `_meta`
+can also be included.
+
 Example:
 
 ```
-data: {"type":"tool-input-start","toolCallId":"call_fJdQDqnXeGxTmr4E3YPSR7Ar","toolName":"getWeatherInformation"}
+data: {"type":"tool-input-start","toolCallId":"call_fJdQDqnXeGxTmr4E3YPSR7Ar","toolName":"getWeatherInformation","_meta":{"ui":{"resourceUri":"https://example.com/tools/weather"}}}
 
 ```
 
@@ -317,10 +320,13 @@ Indicates that tool input is complete and ready for execution.
 
 Format: Server-Sent Event with JSON object
 
+Optional fields such as `title`, `dynamic`, `providerMetadata`, and `_meta`
+can also be included.
+
 Example:
 
 ```
-data: {"type":"tool-input-available","toolCallId":"call_fJdQDqnXeGxTmr4E3YPSR7Ar","toolName":"getWeatherInformation","input":{"city":"San Francisco"}}
+data: {"type":"tool-input-available","toolCallId":"call_fJdQDqnXeGxTmr4E3YPSR7Ar","toolName":"getWeatherInformation","input":{"city":"San Francisco"},"_meta":{"ui":{"resourceUri":"https://example.com/tools/weather"}}}
 
 ```
 

--- a/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
@@ -213,6 +213,9 @@ When used with useChat (`UIMessage` format), dynamic tools appear as `dynamic-to
         return (
           <div>
             <h4>Tool: {part.toolName}</h4>
+            {part._meta?.ui?.resourceUri && (
+              <div>UI resource: {part._meta.ui.resourceUri}</div>
+            )}
             <pre>{JSON.stringify(part.input, null, 2)}</pre>
           </div>
         );
@@ -221,3 +224,7 @@ When used with useChat (`UIMessage` format), dynamic tools appear as `dynamic-to
   });
 }
 ```
+
+When the underlying tool definition includes `_meta`, that metadata is
+preserved on the `dynamic-tool` UI part. This is commonly used with MCP tools
+to expose rendering hints such as `resourceUri`.

--- a/examples/ai-e2e-next/app/api/chat/dynamic-tools/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/dynamic-tools/route.ts
@@ -47,18 +47,31 @@ export type ToolsMessage = UIMessage<
   InferUITools<typeof staticTools>
 >;
 
+const currentLocationTool = {
+  ...dynamicTool({
+    description: 'Get the current location.',
+    title: 'Current Location',
+    inputSchema: z.object({}),
+    execute: async () => {
+      const locations = ['New York', 'London', 'Paris'];
+      return {
+        location: locations[Math.floor(Math.random() * locations.length)],
+      };
+    },
+  }),
+  _meta: {
+    ui: {
+      resourceUri: 'https://example.com/tools/current-location',
+    },
+    example: {
+      displayMode: 'location-card',
+    },
+  },
+};
+
 function dynamicTools(): ToolSet {
   return {
-    currentLocation: dynamicTool({
-      description: 'Get the current location.',
-      inputSchema: z.object({}),
-      execute: async () => {
-        const locations = ['New York', 'London', 'Paris'];
-        return {
-          location: locations[Math.floor(Math.random() * locations.length)],
-        };
-      },
-    }),
+    currentLocation: currentLocationTool,
   };
 }
 

--- a/examples/ai-e2e-next/app/chat/dynamic-tools/page.tsx
+++ b/examples/ai-e2e-next/app/chat/dynamic-tools/page.tsx
@@ -12,8 +12,13 @@ export default function Chat() {
 
   return (
     <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
+      <div className="mb-6 text-sm text-gray-600">
+        Try asking for your location, then send a follow-up question after the
+        tool result. Dynamic tool metadata is rendered below when available.
+      </div>
+
       {messages?.map(message => (
-        <div key={message.id} className="whitespace-pre-wrap">
+        <div key={message.id} className="mb-4 whitespace-pre-wrap">
           <strong>{`${message.role}: `}</strong>
           {message.parts.map((part, index) => {
             switch (part.type) {
@@ -33,7 +38,47 @@ export default function Chat() {
                   case 'input-available':
                   case 'output-available':
                     return (
-                      <pre key={index}>{JSON.stringify(part, null, 2)}</pre>
+                      <div
+                        key={index}
+                        className="my-3 rounded-lg border border-gray-200 bg-gray-50 p-4"
+                      >
+                        <div className="mb-2 text-sm font-semibold text-gray-900">
+                          {part.title ?? part.toolName}
+                        </div>
+                        <div className="mb-2 text-xs uppercase tracking-wide text-gray-500">
+                          State: {part.state}
+                        </div>
+                        {part._meta && (
+                          <div className="mb-3">
+                            <div className="mb-1 text-xs font-semibold text-gray-600">
+                              Tool Metadata
+                            </div>
+                            <pre className="overflow-x-auto rounded bg-white p-2 text-xs">
+                              {JSON.stringify(part._meta, null, 2)}
+                            </pre>
+                          </div>
+                        )}
+                        {'input' in part && part.input !== undefined && (
+                          <div className="mb-3">
+                            <div className="mb-1 text-xs font-semibold text-gray-600">
+                              Input
+                            </div>
+                            <pre className="overflow-x-auto rounded bg-white p-2 text-xs">
+                              {JSON.stringify(part.input, null, 2)}
+                            </pre>
+                          </div>
+                        )}
+                        {'output' in part && part.output !== undefined && (
+                          <div>
+                            <div className="mb-1 text-xs font-semibold text-gray-600">
+                              Output
+                            </div>
+                            <pre className="overflow-x-auto rounded bg-white p-2 text-xs">
+                              {JSON.stringify(part.output, null, 2)}
+                            </pre>
+                          </div>
+                        )}
+                      </div>
                     );
                   case 'output-error':
                     return (

--- a/examples/ai-functions/src/generate-text/openai/mcp-tool-meta.ts
+++ b/examples/ai-functions/src/generate-text/openai/mcp-tool-meta.ts
@@ -1,0 +1,35 @@
+import { createMCPClient } from '@ai-sdk/mcp';
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+// Start examples/mcp/src/tool-meta/server.ts in another terminal first.
+run(async () => {
+  const client = await createMCPClient({
+    transport: {
+      type: 'http',
+      url: 'http://localhost:8084/mcp',
+    },
+  });
+
+  try {
+    const tools = await client.tools();
+
+    console.log('Tool metadata:');
+    console.log(JSON.stringify(tools['get-weather']?._meta, null, 2));
+
+    const result = await generateText({
+      model: openai('gpt-5-mini'),
+      tools,
+      prompt: 'Use the get-weather tool to tell me the weather in Denver.',
+    });
+
+    console.log('\nTool calls:\n');
+    console.dir(result.toolCalls, { depth: Infinity });
+
+    console.log('\nText:\n');
+    console.log(result.text);
+  } finally {
+    await client.close();
+  }
+});

--- a/examples/ai-functions/src/stream-text/openai/mcp-tool-meta-ui-message.ts
+++ b/examples/ai-functions/src/stream-text/openai/mcp-tool-meta-ui-message.ts
@@ -1,0 +1,47 @@
+import { createMCPClient } from '@ai-sdk/mcp';
+import { openai } from '@ai-sdk/openai';
+import {
+  DynamicToolUIPart,
+  readUIMessageStream,
+  stepCountIs,
+  streamText,
+} from 'ai';
+import { run } from '../../lib/run';
+
+// Start examples/mcp/src/tool-meta/server.ts in another terminal first.
+run(async () => {
+  const client = await createMCPClient({
+    transport: {
+      type: 'http',
+      url: 'http://localhost:8084/mcp',
+    },
+  });
+
+  try {
+    const tools = await client.tools();
+
+    const result = streamText({
+      model: openai('gpt-5-mini'),
+      tools,
+      stopWhen: stepCountIs(3),
+      prompt: 'Use the get-weather tool to tell me the weather in Denver.',
+    });
+
+    for await (const uiMessage of readUIMessageStream({
+      stream: result.toUIMessageStream(),
+    })) {
+      const dynamicToolPart = uiMessage.parts.find(
+        (part): part is DynamicToolUIPart => part.type === 'dynamic-tool',
+      );
+
+      if (dynamicToolPart?._meta != null) {
+        console.log('Dynamic tool metadata:');
+        console.log(JSON.stringify(dynamicToolPart._meta, null, 2));
+      }
+
+      console.log(JSON.stringify(uiMessage, null, 2));
+    }
+  } finally {
+    await client.close();
+  }
+});

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -71,6 +71,7 @@ export type SingleRequestTextStreamPart<TOOLS extends ToolSet> =
       providerMetadata?: ProviderMetadata;
       dynamic?: boolean;
       title?: string;
+      _meta?: Record<string, unknown>;
     }
   | {
       type: 'tool-input-delta';

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -408,6 +408,7 @@ export type TextStreamPart<TOOLS extends ToolSet> =
       providerExecuted?: boolean;
       dynamic?: boolean;
       title?: string;
+      _meta?: Record<string, unknown>;
     }
   | {
       type: 'tool-input-end';

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1783,7 +1783,11 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                     case 'tool-input-start': {
                       activeToolCallToolNames[chunk.id] = chunk.toolName;
 
-                      const tool = tools?.[chunk.toolName];
+                      const tool = tools?.[chunk.toolName] as
+                        | (ToolSet[string] & {
+                            _meta?: Record<string, unknown>;
+                          })
+                        | undefined;
                       if (tool?.onInputStart != null) {
                         await tool.onInputStart({
                           toolCallId: chunk.id,
@@ -1797,6 +1801,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                         ...chunk,
                         dynamic: chunk.dynamic ?? tool?.type === 'dynamic',
                         title: tool?.title,
+                        ...(tool?._meta != null ? { _meta: tool._meta } : {}),
                       });
                       break;
                     }
@@ -2372,6 +2377,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                   : {}),
                 ...(dynamic != null ? { dynamic } : {}),
                 ...(part.title != null ? { title: part.title } : {}),
+                ...(part._meta != null ? { _meta: part._meta } : {}),
               });
               break;
             }
@@ -2387,6 +2393,13 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
 
             case 'tool-call': {
               const dynamic = isDynamic(part);
+              const toolMeta = (
+                this.tools?.[part.toolName] as
+                  | {
+                      _meta?: Record<string, unknown>;
+                    }
+                  | undefined
+              )?._meta as Record<string, unknown> | undefined;
 
               if (part.invalid) {
                 controller.enqueue({
@@ -2418,6 +2431,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                     : {}),
                   ...(dynamic != null ? { dynamic } : {}),
                   ...(part.title != null ? { title: part.title } : {}),
+                  ...(toolMeta != null ? { _meta: toolMeta } : {}),
                 });
               }
 

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -44,6 +44,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
         providerMetadata: providerMetadataSchema.optional(),
         dynamic: z.boolean().optional(),
         title: z.string().optional(),
+        _meta: z.record(z.string(), z.unknown()).optional(),
       }),
       z.strictObject({
         type: z.literal('tool-input-delta'),
@@ -59,6 +60,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
         providerMetadata: providerMetadataSchema.optional(),
         dynamic: z.boolean().optional(),
         title: z.string().optional(),
+        _meta: z.record(z.string(), z.unknown()).optional(),
       }),
       z.strictObject({
         type: z.literal('tool-input-error'),
@@ -239,6 +241,7 @@ export type UIMessageChunk<
       providerMetadata?: ProviderMetadata;
       dynamic?: boolean;
       title?: string;
+      _meta?: Record<string, unknown>;
     }
   | {
       type: 'tool-input-error';
@@ -285,6 +288,7 @@ export type UIMessageChunk<
       providerMetadata?: ProviderMetadata;
       dynamic?: boolean;
       title?: string;
+      _meta?: Record<string, unknown>;
     }
   | {
       type: 'tool-input-delta';

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -6,7 +6,11 @@ import {
   processUIMessageStream,
   StreamingUIMessageState,
 } from './process-ui-message-stream';
-import { InferUIMessageData, UIMessage } from './ui-messages';
+import {
+  DynamicToolUIPart,
+  InferUIMessageData,
+  UIMessage,
+} from './ui-messages';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { UIMessageStreamError } from '../error/ui-message-stream-error';
 
@@ -7102,6 +7106,162 @@ describe('processUIMessageStream', () => {
         expect(finalToolPart.title).toBe('Calculator');
         expect(finalToolPart.input).toEqual({ a: 5, b: 3 });
         expect(finalToolPart.output).toEqual({ result: 8 });
+      });
+    });
+
+    describe('dynamic tool with _meta', () => {
+      beforeEach(async () => {
+        const stream = createUIMessageStream([
+          { type: 'start', messageId: 'msg-meta' },
+          { type: 'start-step' },
+          {
+            type: 'tool-input-start',
+            toolCallId: 'tool-call-meta',
+            toolName: 'mcpTool',
+            dynamic: true,
+            title: 'MCP Tool',
+            _meta: {
+              ui: { resourceUri: 'https://example.com/app' },
+            },
+          },
+          {
+            type: 'tool-input-delta',
+            toolCallId: 'tool-call-meta',
+            inputTextDelta: '{"query":"test"}',
+          },
+          {
+            type: 'tool-input-available',
+            toolCallId: 'tool-call-meta',
+            toolName: 'mcpTool',
+            input: { query: 'test' },
+            dynamic: true,
+            title: 'MCP Tool',
+            _meta: {
+              ui: { resourceUri: 'https://example.com/app' },
+            },
+          },
+          {
+            type: 'tool-output-available',
+            toolCallId: 'tool-call-meta',
+            output: { result: 'success' },
+            dynamic: true,
+          },
+          { type: 'finish-step' },
+          { type: 'finish' },
+        ]);
+
+        state = createStreamingUIMessageState({
+          messageId: 'msg-meta',
+          lastMessage: undefined,
+        });
+
+        await consumeStream({
+          stream: processUIMessageStream({
+            stream,
+            runUpdateMessageJob,
+            onError: error => {
+              throw error;
+            },
+          }),
+        });
+      });
+
+      it('should include _meta in dynamic tool invocation', () => {
+        const toolPart = state!.message.parts.find(
+          part => part.type === 'dynamic-tool',
+        ) as DynamicToolUIPart | undefined;
+
+        expect(toolPart).toBeDefined();
+        expect(toolPart?._meta).toEqual({
+          ui: { resourceUri: 'https://example.com/app' },
+        });
+        expect(toolPart?.toolName).toBe('mcpTool');
+      });
+
+      it('should maintain _meta through dynamic tool states', () => {
+        const finalToolPart = state!.message.parts.find(
+          part => part.type === 'dynamic-tool',
+        ) as DynamicToolUIPart | undefined;
+
+        expect(finalToolPart?.state).toBe('output-available');
+        expect(finalToolPart?._meta).toEqual({
+          ui: { resourceUri: 'https://example.com/app' },
+        });
+        expect(finalToolPart?.title).toBe('MCP Tool');
+        expect(finalToolPart?.input).toEqual({ query: 'test' });
+        expect(finalToolPart?.output).toEqual({ result: 'success' });
+      });
+
+      it('should preserve _meta through streaming states', () => {
+        // Verify _meta was present during each write (snapshot)
+        const dynamicToolWrites = writeCalls
+          .map(call =>
+            call.message.parts.find(
+              (part): part is DynamicToolUIPart => part.type === 'dynamic-tool',
+            ),
+          )
+          .filter((part): part is DynamicToolUIPart => part != null);
+
+        // Every write that includes the dynamic tool part should have _meta
+        for (const part of dynamicToolWrites) {
+          expect(part._meta).toEqual({
+            ui: { resourceUri: 'https://example.com/app' },
+          });
+        }
+      });
+    });
+
+    describe('dynamic tool without _meta', () => {
+      beforeEach(async () => {
+        const stream = createUIMessageStream([
+          { type: 'start', messageId: 'msg-no-meta' },
+          { type: 'start-step' },
+          {
+            type: 'tool-input-start',
+            toolCallId: 'tool-call-no-meta',
+            toolName: 'regularTool',
+            dynamic: true,
+          },
+          {
+            type: 'tool-input-available',
+            toolCallId: 'tool-call-no-meta',
+            toolName: 'regularTool',
+            input: { x: 1 },
+            dynamic: true,
+          },
+          {
+            type: 'tool-output-available',
+            toolCallId: 'tool-call-no-meta',
+            output: { y: 2 },
+            dynamic: true,
+          },
+          { type: 'finish-step' },
+          { type: 'finish' },
+        ]);
+
+        state = createStreamingUIMessageState({
+          messageId: 'msg-no-meta',
+          lastMessage: undefined,
+        });
+
+        await consumeStream({
+          stream: processUIMessageStream({
+            stream,
+            runUpdateMessageJob,
+            onError: error => {
+              throw error;
+            },
+          }),
+        });
+      });
+
+      it('should not include _meta when not provided', () => {
+        const toolPart = state!.message.parts.find(
+          part => part.type === 'dynamic-tool',
+        ) as DynamicToolUIPart | undefined;
+
+        expect(toolPart).toBeDefined();
+        expect(toolPart?._meta).toBeUndefined();
       });
     });
 

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -42,6 +42,7 @@ export type StreamingUIMessageState<UI_MESSAGE extends UIMessage> = {
       toolName: string;
       dynamic?: boolean;
       title?: string;
+      _meta?: Record<string, unknown>;
     }
   >;
   finishReason?: FinishReason;
@@ -231,6 +232,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               toolCallId: string;
               providerExecuted?: boolean;
               title?: string;
+              _meta?: Record<string, unknown>;
             } & (
               | {
                   state: 'input-streaming';
@@ -280,6 +282,10 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               // once providerExecuted is set, it stays for streaming
               anyPart.providerExecuted =
                 anyOptions.providerExecuted ?? part.providerExecuted;
+              // once _meta is set, it stays for streaming
+              if (anyOptions._meta != null) {
+                anyPart._meta = anyOptions._meta;
+              }
 
               const providerMetadata = anyOptions.providerMetadata;
 
@@ -310,6 +316,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 preliminary: anyOptions.preliminary,
                 providerExecuted: anyOptions.providerExecuted,
                 title: options.title,
+                ...(options._meta != null ? { _meta: options._meta } : {}),
                 ...(anyOptions.providerMetadata != null &&
                 (options.state === 'output-available' ||
                   options.state === 'output-error')
@@ -503,6 +510,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 index: toolInvocations.length,
                 dynamic: chunk.dynamic,
                 title: chunk.title,
+                _meta: chunk._meta,
               };
 
               if (chunk.dynamic) {
@@ -513,6 +521,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   input: undefined,
                   providerExecuted: chunk.providerExecuted,
                   title: chunk.title,
+                  _meta: chunk._meta,
                   providerMetadata: chunk.providerMetadata,
                 });
               } else {
@@ -556,6 +565,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   state: 'input-streaming',
                   input: partialArgs,
                   title: partialToolCall.title,
+                  _meta: partialToolCall._meta,
                 });
               } else {
                 updateToolPart({
@@ -581,6 +591,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerExecuted: chunk.providerExecuted,
                   providerMetadata: chunk.providerMetadata,
                   title: chunk.title,
+                  _meta: chunk._meta,
                 });
               } else {
                 updateToolPart({

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -334,6 +334,15 @@ export type DynamicToolUIPart = {
    * Whether the tool call was executed by the provider.
    */
   providerExecuted?: boolean;
+
+  /**
+   * Optional metadata from the tool definition.
+   *
+   * For MCP tools, this corresponds to the `_meta` field from the tool definition,
+   * which can include UI hints such as `resourceUri` for rendering tool-specific
+   * app interfaces.
+   */
+  _meta?: Record<string, unknown>;
 } & (
   | {
       state: 'input-streaming';


### PR DESCRIPTION
## Summary

Closes https://github.com/vercel/ai/issues/12982

MCP tools can declare metadata via `_meta` (e.g. `_meta.ui.resourceUri` for [MCP Apps](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool)), and the `@ai-sdk/mcp` adapter already preserves this on the tool object after `toolsFromDefinitions()`. However, this metadata was stripped before reaching the frontend -- `DynamicToolUIPart` had no `_meta` field, forcing web-based MCP hosts to maintain hardcoded client-side registries mapping tool names to app UIs.

This PR threads `_meta` end-to-end through the UI message stream pipeline:

- **`ui-messages.ts`**: Added optional `_meta?: Record<string, unknown>` field to `DynamicToolUIPart` type
- **`ui-message-chunks.ts`**: Added `_meta` to `tool-input-start` and `tool-input-available` chunk types (both Zod schema and TypeScript union)
- **`stream-text.ts`**: Enriches `tool-input-start` with `_meta` from the tool definition (same pattern as `title`), and forwards `_meta` on `tool-input-available` chunks
- **`run-tools-transformation.ts`**: Added `_meta` to `SingleRequestTextStreamPart` `tool-input-start` variant
- **`process-ui-message-stream.ts`**: Carries `_meta` from chunks into `DynamicToolUIPart` construction, preserving it across all state transitions (input-streaming, input-available, output-available, output-error)

The change is fully backwards-compatible -- `_meta` is optional and only present when the tool definition provides it.

## Test plan

- [x] Added test: `dynamic tool with _meta` -- verifies `_meta` is present on `DynamicToolUIPart` after streaming through input-start, input-delta, input-available, and output-available states
- [x] Added test: `dynamic tool without _meta` -- verifies `_meta` is `undefined` when not provided (no regressions for existing tools)
- [x] Added test: `_meta` persists through all streaming write snapshots
- [x] All 94 `process-ui-message-stream` tests pass
- [x] All 45 `@ai-sdk/mcp` client tests pass
- [x] No snapshot regressions in existing tests