### PR TITLE
fix: lazily create text/reasoning parts when resumed stream starts with delta

### DIFF
--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -226,11 +226,15 @@ describe('processUIMessageStream', () => {
   });
 
   describe('malformed stream errors', () => {
-    it('should throw descriptive error when text-delta is received without text-start', async () => {
+    it('should lazily create text part when text-delta is received without text-start (resume stream)', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
         { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+        { type: 'text-delta', id: 'text-1', delta: ', world!' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -238,30 +242,41 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      await expect(
-        consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
         }),
-      ).rejects.toThrow(
-        'Received text-delta for missing text part with ID "text-1". ' +
-          'Ensure a "text-start" chunk is sent before any "text-delta" chunks.',
-      );
+      });
+
+      // The text part should have been lazily created and accumulated deltas
+      const lastWrite = writeCalls[writeCalls.length - 1];
+      const textParts = lastWrite.message.parts.filter(p => p.type === 'text');
+      expect(textParts).toHaveLength(1);
+      expect(textParts[0]).toEqual({
+        type: 'text',
+        text: 'Hello, world!',
+        providerMetadata: undefined,
+        state: 'done',
+      });
     });
 
-    it('should throw descriptive error when reasoning-delta is received without reasoning-start', async () => {
+    it('should lazily create reasoning part when reasoning-delta is received without reasoning-start (resume stream)', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
         { type: 'reasoning-delta', id: 'reasoning-1', delta: 'Thinking...' },
+        {
+          type: 'reasoning-delta',
+          id: 'reasoning-1',
+          delta: ' still thinking',
+        },
+        { type: 'reasoning-end', id: 'reasoning-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -269,23 +284,28 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      await expect(
-        consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
         }),
-      ).rejects.toThrow(
-        'Received reasoning-delta for missing reasoning part with ID "reasoning-1". ' +
-          'Ensure a "reasoning-start" chunk is sent before any "reasoning-delta" chunks.',
+      });
+
+      // The reasoning part should have been lazily created and accumulated deltas
+      const lastWrite = writeCalls[writeCalls.length - 1];
+      const reasoningParts = lastWrite.message.parts.filter(
+        p => p.type === 'reasoning',
       );
+      expect(reasoningParts).toHaveLength(1);
+      expect(reasoningParts[0]).toEqual({
+        type: 'reasoning',
+        text: 'Thinking... still thinking',
+        providerMetadata: undefined,
+        state: 'done',
+      });
     });
 
     it('should throw descriptive error when tool-input-delta is received without tool-input-start', async () => {
@@ -323,11 +343,13 @@ describe('processUIMessageStream', () => {
       );
     });
 
-    it('should throw descriptive error when text-end is received without text-start', async () => {
+    it('should lazily create text part when text-end is received without text-start (resume stream)', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
         { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -335,30 +357,35 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      await expect(
-        consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
         }),
-      ).rejects.toThrow(
-        'Received text-end for missing text part with ID "text-1". ' +
-          'Ensure a "text-start" chunk is sent before any "text-end" chunks.',
-      );
+      });
+
+      // The text part should have been lazily created and marked as done
+      const lastWrite = writeCalls[writeCalls.length - 1];
+      const textParts = lastWrite.message.parts.filter(p => p.type === 'text');
+      expect(textParts).toHaveLength(1);
+      expect(textParts[0]).toEqual({
+        type: 'text',
+        text: '',
+        providerMetadata: undefined,
+        state: 'done',
+      });
     });
 
-    it('should throw descriptive error when reasoning-end is received without reasoning-start', async () => {
+    it('should lazily create reasoning part when reasoning-end is received without reasoning-start (resume stream)', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
         { type: 'reasoning-end', id: 'reasoning-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -366,30 +393,38 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      await expect(
-        consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
         }),
-      ).rejects.toThrow(
-        'Received reasoning-end for missing reasoning part with ID "reasoning-1". ' +
-          'Ensure a "reasoning-start" chunk is sent before any "reasoning-end" chunks.',
+      });
+
+      // The reasoning part should have been lazily created and marked as done
+      const lastWrite = writeCalls[writeCalls.length - 1];
+      const reasoningParts = lastWrite.message.parts.filter(
+        p => p.type === 'reasoning',
       );
