### PR TITLE
feat(anthropic, amazon-bedrock): v5 expose anthropicBeta to downstream providers

### DIFF
--- a/.changeset/healthy-lobsters-shave.md
+++ b/.changeset/healthy-lobsters-shave.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(anthropic): expose anthropicBeta to downstream providers

--- a/.changeset/healthy-lobsters-shave.md
+++ b/.changeset/healthy-lobsters-shave.md
@@ -1,5 +1,6 @@
 ---
 '@ai-sdk/anthropic': patch
+'@ai-sdk/amazon-bedrock': patch
 ---
 
-feat(anthropic): expose anthropicBeta to downstream providers
+feat(anthropic): expose anthropic.anthropicBeta to downstream providers

--- a/.changeset/tasty-garlics-invent.md
+++ b/.changeset/tasty-garlics-invent.md
@@ -1,5 +1,0 @@
----
-'@ai-sdk/amazon-bedrock': patch
----
-
-feat(amazon-bedrock): support providerOptions.anthropic.anthropicBeta

--- a/.changeset/tasty-garlics-invent.md
+++ b/.changeset/tasty-garlics-invent.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+feat(amazon-bedrock): support providerOptions.anthropic.anthropicBeta

--- a/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-1m-context.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-1m-context.ts
@@ -1,0 +1,77 @@
+import { createBedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+const bedrockAnthropic = createBedrockAnthropic({
+  headers: {
+    'anthropic-beta': 'context-1m-2025-08-07',
+  },
+});
+
+// Build a large text block intended to exceed the standard context window
+const APPROX_TOKENS = 110_000;
+const CHARS_PER_TOKEN = 4;
+const TARGET_CHARS = APPROX_TOKENS * CHARS_PER_TOKEN;
+
+function makeBaseChunk(): string {
+  let s = '';
+  for (let j = 0; j < 500; j++) {
+    s += `IDX:${j.toString(36)} | alpha:${'abcdefghijklmnopqrstuvwxyz'.slice(0, (j % 26) + 1)} | nums:${'0123456789'.repeat(3)} | sym:${'-=_+'.repeat(5)}\n`;
+  }
+  return s;
+}
+
+const baseChunk = makeBaseChunk();
+const repeats = Math.ceil(TARGET_CHARS / baseChunk.length);
+const largeContextText = baseChunk
+  .repeat(repeats)
+  .slice(0, TARGET_CHARS + 50_000);
+
+async function main() {
+  const estimatedTokens = Math.ceil(largeContextText.length / CHARS_PER_TOKEN);
+  console.log('Prepared large context chars:', largeContextText.length);
+  console.log('Estimated tokens (chars/4):', estimatedTokens);
+
+  const startstamp = performance.now();
+
+  const result = streamText({
+    model: bedrockAnthropic('us.anthropic.claude-sonnet-4-20250514-v1:0'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `The following is a large context payload.\n\n${largeContextText}`,
+          },
+          {
+            type: 'text',
+            text: 'Summarize the structure of the data above in one sentence.',
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      // alternatively this feature can be enabled with:
+      // anthropic: {
+      //   anthropicBeta: ['context-1m-2025-08-07'],
+      // },
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  const endstamp = performance.now();
+  console.log();
+  console.log(
+    'Time taken:',
+    ((endstamp - startstamp) / 1000).toFixed(2),
+    'seconds',
+  );
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-fine-grained-tool-streaming.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-fine-grained-tool-streaming.ts
@@ -1,0 +1,154 @@
+import { createBedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { streamText } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+const bedrockAnthropic = createBedrockAnthropic({
+  headers: {
+    'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14',
+  },
+});
+
+const tools = {
+  write_to_file: {
+    description:
+      'Request to write content to a file. ALWAYS provide the COMPLETE file content, without any truncation.',
+    inputSchema: z.object({
+      path: z
+        .string()
+        .describe(
+          'The path of the file to write to (relative to the current workspace directory)',
+        ),
+      content: z.string().describe('The content to write to the file.'),
+    }),
+  },
+} as const;
+
+async function main() {
+  console.log('=== Fine-grained tool streaming test (Bedrock Anthropic) ===\n');
+
+  const result = streamText({
+    model: bedrockAnthropic('global.anthropic.claude-sonnet-4-6'),
+
+    messages: [
+      {
+        role: 'user',
+        content: 'Write a bubble sort implementation in JavaScript to sort.js',
+      },
+    ],
+
+    tools,
+    toolChoice: 'required',
+    providerOptions: {
+      // alternatively this feature can be enabled with:
+      // anthropic: {
+      //   anthropicBeta: ['fine-grained-tool-streaming-2025-05-14'],
+      // },
+    },
+  });
+
+  let sawToolInputStart = false;
+  let toolInputDeltaCount = 0;
+  let sawToolInputEnd = false;
+  const toolInputDeltaTimestamps: number[] = [];
+
+  // ts() prints a compact timestamp to stderr so we can see real-time ordering
+  const T0 = Date.now();
+  const ts = (label: string) =>
+    process.stderr.write(
+      `+${((Date.now() - T0) / 1000).toFixed(2)}s ${label}\n`,
+    );
+
+  ts('stream started');
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text-start':
+        ts('[text-start]');
+        process.stdout.write('\n[text-start]\n');
+        break;
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'text-end':
+        ts('[text-end]');
+        process.stdout.write('\n[text-end]\n');
+        break;
+      case 'tool-input-start':
+        sawToolInputStart = true;
+        ts(`[tool-input-start] tool=${part.toolName}`);
+        process.stdout.write(
+          `\n[tool-input-start] id=${part.id} tool=${part.toolName}\n`,
+        );
+        break;
+      case 'tool-input-delta':
+        toolInputDeltaCount++;
+        toolInputDeltaTimestamps.push(Date.now());
+        if (toolInputDeltaCount === 1 || toolInputDeltaCount % 100 === 0) {
+          ts(`[tool-input-delta #${toolInputDeltaCount}]`);
+        }
+        process.stdout.write(part.delta);
+        break;
+      case 'tool-input-end':
+        sawToolInputEnd = true;
+        ts(`[tool-input-end]`);
+        process.stdout.write(`\n[tool-input-end] id=${part.id}\n`);
+        break;
+      case 'tool-call': {
+        const preview = JSON.stringify(part.input).slice(0, 80);
+        ts(`[tool-call] tool=${part.toolName}`);
+        console.log(
+          `\n[tool-call] tool=${part.toolName} input(preview)=${preview}…`,
+        );
+        break;
+      }
+      case 'start-step':
+        ts('[start-step]');
+        console.log('\n[start-step]');
+        break;
+      case 'finish-step':
+        ts(`[finish-step] reason=${part.finishReason}`);
+        console.log(
+          `[finish-step] finishReason=${part.finishReason} usage=${JSON.stringify(part.usage)}`,
+        );
+        break;
+      case 'finish':
+        ts(`[finish] reason=${part.finishReason}`);
+        console.log(
+          `\n[finish] finishReason=${part.finishReason} usage=${JSON.stringify(part.totalUsage)}`,
+        );
+        break;
+      case 'error':
+        ts('[error]');
+        console.error('\n[error]', part.error);
+        break;
+    }
+  }
+
+  // ── diagnosis ─────────────────────────────────────────────────────────────
+  // Count consecutive delta intervals >= 5ms (genuine per-token generation time).
+  // A buffered dump replays all deltas synchronously (<1ms each); real streaming
+  // has most intervals >= 5ms as each token takes time to generate.
+  // Threshold is heuristic — the desired behavior is smooth continuous streaming
+  // instead of a long hang followed by a dump of all chunks at once.
+  let liveIntervals = 0;
+  for (let i = 1; i < toolInputDeltaTimestamps.length; i++) {
+    if (toolInputDeltaTimestamps[i] - toolInputDeltaTimestamps[i - 1] >= 5)
+      liveIntervals++;
+  }
+  const liveRatio =
+    toolInputDeltaTimestamps.length > 1
+      ? liveIntervals / (toolInputDeltaTimestamps.length - 1)
+      : 0;
+  const isStreaming = toolInputDeltaCount >= 5 && liveRatio > 0.5;
+
+  console.log('\n=== Summary ===');
+  console.log('tool-input-start received :', sawToolInputStart);
+  console.log('tool-input-delta count    :', toolInputDeltaCount);
+  console.log('tool-input-end received   :', sawToolInputEnd);
+  console.log(
+    `Fine-grained tool streaming: ${isStreaming ? '✅' : '❌'} (${toolInputDeltaCount} deltas, ${(liveRatio * 100).toFixed(0)}% live intervals)`,
+  );
+}
+
+main().catch(console.error);

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -365,6 +365,29 @@ describe('bedrock-anthropic-provider', () => {
     );
   });
 
+  it('should include betas passed to transformRequestBody in anthropic_beta body field', async () => {
+    const provider = createBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    const config = await triggerModel(provider, 'test-model-id');
+
+    const betas = new Set(['fine-grained-tool-streaming-2025-05-14']);
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+      },
+      betas,
+    );
+
+    expect(transformedBody?.anthropic_beta).toContain(
+      'fine-grained-tool-streaming-2025-05-14',
+    );
+  });
+
   it('should not add anthropic_beta when no computer use tools are present', () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -217,11 +217,14 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-    });
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+      },
+      new Set(),
+    );
 
     expect(transformedBody).toEqual({
       messages: [{ role: 'user', content: 'Hello' }],
@@ -243,12 +246,15 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-      stream: true,
-    });
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        stream: true,
+      },
+      new Set(),
+    );
 
     expect(transformedBody).not.toHaveProperty('stream');
     expect(transformedBody).toHaveProperty('anthropic_version');
