### PR TITLE
fix(provider/groq): surface cached_tokens from prompt_tokens_details

### DIFF
--- a/packages/groq/src/convert-groq-usage.test.ts
+++ b/packages/groq/src/convert-groq-usage.test.ts
@@ -234,4 +234,103 @@ describe('convertGroqUsage', () => {
       raw: {},
     });
   });
+
+  it('should extract cached tokens from prompt_tokens_details', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 3829,
+      completion_tokens: 48,
+      prompt_tokens_details: {
+        cached_tokens: 3584,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 3829,
+        noCache: 245, // 3829 - 3584 = 245
+        cacheRead: 3584,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 48,
+        text: 48,
+        reasoning: undefined,
+      },
+      raw: {
+        prompt_tokens: 3829,
+        completion_tokens: 48,
+        prompt_tokens_details: {
+          cached_tokens: 3584,
+        },
+      },
+    });
+  });
+
+  it('should handle null cached_tokens in prompt_tokens_details', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 20,
+      completion_tokens: 10,
+      prompt_tokens_details: {
+        cached_tokens: null,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 20,
+        noCache: 20,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 10,
+        text: 10,
+        reasoning: undefined,
+      },
+      raw: {
+        prompt_tokens: 20,
+        completion_tokens: 10,
+        prompt_tokens_details: {
+          cached_tokens: null,
+        },
+      },
+    });
+  });
+
+  it('should handle both cached tokens and reasoning tokens', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      prompt_tokens_details: {
+        cached_tokens: 80,
+      },
+      completion_tokens_details: {
+        reasoning_tokens: 30,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      inputTokens: {
+        total: 100,
+        noCache: 20, // 100 - 80 = 20
+        cacheRead: 80,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 50,
+        text: 20, // 50 - 30 = 20
+        reasoning: 30,
+      },
+      raw: {
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        prompt_tokens_details: {
+          cached_tokens: 80,
+        },
+        completion_tokens_details: {
+          reasoning_tokens: 30,
+        },
+      },
+    });
+  });
 });

--- a/packages/groq/src/convert-groq-usage.ts
+++ b/packages/groq/src/convert-groq-usage.ts
@@ -40,6 +40,7 @@ export function convertGroqUsage(
 
   const promptTokens = usage.prompt_tokens ?? 0;
   const completionTokens = usage.completion_tokens ?? 0;
+  const cachedTokens = usage.prompt_tokens_details?.cached_tokens ?? undefined;
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? undefined;
   const textTokens =
@@ -50,8 +51,9 @@ export function convertGroqUsage(
   return {
     inputTokens: {
       total: promptTokens,
-      noCache: promptTokens,
-      cacheRead: undefined,
+      noCache:
+        cachedTokens != null ? promptTokens - cachedTokens : promptTokens,
+      cacheRead: cachedTokens,
       cacheWrite: undefined,
     },
     outputTokens: {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

groq now has models with input cache support. For example: https://console.groq.com/docs/model/moonshotai/kimi-k2-instruct-0905

The AI SDK was not correctly extracting the response from groq into the usage object.

<!-- Why was this change necessary? -->

## Summary

Pull the prompt cache data from the appropriate response field.

<!-- What did you change? -->

## Manual Verification

Here is a raw response object from a call with cached input tokens

```
"rawResponse": {
    "id": "chatcmpl-a46c2c95-4e88-4fca-8165-3bb46e74bb83",
    "object": "chat.completion",
    "created": 1772843463,
    "model": "openai/gpt-oss-20b",
    "choices": [
      {
        "index": 0,
        "message": {
          "role": "assistant",
          "content": "The CAP theorem states that a distributed system can simultaneously provide at most two of the following three guarantees: Consistency, Availability, and Partition tolerance.",
          "reasoning": "We need one sentence answer. Keep concise."
        },
        "logprobs": null,
        "finish_reason": "stop"
      }
    ],
    "usage": {
      "queue_time": 0.041304244,
      "prompt_tokens": 3829,
      "prompt_time": 0.025152422,
      "completion_tokens": 48,
      "completion_time": 0.049817351,
      "total_tokens": 3877,
      "total_time": 0.074969773,
      "prompt_tokens_details": {
        "cached_tokens": 3584
      },
      "completion_tokens_details": {
        "reasoning_tokens": 10
      }
    },
    "usage_breakdown": null,
    "x_groq": {
      "id": "req_xxxx",
      "seed": 1536934315
    },
    "service_tier": "on_demand"
  },
  ```

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
