### PR TITLE
fix(ai): fix missing support for image thought signatures (e.g. for Gemini image models)

### DIFF
--- a/.changeset/young-ducks-rush.md
+++ b/.changeset/young-ducks-rush.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google': patch
+'ai': patch
+---
+
+fix(ai): fix missing support for image thought signatures (e.g. for Gemini image models)

--- a/examples/ai-e2e-next/app/api/chat/google-gemini-image/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/google-gemini-image/route.ts
@@ -1,0 +1,24 @@
+import { google, type GoogleLanguageModelOptions } from '@ai-sdk/google';
+import { streamText, convertToModelMessages } from 'ai';
+
+export const maxDuration = 30;
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = streamText({
+    model: google('gemini-3.1-flash-image-preview'),
+    messages: await convertToModelMessages(messages),
+    providerOptions: {
+      google: {
+        responseModalities: ['TEXT', 'IMAGE'],
+        thinkingConfig: {
+          thinkingLevel: 'high',
+        },
+      } satisfies GoogleLanguageModelOptions,
+    },
+    includeRawChunks: true,
+  });
+
+  return result.toUIMessageStreamResponse();
+}

--- a/examples/ai-e2e-next/app/chat/google-gemini-image/page.tsx
+++ b/examples/ai-e2e-next/app/chat/google-gemini-image/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import ChatInput from '@/components/chat-input';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+
+export default function Chat() {
+  const { status, sendMessage, messages, error, regenerate } = useChat({
+    transport: new DefaultChatTransport({
+      api: '/api/chat/google-gemini-image',
+    }),
+  });
+
+  return (
+    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+      {messages.map(message => (
+        <div key={message.id} className="whitespace-pre-wrap">
+          {message.role === 'user' ? 'User: ' : 'AI: '}
+          {message.parts.map((part, index) => {
+            if (part.type === 'text') {
+              return <div key={index}>{part.text}</div>;
+            } else if (
+              part.type === 'file' &&
+              part.mediaType.startsWith('image/')
+            ) {
+              return (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img key={index} src={part.url} alt="Generated image" />
+              );
+            }
+          })}
+        </div>
+      ))}
+
+      {error && (
+        <div className="mt-4">
+          <div className="text-red-500">An error occurred.</div>
+          <button
+            type="button"
+            className="px-4 py-2 mt-4 text-blue-500 rounded-md border border-blue-500"
+            onClick={() => regenerate()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <ChatInput status={status} onSubmit={text => sendMessage({ text })} />
+    </div>
+  );
+}

--- a/packages/ai/src/generate-text/run-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.test.ts
@@ -99,6 +99,150 @@ describe('runToolsTransformation', () => {
     `);
   });
 
+  it('should forward file parts', async () => {
+    const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      convertArrayToReadableStream([
+        {
+          type: 'file',
+          data: 'Hello World',
+          mediaType: 'text/plain',
+        },
+        {
+          type: 'finish',
+          finishReason: { unified: 'stop', raw: 'stop' },
+          usage: testUsage,
+        },
+      ]);
+
+    const transformedStream = runToolsTransformation({
+      generateId: mockId({ prefix: 'id' }),
+      tools: undefined,
+      generatorStream: inputStream,
+      tracer: new MockTracer(),
+      telemetry: undefined,
+      messages: [],
+      system: undefined,
+      abortSignal: undefined,
+      repairToolCall: undefined,
+      experimental_context: undefined,
+    });
+
+    const result = await convertReadableStreamToArray(transformedStream);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "file": DefaultGeneratedFileWithType {
+            "base64Data": "Hello World",
+            "mediaType": "text/plain",
+            "type": "file",
+            "uint8ArrayData": undefined,
+          },
+          "type": "file",
+        },
+        {
+          "finishReason": "stop",
+          "providerMetadata": undefined,
+          "rawFinishReason": "stop",
+          "type": "finish",
+          "usage": {
+            "cachedInputTokens": undefined,
+            "inputTokenDetails": {
+              "cacheReadTokens": undefined,
+              "cacheWriteTokens": undefined,
+              "noCacheTokens": 3,
+            },
+            "inputTokens": 3,
+            "outputTokenDetails": {
+              "reasoningTokens": undefined,
+              "textTokens": 10,
+            },
+            "outputTokens": 10,
+            "raw": undefined,
+            "reasoningTokens": undefined,
+            "totalTokens": 13,
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should forward file parts with providerMetadata', async () => {
+    const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      convertArrayToReadableStream([
+        {
+          type: 'file',
+          data: 'Hello World',
+          mediaType: 'text/plain',
+          providerMetadata: {
+            testProvider: { signature: 'test-signature' },
+          },
+        },
+        {
+          type: 'finish',
+          finishReason: { unified: 'stop', raw: 'stop' },
+          usage: testUsage,
+        },
+      ]);
+
+    const transformedStream = runToolsTransformation({
+      generateId: mockId({ prefix: 'id' }),
+      tools: undefined,
+      generatorStream: inputStream,
+      tracer: new MockTracer(),
+      telemetry: undefined,
+      messages: [],
+      system: undefined,
+      abortSignal: undefined,
+      repairToolCall: undefined,
+      experimental_context: undefined,
+    });
+
+    const result = await convertReadableStreamToArray(transformedStream);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "file": DefaultGeneratedFileWithType {
+            "base64Data": "Hello World",
+            "mediaType": "text/plain",
+            "type": "file",
+            "uint8ArrayData": undefined,
+          },
+          "providerMetadata": {
+            "testProvider": {
+              "signature": "test-signature",
+            },
+          },
+          "type": "file",
+        },
+        {
+          "finishReason": "stop",
+          "providerMetadata": undefined,
+          "rawFinishReason": "stop",
+          "type": "finish",
+          "usage": {
+            "cachedInputTokens": undefined,
+            "inputTokenDetails": {
+              "cacheReadTokens": undefined,
+              "cacheWriteTokens": undefined,
+              "noCacheTokens": 3,
+            },
+            "inputTokens": 3,
+            "outputTokenDetails": {
+              "reasoningTokens": undefined,
+              "textTokens": 10,
+            },
+            "outputTokens": 10,
+            "raw": undefined,
+            "reasoningTokens": undefined,
+            "totalTokens": 13,
+          },
+        },
+      ]
+    `);
+  });
+
   it('should handle async tool execution', async () => {
     const inputStream: ReadableStream<LanguageModelV3StreamPart> =
       convertArrayToReadableStream([

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -87,11 +87,10 @@ export type SingleRequestTextStreamPart<TOOLS extends ToolSet> =
 
   // Other types:
   | ({ type: 'source' } & Source)
-  | { type: 'file'; file: GeneratedFile } // different because of GeneratedFile object
+  | { type: 'file'; file: GeneratedFile; providerMetadata?: ProviderMetadata } // different because of GeneratedFile object
   | ({ type: 'tool-call' } & TypedToolCall<TOOLS>)
   | ({ type: 'tool-result' } & TypedToolResult<TOOLS>)
   | ({ type: 'tool-error' } & TypedToolError<TOOLS>)
-  | { type: 'file'; file: GeneratedFile } // different because of GeneratedFile object
   | { type: 'stream-start'; warnings: SharedV3Warning[] }
   | {
       type: 'response-metadata';
@@ -224,6 +223,9 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
               data: chunk.data,
               mediaType: chunk.mediaType,
             }),
+            ...(chunk.providerMetadata != null
+              ? { providerMetadata: chunk.providerMetadata }
+              : {}),
           });
           break;
         }

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -421,7 +421,7 @@ export type TextStreamPart<TOOLS extends ToolSet> =
       providerMetadata?: ProviderMetadata;
     }
   | ({ type: 'source' } & Source)
-  | { type: 'file'; file: GeneratedFile } // different because of GeneratedFile object
+  | { type: 'file'; file: GeneratedFile; providerMetadata?: ProviderMetadata } // different because of GeneratedFile object
   | ({ type: 'tool-call' } & TypedToolCall<TOOLS>)
   | ({ type: 'tool-result' } & TypedToolResult<TOOLS>)
   | ({ type: 'tool-error' } & TypedToolError<TOOLS>)

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -226,6 +226,34 @@ const modelWithFiles = new MockLanguageModelV3({
   }),
 });
 