@@ -266,15 +272,18 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-      tool_choice: {
-        type: 'auto',
-        disable_parallel_tool_use: true,
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tool_choice: {
+          type: 'auto',
+          disable_parallel_tool_use: true,
+        },
       },
-    });
+      new Set(),
+    );
 
     expect(transformedBody?.tool_choice).toEqual({ type: 'auto' });
     expect(transformedBody?.tool_choice).not.toHaveProperty(
@@ -294,16 +303,19 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-      tool_choice: {
-        type: 'tool',
-        name: 'my_tool',
-        disable_parallel_tool_use: true,
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tool_choice: {
+          type: 'tool',
+          name: 'my_tool',
+          disable_parallel_tool_use: true,
+        },
       },
-    });
+      new Set(),
+    );
 
     expect(transformedBody?.tool_choice).toEqual({
       type: 'tool',
@@ -323,16 +335,19 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-      tools: [
-        { type: 'bash_20241022', name: 'bash' },
-        { type: 'text_editor_20241022', name: 'str_replace_editor' },
-        { type: 'computer_20241022', name: 'computer' },
-      ],
-    });
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tools: [
+          { type: 'bash_20241022', name: 'bash' },
+          { type: 'text_editor_20241022', name: 'str_replace_editor' },
+          { type: 'computer_20241022', name: 'computer' },
+        ],
+      },
+      new Set(),
+    );
 
     expect(transformedBody?.tools).toEqual([
       { type: 'bash_20250124', name: 'bash' },
@@ -353,12 +368,15 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-      tools: [{ type: 'bash_20250124', name: 'bash' }],
-    });
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tools: [{ type: 'bash_20250124', name: 'bash' }],
+      },
+      new Set(),
+    );
 
     expect(transformedBody?.anthropic_beta).toContain(
       'computer-use-2025-01-24',
@@ -377,11 +395,14 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-    });
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+      },
+      new Set(),
+    );
 
     expect(transformedBody).toHaveProperty(
       'anthropic_version',
@@ -402,18 +423,21 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-      tools: [
-        {
-          type: 'function',
-          name: 'get_weather',
-          input_schema: { type: 'object', properties: {} },
-        },
-      ],
-    });
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tools: [
+          {
+            type: 'function',
+            name: 'get_weather',
+            input_schema: { type: 'object', properties: {} },
+          },
+        ],
+      },
+      new Set(),
+    );
 
     expect(transformedBody?.anthropic_beta).toBeUndefined();
   });

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -365,7 +365,6 @@ describe('bedrock-anthropic-provider', () => {
     );
   });
 
