### PR TITLE
fix(xai): emit tool-result for all provider-executed tools in Responses stream

### DIFF
--- a/packages/xai/src/responses/__snapshots__/xai-responses-language-model.test.ts.snap
+++ b/packages/xai/src/responses/__snapshots__/xai-responses-language-model.test.ts.snap
@@ -10,6 +10,12 @@ exports[`XaiResponsesLanguageModel > doGenerate > code_interpreter tool > should
     "type": "tool-call",
   },
   {
+    "result": {},
+    "toolCallId": "fc_5138abcf-4c4e-b0ab-7e0b-f4c81b98f455_us-east-1_0",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
     "text": "55",
     "type": "text",
   },
@@ -24,6 +30,12 @@ exports[`XaiResponsesLanguageModel > doGenerate > web_search tool > should inclu
     "toolCallId": "fc_25de2f84-163c-6e9e-e42e-cd1dbd6f9ed0_0",
     "toolName": "web_search",
     "type": "tool-call",
+  },
+  {
+    "result": {},
+    "toolCallId": "fc_25de2f84-163c-6e9e-e42e-cd1dbd6f9ed0_0",
+    "toolName": "web_search",
+    "type": "tool-result",
   },
   {
     "text": "xAI is an American artificial intelligence company founded by Elon Musk in July 2023. Its mission is to "understand the true nature of the universe" by advancing scientific discovery through AI. The company is based in the San Francisco Bay Area and focuses on building advanced AI systems, including the Grok chatbot (integrated with the X platform, formerly Twitter). Notable team members include former researchers from OpenAI, DeepMind, and other AI labs.
@@ -79,6 +91,12 @@ exports[`XaiResponsesLanguageModel > doGenerate > x_search tool > should include
     "toolCallId": "fc_84c1a8ea-1f29-4a33-1049-0ed3561b0f64_us-east-1_0",
     "toolName": "x_search",
     "type": "tool-call",
+  },
+  {
+    "result": {},
+    "toolCallId": "fc_84c1a8ea-1f29-4a33-1049-0ed3561b0f64_us-east-1_0",
+    "toolName": "x_search",
+    "type": "tool-result",
   },
   {
     "text": "### What People Are Saying About AI on X (as of Late October 2025)
@@ -11500,6 +11518,12 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream w
     "type": "tool-call",
   },
   {
+    "result": {},
+    "toolCallId": "fc_98a8d4aa-fc8b-fd93-e673-d5a8f1c9cee8_0",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
     "id": "text-msg_98a8d4aa-fc8b-fd93-e673-d5a8f1c9cee8",
     "type": "text-start",
   },
@@ -12950,6 +12974,12 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream x
     "type": "tool-call",
   },
   {
+    "result": {},
+    "toolCallId": "ctc_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_xs_call_24148162",
+    "toolName": "x_search",
+    "type": "tool-result",
+  },
+  {
     "id": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_55360208",
     "toolName": "web_search",
     "type": "tool-input-start",
@@ -13034,6 +13064,30 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream x
     "type": "tool-call",
   },
   {
+    "result": {},
+    "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_09546004",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
+    "result": {},
+    "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_45339693",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
+    "result": {},
+    "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_55360208",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
+    "result": {},
+    "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_63718660",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
     "id": "ctc_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_xs_call_14963218",
     "toolName": "view_x_video",
     "type": "tool-input-start",
@@ -13053,6 +13107,12 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream x
     "toolCallId": "ctc_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_xs_call_14963218",
     "toolName": "view_x_video",
     "type": "tool-call",
+  },
+  {
+    "result": {},
+    "toolCallId": "ctc_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_xs_call_14963218",
+    "toolName": "view_x_video",
+    "type": "tool-result",
   },
   {
     "id": "text-msg_b7b464ea-cc85-d44a-0f2f-1f7320e703c3",

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -1124,9 +1124,11 @@ describe('XaiResponsesLanguageModel', () => {
           ],
         });
 
-        expect(result.content).toHaveLength(2);
+        expect(result.content).toHaveLength(4);
         expect(result.content[0].type).toBe('tool-call');
-        expect(result.content[1].type).toBe('tool-call');
+        expect(result.content[1].type).toBe('tool-result');
+        expect(result.content[2].type).toBe('tool-call');
+        expect(result.content[3].type).toBe('tool-result');
       });
     });
 
@@ -1170,6 +1172,12 @@ describe('XaiResponsesLanguageModel', () => {
             input: '{"query":"test"}',
             providerExecuted: true,
           },
+          {
+            type: 'tool-result',
+            toolCallId: 'ws_123',
+            toolName: 'web_search',
+            result: {},
+          },
         ]);
       });
 
@@ -1211,6 +1219,12 @@ describe('XaiResponsesLanguageModel', () => {
             toolName: 'x_search',
             input: '{"query":"test"}',
             providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'xs_123',
+            toolName: 'x_search',
+            result: {},
           },
         ]);
       });
@@ -1254,6 +1268,12 @@ describe('XaiResponsesLanguageModel', () => {
             input: '{}',
             providerExecuted: true,
           },
+          {
+            type: 'tool-result',
+            toolCallId: 'ci_123',
+            toolName: 'code_execution',
+            result: {},
+          },
         ]);
       });
 
@@ -1296,6 +1316,12 @@ describe('XaiResponsesLanguageModel', () => {
             input: '{}',
             providerExecuted: true,
           },
+          {
+            type: 'tool-result',
+            toolCallId: 'ce_123',
+            toolName: 'code_execution',
+            result: {},
+          },
         ]);
       });
 
@@ -1337,6 +1363,12 @@ describe('XaiResponsesLanguageModel', () => {
             toolName: 'my_custom_search',
             input: '{}',
             providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'ws_123',
+            toolName: 'my_custom_search',
+            result: {},
           },
         ]);
       });
@@ -2159,6 +2191,252 @@ describe('XaiResponsesLanguageModel', () => {
               },
             ],
           },
+        });
+      });
+
+      it('should stream web_search tool call and result', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast-non-reasoning',
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'web_search_call',
+              id: 'ws_stream_123',
+              name: '',
+              arguments: '{"query":"test"}',
+              call_id: '',
+              status: 'in_progress',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'web_search_call',
+              id: 'ws_stream_123',
+              name: '',
+              arguments: '{"query":"test"}',
+              call_id: '',
+              status: 'completed',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'xai.web_search',
+              name: 'web_search',
+              args: {},
+            },
+          ],
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        expect(parts).toContainEqual({
+          type: 'tool-call',
+          toolCallId: 'ws_stream_123',
+          toolName: 'web_search',
+          input: '{"query":"test"}',
+          providerExecuted: true,
+        });
+
+        expect(parts).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_stream_123',
+          toolName: 'web_search',
+          result: {},
+        });
+      });
+
+      it('should stream code_execution tool call and result', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast-non-reasoning',
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'code_execution_call',
+              id: 'ce_stream_123',
+              name: 'code_execution',
+              arguments: '{"code":"print(1)"}',
+              call_id: '',
+              status: 'in_progress',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'code_execution_call',
+              id: 'ce_stream_123',
+              name: 'code_execution',
+              arguments: '{"code":"print(1)"}',
+              call_id: '',
+              status: 'completed',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'xai.code_execution',
+              name: 'code_execution',
+              args: {},
+            },
+          ],
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        expect(parts).toContainEqual({
+          type: 'tool-call',
+          toolCallId: 'ce_stream_123',
+          toolName: 'code_execution',
+          input: '{"code":"print(1)"}',
+          providerExecuted: true,
+        });
+
+        expect(parts).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ce_stream_123',
+          toolName: 'code_execution',
+          result: {},
+        });
+      });
+
+      it('should stream custom_tool_call and result', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast-non-reasoning',
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'custom_tool_call',
+              id: 'ct_stream_123',
+              name: 'x_keyword_search',
+              input: '',
+              call_id: 'xs_call_123',
+              status: 'in_progress',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.custom_tool_call_input.delta',
+            item_id: 'ct_stream_123',
+            output_index: 0,
+            delta: '{"query":"test"}',
+          }),
+          JSON.stringify({
+            type: 'response.custom_tool_call_input.done',
+            item_id: 'ct_stream_123',
+            output_index: 0,
+            input: '{"query":"test"}',
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'custom_tool_call',
+              id: 'ct_stream_123',
+              name: 'x_keyword_search',
+              input: '{"query":"test"}',
+              call_id: 'xs_call_123',
+              status: 'completed',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'xai.x_search',
+              name: 'x_search',
+              args: {},
+            },
+          ],
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        expect(parts).toContainEqual({
+          type: 'tool-call',
+          toolCallId: 'ct_stream_123',
+          toolName: 'x_search',
+          input: '{"query":"test"}',
+          providerExecuted: true,
+        });
+
+        expect(parts).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ct_stream_123',
+          toolName: 'x_search',
+          result: {},
         });
       });
     });

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -318,6 +318,13 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
           providerExecuted: true,
         });
 
+        content.push({
+          type: 'tool-result',
+          toolCallId: part.id,
+          toolName,
+          result: {},
+        });
+
         continue;
       }
 
@@ -852,6 +859,15 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
                     toolName,
                     input: toolInput,
                     providerExecuted: true,
+                  });
+                }
+
+                if (event.type === 'response.output_item.done') {
+                  controller.enqueue({
+                    type: 'tool-result',
+                    toolCallId: part.id,
+                    toolName,
+                    result: {},
                   });
                 }
 


### PR DESCRIPTION
## Summary

Fixes #13218 — Provider-executed tools (web_search, x_search, code_execution, etc.) in the xAI Responses API never emit `tool-result` when they complete, so UIs stay stuck on the 'in progress' state.

## Root Cause

The `doStream` handler for `response.output_item.done` only emits `tool-result` for `file_search_call` but skips all other provider-executed tool types (`web_search_call`, `x_search_call`, `code_interpreter_call`, `code_execution_call`, `view_image_call`, `view_x_video_call`, `custom_tool_call`, `mcp_call`).

Similarly, the non-streaming `doGenerate` handler pushes `tool-call` but not `tool-result` for these tool types.

## Fix

Extended both streaming and non-streaming handlers to emit `tool-result` for all provider-executed tool types, following the same pattern already used for `file_search_call`.

**Streaming (`doStream`):** Added `tool-result` emission on `response.output_item.done` events for all provider-executed tool types in the shared handler block.

**Non-streaming (`doGenerate`):** Added `tool-result` push after `tool-call` for all provider-executed tool types.

## Testing

- Updated 6 existing `doGenerate` tests to verify `tool-result` is now emitted alongside `tool-call` for provider-executed tools
- Updated 5 snapshot tests to include the new `tool-result` entries
- Added 3 new streaming tests:
  - `should stream web_search tool call and result` — verifies `tool-result` on `response.output_item.done`
  - `should stream code_execution tool call and result` — verifies `tool-result` for code_execution_call
  - `should stream custom_tool_call and result` — verifies `tool-result` for custom_tool_call (used by x_search sub-tools)
- All 56 tests pass