### PR TITLE
feat(gateway): add providerTimeouts to provider options

### DIFF
--- a/.changeset/quick-lemons-sleep.md
+++ b/.changeset/quick-lemons-sleep.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(gateway): add providerTimeouts to provider options

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -631,6 +631,14 @@ The following gateway provider options are available:
 
   Restricts routing requests to providers that have zero data retention policies.
 
+- **providerTimeouts** _object_
+
+  Per-provider timeouts for BYOK credentials in milliseconds. Controls how long to wait for a provider to start responding before falling back to the next available provider.
+
+  Example: `providerTimeouts: { byok: { openai: 5000, anthropic: 2000 } }`
+
+  For full details, see [Provider Timeouts](https://vercel.com/docs/ai-gateway/models-and-providers/provider-timeouts).
+
 You can combine these options to have fine-grained control over routing and tracking:
 
 ```ts

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1481,5 +1481,59 @@ describe('GatewayLanguageModel', () => {
         gateway: { order: ['anthropic', 'bedrock', 'openai'] },
       });
     });
+
+    it('should pass providerTimeouts for doGenerate', async () => {
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Test response' },
+      });
+
+      await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          gateway: {
+            providerTimeouts: {
+              byok: { openai: 5000, anthropic: 2000 },
+            },
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        gateway: {
+          providerTimeouts: {
+            byok: { openai: 5000, anthropic: 2000 },
+          },
+        },
+      });
+    });
+
+    it('should pass providerTimeouts for doStream', async () => {
+      prepareStreamResponse({
+        content: ['Hello', ' world'],
+      });
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          gateway: {
+            providerTimeouts: {
+              byok: { anthropic: 3000 },
+            },
+          },
+        },
+      });
+
+      await convertReadableStreamToArray(stream);
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        gateway: {
+          providerTimeouts: {
+            byok: { anthropic: 3000 },
+          },
+        },
+      });
+    });
   });
 });

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -59,6 +59,20 @@ const gatewayLanguageModelOptions = lazySchema(() =>
        * used.
        */
       zeroDataRetention: z.boolean().optional(),
+      /**
+       * Per-provider timeouts for BYOK credentials to trigger fast failover
+       * when a provider is slow to respond. Values are in milliseconds.
+       *
+       * If a provider doesn't start responding within the configured timeout,
+       * the request is aborted and falls back to the next available provider.
+       *
+       * Example: `{ byok: { openai: 5000, anthropic: 2000 } }`
+       */
+      providerTimeouts: z
+        .object({
+          byok: z.record(z.string(), z.number().int().min(100)).optional(),
+        })
+        .optional(),
     }),
   ),
 );

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -70,7 +70,7 @@ const gatewayLanguageModelOptions = lazySchema(() =>
        */
       providerTimeouts: z
         .object({
-          byok: z.record(z.string(), z.number().int().min(100)).optional(),
+          byok: z.record(z.string(), z.number().int().min(1000)).optional(),
         })
         .optional(),
     }),

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -60,11 +60,9 @@ const gatewayLanguageModelOptions = lazySchema(() =>
        */
       zeroDataRetention: z.boolean().optional(),
       /**
-       * Per-provider timeouts for BYOK credentials to trigger fast failover
-       * when a provider is slow to respond. Values are in milliseconds.
-       *
-       * If a provider doesn't start responding within the configured timeout,
-       * the request is aborted and falls back to the next available provider.
+       * Per-provider timeouts for BYOK credentials in milliseconds.
+       * Controls how long to wait for a provider to start responding
+       * before falling back to the next available provider.
        *
        * Example: `{ byok: { openai: 5000, anthropic: 2000 } }`
        */


### PR DESCRIPTION
## Summary

Adds `providerTimeouts` to the gateway provider options schema for type safety and autocomplete support.

This enables per-provider BYOK credential timeouts to trigger fast failover when a provider is slow to respond.

```ts
providerOptions: {
  gateway: {
    providerTimeouts: {
      byok: { openai: 5000, anthropic: 2000 },
    },
  },
}
```

Companion to https://github.com/vercel/ai-gateway/pull/1307

## Test plan

- [x] `pnpm test:node` passes (326 tests)