### PR TITLE
feat(anthropic, amazon-bedrock): expose anthropicBeta to downstream providers

### DIFF
--- a/.changeset/anthropic-beta-downstream-providers.md
+++ b/.changeset/anthropic-beta-downstream-providers.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/anthropic': patch
+'@ai-sdk/amazon-bedrock': patch
+---
+
+feat(anthropic): expose anthropic.anthropicBeta to downstream providers

--- a/.changeset/silver-panthers-repeat.md
+++ b/.changeset/silver-panthers-repeat.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/anthropic': patch
+---
+
+feat(anthropic): expose anthropic.anthropicBeta to downstream provider

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-1m-context.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-1m-context.ts
@@ -1,0 +1,75 @@
+import { createBedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+const bedrockAnthropic = createBedrockAnthropic({
+  headers: {
+    'anthropic-beta': 'context-1m-2025-08-07',
+  },
+});
+
+// Build a large text block intended to exceed the standard context window
+const APPROX_TOKENS = 110_000;
+const CHARS_PER_TOKEN = 4;
+const TARGET_CHARS = APPROX_TOKENS * CHARS_PER_TOKEN;
+
+function makeBaseChunk(): string {
+  let s = '';
+  for (let j = 0; j < 500; j++) {
+    s += `IDX:${j.toString(36)} | alpha:${'abcdefghijklmnopqrstuvwxyz'.slice(0, (j % 26) + 1)} | nums:${'0123456789'.repeat(3)} | sym:${'-=_+'.repeat(5)}\n`;
+  }
+  return s;
+}
+
+const baseChunk = makeBaseChunk();
+const repeats = Math.ceil(TARGET_CHARS / baseChunk.length);
+const largeContextText = baseChunk
+  .repeat(repeats)
+  .slice(0, TARGET_CHARS + 50_000);
+
+run(async () => {
+  const estimatedTokens = Math.ceil(largeContextText.length / CHARS_PER_TOKEN);
+  console.log('Prepared large context chars:', largeContextText.length);
+  console.log('Estimated tokens (chars/4):', estimatedTokens);
+
+  const startstamp = performance.now();
+
+  const result = streamText({
+    model: bedrockAnthropic('us.anthropic.claude-sonnet-4-20250514-v1:0'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `The following is a large context payload.\n\n${largeContextText}`,
+          },
+          {
+            type: 'text',
+            text: 'Summarize the structure of the data above in one sentence.',
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      // alternatively this feature can be enabled with:
+      // anthropic: {
+      //   anthropicBeta: ['context-1m-2025-08-07'],
+      // },
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  const endstamp = performance.now();
+  console.log();
+  console.log(
+    'Time taken:',
+    ((endstamp - startstamp) / 1000).toFixed(2),
+    'seconds',
+  );
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-fine-grained-tool-streaming.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-fine-grained-tool-streaming.ts
@@ -130,7 +130,8 @@ run(async () => {
   // A buffered dump replays all deltas synchronously (<1ms each); real streaming
   // has most intervals >= 5ms as each token takes time to generate.
   // Threshold is heuristic — the desired behavior is smooth continuous streaming
-  // instead of a long hang followed by a dump of all chunks at once.  let liveIntervals = 0;
+  // instead of a long hang followed by a dump of all chunks at once.
+  let liveIntervals = 0;
   for (let i = 1; i < toolInputDeltaTimestamps.length; i++) {
     if (toolInputDeltaTimestamps[i] - toolInputDeltaTimestamps[i - 1] >= 5)
       liveIntervals++;

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-fine-grained-tool-streaming.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-fine-grained-tool-streaming.ts
@@ -1,0 +1,151 @@
+import { createBedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+import { z } from 'zod';
+
+const bedrockAnthropic = createBedrockAnthropic({
+  headers: {
+    'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14',
+  },
+});
+
+const tools = {
+  write_to_file: {
+    description:
+      'Request to write content to a file. ALWAYS provide the COMPLETE file content, without any truncation.',
+    inputSchema: z.object({
+      path: z
+        .string()
+        .describe(
+          'The path of the file to write to (relative to the current workspace directory)',
+        ),
+      content: z.string().describe('The content to write to the file.'),
+    }),
+  },
+} as const;
+
+run(async () => {
+  console.log('=== Fine-grained tool streaming test (Bedrock Anthropic) ===\n');
+
+  const result = streamText({
+    model: bedrockAnthropic('global.anthropic.claude-sonnet-4-6'),
+
+    messages: [
+      {
+        role: 'user',
+        content: 'Write a bubble sort implementation in JavaScript to sort.js',
+      },
+    ],
+
+    tools,
+    toolChoice: 'required',
+    providerOptions: {
+      // alternatively this feature can be enabled with:
+      // anthropic: {
+      //   anthropicBeta: ['fine-grained-tool-streaming-2025-05-14'],
+      // },
+    },
+  });
+
+  let sawToolInputStart = false;
+  let toolInputDeltaCount = 0;
+  let sawToolInputEnd = false;
+  const toolInputDeltaTimestamps: number[] = [];
+
+  // ts() prints a compact timestamp to stderr so we can see real-time ordering
+  const T0 = Date.now();
+  const ts = (label: string) =>
+    process.stderr.write(
+      `+${((Date.now() - T0) / 1000).toFixed(2)}s ${label}\n`,
+    );
+
+  ts('stream started');
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text-start':
+        ts('[text-start]');
+        process.stdout.write('\n[text-start]\n');
+        break;
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'text-end':
+        ts('[text-end]');
+        process.stdout.write('\n[text-end]\n');
+        break;
+      case 'tool-input-start':
+        sawToolInputStart = true;
+        ts(`[tool-input-start] tool=${part.toolName}`);
+        process.stdout.write(
+          `\n[tool-input-start] id=${part.id} tool=${part.toolName}\n`,
+        );
+        break;
+      case 'tool-input-delta':
+        toolInputDeltaCount++;
+        toolInputDeltaTimestamps.push(Date.now());
+        if (toolInputDeltaCount === 1 || toolInputDeltaCount % 100 === 0) {
+          ts(`[tool-input-delta #${toolInputDeltaCount}]`);
+        }
+        process.stdout.write(part.delta);
+        break;
+      case 'tool-input-end':
+        sawToolInputEnd = true;
+        ts(`[tool-input-end]`);
+        process.stdout.write(`\n[tool-input-end] id=${part.id}\n`);
+        break;
+      case 'tool-call': {
+        const preview = JSON.stringify(part.input).slice(0, 80);
+        ts(`[tool-call] tool=${part.toolName}`);
+        console.log(
+          `\n[tool-call] tool=${part.toolName} input(preview)=${preview}…`,
+        );
+        break;
+      }
+      case 'start-step':
+        ts('[start-step]');
+        console.log('\n[start-step]');
+        break;
+      case 'finish-step':
+        ts(`[finish-step] reason=${part.finishReason}`);
+        console.log(
+          `[finish-step] finishReason=${part.finishReason} usage=${JSON.stringify(part.usage)}`,
+        );
+        break;
+      case 'finish':
+        ts(`[finish] reason=${part.finishReason}`);
+        console.log(
+          `\n[finish] finishReason=${part.finishReason} usage=${JSON.stringify(part.totalUsage)}`,
+        );
+        break;
+      case 'error':
+        ts('[error]');
+        console.error('\n[error]', part.error);
+        break;
+    }
+  }
+
+  // ── diagnosis ─────────────────────────────────────────────────────────────
+  // Count consecutive delta intervals >= 5ms (genuine per-token generation time).
+  // A buffered dump replays all deltas synchronously (<1ms each); real streaming
+  // has most intervals >= 5ms as each token takes time to generate.
+  // Threshold is heuristic — the desired behavior is smooth continuous streaming
+  // instead of a long hang followed by a dump of all chunks at once.  let liveIntervals = 0;
+  for (let i = 1; i < toolInputDeltaTimestamps.length; i++) {
+    if (toolInputDeltaTimestamps[i] - toolInputDeltaTimestamps[i - 1] >= 5)
+      liveIntervals++;
+  }
+  const liveRatio =
+    toolInputDeltaTimestamps.length > 1
+      ? liveIntervals / (toolInputDeltaTimestamps.length - 1)
+      : 0;
+  const isStreaming = toolInputDeltaCount >= 5 && liveRatio > 0.5;
+
+  console.log('\n=== Summary ===');
+  console.log('tool-input-start received :', sawToolInputStart);
+  console.log('tool-input-delta count    :', toolInputDeltaCount);
+  console.log('tool-input-end received   :', sawToolInputEnd);
+  console.log(
+    `Fine-grained tool streaming: ${isStreaming ? 'YES' : 'NO'} (${toolInputDeltaCount} deltas, ${(liveRatio * 100).toFixed(0)}% live intervals)`,
+  );
+});

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -221,11 +221,14 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-    });
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+      },
+      new Set(),
+    );
 
     expect(transformedBody).toEqual({
       messages: [{ role: 'user', content: 'Hello' }],
@@ -247,12 +250,15 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-      stream: true,
-    });
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        stream: true,
+      },
+      new Set(),
+    );
 
     expect(transformedBody).not.toHaveProperty('stream');
     expect(transformedBody).toHaveProperty('anthropic_version');
@@ -270,15 +276,18 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-      tool_choice: {
-        type: 'auto',
-        disable_parallel_tool_use: true,
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tool_choice: {
+          type: 'auto',
+          disable_parallel_tool_use: true,
+        },
       },
-    });
+      new Set(),
+    );
 
     expect(transformedBody?.tool_choice).toEqual({ type: 'auto' });
     expect(transformedBody?.tool_choice).not.toHaveProperty(
@@ -298,16 +307,19 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-      tool_choice: {
-        type: 'tool',
-        name: 'my_tool',
-        disable_parallel_tool_use: true,
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tool_choice: {
+          type: 'tool',
+          name: 'my_tool',
+          disable_parallel_tool_use: true,
+        },
       },
-    });
+      new Set(),
+    );
 
     expect(transformedBody?.tool_choice).toEqual({
       type: 'tool',
@@ -327,16 +339,19 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-      tools: [
-        { type: 'bash_20241022', name: 'bash' },
-        { type: 'text_editor_20241022', name: 'str_replace_editor' },
-        { type: 'computer_20241022', name: 'computer' },
-      ],
-    });
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tools: [
+          { type: 'bash_20241022', name: 'bash' },
+          { type: 'text_editor_20241022', name: 'str_replace_editor' },
+          { type: 'computer_20241022', name: 'computer' },
+        ],
+      },
+      new Set(),
+    );
 
     expect(transformedBody?.tools).toEqual([
       { type: 'bash_20250124', name: 'bash' },
@@ -357,16 +372,47 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-      tools: [{ type: 'bash_20250124', name: 'bash' }],
-    });
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tools: [{ type: 'bash_20250124', name: 'bash' }],
+      },
+      new Set(),
+    );
 
     expect(transformedBody?.anthropic_beta).toContain(
       'computer-use-2025-01-24',
     );
