### PR TITLE
feat (provider/klingai): add kling v3.0 motion control support

### DIFF
--- a/.changeset/gold-rules-own.md
+++ b/.changeset/gold-rules-own.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/klingai': patch
+---
+
+feat (provider/klingai): add kling v3.0 motion control support

--- a/content/providers/01-ai-sdk-providers/85-klingai.mdx
+++ b/content/providers/01-ai-sdk-providers/85-klingai.mdx
@@ -184,7 +184,7 @@ import { klingai, type KlingAIVideoModelOptions } from '@ai-sdk/klingai';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { videos } = await generateVideo({
-  model: klingai.video('kling-v2.6-motion-control'),
+  model: klingai.video('kling-v3.0-motion-control'),
   prompt: {
     image: 'https://example.com/character.png',
     text: 'The character performs a smooth dance move',
@@ -194,6 +194,8 @@ const { videos } = await generateVideo({
       videoUrl: 'https://example.com/reference-motion.mp4',
       characterOrientation: 'image',
       mode: 'std',
+      // Optional: reference element from element library (v3.0+, max 1)
+      elementList: [{ element_id: 829836802793406551 }],
     } satisfies KlingAIVideoModelOptions,
   },
 });
@@ -218,6 +220,10 @@ The following provider options are available via `providerOptions.klingai`. Opti
 - **pollTimeoutMs** _number_
 
   Maximum wait time in milliseconds for video generation. Defaults to 600000 (10 minutes).
+
+- **watermarkEnabled** _boolean_
+
+  Whether to generate watermarked results simultaneously.
 
 #### Text-to-Video and Image-to-Video Options
 
@@ -267,9 +273,11 @@ The following provider options are available via `providerOptions.klingai`. Opti
 
   Dynamic brush configurations for motion brush. Up to 6 groups, each with a `mask` (image URL or base64) and `trajectories` (array of `{x, y}` coordinates).
 
+#### Image-to-Video and Motion Control Options
+
 - **elementList** _Array&lt;\{element_id: number\}&gt;_
 
-  Reference elements for element control (Kling v3.0+ I2V). Supports video character elements and multi-image elements. Up to 3 reference elements. Cannot coexist with `voiceList`.
+  Reference elements for element control (Kling v3.0+). Supports video character elements and multi-image elements. Up to 3 elements for I2V (cannot coexist with `voiceList`). Up to 1 element for motion control.
 
 #### Motion Control Only Options
 
@@ -286,10 +294,6 @@ The following provider options are available via `providerOptions.klingai`. Opti
 - **keepOriginalSound** _'yes' | 'no'_
 
   Whether to keep the original sound from the reference video. Defaults to `'yes'`.
-
-- **watermarkEnabled** _boolean_
-
-  Whether to generate watermarked results simultaneously.
 
 <Note>
   Video generation is an asynchronous process that can take several minutes.
@@ -329,6 +333,7 @@ The following provider options are available via `providerOptions.klingai`. Opti
 
 | Model                       | Description                                                  |
 | --------------------------- | ------------------------------------------------------------ |
+| `kling-v3.0-motion-control` | Latest v3.0, enhanced facial consistency via element binding |
 | `kling-v2.6-motion-control` | Transfers motion from a reference video to a character image |
 
 <Note>

--- a/examples/ai-functions/src/generate-video/klingai/motion-control-v3.ts
+++ b/examples/ai-functions/src/generate-video/klingai/motion-control-v3.ts
@@ -1,0 +1,34 @@
+import { type KlingAIVideoModelOptions, klingai } from '@ai-sdk/klingai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner(
+    'Generating KlingAI v3.0 motion control video with element reference...',
+    () =>
+      generateVideo({
+        model: klingai.video('kling-v3.0-motion-control'),
+        prompt: {
+          image:
+            'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+          text: 'The cat waves hello and smiles',
+        },
+        providerOptions: {
+          klingai: {
+            // Required: URL to the reference motion video
+            videoUrl: 'https://example.com/reference-motion.mp4',
+            // Required: whether to match orientation from image or video
+            characterOrientation: 'image',
+            // Required: 'std' (standard) or 'pro' (professional)
+            mode: 'std',
+            // Optional: reference element from element library (v3.0+, max 1)
+            elementList: [{ element_id: 829836802793406551 }],
+          } satisfies KlingAIVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos(videos);
+});

--- a/packages/klingai/src/klingai-video-model.test.ts
+++ b/packages/klingai/src/klingai-video-model.test.ts
@@ -205,6 +205,7 @@ describe('KlingAIVideoModel', () => {
       await model.doGenerate({ ...defaultOptions });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model_name: 'kling-v2-6',
         prompt,
         video_url: 'https://example.com/reference-motion.mp4',
         character_orientation: 'image',
@@ -448,6 +449,38 @@ describe('KlingAIVideoModel', () => {
           feature: 'n',
         }),
       );
+    });
+
+    it('should derive model_name kling-v3 for kling-v3.0-motion-control', async () => {
+      const model = createBasicModel({
+        modelId: 'kling-v3.0-motion-control',
+      });
+
+      await model.doGenerate({ ...defaultOptions });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({ model_name: 'kling-v3' });
+    });
+
+    it('should send element_list when provided for motion control', async () => {
+      const model = createBasicModel({
+        modelId: 'kling-v3.0-motion-control',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          klingai: {
+            ...klingaiProviderOptions.klingai,
+            elementList: [{ element_id: 829836802793406551 }],
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        element_list: [{ element_id: 829836802793406551 }],
+      });
     });
 
     it('should send mode=pro when specified', async () => {
@@ -739,6 +772,25 @@ describe('KlingAIVideoModel', () => {
       expect(body).toMatchObject({
         voice_list: [{ voice_id: 'voice-abc' }],
         sound: 'on',
+      });
+    });
+
+    it('should send watermark_info when watermarkEnabled is set for T2V', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-t2v' });
+
+      await model.doGenerate({
+        ...t2vDefaultOptions,
+        providerOptions: {
+          klingai: {
+            ...t2vProviderOptions.klingai,
+            watermarkEnabled: true,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        watermark_info: { enabled: true },
       });
     });
 
@@ -1064,6 +1116,25 @@ describe('KlingAIVideoModel', () => {
       expect(body).toMatchObject({
         voice_list: [{ voice_id: 'voice-abc' }, { voice_id: 'voice-def' }],
         sound: 'on',
+      });
+    });
+
+    it('should send watermark_info when watermarkEnabled is set for I2V', async () => {
+      const model = createBasicModel({ modelId: 'kling-v2.6-i2v' });
+
+      await model.doGenerate({
+        ...i2vDefaultOptions,
+        providerOptions: {
+          klingai: {
+            ...i2vProviderOptions.klingai,
+            watermarkEnabled: false,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        watermark_info: { enabled: false },
       });
     });
 

--- a/packages/klingai/src/klingai-video-model.ts
+++ b/packages/klingai/src/klingai-video-model.ts
@@ -188,14 +188,16 @@ export type KlingAIVideoModelOptions = {
     duration: string;
   }> | null;
 
-  // --- v3.0 element control (I2V only) ---
+  // --- v3.0 element control (I2V and Motion Control) ---
 
   /**
-   * Reference elements for element control (Kling v3.0+ I2V).
+   * Reference elements for element control (Kling v3.0+).
    * Supports video character elements and multi-image elements.
-   * Up to 3 reference elements.
    *
-   * Cannot coexist with voiceList on the I2V endpoint.
+   * - I2V: Up to 3 reference elements. Cannot coexist with voiceList.
+   * - Motion Control: Currently only 1 element supported.
+   *   When referencing an element, the generated video can only
+   *   refer to the orientation of the person in the video.
    */
   elementList?: Array<{
     element_id: number;
@@ -215,6 +217,13 @@ export type KlingAIVideoModelOptions = {
   voiceList?: Array<{
     voice_id: string;
   }> | null;
+
+  // --- Shared options ---
+
+  /**
+   * Whether to generate watermarked results simultaneously.
+   */
+  watermarkEnabled?: boolean | null;
 
   // --- Motion-control-specific options ---
 
@@ -242,11 +251,6 @@ export type KlingAIVideoModelOptions = {
    * Default: `'yes'`.
    */
   keepOriginalSound?: 'yes' | 'no' | null;
-
-  /**
-   * Whether to generate watermarked results simultaneously.
-   */
-  watermarkEnabled?: boolean | null;
 
   [key: string]: unknown; // For passthrough
 };
@@ -634,6 +638,10 @@ export class KlingAIVideoModel implements Experimental_VideoModelV3 {
       body.voice_list = klingaiOptions.voiceList;
     }
 
+    if (klingaiOptions?.watermarkEnabled != null) {
+      body.watermark_info = { enabled: klingaiOptions.watermarkEnabled };
+    }
+
     // Image is not supported for T2V
     if (options.image != null) {
       warnings.push({
@@ -731,6 +739,10 @@ export class KlingAIVideoModel implements Experimental_VideoModelV3 {
       body.voice_list = klingaiOptions.voiceList;
     }
 
+    if (klingaiOptions?.watermarkEnabled != null) {
+      body.watermark_info = { enabled: klingaiOptions.watermarkEnabled };
+    }
+
     // Map standard SDK duration (number → string)
     if (options.duration != null) {
       body.duration = String(options.duration);
@@ -769,7 +781,9 @@ export class KlingAIVideoModel implements Experimental_VideoModelV3 {
       });
     }
 
+    const mode = 'motion-control' as const;
     const body: Record<string, unknown> = {
+      model_name: getApiModelName(this.modelId, mode),
       video_url: klingaiOptions.videoUrl,
       character_orientation: klingaiOptions.characterOrientation,
       mode: klingaiOptions.mode,
@@ -797,6 +811,11 @@ export class KlingAIVideoModel implements Experimental_VideoModelV3 {
 
     if (klingaiOptions.watermarkEnabled != null) {
       body.watermark_info = { enabled: klingaiOptions.watermarkEnabled };
+    }
+
+    // v3.0 element control
+    if (klingaiOptions.elementList != null) {
+      body.element_list = klingaiOptions.elementList;
     }
 
     // Warn about unsupported standard options for motion control

--- a/packages/klingai/src/klingai-video-settings.ts
+++ b/packages/klingai/src/klingai-video-settings.ts
@@ -19,4 +19,5 @@ export type KlingAIVideoModelId =
   | 'kling-v3.0-i2v'
   // Motion Control
   | 'kling-v2.6-motion-control'
+  | 'kling-v3.0-motion-control'
   | (string & {});


### PR DESCRIPTION
## Background

The KlingAI provider needed to support the new v3.0 motion control model which includes enhanced facial consistency via element binding and additional configuration options.

## Changes

- Added support for `kling-v3.0-motion-control` model with enhanced facial consistency
- Extended `elementList` support to motion control mode (previously I2V only), allowing up to 1 element reference
- Moved `watermarkEnabled` option to shared options section, making it available for all video generation modes
- Updated documentation to reflect v3.0 capabilities and reorganized option categories
- Added example implementation for v3.0 motion control with element reference
- Enhanced test coverage for new v3.0 features including model name derivation and element list handling

## Manual Verification

Tested the new v3.0 motion control model with element references to ensure proper API request formatting and parameter validation. Verified that watermark options work across all video generation modes.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)