### PR TITLE
fix(security): prevent streaming tool calls from finalizing on parsable partial JSON

### DIFF
--- a/.changeset/fix-streaming-tool-call-early-finalization.md
+++ b/.changeset/fix-streaming-tool-call-early-finalization.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/openai': patch
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/deepseek': patch
+'@ai-sdk/alibaba': patch
+---
+
+fix(security): prevent streaming tool calls from finalizing on parsable partial JSON
+
+Streaming tool call arguments were finalized using `isParsableJson()` as a heuristic for completion. If partial accumulated JSON happened to be valid JSON before all chunks arrived, the tool call would be executed with incomplete arguments. Tool call finalization now only occurs in `flush()` after the stream is fully consumed.

--- a/packages/alibaba/src/__snapshots__/alibaba-chat-language-model.test.ts.snap
+++ b/packages/alibaba/src/__snapshots__/alibaba-chat-language-model.test.ts.snap
@@ -2967,6 +2967,11 @@ exports[`doStream > tool call > should stream tool call 1`] = `
     "type": "tool-input-delta",
   },
   {
+    "delta": "",
+    "id": "call_eee11723464a4b9eb8cee71d",
+    "type": "tool-input-delta",
+  },
+  {
     "id": "call_eee11723464a4b9eb8cee71d",
     "type": "tool-input-end",
   },

--- a/packages/alibaba/src/alibaba-chat-language-model.ts
+++ b/packages/alibaba/src/alibaba-chat-language-model.ts
@@ -19,7 +19,6 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
-  isParsableJson,
   parseProviderOptions,
   postJsonToApi,
   type ParseResult,
@@ -426,23 +425,6 @@ export class AlibabaLanguageModel implements LanguageModelV3 {
                     });
                   }
 
-                  // Check if already complete (some providers send full tool call at once)
-                  if (isParsableJson(toolCall.function.arguments)) {
-                    controller.enqueue({
-                      type: 'tool-input-end',
-                      id: toolCall.id,
-                    });
-
-                    controller.enqueue({
-                      type: 'tool-call',
-                      toolCallId: toolCall.id,
-                      toolName: toolCall.function.name,
-                      input: toolCall.function.arguments,
-                    });
-
-                    toolCall.hasFinished = true;
-                  }
-
                   continue;
                 }
 
@@ -463,23 +445,6 @@ export class AlibabaLanguageModel implements LanguageModelV3 {
                     id: toolCall.id,
                     delta: toolCallDelta.function.arguments,
                   });
-                }
-
-                // Check if tool call is now complete
-                if (isParsableJson(toolCall.function.arguments)) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id,
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
-
-                  toolCall.hasFinished = true;
                 }
               }
             }
@@ -503,6 +468,25 @@ export class AlibabaLanguageModel implements LanguageModelV3 {
 
             if (activeText) {
               controller.enqueue({ type: 'text-end', id: '0' });
+            }
+
+            // Finalize any unfinished tool calls on stream end to
+            // prevent premature execution from parsable partial JSON.
+            for (const toolCall of toolCalls) {
+              if (!toolCall.hasFinished) {
+                controller.enqueue({
+                  type: 'tool-input-end',
+                  id: toolCall.id,
+                });
+
+                controller.enqueue({
+                  type: 'tool-call',
+                  toolCallId: toolCall.id,
+                  toolName: toolCall.function.name,
+                  input: toolCall.function.arguments,
+                });
+                toolCall.hasFinished = true;
+              }
             }
 
             controller.enqueue({

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.ts
@@ -17,7 +17,6 @@ import {
   FetchFunction,
   generateId,
   InferSchema,
-  isParsableJson,
   parseProviderOptions,
   ParseResult,
   postJsonToApi,
@@ -421,23 +420,6 @@ export class DeepSeekChatLanguageModel implements LanguageModelV3 {
                         delta: toolCall.function.arguments,
                       });
                     }
-
-                    // check if tool call is complete
-                    // (some providers send the full tool call in one chunk):
-                    if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
-
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                      });
-                      toolCall.hasFinished = true;
-                    }
                   }
 
                   continue;
@@ -461,26 +443,6 @@ export class DeepSeekChatLanguageModel implements LanguageModelV3 {
                   id: toolCall.id,
                   delta: toolCallDelta.function.arguments ?? '',
                 });
-
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
-                  toolCall.hasFinished = true;
-                }
               }
             }
           },

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -1230,6 +1230,11 @@ describe('doStream', () => {
           "type": "tool-input-delta",
         },
         {
+          "delta": "",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
           "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "type": "tool-input-end",
         },

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -17,7 +17,6 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
-  isParsableJson,
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
@@ -465,23 +464,6 @@ export class GroqChatLanguageModel implements LanguageModelV3 {
                         delta: toolCall.function.arguments,
                       });
                     }
-
-                    // check if tool call is complete
-                    // (some providers send the full tool call in one chunk):
-                    if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
-
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                      });
-                      toolCall.hasFinished = true;
-                    }
                   }
 
                   continue;
@@ -505,26 +487,6 @@ export class GroqChatLanguageModel implements LanguageModelV3 {
                   id: toolCall.id,
                   delta: toolCallDelta.function.arguments ?? '',
                 });
-
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
-                  toolCall.hasFinished = true;
-                }
               }
             }
           },
@@ -536,6 +498,25 @@ export class GroqChatLanguageModel implements LanguageModelV3 {
 
             if (isActiveText) {
               controller.enqueue({ type: 'text-end', id: 'txt-0' });
+            }
+
+            // Finalize any unfinished tool calls on stream end to
+            // prevent premature execution from parsable partial JSON.
+            for (const toolCall of toolCalls) {
+              if (!toolCall.hasFinished) {
+                controller.enqueue({
+                  type: 'tool-input-end',
+                  id: toolCall.id,
+                });
+
+                controller.enqueue({
+                  type: 'tool-call',
+                  toolCallId: toolCall.id ?? generateId(),
+                  toolName: toolCall.function.name,
+                  input: toolCall.function.arguments,
+                });
+                toolCall.hasFinished = true;
+              }
             }
 
             controller.enqueue({

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2423,6 +2423,11 @@ describe('doStream', () => {
           "type": "tool-input-delta",
         },
         {
+          "delta": "",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
           "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "type": "tool-input-end",
         },

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -18,7 +18,6 @@ import {
   createJsonResponseHandler,
   FetchFunction,
   generateId,
-  isParsableJson,
   parseProviderOptions,
   ParseResult,
   postJsonToApi,
@@ -567,32 +566,6 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
                         delta: toolCall.function.arguments,
                       });
                     }
-
-                    // check if tool call is complete
-                    // (some providers send the full tool call in one chunk):
-                    if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
-
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                        ...(toolCall.thoughtSignature
-                          ? {
-                              providerMetadata: {
-                                [providerOptionsName]: {
-                                  thoughtSignature: toolCall.thoughtSignature,
-                                },
-                              },
-                            }
-                          : {}),
-                      });
-                      toolCall.hasFinished = true;
-                    }
                   }
 
                   continue;
@@ -616,35 +589,6 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
                   id: toolCall.id,
                   delta: toolCallDelta.function.arguments ?? '',
                 });
-
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                    ...(toolCall.thoughtSignature
-                      ? {
-                          providerMetadata: {
-                            [providerOptionsName]: {
-                              thoughtSignature: toolCall.thoughtSignature,
-                            },
-                          },
-                        }
-                      : {}),
-                  });
-                  toolCall.hasFinished = true;
-                }
               }
             }
           },

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -2784,6 +2784,82 @@ describe('doStream', () => {
     `);
   });
 
