### PR TITLE
fix(security): prevent verify-changesets from leaking runner file contents via symlinks

### DIFF
--- a/.github/workflows/actions/verify-changesets/index.js
+++ b/.github/workflows/actions/verify-changesets/index.js
@@ -14,6 +14,7 @@ if (import.meta.url.endsWith(process.argv[1])) {
       pullRequestEvent,
       process.env,
       fs.readFile,
+      fs.lstat,
     );
     await fs.writeFile(
       process.env.GITHUB_STEP_SUMMARY,
@@ -36,10 +37,10 @@ ${error.message}`,
       );
     }
 
-    if (error.content) {
+    if (error.frontmatter) {
       await fs.appendFile(
         process.env.GITHUB_STEP_SUMMARY,
-        `\n\n\`\`\`yaml\n${error.content}\n\`\`\``,
+        `\n\n\`\`\`yaml\n${error.frontmatter}\n\`\`\``,
       );
     }
 
@@ -51,6 +52,7 @@ export async function verifyChangesets(
   event,
   env = process.env,
   readFile = fs.readFile,
+  lstat = fs.lstat,
 ) {
   // Skip check if pull request has "minor" or "major" label
   const byPassLabel = event.pull_request.labels.find(label =>
@@ -81,16 +83,23 @@ export async function verifyChangesets(
       });
     }
 
+    // Reject symlinks to prevent arbitrary file reads (CWE-59)
+    const filePath = `../../../../${path}`;
+    const stat = await lstat(filePath);
+    if (stat.isSymbolicLink()) {
+      throw Object.assign(
+        new Error(`Invalid .changeset file - symlinks are not allowed`),
+        { path },
+      );
+    }
+
     // find frontmatter
-    const content = await readFile(`../../../../${path}`, 'utf-8');
+    const content = await readFile(filePath, 'utf-8');
     const result = content.match(/---\n([\s\S]+?)\n---/);
     if (!result) {
       throw Object.assign(
         new Error(`Invalid .changeset file - no frontmatter found`),
-        {
-          path,
-          content,
-        },
+        { path },
       );
     }
 
@@ -108,10 +117,8 @@ export async function verifyChangesets(
       const [packageName, versionBump] = line.split(':').map(s => s.trim());
       if (!packageName || !versionBump) {
         throw Object.assign(
-          new Error(`Invalid .changeset file - invalid frontmatter`, {
-            path,
-            content,
-          }),
+          new Error(`Invalid .changeset file - invalid frontmatter`),
+          { path, frontmatter },
         );
       }
 
@@ -121,7 +128,7 @@ export async function verifyChangesets(
           new Error(
             `Invalid .changeset file - duplicate package name "${packageName}"`,
           ),
-          { path, content },
+          { path, frontmatter },
         );
       }
 
@@ -140,7 +147,7 @@ export async function verifyChangesets(
           `Invalid .changeset file - invalid version bump (only "patch" is allowed, see https://ai-sdk.dev/docs/migration-guides/versioning). To bypass, add one of the following labels: ${BYPASS_LABELS.join(', ')}`,
         ),
 
-        { path, content },
+        { path, frontmatter },
       );
     }
   }

--- a/.github/workflows/actions/verify-changesets/test.js
+++ b/.github/workflows/actions/verify-changesets/test.js
@@ -12,6 +12,12 @@ function mockReadFile(handler) {
   });
 }
 
