### PR TITLE
fix: skip data: URLs in downloadAssets to prevent SSRF false positive

### DIFF
--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -195,6 +195,43 @@ describe('convertToLanguageModelPrompt', () => {
           },
         ]);
       });
+
+      it('should not attempt to download data: URL images', async () => {
+        const download = vi.fn();
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'image',
+                    image: 'data:image/png;base64,iVBORw0KGgo=',
+                  },
+                ],
+              },
+            ],
+          },
+          supportedUrls: {},
+          download: download.mockResolvedValue([]),
+        });
+
+        // data: URLs should be excluded from planned downloads
+        expect(download).toHaveBeenCalledWith([]);
+
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                data: 'iVBORw0KGgo=',
+              },
+            ],
+          },
+        ]);
+      });
     });
 
     describe('file parts', () => {
@@ -470,6 +507,44 @@ describe('convertToLanguageModelPrompt', () => {
                 type: 'file',
                 mediaType: 'application/pdf',
                 data: new Uint8Array([0, 1, 2, 3]),
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should not attempt to download data: URL file parts', async () => {
+        const download = vi.fn();
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'file',
+                    data: 'data:application/pdf;base64,dGVzdA==',
+                    mediaType: 'application/pdf',
+                  },
+                ],
+              },
+            ],
+          },
+          supportedUrls: {},
+          download: download.mockResolvedValue([]),
+        });
+
+        // data: URLs should be excluded from planned downloads
+        expect(download).toHaveBeenCalledWith([]);
+
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'application/pdf',
+                data: 'dGVzdA==',
               },
             ],
           },

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -371,7 +371,7 @@ async function downloadAssets(
 
     .filter(
       (part): part is { mediaType: string | undefined; data: URL } =>
-        part.data instanceof URL,
+        part.data instanceof URL && part.data.protocol !== 'data:',
     )
     .map(part => ({
       url: part.data,


### PR DESCRIPTION
**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

Fixes #13103

## Problem

The SSRF protection added in `@ai-sdk/provider-utils@4.0.19` rejects `data:` URLs during the `downloadAssets` phase, breaking inline file attachments (images, PDFs) sent as base64 data URLs.

In `downloadAssets()`, string data from file/image parts is converted to `URL` objects via `new URL(data)`. Since `data:image/png;base64,...` is a valid URL, it becomes a `URL` instance and passes the `instanceof URL` filter. The default download function then calls `validateDownloadUrl()`, which correctly rejects non-`http(s)` protocols — but `data:` URLs are inline data, not remote resources.

## Fix

Filter out `data:` URLs from planned downloads in `downloadAssets()` by adding `&& part.data.protocol !== "data:"` to the existing `instanceof URL` check. This lets `data:` URLs bypass the download pipeline entirely and flow through to `convertToLanguageModelV4DataContent()`, which already handles them correctly by extracting the base64 content.

### Changed files

- **`packages/ai/src/prompt/convert-to-language-model-prompt.ts`**: Added `part.data.protocol !== "data:"` to the URL filter in `downloadAssets()`
- **`packages/ai/src/prompt/convert-to-language-model-prompt.test.ts`**: Added two tests verifying `data:` URLs are not passed to the download function (one for image parts, one for file parts)

### Before

```
Error [AI_DownloadError]: URL scheme must be http or https, got data:
    at validateDownloadUrl
    at download
    at downloadAssets
```

### After

`data:` URLs are correctly skipped during download planning and their inline base64 content is extracted by the existing `convertToLanguageModelV4DataContent()` path.