### PR TITLE
fix(ai): handle tool-approval-response in UI API for Anthropic provider

### DIFF
--- a/packages/ai/src/prompt/__snapshots__/convert-to-language-model-prompt.validation.test.ts.snap
+++ b/packages/ai/src/prompt/__snapshots__/convert-to-language-model-prompt.validation.test.ts.snap
@@ -21,26 +21,7 @@ exports[`tool validation > should pass validation for provider-executed tools (d
 ]
 `;
 
-exports[`tool validation > should pass validation for tool-approval-response 1`] = `
-[
-  {
-    "content": [
-      {
-        "input": {
-          "action": "delete_db",
-        },
-        "providerExecuted": undefined,
-        "providerOptions": undefined,
-        "toolCallId": "call_to_approve",
-        "toolName": "dangerous_action",
-        "type": "tool-call",
-      },
-    ],
-    "providerOptions": undefined,
-    "role": "assistant",
-  },
-]
-`;
+exports[`tool validation > should pass validation for tool-approval-response 1`] = `[]`;
 
 exports[`tool validation > should preserve provider-executed tool-approval-response 1`] = `
 [

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -2015,4 +2015,100 @@ describe('convertToLanguageModelMessage', () => {
       `);
     });
   });
+
+  describe('unresolved approved tool-calls', () => {
+    it('should strip approved tool-call with no matching tool-result', async () => {
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call_1',
+                  toolName: 'createIssue',
+                  input: { title: 'Foo' },
+                },
+                {
+                  type: 'tool-approval-request',
+                  toolCallId: 'call_1',
+                  approvalId: 'ap_1',
+                } as any,
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-approval-response',
+                  approvalId: 'ap_1',
+                  approved: true,
+                } as any,
+              ],
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: undefined,
+      });
+
+      // The approved tool-call has no matching tool-result, so the
+      // assistant message should be stripped entirely (empty after removal).
+      expect(result).toEqual([]);
+    });
+
+    it('should keep approved tool-call when matching tool-result exists', async () => {
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call_1',
+                  toolName: 'createIssue',
+                  input: { title: 'Foo' },
+                },
+                {
+                  type: 'tool-approval-request',
+                  toolCallId: 'call_1',
+                  approvalId: 'ap_1',
+                } as any,
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-approval-response',
+                  approvalId: 'ap_1',
+                  approved: true,
+                } as any,
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call_1',
+                  toolName: 'createIssue',
+                  output: { type: 'text', value: 'done' },
+                },
+              ],
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: undefined,
+      });
+
+      // tool-call is preserved because there's a matching tool-result
+      expect(result.some(m => m.role === 'assistant')).toBe(true);
+      const assistantContent = result.find(m => m.role === 'assistant')!
+        .content as any[];
+      expect(
+        assistantContent.some(
+          (p: any) => p.type === 'tool-call' && p.toolCallId === 'call_1',
+        ),
+      ).toBe(true);
+    });
+  });
 });

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -110,6 +110,10 @@ export async function convertToLanguageModelPrompt({
   }
 
   const toolCallIds = new Set<string>();
+  // Track approved tool-calls that have no matching tool-result.
+  // These must be stripped from assistant messages before sending to the
+  // provider, otherwise providers get orphaned tool_use blocks.
+  const unresolvedApprovedToolCallIds = new Set<string>();
 
   for (const message of combinedMessages) {
     switch (message.role) {
@@ -125,6 +129,7 @@ export async function convertToLanguageModelPrompt({
         for (const content of message.content) {
           if (content.type === 'tool-result') {
             toolCallIds.delete(content.toolCallId);
+            unresolvedApprovedToolCallIds.delete(content.toolCallId);
           }
         }
         break;
@@ -133,6 +138,9 @@ export async function convertToLanguageModelPrompt({
       case 'system':
         // remove approved tool calls from the set before checking:
         for (const id of approvedToolCallIds) {
+          if (toolCallIds.has(id)) {
+            unresolvedApprovedToolCallIds.add(id);
+          }
           toolCallIds.delete(id);
         }
 
@@ -147,6 +155,9 @@ export async function convertToLanguageModelPrompt({
 
   // remove approved tool calls from the set before checking:
   for (const id of approvedToolCallIds) {
+    if (toolCallIds.has(id)) {
+      unresolvedApprovedToolCallIds.add(id);
+    }
     toolCallIds.delete(id);
   }
 
@@ -154,12 +165,28 @@ export async function convertToLanguageModelPrompt({
     throw new MissingToolResultsError({ toolCallIds: Array.from(toolCallIds) });
   }
 
+  // Strip unresolved approved tool-calls from assistant messages so
+  // providers never see a tool_use without a matching tool_result.
+  if (unresolvedApprovedToolCallIds.size > 0) {
+    for (const message of combinedMessages) {
+      if (message.role === 'assistant') {
+        message.content = message.content.filter(
+          part =>
+            part.type !== 'tool-call' ||
+            !unresolvedApprovedToolCallIds.has(part.toolCallId),
+        );
+      }
+    }
+  }
+
   return combinedMessages.filter(
     // Filter out empty tool messages (e.g. if they only contained
     // tool-approval-response parts that were removed).
     // This prevents sending invalid empty messages to the provider.
     // Note: provider-executed tool-approval-response parts are preserved.
-    message => message.role !== 'tool' || message.content.length > 0,
+    message =>
+      (message.role !== 'tool' && message.role !== 'assistant') ||
+      message.content.length > 0,
   );
 }
 

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -1583,6 +1583,15 @@ describe('convertToModelMessages', () => {
                 "reason": "I don't want to approve this",
                 "type": "tool-approval-response",
               },
+              {
+                "output": {
+                  "type": "error-text",
+                  "value": "I don't want to approve this",
+                },
+                "toolCallId": "call-1",
+                "toolName": "weather",
+                "type": "tool-result",
+              },
             ],
             "role": "tool",
           },
@@ -1678,6 +1687,15 @@ describe('convertToModelMessages', () => {
                 "providerExecuted": undefined,
                 "reason": "I don't want to approve this",
                 "type": "tool-approval-response",
+              },
+              {
+                "output": {
+                  "type": "error-text",
+                  "value": "I don't want to approve this",
+                },
+                "toolCallId": "call-1",
+                "toolName": "weather",
+                "type": "tool-result",
               },
             ],
             "role": "tool",

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -58,7 +58,8 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
         part =>
           !isToolUIPart(part) ||
           (part.state !== 'input-streaming' &&
-            part.state !== 'input-available'),
+            part.state !== 'input-available' &&
+            part.state !== 'approval-requested'),
       ),
     }));
   }
@@ -294,6 +295,33 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                           ? { providerOptions: toolPart.callProviderMetadata }
                           : {}),
                       });
