### PR TITLE
fix(anthropic): decouple strict tool schemas from supportsNativeStructuredOutput

### DIFF
--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -129,6 +129,14 @@ type AnthropicMessagesConfig = {
    * When false, the model will use JSON tool fallback for structured outputs.
    */
   supportsNativeStructuredOutput?: boolean;
+
+  /**
+   * When set, controls whether strict tool schemas are supported independently
+   * from native structured output. Defaults to the same as supportsStructuredOutput.
+   * Set to true to enable strict tool schemas even when supportsNativeStructuredOutput
+   * is false (e.g. on providers that support strict tools but not structured output format).
+   */
+  supportsToolStrict?: boolean;
 };
 
 export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
@@ -269,6 +277,14 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     const supportsStructuredOutput =
       (this.config.supportsNativeStructuredOutput ?? true) &&
       modelSupportsStructuredOutput;
+
+    // Strict tool schemas can be enabled independently from structured output
+    // response format. Defaults to the same as supportsStructuredOutput unless
+    // explicitly configured via supportsToolStrict.
+    const supportsToolStrict =
+      this.config.supportsToolStrict !== undefined
+        ? this.config.supportsToolStrict && modelSupportsStructuredOutput
+        : supportsStructuredOutput;
 
     const structureOutputMode =
       anthropicOptions?.structuredOutputMode ?? 'auto';
@@ -621,6 +637,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
             disableParallelToolUse: anthropicOptions?.disableParallelToolUse,
             cacheControlValidator,
             supportsStructuredOutput,
+            supportsToolStrict,
           },
     );
 

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -630,6 +630,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
             disableParallelToolUse: true,
             cacheControlValidator,
             supportsStructuredOutput: false,
+            supportsToolStrict,
           }
         : {
             tools: tools ?? [],

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -231,6 +231,45 @@ describe('prepareTools', () => {
       `);
     });
 
+    it('should include strict and beta when supportsToolStrict is true even if supportsStructuredOutput is false', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+        toolChoice: undefined,
+        supportsStructuredOutput: false,
+        supportsToolStrict: true,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "betas": Set {
+            "structured-outputs-2025-11-13",
+          },
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "cache_control": undefined,
+              "description": "A test function",
+              "input_schema": {
+                "properties": {},
+                "type": "object",
+              },
+              "name": "testFunction",
+              "strict": true,
+            },
+          ],
+        }
+      `);
+    });
+
     it('should include beta when strict is false and supportsStructuredOutput is true', async () => {
       const result = await prepareTools({
         tools: [

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -26,6 +26,7 @@ export async function prepareTools({
   disableParallelToolUse,
   cacheControlValidator,
   supportsStructuredOutput,
+  supportsToolStrict,
 }: {
   tools: LanguageModelV3CallOptions['tools'];
   toolChoice: LanguageModelV3CallOptions['toolChoice'] | undefined;
@@ -36,6 +37,12 @@ export async function prepareTools({
    * Whether the model supports structured output.
    */
   supportsStructuredOutput: boolean;
+
+  /**
+   * Whether the model supports strict tool schemas independently from structured
+   * output response format. Defaults to the same as supportsStructuredOutput.
+   */
+  supportsToolStrict?: boolean;
 }): Promise<{
   tools: Array<AnthropicTool> | undefined;
   toolChoice: AnthropicToolChoice | undefined;
@@ -78,7 +85,8 @@ export async function prepareTools({
           input_schema: tool.inputSchema,
           cache_control: cacheControl,
           ...(eagerInputStreaming ? { eager_input_streaming: true } : {}),
-          ...(supportsStructuredOutput === true && tool.strict != null
+          ...((supportsToolStrict ?? supportsStructuredOutput) === true &&
+          tool.strict != null
             ? { strict: tool.strict }
             : {}),
           ...(deferLoading != null ? { defer_loading: deferLoading } : {}),
@@ -94,7 +102,7 @@ export async function prepareTools({
             : {}),
         });
 
-        if (supportsStructuredOutput === true) {
+        if ((supportsToolStrict ?? supportsStructuredOutput) === true) {
           betas.add('structured-outputs-2025-11-13');
         }
 

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -179,6 +179,9 @@ export function createVertexAnthropic(
       supportedUrls: () => ({}),
       // force the use of JSON tool fallback for structured outputs since beta header isn't supported
       supportsNativeStructuredOutput: false,
+      // Vertex Anthropic supports strict tool schemas via the structured-outputs beta header
+      // even though it does not support the native structured output response format
+      supportsToolStrict: true,
     });
 
   const provider = function (modelId: GoogleVertexAnthropicMessagesModelId) {


### PR DESCRIPTION
## Summary

Fixes #13167

When using `@ai-sdk/google-vertex/anthropic`, tool definitions with `strict: true` are silently ignored. This is because the Vertex Anthropic provider sets `supportsNativeStructuredOutput: false` (to disable the structured output response format, which Vertex doesn't support via the beta header), but this flag also inadvertently disables `strict: true` on tool schemas.

## Root Cause

In `AnthropicMessagesLanguageModel`, `supportsStructuredOutput` gates both:
1. Native structured output response format (JSON schema for model responses)
2. `strict: true` on tool input schemas

The Vertex Anthropic provider sets `supportsNativeStructuredOutput: false` because Vertex doesn't support the native structured output response beta header — but strict tool schemas are a separate capability that Vertex does support.

## Fix

Add a `supportsToolStrict` config option to `AnthropicMessagesConfig` that controls strict tool schema support independently from `supportsNativeStructuredOutput`. Set `supportsToolStrict: true` in the Vertex Anthropic provider.

- `supportsNativeStructuredOutput: false` → still disables structured output response format
- `supportsToolStrict: true` → enables `strict: true` on tool definitions and the `structured-outputs-2025-11-13` beta header for tools

## Testing

Added a test case to `anthropic-prepare-tools.test.ts` verifying that `strict: true` is passed through when `supportsToolStrict: true` even if `supportsStructuredOutput: false`.