+  it('should not finalize tool call early when partial JSON is coincidentally parsable', async () => {
+    // Regression test: if streamed tool call arguments form valid JSON before
+    // all chunks have arrived, the tool call must NOT be finalized early.
+    // For example, {"query": "test"} is valid JSON but the full args are
+    // {"query": "test", "limit": 10}. Finalizing early would lose "limit".
+    server.urls['https://api.openai.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        // initial chunk with tool call start
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":null,` +
+          `"tool_calls":[{"index":0,"id":"call_early123","type":"function",` +
+          `"function":{"name":"search","arguments":""}}]},"finish_reason":null}]}\n\n`,
+        // This chunk produces valid JSON: {"query": "test"}
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":"{\\"query\\": \\"test\\"}"}}]},"finish_reason":null}]}\n\n`,
+        // More data arrives - the full args include "limit"
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":""}}]},"finish_reason":null}]}\n\n`,
+        // Even more data: adding the comma and limit field
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,` +
+          `"function":{"arguments":", \\"limit\\": 10}"}}]},"finish_reason":null}]}\n\n`,
+        // finish
+        `data: {"id":"chatcmpl-early","object":"chat.completion.chunk","created":1733162241,` +
+          `"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'search',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: { type: 'string' },
+              limit: { type: 'number' },
+            },
+            required: ['query'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const result = await convertReadableStreamToArray(stream);
+
+    // Find the tool-call event
+    const toolCallEvent = result.find(
+      (e: { type: string }) => e.type === 'tool-call',
+    );
+
+    // The tool call must contain the COMPLETE arguments, not just the
+    // partial JSON that happened to be parsable mid-stream.
+    expect(toolCallEvent).toEqual({
+      type: 'tool-call',
+      toolCallId: 'call_early123',
+      toolName: 'search',
+      input: '{"query": "test"}, "limit": 10}',
+    });
+
+    // Verify there is exactly one tool-call event (no premature duplicate)
+    const toolCallEvents = result.filter(
+      (e: { type: string }) => e.type === 'tool-call',
+    );
+    expect(toolCallEvents).toHaveLength(1);
+  });
+
   it('should stream tool call with missing type field (Azure AI Foundry / Mistral)', async () => {
     // Azure AI Foundry and Mistral omit the `type` field in streaming tool call deltas.
     // The parser should accept null/undefined type as equivalent to "function".

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -2739,6 +2739,15 @@ describe('doStream', () => {
           "type": "tool-input-delta",
         },
         {
+          "delta": "",
+          "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "type": "tool-input-delta",
+        },
+        {
+          "id": "0",
+          "type": "text-end",
+        },
+        {
           "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "type": "tool-input-end",
         },
@@ -2747,10 +2756,6 @@ describe('doStream', () => {
           "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "toolName": "searchGoogle",
           "type": "tool-call",
-        },
-        {
-          "id": "0",
-          "type": "text-end",
         },
         {
           "finishReason": {

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -17,7 +17,6 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
-  isParsableJson,
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
@@ -605,23 +604,6 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
                         delta: toolCall.function.arguments,
                       });
                     }
-
-                    // check if tool call is complete
-                    // (some providers send the full tool call in one chunk):
-                    if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
-
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                      });
-                      toolCall.hasFinished = true;
-                    }
                   }
 
                   continue;
