### PR TITLE
fix(openai): strip id from reasoning items when store is false

### DIFF
--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -959,7 +959,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1001,7 +1000,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [
                 {
@@ -1043,7 +1041,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: null,
               summary: [
                 {
@@ -1086,7 +1083,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [],
             },
@@ -1123,7 +1119,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [],
             },
@@ -1168,7 +1163,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1230,7 +1224,6 @@ describe('convertToOpenAIResponsesInput', () => {
             [
               {
                 "encrypted_content": "encrypted_content_001",
-                "id": "reasoning_001",
                 "summary": [
                   {
                     "text": "First reasoning step",
@@ -1285,7 +1278,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1296,7 +1288,6 @@ describe('convertToOpenAIResponsesInput', () => {
             },
             {
               type: 'reasoning',
-              id: 'reasoning_002',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1485,7 +1476,6 @@ describe('convertToOpenAIResponsesInput', () => {
             },
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1508,7 +1498,6 @@ describe('convertToOpenAIResponsesInput', () => {
             },
             {
               type: 'reasoning',
-              id: 'reasoning_002',
               encrypted_content: undefined,
               summary: [
                 {
@@ -1656,7 +1645,6 @@ describe('convertToOpenAIResponsesInput', () => {
             // First reasoning block (2 parts merged)
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [
                 {
@@ -1685,7 +1673,6 @@ describe('convertToOpenAIResponsesInput', () => {
             // Second reasoning block (3 parts merged)
             {
               type: 'reasoning',
-              id: 'reasoning_002',
               encrypted_content: 'encrypted_content_002',
               summary: [
                 {

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -428,7 +428,6 @@ export async function convertToOpenAIResponsesInput({
                   if (reasoningMessage === undefined) {
                     reasoningMessages[reasoningId] = {
                       type: 'reasoning',
-                      id: reasoningId,
                       encrypted_content:
                         providerOptions?.reasoningEncryptedContent,
                       summary: summaryParts,


### PR DESCRIPTION
## Summary

Fixes #12687

When using the OpenAI Responses API with `store: false`, reasoning items were still including the `id` field in the request payload sent to the API. Azure OpenAI rejects requests that contain `id` fields on reasoning items when `store` is disabled, causing a blocker for stateless/serverless deployments.

**Root cause:** In `convertToOpenAIResponsesInput()`, the `store: false` code path for reasoning parts unconditionally set `id: reasoningId` on the output reasoning object. The `reasoningId` is used internally to merge consecutive reasoning parts with the same ID, but it should not appear in the serialized output when `store` is `false`.

**Fix:** Remove `id: reasoningId` from the reasoning item constructed in the `store: false` branch. The `reasoningId` is still used as a dictionary key in `reasoningMessages` for merging, but the `id` field is omitted from the output object sent to the API.

## Test plan

- Updated all existing `store: false` reasoning tests to expect output without `id` field
- Verified `store: true` reasoning tests are unchanged (they use `item_reference` with `id`, which is correct)
- No new test files needed — existing test coverage is comprehensive

### Files changed
- `packages/openai/src/responses/convert-to-openai-responses-input.ts` — removed `id: reasoningId` from store-false reasoning path
- `packages/openai/src/responses/convert-to-openai-responses-input.test.ts` — updated 13 test expectations to remove `id` from reasoning items

🤖 Generated with [Claude Code](https://claude.com/claude-code)