### PR TITLE
ci(release): add `--tag ai-v6` to `ci:release` script (#13096)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "publint": "turbo publint",
     "test": "turbo test --concurrency 16 --filter=!@example/*",
     "test:update": "turbo test:update --concurrency 16 --filter=!@example/*",
-    "ci:release": "turbo clean && turbo build && changeset publish",
+    "ci:release": "turbo clean && turbo build && changeset publish --tag ai-v6",
     "ci:version": "changeset version && node .github/scripts/cleanup-examples-changesets.mjs && pnpm install --no-frozen-lockfile",
     "clean-examples": "node .github/scripts/cleanup-examples-changesets.mjs && pnpm install --no-frozen-lockfile"
   },


### PR DESCRIPTION
## Summary

- Adds `--tag ai-v6` to the `ci:release` script in `package.json` so that npm publishes from the `release-v6.0` branch use the `ai-v6` dist-tag instead of `latest`
- This matches what `release-v5.0` already does with `--tag ai-v5`

## Test plan

- [ ] Verify the `ci:release` script in `package.json` includes `--tag ai-v6`
- [ ] Confirm the next release from `release-v6.0` publishes with the `ai-v6` dist-tag


Made with [Cursor](https://cursor.com)