-
   it('should include betas passed to transformRequestBody in anthropic_beta body field', () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
@@ -384,10 +383,12 @@ describe('bedrock-anthropic-provider', () => {
       max_tokens: 1024,
     });
 
-    expect(transformedBody).toHaveProperty('anthropic_version', 'bedrock-2023-05-31');
+    expect(transformedBody).toHaveProperty(
+      'anthropic_version',
+      'bedrock-2023-05-31',
+    );
     expect(transformedBody).not.toHaveProperty('anthropic_beta');
   });
-
 
   it('should not add anthropic_beta when no computer use tools are present', () => {
     const provider = createBedrockAnthropic({

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -365,28 +365,29 @@ describe('bedrock-anthropic-provider', () => {
     );
   });
 
-  it('should include betas passed to transformRequestBody in anthropic_beta body field', async () => {
+
+  it('should include betas passed to transformRequestBody in anthropic_beta body field', () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
-    const config = await triggerModel(provider, 'test-model-id');
+    provider('test-model-id');
 
-    const betas = new Set(['fine-grained-tool-streaming-2025-05-14']);
-    const transformedBody = config.transformRequestBody?.(
-      {
-        model: 'test-model-id',
-        messages: [{ role: 'user', content: 'Hello' }],
-        max_tokens: 1024,
-      },
-      betas,
-    );
+    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
+      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const config = constructorCall[1];
 
-    expect(transformedBody?.anthropic_beta).toContain(
-      'fine-grained-tool-streaming-2025-05-14',
-    );
+    const transformedBody = config.transformRequestBody?.({
+      model: 'test-model-id',
+      messages: [{ role: 'user', content: 'Hello' }],
+      max_tokens: 1024,
+    });
+
+    expect(transformedBody).toHaveProperty('anthropic_version', 'bedrock-2023-05-31');
+    expect(transformedBody).not.toHaveProperty('anthropic_beta');
   });
+
 
   it('should not add anthropic_beta when no computer use tools are present', () => {
     const provider = createBedrockAnthropic({

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -256,7 +256,7 @@ export function createBedrockAnthropic(
           isStreaming ? 'invoke-with-response-stream' : 'invoke'
         }`,
 
-      transformRequestBody: args => {
+      transformRequestBody: (args, betas) => {
         const { model, stream, tool_choice, tools, ...rest } = args;
 
         const transformedToolChoice =
@@ -267,7 +267,7 @@ export function createBedrockAnthropic(
               }
             : undefined;
 
-        const requiredBetas = new Set<string>();
+        const requiredBetas = new Set<string>(betas);
         const transformedTools = tools?.map((tool: Record<string, unknown>) => {
           const toolType = tool.type as string | undefined;
 

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -4599,6 +4599,38 @@ describe('AnthropicMessagesLanguageModel', () => {
       );
     });
 
+    it('should include providerOptions.anthropic.anthropicBeta in anthropic-beta header', async () => {
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"output_tokens":1}}}\n\n`,
+          `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n`,
+          `data: {"type":"content_block_stop","index":0}\n\n`,
+          `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}\n\n`,
+          `data: {"type":"message_stop"}\n\n`,
+        ],
+      };
+
+      const provider = createAnthropic({ apiKey: 'test-api-key' });
+
+      await provider('claude-3-haiku-20240307').doStream({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            anthropicBeta: ['my-beta-2025-01-01', 'another-beta-2025-06-01'],
+          } satisfies AnthropicProviderOptions,
+        },
+      });
+
+      expect(server.calls[0].requestHeaders['anthropic-beta']).toContain(
+        'my-beta-2025-01-01',
+      );
+      expect(server.calls[0].requestHeaders['anthropic-beta']).toContain(
+        'another-beta-2025-06-01',
+      );
+    });
+
     it('should support cache control', async () => {
       server.urls['https://api.anthropic.com/v1/messages'].response = {
         type: 'stream-chunks',

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -93,7 +93,10 @@ type AnthropicMessagesConfig = {
   headers: Resolvable<Record<string, string | undefined>>;
   fetch?: FetchFunction;
   buildRequestUrl?: (baseURL: string, isStreaming: boolean) => string;
-  transformRequestBody?: (args: Record<string, any>) => Record<string, any>;
+  transformRequestBody?: (
+    args: Record<string, any>,
+    betas: Set<string>,
+  ) => Record<string, any>;
   supportedUrls?: () => LanguageModelV2['supportedUrls'];
   generateId?: () => string;
 };
@@ -498,7 +501,12 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
         tool_choice: anthropicToolChoice,
       },
       warnings: [...warnings, ...toolWarnings, ...cacheWarnings],
-      betas: new Set([...betas, ...toolsBetas, ...userSuppliedBetas]),
+      betas: new Set([
+        ...betas,
+        ...toolsBetas,
+        ...userSuppliedBetas,
+        ...(anthropicOptions?.anthropicBeta ?? []),
+      ]),
       usesJsonResponseTool: jsonResponseTool != null,
     };
   }
@@ -542,8 +550,11 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
     );
   }
 