@@ -645,26 +627,6 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
                   id: toolCall.id,
                   delta: toolCallDelta.function.arguments ?? '',
                 });
-
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
-                  toolCall.hasFinished = true;
-                }
               }
             }
 
@@ -685,6 +647,26 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
           flush(controller) {
             if (isActiveText) {
               controller.enqueue({ type: 'text-end', id: '0' });
+            }
+
+            // Finalize any unfinished tool calls. Tool calls are only
+            // finalized here (on stream end) to prevent premature
+            // execution when partial JSON is coincidentally parsable.
+            for (const toolCall of toolCalls) {
+              if (!toolCall.hasFinished) {
+                controller.enqueue({
+                  type: 'tool-input-end',
+                  id: toolCall.id,
+                });
+
+                controller.enqueue({
+                  type: 'tool-call',
+                  toolCallId: toolCall.id ?? generateId(),
+                  toolName: toolCall.function.name,
+                  input: toolCall.function.arguments,
+                });
+                toolCall.hasFinished = true;
+              }
             }
 
             controller.enqueue({


### PR DESCRIPTION
## Background

In 5 OpenAI-compatible providers (`openai`, `openai-compatible`, `groq`, `deepseek`, `alibaba`), streaming tool call arguments were finalized using `isParsableJson()` as a heuristic for completion. If partial accumulated JSON happened to be valid JSON before all chunks arrived, the tool call would be executed with incomplete arguments, potentially dropping safety-relevant parameters.

For example, a model streaming `{"query": "test", "limit": 10}` might produce `{"query": "test"}` as an intermediate value — which is valid JSON. The tool call would be finalized early with only `{"query": "test"}`, and the `"limit": 10` parameter would be silently lost.

Providers not affected: `anthropic` (uses explicit `content_block_stop` events), OpenAI Responses API (different protocol).

## Summary

- Removed all inline `isParsableJson()` checks from the streaming tool call delta handlers across 5 providers
- Moved tool call finalization to the `flush()` handler, which only runs after the stream is fully consumed, ensuring tool calls always receive complete arguments
- Added a regression test demonstrating the vulnerability (first commit fails against unfixed code, second commit fixes it)
- Updated existing test snapshots to reflect the new ordering (tool calls finalize in `flush()` after text-end, rather than inline during streaming)

## Manual Verification

The first commit (`573a744`) adds the regression test only — it fails against the unfixed code, proving the vulnerability exists:
```
- Expected: input: '{"query": "test"}, "limit": 10}'
+ Received: input: '{"query": "test"}'
```

The second commit (`7ae73dd`) applies the fix, making all tests pass.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

VULN-6861