### PR TITLE
fix(ai): reconstruct activeTextParts from message state on stream resume

### DIFF
--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -225,6 +225,84 @@ describe('processUIMessageStream', () => {
     });
   });
 
+  describe('stream resume', () => {
+    it('should apply text-delta to existing streaming text part when text-start was sent before reconnect', async () => {
+      // Simulate a lastMessage that already has an in-progress streaming text part
+      // (text-start was sent before the reconnect cursor).
+      const lastMessage: UIMessage = {
+        id: 'msg-123',
+        role: 'assistant',
+        parts: [
+          { type: 'step-start' },
+          { type: 'text', text: 'Hello, ', state: 'streaming' },
+        ],
+      };
+
+      // The resumed stream only contains text-delta + text-end (no text-start)
+      const stream = createUIMessageStream([
+        { type: 'text-delta', id: 'text-1', delta: 'world!' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+
+      // The text part should contain the concatenation of both deltas
+      expect(state!.message.parts).toContainEqual(
+        expect.objectContaining({
+          type: 'text',
+          text: 'Hello, world!',
+          state: 'done',
+        }),
+      );
+    });
+
+    it('should still throw when text-delta arrives with no streaming text part in message state', async () => {
+      // No lastMessage (or lastMessage with no streaming text parts)
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-456' },
+        { type: 'start-step' },
+        { type: 'text-delta', id: 'text-missing', delta: 'oops' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-456',
+        lastMessage: undefined,
+      });
+
+      await expect(
+        consumeStream({
+          stream: processUIMessageStream({
+            stream,
+            runUpdateMessageJob,
+            onError: error => {
+              throw error;
+            },
+          }),
+          onError: error => {
+            throw error;
+          },
+        }),
+      ).rejects.toThrow(
+        'Received text-delta for missing text part with ID "text-missing".',
+      );
+    });
+  });
+
   describe('malformed stream errors', () => {
     it('should throw descriptive error when text-delta is received without text-start', async () => {
       const stream = createUIMessageStream([

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -301,6 +301,77 @@ describe('processUIMessageStream', () => {
         'Received text-delta for missing text part with ID "text-missing".',
       );
     });
+
+    it('should apply reasoning-delta to existing streaming reasoning part when reasoning-start was sent before reconnect', async () => {
+      const lastMessage: UIMessage = {
+        id: 'msg-123',
+        role: 'assistant',
+        parts: [
+          { type: 'step-start' },
+          { type: 'reasoning', text: 'Thinking...', state: 'streaming' },
+        ],
+      };
+
+      const stream = createUIMessageStream([
+        { type: 'reasoning-delta', id: 'reasoning-1', delta: ' more thoughts' },
+        { type: 'reasoning-end', id: 'reasoning-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+
+      expect(state!.message.parts).toContainEqual(
+        expect.objectContaining({
+          type: 'reasoning',
+          text: 'Thinking... more thoughts',
+          state: 'done',
+        }),
+      );
+    });
+
+    it('should still throw when reasoning-delta arrives with no streaming reasoning part in message state', async () => {
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-456' },
+        { type: 'start-step' },
+        { type: 'reasoning-delta', id: 'reasoning-missing', delta: 'oops' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-456',
+        lastMessage: undefined,
+      });
+
+      await expect(
+        consumeStream({
+          stream: processUIMessageStream({
+            stream,
+            runUpdateMessageJob,
+            onError: error => {
+              throw error;
+            },
+          }),
+          onError: error => {
+            throw error;
+          },
+        }),
+      ).rejects.toThrow(
+        'Received reasoning-delta for missing reasoning part with ID "reasoning-missing".',
+      );
+    });
   });
 
   describe('malformed stream errors', () => {

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -316,15 +316,30 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'text-delta': {
-              const textPart = state.activeTextParts[chunk.id];
+              let textPart = state.activeTextParts[chunk.id];
               if (textPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'text-delta',
-                  chunkId: chunk.id,
-                  message:
-                    `Received text-delta for missing text part with ID "${chunk.id}". ` +
-                    `Ensure a "text-start" chunk is sent before any "text-delta" chunks.`,
-                });
+                // On stream resume, the matching text-start chunk may have been
+                // sent before the reconnect cursor. Reconstruct the active text
+                // part from the existing message state so that resumed deltas
+                // are applied to the correct part rather than throwing.
+                const existingPart = (state.message.parts as TextUIPart[])
+                  .filter(
+                    (p): p is TextUIPart =>
+                      p.type === 'text' && p.state === 'streaming',
+                  )
+                  .at(-1);
+                if (existingPart != null) {
+                  state.activeTextParts[chunk.id] = existingPart;
+                  textPart = existingPart;
+                } else {
+                  throw new UIMessageStreamError({
+                    chunkType: 'text-delta',
+                    chunkId: chunk.id,
+                    message:
+                      `Received text-delta for missing text part with ID "${chunk.id}". ` +
+                      `Ensure a "text-start" chunk is sent before any "text-delta" chunks.`,
+                  });
+                }
               }
               textPart.text += chunk.delta;
               textPart.providerMetadata =
@@ -334,15 +349,28 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'text-end': {
-              const textPart = state.activeTextParts[chunk.id];
+              let textPart = state.activeTextParts[chunk.id];
               if (textPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'text-end',
-                  chunkId: chunk.id,
-                  message:
-                    `Received text-end for missing text part with ID "${chunk.id}". ` +
-                    `Ensure a "text-start" chunk is sent before any "text-end" chunks.`,
-                });
+                // On stream resume, reconstruct the active text part from
+                // existing message state (same logic as text-delta resume).
+                const existingPart = (state.message.parts as TextUIPart[])
+                  .filter(
+                    (p): p is TextUIPart =>
+                      p.type === 'text' && p.state === 'streaming',
+                  )
+                  .at(-1);
+                if (existingPart != null) {
+                  state.activeTextParts[chunk.id] = existingPart;
+                  textPart = existingPart;
+                } else {
+                  throw new UIMessageStreamError({
+                    chunkType: 'text-end',
+                    chunkId: chunk.id,
+                    message:
+                      `Received text-end for missing text part with ID "${chunk.id}". ` +
+                      `Ensure a "text-start" chunk is sent before any "text-end" chunks.`,
+                  });
+                }
               }
               textPart.state = 'done';
               textPart.providerMetadata =

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -394,15 +394,30 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'reasoning-delta': {
-              const reasoningPart = state.activeReasoningParts[chunk.id];
+              let reasoningPart = state.activeReasoningParts[chunk.id];
               if (reasoningPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'reasoning-delta',
-                  chunkId: chunk.id,
-                  message:
-                    `Received reasoning-delta for missing reasoning part with ID "${chunk.id}". ` +
-                    `Ensure a "reasoning-start" chunk is sent before any "reasoning-delta" chunks.`,
-                });
+                // On stream resume, the matching reasoning-start chunk may have
+                // been sent before the reconnect cursor. Reconstruct the active
+                // reasoning part from the existing message state so that resumed
+                // deltas are applied to the correct part rather than throwing.
+                const existingPart = (state.message.parts as ReasoningUIPart[])
+                  .filter(
+                    (p): p is ReasoningUIPart =>
+                      p.type === 'reasoning' && p.state === 'streaming',
+                  )
+                  .at(-1);
+                if (existingPart != null) {
+                  state.activeReasoningParts[chunk.id] = existingPart;
+                  reasoningPart = existingPart;
+                } else {
+                  throw new UIMessageStreamError({
+                    chunkType: 'reasoning-delta',
+                    chunkId: chunk.id,
+                    message:
+                      `Received reasoning-delta for missing reasoning part with ID "${chunk.id}". ` +
+                      `Ensure a "reasoning-start" chunk is sent before any "reasoning-delta" chunks.`,
+                  });
+                }
               }
               reasoningPart.text += chunk.delta;
               reasoningPart.providerMetadata =
@@ -412,15 +427,28 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'reasoning-end': {
-              const reasoningPart = state.activeReasoningParts[chunk.id];
+              let reasoningPart = state.activeReasoningParts[chunk.id];
               if (reasoningPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'reasoning-end',
-                  chunkId: chunk.id,
-                  message:
-                    `Received reasoning-end for missing reasoning part with ID "${chunk.id}". ` +
-                    `Ensure a "reasoning-start" chunk is sent before any "reasoning-end" chunks.`,
-                });
+                // On stream resume, reconstruct the active reasoning part from
+                // existing message state (same logic as reasoning-delta resume).
+                const existingPart = (state.message.parts as ReasoningUIPart[])
+                  .filter(
+                    (p): p is ReasoningUIPart =>
+                      p.type === 'reasoning' && p.state === 'streaming',
+                  )
+                  .at(-1);
+                if (existingPart != null) {
+                  state.activeReasoningParts[chunk.id] = existingPart;
+                  reasoningPart = existingPart;
+                } else {
+                  throw new UIMessageStreamError({
+                    chunkType: 'reasoning-end',
+                    chunkId: chunk.id,
+                    message:
+                      `Received reasoning-end for missing reasoning part with ID "${chunk.id}". ` +
+                      `Ensure a "reasoning-start" chunk is sent before any "reasoning-end" chunks.`,
+                  });
+                }
               }
               reasoningPart.providerMetadata =
                 chunk.providerMetadata ?? reasoningPart.providerMetadata;


### PR DESCRIPTION
## Problem

When `useChat({ resume: true })` reconnects, the stream may start mid-way through a text part — i.e., the `text-start` chunk was sent before the reconnect cursor. The resumed stream then delivers `text-delta` chunks for a part that exists in `state.message.parts` but is missing from `activeTextParts` (which is freshly initialized on each connection).

This causes a `UIMessageStreamError` to be thrown:
```
TypeError: Cannot read properties of undefined (reading 'text')
// → Attempting to resume stream due to error
```
... and the app falls into a reconnect loop.

## Fix

In the `text-delta` (and `text-end`) handlers, when the chunk's ID is not found in `activeTextParts`, fall back to finding the last streaming text part in `state.message.parts` and registering it under `chunk.id`. This reconstructs the part mapping for resume scenarios.

If there is no matching streaming part either (genuinely malformed stream), the original descriptive error is still thrown.

## Tests

Added two new tests in `process-ui-message-stream.test.ts`:
1. ✅ Verifies that a resumed stream applying `text-delta` + `text-end` to an existing streaming text part produces the correct concatenated text
2. ✅ Verifies that the original error is still thrown when no streaming text part exists in message state

Fixes #13160