### PR TITLE
feat(provider/xai): support multiple input images for image editing

### DIFF
--- a/.changeset/wicked-nails-prove.md
+++ b/.changeset/wicked-nails-prove.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(provider/xai): support multiple input images for image editing

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -840,6 +840,27 @@ const { images } = await generateImage({
 });
 ```
 
+#### Multi-Image Editing
+
+Combine or reference multiple input images (up to 3) using `<IMAGE_0>`, `<IMAGE_1>`, etc. placeholders in the prompt:
+
+```ts
+import { xai } from '@ai-sdk/xai';
+import { generateImage } from 'ai';
+import { readFileSync } from 'fs';
+
+const cat = readFileSync('./cat.png');
+const dog = readFileSync('./dog.png');
+
+const { images } = await generateImage({
+  model: xai.image('grok-imagine-image'),
+  prompt: {
+    text: 'Combine these two animals into a group photo',
+    images: [cat, dog],
+  },
+});
+```
+
 #### Style Transfer
 
 Apply artistic styles to an image:
@@ -859,7 +880,7 @@ const { images } = await generateImage({
 
 <Note>
   Input images can be provided as `Buffer`, `ArrayBuffer`, `Uint8Array`, or
-  base64-encoded strings. xAI only supports a single input image per request.
+  base64-encoded strings. Up to 3 input images are supported per request.
 </Note>
 
 ### Model-specific options

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -842,7 +842,7 @@ const { images } = await generateImage({
 
 #### Multi-Image Editing
 
-Combine or reference multiple input images (up to 3) using `<IMAGE_0>`, `<IMAGE_1>`, etc. placeholders in the prompt:
+Combine or reference multiple input images (up to 3) in the prompt:
 
 ```ts
 import { xai } from '@ai-sdk/xai';

--- a/examples/ai-e2e-next/app/api/chat/xai-image-edit/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/xai-image-edit/route.ts
@@ -1,0 +1,85 @@
+import { xai } from '@ai-sdk/xai';
+import {
+  convertToModelMessages,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  generateImage,
+  type ModelMessage,
+} from 'ai';
+
+type DataContent = string | Uint8Array | ArrayBuffer | Buffer;
+
+export const maxDuration = 60;
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const modelMessages: ModelMessage[] = await convertToModelMessages(messages);
+
+  const stream = createUIMessageStream({
+    execute: async ({ writer }) => {
+      const lastUserMessage = modelMessages.findLast(m => m.role === 'user');
+      const userContent = lastUserMessage?.content;
+      const userParts =
+        typeof userContent === 'string'
+          ? [{ type: 'text' as const, text: userContent }]
+          : (userContent ?? []);
+
+      const textPart = userParts.find(p => p.type === 'text');
+      const promptText = textPart && 'text' in textPart ? textPart.text : '';
+
+      const lastAssistantImage = findLastAssistantImage(modelMessages);
+
+      const userUploadedImages = userParts
+        .filter(
+          (p): p is Extract<typeof p, { type: 'file' }> => p.type === 'file',
+        )
+        .map(p => p.data)
+        .filter((data): data is DataContent => !(data instanceof URL));
+
+      const allImages = [
+        ...(lastAssistantImage ? [lastAssistantImage] : []),
+        ...userUploadedImages,
+      ];
+
+      const { images } = await generateImage({
+        model: xai.image('grok-imagine-image'),
+        prompt:
+          allImages.length > 0
+            ? { text: promptText, images: allImages }
+            : promptText,
+      });
+
+      const image = images[0];
+      const base64 = Buffer.from(image.uint8Array).toString('base64');
+      const dataUrl = `data:image/png;base64,${base64}`;
+
+      writer.write({
+        type: 'file',
+        url: dataUrl,
+        mediaType: 'image/png',
+      });
+    },
+  });
+
+  return createUIMessageStreamResponse({ stream });
+}
+
+function findLastAssistantImage(
+  messages: ModelMessage[],
+): DataContent | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role !== 'assistant') continue;
+
+    const content = message.content;
+    if (typeof content === 'string') continue;
+
+    for (let j = content.length - 1; j >= 0; j--) {
+      const part = content[j];
+      if (part.type === 'file' && !(part.data instanceof URL)) {
+        return part.data;
+      }
+    }
+  }
+  return undefined;
+}

