### PR TITLE
docs(contributing): add pre-release cycle documentation

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,7 @@
-# Backport pull requests to the latest stable release branch
-# by adding a "backport" label to pull request against the
-# main branch. The label can be added before or after merging.
+# Backport pull requests to the next-older release branch by adding
+# a "backport" label. Works on PRs against `main` (targets the latest
+# release-v* branch) and on PRs against `release-v*` branches
+# (targets the next-older release-v* branch).
 
 name: Backport
 
@@ -9,6 +10,7 @@ on:
     types: [closed, labeled]
     branches:
       - main
+      - release-v*
 
 concurrency: ${{ github.workflow }}-${{ github.event.pull_request.number }}
 
@@ -18,17 +20,15 @@ permissions:
 
 jobs:
   find-branch:
-    name: Find latest release branch
+    name: Find target release branch
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Only run when backport label is present and PR is merged in main repository
     if: |
       github.repository_owner == 'vercel' &&
       github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'backport') &&
-      github.event.pull_request.base.ref == 'main'
+      contains(github.event.pull_request.labels.*.name, 'backport')
     outputs:
-      release-branch: ${{ steps.find-latest-release.outputs.release-branch }}
+      release-branch: ${{ steps.find-target.outputs.release-branch }}
 
     steps:
       - name: Checkout Repository
@@ -36,13 +36,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Find latest release branch
-        id: find-latest-release
+      - name: Find target release branch
+        id: find-target
         run: |
-          # Fetch all remote branches
           git fetch --all
 
-          # Find all release branches matching the pattern release-vX.Y
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
           RELEASE_BRANCHES=$(git branch -r | grep -E 'origin/release-v[0-9]+\.[0-9]+$' | sed 's/.*origin\///' | sort -V)
 
           if [ -z "$RELEASE_BRANCHES" ]; then
@@ -50,24 +49,30 @@ jobs:
             exit 1
           fi
 
-          # Get the latest release branch (last in sorted order)
-          LATEST_RELEASE=$(echo "$RELEASE_BRANCHES" | tail -n 1)
-
           echo "Found release branches: $RELEASE_BRANCHES"
-          echo "Latest release branch: $LATEST_RELEASE"
-          echo "release-branch=$LATEST_RELEASE" >> "$GITHUB_OUTPUT"
+
+          if [ "$BASE_REF" = "main" ]; then
+            TARGET=$(echo "$RELEASE_BRANCHES" | tail -n 1)
+          else
+            TARGET=$(echo "$RELEASE_BRANCHES" | grep -B1 "^${BASE_REF}$" | head -n 1)
+            if [ "$TARGET" = "$BASE_REF" ] || [ -z "$TARGET" ]; then
+              echo "::error::No older release branch found before $BASE_REF"
+              exit 1
+            fi
+          fi
+
+          echo "Target release branch: $TARGET"
+          echo "release-branch=$TARGET" >> "$GITHUB_OUTPUT"
 
   backport:
     name: Backport to ${{ needs.find-branch.outputs.release-branch }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: find-branch
-    # Only run on merged PRs with backport label in the main repository
     if: |
       github.repository_owner == 'vercel' &&
       github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'backport') &&
-      github.event.pull_request.base.ref == 'main'
+      contains(github.event.pull_request.labels.*.name, 'backport')
 
     steps:
       - name: Create access token for GitHub App

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,7 @@ For a focused conceptual walkthrough of AI functions, model specifications, and 
 | Provider architecture | `contributing/provider-architecture.md` |
 | Building new features | `contributing/building-new-features.md` |
 | Codemods              | `contributing/codemods.md`              |
+| Pre-release cycle     | `contributing/pre-release-cycle.md`     |
 
 ## Changesets
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,6 @@ For a focused conceptual walkthrough of AI functions, model specifications, and 
 | Provider architecture | `contributing/provider-architecture.md` |
 | Building new features | `contributing/building-new-features.md` |
 | Codemods              | `contributing/codemods.md`              |
