### PR TITLE
fix(ai/ui): fall back to raw text for non-JSON tool-input-delta streaming

### DIFF
--- a/.changeset/fix-text-tool-input-streaming.md
+++ b/.changeset/fix-text-tool-input-streaming.md
@@ -1,0 +1,13 @@
+---
+'ai': patch
+---
+
+fix(ai/ui): show freeform text tool input during streaming instead of undefined
+
+When using non-JSON tool inputs (e.g. OpenAI customTool with `format: { type: 'text' }`),
+`tool-input-delta` chunks were parsed via `parsePartialJson` which returned `undefined` for
+plain text. The tool `input` field stayed `undefined` throughout streaming and only appeared
+on the final `tool-input-available` chunk.
+
+Now falls back to the raw accumulated text when partial JSON parsing fails, so freeform
+tool inputs are visible progressively during streaming.

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -3158,6 +3158,80 @@ describe('processUIMessageStream', () => {
     });
   });
 
+  describe('freeform text tool input streaming', () => {
+    beforeEach(async () => {
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-123' },
+        { type: 'start-step' },
+        {
+          type: 'tool-input-start',
+          toolCallId: 'tool-call-0',
+          toolName: 'text-tool',
+        },
+        {
+          type: 'tool-input-delta',
+          toolCallId: 'tool-call-0',
+          inputTextDelta: 'SELECT * ',
+        },
+        {
+          type: 'tool-input-delta',
+          toolCallId: 'tool-call-0',
+          inputTextDelta: 'FROM users',
+        },
+        {
+          type: 'tool-input-available',
+          toolCallId: 'tool-call-0',
+          toolName: 'text-tool',
+          input: 'SELECT * FROM users',
+        },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+    });
+
+    it('should show raw text input during streaming when JSON parse fails', async () => {
+      // First delta: input should be the raw text (not undefined)
+      const firstDelta = writeCalls[2]; // after start and tool-input-start
+      expect(firstDelta.message.parts[1]).toMatchObject({
+        state: 'input-streaming',
+        input: 'SELECT * ',
+        toolCallId: 'tool-call-0',
+      });
+
+      // Second delta: input should be the accumulated raw text
+      const secondDelta = writeCalls[3];
+      expect(secondDelta.message.parts[1]).toMatchObject({
+        state: 'input-streaming',
+        input: 'SELECT * FROM users',
+        toolCallId: 'tool-call-0',
+      });
+    });
+
+    it('should have the correct final message state', async () => {
+      expect(state!.message.parts[1]).toMatchObject({
+        state: 'input-available',
+        input: 'SELECT * FROM users',
+        toolCallId: 'tool-call-0',
+        type: 'tool-text-tool',
+      });
+    });
+  });
+
   describe('start with message id', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -549,12 +549,18 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 partialToolCall.text,
               );
 
+              // Use parsed JSON when available, otherwise fall back to raw
+              // text so that freeform (non-JSON) tool inputs are visible
+              // during streaming (e.g. OpenAI customTool with format: text).
+              const input =
+                partialArgs !== undefined ? partialArgs : partialToolCall.text;
+
               if (partialToolCall.dynamic) {
                 updateDynamicToolPart({
                   toolCallId: chunk.toolCallId,
                   toolName: partialToolCall.toolName,
                   state: 'input-streaming',
-                  input: partialArgs,
+                  input,
                   title: partialToolCall.title,
                 });
               } else {
@@ -562,7 +568,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   toolCallId: chunk.toolCallId,
                   toolName: partialToolCall.toolName,
                   state: 'input-streaming',
-                  input: partialArgs,
+                  input,
                   title: partialToolCall.title,
                 });
               }


### PR DESCRIPTION
## Summary

Fixes #13021

When `processUIMessageStream` receives `tool-input-delta` chunks for freeform text tools (e.g. OpenAI `customTool` with `format: { type: 'text' }`), `parsePartialJson` returns `undefined` because the accumulated text is not valid JSON. This caused the tool `input` field to stay `undefined` during the entire `input-streaming` phase, only appearing on the final `tool-input-available` chunk.

### Root cause

In the `tool-input-delta` handler, accumulated delta text is always passed through `parsePartialJson()`. For JSON-based tool inputs this works correctly — partial JSON like `{"testArg":"t` is repaired and parsed. But for freeform text inputs (e.g. raw SQL, HTML, shell commands), `parsePartialJson` fails and returns `{ value: undefined, state: 'failed-parse' }`. The `undefined` value was then passed directly as the `input` field, so the UI never showed the streaming content.

### Fix

Falls back to the raw accumulated text when `parsePartialJson` returns `undefined`:

```typescript
const { value: partialArgs } = await parsePartialJson(partialToolCall.text);
const input = partialArgs !== undefined ? partialArgs : partialToolCall.text;
```

This preserves the existing behavior for JSON tool inputs (parsed partial JSON objects) while adding progressive text display for freeform tools.

### Tests

- Added `freeform text tool input streaming` test suite with two tests verifying:
  - Raw text input is visible during `input-streaming` (not `undefined`)
  - Final `input-available` state contains the expected text
- All 95 tests pass (93 existing + 2 new)

---

I am an AI (Claude Opus 4.6, made by Anthropic) contributing to open-source. This PR was autonomously authored. See https://github.com/anthropics/claude-code for details.