### PR TITLE
fix(ai): smooth-drain buffer before tool calls to prevent mid-text side effects

### DIFF
--- a/packages/ai/src/generate-text/smooth-stream.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test.ts
@@ -72,6 +72,7 @@ describe('smoothStream', () => {
             "text": "Hello, ",
             "type": "text-delta",
           },
+          "delay 10",
           {
             "id": "1",
             "text": "world!",
@@ -145,6 +146,7 @@ describe('smoothStream', () => {
             "text": "example ",
             "type": "text-delta",
           },
+          "delay 10",
           {
             "id": "1",
             "text": "text.",
@@ -204,6 +206,7 @@ describe('smoothStream', () => {
           text: 'spaces\n    ',
           type: 'text-delta',
         },
+        'delay 10',
         {
           id: '1',
           text: 'Indented',
@@ -277,6 +280,7 @@ describe('smoothStream', () => {
             "text": "in ",
             "type": "text-delta",
           },
+          "delay 10",
           {
             "id": "1",
             "text": "London.",
@@ -369,6 +373,7 @@ describe('smoothStream', () => {
             "text": "in ",
             "type": "text-delta",
           },
+          "delay 10",
           {
             "id": "1",
             "text": "London.",
@@ -404,6 +409,159 @@ describe('smoothStream', () => {
       `);
     });
 
+    it('should smooth-drain buffer with delays before tool call to prevent mid-text side effects', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'text-start', id: '1' },
+        { text: "I'll read the file.", type: 'text-delta', id: '1' },
+        {
+          type: 'tool-call',
+          toolCallId: '1',
+          toolName: 'readFile',
+          input: { path: 'hello.txt' },
+        },
+        {
+          type: 'tool-result',
+          toolCallId: '1',
+          toolName: 'readFile',
+          result: 'Sunny',
+          input: { path: 'hello.txt' },
+        },
+        { text: ' Now I can replace it.', type: 'text-delta', id: '1' },
+        { type: 'text-end', id: '1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      // All text chunks before the tool-call must be emitted with delays,
+      // including the final partial word ("file."). This prevents downstream
+      // tool execution side effects (e.g. console.log) from appearing
+      // mid-text in the consumer's output.
+      expect(events).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "type": "text-start",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "I'll ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "read ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "the ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "file.",
+            "type": "text-delta",
+          },
+          {
+            "input": {
+              "path": "hello.txt",
+            },
+            "toolCallId": "1",
+            "toolName": "readFile",
+            "type": "tool-call",
+          },
+          {
+            "input": {
+              "path": "hello.txt",
+            },
+            "result": "Sunny",
+            "toolCallId": "1",
+            "toolName": "readFile",
+            "type": "tool-result",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": " Now ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "I ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "can ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "replace ",
+            "type": "text-delta",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "it.",
+            "type": "text-delta",
+          },
+          {
+            "id": "1",
+            "type": "text-end",
+          },
+        ]
+      `);
+    });
+
+    it('should flush remaining buffer on stream close', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'text-start', id: '1' },
+        { text: 'Hello world', type: 'text-delta', id: '1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      // The flush handler ensures "world" (which has no trailing whitespace)
+      // is emitted when the stream closes even without a text-end event.
+      expect(events).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "type": "text-start",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "Hello ",
+            "type": "text-delta",
+          },
+          {
+            "id": "1",
+            "text": "world",
+            "type": "text-delta",
+          },
+        ]
+      `);
+    });
+
     it(`doesn't return chunks with just spaces`, async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
@@ -427,6 +585,7 @@ describe('smoothStream', () => {
             "id": "1",
             "type": "text-start",
           },
+          "delay 10",
           {
             "id": "1",
             "text": "   foo",
@@ -534,6 +693,7 @@ describe('smoothStream', () => {
             "id": "1",
             "type": "text-start",
           },
+          "delay 10",
           {
             "id": "1",
             "text": "Text without any line breaks",
@@ -576,6 +736,7 @@ describe('smoothStream', () => {
             "text": "Hello_",
             "type": "text-delta",
           },
+          "delay 10",
           {
             "id": "1",
             "text": ", world!",
@@ -731,6 +892,7 @@ describe('smoothStream', () => {
             "text": "llo, w_",
             "type": "text-delta",
           },
+          "delay 10",
           {
             "id": "1",
             "text": "orld!",
@@ -809,6 +971,7 @@ describe('smoothStream', () => {
             "text": "Hello, ",
             "type": "text-delta",
           },
+          "delay 10",
           {
             "id": "1",
             "text": "world!",
@@ -848,6 +1011,7 @@ describe('smoothStream', () => {
             "text": "Hello, ",
             "type": "text-delta",
           },
+          "delay 20",
           {
             "id": "1",
             "text": "world!",
@@ -887,6 +1051,7 @@ describe('smoothStream', () => {
             "text": "Hello, ",
             "type": "text-delta",
           },
+          "delay null",
           {
             "id": "1",
             "text": "world!",
@@ -1009,6 +1174,7 @@ describe('smoothStream', () => {
             "text": "in ",
             "type": "text-delta",
           },
+          "delay 10",
           {
             "id": "2",
             "text": "London.",
@@ -1062,6 +1228,7 @@ describe('smoothStream', () => {
             "text": "me ",
             "type": "reasoning-delta",
           },
+          "delay 10",
           {
             "id": "1",
             "text": "think...",
@@ -1165,6 +1332,7 @@ describe('smoothStream', () => {
             "text": "solve ",
             "type": "reasoning-delta",
           },
+          "delay 10",
           {
             "id": "1",
             "text": "it.",
@@ -1229,6 +1397,7 @@ describe('smoothStream', () => {
             "text": "the ",
             "type": "reasoning-delta",
           },
+          "delay 10",
           {
             "id": "1",
             "text": "weather",
@@ -1351,6 +1520,7 @@ describe('smoothStream', () => {
             "text": "me ",
             "type": "reasoning-delta",
           },
+          "delay 10",
           {
             "id": "2",
             "text": "think",
@@ -1426,6 +1596,7 @@ describe('smoothStream', () => {
             "text": "is ",
             "type": "text-delta",
           },
+          "delay 10",
           {
             "id": "2",
             "text": "42",

--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -125,11 +125,39 @@ export function smoothStream<TOOLS extends ToolSet>({
       }
     }
 
+    // Drain buffer with smooth delays before emitting non-smoothable chunks
+    // (e.g. tool calls). This prevents tool execution side effects from
+    // appearing mid-text in the consumer's output.
+    async function smoothDrainBuffer(
+      controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>,
+    ) {
+      if (buffer.length > 0 && type !== undefined) {
+        let match;
+        while ((match = detectChunk(buffer)) != null) {
+          controller.enqueue({ type, text: match, id });
+          buffer = buffer.slice(match.length);
+          await delay(delayInMs);
+        }
+
+        if (buffer.length > 0) {
+          controller.enqueue({
+            type,
+            text: buffer,
+            id,
+            ...(providerMetadata != null ? { providerMetadata } : {}),
+          });
+          buffer = '';
+          providerMetadata = undefined;
+          await delay(delayInMs);
+        }
+      }
+    }
+
     return new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
       async transform(chunk, controller) {
-        // Handle non-smoothable chunks: flush buffer and pass through
+        // Handle non-smoothable chunks: drain buffer with delays, then pass through
         if (chunk.type !== 'text-delta' && chunk.type !== 'reasoning-delta') {
-          flushBuffer(controller);
+          await smoothDrainBuffer(controller);
           controller.enqueue(chunk);
           return;
         }
@@ -156,6 +184,10 @@ export function smoothStream<TOOLS extends ToolSet>({
 
           await delay(delayInMs);
         }
+      },
+
+      flush(controller) {
+        flushBuffer(controller);
       },
     });
   };


### PR DESCRIPTION
## Summary

Fixes #13199

When `smoothStream` receives non-smoothable chunks (e.g. `tool-call`, `tool-result`, `tool-input-start`), it now **drains the text buffer with proper smooth delays** instead of flushing it instantly. This prevents tool execution side effects (such as `console.log` from tool implementations) from appearing mid-text in the consumer's output.

### The problem

`smoothStream` delays text chunks using `delayInMs` between each word for a typewriter effect. However, when non-text events (like tool calls) arrived, the remaining text buffer was flushed as a **single instant chunk** and the tool event was emitted immediately after. Because tool execution in the agent pipeline is async and non-blocking (fire-and-forget), tools would start running—and their side effects would appear on stdout—before the `textStream` consumer had processed all preceding text.

In agent workflows with tools that have side effects (e.g. `console.log`), this caused output like:
```
I'll { path: 'hello.txt', ... }     ← tool console.log mid-text
help you replace "Sunny" with "Rainy"
```

### The fix

1. **Smooth drain before non-smoothable chunks**: Instead of instant `flushBuffer()`, a new `smoothDrainBuffer()` function emits remaining buffer content word-by-word with the configured delay, maintaining the typewriter timing right up to the tool-call event. This gives the `textStream` consumer time to process all preceding text before the tool-call event reaches the execution pipeline.

2. **Add `flush()` handler**: Ensures any remaining buffered text is emitted when the stream closes (e.g. due to abort or end of generation without a trailing `text-end`).

### Tests

- Updated existing snapshot tests to reflect the new delay pattern before tool calls
- Added test: tool-call with text before and after verifying smooth drain timing
- Added test: flush on stream close without `text-end` event
- All 36 smooth-stream tests pass