### PR TITLE
feat(openai): add context_management support for responses API

### DIFF
--- a/.changeset/metal-adults-tap.md
+++ b/.changeset/metal-adults-tap.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): add context_management support for responses API

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1045,6 +1045,52 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send contextManagement provider option', async () => {
+        const { warnings } = await createModel('gpt-5').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              contextManagement: [
+                { type: 'compaction', compactThreshold: 50000 },
+              ],
+            },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-5',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          context_management: [
+            { type: 'compaction', compact_threshold: 50000 },
+          ],
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
+      it('should send contextManagement without compactThreshold', async () => {
+        const { warnings } = await createModel('gpt-5').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              contextManagement: [{ type: 'compaction' }],
+            },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-5',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          context_management: [{ type: 'compaction' }],
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should send safetyIdentifier provider option', async () => {
         const { warnings } = await createModel('gpt-5').doGenerate({
           prompt: TEST_PROMPT,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -320,6 +320,12 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       }),
 
       // provider options:
+      context_management: openaiOptions?.contextManagement?.map(entry => ({
+        type: entry.type,
+        ...(entry.compactThreshold != null && {
+          compact_threshold: entry.compactThreshold,
+        }),
+      })),
       conversation: openaiOptions?.conversation,
       max_tool_calls: openaiOptions?.maxToolCalls,
       metadata: openaiOptions?.metadata,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -320,14 +320,12 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       }),
 
       // provider options:
-      ...(openaiOptions?.contextManagement != null && {
-        context_management: openaiOptions.contextManagement.map(entry => ({
-          type: entry.type,
-          ...(entry.compactThreshold != null && {
-            compact_threshold: entry.compactThreshold,
-          }),
-        })),
-      }),
+      context_management: openaiOptions?.contextManagement?.map(entry => ({
+        type: entry.type,
+        ...(entry.compactThreshold != null && {
+          compact_threshold: entry.compactThreshold,
+        }),
+      })),
       conversation: openaiOptions?.conversation,
       max_tool_calls: openaiOptions?.maxToolCalls,
       metadata: openaiOptions?.metadata,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -320,12 +320,14 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       }),
 
       // provider options:
-      context_management: openaiOptions?.contextManagement?.map(entry => ({
-        type: entry.type,
-        ...(entry.compactThreshold != null && {
-          compact_threshold: entry.compactThreshold,
-        }),
-      })),
+      ...(openaiOptions?.contextManagement != null && {
+        context_management: openaiOptions.contextManagement.map(entry => ({
+          type: entry.type,
+          ...(entry.compactThreshold != null && {
+            compact_threshold: entry.compactThreshold,
+          }),
+        })),
+      }),
       conversation: openaiOptions?.conversation,
       max_tool_calls: openaiOptions?.maxToolCalls,
       metadata: openaiOptions?.metadata,

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -120,6 +120,22 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
   zodSchema(
     z.object({
       /**
+       * Configuration for context management, including compaction rules.
+       * Currently only the `compaction` type is supported, which triggers
+       * automatic context compaction when token usage exceeds the threshold.
+       *
+       * @see https://platform.openai.com/docs/api-reference/responses/create#responses-create-context_management
+       */
+      contextManagement: z
+        .array(
+          z.object({
+            type: z.string(),
+            compactThreshold: z.number().nullish(),
+          }),
+        )
+        .nullish(),
+
+      /**
        * The ID of the OpenAI Conversation to continue.
        * You must create a conversation first via the OpenAI API.
        * Cannot be used in conjunction with `previousResponseId`.


### PR DESCRIPTION
## Summary

Adds `contextManagement` provider option to the OpenAI responses provider, enabling automatic context compaction for long conversations.

### Changes
- **`openai-responses-options.ts`**: Add `contextManagement` to the provider options schema — an array of `{ type: string, compactThreshold?: number }` entries
- **`openai-responses-language-model.ts`**: Map `contextManagement` to `context_management` in the API request body with camelCase → snake_case conversion (`compactThreshold` → `compact_threshold`)

### Usage
```ts
const result = await generateText({
  model: openai.responses('gpt-5.3-codex'),
  prompt: 'hello',
  providerOptions: {
    openai: {
      contextManagement: [
        { type: 'compaction', compactThreshold: 50000 }
      ],
    },
  },
});
```

### Notes
- Azure gets this for free since its responses provider delegates to `OpenAIResponsesLanguageModel` and falls back to `providerOptions.openai`
- Currently only the `compaction` type is supported by OpenAI, but the schema accepts any string type for forward compatibility