### PR TITLE
fix(provider/google): backport segment nullish in groundingSupports to v5

### DIFF
--- a/.changeset/backport-segment-nullish.md
+++ b/.changeset/backport-segment-nullish.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(provider/google): make `segment` optional in `groundingSupports` schema
+
+Backport of #12002. When using image search grounding, the Google API returns `groundingSupports` entries without a `segment` field, causing schema validation to fail with "Invalid JSON response".

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -277,6 +277,33 @@ describe('groundingMetadataSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('validates groundingSupports without segment (image search)', () => {
+    const metadata = {
+      imageSearchQueries: [
+        'Aurora Borealis Iceland landscape',
+        'Northern Lights over Iceland',
+      ],
+      groundingChunks: [
+        {
+          image: {
+            sourceUri: 'https://example.com/source',
+            imageUri: 'https://example.com/image.jpg',
+            title: 'Northern Lights in Iceland',
+            domain: 'example.com',
+          },
+        },
+      ],
+      groundingSupports: [
+        {
+          groundingChunkIndices: [0],
+        },
+      ],
+    };
+
+    const result = groundingMetadataSchema.safeParse(metadata);
+    expect(result.success).toBe(true);
+  });
+
   it('rejects invalid data types', () => {
     const metadata = {
       webSearchQueries: 'not an array', // Should be an array

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -839,11 +839,13 @@ export const getGroundingMetadataSchema = () =>
     groundingSupports: z
       .array(
         z.object({
-          segment: z.object({
-            startIndex: z.number().nullish(),
-            endIndex: z.number().nullish(),
-            text: z.string().nullish(),
-          }),
+          segment: z
+            .object({
+              startIndex: z.number().nullish(),
+              endIndex: z.number().nullish(),
+              text: z.string().nullish(),
+            })
+            .nullish(),
           segment_text: z.string().nullish(),
           groundingChunkIndices: z.array(z.number()).nullish(),
           supportChunkIndices: z.array(z.number()).nullish(),


### PR DESCRIPTION
## Summary

Backport of #12002 to `release-v5.0`. When using image search grounding (`searchTypes: { imageSearch: {} }`), the Google API returns `groundingSupports` entries without a `segment` field:

```json
"groundingSupports": [{"groundingChunkIndices": [0, 1, 2]}]
```

The Zod schema required `segment` to be a non-nullable object, causing `safeParseJSON` to reject the response with "Invalid JSON response".

## Changes

- Make `segment` `.nullish()` in the `groundingSupports` schema
- Add unit test for `groundingSupports` without `segment` (image search case)

## Test plan

- [x] All 190 existing + new tests pass (`pnpm test:node` in `packages/google`)
- [ ] Verify image search grounding works end-to-end after publish