### PR TITLE
fix(ai/core): skip SSRF validation for data: URLs in downloadAssets

### DIFF
--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -314,6 +314,43 @@ describe('convertToLanguageModelPrompt', () => {
         ]);
       });
 
+      it('should not attempt to download data: URLs (SSRF false positive)', async () => {
+        const dataUrl = 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==';
+        const downloadFn = vi.fn();
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'file',
+                    data: dataUrl,
+                    mediaType: 'text/plain',
+                  },
+                ],
+              },
+            ],
+          },
+          supportedUrls: {},
+          download: createDefaultDownloadFunction(downloadFn),
+        });
+
+        expect(downloadFn).not.toHaveBeenCalled();
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                data: 'SGVsbG8sIFdvcmxkIQ==',
+                mediaType: 'text/plain',
+              },
+            ],
+          },
+        ]);
+      });
+
       it('should handle file parts with Uint8Array data', async () => {
         const uint8Data = new Uint8Array([72, 101, 108, 108, 111]); // "Hello" in ASCII
         const result = await convertToLanguageModelPrompt({

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -371,7 +371,7 @@ async function downloadAssets(
 
     .filter(
       (part): part is { mediaType: string | undefined; data: URL } =>
-        part.data instanceof URL,
+        part.data instanceof URL && part.data.protocol !== 'data:',
     )
     .map(part => ({
       url: part.data,


### PR DESCRIPTION
## Problem

The SSRF protection added in `@ai-sdk/provider-utils@4.0.19` rejects `data:` URLs during `downloadAssets()`, breaking inline file attachments (images, PDFs) sent as base64 data URLs.

The flow:
1. `downloadAssets()` converts string data to URL objects via `new URL(data)` — `data:` URLs are valid URLs
2. The `instanceof URL` filter passes them through to the download pipeline
3. `validateDownloadUrl()` rejects `data:` protocol (only allows `http:`/`https:`)
4. **Error:** `AI_DownloadError: URL scheme must be http or https, got data:`

## Fix

Add `&& part.data.protocol !== 'data:'` to the filter in `downloadAssets()` so `data:` URLs are excluded from the download queue.

This is safe because `convertToLanguageModelV4DataContent()` in `data-content.ts` already handles `data:` URLs correctly — it extracts the base64 payload and media type at line 53.

## Changes

- `packages/ai/src/prompt/convert-to-language-model-prompt.ts` — one filter condition added
- `packages/ai/src/prompt/convert-to-language-model-prompt.test.ts` — test verifying `data:` URLs are not downloaded and are correctly decoded

Fixes #13103