### PR TITLE
fix(ui): recover streaming state on resume when text-start was missed

### DIFF
--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -226,7 +226,7 @@ describe('processUIMessageStream', () => {
   });
 
   describe('malformed stream errors', () => {
-    it('should throw descriptive error when text-delta is received without text-start', async () => {
+    it('should recover when text-delta is received without text-start by creating a new part', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
@@ -238,26 +238,25 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      await expect(
-        consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
         }),
-      ).rejects.toThrow(
-        'Received text-delta for missing text part with ID "text-1". ' +
-          'Ensure a "text-start" chunk is sent before any "text-delta" chunks.',
-      );
+        onError: error => {
+          throw error;
+        },
+      });
+
+      const textPart = state.message.parts.find(p => p.type === 'text');
+      expect(textPart).toBeDefined();
+      expect((textPart as any).text).toBe('Hello');
     });
 
-    it('should throw descriptive error when reasoning-delta is received without reasoning-start', async () => {
+    it('should recover when reasoning-delta is received without reasoning-start by creating a new part', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
@@ -269,23 +268,24 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      await expect(
-        consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
         }),
-      ).rejects.toThrow(
-        'Received reasoning-delta for missing reasoning part with ID "reasoning-1". ' +
-          'Ensure a "reasoning-start" chunk is sent before any "reasoning-delta" chunks.',
+        onError: error => {
+          throw error;
+        },
+      });
+
+      const reasoningPart = state.message.parts.find(
+        p => p.type === 'reasoning',
       );
+      expect(reasoningPart).toBeDefined();
+      expect((reasoningPart as any).text).toBe('Thinking...');
     });
 
     it('should throw descriptive error when tool-input-delta is received without tool-input-start', async () => {
@@ -323,7 +323,7 @@ describe('processUIMessageStream', () => {
       );
     });
 
-    it('should throw descriptive error when text-end is received without text-start', async () => {
+    it('should silently skip text-end when received without text-start and no streaming part exists', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
@@ -335,26 +335,25 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      await expect(
-        consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
         }),
-      ).rejects.toThrow(
-        'Received text-end for missing text part with ID "text-1". ' +
-          'Ensure a "text-start" chunk is sent before any "text-end" chunks.',
-      );
+        onError: error => {
+          throw error;
+        },
+      });
+
+      // No text part should be created for an orphaned text-end
+      const textParts = state.message.parts.filter(p => p.type === 'text');
+      expect(textParts).toHaveLength(0);
     });
 
-    it('should throw descriptive error when reasoning-end is received without reasoning-start', async () => {
+    it('should silently skip reasoning-end when received without reasoning-start and no streaming part exists', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
@@ -366,30 +365,32 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      await expect(
-        consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
         }),
-      ).rejects.toThrow(
-        'Received reasoning-end for missing reasoning part with ID "reasoning-1". ' +
-          'Ensure a "reasoning-start" chunk is sent before any "reasoning-end" chunks.',
+        onError: error => {
+          throw error;
+        },
+      });
+
+      const reasoningParts = state.message.parts.filter(
+        p => p.type === 'reasoning',
       );
+      expect(reasoningParts).toHaveLength(0);
     });
 
-    it('should throw UIMessageStreamError with correct properties for text-delta without text-start', async () => {
+    it('should recover text-delta without text-start and append delta to new part', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
         { type: 'text-delta', id: 'missing-id', delta: 'Hello' },
+        { type: 'text-delta', id: 'missing-id', delta: ' World' },
+        { type: 'text-end', id: 'missing-id' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -397,29 +398,23 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      let caughtError: unknown;
-      try {
-        await consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
-        });
-      } catch (error) {
-        caughtError = error;
-      }
+        }),
+        onError: error => {
+          throw error;
+        },
+      });
 
-      expect(UIMessageStreamError.isInstance(caughtError)).toBe(true);
-      expect((caughtError as UIMessageStreamError).chunkType).toBe(
-        'text-delta',
-      );
-      expect((caughtError as UIMessageStreamError).chunkId).toBe('missing-id');
+      const textPart = state.message.parts.find(p => p.type === 'text');
+      expect(textPart).toBeDefined();
+      expect((textPart as any).text).toBe('Hello World');
+      expect((textPart as any).state).toBe('done');
     });
 
     it('should throw UIMessageStreamError with correct properties for tool-input-delta without tool-input-start', async () => {

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -316,15 +316,35 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'text-delta': {
-              const textPart = state.activeTextParts[chunk.id];
+              let textPart = state.activeTextParts[chunk.id];
               if (textPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'text-delta',
-                  chunkId: chunk.id,
-                  message:
-                    `Received text-delta for missing text part with ID "${chunk.id}". ` +
-                    `Ensure a "text-start" chunk is sent before any "text-delta" chunks.`,
-                });
+                // On resume, the text-start chunk may have been sent before the
+                // disconnect. Try to recover by finding the last streaming text
+                // part in the existing message and associating it with this id.
+                const existingStreamingPart = state.message.parts
+                  .filter(
+                    (p): p is TextUIPart =>
+                      p.type === 'text' && p.state === 'streaming',
+                  )
+                  .find(
+                    p =>
+                      !Object.values(state.activeTextParts).includes(p),
+                  );
+
+                if (existingStreamingPart != null) {
+                  textPart = existingStreamingPart;
+                  state.activeTextParts[chunk.id] = textPart;
+                } else {
+                  // No streaming text part to recover — create one so the
+                  // resumed delta is not lost.
+                  textPart = {
+                    type: 'text',
+                    text: '',
+                    state: 'streaming',
+                  };
+                  state.activeTextParts[chunk.id] = textPart;
+                  state.message.parts.push(textPart);
+                }
               }
               textPart.text += chunk.delta;
               textPart.providerMetadata =
@@ -334,15 +354,26 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'text-end': {
-              const textPart = state.activeTextParts[chunk.id];
+              let textPart = state.activeTextParts[chunk.id];
               if (textPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'text-end',
-                  chunkId: chunk.id,
-                  message:
-                    `Received text-end for missing text part with ID "${chunk.id}". ` +
-                    `Ensure a "text-start" chunk is sent before any "text-end" chunks.`,
-                });
+                // On resume, try to find an untracked streaming text part.
+                const existingStreamingPart = state.message.parts
+                  .filter(
+                    (p): p is TextUIPart =>
+                      p.type === 'text' && p.state === 'streaming',
+                  )
+                  .find(
+                    p =>
+                      !Object.values(state.activeTextParts).includes(p),
+                  );
+
+                if (existingStreamingPart != null) {
+                  textPart = existingStreamingPart;
+                  state.activeTextParts[chunk.id] = textPart;
+                } else {
+                  // Nothing to close — skip silently.
+                  break;
+                }
               }
               textPart.state = 'done';
               textPart.providerMetadata =
