### PR TITLE
fix: guard toolResultsStreamController against closed-controller crash

### DIFF
--- a/packages/ai/src/generate-text/run-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.test.ts
@@ -1679,4 +1679,84 @@ describe('runToolsTransformation', () => {
       });
     });
   });
+
+  it('should not crash when generator stream errors while tools are executing', async () => {
+    // Regression test for https://github.com/vercel/ai/issues/12874
+    // When the LLM stream errors mid-flight while tools are still executing,
+    // the toolResultsStreamController may be closed before pending tool
+    // callbacks fire. Without guards, this causes:
+    // TypeError: Controller is already closed
+
+    let rejectStream: (error: Error) => void;
+
+    const inputStream = new ReadableStream<LanguageModelV3StreamPart>({
+      start(controller) {
+        // Emit tool calls
+        controller.enqueue({
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'slowTool',
+          input: '{ "value": "a" }',
+        });
+        controller.enqueue({
+          type: 'tool-call',
+          toolCallId: 'call-2',
+          toolName: 'slowTool',
+          input: '{ "value": "b" }',
+        });
+
+        // Error the stream shortly after, while tools are still running
+        rejectStream = (error: Error) => controller.error(error);
+      },
+    });
+
+    const transformedStream = runToolsTransformation({
+      generateId: mockId({ prefix: 'id' }),
+      tools: {
+        slowTool: {
+          title: 'Slow Tool',
+          inputSchema: z.object({ value: z.string() }),
+          execute: async ({ value }) => {
+            await delay(200);
+            return `${value}-result`;
+          },
+        },
+      },
+      generatorStream: inputStream,
+      tracer: new MockTracer(),
+      telemetry: undefined,
+      messages: [],
+      system: undefined,
+      abortSignal: undefined,
+      repairToolCall: undefined,
+      experimental_context: undefined,
+    });
+
+    // Error the stream after a short delay (tools still running)
+    setTimeout(() => {
+      rejectStream(new Error('simulated LLM stream error'));
+    }, 50);
+
+    // Consume the stream — it should reject but NOT throw
+    // "Controller is already closed"
+    const reader = transformedStream.getReader();
+    const chunks: unknown[] = [];
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+    } catch {
+      // Stream error is expected — the important thing is no unhandled crash
+    }
+
+    // Wait for the slow tools to finish their async callbacks
+    await delay(500);
+
+    // If we reach here without an unhandled rejection, the fix works.
+    // The tool-call chunks should have been emitted before the error.
+    expect(chunks.some((c: any) => c.type === 'tool-call')).toBe(true);
+  });
+
 });

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -147,13 +147,39 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
   let toolResultsStreamController: ReadableStreamDefaultController<
     SingleRequestTextStreamPart<TOOLS>
   > | null = null;
+  let toolResultsStreamClosed = false;
   const toolResultsStream = new ReadableStream<
     SingleRequestTextStreamPart<TOOLS>
   >({
     start(controller) {
       toolResultsStreamController = controller;
     },
+    cancel() {
+      toolResultsStreamClosed = true;
+    },
   });
+
+  // Guard wrappers to prevent "Controller is already closed" crashes when
+  // the combined stream is terminated (e.g. LLM error) while tools are
+  // still executing asynchronously.
+  function safeEnqueue(chunk: SingleRequestTextStreamPart<TOOLS>) {
+    if (toolResultsStreamClosed) return;
+    try {
+      toolResultsStreamController!.enqueue(chunk);
+    } catch {
+      toolResultsStreamClosed = true;
+    }
+  }
+
+  function safeClose() {
+    if (toolResultsStreamClosed) return;
+    try {
+      toolResultsStreamController!.close();
+      toolResultsStreamClosed = true;
+    } catch {
+      toolResultsStreamClosed = true;
+    }
+  }
 
   // keep track of outstanding tool results for stream closing:
   const outstandingToolResults = new Set<string>();
@@ -176,10 +202,10 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
       // are received to ensure that the frontend receives tool results before a message
       // finish event arrives.
       if (finishChunk != null) {
-        toolResultsStreamController!.enqueue(finishChunk);
+        safeEnqueue(finishChunk);
       }
 
