### PR TITLE
fix(ai): use errorMode 'text' in approval continuation to preserve tool error messages

### DIFF
--- a/.changeset/brave-gorillas-rhyme.md
+++ b/.changeset/brave-gorillas-rhyme.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): use errorMode 'text' in approval continuation to preserve tool error messages

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -7564,6 +7564,86 @@ describe('generateText', () => {
       });
     });
 
+    describe('when a call from a single tool that needs approval is approved but execute throws', () => {
+      let result: GenerateTextResult<any, any>;
+      let prompts: LanguageModelV3Prompt[];
+
+      beforeEach(async () => {
+        prompts = [];
+        result = await generateText({
+          model: new MockLanguageModelV3({
+            doGenerate: async ({ prompt }) => {
+              prompts.push(prompt);
+              return {
+                ...dummyResponseValues,
+                content: [
+                  {
+                    type: 'text',
+                    text: 'I got an error.',
+                  },
+                ],
+                finishReason: { unified: 'stop', raw: 'stop' },
+              };
+            },
+          }),
+          tools: {
+            tool1: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async (): Promise<string> => {
+                throw new Error('tool execution failed');
+              },
+              needsApproval: true,
+            }),
+          },
+          stopWhen: stepCountIs(3),
+          _internal: {
+            generateId: mockId({ prefix: 'id' }),
+          },
+          messages: [
+            { role: 'user', content: 'test-input' },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  input: { value: 'value' },
+                  providerExecuted: undefined,
+                  providerOptions: undefined,
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  type: 'tool-call',
+                },
+                {
+                  approvalId: 'id-1',
+                  toolCallId: 'call-1',
+                  type: 'tool-approval-request',
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  approvalId: 'id-1',
+                  type: 'tool-approval-response',
+                  approved: true,
+                },
+              ],
+            },
+          ],
+        });
+      });
+
+      it('should send error message text (not "{}") to the model', async () => {
+        const toolMsg = prompts[0]?.find(m => m.role === 'tool');
+        const toolResult = toolMsg?.content?.[0];
+        expect(toolResult?.type).toBe('tool-result');
+        expect((toolResult as any)?.output).toMatchObject({
+          type: 'error-text',
+          value: 'tool execution failed',
+        });
+      });
+    });
+
     describe('when a call from a single tool that needs approval is denied', () => {
       let result: GenerateTextResult<any, any>;
       let prompts: LanguageModelV3Prompt[];

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -7564,7 +7564,7 @@ describe('generateText', () => {
       });
     });
 