+const modelWithFilesAndProviderMetadata = new MockLanguageModelV3({
+  doStream: async () => ({
+    stream: convertArrayToReadableStream([
+      {
+        type: 'file',
+        data: 'Hello World',
+        mediaType: 'text/plain',
+        providerMetadata: {
+          testProvider: { signature: 'sig-1' },
+        },
+      },
+      { type: 'text-start', id: '1' },
+      { type: 'text-delta', id: '1', delta: 'Hello!' },
+      { type: 'text-end', id: '1' },
+      {
+        type: 'file',
+        data: 'QkFVRw==',
+        mediaType: 'image/jpeg',
+      },
+      {
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: testUsage,
+      },
+    ]),
+  }),
+});
+
 const modelWithReasoning = new MockLanguageModelV3({
   doStream: async () => ({
     stream: convertArrayToReadableStream([
@@ -1015,6 +1043,44 @@ describe('streamText', () => {
             },
           ]
         `);
+    });
+
+    it('should send files with providerMetadata', async () => {
+      const result = streamText({
+        model: modelWithFilesAndProviderMetadata,
+        ...defaultSettings(),
+      });
+
+      const parts = await convertAsyncIterableToArray(result.fullStream);
+      const fileParts = parts.filter(p => p.type === 'file');
+
+      expect(fileParts).toMatchInlineSnapshot(`
+        [
+          {
+            "file": DefaultGeneratedFileWithType {
+              "base64Data": "Hello World",
+              "mediaType": "text/plain",
+              "type": "file",
+              "uint8ArrayData": undefined,
+            },
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "sig-1",
+              },
+            },
+            "type": "file",
+          },
+          {
+            "file": DefaultGeneratedFileWithType {
+              "base64Data": "QkFVRw==",
+              "mediaType": "image/jpeg",
+              "type": "file",
+              "uint8ArrayData": undefined,
+            },
+            "type": "file",
+          },
+        ]
+      `);
     });
 
     it('should use fallback response metadata when response metadata is not provided', async () => {
@@ -3221,6 +3287,39 @@ describe('streamText', () => {
             },
           ]
         `);
+    });
+
+    it('should send file content with providerMetadata', async () => {
+      const result = streamText({
+        model: modelWithFilesAndProviderMetadata,
+        ...defaultSettings(),
+      });
+
+      const uiMessageStream = result.toUIMessageStream();
+      const parts = await convertReadableStreamToArray(uiMessageStream);
+      const fileParts = parts.filter(
+        (p: Record<string, unknown>) => p.type === 'file',
+      );
+
+      expect(fileParts).toMatchInlineSnapshot(`
+        [
+          {
+            "mediaType": "text/plain",
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "sig-1",
+              },
+            },
+            "type": "file",
+            "url": "data:text/plain;base64,Hello World",
+          },
+          {
+            "mediaType": "image/jpeg",
+            "type": "file",
+            "url": "data:image/jpeg;base64,QkFVRw==",
+          },
+        ]
+      `);
     });
 
     it('should not generate a new message id when onFinish is provided and generateMessageId is not provided', async () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -978,7 +978,13 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
         }
 
         if (part.type === 'file') {
-          recordedContent.push({ type: 'file', file: part.file });
+          recordedContent.push({
+            type: 'file',
+            file: part.file,
+            ...(part.providerMetadata != null
+              ? { providerMetadata: part.providerMetadata }
+              : {}),
+          });
         }
 
         if (part.type === 'source') {
@@ -2477,6 +2483,9 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                 type: 'file',
                 mediaType: part.file.mediaType,
                 url: `data:${part.file.mediaType};base64,${part.file.base64}`,
+                ...(part.providerMetadata != null
+                  ? { providerMetadata: part.providerMetadata }
+                  : {}),
               });
               break;
             }

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -442,6 +442,40 @@ describe('convertToModelMessages', () => {
       ] as unknown as ModelMessage[]);
     });
 