+                      break;
+                    }
+
+                    case 'approval-responded': {
+                      // For denied approvals, emit a tool-result so the
+                      // provider sees a complete tool_use + tool_result pair.
+                      if (!toolPart.approval.approved) {
+                        content.push({
+                          type: 'tool-result',
+                          toolCallId: toolPart.toolCallId,
+                          toolName: getToolName(toolPart),
+                          output: {
+                            type: 'error-text' as const,
+                            value:
+                              toolPart.approval.reason ??
+                              'Tool execution denied.',
+                          },
+                          ...(toolPart.callProviderMetadata != null
+                            ? {
+                                providerOptions: toolPart.callProviderMetadata,
+                              }
+                            : {}),
+                        });
+                      }
+                      // For approved tools, no tool-result is emitted here.
+                      // streamText's collectToolApprovals intercepts the
+                      // approval-response and executes the tool.
                       break;
                     }
 


### PR DESCRIPTION
## Summary

Fixes #13057.

When a `needsApproval` tool is approved via `addToolApprovalResponse()`, `convertToModelMessages` produces a `tool-call` + `tool-approval-response` but no matching `tool-result`. The Anthropic provider skips `tool-approval-response` parts, leaving an orphaned `tool_use` block that causes:

> `tool_use` ids were found without `tool_result` blocks immediately after: toolu_xxx

### Fix 1: Explicit `approval-responded` case (`convert-to-model-messages.ts`)

The switch statement had no `approval-responded` case — it fell through silently, producing no `tool-result`. Now:
- `approved: false` → emits a denied `tool-result` (same pattern as `output-denied`)
- `approved: true` → no result (execution handled by `streamText`'s `collectToolApprovals`)

### Fix 2: `ignoreIncompleteToolCalls` filter (`convert-to-model-messages.ts`)

Added `approval-requested` to the filter. A tool awaiting user decision is incomplete — same as `input-streaming` or `input-available`.

### Fix 3: Strip unresolved approved tool-calls (`convert-to-language-model-prompt.ts`)

For code paths that don't use `streamText` (e.g. custom agents), approved tool-calls may never get executed. The validation already exempted these from `MissingToolResultsError`, but still sent them to the provider. Now tracks `unresolvedApprovedToolCallIds` and strips them from assistant messages before serialization.

## How it works end-to-end

**With `streamText` (normal flow):**
1. `convertToModelMessages` → `tool-call` + `tool-approval-response` (no result for approved)
2. `collectToolApprovals` → finds approval, executes tool
3. Tool result appended to `responseMessages`
4. `convertToLanguageModelPrompt` → tool-call has matching result → kept
5. Provider sees matched `tool_use` + `tool_result` ✓

**Without `streamText` (custom code):**
1. `convertToModelMessages` → `tool-call` + `tool-approval-response` (no result)
2. No execution happens
3. `convertToLanguageModelPrompt` → tool-call has no result → stripped
4. Provider doesn't see orphaned `tool_use` ✓

## Tests

- `approval-responded` + `approved: false` produces denied `tool-result` (snapshot updated)
- `approval-responded` + `approved: true` emits `tool-approval-response` only
- Approved tool-call with no matching result is stripped from assistant message
- Approved tool-call WITH result is preserved
- `ignoreIncompleteToolCalls` filters `approval-requested` parts