+  });
+
+  it('should include betas passed to transformRequestBody in anthropic_beta body field', () => {
+    const provider = createBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model-id');
+
+    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
+      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const config = constructorCall[1];
+
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+      },
+      new Set(),
+    );
+
+    expect(transformedBody).toHaveProperty(
+      'anthropic_version',
+      'bedrock-2023-05-31',
+    );
+    expect(transformedBody).not.toHaveProperty('anthropic_beta');
   });
 
   it('should not add anthropic_beta when no computer use tools are present', () => {
@@ -381,18 +427,21 @@ describe('bedrock-anthropic-provider', () => {
       .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
     const config = constructorCall[1];
 
-    const transformedBody = config.transformRequestBody?.({
-      model: 'test-model-id',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 1024,
-      tools: [
-        {
-          type: 'function',
-          name: 'get_weather',
-          input_schema: { type: 'object', properties: {} },
-        },
-      ],
-    });
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tools: [
+          {
+            type: 'function',
+            name: 'get_weather',
+            input_schema: { type: 'object', properties: {} },
+          },
+        ],
+      },
+      new Set(),
+    );
 
     expect(transformedBody?.anthropic_beta).toBeUndefined();
   });

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -256,7 +256,7 @@ export function createBedrockAnthropic(
           isStreaming ? 'invoke-with-response-stream' : 'invoke'
         }`,
 
-      transformRequestBody: args => {
+      transformRequestBody: (args, betas) => {
         const { model, stream, tool_choice, tools, ...rest } = args;
 
         const transformedToolChoice =
@@ -267,7 +267,7 @@ export function createBedrockAnthropic(
               }
             : undefined;
 
-        const requiredBetas = new Set<string>();
+        const requiredBetas = new Set<string>(betas);
         const transformedTools = tools?.map((tool: Record<string, unknown>) => {
           const toolType = tool.type as string | undefined;
 

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -6727,6 +6727,38 @@ describe('AnthropicMessagesLanguageModel', () => {
       );
     });
 
+    it('should include providerOptions.anthropic.anthropicBeta in anthropic-beta header', async () => {
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"output_tokens":1}}}\n\n`,
+          `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n`,
+          `data: {"type":"content_block_stop","index":0}\n\n`,
+          `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}\n\n`,
+          `data: {"type":"message_stop"}\n\n`,
+        ],
+      };
+
+      const provider = createAnthropic({ apiKey: 'test-api-key' });
+
+      await provider('claude-3-haiku-20240307').doStream({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            anthropicBeta: ['my-beta-2025-01-01', 'another-beta-2025-06-01'],
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      expect(server.calls[0].requestHeaders['anthropic-beta']).toContain(
+        'my-beta-2025-01-01',
+      );
+      expect(server.calls[0].requestHeaders['anthropic-beta']).toContain(
+        'another-beta-2025-06-01',
+      );
+    });
+
     it('should support cache control', async () => {
       server.urls['https://api.anthropic.com/v1/messages'].response = {
         type: 'stream-chunks',

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -8700,6 +8700,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
           ],
         }),
