### PR TITLE
fix(provider/google): preserve groundingMetadata when streamed before finishReason

### DIFF
--- a/.changeset/google-stream-grounding-metadata.md
+++ b/.changeset/google-stream-grounding-metadata.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(provider/google): preserve groundingMetadata and urlContextMetadata when they arrive in a stream chunk before the finishReason chunk

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -3340,6 +3340,130 @@ describe('doStream', () => {
     `);
   });
 
+  it('should preserve grounding metadata when it arrives before the finishReason chunk', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: { parts: [{ text: 'hello' }], role: 'model' },
+              index: 0,
+              groundingMetadata: {
+                webSearchQueries: ['super bowl 2026 halftime show'],
+                groundingChunks: [
+                  {
+                    web: {
+                      uri: 'https://example.com/superbowl',
+                      title: 'Super Bowl 2026',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: { parts: [{ text: ' world' }], role: 'model' },
+              finishReason: 'STOP',
+              index: 0,
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 38,
+            candidatesTokenCount: 1335,
+            totalTokenCount: 1890,
+          },
+        })}\n\n`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+    const finishEvent = events.find(event => event.type === 'finish');
+
+    expect(
+      finishEvent?.type === 'finish' &&
+        finishEvent.providerMetadata?.google.groundingMetadata,
+    ).toEqual({
+      webSearchQueries: ['super bowl 2026 halftime show'],
+      groundingChunks: [
+        {
+          web: {
+            uri: 'https://example.com/superbowl',
+            title: 'Super Bowl 2026',
+          },
+        },
+      ],
+    });
+
+    expect(events.filter(e => e.type === 'source')).toHaveLength(1);
+  });
+
+  it('should preserve url context metadata when it arrives before the finishReason chunk', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: { parts: [{ text: 'hello' }], role: 'model' },
+              index: 0,
+              urlContextMetadata: {
+                urlMetadata: [
+                  {
+                    retrievedUrl: 'https://example.com/page',
+                    urlRetrievalStatus: 'URL_RETRIEVAL_STATUS_SUCCESS',
+                  },
+                ],
+              },
+            },
+          ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: { parts: [{ text: ' world' }], role: 'model' },
+              finishReason: 'STOP',
+              index: 0,
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 10,
+            candidatesTokenCount: 5,
+            totalTokenCount: 15,
+          },
+        })}\n\n`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+    const finishEvent = events.find(event => event.type === 'finish');
+
+    expect(
+      finishEvent?.type === 'finish' &&
+        finishEvent.providerMetadata?.google.urlContextMetadata,
+    ).toEqual({
+      urlMetadata: [
+        {
+          retrievedUrl: 'https://example.com/page',
+          urlRetrievalStatus: 'URL_RETRIEVAL_STATUS_SUCCESS',
+        },
+      ],
+    });
+  });
+
   it('should expose url context metadata in provider metadata on finish', async () => {
     prepareStreamResponse({
       content: ['test'],

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -388,6 +388,8 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
     };
     let usage: GoogleGenerativeAIUsageMetadata | undefined = undefined;
     let providerMetadata: SharedV3ProviderMetadata | undefined = undefined;
+    let lastGroundingMetadata: GroundingMetadataSchema | null = null;
+    let lastUrlContextMetadata: UrlContextMetadataSchema | null = null;
 
     const generateId = this.config.generateId;
     let hasToolCalls = false;
@@ -438,6 +440,13 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
             }
 
             const content = candidate.content;
+
+            if (candidate.groundingMetadata != null) {
+              lastGroundingMetadata = candidate.groundingMetadata;
+            }
+            if (candidate.urlContextMetadata != null) {
+              lastUrlContextMetadata = candidate.urlContextMetadata;
+            }
 
             const sources = extractSources({
               groundingMetadata: candidate.groundingMetadata,
@@ -651,8 +660,8 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
               providerMetadata = {
                 [providerOptionsName]: {
                   promptFeedback: value.promptFeedback ?? null,
-                  groundingMetadata: candidate.groundingMetadata ?? null,
-                  urlContextMetadata: candidate.urlContextMetadata ?? null,
+                  groundingMetadata: lastGroundingMetadata,
+                  urlContextMetadata: lastUrlContextMetadata,
                   safetyRatings: candidate.safetyRatings ?? null,
                 },
               };


### PR DESCRIPTION
## Summary

For hybrid image models like `gemini-3.1-flash-image-preview`, the Google API sends `groundingMetadata` in an early stream chunk, but the final chunk containing `finishReason` omits it. The streaming handler previously only read `groundingMetadata` from the `finishReason` chunk, so `providerMetadata.google.groundingMetadata` was `null` even when `source` parts were emitted.

This PR accumulates `groundingMetadata` and `urlContextMetadata` across chunks — the same pattern already used for `usageMetadata`.

## Reproduction

```ts
streamText({
  model: google('gemini-3.1-flash-image-preview'),
  providerOptions: { google: { responseModalities: ['TEXT', 'IMAGE'] } },
  tools: { google_search: google.tools.googleSearch({ searchTypes: { imageSearch: {} } }) },
  prompt: 'Search for photos of ... and generate an image',
});
```

Before: `source` parts stream correctly, but `providerMetadata.google.groundingMetadata` is `null` on finish.
After: `groundingMetadata` populated with `webSearchQueries`, `groundingChunks`, etc.

## Test plan

- [x] Unit test: grounding metadata in early chunk, finishReason in later chunk → preserved
- [x] Unit test: url context metadata in early chunk, finishReason in later chunk → preserved
- [x] Both tests fail on main (`Received: null`), pass with fix
- [x] Existing tests unaffected (118/118 pass)