### PR TITLE
fix(provider/google): correctly mark reasoning files as such and fix related multi-turn errors

### DIFF
--- a/.changeset/slimy-coats-attack.md
+++ b/.changeset/slimy-coats-attack.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(provider/google): correctly mark reasoning files as such and fix related multi-turn errors

--- a/examples/ai-e2e-next/app/api/chat/google-gemini-image-thinking/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/google-gemini-image-thinking/route.ts
@@ -1,0 +1,24 @@
+import { google, type GoogleLanguageModelOptions } from '@ai-sdk/google';
+import { streamText, convertToModelMessages } from 'ai';
+
+export const maxDuration = 30;
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = streamText({
+    model: google('gemini-3-pro-image-preview'),
+    messages: await convertToModelMessages(messages),
+    providerOptions: {
+      google: {
+        responseModalities: ['TEXT', 'IMAGE'],
+        thinkingConfig: {
+          includeThoughts: true,
+        },
+      } satisfies GoogleLanguageModelOptions,
+    },
+    includeRawChunks: true,
+  });
+
+  return result.toUIMessageStreamResponse();
+}

--- a/examples/ai-e2e-next/app/chat/google-gemini-image-thinking/page.tsx
+++ b/examples/ai-e2e-next/app/chat/google-gemini-image-thinking/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import ChatInput from '@/components/chat-input';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+
+export default function Chat() {
+  const { status, sendMessage, messages, error, regenerate } = useChat({
+    transport: new DefaultChatTransport({
+      api: '/api/chat/google-gemini-image-thinking',
+    }),
+  });
+
+  return (
+    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+      {messages.map(message => (
+        <div key={message.id} className="whitespace-pre-wrap">
+          {message.role === 'user' ? 'User: ' : 'AI: '}
+          {message.parts.map((part, index) => {
+            if (part.type === 'text') {
+              return <div key={index}>{part.text}</div>;
+            } else if (part.type === 'reasoning') {
+              return (
+                <div
+                  key={index}
+                  className="italic text-gray-500 whitespace-pre-wrap"
+                >
+                  {part.text}
+                </div>
+              );
+            } else if (
+              part.type === 'file' &&
+              part.mediaType.startsWith('image/')
+            ) {
+              return (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img key={index} src={part.url} alt="Generated image" />
+              );
+            }
+          })}
+        </div>
+      ))}
+
+      {error && (
+        <div className="mt-4">
+          <div className="text-red-500">An error occurred.</div>
+          <button
+            type="button"
+            className="px-4 py-2 mt-4 text-blue-500 rounded-md border border-blue-500"
+            onClick={() => regenerate()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <ChatInput status={status} onSubmit={text => sendMessage({ text })} />
+    </div>
+  );
+}

--- a/examples/ai-functions/src/generate-text/google/image-thinking-multi-step.ts
+++ b/examples/ai-functions/src/generate-text/google/image-thinking-multi-step.ts
@@ -1,0 +1,72 @@
+import { google, type GoogleLanguageModelOptions } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import { presentImages } from '../../lib/present-image';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const step1 = await generateText({
+    model: google('gemini-3-pro-image-preview'),
+    prompt: 'Generate a cartoon of a soccer stadium on the moon.',
+    providerOptions: {
+      google: {
+        responseModalities: ['TEXT', 'IMAGE'],
+        thinkingConfig: {
+          includeThoughts: true,
+        },
+      } satisfies GoogleLanguageModelOptions,
+    },
+  });
+
+  console.log('=== STEP 1 ===');
+  console.log('Reasoning:', step1.reasoning ?? '(none)');
+  console.log('Text:', step1.text);
+
+  const fileParts1 = step1.content.filter(part => part.type === 'file');
+  const thoughtFiles1 = fileParts1.filter(
+    p => p.providerMetadata?.google?.thought === true,
+  );
+  const outputFiles1 = fileParts1
+    .filter(p => p.providerMetadata?.google?.thought !== true)
+    .map(p => p.file);
+  console.log(
+    'Reasoning images:',
+    thoughtFiles1.length > 0 ? thoughtFiles1.length : 'none',
+  );
+  await presentImages(outputFiles1);
+
+  const step2 = await generateText({
+    model: google('gemini-3-pro-image-preview'),
+    messages: [
+      ...step1.response.messages,
+      {
+        role: 'user',
+        content: "Change it so that it's on Saturn.",
+      },
+    ],
+    providerOptions: {
+      google: {
+        responseModalities: ['TEXT', 'IMAGE'],
+        thinkingConfig: {
+          includeThoughts: true,
+        },
+      } satisfies GoogleLanguageModelOptions,
+    },
+  });
+
+  console.log('=== STEP 2 ===');
+  console.log('Reasoning:', step2.reasoning ?? '(none)');
+  console.log('Text:', step2.text);
+
+  const fileParts2 = step2.content.filter(part => part.type === 'file');
+  const thoughtFiles2 = fileParts2.filter(
+    p => p.providerMetadata?.google?.thought === true,
+  );
+  const outputFiles2 = fileParts2
+    .filter(p => p.providerMetadata?.google?.thought !== true)
+    .map(p => p.file);
+  console.log(
+    'Reasoning images:',
+    thoughtFiles2.length > 0 ? thoughtFiles2.length : 'none',
+  );
+  await presentImages(outputFiles2);
+});

--- a/examples/ai-functions/src/stream-text/google/image-thinking-multi-step.ts
+++ b/examples/ai-functions/src/stream-text/google/image-thinking-multi-step.ts
@@ -1,0 +1,81 @@
+import { google, type GoogleLanguageModelOptions } from '@ai-sdk/google';
+import { streamText } from 'ai';
+import { presentImages } from '../../lib/present-image';
+import { run } from '../../lib/run';
+
+const providerOptions = {
+  google: {
+    responseModalities: ['TEXT', 'IMAGE'],
+    thinkingConfig: {
+      includeThoughts: true,
+    },
+  } satisfies GoogleLanguageModelOptions,
+};
+
+run(async () => {
+  console.log('=== STEP 1 ===');
+  const step1 = streamText({
+    model: google('gemini-3-pro-image-preview'),
+    prompt: 'Generate a cartoon of a soccer stadium on the moon.',
+    providerOptions,
+  });
+
+  for await (const part of step1.fullStream) {
+    switch (part.type) {
+      case 'reasoning-delta': {
+        process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
+        break;
+      }
+      case 'text-delta': {
+        process.stdout.write(part.text);
+        break;
+      }
+      case 'file': {
+        if (part.providerMetadata?.google?.thought === true) {
+          console.log('Reasoning image:');
+        }
+        if (part.file.mediaType.startsWith('image/')) {
+          await presentImages([part.file]);
+        }
+        break;
+      }
+    }
+  }
+  console.log();
+
+  console.log('=== STEP 2 ===');
+  const step2 = streamText({
+    model: google('gemini-3-pro-image-preview'),
+    messages: [
+      ...(await step1.response).messages,
+      {
+        role: 'user',
+        content: "Change it so that it's on Saturn.",
+      },
+    ],
+    providerOptions,
+  });
+
+  for await (const part of step2.fullStream) {
+    switch (part.type) {
+      case 'reasoning-delta': {
+        process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
+        break;
+      }
+      case 'text-delta': {
+        process.stdout.write(part.text);
+        break;
+      }
+      case 'file': {
+        if (part.providerMetadata?.google?.thought === true) {
+          console.log('Reasoning image:');
+        }
+        if (part.file.mediaType.startsWith('image/')) {
+          await presentImages([part.file]);
+        }
+        break;
+      }
+    }
+  }
+  console.log();
+});

--- a/packages/google/src/convert-to-google-generative-ai-messages.test.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.test.ts
@@ -568,6 +568,55 @@ describe('assistant messages', () => {
     });
   });
 