--- a/examples/ai-e2e-next/app/chat/xai-image-edit/page.tsx
+++ b/examples/ai-e2e-next/app/chat/xai-image-edit/page.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+/* eslint-disable @next/next/no-img-element */
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import { useRef, useState } from 'react';
+
+export default function Page() {
+  const [input, setInput] = useState('');
+  const { messages, sendMessage, status, error, regenerate } = useChat({
+    transport: new DefaultChatTransport({
+      api: '/api/chat/xai-image-edit',
+    }),
+  });
+
+  const [files, setFiles] = useState<FileList | undefined>(undefined);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+      {messages.map(message => (
+        <div key={message.id} className="whitespace-pre-wrap mb-4">
+          <div className="font-bold">
+            {message.role === 'user' ? 'User: ' : 'AI: '}
+          </div>
+          {message.parts.map((part, index) => {
+            if (part.type === 'text') {
+              return <div key={index}>{part.text}</div>;
+            }
+            if (part.type === 'file' && part.mediaType?.startsWith('image/')) {
+              return (
+                <img
+                  key={index}
+                  className="rounded-md mt-2 max-w-full"
+                  src={part.url}
+                  alt="Generated image"
+                />
+              );
+            }
+          })}
+        </div>
+      ))}
+
+      {error && (
+        <div className="mt-4">
+          <div className="text-red-500">An error occurred.</div>
+          <button
+            type="button"
+            className="px-4 py-2 mt-4 text-blue-500 rounded-md border border-blue-500"
+            onClick={() => regenerate()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          sendMessage({ text: input, files });
+          setFiles(undefined);
+          setInput('');
+          if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+          }
+        }}
+        className="fixed bottom-0 w-full max-w-md p-2 flex flex-col gap-2"
+      >
+        <div className="flex flex-row items-end gap-2">
+          {files
+            ? Array.from(files).map(file =>
+                file.type.startsWith('image/') ? (
+                  <div key={file.name}>
+                    <img
+                      className="w-16 rounded-md"
+                      src={URL.createObjectURL(file)}
+                      alt={file.name}
+                    />
+                    <span className="text-xs text-zinc-500">{file.name}</span>
+                  </div>
+                ) : null,
+              )
+            : null}
+        </div>
+        <input
+          type="file"
+          accept="image/*"
+          multiple
+          ref={fileInputRef}
+          onChange={e => {
+            if (e.target.files) {
+              setFiles(e.target.files);
+            }
+          }}
+        />
+        <input
+          value={input}
+          placeholder="Describe what to generate or edit..."
+          onChange={e => setInput(e.target.value)}
+          className="w-full p-2 bg-zinc-100"
+          disabled={status !== 'ready'}
+        />
+      </form>
+    </div>
+  );
+}

--- a/examples/ai-functions/src/generate-image/xai/edit-multi-image.ts
+++ b/examples/ai-functions/src/generate-image/xai/edit-multi-image.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { xai } from '@ai-sdk/xai';
+import { generateImage } from 'ai';
+import { presentImages } from '../../lib/present-image';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const cat = readFileSync('data/comic-cat.png');
+  const dog = readFileSync('data/comic-dog.png');
+
+  console.log('INPUT IMAGES: 2 animal images');
+
+  const prompt =
+    'Combine these two animals into a single image, like a group photo, retaining the style and appearance of the original images';
+  console.log(`PROMPT: ${prompt}`);
+
+  const { images } = await generateImage({
+    model: xai.image('grok-imagine-image'),
+    prompt: {
+      text: prompt,
+      images: [cat, dog],
+    },
+  });
+
+  console.log('OUTPUT IMAGE:');
+  await presentImages(images);
+});

--- a/packages/xai/src/xai-image-model.test.ts
+++ b/packages/xai/src/xai-image-model.test.ts
@@ -56,7 +56,7 @@ describe('XaiImageModel', () => {
       expect(model.provider).toBe('xai.image');
       expect(model.modelId).toBe('grok-2-image-1212');
       expect(model.specificationVersion).toBe('v3');
-      expect(model.maxImagesPerCall).toBe(1);
+      expect(model.maxImagesPerCall).toBe(3);
     });
   });
 
