### PR TITLE
fix: re-throw AbortError in generateText multi-step tool loop

### DIFF
--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -1,4 +1,8 @@
-import { executeTool, ModelMessage } from '@ai-sdk/provider-utils';
+import {
+  executeTool,
+  isAbortError,
+  ModelMessage,
+} from '@ai-sdk/provider-utils';
 import { Tracer } from '@opentelemetry/api';
 import { notify } from '../util/notify';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
@@ -125,6 +129,15 @@ export async function executeToolCall<TOOLS extends ToolSet>({
           }
         }
       } catch (error) {
+        // Re-throw abort errors so they propagate to the caller
+        // instead of being silently converted to tool-error results.
+        // This ensures generateText() throws when an AbortSignal fires
+        // mid-generation in a multi-step tool-use loop.
+        if (isAbortError(error)) {
+          recordErrorOnSpan(span, error);
+          throw error;
+        }
+
         const durationMs = now() - startTime;
 
         await notify({

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -673,6 +673,13 @@ export async function generateText<
         >();
 
         do {
+          // Check if the abort signal has been triggered between steps.
+          // This ensures generateText() throws an AbortError when the signal fires
+          // mid-generation, rather than silently returning a partial result.
+          if (mergedAbortSignal?.aborted) {
+            throw mergedAbortSignal.reason ?? new Error('Aborted');
+          }
+
           // Set up step timeout if configured
           const stepTimeoutId =
             stepTimeoutMs != null


### PR DESCRIPTION
**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

Fixes #12878

## Summary

`generateText()` silently swallows `AbortError` when an `AbortSignal` fires mid-generation in a multi-step tool-use loop. Instead of throwing, it returns a normal result, and the caller has no indication the generation was interrupted.

### Root cause

In `executeToolCall()`, the `catch (error)` block catches **all** errors — including `AbortError` — and converts them into `tool-error` results. This means when a tool's `execute` function is aborted (or when an abort happens during tool execution), the error is swallowed and returned as a normal tool-error result. The `do...while` loop in `generateText()` then either continues (and may hit an AbortError on the next `doGenerate()` call) or terminates normally if the `while` condition evaluates to `false`.

### Changes

1. **`packages/ai/src/generate-text/execute-tool-call.ts`**: Added `isAbortError` check at the top of the `catch` block. If the error is an AbortError, it is recorded on the telemetry span and re-thrown immediately, rather than being converted to a `tool-error` result. This is consistent with how the retry logic in `retry-with-exponential-backoff.ts` already handles AbortErrors (line 98: `if (isAbortError(error)) { throw error; }`).

2. **`packages/ai/src/generate-text/generate-text.ts`**: Added `mergedAbortSignal?.aborted` check at the start of each `do...while` loop iteration. This catches the edge case where the signal fires between steps — after tool execution completes but before the next `doGenerate()` call would detect it.

## Test plan

- [ ] Verify existing tests pass (the abort re-throw should not affect normal tool error handling)
- [ ] Reproduce the issue from #12878: call `generateText()` with an `AbortSignal` that fires during tool execution in a multi-step loop, and confirm it now throws an `AbortError` instead of returning normally
- [ ] Verify that non-abort tool errors (e.g., tool throws a regular Error) are still converted to `tool-error` results as before