### PR TITLE
fix(ai): skip data: URLs in downloadAssets to prevent SSRF false positive

### DIFF
--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -195,6 +195,42 @@ describe('convertToLanguageModelPrompt', () => {
           },
         ]);
       });
+
+      it('should not download data: URLs and instead extract inline content', async () => {
+        const downloadFn = vi.fn();
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'image',
+                    image:
+                      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+                  },
+                ],
+              },
+            ],
+          },
+          supportedUrls: {},
+          download: createDefaultDownloadFunction(downloadFn),
+        });
+
+        expect(downloadFn).not.toHaveBeenCalled();
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+              },
+            ],
+          },
+        ]);
+      });
     });
 
     describe('file parts', () => {
@@ -549,6 +585,42 @@ describe('convertToLanguageModelPrompt', () => {
                 type: 'file',
                 mediaType: 'application/pdf',
                 data: new Uint8Array([0, 1, 2, 3]),
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should not download data: URLs in file parts and instead extract inline content', async () => {
+        const downloadFn = vi.fn();
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'file',
+                    data: 'data:application/pdf;base64,SGVsbG8sIFdvcmxkIQ==',
+                    mediaType: 'application/pdf',
+                  },
+                ],
+              },
+            ],
+          },
+          supportedUrls: {},
+          download: createDefaultDownloadFunction(downloadFn),
+        });
+
+        expect(downloadFn).not.toHaveBeenCalled();
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'application/pdf',
+                data: 'SGVsbG8sIFdvcmxkIQ==',
               },
             ],
           },

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -371,7 +371,7 @@ async function downloadAssets(
 
     .filter(
       (part): part is { mediaType: string | undefined; data: URL } =>
-        part.data instanceof URL,
+        part.data instanceof URL && part.data.protocol !== 'data:',
     )
     .map(part => ({
       url: part.data,


### PR DESCRIPTION
## Summary

Fixes #13103

`data:` URLs encode content inline and don't make network requests, so they should be excluded from the download list in `downloadAssets()`. The downstream `convertToLanguageModelV4DataContent()` already handles `data:` URLs correctly by extracting their base64 content.

## Problem

When a user sends an inline image/file as a `data:` URL (e.g. `data:image/png;base64,...`), the `downloadAssets()` function:
1. Converts the string to a `URL` object
2. Includes it in the planned downloads list
3. The download function calls `validateDownloadUrl()` which rejects it with: `URL scheme must be http or https, got data:`

This was introduced by the SSRF protection in `@ai-sdk/provider-utils@4.0.19`.

## Fix

Filter out `data:` URLs in `downloadAssets()` by adding `&& part.data.protocol !== 'data:'` to the URL filter. This is the correct fix location because:

- `data:` URLs don't need downloading — they contain inline data
- `convertToLanguageModelV4DataContent()` already handles `data:` URLs natively (extracts base64 content)
- `validateDownloadUrl()` should continue to reject `data:` URLs if someone passes them to download functions directly — they should never be fetched

## Tests

Added 2 tests verifying that `data:` URLs in both image parts and file parts:
- Are **not** passed to the download function
- Have their base64 content correctly extracted inline