### PR TITLE
feat(provider/google): add `gemini-3.1-flash-lite-preview`

### DIFF
--- a/.changeset/few-clouds-drum.md
+++ b/.changeset/few-clouds-drum.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/google': patch
+---
+
+feat(provider/google): add `gemini-3.1-flash-lite-preview`

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -1050,6 +1050,7 @@ The following Zod features are known to not work with Google Generative AI:
 | ------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | `gemini-3.1-pro-preview`              | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.1-flash-image-preview`      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-3.1-flash-lite-preview`       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3-pro-preview`                | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3-pro-image-preview`          | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3-flash-preview`              | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/03-community-providers/18-gemini-cli.mdx
+++ b/content/providers/03-community-providers/18-gemini-cli.mdx
@@ -96,6 +96,7 @@ Supported models:
 
 - **gemini-3.1-pro-preview**: Latest model with enhanced reasoning (supports `thinkingLevel`)
 - **gemini-3-flash-preview**: Fast Gemini 3 model (supports `thinkingLevel`)
+- **gemini-3.1-flash-lite-preview**: Latest model with enhanced reasoning (supports `thinkingLevel`)
 - **gemini-2.5-pro**: Production-ready model with 64K output tokens (supports `thinkingBudget`)
 - **gemini-2.5-flash**: Fast, efficient model with 64K output tokens (supports `thinkingBudget`)
 

--- a/examples/ai-functions/src/generate-text/google/gemini-3-1-flash-lite.ts
+++ b/examples/ai-functions/src/generate-text/google/gemini-3-1-flash-lite.ts
@@ -1,0 +1,15 @@
+import { google } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: google('gemini-3.1-flash-lite-preview'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/google/gemini-3-1-flash-lite.ts
+++ b/examples/ai-functions/src/stream-text/google/gemini-3-1-flash-lite.ts
@@ -1,0 +1,18 @@
+import { google } from '@ai-sdk/google';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: google('gemini-3.1-flash-lite-preview'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -58,6 +58,7 @@ export type GatewayModelId =
   | 'google/gemini-3-pro-image'
   | 'google/gemini-3-pro-preview'
   | 'google/gemini-3.1-flash-image-preview'
+  | 'google/gemini-3.1-flash-lite-preview'
   | 'google/gemini-3.1-pro-preview'
   | 'inception/mercury-coder-small'
   | 'kwaipilot/kat-coder-pro-v1'

--- a/packages/google-vertex/src/google-vertex-options.ts
+++ b/packages/google-vertex/src/google-vertex-options.ts
@@ -28,6 +28,7 @@ export type GoogleVertexModelId =
   | 'gemini-3-flash-preview'
   | 'gemini-3.1-pro-preview'
   | 'gemini-3.1-flash-image-preview'
+  | 'gemini-3.1-flash-lite-preview'
   // Experimental models
   | 'gemini-2.0-pro-exp-02-05'
   | 'gemini-2.0-flash-exp'

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -26,6 +26,7 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-3.1-pro-preview'
   | 'gemini-3.1-pro-preview-customtools'
   | 'gemini-3.1-flash-image-preview'
+  | 'gemini-3.1-flash-lite-preview'
   // latest version
   // https://ai.google.dev/gemini-api/docs/models#latest
   | 'gemini-pro-latest'


### PR DESCRIPTION
## Background

Google released `gemini-3.1-flash-lite-preview`. It needs to be added to the SDK's model ID types so users get autocomplete and type safety.

## Summary

Adds `gemini-3.1-flash-lite-preview` to the model ID type unions in `google`, `google-vertex`, and `gateway` packages. Adds a row to the capability table in docs and creates `generateText`/`streamText` examples.

## Manual Verification

Examples are included, which can be used for testing against the model.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Fixes #13024
