### PR TITLE
docs: add Sardis as community provider

### DIFF
--- a/content/providers/03-community-providers/51-sardis.mdx
+++ b/content/providers/03-community-providers/51-sardis.mdx
@@ -1,54 +1,50 @@
 ---
-title: Sardis
-description: Policy-controlled payments for AI agents
+title: 'Sardis'
+description: 'Learn how to use the Sardis AI SDK provider for policy-controlled agent payments.'
 ---
 
-# Sardis Provider
+# Sardis
 
-[Sardis](https://sardis.sh) is the Payment OS for the Agent Economy. The `@sardis/ai-sdk` package provides Vercel AI SDK tools that enable AI agents to make real financial transactions with policy guardrails.
+[Sardis](https://sardis.sh) is the Payment OS for the Agent Economy. The [`@sardis/ai-sdk`](https://www.npmjs.com/package/@sardis/ai-sdk) package provides Vercel AI SDK-compatible tools that let your AI agents make real financial transactions safely, enforced by spending policies.
+
+- Policy-controlled payments with configurable guardrails
+- Non-custodial MPC wallets via Turnkey
+- Multi-chain USDC/USDT support (Base, Polygon, Ethereum, Arbitrum, Optimism)
+- Works with `generateText`, `streamText`, and agentic tool loops
+- Full TypeScript support
 
 ## Setup
 
+The Sardis provider is available in the `@sardis/ai-sdk` module:
+
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-
-```bash
-pnpm add @sardis/ai-sdk
-```
-
+    <Snippet text="pnpm add @sardis/ai-sdk" dark />
   </Tab>
   <Tab>
-
-```bash
-npm install @sardis/ai-sdk
-```
-
+    <Snippet text="npm install @sardis/ai-sdk" dark />
   </Tab>
   <Tab>
-
-```bash
-yarn add @sardis/ai-sdk
-```
-
+    <Snippet text="yarn add @sardis/ai-sdk" dark />
   </Tab>
 </Tabs>
 
 ## Provider Instance
-
-Create Sardis payment tools:
 
 ```ts
 import { createSardisTools } from '@sardis/ai-sdk';
 
 const tools = createSardisTools({
   apiKey: process.env.SARDIS_API_KEY!,
-  walletId: 'wallet_abc123',
+  walletId: 'wal_abc123',
+  maxPaymentAmount: 100,
+  blockedCategories: ['gambling'],
 });
 ```
 
 ## Example
 
-Use with `generateText`:
+### `generateText`
 
 ```ts
 import { generateText } from 'ai';
@@ -57,9 +53,7 @@ import { createSardisTools } from '@sardis/ai-sdk';
 
 const tools = createSardisTools({
   apiKey: process.env.SARDIS_API_KEY!,
-  walletId: 'wallet_abc123',
-  maxPaymentAmount: 100,
-  blockedCategories: ['gambling'],
+  walletId: 'wal_abc123',
 });
 
 const { text, toolResults } = await generateText({
@@ -67,6 +61,29 @@ const { text, toolResults } = await generateText({
   tools,
   prompt: 'Check my balance and pay $25 to OpenAI for API credits',
 });
+```
+
+### `streamText`
+
+```ts
+import { streamText } from 'ai';
+import { anthropic } from '@ai-sdk/anthropic';
+import { createSardisTools } from '@sardis/ai-sdk';
+
+const tools = createSardisTools({
+  apiKey: process.env.SARDIS_API_KEY!,
+  walletId: 'wal_abc123',
+});
+
+const { textStream } = streamText({
+  model: anthropic('claude-sonnet-4-6'),
+  tools,
+  prompt: 'Pay $10 to OpenAI for API credits',
+});
+
+for await (const chunk of textStream) {
+  process.stdout.write(chunk);
+}
 ```
 
 ## Configuration
@@ -112,8 +129,8 @@ const minimalTools = createMinimalSardisTools(config);
 const readOnlyTools = createReadOnlySardisTools(config);
 ```
 
-## Documentation
+## More Information
 
 - [Sardis Documentation](https://sardis.sh/docs)
-- [@sardis/ai-sdk on npm](https://www.npmjs.com/package/@sardis/ai-sdk)
-- [GitHub Repository](https://github.com/EfeDurmaz16/sardis)
+- [npm: @sardis/ai-sdk](https://www.npmjs.com/package/@sardis/ai-sdk)
+- [GitHub](https://github.com/EfeDurmaz16/sardis)

--- a/content/providers/05-community-providers/sardis.mdx
+++ b/content/providers/05-community-providers/sardis.mdx
@@ -1,0 +1,119 @@
+---
+title: Sardis
+description: Policy-controlled payments for AI agents
+---
+
+# Sardis Provider
+
+[Sardis](https://sardis.sh) is the Payment OS for the Agent Economy. The `@sardis/ai-sdk` package provides Vercel AI SDK tools that enable AI agents to make real financial transactions with policy guardrails.
+
+## Setup
+
+<Tabs items={['pnpm', 'npm', 'yarn']}>
+  <Tab>
+
+```bash
+pnpm add @sardis/ai-sdk
+```
+
+  </Tab>
+  <Tab>
+
+```bash
+npm install @sardis/ai-sdk
+```
+
+  </Tab>
+  <Tab>
+
+```bash
+yarn add @sardis/ai-sdk
+```
+
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+Create Sardis payment tools:
+
+```ts
+import { createSardisTools } from '@sardis/ai-sdk';
+
+const tools = createSardisTools({
+  apiKey: process.env.SARDIS_API_KEY!,
+  walletId: 'wallet_abc123',
+});
+```
+
+## Example
+
+Use with `generateText`:
+
+```ts
+import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { createSardisTools } from '@sardis/ai-sdk';
+
+const tools = createSardisTools({
+  apiKey: process.env.SARDIS_API_KEY!,
+  walletId: 'wallet_abc123',
+  maxPaymentAmount: 100,
+  blockedCategories: ['gambling'],
+});
+
+const { text, toolResults } = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Check my balance and pay $25 to OpenAI for API credits',
+});
+```
+
+## Configuration
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `apiKey` | `string` | Sardis API key (required) |
+| `walletId` | `string` | Wallet ID to use (required) |
+| `agentId` | `string` | Agent ID (auto-resolved from wallet if omitted) |
+| `simulationMode` | `boolean` | Test without real transactions |
+| `maxPaymentAmount` | `number` | Maximum single payment amount |
+| `blockedCategories` | `string[]` | Merchant categories to block |
+| `allowedMerchants` | `string[]` | Whitelist of allowed merchants |
+
+## Available Tools
+
+| Tool | Description |
+| --- | --- |
+| `sardis_pay` | Execute a payment from the wallet |
+| `sardis_create_hold` | Pre-authorize funds for a future payment |
+| `sardis_capture_hold` | Capture a previously created hold |
+| `sardis_void_hold` | Cancel a hold and release funds |
+| `sardis_check_policy` | Check if a payment would be allowed |
+| `sardis_get_balance` | Get current wallet balance |
+| `sardis_get_spending` | Get spending summary |
+
+## Tool Presets
+
+```ts
+import {
+  createSardisTools,
+  createMinimalSardisTools,
+  createReadOnlySardisTools,
+} from '@sardis/ai-sdk';
+
+// Full tool suite (7 tools)
+const allTools = createSardisTools(config);
+
+// Minimal (pay + balance only)
+const minimalTools = createMinimalSardisTools(config);
+
+// Read-only (balance + policy + spending)
+const readOnlyTools = createReadOnlySardisTools(config);
+```
+
+## Documentation
+
+- [Sardis Documentation](https://sardis.sh/docs)
+- [@sardis/ai-sdk on npm](https://www.npmjs.com/package/@sardis/ai-sdk)
+- [GitHub Repository](https://github.com/EfeDurmaz16/sardis)


### PR DESCRIPTION
## Summary
- Adds Sardis to the Community Providers docs page
- Package: [`@sardis/ai-sdk`](https://www.npmjs.com/package/@sardis/ai-sdk) on npm

## What is Sardis?
Sardis provides AI SDK tools for policy-controlled stablecoin payments through non-custodial MPC wallets with spending guardrails.

## Tools provided
- `sardis_pay` — Execute payments
- `sardis_create_hold` / `sardis_capture_hold` / `sardis_void_hold` — Pre-authorization flow
- `sardis_check_policy` — Validate against spending policy
- `sardis_get_balance` — Check wallet balance
- `sardis_get_spending` — Spending analytics

Links: [Website](https://sardis.sh) | [npm](https://www.npmjs.com/package/@sardis/ai-sdk) | [GitHub](https://github.com/EfeDurmaz16/sardis)