### PR TITLE
feat(amazon-bedrock): add partition-aware endpoint resolution

### DIFF
--- a/.changeset/bedrock-partition-aware-endpoints.md
+++ b/.changeset/bedrock-partition-aware-endpoints.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+feat(amazon-bedrock): add partition-aware endpoint resolution
+
+Add resolvePartitionDomain() helper that maps AWS region prefixes to the correct DNS suffix for all 7 AWS partitions (aws, aws-cn, aws-us-gov, aws-iso, aws-iso-b, aws-iso-e, aws-iso-f). Previously the provider hardcoded amazonaws.com, which fails in ISO and other non-standard partitions.

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -148,6 +148,13 @@ You can use the following optional settings to customize the Amazon Bedrock prov
   The AWS region that you want to use for the API calls.
   It uses the `AWS_REGION` environment variable by default.
 
+  <Note>
+    The provider automatically resolves the correct endpoint domain for all AWS
+    partitions based on the region, including AWS China (`cn-`), AWS GovCloud
+    (`us-gov-`), and ISO partitions (`us-iso-`, `us-isob-`, `eu-isoe-`,
+    `us-isof-`). No manual `baseURL` override is needed for these partitions.
+  </Note>
+
 - **accessKeyId** _string_
 
   The AWS access key ID that you want to use for the API calls.
@@ -1310,6 +1317,13 @@ You can use the following optional settings to customize the Bedrock Anthropic p
 
   The AWS region that you want to use for the API calls.
   It uses the `AWS_REGION` environment variable by default.
+
+  <Note>
+    The provider automatically resolves the correct endpoint domain for all AWS
+    partitions based on the region, including AWS China (`cn-`), AWS GovCloud
+    (`us-gov-`), and ISO partitions (`us-iso-`, `us-isob-`, `eu-isoe-`,
+    `us-isof-`). No manual `baseURL` override is needed for these partitions.
+  </Note>
 
 - **accessKeyId** _string_
 

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -16,6 +16,7 @@ import {
   anthropicTools,
   AnthropicMessagesLanguageModel,
 } from '@ai-sdk/anthropic/internal';
