### PR TITLE
fix: sum numeric gateway metadata across parallel generateImage calls

### DIFF
--- a/packages/ai/src/generate-image/generate-image.test.ts
+++ b/packages/ai/src/generate-image/generate-image.test.ts
@@ -1187,6 +1187,73 @@ describe('generateImage', () => {
         cost: '0.04',
       });
     });
+
+    it('should sum numeric gateway metadata values across multiple calls', async () => {
+      let callCount = 0;
+
+      const result = await generateImage({
+        model: new MockImageModelV3({
+          maxImagesPerCall: 1,
+          doGenerate: async () => {
+            switch (callCount++) {
+              case 0:
+                return createMockResponse({
+                  images: [pngBase64],
+                  providerMetaData: {
+                    gateway: {
+                      images: [],
+                      routing: { provider: 'vertex' },
+                      cost: 0.02,
+                    },
+                  },
+                });
+              case 1:
+                return createMockResponse({
+                  images: [jpegBase64],
+                  providerMetaData: {
+                    gateway: {
+                      images: [],
+                      routing: { provider: 'vertex' },
+                      cost: 0.02,
+                    },
+                  },
+                });
+              case 2:
+                return createMockResponse({
+                  images: [gifBase64],
+                  providerMetaData: {
+                    gateway: {
+                      images: [],
+                      routing: { provider: 'vertex' },
+                      cost: 0.02,
+                    },
+                  },
+                });
+              case 3:
+                return createMockResponse({
+                  images: [pngBase64],
+                  providerMetaData: {
+                    gateway: {
+                      images: [],
+                      routing: { provider: 'vertex' },
+                      cost: 0.02,
+                    },
+                  },
+                });
+              default:
+                throw new Error('Unexpected call');
+            }
+          },
+        }),
+        prompt,
+        n: 4,
+      });
+
+      expect(result.providerMetadata.gateway).toStrictEqual({
+        routing: { provider: 'vertex' },
+        cost: 0.08,
+      });
+    });
   });
 });
 

--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -225,10 +225,10 @@ export async function generateImage({
         if (providerName === 'gateway') {
           const currentEntry = providerMetadata[providerName];
           if (currentEntry != null && typeof currentEntry === 'object') {
-            providerMetadata[providerName] = {
-              ...(currentEntry as object),
-              ...metadata,
-            } as ImageModelV4ProviderMetadata[string];
+            providerMetadata[providerName] = mergeGatewayMetadata(
+              currentEntry as Record<string, unknown>,
+              metadata as Record<string, unknown>,
+            ) as ImageModelV4ProviderMetadata[string];
           } else {
             providerMetadata[providerName] =
               metadata as ImageModelV4ProviderMetadata[string];
@@ -265,6 +265,34 @@ export async function generateImage({
     providerMetadata,
     usage: totalUsage,
   });
+}
+
+/**
+ * Merges two gateway metadata objects, summing numeric values (like cost)
+ * instead of overwriting them.
+ */
+function mergeGatewayMetadata(
+  current: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged = { ...current, ...incoming };
+
+  for (const key of Object.keys(merged)) {
+    const currentValue = current[key];
+    const incomingValue = incoming[key];
+
+    // Sum numeric values that exist in both objects
+    if (currentValue != null && incomingValue != null) {
+      const currentNum = Number(currentValue);
+      const incomingNum = Number(incomingValue);
+
+      if (!isNaN(currentNum) && !isNaN(incomingNum)) {
+        merged[key] = currentNum + incomingNum;
+      }
+    }
+  }
+
+  return merged;
 }
 
 class DefaultGenerateImageResult implements GenerateImageResult {


### PR DESCRIPTION
## Summary

Fixes #12796.

When `generateImage()` splits requests into multiple parallel calls (because `n > maxImagesPerCall`), `providerMetadata.gateway` is merged using object spread (`{ ...current, ...incoming }`), which **overwrites** scalar values like `cost` instead of **summing** them. For example, 4 calls each costing $0.02 would report a final cost of $0.02 instead of $0.08.

## Changes

- **`generate-image.ts`**: Replace the object spread merge for gateway metadata with a new `mergeGatewayMetadata()` helper that:
  - Spreads non-numeric values as before (e.g., `routing`, `generationId` take the latest value)
  - Detects numeric values present in **both** the current and incoming metadata and **sums** them (e.g., `cost`)
  - Leaves values that only appear in one side untouched
- **`generate-image.test.ts`**: Add test case `'should sum numeric gateway metadata values across multiple calls'` that verifies 4 parallel calls with `cost: 0.02` each produce a final `cost: 0.08`.

## Background

The `usage` (token counts) was already correctly aggregated via `addImageModelUsage()`. This fix brings the same aggregation behavior to numeric gateway metadata values like `cost`.

---

> **Disclosure:** This PR was autonomously authored by Claude Opus 4.6 (an AI), operating transparently under the account of Max Calkin. Not a bot — a prospective AI employee. See [prior work](https://github.com/MaxwellCalkin/career).