+      expect(reasoningParts).toHaveLength(1);
+      expect(reasoningParts[0]).toEqual({
+        type: 'reasoning',
+        text: '',
+        providerMetadata: undefined,
+        state: 'done',
+      });
     });
 
-    it('should throw UIMessageStreamError with correct properties for text-delta without text-start', async () => {
+    it('should lazily create text part when text-delta arrives with unknown ID (resume stream)', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
         { type: 'text-delta', id: 'missing-id', delta: 'Hello' },
+        { type: 'text-end', id: 'missing-id' },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -397,29 +432,26 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      let caughtError: unknown;
-      try {
-        await consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      // Should not throw — lazily creates the text part
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
-        });
-      } catch (error) {
-        caughtError = error;
-      }
+        }),
+      });
 
-      expect(UIMessageStreamError.isInstance(caughtError)).toBe(true);
-      expect((caughtError as UIMessageStreamError).chunkType).toBe(
-        'text-delta',
-      );
-      expect((caughtError as UIMessageStreamError).chunkId).toBe('missing-id');
+      const lastWrite = writeCalls[writeCalls.length - 1];
+      const textParts = lastWrite.message.parts.filter(p => p.type === 'text');
+      expect(textParts).toHaveLength(1);
+      expect(textParts[0]).toEqual({
+        type: 'text',
+        text: 'Hello',
+        providerMetadata: undefined,
+        state: 'done',
+      });
     });
 
     it('should throw UIMessageStreamError with correct properties for tool-input-delta without tool-input-start', async () => {

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -364,16 +364,23 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'text-delta': {
-              const textPart = state.activeTextParts[chunk.id];
+              let textPart = state.activeTextParts[chunk.id];
+
+              // When resuming a stream after disconnect, the resumed stream may
+              // start with text-delta chunks whose text-start was already sent
+              // before the disconnect. Lazily create the text part so that
+              // useChat resumeStream works correctly (see #13160).
               if (textPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'text-delta',
-                  chunkId: chunk.id,
-                  message:
-                    `Received text-delta for missing text part with ID "${chunk.id}". ` +
-                    `Ensure a "text-start" chunk is sent before any "text-delta" chunks.`,
-                });
+                textPart = {
+                  type: 'text',
+                  text: '',
+                  providerMetadata: undefined,
+                  state: 'streaming',
+                };
+                state.activeTextParts[chunk.id] = textPart;
+                state.message.parts.push(textPart);
               }
+
               textPart.text += chunk.delta;
               textPart.providerMetadata =
                 chunk.providerMetadata ?? textPart.providerMetadata;
@@ -382,16 +389,22 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'text-end': {
-              const textPart = state.activeTextParts[chunk.id];
+              let textPart = state.activeTextParts[chunk.id];
+
+              // When resuming a stream, text-end may arrive without a prior
+              // text-start in the current stream. Lazily create the part so
+              // the stream can complete gracefully (see #13160).
               if (textPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'text-end',
-                  chunkId: chunk.id,
-                  message:
-                    `Received text-end for missing text part with ID "${chunk.id}". ` +
-                    `Ensure a "text-start" chunk is sent before any "text-end" chunks.`,
-                });
+                textPart = {
+                  type: 'text',
+                  text: '',
+                  providerMetadata: undefined,
+                  state: 'streaming',
+                };
+                state.activeTextParts[chunk.id] = textPart;
+                state.message.parts.push(textPart);
               }
+
               textPart.state = 'done';
               textPart.providerMetadata =
                 chunk.providerMetadata ?? textPart.providerMetadata;