+function mockLstat({ isSymlink = false } = {}) {
+  return mock.fn(async () => ({
+    isSymbolicLink: () => isSymlink,
+  }));
+}
+
 test('happy path', async () => {
   const event = {
     pull_request: {
@@ -26,14 +32,16 @@ test('happy path', async () => {
     async () =>
       `---\nai: patch\n@ai-sdk/provider: patch\n---\n## Test changeset`,
   );
+  const lstat = mockLstat();
 
-  await verifyChangesets(event, env, readFile);
+  await verifyChangesets(event, env, readFile, lstat);
 
   assert.strictEqual(readFile.mock.callCount(), 2);
   assert.deepStrictEqual(readFile.mock.calls[1].arguments, [
     '../../../../.changeset/some-happy-path.md',
     'utf-8',
   ]);
+  assert.strictEqual(lstat.mock.callCount(), 1);
 });
 
 test('ignores .changeset/README.md', async () => {
@@ -47,10 +55,12 @@ test('ignores .changeset/README.md', async () => {
   };
 
   const readFile = mockReadFile(() => {});
+  const lstat = mockLstat();
 
-  await verifyChangesets(event, env, readFile);
+  await verifyChangesets(event, env, readFile, lstat);
 
   assert.strictEqual(readFile.mock.callCount(), 1);
+  assert.strictEqual(lstat.mock.callCount(), 0);
 });
 
 test('invalid file - not a .changeset file', async () => {
@@ -64,9 +74,10 @@ test('invalid file - not a .changeset file', async () => {
   };
 
   const readFile = mockReadFile(() => {});
+  const lstat = mockLstat();
 
   await assert.rejects(
-    () => verifyChangesets(event, env, readFile),
+    () => verifyChangesets(event, env, readFile, lstat),
     Object.assign(new Error('Invalid file - not a .changeset file'), {
       path: '.changeset/not-a-changeset-file.txt',
     }),
@@ -86,12 +97,12 @@ test('invalid .changeset file - no frontmatter', async () => {
   };
 
   const readFile = mockReadFile(async () => 'frontmatter missing');
+  const lstat = mockLstat();
 
   await assert.rejects(
-    () => verifyChangesets(event, env, readFile),
+    () => verifyChangesets(event, env, readFile, lstat),
     Object.assign(new Error('Invalid .changeset file - no frontmatter found'), {
       path: '.changeset/invalid-changeset-file.md',
-      content: 'frontmatter missing',
     }),
   );
   assert.strictEqual(readFile.mock.callCount(), 2);
@@ -118,16 +129,17 @@ test('minor update', async () => {
 
     return `---\n@ai-sdk/provider: minor\n---\n## Test changeset`;
   });
+  const lstat = mockLstat();
 
   await assert.rejects(
-    () => verifyChangesets(event, env, readFile),
+    () => verifyChangesets(event, env, readFile, lstat),
     Object.assign(
       new Error(
         `Invalid .changeset file - invalid version bump (only "patch" is allowed, see https://ai-sdk.dev/docs/migration-guides/versioning). To bypass, add one of the following labels: minor, major`,
       ),
       {
         path: '.changeset/minor-update.md',
-        content: '---\n@ai-sdk/provider: minor\n---\n## Test changeset',
+        frontmatter: '---\n@ai-sdk/provider: minor\n---',
       },
     ),
   );
@@ -218,8 +230,9 @@ test('major update - allowed when pre-release mode is active', async () => {
 
     return `---\n@ai-sdk/provider: major\n---\n## Test changeset`;
   });
+  const lstat = mockLstat();
 
-  await verifyChangesets(event, env, readFile);
+  await verifyChangesets(event, env, readFile, lstat);
 
   assert.strictEqual(readFile.mock.callCount(), 2);
   assert.deepStrictEqual(readFile.mock.calls[1].arguments, [
@@ -245,9 +258,10 @@ test('invalid changeset - still rejected in pre-release mode', async () => {
 
     return 'frontmatter missing';
   });
+  const lstat = mockLstat();
 
   await assert.rejects(
-    () => verifyChangesets(event, env, readFile),
+    () => verifyChangesets(event, env, readFile, lstat),
     error => error.message.includes('no frontmatter found'),
   );
 });
@@ -265,9 +279,61 @@ test('major update - rejected when not in pre-release mode', async () => {
   const readFile = mockReadFile(async () => {
     return `---\n@ai-sdk/provider: minor\n---\n## Test changeset`;
   });
+  const lstat = mockLstat();
 
   await assert.rejects(
-    () => verifyChangesets(event, env, readFile),
+    () => verifyChangesets(event, env, readFile, lstat),
     error => error.message.includes('invalid version bump'),
   );
+});
+
+test('rejects symlinked changeset files', async () => {
+  const event = {
+    pull_request: {
+      labels: [],
+    },
+  };
+  const env = {
+    CHANGED_FILES: '.changeset/evil-symlink.md',
+  };
+
+  const readFile = mockReadFile(async () => 'should not be read');
+  const lstat = mockLstat({ isSymlink: true });
+
+  await assert.rejects(
+    () => verifyChangesets(event, env, readFile, lstat),
+    Object.assign(
+      new Error('Invalid .changeset file - symlinks are not allowed'),
+      { path: '.changeset/evil-symlink.md' },
+    ),
+  );
+
+  // readFile should only be called once (for pre.json check), not for the symlinked file
+  assert.strictEqual(readFile.mock.callCount(), 1);
+  assert.strictEqual(lstat.mock.callCount(), 1);
+});
+
+test('error does not include raw file content', async () => {
+  const event = {
+    pull_request: {
+      labels: [],
+    },
+  };
+  const env = {
+    CHANGED_FILES: '.changeset/bad-frontmatter.md',
+  };
+
+  const readFile = mockReadFile(
+    async () => '---\n@ai-sdk/provider: minor\n---\nSensitive content here',
+  );
+  const lstat = mockLstat();
+
+  try {
+    await verifyChangesets(event, env, readFile, lstat);
+    assert.fail('Expected error to be thrown');
+  } catch (error) {
+    // Should have frontmatter (safe to display), not full content
+    assert.strictEqual(error.frontmatter, '---\n@ai-sdk/provider: minor\n---');
+    assert.strictEqual(error.content, undefined);
+  }
 });


### PR DESCRIPTION
## Background

The `verify-changesets` GitHub Action reads PR-changed `.changeset/*.md` files via `readFile('../../../../' + path)`. If a changeset file is a symlink, Node follows it and reads the target. On failure, the catch block writes the full file contents (`error.content`) into `$GITHUB_STEP_SUMMARY`, exposing arbitrary runner file contents to anyone who can view the PR's workflow run.

An attacker can exploit this by opening a PR that adds a symlink under `.changeset/` pointing to a sensitive file (e.g. `/etc/passwd`, `/proc/self/environ`).

CWE-59 (Improper Link Resolution Before File Access) / CWE-200 (Exposure of Sensitive Information)

## Summary

Two complementary fixes:

1. **Reject symlinks** — Use `lstat` to check if a changeset file is a symbolic link before reading it. Symlinked files are rejected with an error that does not include file contents.

2. **Stop leaking raw content (defense in depth)** — Error objects no longer attach the full file content. Instead, only the parsed YAML frontmatter (which is safe to display) is attached. The error handler writes `error.frontmatter` instead of `error.content` to the step summary. Even if an attacker bypasses the symlink check, the full file content is never written to the step summary.

## Manual Verification

- Ran all 12 tests (10 existing + 2 new) against the unfixed code: 4 failures (symlink not rejected, raw content leaked)
- Ran all 12 tests against the fixed code: all pass

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)