### PR TITLE
fix(ai): skip data: URLs in downloadAssets to prevent SSRF false positive

### DIFF
--- a/.changeset/skip-data-urls-in-download.md
+++ b/.changeset/skip-data-urls-in-download.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): skip data: URLs in downloadAssets to prevent SSRF false positive

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -555,6 +555,79 @@ describe('convertToLanguageModelPrompt', () => {
         ]);
       });
 
+      it('should not attempt to download data: URLs for file parts', async () => {
+        const downloadFn = vi.fn().mockResolvedValue([]);
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'file',
+                    data: 'data:image/png;base64,iVBORw0KGgo=',
+                    mediaType: 'image/png',
+                  },
+                ],
+              },
+            ],
+          },
+          supportedUrls: {},
+          download: downloadFn,
+        });
+
+        // download is called with an empty array (no planned downloads for data: URLs)
+        expect(downloadFn).toHaveBeenCalledWith([]);
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                data: 'iVBORw0KGgo=',
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should not attempt to download data: URLs for image parts', async () => {
+        const downloadFn = vi.fn().mockResolvedValue([]);
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'image',
+                    image: 'data:image/png;base64,iVBORw0KGgo=',
+                  },
+                ],
+              },
+            ],
+          },
+          supportedUrls: {},
+          download: downloadFn,
+        });
+
+        // download is called with an empty array (no planned downloads for data: URLs)
+        expect(downloadFn).toHaveBeenCalledWith([]);
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                data: 'iVBORw0KGgo=',
+              },
+            ],
+          },
+        ]);
+      });
+
       it('should handle file parts with filename', async () => {
         const result = await convertToLanguageModelPrompt({
           prompt: {

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -371,7 +371,7 @@ async function downloadAssets(
 
     .filter(
       (part): part is { mediaType: string | undefined; data: URL } =>
-        part.data instanceof URL,
+        part.data instanceof URL && part.data.protocol !== 'data:',
     )
     .map(part => ({
       url: part.data,


### PR DESCRIPTION
## Background

The SSRF protection added in `@ai-sdk/provider-utils@4.0.19` (commit `ad4cfc2`, shipped with `ai@6.0.116`) rejects `data:` URLs during the `downloadAssets` phase. This breaks inline file attachments (images, PDFs) sent as base64 data URLs — a common pattern when users upload files directly from the browser.

## Summary

`downloadAssets()` converts string data to `URL` objects via `new URL(data)`. Since `data:image/png;base64,...` is a valid URL, it passes the `instanceof URL` filter and gets sent to the download function. The SSRF protection then rejects it because `data:` is not `http:` or `https:`.

This is a false positive: `data:` URLs are inline data, not remote resources. They are already correctly handled downstream by `convertToLanguageModelV4DataContent()`, which extracts the base64 content. But `downloadAssets` crashes before that code runs.

**Fix**: exclude `data:` URLs from the download filter by adding `&& part.data.protocol !== 'data:'` to the `instanceof URL` check in `downloadAssets()`.

## Manual Verification

Confirmed that the following scenario now works without error:
1. Send a message with an inline image as `data:image/png;base64,...`
2. The data URL is no longer sent to the download function
3. `convertToLanguageModelV4DataContent` handles it correctly downstream

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #13103