@@ -366,15 +397,30 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'reasoning-delta': {
-              const reasoningPart = state.activeReasoningParts[chunk.id];
+              let reasoningPart = state.activeReasoningParts[chunk.id];
               if (reasoningPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'reasoning-delta',
-                  chunkId: chunk.id,
-                  message:
-                    `Received reasoning-delta for missing reasoning part with ID "${chunk.id}". ` +
-                    `Ensure a "reasoning-start" chunk is sent before any "reasoning-delta" chunks.`,
-                });
+                const existingStreamingPart = state.message.parts
+                  .filter(
+                    (p): p is ReasoningUIPart =>
+                      p.type === 'reasoning' && p.state === 'streaming',
+                  )
+                  .find(
+                    p =>
+                      !Object.values(state.activeReasoningParts).includes(p),
+                  );
+
+                if (existingStreamingPart != null) {
+                  reasoningPart = existingStreamingPart;
+                  state.activeReasoningParts[chunk.id] = reasoningPart;
+                } else {
+                  reasoningPart = {
+                    type: 'reasoning',
+                    text: '',
+                    state: 'streaming',
+                  };
+                  state.activeReasoningParts[chunk.id] = reasoningPart;
+                  state.message.parts.push(reasoningPart);
+                }
               }
               reasoningPart.text += chunk.delta;
               reasoningPart.providerMetadata =
@@ -384,15 +430,24 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'reasoning-end': {
-              const reasoningPart = state.activeReasoningParts[chunk.id];
+              let reasoningPart = state.activeReasoningParts[chunk.id];
               if (reasoningPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'reasoning-end',
-                  chunkId: chunk.id,
-                  message:
-                    `Received reasoning-end for missing reasoning part with ID "${chunk.id}". ` +
-                    `Ensure a "reasoning-start" chunk is sent before any "reasoning-end" chunks.`,
-                });
+                const existingStreamingPart = state.message.parts
+                  .filter(
+                    (p): p is ReasoningUIPart =>
+                      p.type === 'reasoning' && p.state === 'streaming',
+                  )
+                  .find(
+                    p =>
+                      !Object.values(state.activeReasoningParts).includes(p),
+                  );
+
+                if (existingStreamingPart != null) {
+                  reasoningPart = existingStreamingPart;
+                  state.activeReasoningParts[chunk.id] = reasoningPart;
+                } else {
+                  break;
+                }
               }
               reasoningPart.providerMetadata =
                 chunk.providerMetadata ?? reasoningPart.providerMetadata;


### PR DESCRIPTION
## Summary

Fixes #13160

When `useChat({ resume: true })` reconnects after a disconnect, the resumed stream may start with `text-delta` or `reasoning-delta` chunks whose corresponding `text-start`/`reasoning-start` was sent before the disconnect.

`createStreamingUIMessageState` reuses the existing `lastMessage` (with its parts), but always initializes `activeTextParts` and `activeReasoningParts` as `{}`. So when a resumed `text-delta` arrives for an already-open text part, the lookup `state.activeTextParts[chunk.id]` returns `undefined` and throws `UIMessageStreamError`, causing a reconnect loop.

## Fix

Instead of throwing when a `text-delta`/`reasoning-delta` has no matching entry in the active parts map, try to recover:

1. Look for an existing streaming text/reasoning part in the message that isn't already tracked
2. If found, associate it with the chunk's id so subsequent deltas append to the right part
3. If no existing part is found, create a new one so the content isn't lost

Same recovery logic is applied to `text-end` and `reasoning-end` for consistency.

## Test plan

- [ ] Simulate a stream disconnect mid-text, resume from a cursor after `text-start` but before `text-end`, verify no crash
- [ ] Verify normal (non-resume) streaming still works — `text-start` → `text-delta` → `text-end` flow unchanged
- [ ] Verify `reasoning-start` → `reasoning-delta` → `reasoning-end` resume works similarly