### PR TITLE
fix(xai): ensure strict mode for tools

### DIFF
--- a/.changeset/hungry-bears-care.md
+++ b/.changeset/hungry-bears-care.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(xai): ensure strict mode for tools

--- a/examples/ai-functions/src/generate-text/xai/strict-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/xai/strict-tool-call.ts
@@ -11,7 +11,7 @@ run(async () => {
         description: 'Get weather by city and unit',
         inputSchema: z.object({
           city: z.string(),
-          unit: z.enum(['celsius', 'bomboclat']),
+          unit: z.enum(['celsius', 'fahrenheit']),
         }),
         strict: true,
         execute: async ({ city, unit }) => {
@@ -19,7 +19,7 @@ run(async () => {
         },
       }),
     },
-    prompt: 'What is the weather in Boston in bomboclat?',
+    prompt: 'What is the weather in Boston?',
   });
 
   console.log('Text:', result.text);

--- a/examples/ai-functions/src/generate-text/xai/strict-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/xai/strict-tool-call.ts
@@ -1,0 +1,28 @@
+import { xai } from '@ai-sdk/xai';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: xai('grok-4-1-fast-reasoning'),
+    tools: {
+      getWeather: tool({
+        description: 'Get weather by city and unit',
+        inputSchema: z.object({
+          city: z.string(),
+          unit: z.enum(['celsius', 'bomboclat']),
+        }),
+        strict: true,
+        execute: async ({ city, unit }) => {
+          return { city, unit, temperature: 72 };
+        },
+      }),
+    },
+    prompt: 'What is the weather in Boston in bomboclat?',
+  });
+
+  console.log('Text:', result.text);
+  console.log('Tool Calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Tool Results:', JSON.stringify(result.toolResults, null, 2));
+});

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -110,6 +110,7 @@ export type XaiResponsesTool =
       name: string;
       description?: string;
       parameters: unknown;
+      strict?: boolean;
     };
 
 const annotationSchema = z.union([

--- a/packages/xai/src/responses/xai-responses-prepare-tools.test.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.test.ts
@@ -425,6 +425,155 @@ describe('prepareResponsesTools', () => {
     });
   });
 
