### PR TITLE
fix(anthropic): reorder assistant content so server_tool_use/web_search_tool_result appear before tool_use

### DIFF
--- a/.changeset/fix-anthropic-server-tool-ordering.md
+++ b/.changeset/fix-anthropic-server-tool-ordering.md
@@ -1,0 +1,12 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): reorder assistant content so server_tool_use/web_search_tool_result appear before tool_use
+
+When the model calls both a provider-executed tool (web_search, code_execution)
+and a regular tool in the same turn, the Anthropic API requires that
+server_tool_use + web_search_tool_result blocks appear before regular tool_use
+blocks. Previously, content was pushed in insertion order, which could place
+server_tool_use/web_search_tool_result after tool_use and cause the API to
+return "tool_use ids were found without tool_result blocks immediately after".

--- a/packages/anthropic/src/__fixtures__/anthropic-web-search-with-tool.1.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-web-search-with-tool.1.chunks.txt
@@ -1,0 +1,16 @@
+{"type":"message_start","message":{"id":"msg_01TestWebAndRegularTool","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":80,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}}
+{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I'll save the results and search for the latest news."}}
+{"type":"content_block_stop","index":0}
+{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01SaveResults","name":"save_results","input":{}}}
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"filename\": \"news.txt\"}"}}
+{"type":"content_block_stop","index":1}
+{"type":"content_block_start","index":2,"content_block":{"type":"server_tool_use","id":"srvtoolu_01WebSearch","name":"web_search","input":{}}}
+{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"query\": \"latest news\"}"}}
+{"type":"content_block_stop","index":2}
+{"type":"content_block_start","index":3,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtoolu_01WebSearch","content":[{"type":"web_search_result","title":"Breaking News Today","url":"https://example.com/news","encrypted_content":"EqMBCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDA==","page_age":"1 hour ago"}]}}
+{"type":"content_block_stop","index":3}
+{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":60}}
+{"type":"message_stop"}

--- a/packages/anthropic/src/__fixtures__/anthropic-web-search-with-tool.1.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-web-search-with-tool.1.json
@@ -1,0 +1,45 @@
+{
+  "id": "msg_01TestWebAndRegularTool",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4-20250514",
+  "content": [
+    {
+      "type": "text",
+      "text": "I'll save the results and search for the latest news."
+    },
+    {
+      "type": "tool_use",
+      "id": "toolu_01SaveResults",
+      "name": "save_results",
+      "input": { "filename": "news.txt" }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01WebSearch",
+      "name": "web_search",
+      "input": { "query": "latest news" }
+    },
+    {
+      "type": "web_search_tool_result",
+      "tool_use_id": "srvtoolu_01WebSearch",
+      "content": [
+        {
+          "type": "web_search_result",
+          "url": "https://example.com/news",
+          "title": "Breaking News Today",
+          "encrypted_content": "EqMBCioICBgCIiRiY2JjZWJjMy1lYTFhLTRmNjktYTUwMy01YzgwNWU1Y2U0NzESDA==",
+          "page_age": "1 hour ago"
+        }
+      ]
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 80,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "output_tokens": 60
+  }
+}

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -3103,4 +3103,90 @@ describe('citations', () => {
       `);
     });
   });
+
+  it('should reorder assistant content so server_tool_use+web_search_tool_result come before tool_use', async () => {
+    // When the model calls both a provider-executed tool (web_search) and a
+    // regular tool in the same turn, the resulting anthropicContent array may
+    // have server_tool_use / web_search_tool_result interspersed after tool_use.
+    // The Anthropic API requires tool_use to be last; this test verifies the
+    // reordering.
+    const warnings: SharedV3Warning[] = [];
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Search and save news.' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: "I'll search and call the schema tool." },
+            {
+              type: 'tool-call',
+              toolCallId: 'toolu_01Regular',
+              toolName: 'get_table_schema',
+              input: {},
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'srvtoolu_01Web',
+              toolName: 'web_search',
+              input: { query: 'news' },
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'srvtoolu_01Web',
+              toolName: 'web_search',
+              output: {
+                type: 'json',
+                value: [
+                  {
+                    type: 'web_search_result',
+                    url: 'https://example.com',
+                    title: 'News',
+                    pageAge: '1h',
+                    encryptedContent: 'enc123',
+                  },
+                ],
+              },
+              providerExecuted: true,
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'toolu_01Regular',
+              toolName: 'get_table_schema',
+              output: { type: 'json', value: { columns: [] } },
+            },
+          ],
+        },
+      ],
+      sendReasoning: false,
+      warnings,
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    const assistantMsg = result.messages.find(m => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+
+    const types = (assistantMsg!.content as Array<{ type: string }>).map(
+      c => c.type,
+    );
+
+    // server_tool_use and web_search_tool_result must come BEFORE tool_use
+    const toolUseIdx = types.indexOf('tool_use');
+    const serverToolUseIdx = types.indexOf('server_tool_use');
+    const webSearchResultIdx = types.indexOf('web_search_tool_result');
+
+    expect(toolUseIdx).toBeGreaterThan(-1);
+    expect(serverToolUseIdx).toBeGreaterThan(-1);
+    expect(webSearchResultIdx).toBeGreaterThan(-1);
+    expect(serverToolUseIdx).toBeLessThan(toolUseIdx);
+    expect(webSearchResultIdx).toBeLessThan(toolUseIdx);
+  });
 });

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -3171,7 +3171,9 @@ describe('citations', () => {
       toolNameMapping: defaultToolNameMapping,
     });
 
-    const assistantMsg = result.messages.find(m => m.role === 'assistant');
+    const assistantMsg = result.prompt.messages.find(
+      m => m.role === 'assistant',
+    );
     expect(assistantMsg).toBeDefined();
 
     const types = (assistantMsg!.content as Array<{ type: string }>).map(

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -3105,11 +3105,23 @@ describe('citations', () => {
   });
 
   it('should reorder assistant content so server_tool_use+web_search_tool_result come before tool_use', async () => {
-    // When the model calls both a provider-executed tool (web_search) and a
-    // regular tool in the same turn, the resulting anthropicContent array may
-    // have server_tool_use / web_search_tool_result interspersed after tool_use.
-    // The Anthropic API requires tool_use to be last; this test verifies the
-    // reordering.
+    // Regression test for https://github.com/vercel/ai/issues/13013.
+    //
+    // The Anthropic API can return a response in which a regular tool_use
+    // block appears at an earlier index than server_tool_use /
+    // web_search_tool_result in the same turn.  The raw streaming format that
+    // triggers this is captured in:
+    //   packages/anthropic/src/__fixtures__/anthropic-web-search-with-tool.1.chunks.txt
+    //
+    // When parsed, the AI SDK represents the response as the `role: 'assistant'`
+    // content below (tool-call for save_results at index 1, server tool-call
+    // and tool-result for web_search at indices 2-3).  This prompt is what
+    // `convertToAnthropicMessagesPrompt` receives when building the next turn.
+    //
+    // The Anthropic API then rejects the request with
+    // "tool_use ids were found without tool_result blocks immediately after"
+    // unless tool_use appears LAST in the assistant message content.
+    // This test verifies the reordering fix.
     const warnings: SharedV3Warning[] = [];
     const result = await convertToAnthropicMessagesPrompt({
       prompt: [

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -997,7 +997,37 @@ export async function convertToAnthropicMessagesPrompt({
           }
         }
 
-        messages.push({ role: 'assistant', content: anthropicContent });
+        // Reorder assistant content so server_tool_use + web_search_tool_result
+        // blocks appear before regular tool_use blocks. The Anthropic API
+        // requires that tool_use items (which have their tool_result in the
+        // subsequent user message) come last in the assistant turn content.
+        // When both server-side tools (web_search, code_execution) and regular
+        // tools are called in the same turn, preserving insertion order would
+        // place server_tool_use / web_search_tool_result after tool_use,
+        // causing "tool_use ids were found without tool_result blocks
+        // immediately after" errors from the API.
+        const serverToolTypes = new Set([
+          'server_tool_use',
+          'web_search_tool_result',
+          'mcp_tool_use',
+          'mcp_tool_result',
+          'code_execution_tool_result',
+        ]);
+        const hasRegularToolUse = anthropicContent.some(
+          c => c.type === 'tool_use',
+        );
+        const hasServerTool = anthropicContent.some(c =>
+          serverToolTypes.has(c.type),
+        );
+        const orderedContent =
+          hasRegularToolUse && hasServerTool
+            ? [
+                ...anthropicContent.filter(c => c.type !== 'tool_use'),
+                ...anthropicContent.filter(c => c.type === 'tool_use'),
+              ]
+            : anthropicContent;
+
+        messages.push({ role: 'assistant', content: orderedContent });
 
         break;
       }


### PR DESCRIPTION
## Problem

When the model calls both a provider-executed tool (`web_search`, `code_execution`) and a regular tool in the same turn, the assembled assistant message can look like:

```
[text, tool_use (regular), server_tool_use (web_search), web_search_tool_result]
```

The Anthropic API requires `tool_use` to come **last** in assistant content (because its result comes in the subsequent user message). Having `server_tool_use`/`web_search_tool_result` after `tool_use` causes:

```
tool_use ids were found without tool_result blocks immediately after: toolu_xxx
```

This is 100% reproducible when a user asks the agent to both search AND call a regular tool in one step (e.g. "search and save news"). Repro script is in the issue.

Fixes #13013

## Fix

Right before pushing the assembled assistant content to `messages`, check if both regular `tool_use` items and server-tool items (e.g. `server_tool_use`, `web_search_tool_result`, `mcp_tool_use`, `mcp_tool_result`, `code_execution_tool_result`) are present. If so, move all non-`tool_use` content before `tool_use` content. Relative order within each group is preserved.

```diff
+const serverToolTypes = new Set([...]);
+const hasRegularToolUse = anthropicContent.some((c) => c.type === 'tool_use');
+const hasServerTool = anthropicContent.some((c) => serverToolTypes.has(c.type));
+const orderedContent =
+  hasRegularToolUse && hasServerTool
+    ? [
+        ...anthropicContent.filter((c) => c.type !== 'tool_use'),
+        ...anthropicContent.filter((c) => c.type === 'tool_use'),
+      ]
+    : anthropicContent;
 messages.push({ role: 'assistant', content: orderedContent });
```

## Testing

Added a unit test in `convert-to-anthropic-messages-prompt.test.ts` that verifies `server_tool_use` and `web_search_tool_result` indices are less than `tool_use` index in the output.