### PR TITLE
fix(xai): support frequencyPenalty, presencePenalty, and stopSequences

### DIFF
--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -91,18 +91,6 @@ export class XaiChatLanguageModel implements LanguageModelV3 {
       warnings.push({ type: 'unsupported', feature: 'topK' });
     }
 
-    if (frequencyPenalty != null) {
-      warnings.push({ type: 'unsupported', feature: 'frequencyPenalty' });
-    }
-
-    if (presencePenalty != null) {
-      warnings.push({ type: 'unsupported', feature: 'presencePenalty' });
-    }
-
-    if (stopSequences != null) {
-      warnings.push({ type: 'unsupported', feature: 'stopSequences' });
-    }
-
     // convert ai sdk messages to xai format
     const { messages, warnings: messageWarnings } =
       convertToXaiChatMessages(prompt);
@@ -132,6 +120,9 @@ export class XaiChatLanguageModel implements LanguageModelV3 {
       max_completion_tokens: maxOutputTokens,
       temperature,
       top_p: topP,
+      frequency_penalty: frequencyPenalty,
+      presence_penalty: presencePenalty,
+      stop: stopSequences,
       seed,
       reasoning_effort: options.reasoningEffort,
 


### PR DESCRIPTION
## Summary

Fixes the high-priority items in #12826.

The xAI Chat Completions API supports `frequency_penalty`, `presence_penalty`, and `stop` parameters ([xAI API docs](https://docs.x.ai/api/endpoints#chat-completions)), but the `@ai-sdk/xai` provider incorrectly marks them as unsupported — emitting warnings and silently dropping the values.

## Changes

- Removed the false "unsupported" warnings for `frequencyPenalty`, `presencePenalty`, and `stopSequences`
- Added the parameters to the API request body with correct field mappings:
  - `frequencyPenalty` → `frequency_penalty`
  - `presencePenalty` → `presence_penalty`
  - `stopSequences` → `stop`

This matches the pattern used by `@ai-sdk/openai`, which the xAI provider is based on (xAI uses an OpenAI-compatible API).

## AI Disclosure

This PR was authored by Claude Opus 4.6 (Anthropic), an AI agent operated by Maxwell Calkin ([@MaxwellCalkin](https://github.com/MaxwellCalkin)). See [our portfolio](https://github.com/MaxwellCalkin) for more about this project.