### PR TITLE
feat(provider/google): support multimodal embeddings

### DIFF
--- a/.changeset/multimodal-embedding-content.md
+++ b/.changeset/multimodal-embedding-content.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(provider/google): support multimodal content parts in embedding provider options

--- a/packages/google/src/google-generative-ai-embedding-model.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.ts
@@ -74,8 +74,15 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV3 {
       headers,
     );
 
-    // For single embeddings, use the single endpoint (ratelimits, etc.)
-    if (values.length === 1) {
+    // Use single endpoint for single values or multimodal content
+    const hasMultimodalContent =
+      googleOptions?.content && googleOptions.content.length > 0;
+
+    if (values.length === 1 || hasMultimodalContent) {
+      const contentParts = hasMultimodalContent
+        ? googleOptions.content
+        : [{ text: values[0] }];
+
       const {
         responseHeaders,
         value: response,
@@ -86,7 +93,7 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV3 {
         body: {
           model: `models/${this.modelId}`,
           content: {
-            parts: [{ text: values[0] }],
+            parts: contentParts,
           },
           outputDimensionality: googleOptions?.outputDimensionality,
           taskType: googleOptions?.taskType,

--- a/packages/google/src/google-generative-ai-embedding-model.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.ts
@@ -78,7 +78,7 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV3 {
     const hasMultimodalContent =
       googleOptions?.content && googleOptions.content.length > 0;
 
-    if (values.length === 1 || hasMultimodalContent) {
+    if (values.length === 1) {
       const contentParts = hasMultimodalContent
         ? googleOptions.content
         : [{ text: values[0] }];

--- a/packages/google/src/google-generative-ai-embedding-model.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.ts
@@ -74,14 +74,15 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV3 {
       headers,
     );
 
-    // Use single endpoint for single values or multimodal content
-    const hasMultimodalContent =
-      googleOptions?.content && googleOptions.content.length > 0;
+    const multimodalContent = googleOptions?.content ?? [];
 
+    // For single embeddings, use the single endpoint
     if (values.length === 1) {
-      const contentParts = hasMultimodalContent
-        ? googleOptions.content
-        : [{ text: values[0] }];
+      const textPart = values[0] ? [{ text: values[0] }] : [];
+      const parts =
+        multimodalContent.length > 0
+          ? [...textPart, ...multimodalContent]
+          : [{ text: values[0] }];
 
       const {
         responseHeaders,
@@ -93,7 +94,7 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV3 {
         body: {
           model: `models/${this.modelId}`,
           content: {
-            parts: contentParts,
+            parts,
           },
           outputDimensionality: googleOptions?.outputDimensionality,
           taskType: googleOptions?.taskType,
@@ -114,6 +115,8 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV3 {
       };
     }
 
+    // For multiple values, use the batch endpoint
+    // If multimodal content is provided, merge it into each request's parts
     const {
       responseHeaders,
       value: response,
@@ -122,12 +125,21 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV3 {
       url: `${this.config.baseURL}/models/${this.modelId}:batchEmbedContents`,
       headers: mergedHeaders,
       body: {
-        requests: values.map(value => ({
-          model: `models/${this.modelId}`,
-          content: { role: 'user', parts: [{ text: value }] },
-          outputDimensionality: googleOptions?.outputDimensionality,
-          taskType: googleOptions?.taskType,
-        })),
+        requests: values.map(value => {
+          const textPart = value ? [{ text: value }] : [];
+          return {
+            model: `models/${this.modelId}`,
+            content: {
+              role: 'user',
+              parts:
+                multimodalContent.length > 0
+                  ? [...textPart, ...multimodalContent]
+                  : [{ text: value }],
+            },
+            outputDimensionality: googleOptions?.outputDimensionality,
+            taskType: googleOptions?.taskType,
+          };
+        }),
       },
       failedResponseHandler: googleFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(

--- a/packages/google/src/google-generative-ai-embedding-options.ts
+++ b/packages/google/src/google-generative-ai-embedding-options.ts
@@ -9,6 +9,16 @@ export type GoogleGenerativeAIEmbeddingModelId =
   | 'gemini-embedding-001'
   | (string & {});
 
+const googleEmbeddingContentPartSchema = z.union([
+  z.object({ text: z.string() }),
+  z.object({
+    inlineData: z.object({
+      mimeType: z.string(),
+      data: z.string(),
+    }),
+  }),
+]);
+
 export const googleEmbeddingModelOptions = lazySchema(() =>
   zodSchema(
     z.object({
@@ -42,6 +52,13 @@ export const googleEmbeddingModelOptions = lazySchema(() =>
           'CODE_RETRIEVAL_QUERY',
         ])
         .optional(),
+
+      /**
+       * Optional. Multimodal content parts for embedding non-text content
+       * (images, video, PDF, audio). When provided, these parts are used
+       * instead of the text values in the embedding request.
+       */
+      content: z.array(googleEmbeddingContentPartSchema).min(1).optional(),
     }),
   ),
 );


### PR DESCRIPTION
## Summary

- Add optional `content` field to Google embedding provider options accepting `inlineData` parts (images, video, PDF, audio)
- When `providerOptions.google.content` is provided, `doEmbed` sends those parts to the Gemini `embedContent` endpoint instead of text-only `{text: values[0]}`

## Test plan

- [x] All 273 existing tests pass (including 8 embedding tests)
- [x] `pnpm build` succeeds