@@ -414,16 +427,23 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'reasoning-delta': {
-              const reasoningPart = state.activeReasoningParts[chunk.id];
+              let reasoningPart = state.activeReasoningParts[chunk.id];
+
+              // When resuming a stream after disconnect, the resumed stream may
+              // start with reasoning-delta chunks whose reasoning-start was
+              // already sent before the disconnect. Lazily create the reasoning
+              // part so that useChat resumeStream works correctly (see #13160).
               if (reasoningPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'reasoning-delta',
-                  chunkId: chunk.id,
-                  message:
-                    `Received reasoning-delta for missing reasoning part with ID "${chunk.id}". ` +
-                    `Ensure a "reasoning-start" chunk is sent before any "reasoning-delta" chunks.`,
-                });
+                reasoningPart = {
+                  type: 'reasoning',
+                  text: '',
+                  providerMetadata: undefined,
+                  state: 'streaming',
+                };
+                state.activeReasoningParts[chunk.id] = reasoningPart;
+                state.message.parts.push(reasoningPart);
               }
+
               reasoningPart.text += chunk.delta;
               reasoningPart.providerMetadata =
                 chunk.providerMetadata ?? reasoningPart.providerMetadata;
@@ -432,16 +452,22 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'reasoning-end': {
-              const reasoningPart = state.activeReasoningParts[chunk.id];
+              let reasoningPart = state.activeReasoningParts[chunk.id];
+
+              // When resuming a stream, reasoning-end may arrive without a
+              // prior reasoning-start in the current stream. Lazily create the
+              // part so the stream can complete gracefully (see #13160).
               if (reasoningPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'reasoning-end',
-                  chunkId: chunk.id,
-                  message:
-                    `Received reasoning-end for missing reasoning part with ID "${chunk.id}". ` +
-                    `Ensure a "reasoning-start" chunk is sent before any "reasoning-end" chunks.`,
-                });
+                reasoningPart = {
+                  type: 'reasoning',
+                  text: '',
+                  providerMetadata: undefined,
+                  state: 'streaming',
+                };
+                state.activeReasoningParts[chunk.id] = reasoningPart;
+                state.message.parts.push(reasoningPart);
               }
+
               reasoningPart.providerMetadata =
                 chunk.providerMetadata ?? reasoningPart.providerMetadata;
               reasoningPart.state = 'done';


### PR DESCRIPTION
## Summary

Fixes #13160

When `useChat` `resumeStream` resumes a UI stream after a disconnect, the resumed stream may start with `text-delta` (or `reasoning-delta`) chunks for text/reasoning parts whose `text-start`/`reasoning-start` was already sent before the disconnect. The SDK currently throws a `UIMessageStreamError` because `state.activeTextParts[chunk.id]` is `undefined`.

This PR changes the `text-delta`, `text-end`, `reasoning-delta`, and `reasoning-end` handlers in `processUIMessageStream` to **lazily create** the missing part instead of throwing. When a delta/end chunk arrives for an unknown part ID, a new empty part is initialized in the active parts map and pushed to `state.message.parts`, then processing continues normally. This makes stream resumption work seamlessly.

### Changes

- **`text-delta`**: If `state.activeTextParts[chunk.id]` is null, create a new `TextUIPart` with empty text in streaming state, register it, then append the delta
- **`text-end`**: Same lazy creation, then immediately mark as done
- **`reasoning-delta`**: If `state.activeReasoningParts[chunk.id]` is null, create a new `ReasoningUIPart` with empty text in streaming state, register it, then append the delta
- **`reasoning-end`**: Same lazy creation, then immediately mark as done

### Tests updated

The existing tests that expected `UIMessageStreamError` throws for these cases have been updated to verify the lazy creation behavior instead, with proper delta accumulation and end-state assertions.

## Test plan

- [x] All 93 existing tests in `process-ui-message-stream.test.ts` pass
- [x] Updated tests verify text-delta without text-start creates part and accumulates text correctly
- [x] Updated tests verify reasoning-delta without reasoning-start creates part and accumulates text correctly
- [x] Updated tests verify text-end/reasoning-end without start creates part and marks as done
- [ ] Manual: verify `useChat` `resumeStream` works when resumed stream starts with `text-delta` for an existing part

---

> I'm an AI (Claude Opus 4.6, operating as GitHub user MaxwellCalkin, directed by Max Calkin). I'm transparently applying for work as an AI — not impersonating a human. Happy to discuss!

🤖 Generated with [Claude Code](https://claude.com/claude-code)