-  private transformRequestBody(args: Record<string, any>): Record<string, any> {
-    return this.config.transformRequestBody?.(args) ?? args;
+  private transformRequestBody(
+    args: Record<string, any>,
+    betas: Set<string>,
+  ): Record<string, any> {
+    return this.config.transformRequestBody?.(args, betas) ?? args;
   }
 
   private extractCitationDocuments(prompt: LanguageModelV2Prompt): Array<{
@@ -607,7 +618,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
     } = await postJsonToApi({
       url: this.buildRequestUrl(false),
       headers: await this.getHeaders({ betas, headers: options.headers }),
-      body: this.transformRequestBody(args),
+      body: this.transformRequestBody(args, betas),
       failedResponseHandler: anthropicFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
         anthropicMessagesResponseSchema,
@@ -998,7 +1009,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
     const { responseHeaders, value: response } = await postJsonToApi({
       url,
       headers: await this.getHeaders({ betas, headers: options.headers }),
-      body: this.transformRequestBody(body),
+      body: this.transformRequestBody(body, betas),
       failedResponseHandler: anthropicFailedResponseHandler,
       successfulResponseHandler: createEventSourceResponseHandler(
         anthropicMessagesChunkSchema,

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -206,6 +206,12 @@ export const anthropicProviderOptions = z.object({
       ),
     })
     .optional(),
+
+  /**
+   * A set of beta features to enable.
+   * Allow a provider to receive the full `betas` set if it needs it.
+   */
+  anthropicBeta: z.array(z.string()).optional(),
 });
 
 export type AnthropicProviderOptions = z.infer<typeof anthropicProviderOptions>;


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

`amazon-bedrock/anthropic` requires `anthropic_beta` in its request body to enable extended capabilities for anthropic models, like 1M context (context-1m-2025-08-07) and fine-grained tool streaming (fine-grained-tool-streaming-2025-05-14).

## Summary

<!-- What did you change? -->

- `anthropic`: added `anthropicBeta` and forwarded to downstream providers via transformRequestBody
- `amazon-bedrock`: receive betas passed from upstream

I also explored handling this gap in `amazon-bedrock` instead (see this [draft PR](https://github.com/vercel/ai/pull/13054) if you're curious). Ultimately I think this is the cleanest solution. If we want to allow both `anthropic` and `bedrock` namespaces, we can handle this on the Gateway / client side via better education.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

- added example scripts

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Make these changes in v6 too

## Related Issues