### PR TITLE
feat(ai): register global telemetry integrations

### DIFF
--- a/.changeset/nice-deers-grab.md
+++ b/.changeset/nice-deers-grab.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): register global telemetry integrations

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -1,7 +1,7 @@
 import { LanguageModelV3CallOptions } from '@ai-sdk/provider';
 import { tool } from '@ai-sdk/provider-utils';
 import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { MockLanguageModelV3 } from '../test/mock-language-model-v3';
 import { ToolLoopAgent } from './tool-loop-agent';
@@ -2573,6 +2573,491 @@ describe('ToolLoopAgent', () => {
             "text": "Hello, world!",
           }
         `);
+      });
+    });
+  });
+
+  describe('telemetry integrations', () => {
+    afterEach(() => {
+      globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = undefined;
+    });
+
+    describe('generate', () => {
+      const dummyResponseValues = {
+        usage: {
+          cachedInputTokens: undefined,
+          inputTokens: {
+            total: 3,
+            noCache: 3,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 10,
+            text: 10,
+            reasoning: undefined,
+          },
+        },
+        warnings: [],
+      };
+
+      function createToolCallMockModel() {
+        let callCount = 0;
+        return new MockLanguageModelV3({
+          doGenerate: async () => {
+            if (callCount++ === 0) {
+              return {
+                ...dummyResponseValues,
+                content: [
+                  {
+                    type: 'tool-call' as const,
+                    toolCallType: 'function' as const,
+                    toolCallId: 'call-1',
+                    toolName: 'testTool',
+                    input: '{ "value": "test" }',
+                  },
+                ],
+                finishReason: {
+                  unified: 'tool-calls' as const,
+                  raw: undefined,
+                },
+              };
+            }
+            return {
+              ...dummyResponseValues,
+              content: [{ type: 'text' as const, text: 'done' }],
+              finishReason: { unified: 'stop' as const, raw: 'stop' },
+            };
+          },
+        });
+      }
+
+      it('should call per-call integration listeners for all lifecycle events', async () => {
+        const events: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: createToolCallMockModel(),
+          tools: {
+            testTool: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async ({ value }: { value: string }) =>
+                `${value}-result`,
+            }),
+          },
+          experimental_telemetry: {
+            integrations: {
+              onStart: async () => {
+                events.push('onStart');
+              },
+              onStepStart: async () => {
+                events.push('onStepStart');
+              },
+              onToolCallStart: async () => {
+                events.push('onToolCallStart');
+              },
+              onToolCallFinish: async () => {
+                events.push('onToolCallFinish');
+              },
+              onStepFinish: async () => {
+                events.push('onStepFinish');
+              },
+              onFinish: async () => {
+                events.push('onFinish');
+              },
+            },
+          },
+        });
+
+        await agent.generate({ prompt: 'test' });
+
+        expect(events).toEqual([
+          'onStart',
+          'onStepStart',
+          'onToolCallStart',
+          'onToolCallFinish',
+          'onStepFinish',
+          'onStepStart',
+          'onStepFinish',
+          'onFinish',
+        ]);
+      });
+
+      it('should call globally registered integration listeners', async () => {
+        const events: string[] = [];
+
+        globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = [
+          {
+            onStart: async () => {
+              events.push('global-onStart');
+            },
+            onStepFinish: async () => {
+              events.push('global-onStepFinish');
+            },
+            onFinish: async () => {
+              events.push('global-onFinish');
+            },
+          },
+        ];
+
+        const agent = new ToolLoopAgent({
+          model: new MockLanguageModelV3({
+            doGenerate: async () => ({
+              content: [{ type: 'text' as const, text: 'Hello!' }],
+              ...dummyResponseValues,
+              finishReason: { unified: 'stop' as const, raw: 'stop' },
+            }),
+          }),
+        });
+
+        await agent.generate({ prompt: 'test' });
+
+        expect(events).toEqual([
+          'global-onStart',
+          'global-onStepFinish',
+          'global-onFinish',
+        ]);
+      });
+
+      it('should call integration listeners alongside agent callbacks', async () => {
+        const events: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: new MockLanguageModelV3({
+            doGenerate: async () => ({
+              content: [{ type: 'text' as const, text: 'Hello!' }],
+              ...dummyResponseValues,
+              finishReason: { unified: 'stop' as const, raw: 'stop' },
+            }),
+          }),
+          experimental_onStart: async () => {
+            events.push('agent-onStart');
+          },
+          onStepFinish: async () => {
+            events.push('agent-onStepFinish');
+          },
+          onFinish: async () => {
+            events.push('agent-onFinish');
+          },
+          experimental_telemetry: {
+            integrations: {
+              onStart: async () => {
+                events.push('integration-onStart');
+              },
+              onStepFinish: async () => {
+                events.push('integration-onStepFinish');
+              },
+              onFinish: async () => {
+                events.push('integration-onFinish');
+              },
+            },
+          },
+        });
+
+        await agent.generate({ prompt: 'test' });
+
+        expect(events).toEqual([
+          'agent-onStart',
+          'integration-onStart',
+          'agent-onStepFinish',
+          'integration-onStepFinish',
+          'agent-onFinish',
+          'integration-onFinish',
+        ]);
+      });
+
+      it('should not break generation when an integration listener throws', async () => {
+        const agent = new ToolLoopAgent({
+          model: new MockLanguageModelV3({
+            doGenerate: async () => ({
+              content: [{ type: 'text' as const, text: 'Hello!' }],
+              ...dummyResponseValues,
+              finishReason: { unified: 'stop' as const, raw: 'stop' },
+            }),
+          }),
+          experimental_telemetry: {
+            integrations: {
+              onStart: async () => {
+                throw new Error('integration error');
+              },
+              onStepFinish: async () => {
+                throw new Error('integration error');
+              },
+              onFinish: async () => {
+                throw new Error('integration error');
+              },
+            },
+          },
+        });
+
+        const result = await agent.generate({ prompt: 'test' });
+
+        expect(result.text).toBe('Hello!');
+      });
+    });
+
+    describe('stream', () => {
+      const dummyStreamFinish = {
+        type: 'finish' as const,
+        finishReason: { unified: 'stop' as const, raw: 'stop' },
+        usage: {
+          inputTokens: {
+            total: 3,
+            noCache: 3,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 10,
+            text: 10,
+            reasoning: undefined,
+          },
+        },
+        providerMetadata: {},
+      };
+
+      function createToolCallStreamMockModel() {
+        let callCount = 0;
+        return new MockLanguageModelV3({
+          doStream: async () => {
+            if (callCount++ === 0) {
+              return {
+                stream: convertArrayToReadableStream([
+                  { type: 'stream-start', warnings: [] },
+                  {
+                    type: 'response-metadata',
+                    id: 'id-0',
+                    modelId: 'mock-model-id',
+                    timestamp: new Date(0),
+                  },
+                  {
+                    type: 'tool-call',
+                    toolCallId: 'call-1',
+                    toolName: 'testTool',
+                    input: '{ "value": "test" }',
+                  },
+                  {
+                    ...dummyStreamFinish,
+                    finishReason: {
+                      unified: 'tool-calls' as const,
+                      raw: undefined,
+                    },
+                  },
+                ]),
+              };
+            }
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'response-metadata',
+                  id: 'id-1',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'done' },
+                { type: 'text-end', id: '1' },
+                dummyStreamFinish,
+              ]),
+            };
+          },
+        });
+      }
+
+      it('should call per-call integration listeners for all lifecycle events', async () => {
+        const events: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: createToolCallStreamMockModel(),
+          tools: {
+            testTool: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async ({ value }: { value: string }) =>
+                `${value}-result`,
+            }),
+          },
+          experimental_telemetry: {
+            integrations: {
+              onStart: async () => {
+                events.push('onStart');
+              },
+              onStepStart: async () => {
+                events.push('onStepStart');
+              },
+              onToolCallStart: async () => {
+                events.push('onToolCallStart');
+              },
+              onToolCallFinish: async () => {
+                events.push('onToolCallFinish');
+              },
+              onStepFinish: async () => {
+                events.push('onStepFinish');
+              },
+              onFinish: async () => {
+                events.push('onFinish');
+              },
+            },
+          },
+        });
+
+        const result = await agent.stream({ prompt: 'test' });
+        await result.consumeStream();
+
+        expect(events).toEqual([
+          'onStart',
+          'onStepStart',
+          'onToolCallStart',
+          'onToolCallFinish',
+          'onStepFinish',
+          'onStepStart',
+          'onStepFinish',
+          'onFinish',
+        ]);
+      });
+
+      it('should call globally registered integration listeners', async () => {
+        const events: string[] = [];
+
+        globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = [
+          {
+            onStart: async () => {
+              events.push('global-onStart');
+            },
+            onStepFinish: async () => {
+              events.push('global-onStepFinish');
+            },
+            onFinish: async () => {
+              events.push('global-onFinish');
+            },
+          },
+        ];
+
+        const agent = new ToolLoopAgent({
+          model: new MockLanguageModelV3({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello!' },
+                { type: 'text-end', id: '1' },
+                dummyStreamFinish,
+              ]),
+            }),
+          }),
+        });
+
+        const result = await agent.stream({ prompt: 'test' });
+        await result.consumeStream();
+
+        expect(events).toEqual([
+          'global-onStart',
+          'global-onStepFinish',
+          'global-onFinish',
+        ]);
+      });
+
+      it('should call integration listeners alongside agent callbacks', async () => {
+        const events: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: new MockLanguageModelV3({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello!' },
+                { type: 'text-end', id: '1' },
+                dummyStreamFinish,
+              ]),
+            }),
+          }),
+          experimental_onStart: async () => {
+            events.push('agent-onStart');
+          },
+          onStepFinish: async () => {
+            events.push('agent-onStepFinish');
+          },
+          onFinish: async () => {
+            events.push('agent-onFinish');
+          },
+          experimental_telemetry: {
+            integrations: {
+              onStart: async () => {
+                events.push('integration-onStart');
+              },
+              onStepFinish: async () => {
+                events.push('integration-onStepFinish');
+              },
+              onFinish: async () => {
+                events.push('integration-onFinish');
+              },
+            },
+          },
+        });
+
+        const result = await agent.stream({ prompt: 'test' });
+        await result.consumeStream();
+
+        expect(events).toEqual([
+          'agent-onStart',
+          'integration-onStart',
+          'agent-onStepFinish',
+          'integration-onStepFinish',
+          'agent-onFinish',
+          'integration-onFinish',
+        ]);
+      });
+
+      it('should not break streaming when an integration listener throws', async () => {
+        const agent = new ToolLoopAgent({
+          model: new MockLanguageModelV3({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello!' },
+                { type: 'text-end', id: '1' },
+                dummyStreamFinish,
+              ]),
+            }),
+          }),
+          experimental_telemetry: {
+            integrations: {
+              onStart: async () => {
+                throw new Error('integration error');
+              },
+              onStepFinish: async () => {
+                throw new Error('integration error');
+              },
+              onFinish: async () => {
+                throw new Error('integration error');
+              },
+            },
+          },
+        });
+
+        const result = await agent.stream({ prompt: 'test' });
+        await result.consumeStream();
+
+        expect(await result.text).toBe('Hello!');
       });
     });
   });

--- a/packages/ai/src/generate-text/execute-tool-call.test.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.test.ts
@@ -673,4 +673,140 @@ describe('executeToolCall', () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe('array callbacks', () => {
+    it('should call all onToolCallStart listeners in an array', async () => {
+      const calls: string[] = [];
+
+      await executeToolCall({
+        toolCall: createToolCall(),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        tracer,
+        telemetry: undefined,
+        messages: [],
+        abortSignal: undefined,
+        experimental_context: undefined,
+        onToolCallStart: [
+          async () => {
+            calls.push('first');
+          },
+          async () => {
+            calls.push('second');
+          },
+        ],
+      });
+
+      expect(calls).toEqual(['first', 'second']);
+    });
+
+    it('should call all onToolCallFinish listeners in an array', async () => {
+      const calls: string[] = [];
+
+      await executeToolCall({
+        toolCall: createToolCall(),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        tracer,
+        telemetry: undefined,
+        messages: [],
+        abortSignal: undefined,
+        experimental_context: undefined,
+        onToolCallFinish: [
+          async () => {
+            calls.push('first');
+          },
+          async () => {
+            calls.push('second');
+          },
+        ],
+      });
+
+      expect(calls).toEqual(['first', 'second']);
+    });
+
+    it('should skip undefined/null entries in callback arrays', async () => {
+      const calls: string[] = [];
+
+      await executeToolCall({
+        toolCall: createToolCall(),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        tracer,
+        telemetry: undefined,
+        messages: [],
+        abortSignal: undefined,
+        experimental_context: undefined,
+        onToolCallStart: [
+          undefined,
+          async () => {
+            calls.push('start');
+          },
+          null,
+        ],
+        onToolCallFinish: [
+          null,
+          async () => {
+            calls.push('finish');
+          },
+          undefined,
+        ],
+      });
+
+      expect(calls).toEqual(['start', 'finish']);
+    });
+
+    it('should not break when one listener in the array throws', async () => {
+      const calls: string[] = [];
+
+      const result = await executeToolCall({
+        toolCall: createToolCall(),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        tracer,
+        telemetry: undefined,
+        messages: [],
+        abortSignal: undefined,
+        experimental_context: undefined,
+        onToolCallStart: [
+          async () => {
+            throw new Error('listener error');
+          },
+          async () => {
+            calls.push('second-start');
+          },
+        ],
+        onToolCallFinish: [
+          async () => {
+            throw new Error('listener error');
+          },
+          async () => {
+            calls.push('second-finish');
+          },
+        ],
+      });
+
+      expect(result).toMatchObject({
+        type: 'tool-result',
+        output: 'test-result',
+      });
+      expect(calls).toEqual(['second-start', 'second-finish']);
+    });
+  });
 });

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -51,8 +51,12 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   stepNumber?: number;
   model?: { provider: string; modelId: string };
   onPreliminaryToolResult?: (result: TypedToolResult<TOOLS>) => void;
-  onToolCallStart?: GenerateTextOnToolCallStartCallback<TOOLS>;
-  onToolCallFinish?: GenerateTextOnToolCallFinishCallback<TOOLS>;
+  onToolCallStart?:
+    | GenerateTextOnToolCallStartCallback<TOOLS>
+    | Array<GenerateTextOnToolCallStartCallback<TOOLS> | undefined | null>;
+  onToolCallFinish?:
+    | GenerateTextOnToolCallFinishCallback<TOOLS>
+    | Array<GenerateTextOnToolCallFinishCallback<TOOLS> | undefined | null>;
 }): Promise<ToolOutput<TOOLS> | undefined> {
   const { toolName, toolCallId, input } = toolCall;
   const tool = tools?.[toolName];

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -8507,4 +8507,235 @@ describe('generateText', () => {
       expect(result.text).toBe('response from without-image-url-support');
     });
   });
+
+  describe('telemetry integrations', () => {
+    afterEach(() => {
+      globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = undefined;
+    });
+
+    it('should call per-call integration listeners for all lifecycle events', async () => {
+      const events: string[] = [];
+
+      await generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: async () => ({
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'testTool',
+                input: '{ "value": "test" }',
+              },
+            ],
+            ...dummyResponseValues,
+          }),
+        }),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        prompt: 'test-input',
+        experimental_telemetry: {
+          integrations: {
+            onStart: async () => {
+              events.push('onStart');
+            },
+            onStepStart: async () => {
+              events.push('onStepStart');
+            },
+            onToolCallStart: async () => {
+              events.push('onToolCallStart');
+            },
+            onToolCallFinish: async () => {
+              events.push('onToolCallFinish');
+            },
+            onStepFinish: async () => {
+              events.push('onStepFinish');
+            },
+            onFinish: async () => {
+              events.push('onFinish');
+            },
+          },
+        },
+      });
+
+      expect(events).toEqual([
+        'onStart',
+        'onStepStart',
+        'onToolCallStart',
+        'onToolCallFinish',
+        'onStepFinish',
+        'onFinish',
+      ]);
+    });
+
+    it('should call globally registered integration listeners', async () => {
+      const events: string[] = [];
+
+      globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = [
+        {
+          onStart: async () => {
+            events.push('global-onStart');
+          },
+          onStepFinish: async () => {
+            events.push('global-onStepFinish');
+          },
+          onFinish: async () => {
+            events.push('global-onFinish');
+          },
+        },
+      ];
+
+      await generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: async () => ({
+            content: [{ type: 'text', text: 'Hello!' }],
+            ...dummyResponseValues,
+          }),
+        }),
+        prompt: 'test-input',
+      });
+
+      expect(events).toEqual([
+        'global-onStart',
+        'global-onStepFinish',
+        'global-onFinish',
+      ]);
+    });
+
+    it('should call global integrations before per-call integrations', async () => {
+      const events: string[] = [];
+
+      globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = [
+        {
+          onStart: async () => {
+            events.push('global');
+          },
+        },
+      ];
+
+      await generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: async () => ({
+            content: [{ type: 'text', text: 'Hello!' }],
+            ...dummyResponseValues,
+          }),
+        }),
+        prompt: 'test-input',
+        experimental_telemetry: {
+          integrations: {
+            onStart: async () => {
+              events.push('per-call');
+            },
+          },
+        },
+      });
+
+      expect(events).toEqual(['global', 'per-call']);
+    });
+
+    it('should call integration listeners alongside user callbacks', async () => {
+      const events: string[] = [];
+
+      await generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: async () => ({
+            content: [{ type: 'text', text: 'Hello!' }],
+            ...dummyResponseValues,
+          }),
+        }),
+        prompt: 'test-input',
+        experimental_onStart: async () => {
+          events.push('user-onStart');
+        },
+        onStepFinish: async () => {
+          events.push('user-onStepFinish');
+        },
+        onFinish: async () => {
+          events.push('user-onFinish');
+        },
+        experimental_telemetry: {
+          integrations: {
+            onStart: async () => {
+              events.push('integration-onStart');
+            },
+            onStepFinish: async () => {
+              events.push('integration-onStepFinish');
+            },
+            onFinish: async () => {
+              events.push('integration-onFinish');
+            },
+          },
+        },
+      });
+
+      expect(events).toEqual([
+        'user-onStart',
+        'integration-onStart',
+        'user-onStepFinish',
+        'integration-onStepFinish',
+        'user-onFinish',
+        'integration-onFinish',
+      ]);
+    });
+
+    it('should not break generation when an integration listener throws', async () => {
+      const result = await generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: async () => ({
+            content: [{ type: 'text', text: 'Hello!' }],
+            ...dummyResponseValues,
+          }),
+        }),
+        prompt: 'test-input',
+        experimental_telemetry: {
+          integrations: {
+            onStart: async () => {
+              throw new Error('integration error');
+            },
+            onStepFinish: async () => {
+              throw new Error('integration error');
+            },
+            onFinish: async () => {
+              throw new Error('integration error');
+            },
+          },
+        },
+      });
+
+      expect(result.text).toBe('Hello!');
+    });
+
+    it('should support multiple per-call integrations as an array', async () => {
+      const events: string[] = [];
+
+      await generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: async () => ({
+            content: [{ type: 'text', text: 'Hello!' }],
+            ...dummyResponseValues,
+          }),
+        }),
+        prompt: 'test-input',
+        experimental_telemetry: {
+          integrations: [
+            {
+              onStart: async () => {
+                events.push('first');
+              },
+            },
+            {
+              onStart: async () => {
+                events.push('second');
+              },
+            },
+          ],
+        },
+      });
+
+      expect(events).toEqual(['first', 'second']);
+    });
+  });
 });

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -39,6 +39,7 @@ import { getTracer } from '../telemetry/get-tracer';
 import { recordSpan } from '../telemetry/record-span';
 import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
 import { stringifyForTelemetry } from '../telemetry/stringify-for-telemetry';
+import { getGlobalTelemetryIntegration } from '../telemetry/get-global-telemetry-integration';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import {
   LanguageModel,
@@ -441,6 +442,9 @@ export async function generateText<
     };
   }): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
   const model = resolveLanguageModel(modelArg);
+  const globalTelemetry = getGlobalTelemetryIntegration<TOOLS, OUTPUT>(
+    telemetry?.integrations,
+  );
   const stopConditions = asArray(stopWhen);
 
   const totalTimeoutMs = getTotalTimeoutMs(timeout);
@@ -509,7 +513,7 @@ export async function generateText<
       metadata: telemetry?.metadata as Record<string, unknown> | undefined,
       experimental_context,
     },
-    callbacks: onStart,
+    callbacks: [onStart, globalTelemetry.onStart],
   });
 
   const tracer = getTracer(telemetry);
@@ -562,8 +566,11 @@ export async function generateText<
             experimental_context,
             stepNumber: 0,
             model: modelInfo,
-            onToolCallStart: onToolCallStart,
-            onToolCallFinish: onToolCallFinish,
+            onToolCallStart: [onToolCallStart, globalTelemetry.onToolCallStart],
+            onToolCallFinish: [
+              onToolCallFinish,
+              globalTelemetry.onToolCallFinish,
+            ],
           });
 
           const toolContent: Array<any> = [];
@@ -735,7 +742,7 @@ export async function generateText<
                   | undefined,
                 experimental_context,
               },
-              callbacks: onStepStart,
+              callbacks: [onStepStart, globalTelemetry.onStepStart],
             });
 
             currentModelResponse = await retry(() =>
@@ -957,8 +964,14 @@ export async function generateText<
                   experimental_context,
                   stepNumber: steps.length,
                   model: stepModelInfo,
-                  onToolCallStart: onToolCallStart,
-                  onToolCallFinish: onToolCallFinish,
+                  onToolCallStart: [
+                    onToolCallStart,
+                    globalTelemetry.onToolCallStart,
+                  ],
+                  onToolCallFinish: [
+                    onToolCallFinish,
+                    globalTelemetry.onToolCallFinish,
+                  ],
                 })),
               );
             }
@@ -1056,7 +1069,10 @@ export async function generateText<
 
             steps.push(currentStepResult);
 
-            await notify({ event: currentStepResult, callbacks: onStepFinish });
+            await notify({
+              event: currentStepResult,
+              callbacks: [onStepFinish, globalTelemetry.onStepFinish],
+            });
           } finally {
             if (stepTimeoutId != null) {
               clearTimeout(stepTimeoutId);
@@ -1152,7 +1168,7 @@ export async function generateText<
             steps,
             totalUsage,
           },
-          callbacks: onFinish,
+          callbacks: [onFinish, globalTelemetry.onFinish],
         });
 
         // parse output only if the last step was finished with "stop":
@@ -1203,8 +1219,14 @@ async function executeTools<TOOLS extends ToolSet>({
   experimental_context: unknown;
   stepNumber: number;
   model: { provider: string; modelId: string };
-  onToolCallStart: GenerateTextOnToolCallStartCallback<TOOLS> | undefined;
-  onToolCallFinish: GenerateTextOnToolCallFinishCallback<TOOLS> | undefined;
+  onToolCallStart:
+    | GenerateTextOnToolCallStartCallback<TOOLS>
+    | Array<GenerateTextOnToolCallStartCallback<TOOLS> | undefined | null>
+    | undefined;
+  onToolCallFinish:
+    | GenerateTextOnToolCallFinishCallback<TOOLS>
+    | Array<GenerateTextOnToolCallFinishCallback<TOOLS> | undefined | null>
+    | undefined;
 }): Promise<Array<ToolOutput<TOOLS>>> {
   const toolOutputs = await Promise.all(
     toolCalls.map(async toolCall =>

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -513,7 +513,12 @@ export async function generateText<
       metadata: telemetry?.metadata as Record<string, unknown> | undefined,
       experimental_context,
     },
-    callbacks: [onStart, globalTelemetry.onStart],
+    callbacks: [
+      onStart,
+      globalTelemetry.onStart as
+        | undefined
+        | GenerateTextOnStartCallback<TOOLS, OUTPUT>,
+    ],
   });
 
   const tracer = getTracer(telemetry);
@@ -566,10 +571,17 @@ export async function generateText<
             experimental_context,
             stepNumber: 0,
             model: modelInfo,
-            onToolCallStart: [onToolCallStart, globalTelemetry.onToolCallStart],
+            onToolCallStart: [
+              onToolCallStart,
+              globalTelemetry.onToolCallStart as
+                | undefined
+                | GenerateTextOnToolCallStartCallback<TOOLS>,
+            ],
             onToolCallFinish: [
               onToolCallFinish,
-              globalTelemetry.onToolCallFinish,
+              globalTelemetry.onToolCallFinish as
+                | undefined
+                | GenerateTextOnToolCallFinishCallback<TOOLS>,
             ],
           });
 
@@ -742,7 +754,12 @@ export async function generateText<
                   | undefined,
                 experimental_context,
               },
-              callbacks: [onStepStart, globalTelemetry.onStepStart],
+              callbacks: [
+                onStepStart,
+                globalTelemetry.onStepStart as
+                  | undefined
+                  | GenerateTextOnStepStartCallback<TOOLS, OUTPUT>,
+              ],
             });
 
             currentModelResponse = await retry(() =>
@@ -966,7 +983,9 @@ export async function generateText<
                   model: stepModelInfo,
                   onToolCallStart: [
                     onToolCallStart,
-                    globalTelemetry.onToolCallStart,
+                    globalTelemetry.onToolCallStart as
+                      | undefined
+                      | GenerateTextOnToolCallStartCallback<TOOLS>,
                   ],
                   onToolCallFinish: [
                     onToolCallFinish,
@@ -1168,7 +1187,12 @@ export async function generateText<
             steps,
             totalUsage,
           },
-          callbacks: [onFinish, globalTelemetry.onFinish],
+          callbacks: [
+            onFinish,
+            globalTelemetry.onFinish as
+              | undefined
+              | GenerateTextOnFinishCallback<TOOLS>,
+          ],
         });
 
         // parse output only if the last step was finished with "stop":

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -442,9 +442,7 @@ export async function generateText<
     };
   }): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
   const model = resolveLanguageModel(modelArg);
-  const globalTelemetry = getGlobalTelemetryIntegration<TOOLS, OUTPUT>(
-    telemetry?.integrations,
-  );
+  const createGlobalTelemetry = getGlobalTelemetryIntegration<TOOLS, OUTPUT>();
   const stopConditions = asArray(stopWhen);
 
   const totalTimeoutMs = getTotalTimeoutMs(timeout);
@@ -483,6 +481,8 @@ export async function generateText<
     prompt,
     messages,
   } as Prompt);
+
+  const globalTelemetry = createGlobalTelemetry(telemetry?.integrations);
 
   await notify({
     event: {

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -137,8 +137,12 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
   generateId: IdGenerator;
   stepNumber?: number;
   model?: { provider: string; modelId: string };
-  onToolCallStart?: StreamTextOnToolCallStartCallback<TOOLS>;
-  onToolCallFinish?: StreamTextOnToolCallFinishCallback<TOOLS>;
+  onToolCallStart?:
+    | StreamTextOnToolCallStartCallback<TOOLS>
+    | Array<StreamTextOnToolCallStartCallback<TOOLS> | undefined | null>;
+  onToolCallFinish?:
+    | StreamTextOnToolCallFinishCallback<TOOLS>
+    | Array<StreamTextOnToolCallFinishCallback<TOOLS> | undefined | null>;
 }): ReadableStream<SingleRequestTextStreamPart<TOOLS>> {
   // tool results stream
   let toolResultsStreamController: ReadableStreamDefaultController<

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -22046,4 +22046,238 @@ describe('streamText', () => {
       expect(await result.text).toBe('response from without-image-url-support');
     });
   });
+
+  describe('telemetry integrations', () => {
+    afterEach(() => {
+      globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = undefined;
+    });
+
+    it('should call per-call integration listeners for all lifecycle events', async () => {
+      const events: string[] = [];
+
+      const result = streamText({
+        model: new MockLanguageModelV3({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'testTool',
+                input: '{ "value": "test" }',
+              },
+              {
+                type: 'finish',
+                finishReason: { unified: 'tool-calls', raw: undefined },
+                usage: testUsage,
+              },
+            ]),
+          }),
+        }),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        prompt: 'test-input',
+        onError: () => {},
+        experimental_telemetry: {
+          integrations: {
+            onStart: async () => {
+              events.push('onStart');
+            },
+            onStepStart: async () => {
+              events.push('onStepStart');
+            },
+            onToolCallStart: async () => {
+              events.push('onToolCallStart');
+            },
+            onToolCallFinish: async () => {
+              events.push('onToolCallFinish');
+            },
+            onStepFinish: async () => {
+              events.push('onStepFinish');
+            },
+            onFinish: async () => {
+              events.push('onFinish');
+            },
+          },
+        },
+      });
+
+      await result.consumeStream();
+
+      expect(events).toEqual([
+        'onStart',
+        'onStepStart',
+        'onToolCallStart',
+        'onToolCallFinish',
+        'onStepFinish',
+        'onFinish',
+      ]);
+    });
+
+    it('should call globally registered integration listeners', async () => {
+      const events: string[] = [];
+
+      globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = [
+        {
+          onStart: async () => {
+            events.push('global-onStart');
+          },
+          onStepFinish: async () => {
+            events.push('global-onStepFinish');
+          },
+          onFinish: async () => {
+            events.push('global-onFinish');
+          },
+        },
+      ];
+
+      const result = streamText({
+        model: createTestModel(),
+        prompt: 'test-input',
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      expect(events).toEqual([
+        'global-onStart',
+        'global-onStepFinish',
+        'global-onFinish',
+      ]);
+    });
+
+    it('should call global integrations before per-call integrations', async () => {
+      const events: string[] = [];
+
+      globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = [
+        {
+          onStart: async () => {
+            events.push('global');
+          },
+        },
+      ];
+
+      const result = streamText({
+        model: createTestModel(),
+        prompt: 'test-input',
+        onError: () => {},
+        experimental_telemetry: {
+          integrations: {
+            onStart: async () => {
+              events.push('per-call');
+            },
+          },
+        },
+      });
+
+      await result.consumeStream();
+
+      expect(events).toEqual(['global', 'per-call']);
+    });
+
+    it('should call integration listeners alongside user callbacks', async () => {
+      const events: string[] = [];
+
+      const result = streamText({
+        model: createTestModel(),
+        prompt: 'test-input',
+        onError: () => {},
+        experimental_onStart: async () => {
+          events.push('user-onStart');
+        },
+        onStepFinish: async () => {
+          events.push('user-onStepFinish');
+        },
+        onFinish: async () => {
+          events.push('user-onFinish');
+        },
+        experimental_telemetry: {
+          integrations: {
+            onStart: async () => {
+              events.push('integration-onStart');
+            },
+            onStepFinish: async () => {
+              events.push('integration-onStepFinish');
+            },
+            onFinish: async () => {
+              events.push('integration-onFinish');
+            },
+          },
+        },
+      });
+
+      await result.consumeStream();
+
+      expect(events).toEqual([
+        'user-onStart',
+        'integration-onStart',
+        'user-onStepFinish',
+        'integration-onStepFinish',
+        'user-onFinish',
+        'integration-onFinish',
+      ]);
+    });
+
+    it('should not break streaming when an integration listener throws', async () => {
+      const result = streamText({
+        model: createTestModel(),
+        prompt: 'test-input',
+        onError: () => {},
+        experimental_telemetry: {
+          integrations: {
+            onStart: async () => {
+              throw new Error('integration error');
+            },
+            onStepFinish: async () => {
+              throw new Error('integration error');
+            },
+            onFinish: async () => {
+              throw new Error('integration error');
+            },
+          },
+        },
+      });
+
+      await result.consumeStream();
+
+      expect(await result.text).toBe('Hello, world!');
+    });
+
+    it('should support multiple per-call integrations as an array', async () => {
+      const events: string[] = [];
+
+      const result = streamText({
+        model: createTestModel(),
+        prompt: 'test-input',
+        onError: () => {},
+        experimental_telemetry: {
+          integrations: [
+            {
+              onStart: async () => {
+                events.push('first');
+              },
+            },
+            {
+              onStart: async () => {
+                events.push('second');
+              },
+            },
+          ],
+        },
+      });
+
+      await result.consumeStream();
+
+      expect(events).toEqual(['first', 'second']);
+    });
+  });
 });

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -42,6 +42,7 @@ import { getTracer } from '../telemetry/get-tracer';
 import { recordSpan } from '../telemetry/record-span';
 import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
 import { stringifyForTelemetry } from '../telemetry/stringify-for-telemetry';
+import { getGlobalTelemetryIntegration } from '../telemetry/get-global-telemetry-integration';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { createTextStreamResponse } from '../text-stream/create-text-stream-response';
 import { pipeTextStreamToResponse } from '../text-stream/pipe-text-stream-to-response';
@@ -807,6 +808,10 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
     this.includeRawChunks = includeRawChunks;
     this.tools = tools;
 
+    const globalTelemetry = getGlobalTelemetryIntegration<TOOLS, OUTPUT>(
+      telemetry?.integrations,
+    );
+
     // promise to ensure that the step has been fully processed by the event processor
     // before a new step is started. This is required because the continuation condition
     // needs the updated steps to determine if another step is needed.
@@ -1029,7 +1034,10 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
             providerMetadata: part.providerMetadata,
           });
 
-          await notify({ event: currentStepResult, callbacks: onStepFinish });
+          await notify({
+            event: currentStepResult,
+            callbacks: [onStepFinish, globalTelemetry.onStepFinish],
+          });
 
           logWarnings({
             warnings: recordedWarnings,
@@ -1115,7 +1123,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
               providerMetadata: finalStep.providerMetadata,
               steps: recordedSteps,
             },
-            callbacks: onFinish,
+            callbacks: [onFinish, globalTelemetry.onFinish],
           });
 
           // Add response information to the root span:
@@ -1304,7 +1312,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
             ...callbackTelemetryProps,
             experimental_context,
           },
-          callbacks: onStart,
+          callbacks: [onStart, globalTelemetry.onStart],
         });
 
         const initialMessages = initialPrompt.messages;
@@ -1374,8 +1382,14 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                   experimental_context,
                   stepNumber: recordedSteps.length,
                   model: modelInfo,
-                  onToolCallStart,
-                  onToolCallFinish,
+                  onToolCallStart: [
+                    onToolCallStart,
+                    globalTelemetry.onToolCallStart,
+                  ],
+                  onToolCallFinish: [
+                    onToolCallFinish,
+                    globalTelemetry.onToolCallFinish,
+                  ],
                   onPreliminaryToolResult: result => {
                     toolExecutionStepStreamController?.enqueue(result);
                   },
@@ -1573,7 +1587,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                 ...callbackTelemetryProps,
                 experimental_context,
               },
-              callbacks: onStepStart,
+              callbacks: [onStepStart, globalTelemetry.onStepStart],
             });
 
             const {
@@ -1656,8 +1670,14 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
               generateId,
               stepNumber: recordedSteps.length,
               model: stepModelInfo,
-              onToolCallStart,
-              onToolCallFinish,
+              onToolCallStart: [
+                onToolCallStart,
+                globalTelemetry.onToolCallStart,
+              ],
+              onToolCallFinish: [
+                onToolCallFinish,
+                globalTelemetry.onToolCallFinish,
+              ],
             });
 
             // Conditionally include request.body based on include settings.

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -19,7 +19,7 @@ import {
 import { Span } from '@opentelemetry/api';
 import { ServerResponse } from 'node:http';
 import { NoOutputGeneratedError } from '../error';
-import { notify } from '../util/notify';
+import { Listener, notify } from '../util/notify';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
 import {
@@ -1123,7 +1123,12 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
               providerMetadata: finalStep.providerMetadata,
               steps: recordedSteps,
             },
-            callbacks: [onFinish, globalTelemetry.onFinish],
+            callbacks: [
+              onFinish,
+              globalTelemetry.onFinish as
+                | undefined
+                | StreamTextOnFinishCallback<TOOLS>,
+            ],
           });
 
           // Add response information to the root span:
@@ -1312,7 +1317,12 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
             ...callbackTelemetryProps,
             experimental_context,
           },
-          callbacks: [onStart, globalTelemetry.onStart],
+          callbacks: [
+            onStart,
+            globalTelemetry.onStart as
+              | undefined
+              | StreamTextOnStartCallback<TOOLS, OUTPUT>,
+          ],
         });
 
         const initialMessages = initialPrompt.messages;
@@ -1384,7 +1394,9 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                   model: modelInfo,
                   onToolCallStart: [
                     onToolCallStart,
-                    globalTelemetry.onToolCallStart,
+                    globalTelemetry.onToolCallStart as
+                      | undefined
+                      | StreamTextOnToolCallStartCallback<TOOLS>,
                   ],
                   onToolCallFinish: [
                     onToolCallFinish,
@@ -1587,7 +1599,12 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                 ...callbackTelemetryProps,
                 experimental_context,
               },
-              callbacks: [onStepStart, globalTelemetry.onStepStart],
+              callbacks: [
+                onStepStart,
+                globalTelemetry.onStepStart as
+                  | undefined
+                  | StreamTextOnStepStartCallback<TOOLS, OUTPUT>,
+              ],
             });
 
             const {
@@ -1672,7 +1689,9 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
               model: stepModelInfo,
               onToolCallStart: [
                 onToolCallStart,
-                globalTelemetry.onToolCallStart,
+                globalTelemetry.onToolCallStart as
+                  | undefined
+                  | StreamTextOnToolCallStartCallback<TOOLS>,
               ],
               onToolCallFinish: [
                 onToolCallFinish,

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -808,9 +808,11 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
     this.includeRawChunks = includeRawChunks;
     this.tools = tools;
 
-    const globalTelemetry = getGlobalTelemetryIntegration<TOOLS, OUTPUT>(
-      telemetry?.integrations,
-    );
+    const createGlobalTelemetry = getGlobalTelemetryIntegration<
+      TOOLS,
+      OUTPUT
+    >();
+    const globalTelemetry = createGlobalTelemetry(telemetry?.integrations);
 
     // promise to ensure that the step has been fully processed by the event processor
     // before a new step is started. This is required because the continuation condition

--- a/packages/ai/src/telemetry/get-global-telemetry-integration.test.ts
+++ b/packages/ai/src/telemetry/get-global-telemetry-integration.test.ts
@@ -13,18 +13,20 @@ beforeEach(() => {
 });
 
 describe('getGlobalTelemetryIntegration', () => {
-  it('returns all undefined listeners when integrations is undefined and no global integrations', () => {
+  it('returns no-op listeners when integrations is undefined and no global integrations', async () => {
     const listeners = getGlobalTelemetryIntegration(undefined);
 
-    expect(listeners.onStart).toBeUndefined();
-    expect(listeners.onStepStart).toBeUndefined();
-    expect(listeners.onToolCallStart).toBeUndefined();
-    expect(listeners.onToolCallFinish).toBeUndefined();
-    expect(listeners.onStepFinish).toBeUndefined();
-    expect(listeners.onFinish).toBeUndefined();
+    expect(listeners.onStart).toBeDefined();
+    expect(listeners.onStepStart).toBeDefined();
+    expect(listeners.onToolCallStart).toBeDefined();
+    expect(listeners.onToolCallFinish).toBeDefined();
+    expect(listeners.onStepFinish).toBeDefined();
+    expect(listeners.onFinish).toBeDefined();
+
+    await expect(listeners.onStart!(dummyEvent)).resolves.toBeUndefined();
   });
 
-  it('accepts a single integration (not wrapped in array)', () => {
+  it('accepts a single integration (not wrapped in array)', async () => {
     const integration: TelemetryIntegration = {
       onStart: vi.fn(),
     };
@@ -32,7 +34,8 @@ describe('getGlobalTelemetryIntegration', () => {
     const listeners = getGlobalTelemetryIntegration(integration);
 
     expect(listeners.onStart).toBeDefined();
-    expect(listeners.onStepStart).toBeUndefined();
+    await listeners.onStart!(dummyEvent);
+    expect(integration.onStart).toHaveBeenCalledWith(dummyEvent);
   });
 
   it('accepts an array of integrations', () => {
@@ -48,15 +51,19 @@ describe('getGlobalTelemetryIntegration', () => {
     expect(listeners.onFinish).toBeDefined();
   });
 
-  it('returns undefined for a lifecycle method no integration implements', () => {
+  it('returns no-op for a lifecycle method no integration implements', async () => {
     const integration: TelemetryIntegration = { onStart: vi.fn() };
 
     const listeners = getGlobalTelemetryIntegration([integration]);
 
-    expect(listeners.onToolCallStart).toBeUndefined();
-    expect(listeners.onToolCallFinish).toBeUndefined();
-    expect(listeners.onStepFinish).toBeUndefined();
-    expect(listeners.onFinish).toBeUndefined();
+    expect(listeners.onToolCallStart).toBeDefined();
+    expect(listeners.onToolCallFinish).toBeDefined();
+    expect(listeners.onStepFinish).toBeDefined();
+    expect(listeners.onFinish).toBeDefined();
+
+    await expect(
+      listeners.onToolCallStart!(dummyEvent),
+    ).resolves.toBeUndefined();
   });
 
   it('broadcasts an event to all integrations that implement the method', async () => {
@@ -166,11 +173,13 @@ describe('getGlobalTelemetryIntegration', () => {
     expect(integration.onFinish).toHaveBeenCalledOnce();
   });
 
-  it('handles an empty array of integrations', () => {
+  it('handles an empty array of integrations', async () => {
     const listeners = getGlobalTelemetryIntegration([]);
 
-    expect(listeners.onStart).toBeUndefined();
-    expect(listeners.onFinish).toBeUndefined();
+    expect(listeners.onStart).toBeDefined();
+    expect(listeners.onFinish).toBeDefined();
+
+    await expect(listeners.onStart!(dummyEvent)).resolves.toBeUndefined();
   });
 
   describe('global integration merging', () => {

--- a/packages/ai/src/telemetry/get-global-telemetry-integration.test.ts
+++ b/packages/ai/src/telemetry/get-global-telemetry-integration.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
 
 describe('getGlobalTelemetryIntegration', () => {
   it('returns no-op listeners when integrations is undefined and no global integrations', async () => {
-    const listeners = getGlobalTelemetryIntegration(undefined);
+    const listeners = getGlobalTelemetryIntegration()(undefined);
 
     expect(listeners.onStart).toBeDefined();
     expect(listeners.onStepStart).toBeDefined();
@@ -31,7 +31,7 @@ describe('getGlobalTelemetryIntegration', () => {
       onStart: vi.fn(),
     };
 
-    const listeners = getGlobalTelemetryIntegration(integration);
+    const listeners = getGlobalTelemetryIntegration()(integration);
 
     expect(listeners.onStart).toBeDefined();
     await listeners.onStart!(dummyEvent);
@@ -42,7 +42,7 @@ describe('getGlobalTelemetryIntegration', () => {
     const integration1: TelemetryIntegration = { onStart: vi.fn() };
     const integration2: TelemetryIntegration = { onFinish: vi.fn() };
 
-    const listeners = getGlobalTelemetryIntegration([
+    const listeners = getGlobalTelemetryIntegration()([
       integration1,
       integration2,
     ]);
@@ -54,7 +54,7 @@ describe('getGlobalTelemetryIntegration', () => {
   it('returns no-op for a lifecycle method no integration implements', async () => {
     const integration: TelemetryIntegration = { onStart: vi.fn() };
 
-    const listeners = getGlobalTelemetryIntegration([integration]);
+    const listeners = getGlobalTelemetryIntegration()([integration]);
 
     expect(listeners.onToolCallStart).toBeDefined();
     expect(listeners.onToolCallFinish).toBeDefined();
@@ -72,7 +72,7 @@ describe('getGlobalTelemetryIntegration', () => {
     const integration1: TelemetryIntegration = { onStart: onStart1 };
     const integration2: TelemetryIntegration = { onStart: onStart2 };
 
-    const listeners = getGlobalTelemetryIntegration([
+    const listeners = getGlobalTelemetryIntegration()([
       integration1,
       integration2,
     ]);
@@ -95,7 +95,7 @@ describe('getGlobalTelemetryIntegration', () => {
       },
     };
 
-    const listeners = getGlobalTelemetryIntegration([
+    const listeners = getGlobalTelemetryIntegration()([
       integration1,
       integration2,
     ]);
@@ -109,7 +109,7 @@ describe('getGlobalTelemetryIntegration', () => {
     const integration1: TelemetryIntegration = { onStart };
     const integration2: TelemetryIntegration = {};
 
-    const listeners = getGlobalTelemetryIntegration([
+    const listeners = getGlobalTelemetryIntegration()([
       integration1,
       integration2,
     ]);
@@ -124,7 +124,7 @@ describe('getGlobalTelemetryIntegration', () => {
     const integration1: TelemetryIntegration = { onStart: onStart1 };
     const integration2: TelemetryIntegration = { onStart: onStart2 };
 
-    const listeners = getGlobalTelemetryIntegration([
+    const listeners = getGlobalTelemetryIntegration()([
       integration1,
       integration2,
     ]);
@@ -141,7 +141,7 @@ describe('getGlobalTelemetryIntegration', () => {
       },
     };
 
-    const listeners = getGlobalTelemetryIntegration([integration]);
+    const listeners = getGlobalTelemetryIntegration()([integration]);
 
     await expect(listeners.onStart!(dummyEvent)).resolves.toBeUndefined();
   });
@@ -156,7 +156,7 @@ describe('getGlobalTelemetryIntegration', () => {
       onFinish: vi.fn(),
     };
 
-    const listeners = getGlobalTelemetryIntegration([integration]);
+    const listeners = getGlobalTelemetryIntegration()([integration]);
 
     await listeners.onStart!(dummyEvent);
     await listeners.onStepStart!(dummyEvent);
@@ -174,7 +174,7 @@ describe('getGlobalTelemetryIntegration', () => {
   });
 
   it('handles an empty array of integrations', async () => {
-    const listeners = getGlobalTelemetryIntegration([]);
+    const listeners = getGlobalTelemetryIntegration()([]);
 
     expect(listeners.onStart).toBeDefined();
     expect(listeners.onFinish).toBeDefined();
@@ -187,7 +187,7 @@ describe('getGlobalTelemetryIntegration', () => {
       const onStart = vi.fn();
       registerTelemetryIntegration({ onStart });
 
-      const listeners = getGlobalTelemetryIntegration(undefined);
+      const listeners = getGlobalTelemetryIntegration()(undefined);
       await listeners.onStart!(dummyEvent);
 
       expect(onStart).toHaveBeenCalledWith(dummyEvent);
@@ -199,7 +199,7 @@ describe('getGlobalTelemetryIntegration', () => {
 
       registerTelemetryIntegration({ onStart: globalOnStart });
 
-      const listeners = getGlobalTelemetryIntegration({
+      const listeners = getGlobalTelemetryIntegration()({
         onStart: localOnStart,
       });
       await listeners.onStart!(dummyEvent);
@@ -217,7 +217,7 @@ describe('getGlobalTelemetryIntegration', () => {
         },
       });
 
-      const listeners = getGlobalTelemetryIntegration({
+      const listeners = getGlobalTelemetryIntegration()({
         onFinish: async () => {
           callOrder.push('local');
         },
@@ -234,7 +234,7 @@ describe('getGlobalTelemetryIntegration', () => {
 
       registerTelemetryIntegration({ onStart: globalOnStart });
 
-      const listeners = getGlobalTelemetryIntegration([
+      const listeners = getGlobalTelemetryIntegration()([
         { onStart: localOnStart1 },
         { onStart: localOnStart2 },
       ]);
@@ -253,7 +253,7 @@ describe('getGlobalTelemetryIntegration', () => {
       });
 
       const localOnStart = vi.fn();
-      const listeners = getGlobalTelemetryIntegration({
+      const listeners = getGlobalTelemetryIntegration()({
         onStart: localOnStart,
       });
       await listeners.onStart!(dummyEvent);
@@ -308,7 +308,7 @@ describe('bindTelemetryIntegration', () => {
 
     const instance = new DevToolsIntegration();
     const bound = bindTelemetryIntegration(instance);
-    const listeners = getGlobalTelemetryIntegration([bound]);
+    const listeners = getGlobalTelemetryIntegration()([bound]);
 
     await listeners.onStart!(dummyEvent);
     await listeners.onFinish!(dummyEvent);

--- a/packages/ai/src/telemetry/get-global-telemetry-integration.ts
+++ b/packages/ai/src/telemetry/get-global-telemetry-integration.ts
@@ -23,52 +23,63 @@ export function bindTelemetryIntegration(
 }
 
 /**
- * Merges globally registered integrations (via `registerTelemetryIntegration`)
- * with per-call integrations into a single composite integration.
- * Global integrations run first.
+ * Creates a factory that merges globally registered integrations
+ * (via `registerTelemetryIntegration`) with per-call integrations
+ * into a single composite integration.
+ *
+ * Returns a factory function that accepts local integrations and
+ * returns the merged TelemetryIntegration.
  */
 export function getGlobalTelemetryIntegration<
   TOOLS extends ToolSet = ToolSet,
   OUTPUT extends Output = Output,
->(
+>(): (
   integrations: TelemetryIntegration | Array<TelemetryIntegration> | undefined,
-): TelemetryIntegration {
+) => TelemetryIntegration {
   const globalIntegrations = getGlobalTelemetryIntegrations();
-  const localIntegrations = asArray(integrations);
-  const allIntegrations = [...globalIntegrations, ...localIntegrations];
 
-  function createTelemetryComposite<EVENT>(
-    getListenerFromIntegration: (
-      integration: TelemetryIntegration,
-    ) => ((event: EVENT) => PromiseLike<void> | void) | undefined,
-  ): ((event: EVENT) => Promise<void>) | undefined {
-    const listeners = allIntegrations
-      .map(getListenerFromIntegration)
-      .filter(Boolean) as Array<(event: EVENT) => PromiseLike<void> | void>;
+  return (
+    integrations:
+      | TelemetryIntegration
+      | Array<TelemetryIntegration>
+      | undefined,
+  ): TelemetryIntegration => {
+    const localIntegrations = asArray(integrations);
+    const allIntegrations = [...globalIntegrations, ...localIntegrations];
 
-    return async (event: EVENT) => {
-      for (const listener of listeners) {
-        try {
-          await listener(event);
-        } catch (_ignored) {}
-      }
+    function createTelemetryComposite<EVENT>(
+      getListenerFromIntegration: (
+        integration: TelemetryIntegration,
+      ) => ((event: EVENT) => PromiseLike<void> | void) | undefined,
+    ): ((event: EVENT) => Promise<void>) | undefined {
+      const listeners = allIntegrations
+        .map(getListenerFromIntegration)
+        .filter(Boolean) as Array<(event: EVENT) => PromiseLike<void> | void>;
+
+      return async (event: EVENT) => {
+        for (const listener of listeners) {
+          try {
+            await listener(event);
+          } catch (_ignored) {}
+        }
+      };
+    }
+
+    return {
+      onStart: createTelemetryComposite(integration => integration.onStart),
+      onStepStart: createTelemetryComposite(
+        integration => integration.onStepStart,
+      ),
+      onToolCallStart: createTelemetryComposite(
+        integration => integration.onToolCallStart,
+      ),
+      onToolCallFinish: createTelemetryComposite(
+        integration => integration.onToolCallFinish,
+      ),
+      onStepFinish: createTelemetryComposite(
+        integration => integration.onStepFinish,
+      ),
+      onFinish: createTelemetryComposite(integration => integration.onFinish),
     };
-  }
-
-  return {
-    onStart: createTelemetryComposite(integration => integration.onStart),
-    onStepStart: createTelemetryComposite(
-      integration => integration.onStepStart,
-    ),
-    onToolCallStart: createTelemetryComposite(
-      integration => integration.onToolCallStart,
-    ),
-    onToolCallFinish: createTelemetryComposite(
-      integration => integration.onToolCallFinish,
-    ),
-    onStepFinish: createTelemetryComposite(
-      integration => integration.onStepFinish,
-    ),
-    onFinish: createTelemetryComposite(integration => integration.onFinish),
   };
 }

--- a/packages/ai/src/telemetry/get-global-telemetry-integration.ts
+++ b/packages/ai/src/telemetry/get-global-telemetry-integration.ts
@@ -32,7 +32,7 @@ export function getGlobalTelemetryIntegration<
   OUTPUT extends Output = Output,
 >(
   integrations: TelemetryIntegration | Array<TelemetryIntegration> | undefined,
-): TelemetryIntegration<TOOLS, OUTPUT> {
+): TelemetryIntegration {
   const globalIntegrations = getGlobalTelemetryIntegrations();
   const localIntegrations = asArray(integrations);
   const allIntegrations = [...globalIntegrations, ...localIntegrations];
@@ -45,8 +45,6 @@ export function getGlobalTelemetryIntegration<
     const listeners = allIntegrations
       .map(getListenerFromIntegration)
       .filter(Boolean) as Array<(event: EVENT) => PromiseLike<void> | void>;
-
-    if (listeners.length === 0) return undefined;
 
     return async (event: EVENT) => {
       for (const listener of listeners) {
@@ -72,5 +70,5 @@ export function getGlobalTelemetryIntegration<
       integration => integration.onStepFinish,
     ),
     onFinish: createTelemetryComposite(integration => integration.onFinish),
-  } as TelemetryIntegration<TOOLS, OUTPUT>;
+  };
 }

--- a/packages/ai/src/telemetry/get-global-telemetry-integration.ts
+++ b/packages/ai/src/telemetry/get-global-telemetry-integration.ts
@@ -1,3 +1,5 @@
+import type { Output } from '../generate-text/output';
+import type { ToolSet } from '../generate-text/tool-set';
 import { asArray } from '../util/as-array';
 import type { TelemetryIntegration } from './telemetry-integration';
 import { getGlobalTelemetryIntegrations } from './telemetry-integration-registry';
@@ -25,9 +27,12 @@ export function bindTelemetryIntegration(
  * with per-call integrations into a single composite integration.
  * Global integrations run first.
  */
-export function getGlobalTelemetryIntegration(
+export function getGlobalTelemetryIntegration<
+  TOOLS extends ToolSet = ToolSet,
+  OUTPUT extends Output = Output,
+>(
   integrations: TelemetryIntegration | Array<TelemetryIntegration> | undefined,
-): TelemetryIntegration {
+): TelemetryIntegration<TOOLS, OUTPUT> {
   const globalIntegrations = getGlobalTelemetryIntegrations();
   const localIntegrations = asArray(integrations);
   const allIntegrations = [...globalIntegrations, ...localIntegrations];
@@ -67,5 +72,5 @@ export function getGlobalTelemetryIntegration(
       integration => integration.onStepFinish,
     ),
     onFinish: createTelemetryComposite(integration => integration.onFinish),
-  };
+  } as TelemetryIntegration<TOOLS, OUTPUT>;
 }

--- a/packages/ai/src/telemetry/telemetry-integration.ts
+++ b/packages/ai/src/telemetry/telemetry-integration.ts
@@ -8,25 +8,17 @@ import type {
 } from '../generate-text/callback-events';
 import type { Output } from '../generate-text/output';
 import type { ToolSet } from '../generate-text/tool-set';
+import { Listener } from '../util/notify';
 
 /**
  * Implement this interface to create custom telemetry integrations.
  * Methods can be sync or return a PromiseLike.
  */
-export interface TelemetryIntegration<
-  TOOLS extends ToolSet = ToolSet,
-  OUTPUT extends Output = Output,
-> {
-  onStart?(event: OnStartEvent<TOOLS, OUTPUT>): PromiseLike<void> | void;
-  onStepStart?(
-    event: OnStepStartEvent<TOOLS, OUTPUT>,
-  ): PromiseLike<void> | void;
-  onToolCallStart?(
-    event: OnToolCallStartEvent<TOOLS>,
-  ): PromiseLike<void> | void;
-  onToolCallFinish?(
-    event: OnToolCallFinishEvent<TOOLS>,
-  ): PromiseLike<void> | void;
-  onStepFinish?(event: OnStepFinishEvent<TOOLS>): PromiseLike<void> | void;
-  onFinish?(event: OnFinishEvent<TOOLS>): PromiseLike<void> | void;
+export interface TelemetryIntegration {
+  onStart?: Listener<OnStartEvent<ToolSet, Output>>;
+  onStepStart?: Listener<OnStepStartEvent<ToolSet, Output>>;
+  onToolCallStart?: Listener<OnToolCallStartEvent<ToolSet>>;
+  onToolCallFinish?: Listener<OnToolCallFinishEvent<ToolSet>>;
+  onStepFinish?: Listener<OnStepFinishEvent<ToolSet>>;
+  onFinish?: Listener<OnFinishEvent<ToolSet>>;
 }

--- a/packages/ai/src/util/notify.ts
+++ b/packages/ai/src/util/notify.ts
@@ -8,9 +8,10 @@ export type Listener<EVENT> = (event: EVENT) => PromiseLike<void> | void;
  */
 export async function notify<EVENT>(options: {
   event: EVENT;
-  callbacks?: Listener<EVENT> | Array<Listener<EVENT>>;
+  callbacks?: Listener<EVENT> | Array<Listener<EVENT> | undefined | null>;
 }): Promise<void> {
   for (const callback of asArray(options.callbacks)) {
+    if (callback == null) continue;
     try {
       await callback(options.event);
     } catch (_ignored) {}

--- a/packages/ai/src/util/notify.ts
+++ b/packages/ai/src/util/notify.ts
@@ -1,5 +1,8 @@
 import { asArray } from './as-array';
 
+/**
+ * A callback function that can be used to notify listeners.
+ */
 export type Listener<EVENT> = (event: EVENT) => PromiseLike<void> | void;
 
 /**


### PR DESCRIPTION
## Background

this is added to the core functions such as generate, stream, agent so that o11y providers can register their packages using the global integration interface separately and don't need to be added in the core functions

## Summary

wire the `TelemetryIntegration` system into core functions so that any integration specified via telemetry.integrations automatically receives all lifecycle events.

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)