### PR TITLE
feat(gateway): AI_GATEWAY_BASE_URL to set the default baseURL

### DIFF
--- a/.changeset/orange-paws-lick.md
+++ b/.changeset/orange-paws-lick.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(gateway): AI_GATEWAY_BASE_URL to set the default baseURL

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -80,7 +80,8 @@ You can use the following optional settings to customize the AI Gateway provider
 
 - **baseURL** _string_
 
-  Use a different URL prefix for API calls. The default prefix is `https://ai-gateway.vercel.sh/v4/ai`.
+  Use a different URL prefix for API calls. It defaults to the `AI_GATEWAY_BASE_URL`
+  environment variable or `https://ai-gateway.vercel.sh/v4/ai`.
 
 - **apiKey** _string_
 

--- a/packages/gateway/src/gateway-provider.test.ts
+++ b/packages/gateway/src/gateway-provider.test.ts
@@ -257,6 +257,9 @@ describe('GatewayProvider', () => {
     if ('AI_GATEWAY_API_KEY' in process.env) {
       Reflect.deleteProperty(process.env, 'AI_GATEWAY_API_KEY');
     }
+    if ('AI_GATEWAY_BASE_URL' in process.env) {
+      Reflect.deleteProperty(process.env, 'AI_GATEWAY_BASE_URL');
+    }
   });
 
   describe('createGateway', () => {
@@ -859,6 +862,44 @@ describe('GatewayProvider', () => {
       expect(GatewayFetchMetadata).toHaveBeenCalledWith(
         expect.objectContaining({
           baseURL: 'https://ai-gateway.vercel.sh/v4/ai',
+        }),
+      );
+    });
+
+    it('should use AI_GATEWAY_BASE_URL when set', async () => {
+      process.env.AI_GATEWAY_BASE_URL =
+        'https://env-gateway.example.com/v3/ai/';
+
+      mockGetAvailableModels.mockReturnValue({ models: [] });
+
+      const testProvider = createGateway({
+        apiKey: 'test-key',
+      });
+
+      await testProvider.getAvailableModels();
+
+      expect(GatewayFetchMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://env-gateway.example.com/v3/ai',
+        }),
+      );
+    });
+
+    it('should prefer options.baseURL over AI_GATEWAY_BASE_URL', async () => {
+      process.env.AI_GATEWAY_BASE_URL = 'https://env-gateway.example.com/v3/ai';
+
+      mockGetAvailableModels.mockReturnValue({ models: [] });
+
+      const testProvider = createGateway({
+        baseURL: 'https://option-gateway.example.com/v3/ai/',
+        apiKey: 'test-key',
+      });
+
+      await testProvider.getAvailableModels();
+
+      expect(GatewayFetchMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://option-gateway.example.com/v3/ai',
         }),
       );
     });

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -222,8 +222,12 @@ export function createGateway(
   let lastFetchTime = 0;
 
   const baseURL =
-    withoutTrailingSlash(options.baseURL) ??
-    'https://ai-gateway.vercel.sh/v4/ai';
+    withoutTrailingSlash(
+      loadOptionalSetting({
+        settingValue: options.baseURL,
+        environmentVariableName: 'AI_GATEWAY_BASE_URL',
+      }),
+    ) ?? 'https://ai-gateway.vercel.sh/v4/ai';
 
   const createAuthHeaders = (auth: {
     token: string;

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,7 @@
       "dependsOn": ["^build"],
       "env": [
         "AI_GATEWAY_API_KEY",
+        "AI_GATEWAY_BASE_URL",
         "AI_SDK_DEVTOOLS_PORT",
         "ALIBABA_API_KEY",
         "ANTHROPIC_API_KEY",


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

Allow us to change the AI Gateway baseURL without modifying the code.

The other alternative we explored was using `setGlobalProvider` or a custom gateway, but having both baseURL and API key set globally is preferred.

## Summary

<!-- What did you change? -->

Added an environment variable AI_GATEWAY_BASE_URL. Setting it overrides the default Vercel AI Gateway base URL.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
