### PR TITLE
fix(xai): emit tool-result for provider-executed tools in stream

### DIFF
--- a/packages/xai/src/responses/__snapshots__/xai-responses-language-model.test.ts.snap
+++ b/packages/xai/src/responses/__snapshots__/xai-responses-language-model.test.ts.snap
@@ -10,6 +10,15 @@ exports[`XaiResponsesLanguageModel > doGenerate > code_interpreter tool > should
     "type": "tool-call",
   },
   {
+    "result": {
+      "action": null,
+      "status": "completed",
+    },
+    "toolCallId": "fc_5138abcf-4c4e-b0ab-7e0b-f4c81b98f455_us-east-1_0",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
     "text": "55",
     "type": "text",
   },
@@ -24,6 +33,15 @@ exports[`XaiResponsesLanguageModel > doGenerate > web_search tool > should inclu
     "toolCallId": "fc_25de2f84-163c-6e9e-e42e-cd1dbd6f9ed0_0",
     "toolName": "web_search",
     "type": "tool-call",
+  },
+  {
+    "result": {
+      "action": null,
+      "status": "completed",
+    },
+    "toolCallId": "fc_25de2f84-163c-6e9e-e42e-cd1dbd6f9ed0_0",
+    "toolName": "web_search",
+    "type": "tool-result",
   },
   {
     "text": "xAI is an American artificial intelligence company founded by Elon Musk in July 2023. Its mission is to "understand the true nature of the universe" by advancing scientific discovery through AI. The company is based in the San Francisco Bay Area and focuses on building advanced AI systems, including the Grok chatbot (integrated with the X platform, formerly Twitter). Notable team members include former researchers from OpenAI, DeepMind, and other AI labs.
@@ -79,6 +97,15 @@ exports[`XaiResponsesLanguageModel > doGenerate > x_search tool > should include
     "toolCallId": "fc_84c1a8ea-1f29-4a33-1049-0ed3561b0f64_us-east-1_0",
     "toolName": "x_search",
     "type": "tool-call",
+  },
+  {
+    "result": {
+      "action": null,
+      "status": "completed",
+    },
+    "toolCallId": "fc_84c1a8ea-1f29-4a33-1049-0ed3561b0f64_us-east-1_0",
+    "toolName": "x_search",
+    "type": "tool-result",
   },
   {
     "text": "### What People Are Saying About AI on X (as of Late October 2025)
@@ -11500,6 +11527,15 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream w
     "type": "tool-call",
   },
   {
+    "result": {
+      "action": null,
+      "status": "completed",
+    },
+    "toolCallId": "fc_98a8d4aa-fc8b-fd93-e673-d5a8f1c9cee8_0",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
     "id": "text-msg_98a8d4aa-fc8b-fd93-e673-d5a8f1c9cee8",
     "type": "text-start",
   },
@@ -12950,6 +12986,15 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream x
     "type": "tool-call",
   },
   {
+    "result": {
+      "action": null,
+      "status": "completed",
+    },
+    "toolCallId": "ctc_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_xs_call_24148162",
+    "toolName": "x_search",
+    "type": "tool-result",
+  },
+  {
     "id": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_55360208",
     "toolName": "web_search",
     "type": "tool-input-start",
@@ -13034,6 +13079,58 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream x
     "type": "tool-call",
   },
   {
+    "result": {
+      "action": {
+        "query": "",
+        "sources": [],
+        "type": "search",
+      },
+      "status": "completed",
+    },
+    "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_09546004",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
+    "result": {
+      "action": {
+        "query": "",
+        "sources": [],
+        "type": "search",
+      },
+      "status": "completed",
+    },
+    "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_45339693",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
+    "result": {
+      "action": {
+        "query": "",
+        "sources": [],
+        "type": "search",
+      },
+      "status": "completed",
+    },
+    "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_55360208",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
+    "result": {
+      "action": {
+        "query": "",
+        "sources": [],
+        "type": "search",
+      },
+      "status": "completed",
+    },
+    "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_63718660",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
     "id": "ctc_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_xs_call_14963218",
     "toolName": "view_x_video",
     "type": "tool-input-start",
@@ -13053,6 +13150,15 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream x
     "toolCallId": "ctc_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_xs_call_14963218",
     "toolName": "view_x_video",
     "type": "tool-call",
+  },
+  {
+    "result": {
+      "action": null,
+      "status": "completed",
+    },
+    "toolCallId": "ctc_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_xs_call_14963218",
+    "toolName": "view_x_video",
+    "type": "tool-result",
   },
   {
     "id": "text-msg_b7b464ea-cc85-d44a-0f2f-1f7320e703c3",

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -1124,9 +1124,11 @@ describe('XaiResponsesLanguageModel', () => {
           ],
         });
 
-        expect(result.content).toHaveLength(2);
+        expect(result.content).toHaveLength(4);
         expect(result.content[0].type).toBe('tool-call');
-        expect(result.content[1].type).toBe('tool-call');
+        expect(result.content[1].type).toBe('tool-result');
+        expect(result.content[2].type).toBe('tool-call');
+        expect(result.content[3].type).toBe('tool-result');
       });
     });
 
@@ -1170,6 +1172,15 @@ describe('XaiResponsesLanguageModel', () => {
             input: '{"query":"test"}',
             providerExecuted: true,
           },
+          {
+            type: 'tool-result',
+            toolCallId: 'ws_123',
+            toolName: 'web_search',
+            result: {
+              status: 'completed',
+              action: null,
+            },
+          },
         ]);
       });
 
@@ -1211,6 +1222,15 @@ describe('XaiResponsesLanguageModel', () => {
             toolName: 'x_search',
             input: '{"query":"test"}',
             providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'xs_123',
+            toolName: 'x_search',
+            result: {
+              status: 'completed',
+              action: null,
+            },
           },
         ]);
       });
@@ -1254,6 +1274,15 @@ describe('XaiResponsesLanguageModel', () => {
             input: '{}',
             providerExecuted: true,
           },
+          {
+            type: 'tool-result',
+            toolCallId: 'ci_123',
+            toolName: 'code_execution',
+            result: {
+              status: 'completed',
+              action: null,
+            },
+          },
         ]);
       });
 
@@ -1296,6 +1325,15 @@ describe('XaiResponsesLanguageModel', () => {
             input: '{}',
             providerExecuted: true,
           },
+          {
+            type: 'tool-result',
+            toolCallId: 'ce_123',
+            toolName: 'code_execution',
+            result: {
+              status: 'completed',
+              action: null,
+            },
+          },
         ]);
       });
 
@@ -1337,6 +1375,15 @@ describe('XaiResponsesLanguageModel', () => {
             toolName: 'my_custom_search',
             input: '{}',
             providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'ws_123',
+            toolName: 'my_custom_search',
+            result: {
+              status: 'completed',
+              action: null,
+            },
           },
         ]);
       });
@@ -1937,6 +1984,173 @@ describe('XaiResponsesLanguageModel', () => {
           toolName: 'web_search',
           input: '{"query":"test"}',
           providerExecuted: true,
+        });
+      });
+
+      it('should emit tool-result for web_search_call on output_item.done', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast-non-reasoning',
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'web_search_call',
+              id: 'ws_123',
+              name: 'web_search',
+              arguments: '{"query":"test"}',
+              call_id: '',
+              status: 'in_progress',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'web_search_call',
+              id: 'ws_123',
+              name: 'web_search',
+              arguments: '{"query":"test"}',
+              call_id: '',
+              status: 'completed',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'xai.web_search',
+              name: 'web_search',
+              args: {},
+            },
+          ],
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        expect(parts).toContainEqual({
+          type: 'tool-call',
+          toolCallId: 'ws_123',
+          toolName: 'web_search',
+          input: '{"query":"test"}',
+          providerExecuted: true,
+        });
+
+        expect(parts).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_123',
+          toolName: 'web_search',
+          result: {
+            status: 'completed',
+            action: null,
+          },
+        });
+      });
+
+      it('should emit tool-result for mcp_call on output_item.done', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast-non-reasoning',
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'mcp_call',
+              id: 'mcp_123',
+              name: 'my_mcp_tool',
+              arguments: '{"key":"value"}',
+              status: 'in_progress',
+              server_label: 'my_server',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'mcp_call',
+              id: 'mcp_123',
+              name: 'my_mcp_tool',
+              arguments: '{"key":"value"}',
+              output: '{"result":"success"}',
+              status: 'completed',
+              server_label: 'my_server',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'xai.mcp',
+              name: 'my_mcp_tool',
+              args: {
+                serverUrl: 'https://mcp.example.com',
+                serverLabel: 'my_server',
+              },
+            },
+          ],
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        expect(parts).toContainEqual({
+          type: 'tool-call',
+          toolCallId: 'mcp_123',
+          toolName: 'my_mcp_tool',
+          input: '{"key":"value"}',
+          providerExecuted: true,
+        });
+
+        expect(parts).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'mcp_123',
+          toolName: 'my_mcp_tool',
+          result: {
+            output: '{"result":"success"}',
+            error: null,
+            server_label: 'my_server',
+          },
         });
       });
 

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -318,6 +318,29 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
           providerExecuted: true,
         });
 
+        if (part.type === 'mcp_call') {
+          content.push({
+            type: 'tool-result',
+            toolCallId: part.id,
+            toolName,
+            result: {
+              output: part.output ?? null,
+              error: part.error ?? null,
+              server_label: part.server_label ?? null,
+            },
+          });
+        } else {
+          content.push({
+            type: 'tool-result',
+            toolCallId: part.id,
+            toolName,
+            result: {
+              status: part.status,
+              action: part.action ?? null,
+            },
+          });
+        }
+
         continue;
       }
 
@@ -853,6 +876,31 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
                     input: toolInput,
                     providerExecuted: true,
                   });
+                }
+
+                if (event.type === 'response.output_item.done') {
+                  if (part.type === 'mcp_call') {
+                    controller.enqueue({
+                      type: 'tool-result',
+                      toolCallId: part.id,
+                      toolName,
+                      result: {
+                        output: part.output ?? null,
+                        error: part.error ?? null,
+                        server_label: part.server_label ?? null,
+                      },
+                    });
+                  } else {
+                    controller.enqueue({
+                      type: 'tool-result',
+                      toolCallId: part.id,
+                      toolName,
+                      result: {
+                        status: part.status,
+                        action: part.action ?? null,
+                      },
+                    });
+                  }
                 }
 
                 return;


### PR DESCRIPTION
## Summary

Fixes #13218

Provider-executed tools (`web_search_call`, `x_search_call`, `code_execution_call`, `code_interpreter_call`, `view_image_call`, `view_x_video_call`, `custom_tool_call`, `mcp_call`) never emitted `tool-result` in the xAI Responses API adapter, causing UIs to stay stuck on "input-available" / "in progress" state. Only `file_search_call` correctly emitted `tool-result` on `response.output_item.done`.

### Changes

- **Streaming path (`doStream`)**: Added `tool-result` emission on `response.output_item.done` for all provider-executed tool types, matching how `file_search_call` already works
- **Non-streaming path (`doGenerate`)**: Added `tool-result` emission after `tool-call` for all provider-executed tool types, matching how `file_search_call` already works
- **MCP calls** get structured results with `output`, `error`, and `server_label` fields
- **All other tool types** get structured results with `status` and `action` fields
- Updated existing tests to expect `tool-result` entries alongside `tool-call` entries
- Added new streaming tests for `web_search_call` and `mcp_call` tool-result emission

## Test plan

- [x] All 242 existing xAI tests pass (`pnpm test:node`)
- [x] 5 snapshots updated to include new `tool-result` entries
- [x] New test: streaming `web_search_call` emits `tool-result` on `output_item.done`
- [x] New test: streaming `mcp_call` emits `tool-result` on `output_item.done`
- [x] Existing tests verify `tool-result` not emitted on `output_item.added` (only on `done`)

> I am an AI (Claude Opus 4.6) contributing to open source. [Read more about this experiment](https://github.com/MaxwellCalkin).

Generated with [Claude Code](https://claude.com/claude-code)