-| Pre-release cycle     | `contributing/pre-release-cycle.md`     |
 
 ## Changesets
 

--- a/contributing/pre-release-cycle.md
+++ b/contributing/pre-release-cycle.md
@@ -64,7 +64,21 @@ Every major release introduces a new provider specification version (e.g. V3 to 
 
 Create V4 counterparts for every mock file in `packages/ai/src/test/` (e.g. `mock-language-model-v3.ts` → `mock-language-model-v4.ts`). Update `packages/ai/test/index.ts` to export the new V4 mocks.
 
-### 6. Merge to `main`
+### 6. Set up the documentation site (ai-sdk.dev)
+
+The documentation site lives in the `ai-studio` repository and uses a Git submodule pointing at this repository. During the pre-release cycle the site needs versioned branches and Vercel deployments for both stable and beta docs.
+
+In the `vercel/ai` repository:
+
+1. Update `.github/workflows/update-sdk-submodule-v6.yml` to track the `release-v6.0` branch instead of `main`.
+2. Create `.github/workflows/update-sdk-submodule-v7.yml` — this workflow fetches `main`, checks out the `sdk/v7` branch in `ai-studio`, and pushes to `origin sdk/v7`.
+
+In the `ai-studio` repository:
+
+3. Create a `sdk/v7` branch (the default branch stays `sdk/v6` for now so the production site continues serving stable docs).
+4. In Vercel, create a v7 preview deployment connected to the `sdk/v7` branch (e.g. `v7.ai-sdk.dev`).
+
+### 7. Merge to `main`
 
 Open a PR with all the changes from steps 2-5. Once merged, the first beta release (e.g. `ai@7.0.0-beta.1`) will be published automatically.
 
@@ -101,6 +115,10 @@ This removes `.changeset/pre.json`. Commit and push (or open a PR).
 
 Once the exit-PR is merged, the next **Version Packages** PR will produce stable versions (e.g. `ai@7.0.0`). Merge it to publish.
 
-### 3. Archive the maintenance branch
+### 3. Switch the documentation site
+
+In the `ai-studio` repository, change the default branch from `sdk/v6` to `sdk/v7` so the production site serves the new major version. Update the Vercel production deployment accordingly.
+
+### 4. Archive the maintenance branch
 
 The maintenance branch (e.g. `release-v6.0`) can remain for emergency patches but will no longer receive regular backports.

--- a/contributing/pre-release-cycle.md
+++ b/contributing/pre-release-cycle.md
@@ -1,0 +1,101 @@
+# Pre-Release Cycle
+
+This guide explains how to start and end a pre-release (beta) cycle for a new major version of the AI SDK.
+
+## Overview
+
+A pre-release cycle lets us develop the next major version on `main` while keeping the current stable version available for patches. During the cycle:
+
+- `main` publishes beta releases (e.g. `ai@7.0.0-beta.1`)
+- A maintenance branch (e.g. `release-v6.0`) receives backported patches and publishes stable releases
+
+## Starting a Pre-Release Cycle
+
+### 1. Create a maintenance branch
+
+Create a branch from the current `main` HEAD so the current stable version can continue receiving patches:
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b release-v<current-major>.0   # e.g. release-v6.0
+git push origin release-v<current-major>.0
+```
+
+The [release workflow](../.github/workflows/release.yml) already runs on `release-v*` branches, so no workflow changes are needed.
+
+### 2. Enter pre-release mode on `main`
+
+Switch back to `main` and enter changeset pre-release mode:
+
+```bash
+git checkout main
+pnpm changeset pre enter beta
+```
+
+This modifies `.changeset/pre.json`. Commit and push the change (or open a PR).
+
+### 3. Create a major changeset
+
+Create a changeset that bumps every published package to the next major version:
+
+```bash
+pnpm changeset
+```
+
+Select **all** published packages and choose `major` for each. Write a summary like:
+
+> Start v7 pre-release
+
+Commit the generated `.changeset/*.md` file.
+
+### 4. Seed the new spec version (if applicable)
+
+If the major bump includes a new provider specification version (e.g. V3 to V4):
+
+1. Copy the current spec directory (e.g. `packages/provider/src/language-model/v3/`) to a new version directory (e.g. `v4/`).
+2. Rename all types from the old version to the new version (e.g. `LanguageModelV3` to `LanguageModelV4`).
+3. Update the `specificationVersion` literal from `'v3'` to `'v4'`.
+4. Add the new version directory to the parent `index.ts` exports.
+5. Create corresponding mock test utilities in `packages/ai/src/test/` for the new spec version.
+
+### 5. Merge to `main`
+
+Open a PR with all the changes from steps 2-4. Once merged, the first beta release (e.g. `ai@7.0.0-beta.1`) will be published automatically.
+
+## During the Pre-Release Cycle
+
+### Day-to-day development
+
+- All feature PRs continue to target `main`.
+- Every PR still needs a changeset (use `patch` by default).
+- Beta versions are published automatically when the **Version Packages** PR is merged.
+
+### Backporting fixes to stable
+
+To backport a fix from `main` to the maintenance branch, add the `backport` label to the merged PR. This creates a new PR targeting the maintenance branch automatically.
+
+### Publishing stable patches
+
+Patches merged into the maintenance branch trigger the release workflow and publish stable patch releases.
+
+## Ending the Pre-Release Cycle
+
+When the new major version is ready for stable release:
+
+### 1. Exit pre-release mode
+
+```bash
+git checkout main
+pnpm changeset pre exit
+```
+
+This removes `.changeset/pre.json`. Commit and push (or open a PR).
+
+### 2. Publish the stable release
+
+Once the exit-PR is merged, the next **Version Packages** PR will produce stable versions (e.g. `ai@7.0.0`). Merge it to publish.
+
+### 3. Archive the maintenance branch
+
+The maintenance branch (e.g. `release-v6.0`) can remain for emergency patches but will no longer receive regular backports.

--- a/contributing/pre-release-cycle.md
+++ b/contributing/pre-release-cycle.md
@@ -35,7 +35,7 @@ git checkout main
 pnpm changeset pre enter beta
 ```
 
-This modifies `.changeset/pre.json`. Commit and push the change (or open a PR).
+This modifies `.changeset/pre.json`. Remove any `@example/*` packages from the `initialVersions` field — example packages are private and should not be tracked in pre-release mode. Commit and push the change (or open a PR).
 
 ### 3. Create a major changeset
 
@@ -45,7 +45,7 @@ Create a changeset that bumps every published package to the next major version:
 pnpm changeset
 ```
 
-Select **all** published packages and choose `major` for each. Write a summary like:
+Select all published packages (skip `@example/*` packages — they are private and not published) and choose `major` for each. Write a summary like:
 
 > Start v7 pre-release
 

--- a/contributing/pre-release-cycle.md
+++ b/contributing/pre-release-cycle.md
@@ -53,17 +53,20 @@ Commit the generated `.changeset/*.md` file.
 
 ### 4. Seed the new spec version
 
-Every major release introduces a new provider specification version (e.g. V3 to V4):
+Every major release introduces a new provider specification version (e.g. V3 to V4). Repeat the following for **every** versioned spec directory under `packages/provider/src/` (language-model, embedding-model, image-model, speech-model, transcription-model, video-model, reranking-model, provider, shared, and all middleware types):
 
-1. Copy the current spec directory (e.g. `packages/provider/src/language-model/v3/`) to a new version directory (e.g. `v4/`).
+1. Copy the current spec directory (e.g. `v3/`) to a new version directory (e.g. `v4/`).
 2. Rename all types from the old version to the new version (e.g. `LanguageModelV3` to `LanguageModelV4`).
 3. Update the `specificationVersion` literal from `'v3'` to `'v4'`.
 4. Add the new version directory to the parent `index.ts` exports.
-5. Create corresponding mock test utilities in `packages/ai/src/test/` for the new spec version.
 
-### 5. Merge to `main`
+### 5. Create mock test utilities
 
-Open a PR with all the changes from steps 2-4. Once merged, the first beta release (e.g. `ai@7.0.0-beta.1`) will be published automatically.
+Create V4 counterparts for every mock file in `packages/ai/src/test/` (e.g. `mock-language-model-v3.ts` → `mock-language-model-v4.ts`). Update `packages/ai/test/index.ts` to export the new V4 mocks.
+
+### 6. Merge to `main`
+
+Open a PR with all the changes from steps 2-5. Once merged, the first beta release (e.g. `ai@7.0.0-beta.1`) will be published automatically.
 
 ## During the Pre-Release Cycle
 

--- a/contributing/pre-release-cycle.md
+++ b/contributing/pre-release-cycle.md
@@ -4,6 +4,8 @@ This guide explains how to start and end a pre-release (beta) cycle for a new ma
 
 ## Overview
 
+Every major release of the AI SDK introduces a new provider specification version (e.g. V3 to V4). Evolving the spec is the reason we do major releases — it lets us make breaking changes to the provider interface while giving provider authors a clear migration target.
+
 A pre-release cycle lets us develop the next major version on `main` while keeping the current stable version available for patches. During the cycle:
 
 - `main` publishes beta releases (e.g. `ai@7.0.0-beta.1`)
@@ -49,9 +51,9 @@ Select **all** published packages and choose `major` for each. Write a summary l
 
 Commit the generated `.changeset/*.md` file.
 
-### 4. Seed the new spec version (if applicable)
+### 4. Seed the new spec version
 
-If the major bump includes a new provider specification version (e.g. V3 to V4):
+Every major release introduces a new provider specification version (e.g. V3 to V4):
 
 1. Copy the current spec directory (e.g. `packages/provider/src/language-model/v3/`) to a new version directory (e.g. `v4/`).
 2. Rename all types from the old version to the new version (e.g. `LanguageModelV3` to `LanguageModelV4`).

--- a/contributing/releases.md
+++ b/contributing/releases.md
@@ -21,21 +21,12 @@ We use [changesets](https://github.com/changesets/action) for automated releases
   1. Create a pull request against the maintenance branch.
   2. Merge it to trigger the release workflow.
 
-## Beta Releases
+## Beta / Pre-Release Cycle
 
-- Create a maintenance branch for the current stable minor version (e.g., if latest is `5.0.24`, create `release-v5.0`).
-- Switch `main` branch to beta release mode:
+For starting and managing a major-version pre-release cycle (beta releases on `main` while maintaining stable patches), see **[Pre-Release Cycle](./pre-release-cycle.md)**.
 
-  ```bash
-  pnpm changeset pre enter beta
-  ```
+Quick reference:
 
-  (This creates a PR like #8710).
-
-- During beta: All PRs continue to target main.
-- In order to backport pull requests to the stable release, add the `backport` label. This will create a new pull request with the same changes against the stable release branch.
-- To exit the beta release mode, run:
-
-  ```bash
-  pnpm changeset pre exit
-  ```
+- Enter beta mode: `pnpm changeset pre enter beta`
+- Exit beta mode: `pnpm changeset pre exit`
+- Backport fixes: add the `backport` label to the merged PR


### PR DESCRIPTION
## Summary

- Add `contributing/pre-release-cycle.md` with detailed documentation for starting, managing, and ending a major-version pre-release cycle (beta releases on `main` while maintaining stable patches on a release branch)
- Update `contributing/releases.md` to reference the new guide instead of inline beta instructions
- Add the new guide to the contributing guides table in `CLAUDE.md`
- update backport workflow to work on release branches

## Context

This documents the process ahead of the v7 pre-release cycle so the steps are well-defined and reusable for future major versions.