### PR TITLE
fix(openai-compat): decode base64 string data

### DIFF
--- a/.changeset/fifty-beers-scream.md
+++ b/.changeset/fifty-beers-scream.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/anthropic': patch
+---
+
+fix(openai-compat): decode base64 string data

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -7,6 +7,7 @@ import {
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import {
+  convertBase64ToUint8Array,
   convertToBase64,
   parseProviderOptions,
   validateTypes,
@@ -31,7 +32,7 @@ import { webSearch_20250305OutputSchema } from './tool/web-search_20250305';
 
 function convertToString(data: LanguageModelV3DataContent): string {
   if (typeof data === 'string') {
-    return Buffer.from(data, 'base64').toString('utf-8');
+    return new TextDecoder().decode(convertBase64ToUint8Array(data));
   }
 
   if (data instanceof Uint8Array) {

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -295,7 +295,10 @@ describe('user messages', () => {
     ).toThrow("'PDF file parts with URLs' functionality not supported");
   });
 
-  it('should convert messages with text/markdown parts', async () => {
+  it('should convert messages with base64-encoded text/markdown parts', async () => {
+    const markdownText = '# Hello World\n\nThis is **markdown** content.';
+    const base64Data = btoa(markdownText);
+
     const result = convertToOpenAICompatibleChatMessages([
       {
         role: 'user',
@@ -303,7 +306,7 @@ describe('user messages', () => {
           { type: 'text', text: 'Summarize this document' },
           {
             type: 'file',
-            data: '# Hello World\n\nThis is **markdown** content.',
+            data: base64Data,
             mediaType: 'text/markdown',
           },
         ],
@@ -317,7 +320,7 @@ describe('user messages', () => {
           { type: 'text', text: 'Summarize this document' },
           {
             type: 'text',
-            text: '# Hello World\n\nThis is **markdown** content.',
+            text: markdownText,
           },
         ],
       },
@@ -333,6 +336,33 @@ describe('user messages', () => {
           {
             type: 'file',
             data: encoder.encode('Plain text content'),
+            mediaType: 'text/plain',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Plain text content',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should decode base64 string data for text/* file parts', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: Buffer.from('Plain text content').toString('base64'),
             mediaType: 'text/plain',
           },
         ],

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -4,7 +4,10 @@ import {
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { OpenAICompatibleChatPrompt } from './openai-compatible-api-types';
-import { convertToBase64 } from '@ai-sdk/provider-utils';
+import {
+  convertBase64ToUint8Array,
+  convertToBase64,
+} from '@ai-sdk/provider-utils';
 
 function getOpenAIMetadata(message: {
   providerOptions?: SharedV3ProviderMetadata;
@@ -119,7 +122,9 @@ export function convertToOpenAICompatibleChatMessages(
                     part.data instanceof URL
                       ? part.data.toString()
                       : typeof part.data === 'string'
-                        ? part.data
+                        ? new TextDecoder().decode(
+                            convertBase64ToUint8Array(part.data),
+                          )
                         : new TextDecoder().decode(part.data);
 
                   return {


### PR DESCRIPTION
## Background

reported in issue #12965

we decoded the base64 data properly in the anthropic provider but not in openai-compat

## Summary

- added `convertBase64ToUint8Array` to properly decode the string before converting to text
- replaced `Buffer.from(data, 'base64').toString('utf-8')` with the edge-runtime-safe equivalent using `convertBase64ToUint8Array`

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #12965 