### PR TITLE
fix(ui/react): abort active stream when `useChat` id changes

### DIFF
--- a/.changeset/fix-use-chat-id-change-abort.md
+++ b/.changeset/fix-use-chat-id-change-abort.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+fix(react): abort active stream when useChat id changes before recreating Chat instance

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -132,6 +132,10 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       chatRef.current.id !== options.id);
 
   if (shouldRecreateChat) {
+    // If library owns Chat, stop current stream before replacing.
+    if (!('chat' in options)) {
+      chatRef.current.stop();
+    }
     chatRef.current = 'chat' in options ? options.chat : new Chat(chatOptions);
   }
 

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -11,9 +11,11 @@ import {
   screen,
   waitFor,
   render,
+  renderHook
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
+  ChatTransport,
   DefaultChatTransport,
   isStaticToolUIPart,
   TextStreamChatTransport,
@@ -2634,6 +2636,117 @@ describe('use-chat', () => {
       ]);
     });
   });
+
+describe('id change aborts previous stream', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should abort the previous stream when id changes during streaming', async () => {
+    let aborted = false;
+
+    const transport: ChatTransport<UIMessage> = {
+      sendMessages({ abortSignal }) {
+        return Promise.resolve(
+          new ReadableStream<UIMessageChunk>({
+            start(controller) {
+              controller.enqueue({ type: 'text-start', id: '0' });
+              controller.enqueue({
+                type: 'text-delta',
+                id: '0',
+                delta: 'Hello',
+              });
+              abortSignal?.addEventListener('abort', () => {
+                aborted = true;
+                controller.error(new DOMException('Aborted', 'AbortError'));
+              });
+            },
+          }),
+        );
+      },
+      reconnectToStream: () => Promise.resolve(null),
+    };
+
+    const { rerender, result } = renderHook(
+      ({ id }: { id: string }) =>
+        useChat({ id, transport, generateId: mockId() }),
+      { initialProps: { id: 'chat-1' } },
+    );
+
+    act(() => {
+      result.current.sendMessage({ text: 'hi' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('streaming');
+    });
+
+    // Switch chat ID while streaming — should abort the previous stream
+    act(() => {
+      rerender({ id: 'chat-2' });
+    });
+
+    await waitFor(() => {
+      expect(aborted).toBe(true);
+    });
+
+    // New chat starts with empty messages
+    expect(result.current.messages).toStrictEqual([]);
+  });
+
+  it('should NOT abort when an external Chat instance is replaced', async () => {
+    let aborted = false;
+
+    const transport: ChatTransport<UIMessage> = {
+      sendMessages({ abortSignal }) {
+        return Promise.resolve(
+          new ReadableStream<UIMessageChunk>({
+            start(controller) {
+              controller.enqueue({ type: 'text-start', id: '0' });
+              controller.enqueue({
+                type: 'text-delta',
+                id: '0',
+                delta: 'Hello',
+              });
+              abortSignal?.addEventListener('abort', () => {
+                aborted = true;
+                controller.error(new DOMException('Aborted', 'AbortError'));
+              });
+            },
+          }),
+        );
+      },
+      reconnectToStream: () => Promise.resolve(null),
+    };
+
+    const chat1 = new Chat({ id: 'chat-1', transport, generateId: mockId() });
+    const chat2 = new Chat({ id: 'chat-2', transport, generateId: mockId() });
+
+    const { rerender, result } = renderHook(
+      ({ chat }: { chat: Chat<UIMessage> }) => useChat({ chat }),
+      { initialProps: { chat: chat1 } },
+    );
+
+    act(() => {
+      result.current.sendMessage({ text: 'hi' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('streaming');
+    });
+
+    // Replace with an external Chat — useChat should NOT auto-stop here
+    act(() => {
+      rerender({ chat: chat2 });
+    });
+
+    // Give time for any (incorrect) stop to be called
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // chat1's stream should NOT have been aborted by useChat
+    expect(aborted).toBe(false);
+  });
+});
 
   describe('chat instance changes', () => {
     setupTestComponent(


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background
When `useChat({ id })` changes during an active stream (e.g., when switching chat rooms), the stream from the previous Chat instance is never aborted.
Since `shouldRecreateChat` replaces `chatRef.current` with a new Chat instance, the previous instance becomes unreachable, causing its stream to continue receiving responses with no way to call `AbortController.abort()`.

This causes:
- The previous `fetch` request running to completion (network/memory waste)
- Stream processing continuing for a response no one consumes
- Server-side resources held open unnecessarily

Developers can manually call `stop()` before changing `id`, but the `id` prop can change from anywhere — URL params, routing, parent state — so there is no reliable point to call `stop()` before the re-render that triggers recreation. When the library creates and replaces the Chat instance, the library should clean it up.

## Summary
The current implementation calls stop() on the old Chat before replacing it, only when useChat internally owns the instance (id-based recreation). The external { chat } pattern is unaffected — lifecycle remains the caller's responsibility.

> [!note]
Note that this stops the stream during render. If a useEffect cleanup–based approach is preferred (as discussed), I'm happy to refactor in that direction — see [this issue comment](https://github.com/vercel/ai/issues/13304#issuecomment-4913251479) for details.

## Manual Verification
Two tests added in `packages/react/src/use-chat.ui.test.tsx` under `describe('id change aborts previous stream')`:
1. **`should abort the previous stream when id changes during streaming`** — starts streaming with `id: 'chat-1'`, rerenders with `id: 'chat-2'`, asserts the old stream's `abortSignal` fires and new chat has empty messages
2. **`should NOT abort when an external Chat instance is replaced`** — uses the `{ chat }` pattern, replaces with a new Chat instance, asserts the old stream is **not** aborted by `useChat`

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues
fixes: #13304 