+    it('should handle assistant message file parts with provider metadata', async () => {
+      const result = await convertToModelMessages([
+        {
+          role: 'assistant',
+          parts: [
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              url: 'data:image/png;base64,dGVzdA==',
+              providerMetadata: {
+                testProvider: { signature: 'test-signature' },
+              },
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              data: 'data:image/png;base64,dGVzdA==',
+              providerOptions: {
+                testProvider: { signature: 'test-signature' },
+              },
+            },
+          ],
+        },
+      ] as unknown as ModelMessage[]);
+    });
+
     it('should handle assistant message with tool output available', async () => {
       const result = await convertToModelMessages([
         {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -162,6 +162,9 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                   mediaType: part.mediaType,
                   filename: part.filename,
                   data: part.url,
+                  ...(part.providerMetadata != null
+                    ? { providerOptions: part.providerMetadata }
+                    : {}),
                 });
               } else if (isReasoningUIPart(part)) {
                 content.push({

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -4463,6 +4463,75 @@ describe('processUIMessageStream', () => {
     });
   });
 
+  describe('file parts with providerMetadata', () => {
+    beforeEach(async () => {
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-123' },
+        { type: 'start-step' },
+        {
+          type: 'file',
+          url: 'data:text/plain;base64,SGVsbG8gV29ybGQ=',
+          mediaType: 'text/plain',
+          providerMetadata: {
+            testProvider: { signature: 'sig-1' },
+          },
+        },
+        {
+          type: 'file',
+          url: 'data:image/jpeg;base64,QkFVRw==',
+          mediaType: 'image/jpeg',
+        },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+    });
+
+    it('should have the correct final message state', async () => {
+      expect(state!.message).toMatchInlineSnapshot(`
+        {
+          "id": "msg-123",
+          "metadata": undefined,
+          "parts": [
+            {
+              "type": "step-start",
+            },
+            {
+              "mediaType": "text/plain",
+              "providerMetadata": {
+                "testProvider": {
+                  "signature": "sig-1",
+                },
+              },
+              "type": "file",
+              "url": "data:text/plain;base64,SGVsbG8gV29ybGQ=",
+            },
+            {
+              "mediaType": "image/jpeg",
+              "type": "file",
+              "url": "data:image/jpeg;base64,QkFVRw==",
+            },
+          ],
+          "role": "assistant",
+        }
+      `);
+    });
+  });
+
   describe('data ui parts (single part)', () => {
     let dataCalls: InferUIMessageData<UIMessage>[] = [];
 

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -408,6 +408,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 type: 'file',
                 mediaType: chunk.mediaType,
                 url: chunk.url,
+                ...(chunk.providerMetadata != null
+                  ? { providerMetadata: chunk.providerMetadata }
+                  : {}),
               });
 
               write();

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -3963,6 +3963,7 @@ describe('doStream', () => {
         {
           "data": "test",
           "mediaType": "text/plain",
+          "providerMetadata": undefined,
           "type": "file",
         },
         {
@@ -4081,29 +4082,49 @@ describe('doStream', () => {
           "type": "text-delta",
         },
         {
+          "id": "0",
+          "type": "text-end",
+        },
+        {
           "data": "image1",
           "mediaType": "image/png",
+          "providerMetadata": undefined,
           "type": "file",
         },
         {
+          "id": "1",
+          "providerMetadata": undefined,
+          "type": "text-start",
+        },
+        {
           "delta": " Step 2: ",
-          "id": "0",
+          "id": "1",
           "providerMetadata": undefined,
           "type": "text-delta",
+        },
+        {
+          "id": "1",
+          "type": "text-end",
         },
         {
           "data": "image2",
           "mediaType": "image/jpeg",
+          "providerMetadata": undefined,
           "type": "file",
         },
         {
+          "id": "2",
+          "providerMetadata": undefined,
+          "type": "text-start",
+        },
+        {
           "delta": " Done",
-          "id": "0",
+          "id": "2",
           "providerMetadata": undefined,
           "type": "text-delta",
         },
         {
-          "id": "0",
+          "id": "2",
           "type": "text-end",
         },
       ]

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -564,11 +564,36 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                     });
                   }
                 } else if ('inlineData' in part) {
+                  // End any active text or reasoning block before starting file output.
+                  // Relevant for multimodal output models.
+                  if (currentTextBlockId !== null) {
+                    controller.enqueue({
+                      type: 'text-end',
+                      id: currentTextBlockId,
+                    });
+                    currentTextBlockId = null;
+                  }
+                  if (currentReasoningBlockId !== null) {
+                    controller.enqueue({
+                      type: 'reasoning-end',
+                      id: currentReasoningBlockId,
+                    });
+                    currentReasoningBlockId = null;
+                  }
+
                   // Process file parts inline to preserve order with text
+                  const thoughtSignatureMetadata = part.thoughtSignature
+                    ? {
+                        [providerOptionsName]: {
+                          thoughtSignature: part.thoughtSignature,
+                        },
+                      }
+                    : undefined;
                   controller.enqueue({
                     type: 'file',
                     mediaType: part.inlineData.mimeType,
                     data: part.inlineData.data,
+                    providerMetadata: thoughtSignatureMetadata,
                   });
                 }
               }


### PR DESCRIPTION
## Summary

This fixes a few problems:

* Image thought signatures were not supported by `ai` at all when streaming, including in UI / `useChat` transformations.
* Image thought signatures were therefore also not being processed when received in a Gemini API response.
* When using Gemini to produce multimodal output (e.g. text and images together), the order of output parts was not respected - images were always displayed after all text, even when in the original response they were in between text paragraphs.

## Manual Verification

Use the new UI example `google-gemini-images` in `examples/ai-e2e-next` to verify. Try a prompt like:
```
Write a 3 verse kids poem about a dog meeting an owl, accompanied by illustrations
```

Without this PR, you will see all images appear after all text, even though this is not the correct order per the streaming chunks. With this PR, that's fixed.

Similarly, without this PR you will not be able to send any follow up messages - they will error because of the missing image thought signatures. With this PR, it works.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Fixes #12988
Fixes #11461
Fixes #10595
