### PR TITLE
fix(provider/google): correct JSDoc for multimodal embedding content option

### DIFF
--- a/.changeset/fix-embedding-jsdoc.md
+++ b/.changeset/fix-embedding-jsdoc.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(provider/google): correct JSDoc for multimodal embedding content option

--- a/packages/google/src/google-generative-ai-embedding-options.ts
+++ b/packages/google/src/google-generative-ai-embedding-options.ts
@@ -55,8 +55,8 @@ export const googleEmbeddingModelOptions = lazySchema(() =>
 
       /**
        * Optional. Multimodal content parts for embedding non-text content
-       * (images, video, PDF, audio). When provided, these parts are used
-       * instead of the text values in the embedding request.
+       * (images, video, PDF, audio). When provided, these parts are merged
+       * with the text values in the embedding request.
        */
       content: z.array(googleEmbeddingContentPartSchema).min(1).optional(),
     }),


### PR DESCRIPTION
## Summary

- Fix inaccurate JSDoc on the `content` embedding provider option: "instead of" → "merged with"
- The code merges multimodal content parts with text values, it doesn't replace them

## Test plan

- Documentation-only change, no behavior change