### PR TITLE
docs(anthropic): document adaptive thinking mode

### DIFF
--- a/.changeset/add-adaptive-thinking-docs.md
+++ b/.changeset/add-adaptive-thinking-docs.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+docs(anthropic): add adaptive thinking (budgetTokens: 0) example to reasoning section

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -244,6 +244,27 @@ console.log(reasoning); // reasoning details including redacted reasoning
 console.log(text); // text response
 ```
 
+#### Adaptive Thinking
+
+Adaptive thinking allows the model to dynamically decide how much reasoning to apply, instead of allocating a fixed budget. Enable it by setting `budgetTokens` to `0`:
+
+```ts highlight="4,8-10"
+import { anthropic, AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const { text, reasoningText, reasoning } = await generateText({
+  model: anthropic('claude-opus-4-20250514'),
+  prompt: 'How many people will live in the world in 2040?',
+  providerOptions: {
+    anthropic: {
+      thinking: { type: 'enabled', budgetTokens: 0 },
+    } satisfies AnthropicLanguageModelOptions,
+  },
+});
+```
+
+With `budgetTokens: 0`, the model uses adaptive thinking — it reasons as much as needed for the task without a hard token cap.
+
 See [AI SDK UI: Chatbot](/docs/ai-sdk-ui/chatbot#reasoning) for more details
 on how to integrate reasoning into your chatbot.
 

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -246,7 +246,7 @@ console.log(text); // text response
 
 #### Adaptive Thinking
 
-Adaptive thinking allows the model to dynamically decide how much reasoning to apply, instead of allocating a fixed budget. Enable it by setting `budgetTokens` to `0`:
+Adaptive thinking allows the model to dynamically decide how much reasoning to apply, instead of allocating a fixed budget. Enable it by setting `type` to `'adaptive'`:
 
 ```ts highlight="4,8-10"
 import { anthropic, AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';
@@ -257,13 +257,13 @@ const { text, reasoningText, reasoning } = await generateText({
   prompt: 'How many people will live in the world in 2040?',
   providerOptions: {
     anthropic: {
-      thinking: { type: 'enabled', budgetTokens: 0 },
+      thinking: { type: 'adaptive' },
     } satisfies AnthropicLanguageModelOptions,
   },
 });
 ```
 
-With `budgetTokens: 0`, the model uses adaptive thinking — it reasons as much as needed for the task without a hard token cap.
+With `type: 'adaptive'`, the model uses adaptive thinking — it reasons as much as needed for the task without a hard token cap.
 
 See [AI SDK UI: Chatbot](/docs/ai-sdk-ui/chatbot#reasoning) for more details
 on how to integrate reasoning into your chatbot.


### PR DESCRIPTION
Fixes #13109

The Anthropic reasoning documentation only showed the `enabled` thinking type with an explicit `budgetTokens`. This PR adds a section explaining **adaptive thinking** (`type: 'adaptive'`), where the model dynamically determines how many tokens to spend on reasoning without a fixed budget.

The `adaptive` type is already implemented in the provider (`anthropic-messages-options.ts`), just not documented.