+        expect.any(Set),
       );
 
       // Verify transformed body was sent
@@ -8746,6 +8747,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           ],
           stream: true,
         }),
+        expect.any(Set),
       );
 
       // Verify transformed body was sent

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -118,7 +118,10 @@ type AnthropicMessagesConfig = {
   headers: Resolvable<Record<string, string | undefined>>;
   fetch?: FetchFunction;
   buildRequestUrl?: (baseURL: string, isStreaming: boolean) => string;
-  transformRequestBody?: (args: Record<string, any>) => Record<string, any>;
+  transformRequestBody?: (
+    args: Record<string, any>,
+    betas: Set<string>,
+  ) => Record<string, any>;
   supportedUrls?: () => LanguageModelV3['supportedUrls'];
   generateId?: () => string;
 
@@ -632,7 +635,12 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
         stream: stream === true ? true : undefined, // do not send when not streaming
       },
       warnings: [...warnings, ...toolWarnings, ...cacheWarnings],
-      betas: new Set([...betas, ...toolsBetas, ...userSuppliedBetas]),
+      betas: new Set([
+        ...betas,
+        ...toolsBetas,
+        ...userSuppliedBetas,
+        ...(anthropicOptions?.anthropicBeta ?? []),
+      ]),
       usesJsonResponseTool: jsonResponseTool != null,
       toolNameMapping,
       providerOptionsName,
