### PR TITLE
fix(anthropic): handle encrypted_code_execution_result for multi-turn with web_fetch/web_search 20260209

### DIFF
--- a/.changeset/mighty-deers-tie.md
+++ b/.changeset/mighty-deers-tie.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(provider/anthropic): handle encrypted_code_execution_result for multi-turn with web_fetch/web_search 20260209

--- a/examples/ai-e2e-next/app/chat/anthropic-programmatic-tool-calling/page.tsx
+++ b/examples/ai-e2e-next/app/chat/anthropic-programmatic-tool-calling/page.tsx
@@ -3,7 +3,7 @@
 import { AnthropicProgrammaticToolCallingMessage } from '@/agent/anthropic/programmatic-tool-calling-agent';
 import { Response } from '@/components/ai-elements/response';
 import ChatInput from '@/components/chat-input';
-import AnthropicCodeExecutionView from '@/components/tool/anthropic-code-execution-view';
+import AnthropicCodeExecution20260120View from '@/components/tool/anthropic-code-execution-20260120-view';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 
@@ -41,7 +41,10 @@ export default function ChatAnthropicProgrammaticToolCalling() {
               }
               case 'tool-code_execution': {
                 return (
-                  <AnthropicCodeExecutionView invocation={part} key={index} />
+                  <AnthropicCodeExecution20260120View
+                    invocation={part}
+                    key={index}
+                  />
                 );
               }
               case 'tool-rollDie': {

--- a/examples/ai-e2e-next/components/tool/anthropic-code-execution-20260120-view.tsx
+++ b/examples/ai-e2e-next/components/tool/anthropic-code-execution-20260120-view.tsx
@@ -87,6 +87,58 @@ export default function AnthropicCodeExecution20260120View({
                   )}
                 </>
               )}
