### PR TITLE
fix(security): add URL validation to prevent SSRF in download functions

### DIFF
--- a/.changeset/fix-ssrf-download-validation.md
+++ b/.changeset/fix-ssrf-download-validation.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+Add URL validation to `downloadBlob` and `download` to prevent blind SSRF attacks. Private/internal IP addresses, localhost, and non-HTTP protocols are now rejected before fetching.

--- a/packages/ai/src/util/download/download.test.ts
+++ b/packages/ai/src/util/download/download.test.ts
@@ -8,6 +8,26 @@ const server = createTestServer({
   'http://example.com/large': {},
 });
 
+describe('download SSRF protection', () => {
+  it('should reject private IPv4 addresses', async () => {
+    await expect(
+      download({ url: new URL('http://127.0.0.1/file') }),
+    ).rejects.toThrow(DownloadError);
+    await expect(
+      download({ url: new URL('http://10.0.0.1/file') }),
+    ).rejects.toThrow(DownloadError);
+    await expect(
+      download({ url: new URL('http://169.254.169.254/latest/meta-data/') }),
+    ).rejects.toThrow(DownloadError);
+  });
+
+  it('should reject localhost', async () => {
+    await expect(
+      download({ url: new URL('http://localhost/file') }),
+    ).rejects.toThrow(DownloadError);
+  });
+});
+
 describe('download', () => {
   it('should download data successfully and match expected bytes', async () => {
     const expectedBytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/packages/ai/src/util/download/download.ts
+++ b/packages/ai/src/util/download/download.ts
@@ -2,6 +2,7 @@ import {
   DownloadError,
   readResponseWithSizeLimit,
   DEFAULT_MAX_DOWNLOAD_SIZE,
+  validateDownloadUrl,
 } from '@ai-sdk/provider-utils';
 import {
   withUserAgentSuffix,
@@ -29,6 +30,7 @@ export const download = async ({
   abortSignal?: AbortSignal;
 }) => {
   const urlText = url.toString();
+  validateDownloadUrl(urlText);
   try {
     const response = await fetch(urlText, {
       headers: withUserAgentSuffix(

--- a/packages/provider-utils/src/download-blob.test.ts
+++ b/packages/provider-utils/src/download-blob.test.ts
@@ -180,6 +180,32 @@ describe('downloadBlob()', () => {
   });
 });
 
+describe('downloadBlob() SSRF protection', () => {
+  it('should reject private IPv4 addresses', async () => {
+    await expect(downloadBlob('http://127.0.0.1/file')).rejects.toThrow(
+      DownloadError,
+    );
+    await expect(downloadBlob('http://10.0.0.1/file')).rejects.toThrow(
+      DownloadError,
+    );
+    await expect(
+      downloadBlob('http://169.254.169.254/latest/meta-data/'),
+    ).rejects.toThrow(DownloadError);
+  });
+
+  it('should reject localhost', async () => {
+    await expect(downloadBlob('http://localhost/file')).rejects.toThrow(
+      DownloadError,
+    );
+  });
+
+  it('should reject non-http protocols', async () => {
+    await expect(downloadBlob('file:///etc/passwd')).rejects.toThrow(
+      DownloadError,
+    );
+  });
+});
+
 describe('DownloadError', () => {
   it('should create error with status code and text', () => {
     const error = new DownloadError({

--- a/packages/provider-utils/src/download-blob.ts
+++ b/packages/provider-utils/src/download-blob.ts
@@ -3,6 +3,7 @@ import {
   readResponseWithSizeLimit,
   DEFAULT_MAX_DOWNLOAD_SIZE,
 } from './read-response-with-size-limit';
+import { validateDownloadUrl } from './validate-download-url';
 
 /**
  * Download a file from a URL and return it as a Blob.
@@ -19,6 +20,7 @@ export async function downloadBlob(
   url: string,
   options?: { maxBytes?: number; abortSignal?: AbortSignal },
 ): Promise<Blob> {
+  validateDownloadUrl(url);
   try {
     const response = await fetch(url, {
       signal: options?.abortSignal,

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -56,6 +56,7 @@ export {
 } from './schema';
 export { stripFileExtension } from './strip-file-extension';
 export * from './uint8-utils';
+export { validateDownloadUrl } from './validate-download-url';
 export * from './validate-types';
 export { VERSION } from './version';
 export { withUserAgentSuffix } from './with-user-agent-suffix';

--- a/packages/provider-utils/src/validate-download-url.test.ts
+++ b/packages/provider-utils/src/validate-download-url.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import { validateDownloadUrl } from './validate-download-url';
+import { DownloadError } from './download-error';
+
+describe('validateDownloadUrl', () => {
+  describe('allowed URLs', () => {
+    it('should allow https URLs', () => {
+      expect(() =>
+        validateDownloadUrl('https://example.com/image.png'),
+      ).not.toThrow();
+    });
+
+    it('should allow http URLs', () => {
+      expect(() =>
+        validateDownloadUrl('http://example.com/image.png'),
+      ).not.toThrow();
+    });
+
+    it('should allow public IP addresses', () => {
+      expect(() =>
+        validateDownloadUrl('https://203.0.113.1/file'),
+      ).not.toThrow();
+    });
+
+    it('should allow URLs with ports', () => {
+      expect(() =>
+        validateDownloadUrl('https://example.com:8080/file'),
+      ).not.toThrow();
+    });
+  });
+
+  describe('blocked protocols', () => {
+    it('should block file:// URLs', () => {
+      expect(() => validateDownloadUrl('file:///etc/passwd')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block ftp:// URLs', () => {
+      expect(() => validateDownloadUrl('ftp://example.com/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block javascript: URLs', () => {
+      expect(() => validateDownloadUrl('javascript:alert(1)')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block data: URLs', () => {
+      expect(() => validateDownloadUrl('data:text/plain,hello')).toThrow(
+        DownloadError,
+      );
+    });
+  });
+
+  describe('malformed URLs', () => {
+    it('should block invalid URLs', () => {
+      expect(() => validateDownloadUrl('not-a-url')).toThrow(DownloadError);
+    });
+  });
+
+  describe('blocked hostnames', () => {
+    it('should block localhost', () => {
+      expect(() => validateDownloadUrl('http://localhost/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block localhost with port', () => {
+      expect(() => validateDownloadUrl('http://localhost:3000/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block .local domains', () => {
+      expect(() => validateDownloadUrl('http://myhost.local/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block .localhost domains', () => {
+      expect(() => validateDownloadUrl('http://app.localhost/file')).toThrow(
+        DownloadError,
+      );
+    });
+  });
+
+  describe('blocked IPv4 addresses', () => {
+    it('should block 127.0.0.1 (loopback)', () => {
+      expect(() => validateDownloadUrl('http://127.0.0.1/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block 127.x.x.x range', () => {
+      expect(() => validateDownloadUrl('http://127.255.0.1/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block 10.x.x.x (private)', () => {
+      expect(() => validateDownloadUrl('http://10.0.0.1/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block 172.16.x.x - 172.31.x.x (private)', () => {
+      expect(() => validateDownloadUrl('http://172.16.0.1/file')).toThrow(
+        DownloadError,
+      );
+      expect(() => validateDownloadUrl('http://172.31.255.255/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should allow 172.15.x.x and 172.32.x.x (public)', () => {
+      expect(() => validateDownloadUrl('http://172.15.0.1/file')).not.toThrow();
+      expect(() => validateDownloadUrl('http://172.32.0.1/file')).not.toThrow();
+    });
+
+    it('should block 192.168.x.x (private)', () => {
+      expect(() => validateDownloadUrl('http://192.168.1.1/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block 169.254.x.x (link-local / cloud metadata)', () => {
+      expect(() =>
+        validateDownloadUrl('http://169.254.169.254/latest/meta-data/'),
+      ).toThrow(DownloadError);
+    });
+
+    it('should block 0.0.0.0', () => {
+      expect(() => validateDownloadUrl('http://0.0.0.0/file')).toThrow(
+        DownloadError,
+      );
+    });
+  });
+
+  describe('blocked IPv6 addresses', () => {
+    it('should block ::1 (loopback)', () => {
+      expect(() => validateDownloadUrl('http://[::1]/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block :: (unspecified)', () => {
+      expect(() => validateDownloadUrl('http://[::]/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block fc00::/7 (unique local)', () => {
+      expect(() => validateDownloadUrl('http://[fc00::1]/file')).toThrow(
+        DownloadError,
+      );
+      expect(() => validateDownloadUrl('http://[fd12::1]/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block fe80::/10 (link-local)', () => {
+      expect(() => validateDownloadUrl('http://[fe80::1]/file')).toThrow(
+        DownloadError,
+      );
+    });
+  });
+
+  describe('IPv4-mapped IPv6 addresses', () => {
+    it('should block ::ffff:127.0.0.1', () => {
+      expect(() =>
+        validateDownloadUrl('http://[::ffff:127.0.0.1]/file'),
+      ).toThrow(DownloadError);
+    });
+
+    it('should block ::ffff:10.0.0.1', () => {
+      expect(() =>
+        validateDownloadUrl('http://[::ffff:10.0.0.1]/file'),
+      ).toThrow(DownloadError);
+    });
+
+    it('should block ::ffff:169.254.169.254', () => {
+      expect(() =>
+        validateDownloadUrl('http://[::ffff:169.254.169.254]/file'),
+      ).toThrow(DownloadError);
+    });
+
+    it('should allow ::ffff: with public IP', () => {
+      expect(() =>
+        validateDownloadUrl('http://[::ffff:203.0.113.1]/file'),
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/provider-utils/src/validate-download-url.ts
+++ b/packages/provider-utils/src/validate-download-url.ts
@@ -1,0 +1,143 @@
+import { DownloadError } from './download-error';
+
+/**
+ * Validates that a URL is safe to download from, blocking private/internal addresses
+ * to prevent SSRF attacks.
+ *
+ * @param url - The URL string to validate.
+ * @throws DownloadError if the URL is unsafe.
+ */
+export function validateDownloadUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new DownloadError({
+      url,
+      message: `Invalid URL: ${url}`,
+    });
+  }
+
+  // Only allow http and https protocols
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new DownloadError({
+      url,
+      message: `URL scheme must be http or https, got ${parsed.protocol}`,
+    });
+  }
+
+  const hostname = parsed.hostname;
+
+  // Block empty hostname
+  if (!hostname) {
+    throw new DownloadError({
+      url,
+      message: `URL must have a hostname`,
+    });
+  }
+
+  // Block localhost and .local domains
+  if (
+    hostname === 'localhost' ||
+    hostname.endsWith('.local') ||
+    hostname.endsWith('.localhost')
+  ) {
+    throw new DownloadError({
+      url,
+      message: `URL with hostname ${hostname} is not allowed`,
+    });
+  }
+
+  // Check for IPv6 addresses (enclosed in brackets in URLs)
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    const ipv6 = hostname.slice(1, -1);
+    if (isPrivateIPv6(ipv6)) {
+      throw new DownloadError({
+        url,
+        message: `URL with IPv6 address ${hostname} is not allowed`,
+      });
+    }
+    return;
+  }
+
+  // Check for IPv4 addresses
+  if (isIPv4(hostname)) {
+    if (isPrivateIPv4(hostname)) {
+      throw new DownloadError({
+        url,
+        message: `URL with IP address ${hostname} is not allowed`,
+      });
+    }
+    return;
+  }
+}
+
+function isIPv4(hostname: string): boolean {
+  const parts = hostname.split('.');
+  if (parts.length !== 4) return false;
+  return parts.every(part => {
+    const num = Number(part);
+    return (
+      Number.isInteger(num) && num >= 0 && num <= 255 && String(num) === part
+    );
+  });
+}
+
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split('.').map(Number);
+  const [a, b] = parts;
+
+  // 0.0.0.0/8
+  if (a === 0) return true;
+  // 10.0.0.0/8
+  if (a === 10) return true;
+  // 127.0.0.0/8
+  if (a === 127) return true;
+  // 169.254.0.0/16
+  if (a === 169 && b === 254) return true;
+  // 172.16.0.0/12
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16
+  if (a === 192 && b === 168) return true;
+
+  return false;
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+
+  // ::1 (loopback)
+  if (normalized === '::1') return true;
+  // :: (unspecified)
+  if (normalized === '::') return true;
+
+  // Check for IPv4-mapped addresses (::ffff:x.x.x.x or ::ffff:HHHH:HHHH)
+  if (normalized.startsWith('::ffff:')) {
+    const mappedPart = normalized.slice(7);
+    // Dotted-decimal form: ::ffff:127.0.0.1
+    if (isIPv4(mappedPart)) {
+      return isPrivateIPv4(mappedPart);
+    }
+    // Hex form: ::ffff:7f00:1 (URL parser normalizes to this)
+    const hexParts = mappedPart.split(':');
+    if (hexParts.length === 2) {
+      const high = parseInt(hexParts[0], 16);
+      const low = parseInt(hexParts[1], 16);
+      if (!isNaN(high) && !isNaN(low)) {
+        const a = (high >> 8) & 0xff;
+        const b = high & 0xff;
+        const c = (low >> 8) & 0xff;
+        const d = low & 0xff;
+        return isPrivateIPv4(`${a}.${b}.${c}.${d}`);
+      }
+    }
+  }
+
+  // fc00::/7 (unique local addresses - fc00:: and fd00::)
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true;
+
+  // fe80::/10 (link-local)
+  if (normalized.startsWith('fe80')) return true;
+
+  return false;
+}


### PR DESCRIPTION
## Background

The `downloadBlob` function (`@ai-sdk/provider-utils`) and `download` function (`ai`) fetch user-provided URLs without any validation. When users pass image URLs to `generateImage()`, strings starting with "http" flow directly to `fetch()` via `downloadBlob(file.url)` in OpenAI, OpenAI-compatible, and DeepInfra image models. This enables blind SSRF — attackers can make the server request internal resources (localhost, cloud metadata endpoints like `169.254.169.254`, private IPs).

## Summary

Added a shared `validateDownloadUrl` utility in `@ai-sdk/provider-utils` that both `downloadBlob` and `download` call before `fetch`. It throws `DownloadError` if the URL is unsafe:

- **Protocol** — only `http:` and `https:` allowed
- **Hostname** — blocks `localhost`, `*.local`, `*.localhost`, empty hostname
- **IPv4** — blocks private ranges: `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `0.0.0.0/8`
- **IPv6** — blocks `::1`, `fc00::/7`, `fe80::/10`, `::`, and IPv4-mapped addresses (`::ffff:x.x.x.x`)

No DNS resolution checks (not available in edge runtimes). Reuses `DownloadError` for rejected URLs.

## Manual Verification

- Ran `pnpm vitest run src/validate-download-url.test.ts` in `packages/provider-utils` — 29 tests pass
- Ran `pnpm vitest run src/download-blob.test.ts` in `packages/provider-utils` — 13 tests pass
- Ran `pnpm vitest run src/util/download/download.test.ts` in `packages/ai` — 7 tests pass

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- DNS rebinding protection could be added if a DNS resolution API becomes available in edge runtimes
- Consider making the blocklist configurable for users who need to access private networks intentionally