### PR TITLE
Fix broken link for LMStudio docs

### DIFF
--- a/content/providers/02-openai-compatible-providers/30-lmstudio.mdx
+++ b/content/providers/02-openai-compatible-providers/30-lmstudio.mdx
@@ -8,7 +8,7 @@ description: Use the LM Studio OpenAI compatible API with the AI SDK.
 [LM Studio](https://lmstudio.ai/) is a user interface for running local models.
 
 It contains an OpenAI compatible API server that you can use with the AI SDK.
-You can start the local server under the [Local Server tab](https://lmstudio.ai/docs/basics/server) in the LM Studio UI ("Start Server" button).
+You can start the local server under the [Local Server tab](https://lmstudio.ai/docs/developer/core/server) in the LM Studio UI ("Start Server" button).
 
 ## Setup
 


### PR DESCRIPTION
## Background

The link to the LMStudio docs was broken.

## Summary

I fixed the link.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)