+              {invocation.output.type === 'encrypted_code_execution_result' && (
+                <>
+                  <span className="font-semibold">Encrypted Stdout:</span>
+                  <br />
+                  {invocation.output.encrypted_stdout}
+                  <br />
+                  {invocation.output.stderr && (
+                    <>
+                      <span className="font-semibold">Stderr:</span>
+                      <br />
+                      {invocation.output.stderr}
+                      <br />
+                    </>
+                  )}
+                  {invocation.output.content.length > 0 && (
+                    <div className="bg-gray-200 py-2 px-2 rounded-lg flex flex-col gap-1">
+                      <div className="px-1">
+                        <p className="text-black">
+                          {invocation.output.content.length > 1
+                            ? 'downloads'
+                            : 'download'}
+                        </p>
+                      </div>
+                      {invocation.output.content.map(file => (
+                        <button
+                          className="bg-cyan-800 hover:bg-cyan-700 text-white rounded-lg py-1 px-2 border border-white cursor-pointer"
+                          key={file.file_id}
+                          onClick={() =>
+                            window.open(
+                              `/api/code-execution-files/anthropic/${file.file_id}`,
+                              '_blank',
+                            )
+                          }
+                        >
+                          <div className="flex gap-1 items-center justify-center">
+                            <Download />
+                            <p>{file.file_id}</p>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  {invocation.output.return_code != null && (
+                    <>
+                      <span className="font-semibold">Return Code:</span>
+                      <br />
+                      {invocation.output.return_code}
+                      <br />
+                    </>
+                  )}
+                </>
+              )}
               {invocation.output.type === 'bash_code_execution_result' && (
                 <>
                   <span className="font-semibold">Stdout:</span>

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -1056,6 +1056,19 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                 content: part.content.content ?? [],
               },
             });
+          } else if (part.content.type === 'encrypted_code_execution_result') {
+            content.push({
+              type: 'tool-result',
+              toolCallId: part.tool_use_id,
+              toolName: toolNameMapping.toCustomToolName('code_execution'),
+              result: {
+                type: part.content.type,
+                encrypted_stdout: part.content.encrypted_stdout,
+                stderr: part.content.stderr,
+                return_code: part.content.return_code,
+                content: part.content.content ?? [],
+              },
+            });
           } else if (part.content.type === 'code_execution_tool_result_error') {
             content.push({
               type: 'tool-result',
@@ -1617,6 +1630,22 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                       result: {
                         type: part.content.type,
                         stdout: part.content.stdout,
+                        stderr: part.content.stderr,
+                        return_code: part.content.return_code,
+                        content: part.content.content ?? [],
+                      },
+                    });
+                  } else if (
+                    part.content.type === 'encrypted_code_execution_result'
+                  ) {
+                    controller.enqueue({
+                      type: 'tool-result',
+                      toolCallId: part.tool_use_id,
+                      toolName:
+                        toolNameMapping.toCustomToolName('code_execution'),
+                      result: {
+                        type: part.content.type,
+                        encrypted_stdout: part.content.encrypted_stdout,
                         stderr: part.content.stderr,
                         return_code: part.content.return_code,
                         content: part.content.content ?? [],

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -1739,6 +1739,88 @@ describe('assistant messages', () => {
       `);
       expect(warnings).toMatchInlineSnapshot(`[]`);
     });
+
+    it('should pass back encrypted_code_execution_result for multi-turn (web_fetch_20260209/web_search_20260209)', async () => {
+      const warnings: SharedV3Warning[] = [];
+      const result = await convertToAnthropicMessagesPrompt({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'srvtoolu_webfetch_01',
+                toolName: 'web_fetch',
+                input: { url: 'https://example.com' },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'srvtoolu_webfetch_01',
+                toolName: 'web_fetch',
+                output: {
+                  type: 'json',
+                  value: {
+                    type: 'web_fetch_result',
+                    url: 'https://example.com',
+                    retrievedAt: '2026-01-01T00:00:00Z',
+                    content: {
+                      type: 'document',
+                      title: 'Example',
+                      source: {
+                        type: 'text',
+                        mediaType: 'text/plain',
+                        data: 'hello',
+                      },
+                    },
+                  },
+                },
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'srvtoolu_codeexec_01',
+                toolName: 'code_execution',
+                input: { code: 'print("done")' },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'srvtoolu_codeexec_01',
+                toolName: 'code_execution',
+                output: {
+                  type: 'json',
+                  value: {
+                    type: 'encrypted_code_execution_result',
+                    encrypted_stdout: 'enc_abc123',
+                    stderr: '',
+                    return_code: 0,
+                    content: [],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        sendReasoning: false,
+        warnings,
+        toolNameMapping: defaultToolNameMapping,
+      });
+
+      const assistantMessage = result.prompt.messages[0];
+      expect(assistantMessage.role).toBe('assistant');
+      const codeExecResult = (assistantMessage.content as any[]).find(
+        (c: any) => c.type === 'code_execution_tool_result',
+      );
+      expect(codeExecResult).toBeDefined();
+      expect(codeExecResult.content).toEqual({
+        type: 'encrypted_code_execution_result',
+        encrypted_stdout: 'enc_abc123',
+        stderr: '',
+        return_code: 0,
+        content: [],
+      });
+      expect(warnings).toMatchInlineSnapshot(`[]`);
+    });
   });
 
   describe('code_execution 20250825', () => {

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -767,9 +767,35 @@ export async function convertToAnthropicMessagesPrompt({
                     break;
                   }
 
-                  // to distinguish between code execution 20250522 and 20250825,
-                  // we check if a type property is present in the output.value
-                  if (output.value.type === 'code_execution_result') {
+                  // to distinguish between code execution 20250522, 20250825,
+                  // and encrypted results (from web_fetch_20260209/web_search_20260209 injection),
+                  // we check the type property in output.value
+                  if (output.value.type === 'encrypted_code_execution_result') {
+                    // encrypted result injected by web_fetch_20260209/web_search_20260209 —
+                    // pass back as-is; Anthropic requires it for multi-turn continuity
+                    const encryptedOutput = output.value as {
+                      type: 'encrypted_code_execution_result';
+                      encrypted_stdout: string;
+                      stderr: string;
+                      return_code: number;
+                      content: Array<{
+                        type: 'code_execution_output';
+                        file_id: string;
+                      }>;
+                    };
+                    anthropicContent.push({
+                      type: 'code_execution_tool_result',
+                      tool_use_id: part.toolCallId,
+                      content: {
+                        type: encryptedOutput.type,
+                        encrypted_stdout: encryptedOutput.encrypted_stdout,
+                        stderr: encryptedOutput.stderr,
+                        return_code: encryptedOutput.return_code,
+                        content: encryptedOutput.content ?? [],
+                      },
+                      cache_control: cacheControl,
+                    });
+                  } else if (output.value.type === 'code_execution_result') {
                     // code execution 20250522
                     const codeExecutionOutput = await validateTypes({
                       value: output.value,

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -26,6 +26,7 @@ import { anthropicFilePartProviderOptions } from './anthropic-messages-options';
 import { CacheControlValidator } from './get-cache-control';
 import { codeExecution_20250522OutputSchema } from './tool/code-execution_20250522';
 import { codeExecution_20250825OutputSchema } from './tool/code-execution_20250825';
+import { codeExecution_20260120OutputSchema } from './tool/code-execution_20260120';
 import { toolSearchRegex_20251119OutputSchema as toolSearchOutputSchema } from './tool/tool-search-regex_20251119';
 import { webFetch_20250910OutputSchema } from './tool/web-fetch-20250910';
 import { webSearch_20250305OutputSchema } from './tool/web-search_20250305';
@@ -770,32 +771,7 @@ export async function convertToAnthropicMessagesPrompt({
                   // to distinguish between code execution 20250522, 20250825,
                   // and encrypted results (from web_fetch_20260209/web_search_20260209 injection),
                   // we check the type property in output.value
-                  if (output.value.type === 'encrypted_code_execution_result') {
-                    // encrypted result injected by web_fetch_20260209/web_search_20260209 —
-                    // pass back as-is; Anthropic requires it for multi-turn continuity
-                    const encryptedOutput = output.value as {
-                      type: 'encrypted_code_execution_result';
-                      encrypted_stdout: string;
-                      stderr: string;
-                      return_code: number;
-                      content: Array<{
-                        type: 'code_execution_output';
-                        file_id: string;
-                      }>;
-                    };
-                    anthropicContent.push({
-                      type: 'code_execution_tool_result',
-                      tool_use_id: part.toolCallId,
-                      content: {
-                        type: encryptedOutput.type,
-                        encrypted_stdout: encryptedOutput.encrypted_stdout,
-                        stderr: encryptedOutput.stderr,
-                        return_code: encryptedOutput.return_code,
-                        content: encryptedOutput.content ?? [],
-                      },
-                      cache_control: cacheControl,
-                    });
-                  } else if (output.value.type === 'code_execution_result') {
+                  if (output.value.type === 'code_execution_result') {
                     // code execution 20250522
                     const codeExecutionOutput = await validateTypes({
                       value: output.value,
@@ -814,6 +790,33 @@ export async function convertToAnthropicMessagesPrompt({
                       },
                       cache_control: cacheControl,
                     });
+                  } else if (
+                    output.value.type === 'encrypted_code_execution_result'
+                  ) {
+                    // code execution 20260120 encrypted result
+                    const codeExecutionOutput = await validateTypes({
+                      value: output.value,
+                      schema: codeExecution_20260120OutputSchema,
+                    });
+
+                    if (
+                      codeExecutionOutput.type ===
+                      'encrypted_code_execution_result'
+                    ) {
+                      anthropicContent.push({
+                        type: 'code_execution_tool_result',
+                        tool_use_id: part.toolCallId,
+                        content: {
+                          type: codeExecutionOutput.type,
+                          encrypted_stdout:
+                            codeExecutionOutput.encrypted_stdout,
+                          stderr: codeExecutionOutput.stderr,
+                          return_code: codeExecutionOutput.return_code,
+                          content: codeExecutionOutput.content ?? [],
+                        },
+                        cache_control: cacheControl,
+                      });
+                    }
                   } else {
                     // code execution 20250825
                     const codeExecutionOutput = await validateTypes({
@@ -822,7 +825,6 @@ export async function convertToAnthropicMessagesPrompt({
                     });
 
                     if (codeExecutionOutput.type === 'code_execution_result') {
-                      // Programmatic tool calling result - same format as 20250522
                       anthropicContent.push({
                         type: 'code_execution_tool_result',
                         tool_use_id: part.toolCallId,

--- a/packages/anthropic/src/tool/code-execution_20260120.ts
+++ b/packages/anthropic/src/tool/code-execution_20260120.ts
@@ -24,6 +24,21 @@ export const codeExecution_20260120OutputSchema = lazySchema(() =>
           .default([]),
       }),
       z.object({
+        type: z.literal('encrypted_code_execution_result'),
+        encrypted_stdout: z.string(),
+        stderr: z.string(),
+        return_code: z.number(),
+        content: z
+          .array(
+            z.object({
+              type: z.literal('code_execution_output'),
+              file_id: z.string(),
+            }),
+          )
+          .optional()
+          .default([]),
+      }),
+      z.object({
         type: z.literal('bash_code_execution_result'),
         content: z.array(
           z.object({
@@ -172,6 +187,29 @@ const factory = createProviderToolFactoryWithOutputSchema<
        * Output from successful execution
        */
       stdout: string;
+
+      /**
+       * Error messages if execution fails
+       */
+      stderr: string;
+
+      /**
+       * 0 for success, non-zero for failure
+       */
+      return_code: number;
+
+      /**
+       * Output file Id list
+       */
+      content: Array<{ type: 'code_execution_output'; file_id: string }>;
+    }
+  | {
+      type: 'encrypted_code_execution_result';
+
+      /**
+       * Encrypted output from successful execution
+       */
+      encrypted_stdout: string;
 
       /**
        * Error messages if execution fails


### PR DESCRIPTION
## Problem

When using `web_fetch_20260209` or `web_search_20260209`, the Anthropic API auto-injects a `code_execution` `server_tool_use` block in the response and returns its result as an `encrypted_code_execution_result`. The SDK previously only handled `code_execution_result` and `code_execution_tool_result_error` types, so the encrypted result was **silently dropped**.

In multi-turn conversations, the absence of this `code_execution_tool_result` in the subsequent user message caused the Anthropic API to return:

```
messages.1: `code_execution` tool use with id `srvtoolu_01HopAaXMHo9To3RavUYwqy7` was found without a corresponding `code_execution_tool_result` block
```

Repro: use the example pages in `examples/ai-e2e-next`:
- `/chat/anthropic-web-fetch-20260209`
- `/chat/anthropic-web-search-20260209`

Then send a follow-up message after a tool call was made in the previous response.

Fixes #13040

## Fix

- **`anthropic-messages-language-model.ts`** (both streaming and non-streaming paths): when `code_execution_tool_result.content.type === 'encrypted_code_execution_result'`, emit a `tool-result` event carrying the encrypted payload so it is preserved in the conversation history
- **`convert-to-anthropic-messages-prompt.ts`**: when reconstructing the user message for multi-turn, detect `encrypted_code_execution_result` output and emit the correct `code_execution_tool_result` block with the encrypted content (checked before the existing `code_execution_result` branch)
- **`convert-to-anthropic-messages-prompt.test.ts`**: add a test covering the encrypted result round-trip in a multi-turn context