+  it('should include thought flag on file parts when set in providerOptions', async () => {
+    const result = convertToGoogleGenerativeAIMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'file',
+            data: 'AAECAw==',
+            mediaType: 'image/png',
+            providerOptions: {
+              google: { thought: true, thoughtSignature: 'sig1' },
+            },
+          },
+          {
+            type: 'file',
+            data: 'BAUG',
+            mediaType: 'image/jpeg',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      systemInstruction: undefined,
+      contents: [
+        {
+          role: 'model',
+          parts: [
+            {
+              inlineData: {
+                data: 'AAECAw==',
+                mimeType: 'image/png',
+              },
+              thought: true,
+              thoughtSignature: 'sig1',
+            },
+            {
+              inlineData: {
+                data: 'BAUG',
+                mimeType: 'image/jpeg',
+              },
+              thoughtSignature: undefined,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('should throw error for URL file data in assistant messages', async () => {
     expect(() =>
       convertToGoogleGenerativeAIMessages([

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -125,6 +125,9 @@ export function convertToGoogleGenerativeAIMessages(
                       mimeType: part.mediaType,
                       data: convertToBase64(part.data),
                     },
+                    ...(providerOpts?.thought === true
+                      ? { thought: true }
+                      : {}),
                     thoughtSignature,
                   };
                 }

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -2299,6 +2299,71 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should preserve thought flag on file parts in providerMetadata', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  inlineData: {
+                    mimeType: 'image/png',
+                    data: 'thoughtimagedata',
+                  },
+                  thought: true,
+                  thoughtSignature: 'img_sig1',
+                },
+                {
+                  inlineData: {
+                    mimeType: 'image/jpeg',
+                    data: 'regularimagedata',
+                  },
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+            index: 0,
+            safetyRatings: SAFETY_RATINGS,
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+          totalTokenCount: 30,
+        },
+      },
+    };
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "data": "thoughtimagedata",
+          "mediaType": "image/png",
+          "providerMetadata": {
+            "google": {
+              "thought": true,
+              "thoughtSignature": "img_sig1",
+            },
+          },
+          "type": "file",
+        },
+        {
+          "data": "regularimagedata",
+          "mediaType": "image/jpeg",
+          "providerMetadata": undefined,
+          "type": "file",
+        },
+      ]
+    `);
+  });
+
   it('should pass responseModalities in provider options', async () => {
     prepareJsonFixtureResponse('google-text');
 
@@ -4215,6 +4280,74 @@ describe('doStream', () => {
               "totalTokenCount": 527,
             },
           },
+        },
+      ]
+    `);
+  });
+
+  it('should stream file parts with thought flag in providerMetadata', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: { data: 'thoughtimg', mimeType: 'image/png' },
+                    thought: true,
+                    thoughtSignature: 'stream_sig',
+                  },
+                  {
+                    inlineData: {
+                      data: 'regularimg',
+                      mimeType: 'image/jpeg',
+                    },
+                  },
+                ],
+                role: 'model',
+              },
+              finishReason: 'STOP',
+              index: 0,
+              safetyRatings: SAFETY_RATINGS,
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 10,
+            candidatesTokenCount: 20,
+            totalTokenCount: 30,
+          },
+        })}\n\n`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+
+    const fileEvents = events.filter(e => e.type === 'file');
+    expect(fileEvents).toMatchInlineSnapshot(`
+      [
+        {
+          "data": "thoughtimg",
+          "mediaType": "image/png",
+          "providerMetadata": {
+            "google": {
+              "thought": true,
+              "thoughtSignature": "stream_sig",
+            },
+          },
+          "type": "file",
+        },
+        {
+          "data": "regularimg",
+          "mediaType": "image/jpeg",
+          "providerMetadata": undefined,
+          "type": "file",
         },
       ]
     `);

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -304,17 +304,23 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
             : undefined,
         });
       } else if ('inlineData' in part) {
+        const hasThought = part.thought === true;
+        const hasThoughtSignature = !!part.thoughtSignature;
         content.push({
           type: 'file' as const,
           data: part.inlineData.data,
           mediaType: part.inlineData.mimeType,
-          providerMetadata: part.thoughtSignature
-            ? {
-                [providerOptionsName]: {
-                  thoughtSignature: part.thoughtSignature,
-                },
-              }
-            : undefined,
+          providerMetadata:
+            hasThought || hasThoughtSignature
+              ? {
+                  [providerOptionsName]: {
+                    ...(hasThought ? { thought: true } : {}),
+                    ...(hasThoughtSignature
+                      ? { thoughtSignature: part.thoughtSignature }
+                      : {}),
+                  },
+                }
+              : undefined,
         });
       }
     }
@@ -590,19 +596,24 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                     currentReasoningBlockId = null;
                   }
 
-                  // Process file parts inline to preserve order with text
-                  const thoughtSignatureMetadata = part.thoughtSignature
-                    ? {
-                        [providerOptionsName]: {
-                          thoughtSignature: part.thoughtSignature,
-                        },
-                      }
-                    : undefined;
+                  const hasThought = part.thought === true;
+                  const hasThoughtSignature = !!part.thoughtSignature;
+                  const fileMeta =
+                    hasThought || hasThoughtSignature
+                      ? {
+                          [providerOptionsName]: {
+                            ...(hasThought ? { thought: true } : {}),
+                            ...(hasThoughtSignature
+                              ? { thoughtSignature: part.thoughtSignature }
+                              : {}),
+                          },
+                        }
+                      : undefined;
                   controller.enqueue({
                     type: 'file',
                     mediaType: part.inlineData.mimeType,
                     data: part.inlineData.data,
-                    providerMetadata: thoughtSignatureMetadata,
+                    providerMetadata: fileMeta,
                   });
                 }
               }
@@ -935,6 +946,7 @@ const getContentSchema = () =>
               mimeType: z.string(),
               data: z.string(),
             }),
+            thought: z.boolean().nullish(),
             thoughtSignature: z.string().nullish(),
           }),
           z.object({


### PR DESCRIPTION
## Background

When using Gemini thinking models with image output, the Google API returns `thought: true` on non-text parts (e.g. `inlineData` images). The SDK correctly maps `thought: true` on text parts to `type: 'reasoning'`, but silently strips the flag from file parts. This causes problems in multi-turn exchanges: the thought-image gets sent back as a regular image, causing API errors because they're interpreted as regular images but lack thought signatures (which per Google API are only present on the non-reasoning images).

## Summary

Since we can't introduce a new part type without a spec change, this preserves the `thought` flag on file parts via `providerMetadata`/`providerOptions`.

- Add `thought: z.boolean().nullish()` to the `inlineData` member in the provider-specific response schema
- In both `doGenerate` and `doStream`, propagate `thought: true` into `providerMetadata` on file parts (alongside `thoughtSignature`)
- In `convertToGoogleGenerativeAIMessages`, read `thought` from `providerMetadata` and send it back to the API on file parts

Function examples for `generate-text` and `stream-text` demonstrating multi-step image generation with thinking are added, as well as an E2E example that allows interactive multi-turn with reasoning output that includes the images.

## Manual Verification

Test with the new examples to verify; for the E2E example making two turns would result in an error without the `packages` fixes from this PR.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

A provider-agnostic mechanism to distinguish thought content from output content regardless of part type (as discussed in #12516) would be the ideal long-term solution, removing the need for provider-specific `providerMetadata` checks. However, this will require a spec change and therefore is only an option for v7 - we should explore that further.

## Related Issues

Fixes #11461
