### PR TITLE
feat(openai): add Responses context management option

### DIFF
--- a/.changeset/openai-context-management.md
+++ b/.changeset/openai-context-management.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): add Responses API context management provider option

--- a/content/docs/02-foundations/06-provider-options.mdx
+++ b/content/docs/02-foundations/06-provider-options.mdx
@@ -129,6 +129,33 @@ console.log('Reasoning:', result.reasoning);
 | `'auto'`     | Condensed summary of reasoning |
 | `'detailed'` | Comprehensive reasoning output |
 
+### Context Management
+
+Control how the Responses API manages conversation context over time. The SDK currently supports OpenAI's `compaction` policy, and `compactThreshold` lets you choose when compaction starts.
+
+```ts
+import {
+  openai,
+  type OpenAILanguageModelResponsesOptions,
+} from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: openai('gpt-5.2'),
+  prompt: 'Summarize our conversation so far.',
+  providerOptions: {
+    openai: {
+      contextManagement: [
+        {
+          type: 'compaction',
+          compactThreshold: 20000,
+        },
+      ],
+    } satisfies OpenAILanguageModelResponsesOptions,
+  },
+});
+```
+
 ### Text Verbosity
 
 Control the length and detail of the model's text response independently of reasoning:

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -182,6 +182,9 @@ The following provider options are available:
 - **previousResponseId** _string_
   The ID of the previous response. You can use it to continue a conversation. Defaults to `undefined`.
 
+- **contextManagement** _Array&lt;{ type: 'compaction'; compactThreshold?: number }&gt;_
+  Controls how the Responses API manages conversation context over time. Currently, the SDK supports OpenAI's `compaction` policy. Use `compactThreshold` to set the token threshold before compaction begins.
+
 - **instructions** _string_
   Instructions for the model.
   They can be used to change the system or developer message when continuing a conversation using the `previousResponseId` option.

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -696,6 +696,37 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send contextManagement provider option', async () => {
+        const { warnings } = await createModel('gpt-4o').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              contextManagement: [
+                {
+                  type: 'compaction',
+                  compactThreshold: 2000,
+                },
+              ],
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-4o',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          context_management: [
+            {
+              type: 'compaction',
+              compact_threshold: 2000,
+            },
+          ],
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should send metadata provider option', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           prompt: TEST_PROMPT,
@@ -747,6 +778,36 @@ describe('OpenAIResponsesLanguageModel', () => {
           expect(warnings).toStrictEqual([]);
         },
       );
+
+      it('should send contextManagement alongside reasoning provider options', async () => {
+        const { warnings } = await createModel('gpt-5').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              contextManagement: [{ type: 'compaction' }],
+              reasoningEffort: 'low',
+              reasoningSummary: 'auto',
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-5',
+          input: [
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'Hello' }],
+            },
+          ],
+          context_management: [{ type: 'compaction' }],
+          reasoning: {
+            effort: 'low',
+            summary: 'auto',
+          },
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
 
       it('should allow forcing reasoning mode for unrecognized model IDs via providerOptions', async () => {
         const { warnings } = await createModel(

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -321,6 +321,12 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
       // provider options:
       conversation: openaiOptions?.conversation,
+      context_management: openaiOptions?.contextManagement?.map(
+        contextRule => ({
+          type: contextRule.type,
+          compact_threshold: contextRule.compactThreshold,
+        }),
+      ),
       max_tool_calls: openaiOptions?.maxToolCalls,
       metadata: openaiOptions?.metadata,
       parallel_tool_calls: openaiOptions?.parallelToolCalls,

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -151,6 +151,25 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
         .nullish(),
 
       /**
+       * Context management policies for the response.
+       *
+       * Currently, only the `compaction` policy is supported.
+       */
+      contextManagement: z
+        .array(
+          z.object({
+            type: z.literal('compaction'),
+
+            /**
+             * The token threshold to use before compacting the context.
+             * Must be at least 1000.
+             */
+            compactThreshold: z.number().int().min(1000).nullish(),
+          }),
+        )
+        .nullish(),
+
+      /**
        * Instructions for the model.
        * They can be used to change the system or developer message when continuing a conversation using the `previousResponseId` option.
        * Defaults to `undefined`.


### PR DESCRIPTION
## Background

OpenAI's Responses API supports `context_management`, but `@ai-sdk/openai` did not expose it as a Responses provider option.

## Summary

- add `contextManagement` to `OpenAILanguageModelResponsesOptions`
- map the option to the top-level `context_management` request field for OpenAI Responses
- add request-body regression tests for standalone and reasoning-combined usage
- document the new option in both provider-options docs pages
- add a patch changeset for `@ai-sdk/openai`

## Manual Verification

- `pnpm exec prettier --check packages/openai/src/responses/openai-responses-options.ts packages/openai/src/responses/openai-responses-language-model.ts packages/openai/src/responses/openai-responses-language-model.test.ts content/docs/02-foundations/06-provider-options.mdx content/providers/01-ai-sdk-providers/03-openai.mdx .changeset/openai-context-management.md`
- attempted `pnpm test:node -- src/responses/openai-responses-language-model.test.ts` in `packages/openai`, but the workspace is currently blocked by existing test/runtime issues (`lazySchema is not a function`, missing `@ai-sdk/test-server/with-vitest`)
- attempted `pnpm type-check:full`, but the workspace is currently blocked by pre-existing TypeScript errors outside this change

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- rerun the OpenAI Responses test file and full typecheck once the current workspace test/typecheck issues are resolved
