### PR TITLE
feat(provider/openai): add `gpt-5.3-chat-latest`

### DIFF
--- a/.changeset/selfish-fishes-check.md
+++ b/.changeset/selfish-fishes-check.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(provider/openai): add `gpt-5.3-chat-latest`

--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -115,6 +115,9 @@ Here are the capabilities of popular models:
 | [xAI Grok](/providers/ai-sdk-providers/xai)        | `grok-3-mini`                               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)        | `grok-2-vision-1212`                        | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Vercel](/providers/ai-sdk-providers/vercel)       | `v0-1.0-md`                                 | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| [OpenAI](/providers/ai-sdk-providers/openai)       | `gpt-5.4-pro`                               | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| [OpenAI](/providers/ai-sdk-providers/openai)       | `gpt-5.4`                                   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| [OpenAI](/providers/ai-sdk-providers/openai)       | `gpt-5.3-chat-latest`                       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [OpenAI](/providers/ai-sdk-providers/openai)       | `gpt-5.2-pro`                               | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [OpenAI](/providers/ai-sdk-providers/openai)       | `gpt-5.2-chat-latest`                       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [OpenAI](/providers/ai-sdk-providers/openai)       | `gpt-5.2`                                   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -2041,6 +2041,9 @@ The following optional provider options are available for OpenAI completion mode
 
 | Model                 | Image Input         | Audio Input         | Object Generation   | Tool Usage          |
 | --------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gpt-5.4-pro`         | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5.4`             | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5.3-chat-latest` | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gpt-5.2-pro`         | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gpt-5.2-chat-latest` | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gpt-5.2`             | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/packages/openai/src/chat/openai-chat-options.ts
+++ b/packages/openai/src/chat/openai-chat-options.ts
@@ -51,6 +51,7 @@ export type OpenAIChatModelId =
   | 'gpt-5.2-chat-latest'
   | 'gpt-5.2-pro'
   | 'gpt-5.2-pro-2025-12-11'
+  | 'gpt-5.3-chat-latest'
   | 'gpt-5.4'
   | 'gpt-5.4-2026-03-05'
   | 'gpt-5.4-pro'

--- a/packages/openai/src/openai-language-model-capabilities.test.ts
+++ b/packages/openai/src/openai-language-model-capabilities.test.ts
@@ -62,6 +62,7 @@ describe('getOpenAILanguageModelCapabilities', () => {
       ['gpt-5.2', true],
       ['gpt-5.2-pro', true],
       ['gpt-5.2-chat-latest', true],
+      ['gpt-5.3-chat-latest', true],
       ['gpt-5.4', true],
       ['gpt-5.4-pro', true],
       ['gpt-5.4-2026-03-05', true],

--- a/packages/openai/src/openai-language-model-capabilities.ts
+++ b/packages/openai/src/openai-language-model-capabilities.ts
@@ -40,6 +40,7 @@ export function getOpenAILanguageModelCapabilities(
   const supportsNonReasoningParameters =
     modelId.startsWith('gpt-5.1') ||
     modelId.startsWith('gpt-5.2') ||
+    modelId.startsWith('gpt-5.3') ||
     modelId.startsWith('gpt-5.4');
 
   const systemMessageMode = isReasoningModel ? 'developer' : 'system';

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -37,11 +37,12 @@ export const openaiResponsesReasoningModelIds = [
   'gpt-5.2-chat-latest',
   'gpt-5.2-pro',
   'gpt-5.2-codex',
+  'gpt-5.3-chat-latest',
+  'gpt-5.3-codex',
   'gpt-5.4',
   'gpt-5.4-2026-03-05',
   'gpt-5.4-pro',
   'gpt-5.4-pro-2026-03-05',
-  'gpt-5.3-codex',
 ] as const;
 
 export const openaiResponsesModelIds = [
@@ -98,11 +99,12 @@ export type OpenAIResponsesModelId =
   | 'gpt-5.2-pro'
   | 'gpt-5.2-pro-2025-12-11'
   | 'gpt-5.2-codex'
+  | 'gpt-5.3-chat-latest'
+  | 'gpt-5.3-codex'
   | 'gpt-5.4'
   | 'gpt-5.4-2026-03-05'
   | 'gpt-5.4-pro'
   | 'gpt-5.4-pro-2026-03-05'
-  | 'gpt-5.3-codex'
   | 'gpt-5-2025-08-07'
   | 'gpt-5-chat-latest'
   | 'gpt-5-codex'


### PR DESCRIPTION
## Background

Addresses new model ID `gpt-5.3-chat-latest` reported in #13035.

## Summary

- Adds `gpt-5.3-chat-latest` to the OpenAI provider type definitions (chat and responses), capability tables in docs, and the gateway.
- Sorts the previously misplaced `gpt-5.3-codex` entry and adds `gpt-5.3` to `supportsNonReasoningParameters` (was missing — 5.1, 5.2, 5.4 already had it).
- Adds `gpt-5.4` and `gpt-5.4-pro` to doc capability tables where they were missing (oversight from #13115).

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #13035