+  describe('function tools strict mode', () => {
+    it('should pass through strict mode when strict is true', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "description": "A test function",
+              "name": "testFunction",
+              "parameters": {
+                "properties": {},
+                "type": "object",
+              },
+              "strict": true,
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('should pass through strict mode when strict is false', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: false,
+          },
+        ],
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "description": "A test function",
+              "name": "testFunction",
+              "parameters": {
+                "properties": {},
+                "type": "object",
+              },
+              "strict": false,
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('should not include strict when strict is undefined', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      });
+
+      const tool = result.tools![0];
+      expect(tool).not.toHaveProperty('strict');
+    });
+
+    it('should pass through strict mode for multiple tools with different strict settings', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'strictTool',
+            description: 'A strict tool',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+          {
+            type: 'function',
+            name: 'nonStrictTool',
+            description: 'A non-strict tool',
+            inputSchema: { type: 'object', properties: {} },
+            strict: false,
+          },
+          {
+            type: 'function',
+            name: 'defaultTool',
+            description: 'A tool without strict setting',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "description": "A strict tool",
+              "name": "strictTool",
+              "parameters": {
+                "properties": {},
+                "type": "object",
+              },
+              "strict": true,
+              "type": "function",
+            },
+            {
+              "description": "A non-strict tool",
+              "name": "nonStrictTool",
+              "parameters": {
+                "properties": {},
+                "type": "object",
+              },
+              "strict": false,
+              "type": "function",
+            },
+            {
+              "description": "A tool without strict setting",
+              "name": "defaultTool",
+              "parameters": {
+                "properties": {},
+                "type": "object",
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+  });
+
   describe('tool choice', () => {
     it('should handle tool choice auto', async () => {
       const result = await prepareResponsesTools({

--- a/packages/xai/src/responses/xai-responses-prepare-tools.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.ts
@@ -143,6 +143,7 @@ export async function prepareResponsesTools({
         name: tool.name,
         description: tool.description,
         parameters: tool.inputSchema,
+        ...(tool.strict != null ? { strict: tool.strict } : {}),
       });
     }
   }

--- a/packages/xai/src/xai-prepare-tools.test.ts
+++ b/packages/xai/src/xai-prepare-tools.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it } from 'vitest';
+import { prepareTools } from './xai-prepare-tools';
+
+describe('prepareTools', () => {
+  it('should return undefined tools and toolChoice when tools are undefined', () => {
+    const result = prepareTools({
+      tools: undefined,
+    });
+
+    expect(result).toEqual({
+      tools: undefined,
+      toolChoice: undefined,
+      toolWarnings: [],
+    });
+  });
+
+  it('should return undefined tools and toolChoice when tools are empty', () => {
+    const result = prepareTools({
+      tools: [],
+    });
+
+    expect(result).toEqual({
+      tools: undefined,
+      toolChoice: undefined,
+      toolWarnings: [],
+    });
+  });
+
+  it('should correctly prepare function tools', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'A test function',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "toolChoice": undefined,
+        "toolWarnings": [],
+        "tools": [
+          {
+            "function": {
+              "description": "A test function",
+              "name": "testFunction",
+              "parameters": {
+                "properties": {},
+                "type": "object",
+              },
+            },
+            "type": "function",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should add warnings for provider-defined tools', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'provider',
+          id: 'xai.unsupported_tool',
+          name: 'unsupported_tool',
+          args: {},
+        },
+      ],
+    });
+
+    expect(result.tools).toEqual([]);
+    expect(result.toolChoice).toBeUndefined();
+    expect(result.toolWarnings).toMatchInlineSnapshot(`
+      [
+        {
+          "feature": "provider-defined tool unsupported_tool",
+          "type": "unsupported",
+        },
+      ]
+    `);
+  });
+
+  it('should handle multiple tools including provider-defined and function tools', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'calculator',
+          description: 'calculate numbers',
+          inputSchema: { type: 'object', properties: {} },
+        },
+        {
+          type: 'provider',
+          id: 'xai.some_tool',
+          name: 'some_tool',
+          args: {},
+        },
+        {
+          type: 'function',
+          name: 'weather',
+          description: 'get weather',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+    });
+
+    expect(result.tools).toHaveLength(2);
+    expect(result.tools![0].function.name).toBe('calculator');
+    expect(result.tools![1].function.name).toBe('weather');
+    expect(result.toolWarnings).toHaveLength(1);
+    expect(result.toolWarnings[0]).toEqual({
+      type: 'unsupported',
+      feature: 'provider-defined tool some_tool',
+    });
+  });
+
+  describe('tool choice', () => {
+    it('should handle tool choice "auto"', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'Test',
+            inputSchema: {},
+          },
+        ],
+        toolChoice: { type: 'auto' },
+      });
+      expect(result.toolChoice).toBe('auto');
+    });
+
+    it('should handle tool choice "none"', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'Test',
+            inputSchema: {},
+          },
+        ],
+        toolChoice: { type: 'none' },
+      });
+      expect(result.toolChoice).toBe('none');
+    });
+
+    it('should handle tool choice "required"', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'Test',
+            inputSchema: {},
+          },
+        ],
+        toolChoice: { type: 'required' },
+      });
+      expect(result.toolChoice).toBe('required');
+    });
+
+    it('should handle tool choice "tool"', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'Test',
+            inputSchema: {},
+          },
+        ],
+        toolChoice: { type: 'tool', toolName: 'testFunction' },
+      });
+      expect(result.toolChoice).toEqual({
+        type: 'function',
+        function: { name: 'testFunction' },
+      });
+    });
+
+    it('should return undefined toolChoice when toolChoice is not provided', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'Test',
+            inputSchema: {},
+          },
+        ],
+      });
+      expect(result.toolChoice).toBeUndefined();
+    });
+  });
+
+  describe('strict mode for function tools', () => {
+    it('should pass through strict mode when strict is true', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "function": {
+                "description": "A test function",
+                "name": "testFunction",
+                "parameters": {
+                  "properties": {},
+                  "type": "object",
+                },
+                "strict": true,
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('should pass through strict mode when strict is false', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: false,
+          },
+        ],
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "function": {
+                "description": "A test function",
+                "name": "testFunction",
+                "parameters": {
+                  "properties": {},
+                  "type": "object",
+                },
+                "strict": false,
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('should not include strict when strict is undefined', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      });
+
+      const functionDef = result.tools![0].function;
+      expect(functionDef).not.toHaveProperty('strict');
+    });
+
+    it('should pass through strict mode for multiple tools with different strict settings', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'strictTool',
+            description: 'A strict tool',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+          {
+            type: 'function',
+            name: 'nonStrictTool',
+            description: 'A non-strict tool',
+            inputSchema: { type: 'object', properties: {} },
+            strict: false,
+          },
+          {
+            type: 'function',
+            name: 'defaultTool',
+            description: 'A tool without strict setting',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "function": {
+                "description": "A strict tool",
+                "name": "strictTool",
+                "parameters": {
+                  "properties": {},
+                  "type": "object",
+                },
+                "strict": true,
+              },
+              "type": "function",
+            },
+            {
+              "function": {
+                "description": "A non-strict tool",
+                "name": "nonStrictTool",
+                "parameters": {
+                  "properties": {},
+                  "type": "object",
+                },
+                "strict": false,
+              },
+              "type": "function",
+            },
+            {
+              "function": {
+                "description": "A tool without strict setting",
+                "name": "defaultTool",
+                "parameters": {
+                  "properties": {},
+                  "type": "object",
+                },
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+  });
+});

--- a/packages/xai/src/xai-prepare-tools.ts
+++ b/packages/xai/src/xai-prepare-tools.ts
@@ -19,6 +19,7 @@ export function prepareTools({
           name: string;
           description: string | undefined;
           parameters: unknown;
+          strict?: boolean;
         };
       }>
     | undefined;
@@ -41,6 +42,7 @@ export function prepareTools({
       name: string;
       description: string | undefined;
       parameters: unknown;
+      strict?: boolean;
     };
   }> = [];
 
@@ -57,6 +59,7 @@ export function prepareTools({
           name: tool.name,
           description: tool.description,
           parameters: tool.inputSchema,
+          ...(tool.strict != null ? { strict: tool.strict } : {}),
         },
       });
     }


### PR DESCRIPTION
## Background

as a follow up to https://github.com/vercel/ai/issues/12766, we were ignoring the strict mode for tools for the xai provider

## Summary

ensure choice for strict mode on tools isn't ignored for both: 
- responses api
- chat api

## Manual Verification

verified by running the example `examples/ai-functions/src/generate-text/xai/strict-tool-call.ts`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] na ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)