### PR TITLE
fix(ai): add flush handler to smoothStream to prevent text loss

### DIFF
--- a/packages/ai/src/generate-text/smooth-stream.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test.ts
@@ -2098,4 +2098,154 @@ describe('smoothStream', () => {
       `);
     });
   });
+
+  describe('flush on stream close', () => {
+    it('should flush remaining text buffer when stream closes', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'text-start', id: '1' },
+        { text: 'Hello', type: 'text-delta', id: '1' },
+        { text: ', world', type: 'text-delta', id: '1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "type": "text-start",
+          },
+          {
+            "id": "1",
+            "text": "Hello, world",
+            "type": "text-delta",
+          },
+        ]
+      `);
+    });
+
+    it('should flush remaining reasoning buffer when stream closes', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'reasoning-start', id: '1' },
+        { text: 'thinking about', type: 'reasoning-delta', id: '1' },
+        { text: ' this', type: 'reasoning-delta', id: '1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "type": "reasoning-start",
+          },
+          {
+            "id": "1",
+            "text": "thinking about this",
+            "type": "reasoning-delta",
+          },
+        ]
+      `);
+    });
+
+    it('should flush text buffer with partial word before tool call on stream close', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'text-start', id: '1' },
+        { text: 'I will check the weather', type: 'text-delta', id: '1' },
+        {
+          type: 'tool-call',
+          toolCallId: '1',
+          toolName: 'weather',
+          input: { city: 'London' },
+        },
+        { text: 'The weather is sunny', type: 'text-delta', id: '1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "type": "text-start",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "I ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "will ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "check ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "the ",
+            "type": "text-delta",
+          },
+          {
+            "id": "1",
+            "text": "weather",
+            "type": "text-delta",
+          },
+          {
+            "input": {
+              "city": "London",
+            },
+            "toolCallId": "1",
+            "toolName": "weather",
+            "type": "tool-call",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "The ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "weather ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "is ",
+            "type": "text-delta",
+          },
+          {
+            "id": "1",
+            "text": "sunny",
+            "type": "text-delta",
+          },
+        ]
+      `);
+    });
+  });
 });

--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -157,6 +157,10 @@ export function smoothStream<TOOLS extends ToolSet>({
           await delay(delayInMs);
         }
       },
+
+      flush(controller) {
+        flushBuffer(controller);
+      },
     });
   };
 }


### PR DESCRIPTION
## Summary

Fixes #13199

The `smoothStream` transform's `TransformStream` was missing a `flush` handler. This meant that when the stream closes (e.g., due to abort, error, or the end of generation), any text remaining in the chunking buffer was silently dropped rather than being emitted to the consumer.

This is particularly noticeable in agent/tool-calling workflows where:
- Text segments can end abruptly before a complete word boundary is reached
- The last word(s) of a text segment before a tool call may not have trailing whitespace to match the word-chunking regex (`/\S+\s+/`)
- On stream close, any partial word still in the buffer was lost

### The fix

Add a `flush()` handler to the `TransformStream` that calls the existing `flushBuffer()` helper. This ensures any remaining buffered text or reasoning content is emitted when the writable side closes, matching the same behavior that already exists when non-smoothable chunks (like `tool-call`, `text-end`, etc.) arrive mid-stream.

### Changes

- **`packages/ai/src/generate-text/smooth-stream.ts`**: Add `flush(controller) { flushBuffer(controller); }` to the TransformStream options
- **`packages/ai/src/generate-text/smooth-stream.test.ts`**: Add tests for:
  - Flushing remaining text buffer on stream close (no trailing `text-end`)
  - Flushing remaining reasoning buffer on stream close
  - Text-before-tool-call-then-more-text pattern with flush on close

### Disclosure

This PR was authored by an AI (Claude Opus 4.6, Anthropic). The GitHub account is human-owned. See [maxwellcalkin.com](https://maxwellcalkin.com) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)