### PR TITLE
fix: use errorMode 'text' for tool errors to preserve error messages

### DIFF
--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -595,7 +595,7 @@ export async function generateText<
               tool: tools?.[output.toolName],
               output:
                 output.type === 'tool-result' ? output.output : output.error,
-              errorMode: output.type === 'tool-error' ? 'json' : 'none',
+              errorMode: output.type === 'tool-error' ? 'text' : 'none',
             });
 
             toolContent.push({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1451,7 +1451,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                       output.type === 'tool-result'
                         ? output.output
                         : output.error,
-                    errorMode: output.type === 'tool-error' ? 'json' : 'none',
+                    errorMode: output.type === 'tool-error' ? 'text' : 'none',
                   }),
                 });
               }


### PR DESCRIPTION
## Summary

When a tool with `needsApproval` throws an error during execution, the error message is silently lost because `errorMode: 'json'` routes to `createToolModelOutput` which does `JSON.stringify(new Error('msg'))` resulting in `{}` since Error properties are non-enumerable.

## Fix

Changed `'json'` → `'text'` in both `generateText` and `streamText` to align with the normal multi-step flow that correctly uses `getErrorMessage`.

## Files changed

- `packages/ai/src/generate-text/generate-text.ts`
- `packages/ai/src/generate-text/stream-text.ts`

Closes #13056