### PR TITLE
fix(ui): filter transient parts from finalized messages

### DIFF
--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -680,6 +680,15 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         },
       });
 
+      // Remove the message if it ended up with no parts (e.g. transient-only
+      // data streams should not leave an empty message in the array).
+      if (activeResponse.state.message.parts.length === 0) {
+        const last = this.state.messages[this.state.messages.length - 1];
+        if (last?.id === activeResponse.state.message.id) {
+          this.state.popMessage();
+        }
+      }
+
       this.setStatus({ status: 'ready' });
     } catch (err) {
       // Ignore abort errors as they are expected.

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -4609,6 +4609,14 @@ describe('processUIMessageStream', () => {
               "role": "assistant",
             },
           },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [],
+              "role": "assistant",
+            },
+          },
         ]
       `);
     });
@@ -4618,11 +4626,7 @@ describe('processUIMessageStream', () => {
         {
           "id": "msg-123",
           "metadata": undefined,
-          "parts": [
-            {
-              "type": "step-start",
-            },
-          ],
+          "parts": [],
           "role": "assistant",
         }
       `);
@@ -4633,6 +4637,77 @@ describe('processUIMessageStream', () => {
         [
           {
             "data": "example-data-can-be-anything",
+            "transient": true,
+            "type": "data-test",
+          },
+        ]
+      `);
+    });
+  });
+
+  describe('data ui parts (transient part does not leak into multi-step message)', () => {
+    let dataCalls: InferUIMessageData<UIMessage>[] = [];
+
+    beforeEach(async () => {
+      dataCalls = [];
+
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-123' },
+        { type: 'start-step' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'start-step' },
+        {
+          type: 'data-test',
+          data: 'transient-only-step',
+          transient: true,
+        },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+          onData: data => {
+            dataCalls.push(data);
+          },
+        }),
+      });
+    });
+
+    it('should strip orphaned trailing step-start from the final message', async () => {
+      expect(state!.message.parts).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "step-start",
+          },
+          {
+            "providerMetadata": undefined,
+            "state": "done",
+            "text": "Hello",
+            "type": "text",
+          },
+        ]
+      `);
+    });
+
+    it('should still call the onData callback with the transient part', async () => {
+      expect(dataCalls).toMatchInlineSnapshot(`
+        [
+          {
+            "data": "transient-only-step",
             "transient": true,
             "type": "data-test",
           },

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -692,7 +692,20 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 state.finishReason = chunk.finishReason;
               }
               await updateMessageMetadata(chunk.messageMetadata);
-              if (chunk.messageMetadata != null) {
+
+              // Remove trailing step-start parts that have no content
+              // following them (e.g. from transient-only data streams)
+              let cleanedUpOrphanedSteps = false;
+              while (
+                state.message.parts.length > 0 &&
+                state.message.parts[state.message.parts.length - 1].type ===
+                  'step-start'
+              ) {
+                state.message.parts.pop();
+                cleanedUpOrphanedSteps = true;
+              }
+
+              if (chunk.messageMetadata != null || cleanedUpOrphanedSteps) {
                 write();
               }
               break;


### PR DESCRIPTION
## Summary

Fixes #13080 — Transient parts appear as `undefined` on the messages array (`useChat`).

### Problem

When a stream contains only transient data parts, the `start` chunk handler pushes a message to the messages array with empty parts. Because transient parts correctly skip `write()`, no subsequent state update ever occurs. This leaves an orphaned message in the `messages` array with empty or step-only parts, which can break UI rendering.

### Fix

**`processUIMessageStream.ts`** — In the `finish` handler:
- Strip trailing `step-start` parts that have no following content (orphaned step markers from transient-only steps)
- Call `write()` when cleanup occurred to flush the corrected state

**`chat.ts`** — After `consumeStream` completes:
- Pop the message from the messages array if it ended up with zero parts (transient-only scenario)

### Tests

- Updated existing transient part test expectations to verify orphaned `step-start` parts are removed and the final message state has empty parts
- Added a new test: *"transient part does not leak into multi-step message"* — verifies that a multi-step stream where the last step is transient-only correctly strips the trailing orphaned `step-start` while preserving earlier content