### PR TITLE
feat(google): expose finishMessage in providerMetadata

### DIFF
--- a/packages/google/src/__snapshots__/google-generative-ai-language-model.test.ts.snap
+++ b/packages/google/src/__snapshots__/google-generative-ai-language-model.test.ts.snap
@@ -21,6 +21,7 @@ Here is the breakdown: st**r**awbe**rr**y.",
   },
   "providerMetadata": {
     "google": {
+      "finishMessage": null,
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
@@ -150,6 +151,7 @@ Here is the breakdown: st**r**awbe**rr**y.",
   },
   "providerMetadata": {
     "google": {
+      "finishMessage": null,
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
@@ -301,6 +303,7 @@ exports[`doGenerate > tool-call > should extract tool calls 1`] = `
   },
   "providerMetadata": {
     "google": {
+      "finishMessage": "Model generated function call(s).",
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
@@ -454,6 +457,7 @@ exports[`doGenerate > tool-call-gemini3 > should extract tool call with thoughtS
   },
   "providerMetadata": {
     "google": {
+      "finishMessage": "Model generated function call(s).",
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
@@ -612,6 +616,7 @@ Here is the breakdown: st**r**awbe**rr**y.",
     },
     "providerMetadata": {
       "google": {
+        "finishMessage": null,
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
@@ -694,6 +699,7 @@ exports[`doStream > reasoning-gemini3 > should stream reasoning with thoughtSign
     },
     "providerMetadata": {
       "google": {
+        "finishMessage": null,
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
@@ -881,6 +887,7 @@ st**r**awbe**rr**y",
     },
     "providerMetadata": {
       "google": {
+        "finishMessage": null,
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
@@ -970,6 +977,7 @@ exports[`doStream > tool-call > should stream tool call 1`] = `
     },
     "providerMetadata": {
       "google": {
+        "finishMessage": null,
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
@@ -1059,6 +1067,7 @@ exports[`doStream > tool-call-gemini3 > should stream tool call with thoughtSign
     },
     "providerMetadata": {
       "google": {
+        "finishMessage": null,
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -1549,6 +1549,42 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should expose finishMessage in provider metadata for MALFORMED_FUNCTION_CALL', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: { parts: [{ text: '' }], role: 'model' },
+            finishReason: 'MALFORMED_FUNCTION_CALL',
+            finishMessage: 'Function call is malformed: missing required field',
+            index: 0,
+            safetyRatings: SAFETY_RATINGS,
+          },
+        ],
+        promptFeedback: { safetyRatings: SAFETY_RATINGS },
+      },
+    };
+
+    const { providerMetadata } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(providerMetadata?.google.finishMessage).toBe(
+      'Function call is malformed: missing required field',
+    );
+  });
+
+  it('should expose null finishMessage in provider metadata for normal finish', async () => {
+    prepareJsonResponse({ content: 'test response' });
+
+    const { providerMetadata } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(providerMetadata?.google.finishMessage).toBeNull();
+  });
+
   it('should expose grounding metadata in provider metadata', async () => {
     prepareJsonResponse({
       content: 'test response',
@@ -3396,6 +3432,32 @@ describe('doStream', () => {
     `);
   });
 
+  it('should expose finishMessage in provider metadata on finish', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"candidates": [{"content": {"parts": [{"text": ""}],"role": "model"},` +
+          `"finishReason": "MALFORMED_FUNCTION_CALL",` +
+          `"finishMessage": "Function call is malformed: missing required field",` +
+          `"index": 0}]}
+
+`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+    const finishEvent = events.find(event => event.type === 'finish');
+
+    expect(
+      finishEvent?.type === 'finish' &&
+        finishEvent.providerMetadata?.google.finishMessage,
+    ).toBe('Function call is malformed: missing required field');
+  });
+
   it('should stream code execution tool calls and results', async () => {
     server.urls[TEST_URL_GEMINI_2_0_PRO].response = {
       type: 'stream-chunks',
@@ -3972,6 +4034,7 @@ describe('doStream', () => {
           },
           "providerMetadata": {
             "google": {
+              "finishMessage": null,
               "groundingMetadata": null,
               "promptFeedback": null,
               "safetyRatings": [
@@ -4360,6 +4423,7 @@ describe('doStream', () => {
           },
           "providerMetadata": {
             "google": {
+              "finishMessage": null,
               "groundingMetadata": null,
               "promptFeedback": null,
               "safetyRatings": null,
@@ -4504,6 +4568,7 @@ describe('doStream', () => {
           },
           "providerMetadata": {
             "google": {
+              "finishMessage": null,
               "groundingMetadata": null,
               "promptFeedback": null,
               "safetyRatings": [

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -348,6 +348,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
           groundingMetadata: candidate.groundingMetadata ?? null,
           urlContextMetadata: candidate.urlContextMetadata ?? null,
           safetyRatings: candidate.safetyRatings ?? null,
+          finishMessage: candidate.finishMessage ?? null,
           usageMetadata: usageMetadata ?? null,
         },
       },
@@ -629,6 +630,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                   groundingMetadata: candidate.groundingMetadata ?? null,
                   urlContextMetadata: candidate.urlContextMetadata ?? null,
                   safetyRatings: candidate.safetyRatings ?? null,
+                  finishMessage: candidate.finishMessage ?? null,
                 },
               };
               if (usageMetadata != null) {
@@ -944,6 +946,7 @@ const responseSchema = lazySchema(() =>
         z.object({
           content: getContentSchema().nullish().or(z.object({}).strict()),
           finishReason: z.string().nullish(),
+          finishMessage: z.string().nullish(),
           safetyRatings: z.array(getSafetyRatingSchema()).nullish(),
           groundingMetadata: getGroundingMetadataSchema().nullish(),
           urlContextMetadata: getUrlContextMetadataSchema().nullish(),
@@ -989,6 +992,7 @@ const chunkSchema = lazySchema(() =>
           z.object({
             content: getContentSchema().nullish(),
             finishReason: z.string().nullish(),
+            finishMessage: z.string().nullish(),
             safetyRatings: z.array(getSafetyRatingSchema()).nullish(),
             groundingMetadata: getGroundingMetadataSchema().nullish(),
             urlContextMetadata: getUrlContextMetadataSchema().nullish(),


### PR DESCRIPTION
Closes #12986

## Summary

Exposes the Gemini API `finishMessage` field through `providerMetadata.google.finishMessage` (or `providerMetadata.vertex.finishMessage` for Vertex). This field contains diagnostic information that is particularly useful when `finishReason` is `MALFORMED_FUNCTION_CALL`.

## Changes

- Added `finishMessage` to the Zod response and chunk schemas for Gemini candidates
- Included `finishMessage` in `providerMetadata` for both `doGenerate` and `doStream`
- Added tests covering finishMessage presence and absence

## Why providerMetadata?

`finishMessage` is Google-specific diagnostic data (not a standardized field), so it follows the existing pattern used for `safetyRatings`, `groundingMetadata`, etc.