-      toolResultsStreamController!.close();
+      safeClose();
     }
   }
 
@@ -244,7 +270,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
         case 'tool-approval-request': {
           const toolCall = toolCallsByToolCallId.get(chunk.toolCallId);
           if (toolCall == null) {
-            toolResultsStreamController!.enqueue({
+            safeEnqueue({
               type: 'error',
               error: new ToolCallNotFoundForApprovalError({
                 toolCallId: chunk.toolCallId,
@@ -277,7 +303,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
             controller.enqueue(toolCall);
 
             if (toolCall.invalid) {
-              toolResultsStreamController!.enqueue({
+              safeEnqueue({
                 type: 'tool-error',
                 toolCallId: toolCall.toolCallId,
                 toolName: toolCall.toolName,
@@ -315,7 +341,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                 experimental_context,
               })
             ) {
-              toolResultsStreamController!.enqueue({
+              safeEnqueue({
                 type: 'tool-approval-request',
                 approvalId: generateId(),
                 toolCall,
@@ -346,14 +372,14 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                 onToolCallStart,
                 onToolCallFinish,
                 onPreliminaryToolResult: result => {
-                  toolResultsStreamController!.enqueue(result);
+                  safeEnqueue(result);
                 },
               })
                 .then(result => {
-                  toolResultsStreamController!.enqueue(result);
+                  safeEnqueue(result);
                 })
                 .catch(error => {
-                  toolResultsStreamController!.enqueue({
+                  safeEnqueue({
                     type: 'error',
                     error,
                   });
@@ -364,7 +390,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                 });
             }
           } catch (error) {
-            toolResultsStreamController!.enqueue({ type: 'error', error });
+            safeEnqueue({ type: 'error', error });
           }
 
           break;
@@ -374,7 +400,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
           const toolName = chunk.toolName as keyof TOOLS & string;
 
           if (chunk.isError) {
-            toolResultsStreamController!.enqueue({
+            safeEnqueue({
               type: 'tool-error',
               toolCallId: chunk.toolCallId,
               toolName,


### PR DESCRIPTION
## Summary

Fixes #12874. `streamText()` with tools crashes with an unhandled `TypeError: Controller is already closed` when the LLM model stream errors while tools are still executing asynchronously.

**Root cause:** In `run-tools-transformation.ts`, tool executions are fire-and-forget promises. Their `.then()`/`.catch()`/`.finally()` callbacks call `toolResultsStreamController.enqueue()` without checking if the controller is still open. When the stream is terminated (e.g. LLM network error, API 5xx mid-stream), `terminate()` cascades a cancel to `toolResultsStreamController`, closing it before pending tool callbacks fire.

**Fix:** Add `safeEnqueue()`/`safeClose()` guard wrappers around all 10 `toolResultsStreamController.enqueue()` and 1 `.close()` call sites. A `toolResultsStreamClosed` flag is set via the `cancel()` handler on `toolResultsStream` and also defensively in try-catch blocks. This pattern already exists in the codebase for `stitchableStream`.

## Changes

- `packages/ai/src/generate-text/run-tools-transformation.ts`
  - Add `toolResultsStreamClosed` boolean flag
  - Add `cancel()` handler on `toolResultsStream` to set the flag when the stream is cancelled
  - Add `safeEnqueue()` and `safeClose()` helper functions that check the flag and wrap operations in try-catch
  - Replace all 10 `toolResultsStreamController!.enqueue()` calls with `safeEnqueue()`
  - Replace `toolResultsStreamController!.close()` with `safeClose()`

- `packages/ai/src/generate-text/run-tools-transformation.test.ts`
  - Add regression test: "should not crash when generator stream errors while tools are executing"
  - Creates a stream that emits tool calls then errors while slow tools are still executing
  - Verifies no unhandled rejection occurs when tool callbacks fire after controller is closed

## Test plan

- [ ] New test case covers the exact crash scenario from #12874
- [ ] Existing tests should continue to pass — `safeEnqueue`/`safeClose` are transparent when the controller is open

Note: I am an AI (Claude) contributing transparently. This PR was created by Max Calkin's AI agent.