### PR TITLE
fix(google): resolve thoughtSignature from vertex namespace on gateway failover

### DIFF
--- a/.changeset/fix-thought-signature-failover.md
+++ b/.changeset/fix-thought-signature-failover.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Fix gateway failover losing thoughtSignature when failing over from Vertex to Google AI Studio. The Google provider now falls back to checking the vertex namespace for thoughtSignature, matching the existing Vertex-to-Google fallback behavior.

--- a/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
@@ -4,26 +4,23 @@ import { stepCountIs, streamText, tool } from 'ai';
 import { z } from 'zod';
 
 /**
- * Repro for https://github.com/vercel/ai/issues/11413
+ * Verification for https://github.com/vercel/ai/issues/11413
  *
  * Simulates a gateway cross-provider failover scenario:
  *   Turn 1: Vertex AI handles the request (thoughtSignature stored under "vertex" key)
  *   Turn 2: Fails over to Google AI Studio (looks for thoughtSignature under "google" key)
  *
- * The Google provider's convertToGoogleGenerativeAIMessages only checks:
- *   1. providerOptions[providerOptionsName] (e.g. "google")
- *   2. Falls back to providerOptions.google only when providerOptionsName !== "google"
+ * The fix makes convertToGoogleGenerativeAIMessages check both namespaces:
+ *   - Primary: providerOptions[providerOptionsName] (e.g. "google")
+ *   - Fallback: providerOptions.vertex (when providerOptionsName === "google")
+ *             or providerOptions.google (when providerOptionsName === "vertex")
  *
- * So when providerOptionsName is "google" and the data is under "vertex", the
- * thoughtSignature is silently dropped, causing the API error.
- *
- * We test three scenarios:
+ * We test two scenarios:
  *   A) Normal: thoughtSignature under "google" key (works)
- *   B) Failover: thoughtSignature under "vertex" key only (signature dropped → API warning)
- *   C) Wrong signature: an invalid signature under "google" key (→ API error)
+ *   B) Failover: thoughtSignature under "vertex" key only (now works with fix)
  */
 async function main() {
-  console.log('Issue #11413: Simulating gateway cross-provider failover\n');
+  console.log('Issue #11413: Verifying gateway cross-provider failover fix\n');
 
   const weatherTool = tool({
     description: 'Get the weather for a location',
@@ -55,7 +52,6 @@ async function main() {
 
   const response1 = await turn1.response;
 
-  // Verify thoughtSignature is present
   let hasThoughtSignature = false;
   for (const msg of response1.messages) {
     if (msg.role === 'assistant' && typeof msg.content !== 'string') {
@@ -74,7 +70,9 @@ async function main() {
     }
   }
   if (!hasThoughtSignature) {
-    console.log('\nTurn 1 did not produce thoughtSignature — cannot reproduce');
+    console.log(
+      '\nTurn 1 did not produce thoughtSignature — cannot test failover',
+    );
     process.exit(0);
   }
 
@@ -133,9 +131,11 @@ async function main() {
     return msg;
   });
 
-  console.log('Messages rewritten: providerOptions "google" → "vertex"');
   console.log(
-    'Google provider will NOT find thoughtSignature (only checks "google" key)\n',
+    'Messages rewritten: providerOptions "google" → "vertex" (simulates Vertex→Google failover)',
+  );
+  console.log(
+    'Google provider should find thoughtSignature via vertex fallback\n',
   );
 
   try {
@@ -156,103 +156,15 @@ async function main() {
       }
     }
 
-    console.log(
-      '\n⚠ Scenario B: API accepted request with missing thoughtSignature',
-    );
-    console.log(
-      '  (Google warns this may lead to degraded model performance)\n',
-    );
+    console.log('\n✓ Scenario B succeeded — fix verified!\n');
   } catch (error: any) {
     console.error('\n✗ Scenario B FAILED:');
     console.error('  Error:', error.message?.substring(0, 200));
+    console.error(
+      '\n  The fix did not work — thoughtSignature was not resolved from vertex namespace.',
+    );
     console.log();
   }
-
-  // --- Scenario C: Wrong signature — an invalid signature under "google" key ---
-  console.log(
-    '=== Scenario C: Invalid signature — dummy value under "google" key ===\n',
-  );
-
-  const invalidSigMessages = response1.messages.map(msg => {
-    if (
-      (msg.role === 'assistant' || msg.role === 'tool') &&
-      typeof msg.content !== 'string'
-    ) {
-      return {
-        ...msg,
-        content: msg.content.map(part => {
-          if (
-            'providerOptions' in part &&
-            part.providerOptions?.google?.thoughtSignature
-          ) {
-            return {
-              ...part,
-              providerOptions: {
-                ...part.providerOptions,
-                google: {
-                  ...part.providerOptions.google,
-                  thoughtSignature: 'INVALID_SIGNATURE_FROM_DIFFERENT_PROVIDER',
-                },
-              },
-            };
-          }
-          return part;
-        }),
-      };
-    }
-    return msg;
-  });
-
-  console.log(
-    'Messages modified: thoughtSignature replaced with invalid value\n',
-  );
-
-  let scenarioCError: any = null;
-  const scenarioC = streamText({
-    model: google('gemini-3.1-pro-preview'),
-    tools: { weather: weatherTool },
-    messages: [
-      { role: 'user', content: 'What is the weather in San Francisco?' },
-      ...(invalidSigMessages as any),
-      { role: 'user', content: 'What about New York?' },
-    ],
-    stopWhen: stepCountIs(2),
-    onError: ({ error }) => {
-      scenarioCError = error;
-    },
-  });
-
-  for await (const chunk of scenarioC.fullStream) {
-    if (chunk.type === 'text-delta') {
-      process.stdout.write(chunk.text);
-    }
-  }
-
-  if (scenarioCError) {
-    const msg = String(
-      scenarioCError?.responseBody ?? scenarioCError?.message ?? scenarioCError,
-    );
-    console.error('✗ Scenario C FAILED with thought_signature error:');
-    console.error(`  Status: ${scenarioCError.statusCode ?? 'unknown'}`);
-    if (msg.includes('thought_signature')) {
-      console.error(
-        '  Error: Invalid/incompatible thought_signature rejected by API',
-      );
-      console.error(
-        '\n  This confirms issue #11413: when the gateway fails over from',
-      );
-      console.error(
-        '  Vertex to Google AI Studio, an incompatible signature causes a 400 error.',
-      );
-    } else {
-      console.error('  Error:', msg.substring(0, 200));
-    }
-  } else {
-    console.log(
-      '\n⚠ Scenario C succeeded — API accepted invalid thoughtSignature',
-    );
-  }
-  console.log();
 }
 
 main().catch(console.error);

--- a/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
@@ -1,26 +1,30 @@
 import 'dotenv/config';
 import { google } from '@ai-sdk/google';
+import { createVertex } from '@ai-sdk/google-vertex';
 import { stepCountIs, streamText, tool } from 'ai';
 import { z } from 'zod';
 
 /**
  * Verification for https://github.com/vercel/ai/issues/11413
  *
- * Simulates a gateway cross-provider failover scenario:
- *   Turn 1: Vertex AI handles the request (thoughtSignature stored under "vertex" key)
- *   Turn 2: Fails over to Google AI Studio (looks for thoughtSignature under "google" key)
+ * Simulates gateway cross-provider failover scenarios between Google AI Studio
+ * and Vertex AI. Both providers share the same GoogleGenerativeAILanguageModel
+ * but store thoughtSignature under different providerOptions keys ("google"
+ * vs "vertex").
  *
  * The fix makes convertToGoogleGenerativeAIMessages check both namespaces:
- *   - Primary: providerOptions[providerOptionsName] (e.g. "google")
- *   - Fallback: providerOptions.vertex (when providerOptionsName === "google")
- *             or providerOptions.google (when providerOptionsName === "vertex")
+ *   - Primary: providerOptions[providerOptionsName]
+ *   - Fallback: the other namespace ("vertex" or "google")
  *
- * We test two scenarios:
- *   A) Normal: thoughtSignature under "google" key (works)
- *   B) Failover: thoughtSignature under "vertex" key only (now works with fix)
+ * We test three scenarios:
+ *   A) Normal: thoughtSignature under "google" key, Google provider (baseline)
+ *   B) Vertex → Google failover: thoughtSignature under "vertex" key, Google provider
+ *   C) Google → Vertex failover: thoughtSignature under "google" key, Vertex provider
  */
 async function main() {
-  console.log('Issue #11413: Verifying gateway cross-provider failover fix\n');
+  console.log('Issue #11413: Verifying bidirectional gateway failover fix\n');
+
+  const vertex = createVertex();
 
   const weatherTool = tool({
     description: 'Get the weather for a location',
@@ -104,12 +108,12 @@ async function main() {
     console.error('\n✗ Scenario A FAILED (unexpected):', error.message);
   }
 
-  // --- Scenario B: Failover — thoughtSignature under "vertex" key only ---
+  // --- Scenario B: Vertex → Google failover ---
   console.log(
-    '=== Scenario B: Failover — thoughtSignature under "vertex" key only ===\n',
+    '=== Scenario B: Vertex → Google failover — thoughtSignature under "vertex" key ===\n',
   );
 
-  const rewrittenMessages = response1.messages.map(msg => {
+  const vertexKeyMessages = response1.messages.map(msg => {
     if (
       (msg.role === 'assistant' || msg.role === 'tool') &&
       typeof msg.content !== 'string'
@@ -144,7 +148,7 @@ async function main() {
       tools: { weather: weatherTool },
       messages: [
         { role: 'user', content: 'What is the weather in San Francisco?' },
-        ...(rewrittenMessages as any),
+        ...(vertexKeyMessages as any),
         { role: 'user', content: 'What about New York?' },
       ],
       stopWhen: stepCountIs(2),
@@ -156,14 +160,54 @@ async function main() {
       }
     }
 
-    console.log('\n✓ Scenario B succeeded — fix verified!\n');
+    console.log('\n✓ Scenario B succeeded — Vertex→Google failover works!\n');
   } catch (error: any) {
     console.error('\n✗ Scenario B FAILED:');
     console.error('  Error:', error.message?.substring(0, 200));
-    console.error(
-      '\n  The fix did not work — thoughtSignature was not resolved from vertex namespace.',
-    );
     console.log();
+  }
+
+  // --- Scenario C: Google → Vertex failover ---
+  console.log(
+    '=== Scenario C: Google → Vertex failover — thoughtSignature under "google" key ===\n',
+  );
+
+  if (!process.env.GOOGLE_VERTEX_API_KEY) {
+    console.log(
+      '⏭ Scenario C skipped — GOOGLE_VERTEX_API_KEY not set\n' +
+        '  Set this env var to test the Google→Vertex failover direction.\n' +
+        '  (This direction was already working before the fix and is covered by unit tests.)\n',
+    );
+  } else {
+    console.log('Messages kept as-is with providerOptions under "google" key');
+    console.log(
+      'Vertex provider should find thoughtSignature via google fallback\n',
+    );
+
+    try {
+      const scenarioC = streamText({
+        model: vertex('gemini-3.1-pro-preview'),
+        tools: { weather: weatherTool },
+        messages: [
+          { role: 'user', content: 'What is the weather in San Francisco?' },
+          ...response1.messages,
+          { role: 'user', content: 'What about New York?' },
+        ],
+        stopWhen: stepCountIs(2),
+      });
+
+      for await (const chunk of scenarioC.fullStream) {
+        if (chunk.type === 'text-delta') {
+          process.stdout.write(chunk.text);
+        }
+      }
+
+      console.log('\n✓ Scenario C succeeded — Google→Vertex failover works!\n');
+    } catch (error: any) {
+      console.error('\n✗ Scenario C FAILED:');
+      console.error('  Error:', error.message?.substring(0, 200));
+      console.log();
+    }
   }
 }
 

--- a/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { google } from '@ai-sdk/google';
-import { streamText, tool } from 'ai';
+import { stepCountIs, streamText, tool } from 'ai';
 import { z } from 'zod';
 
 /**
@@ -44,7 +44,7 @@ async function main() {
     model: google('gemini-3.1-pro-preview'),
     tools: { weather: weatherTool },
     prompt: 'What is the weather in San Francisco?',
-    maxSteps: 2,
+    stopWhen: stepCountIs(2),
   });
 
   for await (const chunk of turn1.fullStream) {
@@ -92,7 +92,7 @@ async function main() {
         ...response1.messages,
         { role: 'user', content: 'What about New York?' },
       ],
-      maxSteps: 2,
+      stopWhen: stepCountIs(2),
     });
 
     for await (const chunk of scenarioA.fullStream) {
@@ -147,7 +147,7 @@ async function main() {
         ...(rewrittenMessages as any),
         { role: 'user', content: 'What about New York?' },
       ],
-      maxSteps: 2,
+      stopWhen: stepCountIs(2),
     });
 
     for await (const chunk of scenarioB.fullStream) {
@@ -213,7 +213,7 @@ async function main() {
       ...(invalidSigMessages as any),
       { role: 'user', content: 'What about New York?' },
     ],
-    maxSteps: 2,
+    stopWhen: stepCountIs(2),
     onError: ({ error }) => {
       scenarioCError = error;
     },

--- a/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
@@ -119,7 +119,7 @@ async function main() {
       return {
         ...msg,
         content: msg.content.map(part => {
-          if (part.providerOptions?.google) {
+          if ('providerOptions' in part && part.providerOptions?.google) {
             const { google: googleOpts, ...rest } = part.providerOptions;
             return {
               ...part,
@@ -181,7 +181,10 @@ async function main() {
       return {
         ...msg,
         content: msg.content.map(part => {
-          if (part.providerOptions?.google?.thoughtSignature) {
+          if (
+            'providerOptions' in part &&
+            part.providerOptions?.google?.thoughtSignature
+          ) {
             return {
               ...part,
               providerOptions: {

--- a/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
@@ -1,163 +1,255 @@
+import 'dotenv/config';
+import { google } from '@ai-sdk/google';
 import { streamText, tool } from 'ai';
 import { z } from 'zod';
-import { run } from '../../lib/run';
 
-run(async () => {
-  console.log(
-    'Repro for https://github.com/vercel/ai/issues/11413#issuecomment-3787919558',
-  );
-  console.log(
-    'Testing gateway with google/gemini-3-flash and tool calls (multi-turn)\n',
-  );
+/**
+ * Repro for https://github.com/vercel/ai/issues/11413
+ *
+ * Simulates a gateway cross-provider failover scenario:
+ *   Turn 1: Vertex AI handles the request (thoughtSignature stored under "vertex" key)
+ *   Turn 2: Fails over to Google AI Studio (looks for thoughtSignature under "google" key)
+ *
+ * The Google provider's convertToGoogleGenerativeAIMessages only checks:
+ *   1. providerOptions[providerOptionsName] (e.g. "google")
+ *   2. Falls back to providerOptions.google only when providerOptionsName !== "google"
+ *
+ * So when providerOptionsName is "google" and the data is under "vertex", the
+ * thoughtSignature is silently dropped, causing the API error.
+ *
+ * We test three scenarios:
+ *   A) Normal: thoughtSignature under "google" key (works)
+ *   B) Failover: thoughtSignature under "vertex" key only (signature dropped → API warning)
+ *   C) Wrong signature: an invalid signature under "google" key (→ API error)
+ */
+async function main() {
+  console.log('Issue #11413: Simulating gateway cross-provider failover\n');
 
   const weatherTool = tool({
     description: 'Get the weather for a location',
     inputSchema: z.object({
       location: z.string().describe('The location to get weather for'),
     }),
-    execute: async ({ location }) => {
-      return {
-        location,
-        temperature: 72,
-        condition: 'sunny',
-      };
-    },
+    execute: async ({ location }) => ({
+      location,
+      temperature: 72,
+      condition: 'sunny',
+    }),
   });
 
-  console.log('=== Turn 1: Initial request with tool call ===\n');
+  // --- Turn 1: Get a real response with thoughtSignature ---
+  console.log('=== Turn 1: Get response with thoughtSignature ===\n');
 
   const turn1 = streamText({
-    model: 'google/gemini-3-flash',
+    model: google('gemini-3.1-pro-preview'),
     tools: { weather: weatherTool },
     prompt: 'What is the weather in San Francisco?',
     maxSteps: 2,
-    includeRawChunks: true,
-    onStepFinish: ({ toolCalls, toolResults }) => {
-      if (toolCalls) {
-        console.log(`\nTool calls: ${toolCalls.length}`);
-        toolCalls.forEach(call => {
-          console.log(
-            `  ${call.toolName} providerMetadata:`,
-            JSON.stringify(call.providerMetadata, null, 2),
-          );
-        });
-      }
-      if (toolResults) {
-        console.log(`Tool results: ${toolResults.length}`);
-        toolResults.forEach(result => {
-          console.log(
-            `  ${result.toolName} providerMetadata:`,
-            JSON.stringify(result.providerMetadata, null, 2),
-          );
-        });
-      }
-    },
   });
 
   for await (const chunk of turn1.fullStream) {
     if (chunk.type === 'text-delta') {
       process.stdout.write(chunk.text);
-    } else if (chunk.type === 'tool-call') {
-      console.log(
-        `[stream] tool-call: ${chunk.toolName}, providerMetadata:`,
-        JSON.stringify(chunk.providerMetadata, null, 2),
-      );
-    } else if (chunk.type === 'raw') {
-      const raw = chunk.rawValue as any;
-      if (raw?.candidates?.[0]?.content?.parts) {
-        for (const part of raw.candidates[0].content.parts) {
-          if (part.functionCall) {
-            console.log(
-              `[raw] functionCall: ${part.functionCall.name}, thoughtSignature: ${part.thoughtSignature ? '✓' : '❌ not present'}`,
-            );
-          }
-        }
-      }
     }
   }
 
   const response1 = await turn1.response;
-  console.log('\n\nTurn 1 complete. Checking messages for thoughtSignatures:');
 
+  // Verify thoughtSignature is present
+  let hasThoughtSignature = false;
   for (const msg of response1.messages) {
     if (msg.role === 'assistant' && typeof msg.content !== 'string') {
       for (const part of msg.content) {
-        if (part.type === 'tool-call') {
+        if (
+          part.type === 'tool-call' &&
+          part.providerOptions?.google?.thoughtSignature
+        ) {
+          hasThoughtSignature = true;
+          const sig = String(part.providerOptions.google.thoughtSignature);
           console.log(
-            `  assistant tool-call ${part.toolName} providerOptions:`,
-            JSON.stringify(part.providerOptions, null, 2),
-          );
-        }
-      }
-    }
-    if (msg.role === 'tool') {
-      for (const part of msg.content) {
-        if (part.type === 'tool-result') {
-          console.log(
-            `  tool-result ${part.toolName} providerOptions:`,
-            JSON.stringify(part.providerOptions, null, 2),
+            `\nTurn 1 tool-call thoughtSignature: ${sig.substring(0, 40)}... (${sig.length} chars)`,
           );
         }
       }
     }
   }
+  if (!hasThoughtSignature) {
+    console.log('\nTurn 1 did not produce thoughtSignature — cannot reproduce');
+    process.exit(0);
+  }
 
-  console.log('\n=== Turn 2: Multi-turn continuation ===\n');
+  // --- Scenario A: Normal (thoughtSignature under "google" key) ---
+  console.log(
+    '\n\n=== Scenario A: Normal — thoughtSignature under "google" key ===\n',
+  );
 
   try {
-    const turn2 = streamText({
-      model: 'google/gemini-3-flash',
+    const scenarioA = streamText({
+      model: google('gemini-3.1-pro-preview'),
       tools: { weather: weatherTool },
       messages: [
         { role: 'user', content: 'What is the weather in San Francisco?' },
         ...response1.messages,
-        {
-          role: 'user',
-          content: 'What about New York? Use the weather tool again.',
-        },
+        { role: 'user', content: 'What about New York?' },
       ],
       maxSteps: 2,
-      includeRawChunks: true,
-      onStepFinish: ({ toolCalls, toolResults }) => {
-        if (toolCalls) {
-          console.log(`\nTool calls: ${toolCalls.length}`);
-          toolCalls.forEach(call => {
-            console.log(
-              `  ${call.toolName} providerMetadata:`,
-              JSON.stringify(call.providerMetadata, null, 2),
-            );
-          });
-        }
-        if (toolResults) {
-          console.log(`Tool results: ${toolResults.length}`);
-          toolResults.forEach(result => {
-            console.log(
-              `  ${result.toolName} providerMetadata:`,
-              JSON.stringify(result.providerMetadata, null, 2),
-            );
-          });
-        }
-      },
     });
 
-    for await (const chunk of turn2.fullStream) {
+    for await (const chunk of scenarioA.fullStream) {
       if (chunk.type === 'text-delta') {
         process.stdout.write(chunk.text);
       }
     }
 
-    console.log('\n\nTurn 2 succeeded!');
-  } catch (error) {
-    console.error('\n\nTurn 2 FAILED:');
-    console.error(error);
-    if (
-      error instanceof Error &&
-      error.message?.includes('thought_signature')
-    ) {
-      console.error(
-        '\n>>> This is the thought_signature error from issue #11413 <<<',
-      );
-    }
-    process.exit(1);
+    console.log('\n✓ Scenario A succeeded (expected)\n');
+  } catch (error: any) {
+    console.error('\n✗ Scenario A FAILED (unexpected):', error.message);
   }
-});
+
+  // --- Scenario B: Failover — thoughtSignature under "vertex" key only ---
+  console.log(
+    '=== Scenario B: Failover — thoughtSignature under "vertex" key only ===\n',
+  );
+
+  const rewrittenMessages = response1.messages.map(msg => {
+    if (
+      (msg.role === 'assistant' || msg.role === 'tool') &&
+      typeof msg.content !== 'string'
+    ) {
+      return {
+        ...msg,
+        content: msg.content.map(part => {
+          if (part.providerOptions?.google) {
+            const { google: googleOpts, ...rest } = part.providerOptions;
+            return {
+              ...part,
+              providerOptions: { ...rest, vertex: googleOpts },
+            };
+          }
+          return part;
+        }),
+      };
+    }
+    return msg;
+  });
+
+  console.log('Messages rewritten: providerOptions "google" → "vertex"');
+  console.log(
+    'Google provider will NOT find thoughtSignature (only checks "google" key)\n',
+  );
+
+  try {
+    const scenarioB = streamText({
+      model: google('gemini-3.1-pro-preview'),
+      tools: { weather: weatherTool },
+      messages: [
+        { role: 'user', content: 'What is the weather in San Francisco?' },
+        ...(rewrittenMessages as any),
+        { role: 'user', content: 'What about New York?' },
+      ],
+      maxSteps: 2,
+    });
+
+    for await (const chunk of scenarioB.fullStream) {
+      if (chunk.type === 'text-delta') {
+        process.stdout.write(chunk.text);
+      }
+    }
+
+    console.log(
+      '\n⚠ Scenario B: API accepted request with missing thoughtSignature',
+    );
+    console.log(
+      '  (Google warns this may lead to degraded model performance)\n',
+    );
+  } catch (error: any) {
+    console.error('\n✗ Scenario B FAILED:');
+    console.error('  Error:', error.message?.substring(0, 200));
+    console.log();
+  }
+
+  // --- Scenario C: Wrong signature — an invalid signature under "google" key ---
+  console.log(
+    '=== Scenario C: Invalid signature — dummy value under "google" key ===\n',
+  );
+
+  const invalidSigMessages = response1.messages.map(msg => {
+    if (
+      (msg.role === 'assistant' || msg.role === 'tool') &&
+      typeof msg.content !== 'string'
+    ) {
+      return {
+        ...msg,
+        content: msg.content.map(part => {
+          if (part.providerOptions?.google?.thoughtSignature) {
+            return {
+              ...part,
+              providerOptions: {
+                ...part.providerOptions,
+                google: {
+                  ...part.providerOptions.google,
+                  thoughtSignature: 'INVALID_SIGNATURE_FROM_DIFFERENT_PROVIDER',
+                },
+              },
+            };
+          }
+          return part;
+        }),
+      };
+    }
+    return msg;
+  });
+
+  console.log(
+    'Messages modified: thoughtSignature replaced with invalid value\n',
+  );
+
+  let scenarioCError: any = null;
+  const scenarioC = streamText({
+    model: google('gemini-3.1-pro-preview'),
+    tools: { weather: weatherTool },
+    messages: [
+      { role: 'user', content: 'What is the weather in San Francisco?' },
+      ...(invalidSigMessages as any),
+      { role: 'user', content: 'What about New York?' },
+    ],
+    maxSteps: 2,
+    onError: ({ error }) => {
+      scenarioCError = error;
+    },
+  });
+
+  for await (const chunk of scenarioC.fullStream) {
+    if (chunk.type === 'text-delta') {
+      process.stdout.write(chunk.text);
+    }
+  }
+
+  if (scenarioCError) {
+    const msg = String(
+      scenarioCError?.responseBody ?? scenarioCError?.message ?? scenarioCError,
+    );
+    console.error('✗ Scenario C FAILED with thought_signature error:');
+    console.error(`  Status: ${scenarioCError.statusCode ?? 'unknown'}`);
+    if (msg.includes('thought_signature')) {
+      console.error(
+        '  Error: Invalid/incompatible thought_signature rejected by API',
+      );
+      console.error(
+        '\n  This confirms issue #11413: when the gateway fails over from',
+      );
+      console.error(
+        '  Vertex to Google AI Studio, an incompatible signature causes a 400 error.',
+      );
+    } else {
+      console.error('  Error:', msg.substring(0, 200));
+    }
+  } else {
+    console.log(
+      '\n⚠ Scenario C succeeded — API accepted invalid thoughtSignature',
+    );
+  }
+  console.log();
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
@@ -1,0 +1,163 @@
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  console.log(
+    'Repro for https://github.com/vercel/ai/issues/11413#issuecomment-3787919558',
+  );
+  console.log(
+    'Testing gateway with google/gemini-3-flash and tool calls (multi-turn)\n',
+  );
+
+  const weatherTool = tool({
+    description: 'Get the weather for a location',
+    inputSchema: z.object({
+      location: z.string().describe('The location to get weather for'),
+    }),
+    execute: async ({ location }) => {
+      return {
+        location,
+        temperature: 72,
+        condition: 'sunny',
+      };
+    },
+  });
+
+  console.log('=== Turn 1: Initial request with tool call ===\n');
+
+  const turn1 = streamText({
+    model: 'google/gemini-3-flash',
+    tools: { weather: weatherTool },
+    prompt: 'What is the weather in San Francisco?',
+    maxSteps: 2,
+    includeRawChunks: true,
+    onStepFinish: ({ toolCalls, toolResults }) => {
+      if (toolCalls) {
+        console.log(`\nTool calls: ${toolCalls.length}`);
+        toolCalls.forEach(call => {
+          console.log(
+            `  ${call.toolName} providerMetadata:`,
+            JSON.stringify(call.providerMetadata, null, 2),
+          );
+        });
+      }
+      if (toolResults) {
+        console.log(`Tool results: ${toolResults.length}`);
+        toolResults.forEach(result => {
+          console.log(
+            `  ${result.toolName} providerMetadata:`,
+            JSON.stringify(result.providerMetadata, null, 2),
+          );
+        });
+      }
+    },
+  });
+
+  for await (const chunk of turn1.fullStream) {
+    if (chunk.type === 'text-delta') {
+      process.stdout.write(chunk.text);
+    } else if (chunk.type === 'tool-call') {
+      console.log(
+        `[stream] tool-call: ${chunk.toolName}, providerMetadata:`,
+        JSON.stringify(chunk.providerMetadata, null, 2),
+      );
+    } else if (chunk.type === 'raw') {
+      const raw = chunk.rawValue as any;
+      if (raw?.candidates?.[0]?.content?.parts) {
+        for (const part of raw.candidates[0].content.parts) {
+          if (part.functionCall) {
+            console.log(
+              `[raw] functionCall: ${part.functionCall.name}, thoughtSignature: ${part.thoughtSignature ? '✓' : '❌ not present'}`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  const response1 = await turn1.response;
+  console.log('\n\nTurn 1 complete. Checking messages for thoughtSignatures:');
+
+  for (const msg of response1.messages) {
+    if (msg.role === 'assistant' && typeof msg.content !== 'string') {
+      for (const part of msg.content) {
+        if (part.type === 'tool-call') {
+          console.log(
+            `  assistant tool-call ${part.toolName} providerOptions:`,
+            JSON.stringify(part.providerOptions, null, 2),
+          );
+        }
+      }
+    }
+    if (msg.role === 'tool') {
+      for (const part of msg.content) {
+        if (part.type === 'tool-result') {
+          console.log(
+            `  tool-result ${part.toolName} providerOptions:`,
+            JSON.stringify(part.providerOptions, null, 2),
+          );
+        }
+      }
+    }
+  }
+
+  console.log('\n=== Turn 2: Multi-turn continuation ===\n');
+
+  try {
+    const turn2 = streamText({
+      model: 'google/gemini-3-flash',
+      tools: { weather: weatherTool },
+      messages: [
+        { role: 'user', content: 'What is the weather in San Francisco?' },
+        ...response1.messages,
+        {
+          role: 'user',
+          content: 'What about New York? Use the weather tool again.',
+        },
+      ],
+      maxSteps: 2,
+      includeRawChunks: true,
+      onStepFinish: ({ toolCalls, toolResults }) => {
+        if (toolCalls) {
+          console.log(`\nTool calls: ${toolCalls.length}`);
+          toolCalls.forEach(call => {
+            console.log(
+              `  ${call.toolName} providerMetadata:`,
+              JSON.stringify(call.providerMetadata, null, 2),
+            );
+          });
+        }
+        if (toolResults) {
+          console.log(`Tool results: ${toolResults.length}`);
+          toolResults.forEach(result => {
+            console.log(
+              `  ${result.toolName} providerMetadata:`,
+              JSON.stringify(result.providerMetadata, null, 2),
+            );
+          });
+        }
+      },
+    });
+
+    for await (const chunk of turn2.fullStream) {
+      if (chunk.type === 'text-delta') {
+        process.stdout.write(chunk.text);
+      }
+    }
+
+    console.log('\n\nTurn 2 succeeded!');
+  } catch (error) {
+    console.error('\n\nTurn 2 FAILED:');
+    console.error(error);
+    if (
+      error instanceof Error &&
+      error.message?.includes('thought_signature')
+    ) {
+      console.error(
+        '\n>>> This is the thought_signature error from issue #11413 <<<',
+      );
+    }
+    process.exit(1);
+  }
+});

--- a/packages/google/src/convert-to-google-generative-ai-messages.test.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.test.ts
@@ -209,6 +209,127 @@ describe('thought signatures with vertex providerOptionsName', () => {
   });
 });
 
+describe('thought signatures with google providerOptionsName (gateway failover)', () => {
+  it('should resolve thoughtSignature from vertex namespace when using google providerOptionsName', async () => {
+    const result = convertToGoogleGenerativeAIMessages(
+      [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'Regular text',
+              providerOptions: { vertex: { thoughtSignature: 'sig1' } },
+            },
+            {
+              type: 'reasoning',
+              text: 'Reasoning text',
+              providerOptions: { vertex: { thoughtSignature: 'sig2' } },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'call1',
+              toolName: 'getWeather',
+              input: { location: 'London' },
+              providerOptions: { vertex: { thoughtSignature: 'sig3' } },
+            },
+          ],
+        },
+      ],
+      { providerOptionsName: 'google' },
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Regular text",
+                "thoughtSignature": "sig1",
+              },
+              {
+                "text": "Reasoning text",
+                "thought": true,
+                "thoughtSignature": "sig2",
+              },
+              {
+                "functionCall": {
+                  "args": {
+                    "location": "London",
+                  },
+                  "name": "getWeather",
+                },
+                "thoughtSignature": "sig3",
+              },
+            ],
+            "role": "model",
+          },
+        ],
+        "systemInstruction": undefined,
+      }
+    `);
+  });
+
+  it('should prefer google namespace over vertex namespace when both are present', async () => {
+    const result = convertToGoogleGenerativeAIMessages(
+      [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call1',
+              toolName: 'getWeather',
+              input: { location: 'London' },
+              providerOptions: {
+                google: { thoughtSignature: 'google_sig' },
+                vertex: { thoughtSignature: 'vertex_sig' },
+              },
+            },
+          ],
+        },
+      ],
+      { providerOptionsName: 'google' },
+    );
+
+    expect(result.contents[0].parts[0]).toEqual({
+      functionCall: {
+        name: 'getWeather',
+        args: { location: 'London' },
+      },
+      thoughtSignature: 'google_sig',
+    });
+  });
+
+  it('should resolve thoughtSignature from vertex namespace when google namespace is absent (default providerOptionsName)', async () => {
+    const result = convertToGoogleGenerativeAIMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call1',
+            toolName: 'getWeather',
+            input: { location: 'London' },
+            providerOptions: {
+              vertex: { thoughtSignature: 'vertex_sig' },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.contents[0].parts[0]).toEqual({
+      functionCall: {
+        name: 'getWeather',
+        args: { location: 'London' },
+      },
+      thoughtSignature: 'vertex_sig',
+    });
+  });
+});
+
 describe('Gemma model system instructions', () => {
   it('should prepend system instruction to first user message for Gemma models', async () => {
     const result = convertToGoogleGenerativeAIMessages(

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -86,7 +86,7 @@ export function convertToGoogleGenerativeAIMessages(
                 part.providerOptions?.[providerOptionsName] ??
                 (providerOptionsName !== 'google'
                   ? part.providerOptions?.google
-                  : undefined);
+                  : part.providerOptions?.vertex);
               const thoughtSignature =
                 providerOpts?.thoughtSignature != null
                   ? String(providerOpts.thoughtSignature)


### PR DESCRIPTION
Fixes #11413

## Problem

When the Vercel AI Gateway fails over between Google Vertex and Google AI Studio (both serving the same Gemini model), `thoughtSignature` values get lost, causing the Gemini API to return a 400 error:

> Function call is missing a thought_signature in functionCall parts.

### Root cause

Both `@ai-sdk/google` and `@ai-sdk/google-vertex` share the same `GoogleGenerativeAILanguageModel` implementation but use different `providerOptionsName` values (`"google"` vs `"vertex"`). When storing `thoughtSignature` in the response, it's placed under `providerMetadata[providerOptionsName]`. When reading it back for the next API call, the lookup was **asymmetric**:

- **Vertex** (`providerOptionsName === 'vertex'`): checks `vertex`, falls back to `google` — worked
- **Google** (`providerOptionsName === 'google'`): checks `google` only — **no fallback to `vertex`**

So a Vertex → Google failover silently dropped the `thoughtSignature`, and the Gemini API rejected the request.

## Fix

Make the fallback bidirectional in `convertToGoogleGenerativeAIMessages`: when `providerOptionsName` is `"google"` and `providerOptions.google` is absent, fall back to `providerOptions.vertex`.

This is safe because:
- The fallback only affects `thoughtSignature` extraction
- Both providers serve the same Gemini models, so signatures are interchangeable
- The primary namespace always takes precedence

## Test plan

- [x] Added unit tests for the new Google → Vertex fallback
- [x] Existing tests still pass (258 tests)
- [ ] Run the reproduction example (`examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts`) to confirm the fix