@@ -679,8 +687,11 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     );
   }
 
-  private transformRequestBody(args: Record<string, any>): Record<string, any> {
-    return this.config.transformRequestBody?.(args) ?? args;
+  private transformRequestBody(
+    args: Record<string, any>,
+    betas: Set<string>,
+  ): Record<string, any> {
+    return this.config.transformRequestBody?.(args, betas) ?? args;
   }
 
   private extractCitationDocuments(prompt: LanguageModelV3Prompt): Array<{
@@ -759,7 +770,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     } = await postJsonToApi({
       url: this.buildRequestUrl(false),
       headers: await this.getHeaders({ betas, headers: options.headers }),
-      body: this.transformRequestBody(args),
+      body: this.transformRequestBody(args, betas),
       failedResponseHandler: anthropicFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
         anthropicMessagesResponseSchema,
@@ -1237,7 +1248,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     const { responseHeaders, value: response } = await postJsonToApi({
       url,
       headers: await this.getHeaders({ betas, headers: options.headers }),
-      body: this.transformRequestBody(body),
+      body: this.transformRequestBody(body, betas),
       failedResponseHandler: anthropicFailedResponseHandler,
       successfulResponseHandler: createEventSourceResponseHandler(
         anthropicMessagesChunkSchema,

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -173,6 +173,12 @@ export const anthropicLanguageModelOptions = z.object({
    */
   speed: z.enum(['fast', 'standard']).optional(),
 
+  /**
+   * A set of beta features to enable.
+   * Allow a provider to receive the full `betas` set if it needs it.
+   */
+  anthropicBeta: z.array(z.string()).optional(),
+
   contextManagement: z
     .object({
       edits: z.array(


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

`amazon-bedrock/anthropic` requires `anthropic_beta` in its request body to enable extended capabilities for anthropic models, like 1M context (context-1m-2025-08-07) and fine-grained tool streaming (fine-grained-tool-streaming-2025-05-14).

## Summary

<!-- What did you change? -->

- `anthropic`: added `anthropicBeta` and forwarded to downstream providers via transformRequestBody
- `amazon-bedrock`: receive betas passed from upstream
- `v5` changes here: #13059 

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

- added example scripts with verification checks

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)