### PR TITLE
docs: add Codex ASP community provider

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -96,6 +96,7 @@ The open-source community has created the following providers:
 - [OLLM Provider](/providers/community-providers/ollm) (`@ofoundation/ollm`)
 - [ZeroEntropy Provider](/providers/community-providers/zeroentropy) (`zeroentropy-ai-provider`)
 - [Neon AI Gateway Provider](/providers/community-providers/neon-ai-gateway) (`@neon/ai-sdk-provider`)
+- [Codex ASP Provider](/providers/community-providers/codex-asp) (`@janole/ai-sdk-provider-codex-asp`)
 
 ## Self-Hosted Models
 

--- a/content/providers/03-community-providers/52-codex-asp.mdx
+++ b/content/providers/03-community-providers/52-codex-asp.mdx
@@ -1,0 +1,277 @@
+---
+title: Codex ASP
+description: Learn how to use the Codex ASP provider for direct AI SDK tool support, thread continuation, and human-in-the-loop approvals with Codex app-server mode.
+---
+
+# Codex ASP Provider
+
+The [@janole/ai-sdk-provider-codex-asp](https://github.com/janole/ai-sdk-provider-codex-asp) community provider wraps [Codex](https://github.com/openai/codex) in app-server mode as a fully AI SDK v6-compatible language model.
+
+It bridges the gap between the AI SDK tool ecosystem and Codex's agentic capabilities, so you can use standard `tool()` definitions, streaming, and multi-turn conversations — all backed by Codex.
+
+### Key Differentiators
+
+- **AI SDK `tool()` support** — define tools with the standard AI SDK `tool()` API; the provider automatically injects them into Codex via dynamic tools and routes results back
+- **Thread continuation** — persistent worker pools enable multi-turn sessions that preserve full context, even across process restarts
+- **Human-in-the-loop approvals** — intercept Codex command execution and file changes through approval callbacks
+- **Streaming & non-streaming** — full support for both `streamText` and `generateText`
+
+## Setup
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @janole/ai-sdk-provider-codex-asp ai" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @janole/ai-sdk-provider-codex-asp ai" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @janole/ai-sdk-provider-codex-asp ai" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @janole/ai-sdk-provider-codex-asp ai" dark />
+  </Tab>
+</Tabs>
+
+You also need [Codex CLI](https://github.com/openai/codex) v0.128.0 or above (with app-server support) available in your `PATH`.
+
+## Provider Instance
+
+Create a provider instance with `createCodexAppServer`:
+
+```ts
+import { createCodexAppServer } from '@janole/ai-sdk-provider-codex-asp';
+
+const codex = createCodexAppServer();
+```
+
+The provider instance is also a function shorthand for creating language models:
+
+```ts
+const model = codex('gpt-5.3-codex');
+```
+
+## Quick Start
+
+```ts
+import { generateText } from 'ai';
+import { createCodexAppServer } from '@janole/ai-sdk-provider-codex-asp';
+
+const codex = createCodexAppServer();
+
+const { text } = await generateText({
+  model: codex('gpt-5.3-codex'),
+  prompt: 'Explain what Codex app-server mode does in one sentence.',
+});
+
+console.log(text);
+```
+
+## AI SDK Tools
+
+Use standard AI SDK `tool()` definitions — the provider injects them into Codex as dynamic tools and routes results back within the same session. No Codex-specific API required.
+
+Tool support requires a persistent transport so results can flow back:
+
+```ts
+import { stepCountIs, streamText, tool } from 'ai';
+import { z } from 'zod';
+import { createCodexAppServer } from '@janole/ai-sdk-provider-codex-asp';
+
+const codex = createCodexAppServer({
+  persistent: { scope: 'global', poolSize: 1, idleTimeoutMs: 60_000 },
+});
+
+const result = streamText({
+  model: codex('gpt-5.3-codex'),
+  prompt: 'Check ticket TICK-42 and the weather in Berlin.',
+  tools: {
+    lookupTicket: tool({
+      description: 'Get a support ticket by ID.',
+      inputSchema: z.object({ id: z.string() }),
+      execute: async ({ id }) =>
+        `Ticket ${id} is open, assigned to team Alpha.`,
+    }),
+    checkWeather: tool({
+      description: 'Get the current weather for a location.',
+      inputSchema: z.object({ location: z.string() }),
+      execute: async ({ location }) => `${location}: 22 °C, sunny.`,
+    }),
+  },
+  stopWhen: stepCountIs(5),
+});
+
+for await (const chunk of result.textStream) {
+  process.stdout.write(chunk);
+}
+
+await codex.shutdown();
+```
+
+## Thread Continuation
+
+The provider embeds a `threadId` in the response's `providerMetadata`. When you pass `response.messages` back in subsequent calls, the provider picks up the threadId automatically and resumes the Codex thread. This works even across process restarts, since Codex persists threads to disk:
+
+```ts
+import { generateText } from 'ai';
+import { createCodexAppServer } from '@janole/ai-sdk-provider-codex-asp';
+
+const codex = createCodexAppServer();
+const model = codex('gpt-5.3-codex');
+
+const messages = [];
+
+// Turn 1
+messages.push({
+  role: 'user',
+  content: 'My secret number is 42. Remember it.',
+});
+const turn1 = await generateText({ model, messages });
+messages.push(...turn1.response.messages);
+
+// Turn 2 — threadId flows through automatically
+messages.push({ role: 'user', content: 'What was my secret number?' });
+const turn2 = await generateText({ model, messages });
+
+console.log(turn2.text); // 42
+
+await codex.shutdown();
+```
+
+Thread continuation works with both `streamText` and `generateText` — just pass `response.messages` back and the provider handles the rest. The `providerMetadata` on each response also includes a `threadPath` property with the path to the Codex thread file on disk, useful for debugging or external thread management.
+
+## Human-in-the-Loop Approvals
+
+Intercept Codex tool execution and file change actions through approval callbacks, enabling review workflows before the agent acts:
+
+```ts
+const codex = createCodexAppServer({
+  approvals: {
+    onCommandApproval: req => {
+      console.log('Command approval requested:', req.command);
+      return 'accept'; // or 'decline', 'acceptForSession', 'cancel'
+    },
+    onFileChangeApproval: req => {
+      console.log('File change approval requested:', req.reason);
+      return 'accept'; // or 'decline', 'acceptForSession', 'cancel'
+    },
+    onElicitation: req => {
+      // MCP tool approval — the "Allow / Allow for session / Always allow" prompt
+      console.log('MCP elicitation requested:', req.message);
+      return { action: 'accept' };
+      // Use _meta to persist: { action: 'accept', _meta: { persist: 'session' } }
+    },
+  },
+});
+```
+
+For fully autonomous operation, set `approvalsReviewer` to `"guardian_subagent"` to let Codex route approval decisions to its built-in reviewer agent instead of surfacing them to your callbacks:
+
+```ts
+const codex = createCodexAppServer({
+  defaultThreadSettings: {
+    approvalsReviewer: 'guardian_subagent',
+  },
+});
+```
+
+## Configuration
+
+```ts
+const codex = createCodexAppServer({
+  defaultModel: 'gpt-5.3-codex',
+  clientInfo: { name: 'my-app', version: '1.0.0' },
+  transport: { type: 'stdio' }, // 'stdio' (default) or 'websocket'
+  persistent: {
+    scope: 'global', // 'global' or 'keyed'
+    poolSize: 1,
+    idleTimeoutMs: 60_000,
+  },
+  compaction: {
+    shouldCompactOnResume: true, // compact context on resumed threads
+  },
+  defaultTurnSettings: {
+    approvalPolicy: 'on-request',
+    sandboxPolicy: { type: 'externalSandbox', networkAccess: 'enabled' },
+  },
+  toolTimeoutMs: 30_000,
+  interruptTimeoutMs: 10_000,
+});
+```
+
+## Per-Call Options
+
+Override provider settings on individual calls without recreating the provider using `codexCallOptions`:
+
+```ts
+import { streamText } from 'ai';
+import {
+  codexCallOptions,
+  createCodexAppServer,
+} from '@janole/ai-sdk-provider-codex-asp';
+
+const codex = createCodexAppServer({
+  defaultTurnSettings: { effort: 'low' },
+});
+
+// Override model, effort, and working directory for this call only
+const result = streamText({
+  model: codex('gpt-5.3-codex'),
+  prompt: 'Summarize this project.',
+  providerOptions: codexCallOptions({
+    model: 'gpt-5.1-codex-max',
+    effort: 'high',
+    cwd: '/tmp/my-project',
+  }),
+});
+```
+
+You can override `model`, `effort`, `cwd`, `approvalPolicy`, `sandboxPolicy`, and approval callbacks per call.
+
+## Model Capabilities
+
+The provider passes the model ID to Codex, so any model supported by your Codex installation works. Common models:
+
+| Model                | Streaming           | AI SDK Tools        | Thread Continuation | HITL Approvals      |
+| -------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gpt-5.3-codex`      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5.1-codex-max`  | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5.1-codex-mini` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+
+## Model Discovery
+
+Query available models directly from your Codex installation:
+
+```ts
+const codex = createCodexAppServer();
+
+const models = await codex.listModels();
+
+for (const model of models) {
+  console.log(`${model.id}: ${model.description}`);
+}
+```
+
+## Additional Features
+
+The provider also supports:
+
+- **Structured output** — forward JSON schemas to Codex for structured responses via `generateObject`
+- **Image and file inputs** — pass images and files in prompts; the provider resolves them for Codex automatically
+- **Session access via `onSessionCreated`** — get a live session handle for mid-turn message injection or interruption
+- **MCP server configuration** — pass MCP server configs through provider settings
+- **Context compaction** — optionally compact thread context on resumed sessions to stay within token limits
+
+See the [examples directory](https://github.com/janole/ai-sdk-provider-codex-asp/tree/main/examples) for working code for each feature.
+
+## Requirements
+
+- Node.js 18+
+- [Codex CLI](https://github.com/openai/codex) with app-server support in `PATH`
+- AI SDK v6
+
+## Links
+
+- [GitHub Repository](https://github.com/janole/ai-sdk-provider-codex-asp)
+- [npm Package](https://www.npmjs.com/package/@janole/ai-sdk-provider-codex-asp)
+- [Examples](https://github.com/janole/ai-sdk-provider-codex-asp/tree/main/examples)

--- a/content/providers/05-community-providers/53-codex-asp.mdx
+++ b/content/providers/05-community-providers/53-codex-asp.mdx
@@ -1,0 +1,297 @@
+---
+title: Codex ASP
+description: Learn how to use the Codex ASP provider for direct AI SDK tool support, thread continuation, and human-in-the-loop approvals with Codex app-server mode.
+---
+
+# Codex ASP Provider
+
+The [@janole/ai-sdk-provider-codex-asp](https://github.com/janole/ai-sdk-provider-codex-asp) community provider wraps [Codex](https://github.com/openai/codex) in app-server mode as a language model, supporting **both AI SDK v6 and v7 from one package**.
+
+It bridges the gap between the AI SDK tool ecosystem and Codex's agentic capabilities, so you can use standard `tool()` definitions, streaming, and multi-turn conversations — all backed by Codex.
+
+### Key Differentiators
+
+- **AI SDK `tool()` support** — define tools with the standard AI SDK `tool()` API; the provider automatically injects them into Codex via dynamic tools and routes results back
+- **Thread continuation** — persistent worker pools enable multi-turn sessions that preserve full context, even across process restarts
+- **Human-in-the-loop approvals** — intercept Codex command execution and file changes through approval callbacks
+- **Provider-executed tools** — Codex's own command executions, file changes, web searches, and MCP tool calls surface as standard AI SDK provider-executed tool parts
+- **Streaming & non-streaming** — full support for both `streamText` and `generateText`
+
+## Version Compatibility
+
+| Provider Version | AI SDK Version | Node.js | Status |
+| ---------------- | -------------- | ------- | ------ |
+| 0.5.x            | v6             | 20+     | Stable |
+| 0.5.x            | v7             | 22+     | Stable |
+
+One package covers both. The provider implements `LanguageModelV3`, which `ai@6`
+uses natively and `ai@7` accepts through its built-in v3→v4 model proxy — nothing
+needs to be configured differently. The Node.js 22 floor for `ai@7` is the AI
+SDK's own requirement.
+
+## Setup
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @janole/ai-sdk-provider-codex-asp ai" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @janole/ai-sdk-provider-codex-asp ai" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @janole/ai-sdk-provider-codex-asp ai" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @janole/ai-sdk-provider-codex-asp ai" dark />
+  </Tab>
+</Tabs>
+
+You also need [Codex CLI](https://github.com/openai/codex) (with app-server support) available in your `PATH`. The provider is tested against Codex 0.144.4.
+
+## Provider Instance
+
+Create a provider instance with `createCodexAppServer`:
+
+```ts
+import { createCodexAppServer } from '@janole/ai-sdk-provider-codex-asp';
+
+const codex = createCodexAppServer();
+```
+
+The provider instance is also a function shorthand for creating language models:
+
+```ts
+const model = codex('gpt-5.6-sol');
+```
+
+## Quick Start
+
+```ts
+import { generateText } from 'ai';
+import { createCodexAppServer } from '@janole/ai-sdk-provider-codex-asp';
+
+const codex = createCodexAppServer();
+
+const { text } = await generateText({
+  model: codex('gpt-5.6-sol'),
+  prompt: 'Explain what Codex app-server mode does in one sentence.',
+});
+
+console.log(text);
+```
+
+## AI SDK Tools
+
+Use standard AI SDK `tool()` definitions — the provider injects them into Codex as dynamic tools and routes results back within the same session. No Codex-specific API required.
+
+Tool support requires a persistent transport so results can flow back:
+
+```ts
+import { stepCountIs, streamText, tool } from 'ai';
+import { z } from 'zod';
+import { createCodexAppServer } from '@janole/ai-sdk-provider-codex-asp';
+
+const codex = createCodexAppServer({
+  persistent: { scope: 'global', poolSize: 1, idleTimeoutMs: 60_000 },
+});
+
+const result = streamText({
+  model: codex('gpt-5.6-sol'),
+  prompt: 'Check ticket TICK-42 and the weather in Berlin.',
+  tools: {
+    lookupTicket: tool({
+      description: 'Get a support ticket by ID.',
+      inputSchema: z.object({ id: z.string() }),
+      execute: async ({ id }) =>
+        `Ticket ${id} is open, assigned to team Alpha.`,
+    }),
+    checkWeather: tool({
+      description: 'Get the current weather for a location.',
+      inputSchema: z.object({ location: z.string() }),
+      execute: async ({ location }) => `${location}: 22 °C, sunny.`,
+    }),
+  },
+  stopWhen: stepCountIs(5),
+});
+
+for await (const chunk of result.textStream) {
+  process.stdout.write(chunk);
+}
+
+await codex.shutdown();
+```
+
+## Thread Continuation
+
+The provider embeds a `threadId` in the response's `providerMetadata`. When you pass `response.messages` back in subsequent calls, the provider picks up the threadId automatically and resumes the Codex thread. This works even across process restarts, since Codex persists threads to disk:
+
+```ts
+import { generateText } from 'ai';
+import { createCodexAppServer } from '@janole/ai-sdk-provider-codex-asp';
+
+const codex = createCodexAppServer();
+const model = codex('gpt-5.6-sol');
+
+const messages = [];
+
+// Turn 1
+messages.push({
+  role: 'user',
+  content: 'My secret number is 42. Remember it.',
+});
+const turn1 = await generateText({ model, messages });
+messages.push(...turn1.response.messages);
+
+// Turn 2 — threadId flows through automatically
+messages.push({ role: 'user', content: 'What was my secret number?' });
+const turn2 = await generateText({ model, messages });
+
+console.log(turn2.text); // 42
+
+await codex.shutdown();
+```
+
+Thread continuation works with both `streamText` and `generateText` — just pass `response.messages` back and the provider handles the rest. The `providerMetadata` on each response also includes a `threadPath` property with the path to the Codex thread file on disk, useful for debugging or external thread management.
+
+## Human-in-the-Loop Approvals
+
+Intercept Codex tool execution and file change actions through approval callbacks, enabling review workflows before the agent acts:
+
+```ts
+const codex = createCodexAppServer({
+  approvals: {
+    onCommandApproval: req => {
+      console.log('Command approval requested:', req.command);
+      return 'accept'; // or 'decline', 'acceptForSession', 'cancel'
+    },
+    onFileChangeApproval: req => {
+      console.log('File change approval requested:', req.reason);
+      return 'accept'; // or 'decline', 'acceptForSession', 'cancel'
+    },
+    onElicitation: req => {
+      // MCP tool approval — the "Allow / Allow for session / Always allow" prompt
+      console.log('MCP elicitation requested:', req.message);
+      return { action: 'accept' };
+      // Use _meta to persist: { action: 'accept', _meta: { persist: 'session' } }
+    },
+  },
+});
+```
+
+For fully autonomous operation, set `approvalsReviewer` to `"guardian_subagent"` to let Codex route approval decisions to its built-in reviewer agent instead of surfacing them to your callbacks:
+
+```ts
+const codex = createCodexAppServer({
+  defaultThreadSettings: {
+    approvalsReviewer: 'guardian_subagent',
+  },
+});
+```
+
+## Configuration
+
+```ts
+const codex = createCodexAppServer({
+  defaultModel: 'gpt-5.6-sol',
+  clientInfo: { name: 'my-app', version: '1.0.0' },
+  transport: { type: 'stdio' }, // 'stdio' (default) or 'websocket'
+  persistent: {
+    scope: 'global', // 'global' or 'keyed'
+    poolSize: 1,
+    idleTimeoutMs: 60_000,
+  },
+  compaction: {
+    shouldCompactOnResume: true, // compact context on resumed threads
+  },
+  defaultTurnSettings: {
+    approvalPolicy: 'on-request',
+    sandboxPolicy: { type: 'externalSandbox', networkAccess: 'enabled' },
+  },
+  toolTimeoutMs: 30_000,
+  interruptTimeoutMs: 10_000,
+});
+```
+
+## Per-Call Options
+
+Override provider settings on individual calls without recreating the provider using `codexCallOptions`:
+
+```ts
+import { streamText } from 'ai';
+import {
+  codexCallOptions,
+  createCodexAppServer,
+} from '@janole/ai-sdk-provider-codex-asp';
+
+const codex = createCodexAppServer({
+  defaultTurnSettings: { effort: 'low' },
+});
+
+// Override model, effort, and working directory for this call only
+const result = streamText({
+  model: codex('gpt-5.6-luna'),
+  prompt: 'Summarize this project.',
+  providerOptions: codexCallOptions({
+    model: 'gpt-5.6-sol',
+    effort: 'high',
+    cwd: '/tmp/my-project',
+  }),
+});
+```
+
+You can override `model`, `effort`, `cwd`, `approvalPolicy`, `sandboxPolicy`, and approval callbacks per call.
+
+## Model Capabilities
+
+The provider passes the model ID to Codex, so any model supported by your Codex installation works. Common models:
+
+| Model           | Streaming           | AI SDK Tools        | Thread Continuation | HITL Approvals      |
+| --------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gpt-5.6-sol`   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5.6-terra` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5.6-luna`  | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5.5`       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5.4`       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5.4-mini`  | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+
+## Model Discovery
+
+Query available models directly from your Codex installation:
+
+```ts
+const codex = createCodexAppServer();
+
+const models = await codex.listModels();
+
+for (const model of models) {
+  console.log(`${model.id}: ${model.description}`);
+}
+```
+
+## Additional Features
+
+The provider also supports:
+
+- **Structured output** — forward JSON schemas to Codex for structured responses via `generateObject`
+- **Image and file inputs** — pass images and files in prompts; the provider resolves them for Codex automatically
+- **Generated images** — images produced by Codex are surfaced as AI SDK `file` parts (`image/png`)
+- **Web search** — completed Codex web searches are emitted as provider-executed tool calls carrying their results
+- **Session access via `onSessionCreated`** — get a live session handle for mid-turn message injection or interruption
+- **MCP server configuration** — pass MCP server configs through provider settings
+- **Ephemeral threads** — opt out of on-disk thread persistence per thread
+- **Context compaction** — optionally compact thread context on resumed sessions to stay within token limits
+- **Immediate abort** — aborting a request closes the stream right away; the Codex turn interrupt and resource teardown settle in the background
+
+See the [examples directory](https://github.com/janole/ai-sdk-provider-codex-asp/tree/main/examples) for working code for each feature.
+
+## Requirements
+
+- Node.js 20+ (22+ when using `ai@7`)
+- [Codex CLI](https://github.com/openai/codex) with app-server support in `PATH` (tested against 0.144.4)
+- AI SDK v6 or v7
+
+## Links
+
+- [GitHub Repository](https://github.com/janole/ai-sdk-provider-codex-asp)
+- [npm Package](https://www.npmjs.com/package/@janole/ai-sdk-provider-codex-asp)
+- [Examples](https://github.com/janole/ai-sdk-provider-codex-asp/tree/main/examples)


### PR DESCRIPTION
## Summary

Adds documentation for the [@janole/ai-sdk-provider-codex-asp](https://github.com/janole/ai-sdk-provider-codex-asp) community provider.

This provider wraps Codex in **app-server mode** as a language model compatible with both AI SDK v6 and v7, so you can use standard [AI SDK tools](https://ai-sdk.dev/docs/foundations/tools) and patterns with Codex under the hood. 

### Key Features

| Feature | Supported |
|---------|-----------|
| Direct AI SDK `tool()` support | ✅ |
| Thread continuation (across restarts) | ✅ |
| Human-in-the-loop (HITL) approvals | ✅ |
| Mid-execution injection | ✅ |
| Model discovery | ✅ |
| Structured output | ✅ |
| Streaming & non-streaming | ✅ |
| Image inputs | ✅ |
| MCP server configuration | ✅ |

## Checklist

- [x] Provider published to [GitHub](https://github.com/janole/ai-sdk-provider-codex-asp) and [npm](https://www.npmjs.com/package/@janole/ai-sdk-provider-codex-asp)
- [x] Documentation follows existing community provider format
- [x] Examples included
- [x] Prettier formatting applied
