### PR TITLE
feat(amazon-bedrock): allow anthropicBeta through bedrock providerOptions in bedrock/anthropic

### DIFF
--- a/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-1m-context.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-1m-context.ts
@@ -60,7 +60,11 @@ async function main() {
 
   const endstamp = performance.now();
   console.log();
-  console.log('Time taken:', ((endstamp - startstamp) / 1000).toFixed(2), 'seconds');
+  console.log(
+    'Time taken:',
+    ((endstamp - startstamp) / 1000).toFixed(2),
+    'seconds',
+  );
   console.log('Token usage:', await result.usage);
   console.log('Finish reason:', await result.finishReason);
 }

--- a/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-1m-context.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-1m-context.ts
@@ -1,0 +1,68 @@
+import { createBedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+const bedrockAnthropic = createBedrockAnthropic();
+
+// Build a large text block intended to exceed the standard context window
+const APPROX_TOKENS = 110_000;
+const CHARS_PER_TOKEN = 4;
+const TARGET_CHARS = APPROX_TOKENS * CHARS_PER_TOKEN;
+
+function makeBaseChunk(): string {
+  let s = '';
+  for (let j = 0; j < 500; j++) {
+    s += `IDX:${j.toString(36)} | alpha:${'abcdefghijklmnopqrstuvwxyz'.slice(0, (j % 26) + 1)} | nums:${'0123456789'.repeat(3)} | sym:${'-=_+'.repeat(5)}\n`;
+  }
+  return s;
+}
+
+const baseChunk = makeBaseChunk();
+const repeats = Math.ceil(TARGET_CHARS / baseChunk.length);
+const largeContextText = baseChunk
+  .repeat(repeats)
+  .slice(0, TARGET_CHARS + 50_000);
+
+async function main() {
+  const estimatedTokens = Math.ceil(largeContextText.length / CHARS_PER_TOKEN);
+  console.log('Prepared large context chars:', largeContextText.length);
+  console.log('Estimated tokens (chars/4):', estimatedTokens);
+
+  const startstamp = performance.now();
+
+  const result = streamText({
+    model: bedrockAnthropic('us.anthropic.claude-sonnet-4-20250514-v1:0'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `The following is a large context payload.\n\n${largeContextText}`,
+          },
+          {
+            type: 'text',
+            text: 'Summarize the structure of the data above in one sentence.',
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      bedrock: {
+        anthropicBeta: ['context-1m-2025-08-07'],
+      },
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  const endstamp = performance.now();
+  console.log();
+  console.log('Time taken:', ((endstamp - startstamp) / 1000).toFixed(2), 'seconds');
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-fine-grained-tool-streaming.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-fine-grained-tool-streaming.ts
@@ -1,0 +1,148 @@
+import { createBedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { streamText } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+const bedrockAnthropic = createBedrockAnthropic();
+
+const tools = {
+  write_to_file: {
+    description:
+      'Request to write content to a file. ALWAYS provide the COMPLETE file content, without any truncation.',
+    inputSchema: z.object({
+      path: z
+        .string()
+        .describe(
+          'The path of the file to write to (relative to the current workspace directory)',
+        ),
+      content: z.string().describe('The content to write to the file.'),
+    }),
+  },
+} as const;
+
+async function main() {
+  console.log('=== Fine-grained tool streaming test (Bedrock Anthropic) ===\n');
+
+  const result = streamText({
+    model: bedrockAnthropic('global.anthropic.claude-sonnet-4-6'),
+
+    messages: [
+      {
+        role: 'user',
+        content:
+          'Write a bubble sort implementation in JavaScript to sort.js',
+      },
+    ],
+
+    tools,
+    toolChoice: 'required',
+    providerOptions: {
+      bedrock: {
+        anthropicBeta: ['fine-grained-tool-streaming-2025-05-14'],
+      },
+    },
+  });
+
+  let sawToolInputStart = false;
+  let toolInputDeltaCount = 0;
+  let sawToolInputEnd = false;
+  const toolInputDeltaTimestamps: number[] = [];
+
+  // ts() prints a compact timestamp to stderr so we can see real-time ordering
+  const T0 = Date.now();
+  const ts = (label: string) =>
+    process.stderr.write(`+${((Date.now() - T0) / 1000).toFixed(2)}s ${label}\n`);
+
+  ts('stream started');
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text-start':
+        ts('[text-start]');
+        process.stdout.write('\n[text-start]\n');
+        break;
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'text-end':
+        ts('[text-end]');
+        process.stdout.write('\n[text-end]\n');
+        break;
+      case 'tool-input-start':
+        sawToolInputStart = true;
+        ts(`[tool-input-start] tool=${part.toolName}`);
+        process.stdout.write(
+          `\n[tool-input-start] id=${part.id} tool=${part.toolName}\n`,
+        );
+        break;
+      case 'tool-input-delta':
+        toolInputDeltaCount++;
+        toolInputDeltaTimestamps.push(Date.now());
+        if (toolInputDeltaCount === 1 || toolInputDeltaCount % 100 === 0) {
+          ts(`[tool-input-delta #${toolInputDeltaCount}]`);
+        }
+        process.stdout.write(part.delta);
+        break;
+      case 'tool-input-end':
+        sawToolInputEnd = true;
+        ts(`[tool-input-end]`);
+        process.stdout.write(`\n[tool-input-end] id=${part.id}\n`);
+        break;
+      case 'tool-call': {
+        const preview = JSON.stringify(part.input).slice(0, 80);
+        ts(`[tool-call] tool=${part.toolName}`);
+        console.log(
+          `\n[tool-call] tool=${part.toolName} input(preview)=${preview}…`,
+        );
+        break;
+      }
+      case 'start-step':
+        ts('[start-step]');
+        console.log('\n[start-step]');
+        break;
+      case 'finish-step':
+        ts(`[finish-step] reason=${part.finishReason}`);
+        console.log(
+          `[finish-step] finishReason=${part.finishReason} usage=${JSON.stringify(part.usage)}`,
+        );
+        break;
+      case 'finish':
+        ts(`[finish] reason=${part.finishReason}`);
+        console.log(
+          `\n[finish] finishReason=${part.finishReason} usage=${JSON.stringify(part.usage)}`,
+        );
+        break;
+      case 'error':
+        ts('[error]');
+        console.error('\n[error]', part.error);
+        break;
+    }
+  }
+
+  // ── diagnosis ─────────────────────────────────────────────────────────────
+  // Count consecutive delta intervals >= 5ms (genuine per-token generation time).
+  // A buffered dump replays all deltas synchronously (<1ms each); real streaming
+  // has most intervals >= 5ms as each token takes time to generate.
+  // Threshold is heuristic — the desired behavior is smooth continuous streaming
+  // instead of a long hang followed by a dump of all chunks at once.
+  let liveIntervals = 0;
+  for (let i = 1; i < toolInputDeltaTimestamps.length; i++) {
+    if (toolInputDeltaTimestamps[i] - toolInputDeltaTimestamps[i - 1] >= 5)
+      liveIntervals++;
+  }
+  const liveRatio =
+    toolInputDeltaTimestamps.length > 1
+      ? liveIntervals / (toolInputDeltaTimestamps.length - 1)
+      : 0;
+  const isStreaming = toolInputDeltaCount >= 5 && liveRatio > 0.5;
+
+  console.log('\n=== Summary ===');
+  console.log('tool-input-start received :', sawToolInputStart);
+  console.log('tool-input-delta count    :', toolInputDeltaCount);
+  console.log('tool-input-end received   :', sawToolInputEnd);
+  console.log(
+    `Fine-grained tool streaming: ${isStreaming ? '✅' : '❌'} (${toolInputDeltaCount} deltas, ${(liveRatio * 100).toFixed(0)}% live intervals)`,
+  );
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-fine-grained-tool-streaming.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-fine-grained-tool-streaming.ts
@@ -29,8 +29,7 @@ async function main() {
     messages: [
       {
         role: 'user',
-        content:
-          'Write a bubble sort implementation in JavaScript to sort.js',
+        content: 'Write a bubble sort implementation in JavaScript to sort.js',
       },
     ],
 
@@ -51,7 +50,9 @@ async function main() {
   // ts() prints a compact timestamp to stderr so we can see real-time ordering
   const T0 = Date.now();
   const ts = (label: string) =>
-    process.stderr.write(`+${((Date.now() - T0) / 1000).toFixed(2)}s ${label}\n`);
+    process.stderr.write(
+      `+${((Date.now() - T0) / 1000).toFixed(2)}s ${label}\n`,
+    );
 
   ts('stream started');
 

--- a/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-fine-grained-tool-streaming.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-fine-grained-tool-streaming.ts
@@ -109,7 +109,7 @@ async function main() {
       case 'finish':
         ts(`[finish] reason=${part.finishReason}`);
         console.log(
-          `\n[finish] finishReason=${part.finishReason} usage=${JSON.stringify(part.usage)}`,
+          `\n[finish] finishReason=${part.finishReason} usage=${JSON.stringify(part.totalUsage)}`,
         );
         break;
       case 'error':

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -41,14 +41,12 @@ vi.mock('@ai-sdk/anthropic/internal', async () => {
       doStream: vi
         .fn()
         .mockResolvedValue({ stream: new ReadableStream(), rawCall: {} }),
-      doGenerate: vi
-        .fn()
-        .mockResolvedValue({
-          content: [],
-          finishReason: 'stop',
-          rawCall: {},
-          usage: {},
-        }),
+      doGenerate: vi.fn().mockResolvedValue({
+        content: [],
+        finishReason: 'stop',
+        rawCall: {},
+        usage: {},
+      }),
       provider: 'bedrock.anthropic.messages',
       modelId: 'test-model',
       supportedUrls: vi.fn().mockReturnValue({}),
@@ -62,7 +60,9 @@ vi.mock('../bedrock-sigv4-fetch', () => ({
 }));
 
 const TEST_STREAM_OPTIONS = {
-  prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: '' }] }],
+  prompt: [
+    { role: 'user' as const, content: [{ type: 'text' as const, text: '' }] },
+  ],
 };
 
 async function triggerModel(
@@ -193,7 +193,10 @@ describe('bedrock-anthropic-provider', () => {
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    const config = await triggerModel(provider, 'anthropic.claude-3-sonnet-20240229-v1:0');
+    const config = await triggerModel(
+      provider,
+      'anthropic.claude-3-sonnet-20240229-v1:0',
+    );
 
     const url = config.buildRequestUrl?.(
       'https://bedrock-runtime.us-east-1.amazonaws.com',
@@ -210,7 +213,10 @@ describe('bedrock-anthropic-provider', () => {
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    const config = await triggerModel(provider, 'anthropic.claude-3-sonnet-20240229-v1:0');
+    const config = await triggerModel(
+      provider,
+      'anthropic.claude-3-sonnet-20240229-v1:0',
+    );
 
     const url = config.buildRequestUrl?.(
       'https://bedrock-runtime.us-east-1.amazonaws.com',
@@ -449,7 +455,10 @@ describe('bedrock-anthropic-provider', () => {
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    const config = await triggerModel(provider, 'us.anthropic.claude-3-5-sonnet-20240620-v1:0');
+    const config = await triggerModel(
+      provider,
+      'us.anthropic.claude-3-5-sonnet-20240620-v1:0',
+    );
 
     const url = config.buildRequestUrl?.(
       'https://bedrock-runtime.us-east-1.amazonaws.com',

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -61,18 +61,31 @@ vi.mock('../bedrock-sigv4-fetch', () => ({
   createApiKeyFetchFunction: vi.fn().mockReturnValue(vi.fn()),
 }));
 
+const TEST_STREAM_OPTIONS = {
+  prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: '' }] }],
+};
+
+async function triggerModel(
+  provider: ReturnType<typeof createBedrockAnthropic>,
+  modelId: string,
+) {
+  await provider(modelId).doStream(TEST_STREAM_OPTIONS as any);
+  const calls = vi.mocked(AnthropicMessagesLanguageModel).mock.calls;
+  return calls[calls.length - 1][1];
+}
+
 describe('bedrock-anthropic-provider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should create a language model with default settings', () => {
+  it('should create a language model with default settings', async () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('anthropic.claude-3-5-sonnet-20241022-v2:0');
+    await triggerModel(provider, 'anthropic.claude-3-5-sonnet-20241022-v2:0');
 
     expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
       'anthropic.claude-3-5-sonnet-20241022-v2:0',
@@ -99,7 +112,7 @@ describe('bedrock-anthropic-provider', () => {
     );
   });
 
-  it('should pass custom baseURL to the model when created', () => {
+  it('should pass custom baseURL to the model when created', async () => {
     const customBaseURL = 'https://custom-bedrock.amazonaws.com';
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
@@ -107,7 +120,7 @@ describe('bedrock-anthropic-provider', () => {
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('test-model-id');
+    await triggerModel(provider, 'test-model-id');
 
     expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
       expect.anything(),
@@ -159,7 +172,7 @@ describe('bedrock-anthropic-provider', () => {
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('test-model-id');
+    const config = await triggerModel(provider, 'test-model-id');
 
     expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
       expect.anything(),
@@ -168,27 +181,19 @@ describe('bedrock-anthropic-provider', () => {
       }),
     );
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
-
     expect(config.headers).toEqual(expect.any(Function));
     const resolvedHeaders = await (config.headers as Function)();
     expect(resolvedHeaders).toMatchObject(customHeaders);
     expect(resolvedHeaders['user-agent']).toContain('ai-sdk/amazon-bedrock/');
   });
 
-  it('should build correct URL for non-streaming requests', () => {
+  it('should build correct URL for non-streaming requests', async () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('anthropic.claude-3-sonnet-20240229-v1:0');
-
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
+    const config = await triggerModel(provider, 'anthropic.claude-3-sonnet-20240229-v1:0');
 
     const url = config.buildRequestUrl?.(
       'https://bedrock-runtime.us-east-1.amazonaws.com',
@@ -199,17 +204,13 @@ describe('bedrock-anthropic-provider', () => {
     );
   });
 
-  it('should build correct URL for streaming requests', () => {
+  it('should build correct URL for streaming requests', async () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('anthropic.claude-3-sonnet-20240229-v1:0');
-
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
+    const config = await triggerModel(provider, 'anthropic.claude-3-sonnet-20240229-v1:0');
 
     const url = config.buildRequestUrl?.(
       'https://bedrock-runtime.us-east-1.amazonaws.com',
@@ -220,17 +221,13 @@ describe('bedrock-anthropic-provider', () => {
     );
   });
 
-  it('should transform request body to add anthropic_version and remove model', () => {
+  it('should transform request body to add anthropic_version and remove model', async () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('test-model-id');
-
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
+    const config = await triggerModel(provider, 'test-model-id');
 
     const transformedBody = config.transformRequestBody?.({
       model: 'test-model-id',
@@ -246,17 +243,13 @@ describe('bedrock-anthropic-provider', () => {
     expect(transformedBody).not.toHaveProperty('model');
   });
 
-  it('should strip stream parameter from request body', () => {
+  it('should strip stream parameter from request body', async () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('test-model-id');
-
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
+    const config = await triggerModel(provider, 'test-model-id');
 
     const transformedBody = config.transformRequestBody?.({
       model: 'test-model-id',
@@ -269,17 +262,13 @@ describe('bedrock-anthropic-provider', () => {
     expect(transformedBody).toHaveProperty('anthropic_version');
   });
 
-  it('should strip disable_parallel_tool_use from tool_choice', () => {
+  it('should strip disable_parallel_tool_use from tool_choice', async () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('test-model-id');
-
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
+    const config = await triggerModel(provider, 'test-model-id');
 
     const transformedBody = config.transformRequestBody?.({
       model: 'test-model-id',
@@ -297,17 +286,13 @@ describe('bedrock-anthropic-provider', () => {
     );
   });
 
-  it('should preserve tool_choice name when present', () => {
+  it('should preserve tool_choice name when present', async () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('test-model-id');
-
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
+    const config = await triggerModel(provider, 'test-model-id');
 
     const transformedBody = config.transformRequestBody?.({
       model: 'test-model-id',
@@ -326,17 +311,13 @@ describe('bedrock-anthropic-provider', () => {
     });
   });
 
-  it('should map old tool versions to Bedrock-supported versions', () => {
+  it('should map old tool versions to Bedrock-supported versions', async () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('test-model-id');
-
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
+    const config = await triggerModel(provider, 'test-model-id');
 
     const transformedBody = config.transformRequestBody?.({
       model: 'test-model-id',
@@ -356,17 +337,13 @@ describe('bedrock-anthropic-provider', () => {
     ]);
   });
 
-  it('should add anthropic_beta when computer use tools are detected', () => {
+  it('should add anthropic_beta when computer use tools are detected', async () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('test-model-id');
-
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
+    const config = await triggerModel(provider, 'test-model-id');
 
     const transformedBody = config.transformRequestBody?.({
       model: 'test-model-id',
@@ -380,17 +357,13 @@ describe('bedrock-anthropic-provider', () => {
     );
   });
 
-  it('should not add anthropic_beta when no computer use tools are present', () => {
+  it('should not add anthropic_beta when no computer use tools are present', async () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('test-model-id');
-
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
+    const config = await triggerModel(provider, 'test-model-id');
 
     const transformedBody = config.transformRequestBody?.({
       model: 'test-model-id',
@@ -408,17 +381,13 @@ describe('bedrock-anthropic-provider', () => {
     expect(transformedBody?.anthropic_beta).toBeUndefined();
   });
 
-  it('should not support URL sources to force base64 conversion', () => {
+  it('should not support URL sources to force base64 conversion', async () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('test-model-id');
-
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
+    const config = await triggerModel(provider, 'test-model-id');
 
     expect(config.supportedUrls?.()).toEqual({});
   });
@@ -474,17 +443,13 @@ describe('bedrock-anthropic-provider', () => {
     );
   });
 
-  it('should handle models with us. prefix for inference profiles', () => {
+  it('should handle models with us. prefix for inference profiles', async () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    provider('us.anthropic.claude-3-5-sonnet-20240620-v1:0');
-
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
+    const config = await triggerModel(provider, 'us.anthropic.claude-3-5-sonnet-20240620-v1:0');
 
     const url = config.buildRequestUrl?.(
       'https://bedrock-runtime.us-east-1.amazonaws.com',

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -37,7 +37,13 @@ vi.mock('@ai-sdk/anthropic/internal', async () => {
   const originalModule = await vi.importActual('@ai-sdk/anthropic/internal');
   return {
     ...originalModule,
-    AnthropicMessagesLanguageModel: vi.fn(),
+    AnthropicMessagesLanguageModel: vi.fn().mockImplementation(() => ({
+      doStream: vi.fn().mockResolvedValue({ stream: new ReadableStream(), rawCall: {} }),
+      doGenerate: vi.fn().mockResolvedValue({ content: [], finishReason: 'stop', rawCall: {}, usage: {} }),
+      provider: 'bedrock.anthropic.messages',
+      modelId: 'test-model',
+      supportedUrls: vi.fn().mockReturnValue({}),
+    })),
   };
 });
 
@@ -427,6 +433,36 @@ describe('bedrock-anthropic-provider', () => {
 
     expect(provider.languageModel).toBeDefined();
     expect(typeof provider.languageModel).toBe('function');
+  });
+
+  it('should include providerOptions.bedrock.anthropicBeta in anthropic_beta in the request body', async () => {
+    const provider = createBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    const model = provider('test-model-id');
+
+    await model.doStream({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      providerOptions: {
+        bedrock: { anthropicBeta: ['fine-grained-tool-streaming-2025-05-14'] },
+      },
+    } as any);
+
+    const calls = vi.mocked(AnthropicMessagesLanguageModel).mock.calls;
+    const lastCall = calls[calls.length - 1];
+    const config = lastCall[1];
+
+    const transformedBody = config.transformRequestBody?.({
+      model: 'test-model-id',
+      messages: [{ role: 'user', content: 'Hello' }],
+      max_tokens: 1024,
+    });
+
+    expect(transformedBody?.anthropic_beta).toContain(
+      'fine-grained-tool-streaming-2025-05-14',
+    );
   });
 
   it('should handle models with us. prefix for inference profiles', () => {

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -38,8 +38,17 @@ vi.mock('@ai-sdk/anthropic/internal', async () => {
   return {
     ...originalModule,
     AnthropicMessagesLanguageModel: vi.fn().mockImplementation(() => ({
-      doStream: vi.fn().mockResolvedValue({ stream: new ReadableStream(), rawCall: {} }),
-      doGenerate: vi.fn().mockResolvedValue({ content: [], finishReason: 'stop', rawCall: {}, usage: {} }),
+      doStream: vi
+        .fn()
+        .mockResolvedValue({ stream: new ReadableStream(), rawCall: {} }),
+      doGenerate: vi
+        .fn()
+        .mockResolvedValue({
+          content: [],
+          finishReason: 'stop',
+          rawCall: {},
+          usage: {},
+        }),
       provider: 'bedrock.anthropic.messages',
       modelId: 'test-model',
       supportedUrls: vi.fn().mockReturnValue({}),

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -7,11 +7,13 @@ import {
   FetchFunction,
   loadOptionalSetting,
   loadSetting,
+  parseProviderOptions,
   Resolvable,
   resolve,
   withoutTrailingSlash,
   withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
+import { bedrockProviderOptions } from '../bedrock-chat-options';
 import {
   anthropicTools,
   AnthropicMessagesLanguageModel,
@@ -244,7 +246,10 @@ export function createBedrockAnthropic(
     return withUserAgentSuffix(baseHeaders, `ai-sdk/amazon-bedrock/${VERSION}`);
   };
 
-  const createChatModel = (modelId: BedrockAnthropicModelId) =>
+  const createChatModel = (
+    modelId: BedrockAnthropicModelId,
+    betas: string[] = [],
+  ) =>
     new AnthropicMessagesLanguageModel(modelId, {
       provider: 'bedrock.anthropic.messages',
       baseURL: getBaseURL(),
@@ -267,7 +272,7 @@ export function createBedrockAnthropic(
               }
             : undefined;
 
-        const requiredBetas = new Set<string>();
+        const requiredBetas = new Set<string>(betas);
         const transformedTools = tools?.map((tool: Record<string, unknown>) => {
           const toolType = tool.type as string | undefined;
 
@@ -283,11 +288,7 @@ export function createBedrockAnthropic(
               newType in BEDROCK_TOOL_NAME_MAP
                 ? BEDROCK_TOOL_NAME_MAP[newType]
                 : tool.name;
-            return {
-              ...tool,
-              type: newType,
-              name: newName,
-            };
+            return { ...tool, type: newType, name: newName };
           }
 
           if (toolType && toolType in BEDROCK_TOOL_BETA_MAP) {
@@ -295,10 +296,7 @@ export function createBedrockAnthropic(
           }
 
           if (toolType && toolType in BEDROCK_TOOL_NAME_MAP) {
-            return {
-              ...tool,
-              name: BEDROCK_TOOL_NAME_MAP[toolType],
-            };
+            return { ...tool, name: BEDROCK_TOOL_NAME_MAP[toolType] };
           }
 
           return tool;
@@ -321,6 +319,45 @@ export function createBedrockAnthropic(
       supportedUrls: () => ({}),
     });
 
+  const createChatModelWithProviderOptions = (
+    modelId: BedrockAnthropicModelId,
+  ): LanguageModelV2 => {
+    const baseModel = createChatModel(modelId);
+
+    return {
+      specificationVersion: 'v2' as const,
+      provider: baseModel.provider,
+      modelId: baseModel.modelId,
+      supportedUrls: () => ({}),
+
+      async doGenerate(callOptions) {
+        const bedrockOpts =
+          (await parseProviderOptions({
+            provider: 'bedrock',
+            providerOptions: callOptions.providerOptions,
+            schema: bedrockProviderOptions,
+          })) ?? {};
+        const betas = bedrockOpts.anthropicBeta ?? [];
+        return (
+          betas.length > 0 ? createChatModel(modelId, betas) : baseModel
+        ).doGenerate(callOptions);
+      },
+
+      async doStream(callOptions) {
+        const bedrockOpts =
+          (await parseProviderOptions({
+            provider: 'bedrock',
+            providerOptions: callOptions.providerOptions,
+            schema: bedrockProviderOptions,
+          })) ?? {};
+        const betas = bedrockOpts.anthropicBeta ?? [];
+        return (
+          betas.length > 0 ? createChatModel(modelId, betas) : baseModel
+        ).doStream(callOptions);
+      },
+    };
+  };
+
   const provider = function (modelId: BedrockAnthropicModelId) {
     if (new.target) {
       throw new Error(
@@ -328,13 +365,13 @@ export function createBedrockAnthropic(
       );
     }
 
-    return createChatModel(modelId);
+    return createChatModelWithProviderOptions(modelId);
   };
 
   provider.specificationVersion = 'v2' as const;
-  provider.languageModel = createChatModel;
-  provider.chat = createChatModel;
-  provider.messages = createChatModel;
+  provider.languageModel = createChatModelWithProviderOptions;
+  provider.chat = createChatModelWithProviderOptions;
+  provider.messages = createChatModelWithProviderOptions;
 
   provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'textEmbeddingModel' });

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -288,10 +288,10 @@ export function createBedrockAnthropic(
               newType in BEDROCK_TOOL_NAME_MAP
                 ? BEDROCK_TOOL_NAME_MAP[newType]
                 : tool.name;
-            return { 
-              ...tool, 
-              type: newType, 
-              name: newName 
+            return {
+              ...tool,
+              type: newType,
+              name: newName,
             };
           }
 
@@ -300,9 +300,9 @@ export function createBedrockAnthropic(
           }
 
           if (toolType && toolType in BEDROCK_TOOL_NAME_MAP) {
-            return { 
-              ...tool, 
-              name: BEDROCK_TOOL_NAME_MAP[toolType] 
+            return {
+              ...tool,
+              name: BEDROCK_TOOL_NAME_MAP[toolType],
             };
           }
 

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -288,7 +288,11 @@ export function createBedrockAnthropic(
               newType in BEDROCK_TOOL_NAME_MAP
                 ? BEDROCK_TOOL_NAME_MAP[newType]
                 : tool.name;
-            return { ...tool, type: newType, name: newName };
+            return { 
+              ...tool, 
+              type: newType, 
+              name: newName 
+            };
           }
 
           if (toolType && toolType in BEDROCK_TOOL_BETA_MAP) {
@@ -296,7 +300,10 @@ export function createBedrockAnthropic(
           }
 
           if (toolType && toolType in BEDROCK_TOOL_NAME_MAP) {
-            return { ...tool, name: BEDROCK_TOOL_NAME_MAP[toolType] };
+            return { 
+              ...tool, 
+              name: BEDROCK_TOOL_NAME_MAP[toolType] 
+            };
           }
 
           return tool;
@@ -328,7 +335,7 @@ export function createBedrockAnthropic(
       specificationVersion: 'v2' as const,
       provider: baseModel.provider,
       modelId: baseModel.modelId,
-      supportedUrls: () => ({}),
+      supportedUrls: baseModel.supportedUrls,
 
       async doGenerate(callOptions) {
         const bedrockOpts =

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -328,42 +328,34 @@ export function createBedrockAnthropic(
 
   const createChatModelWithProviderOptions = (
     modelId: BedrockAnthropicModelId,
-  ): LanguageModelV2 => {
-    const baseModel = createChatModel(modelId);
+  ): LanguageModelV2 => ({
+    specificationVersion: 'v2' as const,
+    provider: 'bedrock.anthropic.messages',
+    modelId,
+    supportedUrls: {},
 
-    return {
-      specificationVersion: 'v2' as const,
-      provider: baseModel.provider,
-      modelId: baseModel.modelId,
-      supportedUrls: baseModel.supportedUrls,
+    async doGenerate(callOptions) {
+      const bedrockOpts =
+        (await parseProviderOptions({
+          provider: 'bedrock',
+          providerOptions: callOptions.providerOptions,
+          schema: bedrockProviderOptions,
+        })) ?? {};
+      const model = createChatModel(modelId, bedrockOpts.anthropicBeta ?? []);
+      return model.doGenerate(callOptions);
+    },
 
-      async doGenerate(callOptions) {
-        const bedrockOpts =
-          (await parseProviderOptions({
-            provider: 'bedrock',
-            providerOptions: callOptions.providerOptions,
-            schema: bedrockProviderOptions,
-          })) ?? {};
-        const betas = bedrockOpts.anthropicBeta ?? [];
-        return (
-          betas.length > 0 ? createChatModel(modelId, betas) : baseModel
-        ).doGenerate(callOptions);
-      },
-
-      async doStream(callOptions) {
-        const bedrockOpts =
-          (await parseProviderOptions({
-            provider: 'bedrock',
-            providerOptions: callOptions.providerOptions,
-            schema: bedrockProviderOptions,
-          })) ?? {};
-        const betas = bedrockOpts.anthropicBeta ?? [];
-        return (
-          betas.length > 0 ? createChatModel(modelId, betas) : baseModel
-        ).doStream(callOptions);
-      },
-    };
-  };
+    async doStream(callOptions) {
+      const bedrockOpts =
+        (await parseProviderOptions({
+          provider: 'bedrock',
+          providerOptions: callOptions.providerOptions,
+          schema: bedrockProviderOptions,
+        })) ?? {};
+      const model = createChatModel(modelId, bedrockOpts.anthropicBeta ?? []);
+      return model.doStream(callOptions);
+    },
+  });
 
   const provider = function (modelId: BedrockAnthropicModelId) {
     if (new.target) {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

Bedrock requires `anthropic_beta` in its request body to enable extended capabilities like 1M context (context-1m-2025-08-07) and fine-grained tool streaming (fine-grained-tool-streaming-2025-05-14). 

## Summary

<!-- What did you change? -->

By design, `bedrock/anthropic` was ignoring providerOptions.bedrock.anthropicBeta.
Why not pass beta from anthropic back to bedrock? 
1. This is bedrock specific issue, and I think it might be better handled in bedrock
2. For namespaces consistency and backward compatibility, I'm taking a similar approach to [this PR](https://github.com/vercel/ai/pull/10983) which accepts vertex/google provider options for vertex provider.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