@@ -184,6 +184,96 @@ describe('XaiImageModel', () => {
           url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE=',
           type: 'image_url',
         },
+      });
+    });
+
+    it('should send multiple files as images array', async () => {
+      const model = createModel();
+      const imageData1 = new Uint8Array([137, 80, 78, 71]);
+      const imageData2 = new Uint8Array([255, 216, 255, 224]);
+
+      await model.doGenerate({
+        prompt: 'Combine these images',
+        files: [
+          {
+            type: 'file',
+            data: imageData1,
+            mediaType: 'image/png',
+          },
+          {
+            type: 'file',
+            data: imageData2,
+            mediaType: 'image/jpeg',
+          },
+        ],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(server.calls[0].requestUrl).toBe(
+        'https://api.example.com/images/edits',
+      );
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'grok-2-image-1212',
+        prompt: 'Combine these images',
+        n: 1,
+        response_format: 'url',
+        images: [
+          {
+            url: 'data:image/png;base64,iVBORw==',
+            type: 'image_url',
+          },
+          {
+            url: 'data:image/jpeg;base64,/9j/4A==',
+            type: 'image_url',
+          },
+        ],
+      });
+    });
+
+    it('should send mixed file types as images array', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        prompt: 'Combine these images',
+        files: [
+          {
+            type: 'url',
+            url: 'https://example.com/input.png',
+          },
+          {
+            type: 'file',
+            data: new Uint8Array([137, 80, 78, 71]),
+            mediaType: 'image/png',
+          },
+        ],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'grok-2-image-1212',
+        prompt: 'Combine these images',
+        n: 1,
+        response_format: 'url',
+        images: [
+          {
+            url: 'https://example.com/input.png',
+            type: 'image_url',
+          },
+          {
+            url: 'data:image/png;base64,iVBORw==',
+            type: 'image_url',
+          },
+        ],
       });
     });
 
@@ -419,7 +509,7 @@ describe('XaiImageModel', () => {
         });
       });
 
-      it('should warn when multiple files are provided', async () => {
+      it('should not warn when multiple files are provided', async () => {
         const model = createModel();
         const imageData = new Uint8Array([137, 80, 78, 71]);
 
@@ -445,11 +535,9 @@ describe('XaiImageModel', () => {
           providerOptions: {},
         });
 
-        expect(result.warnings).toContainEqual({
-          type: 'other',
-          message:
-            'xAI only supports a single input image. Additional images are ignored.',
-        });
+        expect(result.warnings).not.toContainEqual(
+          expect.objectContaining({ type: 'other' }),
+        );
       });
     });
 

--- a/packages/xai/src/xai-image-model.ts
+++ b/packages/xai/src/xai-image-model.ts
@@ -27,7 +27,7 @@ interface XaiImageModelConfig {
 
 export class XaiImageModel implements ImageModelV3 {
   readonly specificationVersion = 'v3';
-  readonly maxImagesPerCall = 1;
+  readonly maxImagesPerCall = 3;
 
   get provider(): string {
     return this.config.provider;
@@ -84,19 +84,9 @@ export class XaiImageModel implements ImageModelV3 {
     });
 
     const hasFiles = files != null && files.length > 0;
-    let imageUrl: string | undefined;
-
-    if (hasFiles) {
-      imageUrl = convertImageModelFileToDataUri(files[0]);
-
-      if (files.length > 1) {
-        warnings.push({
-          type: 'other',
-          message:
-            'xAI only supports a single input image. Additional images are ignored.',
-        });
-      }
-    }
+    const imageUrls = hasFiles
+      ? files.map(file => convertImageModelFileToDataUri(file))
+      : [];
 
     const endpoint = hasFiles ? '/images/edits' : '/images/generations';
 
@@ -127,8 +117,10 @@ export class XaiImageModel implements ImageModelV3 {
       body.resolution = xaiOptions.resolution;
     }
 
-    if (imageUrl != null) {
-      body.image = { url: imageUrl, type: 'image_url' };
+    if (imageUrls.length === 1) {
+      body.image = { url: imageUrls[0], type: 'image_url' };
+    } else if (imageUrls.length > 1) {
+      body.images = imageUrls.map(url => ({ url, type: 'image_url' }));
     }
 
     const baseURL = this.config.baseURL ?? 'https://api.x.ai/v1';


### PR DESCRIPTION
## Background

The xAI `/images/edits` endpoint supports an `images` array for multi-reference editing with up to 3 images, but the provider previously only sent the first image and warned that additional images were ignored.

This addresses priority 8 from #12825.

## Summary

When multiple files are provided to the xai image model, they are now sent as an `images` array instead of dropping all but the first. Single-image edits continue to use the existing `image` field for backward compatibility.

- `maxImagesPerCall` changed from `1` to `3`
- Single file → `body.image` (unchanged behavior)
- Multiple files → `body.images` array
- Removed the "additional images are ignored" warning
- Added `ai-functions` example for multi-image editing
- Added `ai-e2e-next` example with iterative image editing including multi-image support
- Updated docs

## Manual Verification

The new examples can be used to verify. See screenshot below:

<img width="483" height="1374" alt="xai-image-edit-multi-turn" src="https://github.com/user-attachments/assets/056c829c-970b-491f-a65c-11beda8ea994" />

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- `mask` support for image edits (also tracked in #12828)

## Related Issues

- #12825
- #12828
