### PR TITLE
fix(openai-compatible,provider-utils): JSON schema validation

### DIFF
--- a/.changeset/late-cougars-cheat.md
+++ b/.changeset/late-cougars-cheat.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/provider-utils': patch
+---
+
+fix(openai-compatible,provider-utils): JSON schema validation

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
@@ -12,6 +12,7 @@ describe('convertToDeepSeekChatMessages', () => {
           },
         ],
         responseFormat: undefined,
+        thinkingMode: false,
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -43,6 +44,7 @@ describe('convertToDeepSeekChatMessages', () => {
           },
         ],
         responseFormat: undefined,
+        thinkingMode: false,
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -92,6 +94,7 @@ describe('convertToDeepSeekChatMessages', () => {
           },
         ],
         responseFormat: undefined,
+        thinkingMode: false,
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -150,6 +153,7 @@ describe('convertToDeepSeekChatMessages', () => {
           },
         ],
         responseFormat: undefined,
+        thinkingMode: false,
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -216,6 +220,7 @@ describe('convertToDeepSeekChatMessages', () => {
           },
         ],
         responseFormat: undefined,
+        thinkingMode: true,
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -290,6 +295,7 @@ describe('convertToDeepSeekChatMessages', () => {
           },
         ],
         responseFormat: undefined,
+        thinkingMode: true,
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -327,6 +333,84 @@ describe('convertToDeepSeekChatMessages', () => {
           "warnings": [],
         }
       `);
+    });
+    it('should include empty reasoning_content in assistant turns that are part of a multi-turn tool chain', () => {
+      const { messages } = convertToDeepSeekChatMessages({
+        prompt: [
+          // User question
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'What is the weather in Berlin?' }],
+          },
+          // First assistant turn: reasoning + tool call
+          {
+            role: 'assistant',
+            content: [
+              { type: 'reasoning', text: 'I need to call the weather API.' },
+              {
+                type: 'tool-call',
+                toolCallId: 'call_1',
+                toolName: 'get_weather',
+                input: { city: 'Berlin' },
+              },
+            ],
+          },
+          // Tool response
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_1',
+                toolName: 'get_weather',
+                output: { type: 'text', value: 'Sunny, 20°C' },
+              },
+            ],
+          },
+          // Second assistant turn: only a tool call (no reasoning)
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call_2',
+                toolName: 'get_uv_index',
+                input: { city: 'Berlin' },
+              },
+            ],
+          },
+        ],
+        responseFormat: undefined,
+        thinkingMode: true,
+      });
+
+      // There should be 4 messages in the DeepSeek format:
+      // user, assistant (with reasoning + tool), tool, assistant (with tool only)
+      expect(messages).toHaveLength(4);
+
+      // Check the first assistant message
+      expect(messages[1]).toMatchObject({
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'I need to call the weather API.',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'get_weather', arguments: '{"city":"Berlin"}' },
+          },
+        ],
+      });
+
+      // Check the second assistant message (the one without reasoning)
+      const secondAssistant =
+        messages[3] as import('./deepseek-chat-api-types').DeepSeekAssistantMessage;
+      expect(secondAssistant.role).toBe('assistant');
+      expect(secondAssistant.content).toBe('');
+      // According to DeepSeek docs, during a multi-turn tool chain,
+      // reasoning_content must be present (even if empty) to avoid 400 errors.
+      expect(secondAssistant.reasoning_content).toBe('');
+      expect(secondAssistant.tool_calls).toHaveLength(1);
     });
   });
 });

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -124,14 +124,15 @@ export function convertToDeepSeekChatMessages({
         }
 
         // Only include reasoning_content if thinking mode is enabled
-        // or if reasoning content is explicitly provided
+        // then reasoning content *must* be provided 
+        // for every assistant message in current thinking chain even if empty
         const reasoningContent = thinkingMode
           ? toolCalls.length > 0 &&
             reasoning === undefined &&
             index > lastUserMessageIndex
             ? ''
             : reasoning
-          : reasoning;
+          : undefined;
 
         messages.push({
           role: 'assistant',

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -8,9 +8,11 @@ import { DeepSeekChatPrompt } from './deepseek-chat-api-types';
 export function convertToDeepSeekChatMessages({
   prompt,
   responseFormat,
+  thinkingMode = false,
 }: {
   prompt: LanguageModelV3Prompt;
   responseFormat: LanguageModelV3CallOptions['responseFormat'];
+  thinkingMode?: boolean;
 }): {
   messages: DeepSeekChatPrompt;
   warnings: Array<SharedV3Warning>;
@@ -121,10 +123,21 @@ export function convertToDeepSeekChatMessages({
           }
         }
 
+        // Only include reasoning_content if thinking mode is enabled
+        // or if reasoning content is explicitly provided
+        const reasoningContent = thinkingMode
+          ? toolCalls.length > 0 &&
+            reasoning === undefined &&
+            index > lastUserMessageIndex
+            ? ''
+            : reasoning
+          : reasoning;
+
         messages.push({
           role: 'assistant',
           content: text,
-          reasoning_content: reasoning,
+
+          reasoning_content: reasoningContent,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.ts
@@ -96,9 +96,16 @@ export class DeepSeekChatLanguageModel implements LanguageModelV3 {
         schema: deepseekLanguageModelOptions,
       })) ?? {};
 
+    // Determine if thinking mode is enabled
+    const thinkingMode =
+      deepseekOptions.thinking?.type === 'enabled' ||
+      (this.modelId === 'deepseek-reasoner' &&
+        deepseekOptions.thinking?.type !== 'disabled');
+
     const { messages, warnings } = convertToDeepSeekChatMessages({
       prompt,
       responseFormat,
+      thinkingMode,
     });
 
     if (topK != null) {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.
We suggest you read the following contributing guide we've created before submitting:
https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background
OpenAI-compatible providers with strict JSON schema validation (like DeepSeek) reject all tool calls with the error:
`Invalid schema for function: schema must be a JSON Schema of 'type: "object"', got 'type: null'.`

This issue (#7924) affects all OpenAI-compatible providers when tools have no explicit `inputSchema` or when `asSchema()` creates empty schemas without the required `type: "object"` field.

## Summary
Fixed JSON schema validation by:

1. **`@ai-sdk/provider-utils`**: Added missing `type: 'object'` to empty JSON schemas in `asSchema()` function
2. **`@ai-sdk/openai-compatible`**: Made `prepareTools()` async and added `jsonSchema()` fallback for undefined `inputSchema`

These changes ensure that all generated JSON schemas are valid according to JSON Schema Draft 7 specification, which requires the `type` field.

## Manual Verification
**Verified with real DeepSeek API requests**:
- Tool calling with DeepSeek no longer fails with `"type: null"` schema validation errors
- Tools with explicit schemas continue to work correctly
- Tools without explicit schemas now receive valid `{type: 'object', properties: {}, additionalProperties: false}` schemas
- All existing OpenAI-compatible provider tests pass (177 tests)

**Test commands executed**:
```bash
# Build affected packages
cd packages/provider-utils && pnpm build
cd packages/openai-compatible && pnpm build

# Run tests
cd packages/openai-compatible && pnpm test  # All 177 tests pass

## Related Issues
Fixes #7924