-    describe('when a call from a single tool that needs approval is approved but execute throws', () => {
+    describe('when a call from a single tool that needs approval is approved and the tool throws', () => {
       let result: GenerateTextResult<any, any>;
       let prompts: LanguageModelV3Prompt[];
 
@@ -7579,7 +7579,7 @@ describe('generateText', () => {
                 content: [
                   {
                     type: 'text',
-                    text: 'I got an error.',
+                    text: 'Hello, world!',
                   },
                 ],
                 finishReason: { unified: 'stop', raw: 'stop' },
@@ -7590,7 +7590,7 @@ describe('generateText', () => {
             tool1: tool({
               inputSchema: z.object({ value: z.string() }),
               execute: async (): Promise<string> => {
-                throw new Error('tool execution failed');
+                throw new Error('No valid token for plugin');
               },
               needsApproval: true,
             }),
@@ -7605,7 +7605,9 @@ describe('generateText', () => {
               role: 'assistant',
               content: [
                 {
-                  input: { value: 'value' },
+                  input: {
+                    value: 'value',
+                  },
                   providerExecuted: undefined,
                   providerOptions: undefined,
                   toolCallId: 'call-1',
@@ -7633,14 +7635,46 @@ describe('generateText', () => {
         });
       });
 
-      it('should send error message text (not "{}") to the model', async () => {
-        const toolMsg = prompts[0]?.find(m => m.role === 'tool');
-        const toolResult = toolMsg?.content?.[0];
-        expect(toolResult?.type).toBe('tool-result');
-        expect((toolResult as any)?.output).toMatchObject({
-          type: 'error-text',
-          value: 'tool execution failed',
-        });
+      it('should serialize the tool error as error-text in the continuation prompt', async () => {
+        expect(prompts).toEqual([
+          [
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerOptions: undefined,
+            },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  input: { value: 'value' },
+                  providerExecuted: undefined,
+                  providerOptions: undefined,
+                },
+              ],
+              providerOptions: undefined,
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  output: {
+                    type: 'error-text',
+                    value: 'No valid token for plugin',
+                  },
+                  providerOptions: undefined,
+                },
+              ],
+              providerOptions: undefined,
+            },
+          ],
+        ]);
       });
     });
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -595,7 +595,7 @@ export async function generateText<
               tool: tools?.[output.toolName],
               output:
                 output.type === 'tool-result' ? output.output : output.error,
-              errorMode: output.type === 'tool-error' ? 'json' : 'none',
+              errorMode: output.type === 'tool-error' ? 'text' : 'none',
             });
 
             toolContent.push({

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -20705,7 +20705,7 @@ describe('streamText', () => {
       });
     });
 
-    describe('when a call from a single tool that needs approval is approved but execute throws', () => {
+    describe('when a call from a single tool that needs approval is approved and the tool throws', () => {
       let result: StreamTextResult<any, any>;
       let prompts: LanguageModelV3Prompt[];
 
@@ -20722,7 +20722,7 @@ describe('streamText', () => {
                   {
                     type: 'text-delta',
                     id: '1',
-                    delta: 'I got an error.',
+                    delta: 'Hello, world!',
                   },
                   { type: 'text-end', id: '1' },
                   {
@@ -20738,7 +20738,7 @@ describe('streamText', () => {
             tool1: tool({
               inputSchema: z.object({ value: z.string() }),
               execute: async (): Promise<string> => {
-                throw new Error('tool execution failed');
+                throw new Error('No valid token for plugin');
               },
               needsApproval: true,
             }),
@@ -20753,7 +20753,9 @@ describe('streamText', () => {
               role: 'assistant',
               content: [
                 {
-                  input: { value: 'value' },
+                  input: {
+                    value: 'value',
+                  },
                   providerExecuted: undefined,
                   providerOptions: undefined,
                   toolCallId: 'call-1',
@@ -20783,14 +20785,46 @@ describe('streamText', () => {
         await result.consumeStream();
       });
 
-      it('should send error message text (not "{}") to the model', async () => {
-        const toolMsg = prompts[0]?.find(m => m.role === 'tool');
-        const toolResult = toolMsg?.content?.[0];
-        expect(toolResult?.type).toBe('tool-result');
-        expect((toolResult as any)?.output).toMatchObject({
-          type: 'error-text',
-          value: 'tool execution failed',
-        });
+      it('should serialize the tool error as error-text in the continuation prompt', async () => {
+        expect(prompts).toEqual([
+          [
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerOptions: undefined,
+            },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  input: { value: 'value' },
+                  providerExecuted: undefined,
+                  providerOptions: undefined,
+                },
+              ],
+              providerOptions: undefined,
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  output: {
+                    type: 'error-text',
+                    value: 'No valid token for plugin',
+                  },
+                  providerOptions: undefined,
+                },
+              ],
+              providerOptions: undefined,
+            },
+          ],
+        ]);
       });
     });
 

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -20705,6 +20705,95 @@ describe('streamText', () => {
       });
     });
 
+    describe('when a call from a single tool that needs approval is approved but execute throws', () => {
+      let result: StreamTextResult<any, any>;
+      let prompts: LanguageModelV3Prompt[];
+
+      beforeEach(async () => {
+        prompts = [];
+        result = streamText({
+          model: new MockLanguageModelV3({
+            doStream: async ({ prompt }) => {
+              prompts.push(prompt);
+              return {
+                stream: convertArrayToReadableStream([
+                  { type: 'stream-start', warnings: [] },
+                  { type: 'text-start', id: '1' },
+                  {
+                    type: 'text-delta',
+                    id: '1',
+                    delta: 'I got an error.',
+                  },
+                  { type: 'text-end', id: '1' },
+                  {
+                    type: 'finish',
+                    finishReason: { unified: 'stop', raw: 'stop' },
+                    usage: testUsage,
+                  },
+                ]),
+              };
+            },
+          }),
+          tools: {
+            tool1: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async (): Promise<string> => {
+                throw new Error('tool execution failed');
+              },
+              needsApproval: true,
+            }),
+          },
+          stopWhen: stepCountIs(3),
+          _internal: {
+            generateId: mockId({ prefix: 'id' }),
+          },
+          messages: [
+            { role: 'user', content: 'test-input' },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  input: { value: 'value' },
+                  providerExecuted: undefined,
+                  providerOptions: undefined,
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  type: 'tool-call',
+                },
+                {
+                  approvalId: 'id-1',
+                  toolCallId: 'call-1',
+                  type: 'tool-approval-request',
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  approvalId: 'id-1',
+                  type: 'tool-approval-response',
+                  approved: true,
+                },
+              ],
+            },
+          ],
+        });
+
+        await result.consumeStream();
+      });
+
+      it('should send error message text (not "{}") to the model', async () => {
+        const toolMsg = prompts[0]?.find(m => m.role === 'tool');
+        const toolResult = toolMsg?.content?.[0];
+        expect(toolResult?.type).toBe('tool-result');
+        expect((toolResult as any)?.output).toMatchObject({
+          type: 'error-text',
+          value: 'tool execution failed',
+        });
+      });
+    });
+
     describe('when a call from a single tool with preliminary results that needs approval is approved', () => {
       let result: StreamTextResult<any, any>;
       let prompts: LanguageModelV3Prompt[];

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1451,7 +1451,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                       output.type === 'tool-result'
                         ? output.output
                         : output.error,
-                    errorMode: output.type === 'tool-error' ? 'json' : 'none',
+                    errorMode: output.type === 'tool-error' ? 'text' : 'none',
                   }),
                 });
               }


### PR DESCRIPTION
## Problem

When a tool with `needsApproval` throws an error during execution, the error message is silently lost. The model receives `{}` instead of the actual error text, causing it to hallucinate success.

Closes #13048

## Root Cause

The approval continuation path in both `streamText` and `generateText` used:

```ts
errorMode: output.type === 'tool-error' ? 'json' : 'none'
```

`errorMode: 'json'` routes to `createToolModelOutput` which does `toJSONValue(error)` → `JSON.stringify(new Error('msg'))` → `'{}'` because `Error` properties (`message`, `stack`) are non-enumerable.

The normal multi-step flow and `to-response-messages.ts` correctly use `errorMode: 'text'` which calls `getErrorMessage(error)` to extract the message string.

## Fix

Change `'json'` → `'text'` in both locations to align with the normal flow:

```ts
// Before (broken):
errorMode: output.type === 'tool-error' ? 'json' : 'none'

// After (fixed):
errorMode: output.type === 'tool-error' ? 'text' : 'none'
```

## Tests

Added test cases for both `generateText` and `streamText` that verify when an approved `needsApproval` tool throws, the model receives `{ type: 'error-text', value: 'tool execution failed' }` instead of `{ type: 'error-json', value: {} }`.