+import { resolvePartitionDomain } from '../bedrock-partition';
 import {
   BedrockCredentials,
   createApiKeyFetchFunction,
@@ -228,16 +229,19 @@ export function createBedrockAnthropic(
   // Wrap with Bedrock event stream to SSE transformer for streaming support
   const fetchFunction = createBedrockAnthropicFetch(baseFetchFunction);
 
-  const getBaseURL = (): string =>
-    withoutTrailingSlash(
-      options.baseURL ??
-        `https://bedrock-runtime.${loadSetting({
-          settingValue: options.region,
-          settingName: 'region',
-          environmentVariableName: 'AWS_REGION',
-          description: 'AWS region',
-        })}.amazonaws.com`,
-    ) ?? 'https://bedrock-runtime.us-east-1.amazonaws.com';
+  const getBaseURL = (): string => {
+    if (options.baseURL) {
+      return withoutTrailingSlash(options.baseURL) ?? options.baseURL;
+    }
+    const region = loadSetting({
+      settingValue: options.region,
+      settingName: 'region',
+      environmentVariableName: 'AWS_REGION',
+      description: 'AWS region',
+    });
+    const domain = resolvePartitionDomain(region);
+    return `https://bedrock-runtime.${region}.${domain}`;
+  };
 
   const getHeaders = async () => {
     const baseHeaders = (await resolve(options.headers)) ?? {};

--- a/packages/amazon-bedrock/src/bedrock-partition.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-partition.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePartitionDomain } from './bedrock-partition';
+
+describe('resolvePartitionDomain', () => {
+  it('should return amazonaws.com for standard commercial regions', () => {
+    expect(resolvePartitionDomain('us-east-1')).toBe('amazonaws.com');
+    expect(resolvePartitionDomain('us-west-2')).toBe('amazonaws.com');
+    expect(resolvePartitionDomain('eu-west-1')).toBe('amazonaws.com');
+    expect(resolvePartitionDomain('ap-southeast-1')).toBe('amazonaws.com');
+  });
+
+  it('should return amazonaws.com for GovCloud regions', () => {
+    expect(resolvePartitionDomain('us-gov-west-1')).toBe('amazonaws.com');
+    expect(resolvePartitionDomain('us-gov-east-1')).toBe('amazonaws.com');
+  });
+
+  it('should return amazonaws.com.cn for China regions', () => {
+    expect(resolvePartitionDomain('cn-north-1')).toBe('amazonaws.com.cn');
+    expect(resolvePartitionDomain('cn-northwest-1')).toBe('amazonaws.com.cn');
+  });
+
+  it('should return c2s.ic.gov for aws-iso regions', () => {
+    expect(resolvePartitionDomain('us-iso-east-1')).toBe('c2s.ic.gov');
+    expect(resolvePartitionDomain('us-iso-west-1')).toBe('c2s.ic.gov');
+  });
+
+  it('should return sc2s.sgov.gov for aws-iso-b regions', () => {
+    expect(resolvePartitionDomain('us-isob-east-1')).toBe('sc2s.sgov.gov');
+    expect(resolvePartitionDomain('us-isob-west-1')).toBe('sc2s.sgov.gov');
+  });
+
+  it('should return cloud.adc-e.uk for aws-iso-e regions', () => {
+    expect(resolvePartitionDomain('eu-isoe-west-1')).toBe('cloud.adc-e.uk');
+  });
+
+  it('should return csp.hci.ic.gov for aws-iso-f regions', () => {
+    expect(resolvePartitionDomain('us-isof-east-1')).toBe('csp.hci.ic.gov');
+    expect(resolvePartitionDomain('us-isof-south-1')).toBe('csp.hci.ic.gov');
+  });
+});

--- a/packages/amazon-bedrock/src/bedrock-partition.ts
+++ b/packages/amazon-bedrock/src/bedrock-partition.ts
@@ -1,0 +1,27 @@
+/**
+ * Resolves the DNS domain suffix for a given AWS region based on its partition.
+ *
+ * Note: partition IDs (e.g. "aws-iso-b") differ from the region prefixes used
+ * to identify them (e.g. "us-isob-"). The table below shows the mapping:
+ *
+ * | Name                        | Partition   | Region Prefix | DNS Suffix       |
+ * |-----------------------------|-------------|---------------|------------------|
+ * | AWS Standard                | aws         | us-, eu-, ... | amazonaws.com    |
+ * | AWS China                   | aws-cn      | cn-           | amazonaws.com.cn |
+ * | AWS GovCloud (US)           | aws-us-gov  | us-gov-       | amazonaws.com    |
+ * | AWS ISO (US)                | aws-iso     | us-iso-       | c2s.ic.gov       |
+ * | AWS ISOB (US)               | aws-iso-b   | us-isob-      | sc2s.sgov.gov    |
+ * | AWS ISOE (Europe)           | aws-iso-e   | eu-isoe-      | cloud.adc-e.uk   |
+ * | AWS ISOF                    | aws-iso-f   | us-isof-      | csp.hci.ic.gov   |
+ *
+ * Source (AWS SDK for JS v3 partition metadata):
+ * https://github.com/aws/aws-sdk-js-v3/blob/main/packages-internal/util-endpoints/src/lib/aws/partitions.json
+ */
+export function resolvePartitionDomain(region: string): string {
+  if (region.startsWith('cn-')) return 'amazonaws.com.cn';
+  if (region.startsWith('us-isof-')) return 'csp.hci.ic.gov';
+  if (region.startsWith('us-isob-')) return 'sc2s.sgov.gov';
+  if (region.startsWith('us-iso-')) return 'c2s.ic.gov';
+  if (region.startsWith('eu-isoe-')) return 'cloud.adc-e.uk';
+  return 'amazonaws.com';
+}

--- a/packages/amazon-bedrock/src/bedrock-provider.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.test.ts
@@ -391,6 +391,72 @@ describe('AmazonBedrockProvider', () => {
         );
       });
 
+      it('should resolve aws-iso partition endpoint for us-iso regions', () => {
+        const provider = createAmazonBedrock({
+          region: 'us-iso-east-1',
+        });
+
+        provider('anthropic.claude-v2');
+
+        const constructorCall = BedrockChatLanguageModelMock.mock.calls[0];
+        expect(constructorCall[1].baseUrl()).toBe(
+          'https://bedrock-runtime.us-iso-east-1.c2s.ic.gov',
+        );
+      });
+
+      it('should resolve aws-iso-b partition endpoint for us-isob regions', () => {
+        const provider = createAmazonBedrock({
+          region: 'us-isob-east-1',
+        });
+
+        provider('anthropic.claude-v2');
+
+        const constructorCall = BedrockChatLanguageModelMock.mock.calls[0];
+        expect(constructorCall[1].baseUrl()).toBe(
+          'https://bedrock-runtime.us-isob-east-1.sc2s.sgov.gov',
+        );
+      });
+
+      it('should resolve aws-cn partition endpoint for China regions', () => {
+        const provider = createAmazonBedrock({
+          region: 'cn-north-1',
+        });
+
+        provider('anthropic.claude-v2');
+
+        const constructorCall = BedrockChatLanguageModelMock.mock.calls[0];
+        expect(constructorCall[1].baseUrl()).toBe(
+          'https://bedrock-runtime.cn-north-1.amazonaws.com.cn',
+        );
+      });
+
+      it('should resolve standard endpoint for us-gov regions', () => {
+        const provider = createAmazonBedrock({
+          region: 'us-gov-west-1',
+        });
+
+        provider('anthropic.claude-v2');
+
+        const constructorCall = BedrockChatLanguageModelMock.mock.calls[0];
+        expect(constructorCall[1].baseUrl()).toBe(
+          'https://bedrock-runtime.us-gov-west-1.amazonaws.com',
+        );
+      });
+
+      it('should use explicit baseURL over partition resolution', () => {
+        const provider = createAmazonBedrock({
+          region: 'us-iso-east-1',
+          baseURL: 'https://custom-endpoint.example.com',
+        });
+
+        provider('anthropic.claude-v2');
+
+        const constructorCall = BedrockChatLanguageModelMock.mock.calls[0];
+        expect(constructorCall[1].baseUrl()).toBe(
+          'https://custom-endpoint.example.com',
+        );
+      });
+
       it('should work with credential provider when no API key is provided', () => {
         // Mock loadOptionalSetting to return undefined (no API key)
         mockLoadOptionalSetting.mockImplementation(() => undefined);

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -25,6 +25,7 @@ import {
   createApiKeyFetchFunction,
   createSigV4FetchFunction,
 } from './bedrock-sigv4-fetch';
+import { resolvePartitionDomain } from './bedrock-partition';
 import { BedrockRerankingModel } from './reranking/bedrock-reranking-model';
 import { BedrockRerankingModelId } from './reranking/bedrock-reranking-options';
 import { VERSION } from './version';
@@ -263,27 +264,33 @@ export function createAmazonBedrock(
     return withUserAgentSuffix(baseHeaders, `ai-sdk/amazon-bedrock/${VERSION}`);
   };
 
-  const getBedrockRuntimeBaseUrl = (): string =>
-    withoutTrailingSlash(
-      options.baseURL ??
-        `https://bedrock-runtime.${loadSetting({
-          settingValue: options.region,
-          settingName: 'region',
-          environmentVariableName: 'AWS_REGION',
-          description: 'AWS region',
-        })}.amazonaws.com`,
-    ) ?? `https://bedrock-runtime.us-east-1.amazonaws.com`;
+  const getBedrockRuntimeBaseUrl = (): string => {
+    if (options.baseURL) {
+      return withoutTrailingSlash(options.baseURL) ?? options.baseURL;
+    }
+    const region = loadSetting({
+      settingValue: options.region,
+      settingName: 'region',
+      environmentVariableName: 'AWS_REGION',
+      description: 'AWS region',
+    });
+    const domain = resolvePartitionDomain(region);
+    return `https://bedrock-runtime.${region}.${domain}`;
+  };
 
-  const getBedrockAgentRuntimeBaseUrl = (): string =>
-    withoutTrailingSlash(
-      options.baseURL ??
-        `https://bedrock-agent-runtime.${loadSetting({
-          settingValue: options.region,
-          settingName: 'region',
-          environmentVariableName: 'AWS_REGION',
-          description: 'AWS region',
-        })}.amazonaws.com`,
-    ) ?? `https://bedrock-agent-runtime.us-west-2.amazonaws.com`;
+  const getBedrockAgentRuntimeBaseUrl = (): string => {
+    if (options.baseURL) {
+      return withoutTrailingSlash(options.baseURL) ?? options.baseURL;
+    }
+    const region = loadSetting({
+      settingValue: options.region,
+      settingName: 'region',
+      environmentVariableName: 'AWS_REGION',
+      description: 'AWS region',
+    });
+    const domain = resolvePartitionDomain(region);
+    return `https://bedrock-agent-runtime.${region}.${domain}`;
+  };
 
   const createChatModel = (modelId: BedrockChatModelId) =>
     new BedrockChatLanguageModel(modelId, {


### PR DESCRIPTION
## Background

The Bedrock provider hardcodes `amazonaws.com` as the domain suffix when constructing endpoint URLs. This fails in non-standard AWS partitions (ISO, ISOB, China, etc.) where the DNS suffix differs. Users in these environments must override `baseURL` manually, which is error-prone and can break other operations.

Relates to #11197.

## Summary

Added a lightweight `resolvePartitionDomain()` helper that maps AWS region prefixes to the correct DNS suffix for all 7 AWS partitions:

| Name              | Partition   | Region Prefix | DNS Suffix       |
|-------------------|-------------|---------------|------------------|
| AWS Standard      | aws         | us-, eu-, ... | amazonaws.com    |
| AWS China         | aws-cn      | cn-           | amazonaws.com.cn |
| AWS GovCloud (US) | aws-us-gov  | us-gov-       | amazonaws.com    |
| AWS ISO (US)      | aws-iso     | us-iso-       | c2s.ic.gov       |
| AWS ISOB (US)     | aws-iso-b   | us-isob-      | sc2s.sgov.gov    |
| AWS ISOE (Europe) | aws-iso-e   | eu-isoe-      | cloud.adc-e.uk   |
| AWS ISOF          | aws-iso-f   | us-isof-      | csp.hci.ic.gov   |

The helper is used in three places where endpoints are constructed:
- `bedrock-provider.ts` — `getBedrockRuntimeBaseUrl()` and `getBedrockAgentRuntimeBaseUrl()`
- `bedrock-anthropic-provider.ts` — `getBaseURL()`

Explicit `baseURL` overrides continue to take precedence. No new dependencies introduced. Partition data sourced from the [AWS SDK for JS v3 partition metadata](https://github.com/aws/aws-sdk-js-v3/blob/main/packages-internal/util-endpoints/src/lib/aws/partitions.json).

## Manual Verification

- Ran the full test suite for `@ai-sdk/amazon-bedrock` (327 tests passing)
- Verified endpoint construction for `us-east-1`, `cn-north-1`, `us-gov-west-1`, `us-iso-east-1`, `us-isob-east-1`, `eu-isoe-west-1`, and `us-isof-east-1`
- Verified explicit `baseURL` override still takes precedence over partition resolution
- Build and formatting checks pass

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- If Bedrock becomes available in new partitions, the `resolvePartitionDomain()` helper can be updated to match the upstream [partitions.json](https://github.com/aws/aws-sdk-js-v3/blob/main/packages-internal/util-endpoints/src/lib/aws/partitions.json).

## Related Issues

Fixes #11197
