### PR TITLE
feat: add typed approval data schema support for tool definitions

### DIFF
--- a/.changeset/tool-approval-data.md
+++ b/.changeset/tool-approval-data.md
@@ -1,0 +1,16 @@
+---
+"@ai-sdk/provider-utils": patch
+"ai": patch
+---
+
+Add support for extra data in tool approval responses with typed schema.
+
+- Added `data` field to `ToolApprovalResponse` type for passing extra data with approval responses
+- Added `approvalData` field to `ToolExecutionOptions` so the approval data is available in tool `execute` functions
+- Added `approvalDataSchema` field to `Tool` type for defining the schema of approval data with full type inference
+- Added `APPROVAL_DATA` type parameter to `Tool`, `ToolExecutionOptions`, and `ToolExecuteFunction` types
+- Added `InferToolApprovalData` helper type for inferring the approval data type from a tool
+- Updated `ChatAddToolApproveResponseFunction` to accept a `data` parameter
+- Updated `UIToolInvocation` approval object to include optional `data` field
+
+This allows users to pass additional information when approving tool calls (e.g., user notes, selected options, confirmation details) that can then be used during tool execution with full type safety.

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -1,20 +1,20 @@
-import { executeTool, ModelMessage } from '@ai-sdk/provider-utils';
-import { Tracer } from '@opentelemetry/api';
-import { notify } from '../util/notify';
-import { assembleOperationName } from '../telemetry/assemble-operation-name';
-import { recordErrorOnSpan, recordSpan } from '../telemetry/record-span';
-import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
-import { TelemetrySettings } from '../telemetry/telemetry-settings';
-import { now } from '../util/now';
+import { executeTool, ModelMessage } from "@ai-sdk/provider-utils";
+import { Tracer } from "@opentelemetry/api";
+import { notify } from "../util/notify";
+import { assembleOperationName } from "../telemetry/assemble-operation-name";
+import { recordErrorOnSpan, recordSpan } from "../telemetry/record-span";
+import { selectTelemetryAttributes } from "../telemetry/select-telemetry-attributes";
+import { TelemetrySettings } from "../telemetry/telemetry-settings";
+import { now } from "../util/now";
 import {
   GenerateTextOnToolCallFinishCallback,
   GenerateTextOnToolCallStartCallback,
-} from './generate-text';
-import { TypedToolCall } from './tool-call';
-import { ToolOutput } from './tool-output';
-import { ToolSet } from './tool-set';
-import { TypedToolResult } from './tool-result';
-import { TypedToolError } from './tool-error';
+} from "./generate-text";
+import { TypedToolCall } from "./tool-call";
+import { ToolOutput } from "./tool-output";
+import { ToolSet } from "./tool-set";
+import { TypedToolResult } from "./tool-result";
+import { TypedToolError } from "./tool-error";
 
 /**
  * Executes a single tool call and manages its lifecycle callbacks.
@@ -35,6 +35,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   messages,
   abortSignal,
   experimental_context,
+  approvalData,
   stepNumber,
   model,
   onPreliminaryToolResult,
@@ -48,6 +49,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   messages: ModelMessage[];
   abortSignal: AbortSignal | undefined;
   experimental_context: unknown;
+  approvalData?: unknown;
   stepNumber?: number;
   model?: { provider: string; modelId: string };
   onPreliminaryToolResult?: (result: TypedToolResult<TOOLS>) => void;
@@ -77,23 +79,23 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   };
 
   return recordSpan({
-    name: 'ai.toolCall',
+    name: "ai.toolCall",
     attributes: selectTelemetryAttributes({
       telemetry,
       attributes: {
         ...assembleOperationName({
-          operationId: 'ai.toolCall',
+          operationId: "ai.toolCall",
           telemetry,
         }),
-        'ai.toolCall.name': toolName,
-        'ai.toolCall.id': toolCallId,
-        'ai.toolCall.args': {
+        "ai.toolCall.name": toolName,
+        "ai.toolCall.id": toolCallId,
+        "ai.toolCall.args": {
           output: () => JSON.stringify(input),
         },
       },
     }),
     tracer,
-    fn: async span => {
+    fn: async (span) => {
       let output: unknown;
 
       await notify({ event: baseCallbackEvent, callbacks: onToolCallStart });
@@ -109,14 +111,15 @@ export async function executeToolCall<TOOLS extends ToolSet>({
             messages,
             abortSignal,
             experimental_context,
+            approvalData,
           },
         });
 
         for await (const part of stream) {
-          if (part.type === 'preliminary') {
+          if (part.type === "preliminary") {
             onPreliminaryToolResult?.({
               ...toolCall,
-              type: 'tool-result',
+              type: "tool-result",
               output: part.output,
               preliminary: true,
             });
@@ -139,12 +142,12 @@ export async function executeToolCall<TOOLS extends ToolSet>({
 
         recordErrorOnSpan(span, error);
         return {
-          type: 'tool-error',
+          type: "tool-error",
           toolCallId,
           toolName,
           input,
           error,
-          dynamic: tool.type === 'dynamic',
+          dynamic: tool.type === "dynamic",
           ...(toolCall.providerMetadata != null
             ? { providerMetadata: toolCall.providerMetadata }
             : {}),
@@ -168,7 +171,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
           await selectTelemetryAttributes({
             telemetry,
             attributes: {
-              'ai.toolCall.result': {
+              "ai.toolCall.result": {
                 output: () => JSON.stringify(output),
               },
             },
@@ -182,12 +185,12 @@ export async function executeToolCall<TOOLS extends ToolSet>({
       }
 
       return {
-        type: 'tool-result',
+        type: "tool-result",
         toolCallId,
         toolName,
         input,
         output,
-        dynamic: tool.type === 'dynamic',
+        dynamic: tool.type === "dynamic",
         ...(toolCall.providerMetadata != null
           ? { providerMetadata: toolCall.providerMetadata }
           : {}),

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -7637,6 +7637,70 @@ describe('generateText', () => {
         );
       });
 
+      it('should pass approval data to the tool execution options', async () => {
+        const executeFunction = vi.fn().mockReturnValue('result1');
+
+        await generateText({
+          model: new MockLanguageModelV3({
+            doGenerate: async () => ({
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: 'Hello, world!' }],
+              finishReason: { unified: 'stop', raw: 'stop' },
+            }),
+          }),
+          tools: {
+            tool1: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: executeFunction,
+              needsApproval: true,
+            }),
+          },
+          stopWhen: stepCountIs(3),
+          _internal: {
+            generateId: mockId({ prefix: 'id' }),
+          },
+          messages: [
+            { role: 'user', content: 'test-input' },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  input: { value: 'value' },
+                  providerExecuted: undefined,
+                  providerOptions: undefined,
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  type: 'tool-call',
+                },
+                {
+                  approvalId: 'id-1',
+                  toolCallId: 'call-1',
+                  type: 'tool-approval-request',
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  approvalId: 'id-1',
+                  type: 'tool-approval-response',
+                  approved: true,
+                  data: { token: 'abc123', confirmedBy: 'user' },
+                },
+              ],
+            },
+          ],
+        });
+
+        expect(executeFunction).toHaveBeenCalledWith(
+          { value: 'value' },
+          expect.objectContaining({
+            approvalData: { token: 'abc123', confirmedBy: 'user' },
+          }),
+        );
+      });
+
       it('should call the model with a prompt that includes the tool result', async () => {
         expect(prompts).toMatchInlineSnapshot(`
           [

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -2,57 +2,57 @@ import {
   LanguageModelV3,
   LanguageModelV3Content,
   LanguageModelV3ToolCall,
-} from '@ai-sdk/provider';
+} from "@ai-sdk/provider";
 import {
   createIdGenerator,
   getErrorMessage,
   IdGenerator,
   ProviderOptions,
   withUserAgentSuffix,
-} from '@ai-sdk/provider-utils';
-import { Tracer } from '@opentelemetry/api';
-import { NoOutputGeneratedError } from '../error';
-import { notify } from '../util/notify';
-import { logWarnings } from '../logger/log-warnings';
-import { resolveLanguageModel } from '../model/resolve-model';
-import { ModelMessage } from '../prompt';
+} from "@ai-sdk/provider-utils";
+import { Tracer } from "@opentelemetry/api";
+import { NoOutputGeneratedError } from "../error";
+import { notify } from "../util/notify";
+import { logWarnings } from "../logger/log-warnings";
+import { resolveLanguageModel } from "../model/resolve-model";
+import { ModelMessage } from "../prompt";
 import {
   CallSettings,
   getStepTimeoutMs,
   getTotalTimeoutMs,
   TimeoutConfiguration,
-} from '../prompt/call-settings';
-import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
-import { createToolModelOutput } from '../prompt/create-tool-model-output';
-import { prepareCallSettings } from '../prompt/prepare-call-settings';
-import { prepareToolsAndToolChoice } from '../prompt/prepare-tools-and-tool-choice';
-import { Prompt } from '../prompt/prompt';
-import { standardizePrompt } from '../prompt/standardize-prompt';
-import { wrapGatewayError } from '../prompt/wrap-gateway-error';
-import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
-import { assembleOperationName } from '../telemetry/assemble-operation-name';
-import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
-import { getTracer } from '../telemetry/get-tracer';
-import { recordSpan } from '../telemetry/record-span';
-import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
-import { stringifyForTelemetry } from '../telemetry/stringify-for-telemetry';
-import { getGlobalTelemetryIntegration } from '../telemetry/get-global-telemetry-integration';
-import { TelemetrySettings } from '../telemetry/telemetry-settings';
+} from "../prompt/call-settings";
+import { convertToLanguageModelPrompt } from "../prompt/convert-to-language-model-prompt";
+import { createToolModelOutput } from "../prompt/create-tool-model-output";
+import { prepareCallSettings } from "../prompt/prepare-call-settings";
+import { prepareToolsAndToolChoice } from "../prompt/prepare-tools-and-tool-choice";
+import { Prompt } from "../prompt/prompt";
+import { standardizePrompt } from "../prompt/standardize-prompt";
+import { wrapGatewayError } from "../prompt/wrap-gateway-error";
+import { ToolCallNotFoundForApprovalError } from "../error/tool-call-not-found-for-approval-error";
+import { assembleOperationName } from "../telemetry/assemble-operation-name";
+import { getBaseTelemetryAttributes } from "../telemetry/get-base-telemetry-attributes";
+import { getTracer } from "../telemetry/get-tracer";
+import { recordSpan } from "../telemetry/record-span";
+import { selectTelemetryAttributes } from "../telemetry/select-telemetry-attributes";
+import { stringifyForTelemetry } from "../telemetry/stringify-for-telemetry";
+import { getGlobalTelemetryIntegration } from "../telemetry/get-global-telemetry-integration";
+import { TelemetrySettings } from "../telemetry/telemetry-settings";
 import {
   LanguageModel,
   LanguageModelRequestMetadata,
   ToolChoice,
-} from '../types';
+} from "../types";
 import {
   addLanguageModelUsage,
   asLanguageModelUsage,
   LanguageModelUsage,
-} from '../types/usage';
-import { asArray } from '../util/as-array';
-import { DownloadFunction } from '../util/download/download-function';
-import { mergeObjects } from '../util/merge-objects';
-import { prepareRetries } from '../util/prepare-retries';
-import { VERSION } from '../version';
+} from "../types/usage";
+import { asArray } from "../util/as-array";
+import { DownloadFunction } from "../util/download/download-function";
+import { mergeObjects } from "../util/merge-objects";
+import { prepareRetries } from "../util/prepare-retries";
+import { VERSION } from "../version";
 import type {
   OnFinishEvent,
   OnStartEvent,
@@ -60,38 +60,38 @@ import type {
   OnStepStartEvent,
   OnToolCallFinishEvent,
   OnToolCallStartEvent,
-} from './callback-events';
-import { collectToolApprovals } from './collect-tool-approvals';
-import { ContentPart } from './content-part';
-import { executeToolCall } from './execute-tool-call';
-import { extractReasoningContent } from './extract-reasoning-content';
-import { extractTextContent } from './extract-text-content';
-import { GenerateTextResult } from './generate-text-result';
-import { DefaultGeneratedFile } from './generated-file';
-import { isApprovalNeeded } from './is-approval-needed';
-import { Output, text } from './output';
-import { InferCompleteOutput } from './output-utils';
-import { parseToolCall } from './parse-tool-call';
-import { PrepareStepFunction } from './prepare-step';
-import { ResponseMessage } from './response-message';
-import { DefaultStepResult, StepResult } from './step-result';
+} from "./callback-events";
+import { collectToolApprovals } from "./collect-tool-approvals";
+import { ContentPart } from "./content-part";
+import { executeToolCall } from "./execute-tool-call";
+import { extractReasoningContent } from "./extract-reasoning-content";
+import { extractTextContent } from "./extract-text-content";
+import { GenerateTextResult } from "./generate-text-result";
+import { DefaultGeneratedFile } from "./generated-file";
+import { isApprovalNeeded } from "./is-approval-needed";
+import { Output, text } from "./output";
+import { InferCompleteOutput } from "./output-utils";
+import { parseToolCall } from "./parse-tool-call";
+import { PrepareStepFunction } from "./prepare-step";
+import { ResponseMessage } from "./response-message";
+import { DefaultStepResult, StepResult } from "./step-result";
 import {
   isStopConditionMet,
   stepCountIs,
   StopCondition,
-} from './stop-condition';
-import { toResponseMessages } from './to-response-messages';
-import { ToolApprovalRequestOutput } from './tool-approval-request-output';
-import { TypedToolCall } from './tool-call';
-import { ToolCallRepairFunction } from './tool-call-repair-function';
-import { TypedToolError } from './tool-error';
-import { ToolOutput } from './tool-output';
-import { TypedToolResult } from './tool-result';
-import { ToolSet } from './tool-set';
-import { mergeAbortSignals } from '../util/merge-abort-signals';
+} from "./stop-condition";
+import { toResponseMessages } from "./to-response-messages";
+import { ToolApprovalRequestOutput } from "./tool-approval-request-output";
+import { TypedToolCall } from "./tool-call";
+import { ToolCallRepairFunction } from "./tool-call-repair-function";
+import { TypedToolError } from "./tool-error";
+import { ToolOutput } from "./tool-output";
+import { TypedToolResult } from "./tool-result";
+import { ToolSet } from "./tool-set";
+import { mergeAbortSignals } from "../util/merge-abort-signals";
 
 const originalGenerateId = createIdGenerator({
-  prefix: 'aitxt',
+  prefix: "aitxt",
   size: 24,
 });
 
@@ -522,26 +522,26 @@ export async function generateText<
 
   try {
     return await recordSpan({
-      name: 'ai.generateText',
+      name: "ai.generateText",
       attributes: selectTelemetryAttributes({
         telemetry,
         attributes: {
           ...assembleOperationName({
-            operationId: 'ai.generateText',
+            operationId: "ai.generateText",
             telemetry,
           }),
           ...baseTelemetryAttributes,
           // model:
-          'ai.model.provider': model.provider,
-          'ai.model.id': model.modelId,
+          "ai.model.provider": model.provider,
+          "ai.model.id": model.modelId,
           // specific settings that only make sense on the outer level:
-          'ai.prompt': {
+          "ai.prompt": {
             input: () => JSON.stringify({ system, prompt, messages }),
           },
         },
       }),
       tracer,
-      fn: async span => {
+      fn: async (span) => {
         const initialMessages = initialPrompt.messages;
         const responseMessages: Array<ResponseMessage> = [];
 
@@ -549,16 +549,24 @@ export async function generateText<
           collectToolApprovals<TOOLS>({ messages: initialMessages });
 
         const localApprovedToolApprovals = approvedToolApprovals.filter(
-          toolApproval => !toolApproval.toolCall.providerExecuted,
+          (toolApproval) => !toolApproval.toolCall.providerExecuted,
         );
 
         if (
           deniedToolApprovals.length > 0 ||
           localApprovedToolApprovals.length > 0
         ) {
+          const approvalDataByToolCallId: Record<string, unknown> = {};
+          for (const approval of localApprovedToolApprovals) {
+            if (approval.approvalResponse.data !== undefined) {
+              approvalDataByToolCallId[approval.toolCall.toolCallId] =
+                approval.approvalResponse.data;
+            }
+          }
+
           const toolOutputs = await executeTools({
             toolCalls: localApprovedToolApprovals.map(
-              toolApproval => toolApproval.toolCall,
+              (toolApproval) => toolApproval.toolCall,
             ),
             tools: tools as TOOLS,
             tracer,
@@ -566,6 +574,7 @@ export async function generateText<
             messages: initialMessages,
             abortSignal: mergedAbortSignal,
             experimental_context,
+            approvalDataByToolCallId,
             stepNumber: 0,
             model: modelInfo,
             onToolCallStart: [
@@ -591,12 +600,12 @@ export async function generateText<
               input: output.input,
               tool: tools?.[output.toolName],
               output:
-                output.type === 'tool-result' ? output.output : output.error,
-              errorMode: output.type === 'tool-error' ? 'text' : 'none',
+                output.type === "tool-result" ? output.output : output.error,
+              errorMode: output.type === "tool-error" ? "text" : "none",
             });
 
             toolContent.push({
-              type: 'tool-result' as const,
+              type: "tool-result" as const,
               toolCallId: output.toolCallId,
               toolName: output.toolName,
               output: modelOutput,
@@ -606,11 +615,11 @@ export async function generateText<
           // add execution denied tool results for all denied tool approvals:
           for (const toolApproval of deniedToolApprovals) {
             toolContent.push({
-              type: 'tool-result' as const,
+              type: "tool-result" as const,
               toolCallId: toolApproval.toolCall.toolCallId,
               toolName: toolApproval.toolCall.toolName,
               output: {
-                type: 'execution-denied' as const,
+                type: "execution-denied" as const,
                 reason: toolApproval.approvalResponse.reason,
                 // For provider-executed tools, include approvalId so provider can correlate
                 ...(toolApproval.toolCall.providerExecuted && {
@@ -625,7 +634,7 @@ export async function generateText<
           }
 
           responseMessages.push({
-            role: 'tool',
+            role: "tool",
             content: toolContent,
           });
         }
@@ -633,11 +642,11 @@ export async function generateText<
         const callSettings = prepareCallSettings(settings);
 
         let currentModelResponse: Awaited<
-          ReturnType<LanguageModelV3['doGenerate']>
+          ReturnType<LanguageModelV3["doGenerate"]>
         > & { response: { id: string; timestamp: Date; modelId: string } };
         let clientToolCalls: Array<TypedToolCall<TOOLS>> = [];
         let clientToolOutputs: Array<ToolOutput<TOOLS>> = [];
-        const steps: GenerateTextResult<TOOLS, OUTPUT>['steps'] = [];
+        const steps: GenerateTextResult<TOOLS, OUTPUT>["steps"] = [];
 
         // Track provider-executed tool calls that support deferred results
         // (e.g., code_execution in programmatic tool calling scenarios).
@@ -739,27 +748,28 @@ export async function generateText<
 
             currentModelResponse = await retry(() =>
               recordSpan({
-                name: 'ai.generateText.doGenerate',
+                name: "ai.generateText.doGenerate",
                 attributes: selectTelemetryAttributes({
                   telemetry,
                   attributes: {
                     ...assembleOperationName({
-                      operationId: 'ai.generateText.doGenerate',
+                      operationId: "ai.generateText.doGenerate",
                       telemetry,
                     }),
                     ...baseTelemetryAttributes,
                     // model:
-                    'ai.model.provider': stepModel.provider,
-                    'ai.model.id': stepModel.modelId,
+                    "ai.model.provider": stepModel.provider,
+                    "ai.model.id": stepModel.modelId,
                     // prompt:
-                    'ai.prompt.messages': {
+                    "ai.prompt.messages": {
                       input: () => stringifyForTelemetry(promptMessages),
                     },
-                    'ai.prompt.tools': {
+                    "ai.prompt.tools": {
                       // convert the language model level tools:
-                      input: () => stepTools?.map(tool => JSON.stringify(tool)),
+                      input: () =>
+                        stepTools?.map((tool) => JSON.stringify(tool)),
                     },
-                    'ai.prompt.toolChoice': {
+                    "ai.prompt.toolChoice": {
                       input: () =>
                         stepToolChoice != null
                           ? JSON.stringify(stepToolChoice)
@@ -767,21 +777,21 @@ export async function generateText<
                     },
 
                     // standardized gen-ai llm span attributes:
-                    'gen_ai.system': stepModel.provider,
-                    'gen_ai.request.model': stepModel.modelId,
-                    'gen_ai.request.frequency_penalty':
+                    "gen_ai.system": stepModel.provider,
+                    "gen_ai.request.model": stepModel.modelId,
+                    "gen_ai.request.frequency_penalty":
                       settings.frequencyPenalty,
-                    'gen_ai.request.max_tokens': settings.maxOutputTokens,
-                    'gen_ai.request.presence_penalty': settings.presencePenalty,
-                    'gen_ai.request.stop_sequences': settings.stopSequences,
-                    'gen_ai.request.temperature':
+                    "gen_ai.request.max_tokens": settings.maxOutputTokens,
+                    "gen_ai.request.presence_penalty": settings.presencePenalty,
+                    "gen_ai.request.stop_sequences": settings.stopSequences,
+                    "gen_ai.request.temperature":
                       settings.temperature ?? undefined,
-                    'gen_ai.request.top_k': settings.topK,
-                    'gen_ai.request.top_p': settings.topP,
+                    "gen_ai.request.top_k": settings.topK,
+                    "gen_ai.request.top_p": settings.topP,
                   },
                 }),
                 tracer,
-                fn: async span => {
+                fn: async (span) => {
                   const result = await stepModel.doGenerate({
                     ...callSettings,
                     tools: stepTools,
@@ -808,14 +818,14 @@ export async function generateText<
                     await selectTelemetryAttributes({
                       telemetry,
                       attributes: {
-                        'ai.response.finishReason': result.finishReason.unified,
-                        'ai.response.text': {
+                        "ai.response.finishReason": result.finishReason.unified,
+                        "ai.response.text": {
                           output: () => extractTextContent(result.content),
                         },
-                        'ai.response.reasoning': {
+                        "ai.response.reasoning": {
                           output: () => extractReasoningContent(result.content),
                         },
-                        'ai.response.toolCalls': {
+                        "ai.response.toolCalls": {
                           output: () => {
                             const toolCalls = asToolCalls(result.content);
                             return toolCalls == null
@@ -823,42 +833,42 @@ export async function generateText<
                               : JSON.stringify(toolCalls);
                           },
                         },
-                        'ai.response.id': responseData.id,
-                        'ai.response.model': responseData.modelId,
-                        'ai.response.timestamp':
+                        "ai.response.id": responseData.id,
+                        "ai.response.model": responseData.modelId,
+                        "ai.response.timestamp":
                           responseData.timestamp.toISOString(),
-                        'ai.response.providerMetadata': JSON.stringify(
+                        "ai.response.providerMetadata": JSON.stringify(
                           result.providerMetadata,
                         ),
 
-                        'ai.usage.inputTokens': result.usage.inputTokens.total,
-                        'ai.usage.inputTokenDetails.noCacheTokens':
+                        "ai.usage.inputTokens": result.usage.inputTokens.total,
+                        "ai.usage.inputTokenDetails.noCacheTokens":
                           result.usage.inputTokens.noCache,
-                        'ai.usage.inputTokenDetails.cacheReadTokens':
+                        "ai.usage.inputTokenDetails.cacheReadTokens":
                           result.usage.inputTokens.cacheRead,
-                        'ai.usage.inputTokenDetails.cacheWriteTokens':
+                        "ai.usage.inputTokenDetails.cacheWriteTokens":
                           result.usage.inputTokens.cacheWrite,
-                        'ai.usage.outputTokens':
+                        "ai.usage.outputTokens":
                           result.usage.outputTokens.total,
-                        'ai.usage.outputTokenDetails.textTokens':
+                        "ai.usage.outputTokenDetails.textTokens":
                           result.usage.outputTokens.text,
-                        'ai.usage.outputTokenDetails.reasoningTokens':
+                        "ai.usage.outputTokenDetails.reasoningTokens":
                           result.usage.outputTokens.reasoning,
-                        'ai.usage.totalTokens': usage.totalTokens,
-                        'ai.usage.reasoningTokens':
+                        "ai.usage.totalTokens": usage.totalTokens,
+                        "ai.usage.reasoningTokens":
                           result.usage.outputTokens.reasoning,
-                        'ai.usage.cachedInputTokens':
+                        "ai.usage.cachedInputTokens":
                           result.usage.inputTokens.cacheRead,
 
                         // standardized gen-ai llm span attributes:
-                        'gen_ai.response.finish_reasons': [
+                        "gen_ai.response.finish_reasons": [
                           result.finishReason.unified,
                         ],
-                        'gen_ai.response.id': responseData.id,
-                        'gen_ai.response.model': responseData.modelId,
-                        'gen_ai.usage.input_tokens':
+                        "gen_ai.response.id": responseData.id,
+                        "gen_ai.response.model": responseData.modelId,
+                        "gen_ai.usage.input_tokens":
                           result.usage.inputTokens.total,
-                        'gen_ai.usage.output_tokens':
+                        "gen_ai.usage.output_tokens":
                           result.usage.outputTokens.total,
                       },
                     }),
@@ -874,9 +884,9 @@ export async function generateText<
               currentModelResponse.content
                 .filter(
                   (part): part is LanguageModelV3ToolCall =>
-                    part.type === 'tool-call',
+                    part.type === "tool-call",
                 )
-                .map(toolCall =>
+                .map((toolCall) =>
                   parseToolCall({
                     toolCall,
                     tools,
@@ -924,7 +934,7 @@ export async function generateText<
                 })
               ) {
                 toolApprovalRequests[toolCall.toolCallId] = {
-                  type: 'tool-approval-request',
+                  type: "tool-approval-request",
                   approvalId: generateId(),
                   toolCall,
                 };
@@ -934,14 +944,14 @@ export async function generateText<
             // insert error tool outputs for invalid tool calls:
             // TODO AI SDK 6: invalid inputs should not require output parts
             const invalidToolCalls = stepToolCalls.filter(
-              toolCall => toolCall.invalid && toolCall.dynamic,
+              (toolCall) => toolCall.invalid && toolCall.dynamic,
             );
 
             clientToolOutputs = [];
 
             for (const toolCall of invalidToolCalls) {
               clientToolOutputs.push({
-                type: 'tool-error',
+                type: "tool-error",
                 toolCallId: toolCall.toolCallId,
                 toolName: toolCall.toolName,
                 input: toolCall.input,
@@ -952,14 +962,14 @@ export async function generateText<
 
             // execute client tool calls:
             clientToolCalls = stepToolCalls.filter(
-              toolCall => !toolCall.providerExecuted,
+              (toolCall) => !toolCall.providerExecuted,
             );
 
             if (tools != null) {
               clientToolOutputs.push(
                 ...(await executeTools({
                   toolCalls: clientToolCalls.filter(
-                    toolCall =>
+                    (toolCall) =>
                       !toolCall.invalid &&
                       toolApprovalRequests[toolCall.toolCallId] == null,
                   ),
@@ -992,11 +1002,11 @@ export async function generateText<
             for (const toolCall of stepToolCalls) {
               if (!toolCall.providerExecuted) continue;
               const tool = tools?.[toolCall.toolName];
-              if (tool?.type === 'provider' && tool.supportsDeferredResults) {
+              if (tool?.type === "provider" && tool.supportsDeferredResults) {
                 // Check if this tool call already has a result in the current response
                 const hasResultInResponse = currentModelResponse.content.some(
-                  part =>
-                    part.type === 'tool-result' &&
+                  (part) =>
+                    part.type === "tool-result" &&
                     part.toolCallId === toolCall.toolCallId,
                 );
                 if (!hasResultInResponse) {
@@ -1009,7 +1019,7 @@ export async function generateText<
 
             // Mark deferred tool calls as resolved when we receive their results
             for (const part of currentModelResponse.content) {
-              if (part.type === 'tool-result') {
+              if (part.type === "tool-result") {
                 pendingDeferredToolCalls.delete(part.toolCallId);
               }
             }
@@ -1103,16 +1113,16 @@ export async function generateText<
           await selectTelemetryAttributes({
             telemetry,
             attributes: {
-              'ai.response.finishReason':
+              "ai.response.finishReason":
                 currentModelResponse.finishReason.unified,
-              'ai.response.text': {
+              "ai.response.text": {
                 output: () => extractTextContent(currentModelResponse.content),
               },
-              'ai.response.reasoning': {
+              "ai.response.reasoning": {
                 output: () =>
                   extractReasoningContent(currentModelResponse.content),
               },
-              'ai.response.toolCalls': {
+              "ai.response.toolCalls": {
                 output: () => {
                   const toolCalls = asToolCalls(currentModelResponse.content);
                   return toolCalls == null
@@ -1120,7 +1130,7 @@ export async function generateText<
                     : JSON.stringify(toolCalls);
                 },
               },
-              'ai.response.providerMetadata': JSON.stringify(
+              "ai.response.providerMetadata": JSON.stringify(
                 currentModelResponse.providerMetadata,
               ),
             },
@@ -1146,22 +1156,22 @@ export async function generateText<
           await selectTelemetryAttributes({
             telemetry,
             attributes: {
-              'ai.usage.inputTokens': totalUsage.inputTokens,
-              'ai.usage.inputTokenDetails.noCacheTokens':
+              "ai.usage.inputTokens": totalUsage.inputTokens,
+              "ai.usage.inputTokenDetails.noCacheTokens":
                 totalUsage.inputTokenDetails?.noCacheTokens,
-              'ai.usage.inputTokenDetails.cacheReadTokens':
+              "ai.usage.inputTokenDetails.cacheReadTokens":
                 totalUsage.inputTokenDetails?.cacheReadTokens,
-              'ai.usage.inputTokenDetails.cacheWriteTokens':
+              "ai.usage.inputTokenDetails.cacheWriteTokens":
                 totalUsage.inputTokenDetails?.cacheWriteTokens,
-              'ai.usage.outputTokens': totalUsage.outputTokens,
-              'ai.usage.outputTokenDetails.textTokens':
+              "ai.usage.outputTokens": totalUsage.outputTokens,
+              "ai.usage.outputTokenDetails.textTokens":
                 totalUsage.outputTokenDetails?.textTokens,
-              'ai.usage.outputTokenDetails.reasoningTokens':
+              "ai.usage.outputTokenDetails.reasoningTokens":
                 totalUsage.outputTokenDetails?.reasoningTokens,
-              'ai.usage.totalTokens': totalUsage.totalTokens,
-              'ai.usage.reasoningTokens':
+              "ai.usage.totalTokens": totalUsage.totalTokens,
+              "ai.usage.reasoningTokens":
                 totalUsage.outputTokenDetails?.reasoningTokens,
-              'ai.usage.cachedInputTokens':
+              "ai.usage.cachedInputTokens":
                 totalUsage.inputTokenDetails?.cacheReadTokens,
             },
           }),
@@ -1206,7 +1216,7 @@ export async function generateText<
 
         // parse output only if the last step was finished with "stop":
         let resolvedOutput;
-        if (lastStep.finishReason === 'stop') {
+        if (lastStep.finishReason === "stop") {
           const outputSpecification = output ?? text();
           resolvedOutput = await outputSpecification.parseCompleteOutput(
             { text: lastStep.text },
@@ -1238,6 +1248,7 @@ async function executeTools<TOOLS extends ToolSet>({
   messages,
   abortSignal,
   experimental_context,
+  approvalDataByToolCallId,
   stepNumber,
   model,
   onToolCallStart,
@@ -1250,6 +1261,7 @@ async function executeTools<TOOLS extends ToolSet>({
   messages: ModelMessage[];
   abortSignal: AbortSignal | undefined;
   experimental_context: unknown;
+  approvalDataByToolCallId?: Record<string, unknown>;
   stepNumber: number;
   model: { provider: string; modelId: string };
   onToolCallStart:
@@ -1262,7 +1274,7 @@ async function executeTools<TOOLS extends ToolSet>({
     | undefined;
 }): Promise<Array<ToolOutput<TOOLS>>> {
   const toolOutputs = await Promise.all(
-    toolCalls.map(async toolCall =>
+    toolCalls.map(async (toolCall) =>
       executeToolCall({
         toolCall,
         tools,
@@ -1271,6 +1283,7 @@ async function executeTools<TOOLS extends ToolSet>({
         messages,
         abortSignal,
         experimental_context,
+        approvalData: approvalDataByToolCallId?.[toolCall.toolCallId],
         stepNumber,
         model,
         onToolCallStart,
@@ -1284,16 +1297,15 @@ async function executeTools<TOOLS extends ToolSet>({
   );
 }
 
-class DefaultGenerateTextResult<
-  TOOLS extends ToolSet,
-  OUTPUT extends Output,
-> implements GenerateTextResult<TOOLS, OUTPUT> {
-  readonly steps: GenerateTextResult<TOOLS, OUTPUT>['steps'];
+class DefaultGenerateTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
+  implements GenerateTextResult<TOOLS, OUTPUT>
+{
+  readonly steps: GenerateTextResult<TOOLS, OUTPUT>["steps"];
   readonly totalUsage: LanguageModelUsage;
   private readonly _output: InferCompleteOutput<OUTPUT> | undefined;
 
   constructor(options: {
-    steps: GenerateTextResult<TOOLS, OUTPUT>['steps'];
+    steps: GenerateTextResult<TOOLS, OUTPUT>["steps"];
     output: InferCompleteOutput<OUTPUT> | undefined;
     totalUsage: LanguageModelUsage;
   }) {
@@ -1397,14 +1409,14 @@ class DefaultGenerateTextResult<
 
 function asToolCalls(content: Array<LanguageModelV3Content>) {
   const parts = content.filter(
-    (part): part is LanguageModelV3ToolCall => part.type === 'tool-call',
+    (part): part is LanguageModelV3ToolCall => part.type === "tool-call",
   );
 
   if (parts.length === 0) {
     return undefined;
   }
 
-  return parts.map(toolCall => ({
+  return parts.map((toolCall) => ({
     toolCallId: toolCall.toolCallId,
     toolName: toolCall.toolName,
     input: toolCall.input,
@@ -1428,15 +1440,15 @@ function asContent<TOOLS extends ToolSet>({
 
   for (const part of content) {
     switch (part.type) {
-      case 'text':
-      case 'reasoning':
-      case 'source':
+      case "text":
+      case "reasoning":
+      case "source":
         contentParts.push(part);
         break;
 
-      case 'file': {
+      case "file": {
         contentParts.push({
-          type: 'file' as const,
+          type: "file" as const,
           file: new DefaultGeneratedFile(part),
           ...(part.providerMetadata != null
             ? { providerMetadata: part.providerMetadata }
@@ -1445,16 +1457,18 @@ function asContent<TOOLS extends ToolSet>({
         break;
       }
 
-      case 'tool-call': {
+      case "tool-call": {
         contentParts.push(
-          toolCalls.find(toolCall => toolCall.toolCallId === part.toolCallId)!,
+          toolCalls.find(
+            (toolCall) => toolCall.toolCallId === part.toolCallId,
+          )!,
         );
         break;
       }
 
-      case 'tool-result': {
+      case "tool-result": {
         const toolCall = toolCalls.find(
-          toolCall => toolCall.toolCallId === part.toolCallId,
+          (toolCall) => toolCall.toolCallId === part.toolCallId,
         );
 
         // Handle deferred results for provider-executed tools (e.g., programmatic tool calling).
@@ -1464,7 +1478,7 @@ function asContent<TOOLS extends ToolSet>({
         if (toolCall == null) {
           const tool = tools?.[part.toolName];
           const supportsDeferredResults =
-            tool?.type === 'provider' && tool.supportsDeferredResults;
+            tool?.type === "provider" && tool.supportsDeferredResults;
 
           if (!supportsDeferredResults) {
             throw new Error(`Tool call ${part.toolCallId} not found.`);
@@ -1473,7 +1487,7 @@ function asContent<TOOLS extends ToolSet>({
           // Create tool result without tool call input (deferred result)
           if (part.isError) {
             contentParts.push({
-              type: 'tool-error' as const,
+              type: "tool-error" as const,
               toolCallId: part.toolCallId,
               toolName: part.toolName as keyof TOOLS & string,
               input: undefined,
@@ -1486,7 +1500,7 @@ function asContent<TOOLS extends ToolSet>({
             } as TypedToolError<TOOLS>);
           } else {
             contentParts.push({
-              type: 'tool-result' as const,
+              type: "tool-result" as const,
               toolCallId: part.toolCallId,
               toolName: part.toolName as keyof TOOLS & string,
               input: undefined,
@@ -1503,7 +1517,7 @@ function asContent<TOOLS extends ToolSet>({
 
         if (part.isError) {
           contentParts.push({
-            type: 'tool-error' as const,
+            type: "tool-error" as const,
             toolCallId: part.toolCallId,
             toolName: part.toolName as keyof TOOLS & string,
             input: toolCall.input,
@@ -1516,7 +1530,7 @@ function asContent<TOOLS extends ToolSet>({
           } as TypedToolError<TOOLS>);
         } else {
           contentParts.push({
-            type: 'tool-result' as const,
+            type: "tool-result" as const,
             toolCallId: part.toolCallId,
             toolName: part.toolName as keyof TOOLS & string,
             input: toolCall.input,
@@ -1531,9 +1545,9 @@ function asContent<TOOLS extends ToolSet>({
         break;
       }
 
-      case 'tool-approval-request': {
+      case "tool-approval-request": {
         const toolCall = toolCalls.find(
-          toolCall => toolCall.toolCallId === part.toolCallId,
+          (toolCall) => toolCall.toolCallId === part.toolCallId,
         );
 
         if (toolCall == null) {
@@ -1544,7 +1558,7 @@ function asContent<TOOLS extends ToolSet>({
         }
 
         contentParts.push({
-          type: 'tool-approval-request' as const,
+          type: "tool-approval-request" as const,
           approvalId: part.approvalId,
           toolCall,
         });

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -21103,6 +21103,84 @@ describe('streamText', () => {
         );
       });
 
+      it('should pass approval data to the tool execution options', async () => {
+        const executeFunction = vi.fn().mockReturnValue('result1');
+
+        const result = streamText({
+          model: new MockLanguageModelV3({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                { type: 'text-start', id: '1' },
+                {
+                  type: 'text-delta',
+                  id: '1',
+                  delta: 'Hello, world!',
+                },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            }),
+          }),
+          tools: {
+            tool1: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: executeFunction,
+              needsApproval: true,
+            }),
+          },
+          stopWhen: stepCountIs(3),
+          _internal: {
+            generateId: mockId({ prefix: 'id' }),
+          },
+          messages: [
+            { role: 'user', content: 'test-input' },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  input: { value: 'value' },
+                  providerExecuted: undefined,
+                  providerOptions: undefined,
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  type: 'tool-call',
+                },
+                {
+                  approvalId: 'id-1',
+                  toolCallId: 'call-1',
+                  type: 'tool-approval-request',
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  approvalId: 'id-1',
+                  type: 'tool-approval-response',
+                  approved: true,
+                  data: { token: 'abc123', confirmedBy: 'user' },
+                },
+              ],
+            },
+          ],
+        });
+
+        await result.consumeStream();
+
+        expect(executeFunction).toHaveBeenCalledWith(
+          { value: 'value' },
+          expect.objectContaining({
+            approvalData: { token: 'abc123', confirmedBy: 'user' },
+          }),
+        );
+      });
+
       it('should call the model with a prompt that includes the tool result', async () => {
         expect(prompts).toMatchInlineSnapshot(`
           [

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -3,7 +3,7 @@ import {
   LanguageModelV3,
   SharedV3Warning,
   UnsupportedFunctionalityError,
-} from '@ai-sdk/provider';
+} from "@ai-sdk/provider";
 import {
   createIdGenerator,
   DelayedPromise,
@@ -11,74 +11,74 @@ import {
   isAbortError,
   ProviderOptions,
   ToolContent,
-} from '@ai-sdk/provider-utils';
-import { Span } from '@opentelemetry/api';
-import { ServerResponse } from 'node:http';
-import { NoOutputGeneratedError } from '../error';
-import { notify } from '../util/notify';
-import { logWarnings } from '../logger/log-warnings';
-import { resolveLanguageModel } from '../model/resolve-model';
+} from "@ai-sdk/provider-utils";
+import { Span } from "@opentelemetry/api";
+import { ServerResponse } from "node:http";
+import { NoOutputGeneratedError } from "../error";
+import { notify } from "../util/notify";
+import { logWarnings } from "../logger/log-warnings";
+import { resolveLanguageModel } from "../model/resolve-model";
 import {
   CallSettings,
   getChunkTimeoutMs,
   getStepTimeoutMs,
   getTotalTimeoutMs,
   TimeoutConfiguration,
-} from '../prompt/call-settings';
-import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
-import { createToolModelOutput } from '../prompt/create-tool-model-output';
-import { prepareCallSettings } from '../prompt/prepare-call-settings';
-import { prepareToolsAndToolChoice } from '../prompt/prepare-tools-and-tool-choice';
-import { Prompt } from '../prompt/prompt';
-import { standardizePrompt } from '../prompt/standardize-prompt';
-import { wrapGatewayError } from '../prompt/wrap-gateway-error';
-import { assembleOperationName } from '../telemetry/assemble-operation-name';
-import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
-import { getTracer } from '../telemetry/get-tracer';
-import { recordSpan } from '../telemetry/record-span';
-import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
-import { stringifyForTelemetry } from '../telemetry/stringify-for-telemetry';
-import { getGlobalTelemetryIntegration } from '../telemetry/get-global-telemetry-integration';
-import { TelemetrySettings } from '../telemetry/telemetry-settings';
-import { createTextStreamResponse } from '../text-stream/create-text-stream-response';
-import { pipeTextStreamToResponse } from '../text-stream/pipe-text-stream-to-response';
-import { LanguageModelRequestMetadata } from '../types';
+} from "../prompt/call-settings";
+import { convertToLanguageModelPrompt } from "../prompt/convert-to-language-model-prompt";
+import { createToolModelOutput } from "../prompt/create-tool-model-output";
+import { prepareCallSettings } from "../prompt/prepare-call-settings";
+import { prepareToolsAndToolChoice } from "../prompt/prepare-tools-and-tool-choice";
+import { Prompt } from "../prompt/prompt";
+import { standardizePrompt } from "../prompt/standardize-prompt";
+import { wrapGatewayError } from "../prompt/wrap-gateway-error";
+import { assembleOperationName } from "../telemetry/assemble-operation-name";
+import { getBaseTelemetryAttributes } from "../telemetry/get-base-telemetry-attributes";
+import { getTracer } from "../telemetry/get-tracer";
+import { recordSpan } from "../telemetry/record-span";
+import { selectTelemetryAttributes } from "../telemetry/select-telemetry-attributes";
+import { stringifyForTelemetry } from "../telemetry/stringify-for-telemetry";
+import { getGlobalTelemetryIntegration } from "../telemetry/get-global-telemetry-integration";
+import { TelemetrySettings } from "../telemetry/telemetry-settings";
+import { createTextStreamResponse } from "../text-stream/create-text-stream-response";
+import { pipeTextStreamToResponse } from "../text-stream/pipe-text-stream-to-response";
+import { LanguageModelRequestMetadata } from "../types";
 import {
   CallWarning,
   FinishReason,
   LanguageModel,
   ToolChoice,
-} from '../types/language-model';
-import { ProviderMetadata } from '../types/provider-metadata';
+} from "../types/language-model";
+import { ProviderMetadata } from "../types/provider-metadata";
 import {
   addLanguageModelUsage,
   createNullLanguageModelUsage,
   LanguageModelUsage,
-} from '../types/usage';
-import { UIMessage } from '../ui';
-import { createUIMessageStreamResponse } from '../ui-message-stream/create-ui-message-stream-response';
-import { getResponseUIMessageId } from '../ui-message-stream/get-response-ui-message-id';
-import { handleUIMessageStreamFinish } from '../ui-message-stream/handle-ui-message-stream-finish';
-import { pipeUIMessageStreamToResponse } from '../ui-message-stream/pipe-ui-message-stream-to-response';
+} from "../types/usage";
+import { UIMessage } from "../ui";
+import { createUIMessageStreamResponse } from "../ui-message-stream/create-ui-message-stream-response";
+import { getResponseUIMessageId } from "../ui-message-stream/get-response-ui-message-id";
+import { handleUIMessageStreamFinish } from "../ui-message-stream/handle-ui-message-stream-finish";
+import { pipeUIMessageStreamToResponse } from "../ui-message-stream/pipe-ui-message-stream-to-response";
 import {
   InferUIMessageChunk,
   UIMessageChunk,
-} from '../ui-message-stream/ui-message-chunks';
-import { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-stream-response-init';
-import { InferUIMessageData, InferUIMessageMetadata } from '../ui/ui-messages';
-import { asArray } from '../util/as-array';
+} from "../ui-message-stream/ui-message-chunks";
+import { UIMessageStreamResponseInit } from "../ui-message-stream/ui-message-stream-response-init";
+import { InferUIMessageData, InferUIMessageMetadata } from "../ui/ui-messages";
+import { asArray } from "../util/as-array";
 import {
   AsyncIterableStream,
   createAsyncIterableStream,
-} from '../util/async-iterable-stream';
-import { consumeStream } from '../util/consume-stream';
-import { createStitchableStream } from '../util/create-stitchable-stream';
-import { DownloadFunction } from '../util/download/download-function';
-import { mergeAbortSignals } from '../util/merge-abort-signals';
-import { mergeObjects } from '../util/merge-objects';
-import { now as originalNow } from '../util/now';
-import { prepareRetries } from '../util/prepare-retries';
-import { collectToolApprovals } from './collect-tool-approvals';
+} from "../util/async-iterable-stream";
+import { consumeStream } from "../util/consume-stream";
+import { createStitchableStream } from "../util/create-stitchable-stream";
+import { DownloadFunction } from "../util/download/download-function";
+import { mergeAbortSignals } from "../util/merge-abort-signals";
+import { mergeObjects } from "../util/merge-objects";
+import { now as originalNow } from "../util/now";
+import { prepareRetries } from "../util/prepare-retries";
+import { collectToolApprovals } from "./collect-tool-approvals";
 import type {
   OnFinishEvent,
   OnStartEvent,
@@ -86,42 +86,42 @@ import type {
   OnStepStartEvent,
   OnToolCallFinishEvent,
   OnToolCallStartEvent,
-} from './callback-events';
-import { ContentPart } from './content-part';
-import { executeToolCall } from './execute-tool-call';
-import { Output, text } from './output';
+} from "./callback-events";
+import { ContentPart } from "./content-part";
+import { executeToolCall } from "./execute-tool-call";
+import { Output, text } from "./output";
 import {
   InferCompleteOutput,
   InferElementOutput,
   InferPartialOutput,
-} from './output-utils';
-import { PrepareStepFunction } from './prepare-step';
-import { ResponseMessage } from './response-message';
+} from "./output-utils";
+import { PrepareStepFunction } from "./prepare-step";
+import { ResponseMessage } from "./response-message";
 import {
   runToolsTransformation,
   SingleRequestTextStreamPart,
-} from './run-tools-transformation';
-import { DefaultStepResult, StepResult } from './step-result';
+} from "./run-tools-transformation";
+import { DefaultStepResult, StepResult } from "./step-result";
 import {
   isStopConditionMet,
   stepCountIs,
   StopCondition,
-} from './stop-condition';
+} from "./stop-condition";
 import {
   ConsumeStreamOptions,
   StreamTextResult,
   TextStreamPart,
   UIMessageStreamOptions,
-} from './stream-text-result';
-import { toResponseMessages } from './to-response-messages';
-import { TypedToolCall } from './tool-call';
-import { ToolCallRepairFunction } from './tool-call-repair-function';
-import { ToolOutput } from './tool-output';
-import { StaticToolOutputDenied } from './tool-output-denied';
-import { ToolSet } from './tool-set';
+} from "./stream-text-result";
+import { toResponseMessages } from "./to-response-messages";
+import { TypedToolCall } from "./tool-call";
+import { ToolCallRepairFunction } from "./tool-call-repair-function";
+import { ToolOutput } from "./tool-output";
+import { StaticToolOutputDenied } from "./tool-output-denied";
+import { ToolSet } from "./tool-set";
 
 const originalGenerateId = createIdGenerator({
-  prefix: 'aitxt',
+  prefix: "aitxt",
   size: 24,
 });
 
@@ -164,14 +164,14 @@ export type StreamTextOnChunkCallback<TOOLS extends ToolSet> = (event: {
     TextStreamPart<TOOLS>,
     {
       type:
-        | 'text-delta'
-        | 'reasoning-delta'
-        | 'source'
-        | 'tool-call'
-        | 'tool-input-start'
-        | 'tool-input-delta'
-        | 'tool-result'
-        | 'raw';
+        | "text-delta"
+        | "reasoning-delta"
+        | "source"
+        | "tool-call"
+        | "tool-input-start"
+        | "tool-input-delta"
+        | "tool-result"
+        | "raw";
     }
   >;
 }) => PromiseLike<void> | void;
@@ -593,10 +593,10 @@ function createOutputTransformStream<
   EnrichedStreamPart<TOOLS, InferPartialOutput<OUTPUT>>
 > {
   let firstTextChunkId: string | undefined = undefined;
-  let text = '';
-  let textChunk = '';
+  let text = "";
+  let textChunk = "";
   let textProviderMetadata: ProviderMetadata | undefined = undefined;
-  let lastPublishedValue = '';
+  let lastPublishedValue = "";
 
   function publishTextChunk({
     controller,
@@ -609,14 +609,14 @@ function createOutputTransformStream<
   }) {
     controller.enqueue({
       part: {
-        type: 'text-delta',
+        type: "text-delta",
         id: firstTextChunkId!,
         text: textChunk,
         providerMetadata: textProviderMetadata,
       },
       partialOutput,
     });
-    textChunk = '';
+    textChunk = "";
   }
 
   return new TransformStream<
@@ -625,14 +625,14 @@ function createOutputTransformStream<
   >({
     async transform(chunk, controller) {
       // ensure that we publish the last text chunk before the step finish:
-      if (chunk.type === 'finish-step' && textChunk.length > 0) {
+      if (chunk.type === "finish-step" && textChunk.length > 0) {
         publishTextChunk({ controller });
       }
 
       if (
-        chunk.type !== 'text-delta' &&
-        chunk.type !== 'text-start' &&
-        chunk.type !== 'text-end'
+        chunk.type !== "text-delta" &&
+        chunk.type !== "text-start" &&
+        chunk.type !== "text-end"
       ) {
         controller.enqueue({ part: chunk, partialOutput: undefined });
         return;
@@ -647,12 +647,12 @@ function createOutputTransformStream<
         return;
       }
 
-      if (chunk.type === 'text-start') {
+      if (chunk.type === "text-start") {
         controller.enqueue({ part: chunk, partialOutput: undefined });
         return;
       }
 
-      if (chunk.type === 'text-end') {
+      if (chunk.type === "text-end") {
         if (textChunk.length > 0) {
           publishTextChunk({ controller });
         }
@@ -672,7 +672,7 @@ function createOutputTransformStream<
         // only send new value if it has changed:
         // For string partials (text output), compare directly to avoid unnecessary JSON.stringify overhead
         const currentValue =
-          typeof result.partial === 'string'
+          typeof result.partial === "string"
             ? result.partial
             : JSON.stringify(result.partial);
         if (currentValue !== lastPublishedValue) {
@@ -684,21 +684,20 @@ function createOutputTransformStream<
   });
 }
 
-class DefaultStreamTextResult<
-  TOOLS extends ToolSet,
-  OUTPUT extends Output,
-> implements StreamTextResult<TOOLS, OUTPUT> {
+class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
+  implements StreamTextResult<TOOLS, OUTPUT>
+{
   private readonly _totalUsage = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, OUTPUT>['usage']>
+    Awaited<StreamTextResult<TOOLS, OUTPUT>["usage"]>
   >();
   private readonly _finishReason = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, OUTPUT>['finishReason']>
+    Awaited<StreamTextResult<TOOLS, OUTPUT>["finishReason"]>
   >();
   private readonly _rawFinishReason = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, OUTPUT>['rawFinishReason']>
+    Awaited<StreamTextResult<TOOLS, OUTPUT>["rawFinishReason"]>
   >();
   private readonly _steps = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, OUTPUT>['steps']>
+    Awaited<StreamTextResult<TOOLS, OUTPUT>["steps"]>
   >();
 
   private readonly addStream: (
@@ -762,16 +761,16 @@ class DefaultStreamTextResult<
     model: LanguageModelV3;
     telemetry: TelemetrySettings | undefined;
     headers: Record<string, string | undefined> | undefined;
-    settings: Omit<CallSettings, 'abortSignal' | 'headers'>;
+    settings: Omit<CallSettings, "abortSignal" | "headers">;
     maxRetries: number | undefined;
     abortSignal: AbortSignal | undefined;
     stepTimeoutMs: number | undefined;
     stepAbortController: AbortController | undefined;
     chunkTimeoutMs: number | undefined;
     chunkAbortController: AbortController | undefined;
-    system: Prompt['system'];
-    prompt: Prompt['prompt'];
-    messages: Prompt['messages'];
+    system: Prompt["system"];
+    prompt: Prompt["prompt"];
+    messages: Prompt["messages"];
     tools: TOOLS | undefined;
     toolChoice: ToolChoice<TOOLS> | undefined;
     transforms: Array<StreamTextTransform<TOOLS>>;
@@ -839,7 +838,7 @@ class DefaultStreamTextResult<
     let activeTextContent: Record<
       string,
       {
-        type: 'text';
+        type: "text";
         text: string;
         providerMetadata: ProviderMetadata | undefined;
       }
@@ -848,7 +847,7 @@ class DefaultStreamTextResult<
     let activeReasoningContent: Record<
       string,
       {
-        type: 'reasoning';
+        type: "reasoning";
         text: string;
         providerMetadata: ProviderMetadata | undefined;
       }
@@ -864,39 +863,39 @@ class DefaultStreamTextResult<
         const { part } = chunk;
 
         if (
-          part.type === 'text-delta' ||
-          part.type === 'reasoning-delta' ||
-          part.type === 'source' ||
-          part.type === 'tool-call' ||
-          part.type === 'tool-result' ||
-          part.type === 'tool-input-start' ||
-          part.type === 'tool-input-delta' ||
-          part.type === 'raw'
+          part.type === "text-delta" ||
+          part.type === "reasoning-delta" ||
+          part.type === "source" ||
+          part.type === "tool-call" ||
+          part.type === "tool-result" ||
+          part.type === "tool-input-start" ||
+          part.type === "tool-input-delta" ||
+          part.type === "raw"
         ) {
           await onChunk?.({ chunk: part });
         }
 
-        if (part.type === 'error') {
+        if (part.type === "error") {
           await onError({ error: wrapGatewayError(part.error) });
         }
 
-        if (part.type === 'text-start') {
+        if (part.type === "text-start") {
           activeTextContent[part.id] = {
-            type: 'text',
-            text: '',
+            type: "text",
+            text: "",
             providerMetadata: part.providerMetadata,
           };
 
           recordedContent.push(activeTextContent[part.id]);
         }
 
-        if (part.type === 'text-delta') {
+        if (part.type === "text-delta") {
           const activeText = activeTextContent[part.id];
 
           if (activeText == null) {
             controller.enqueue({
               part: {
-                type: 'error',
+                type: "error",
                 error: `text part ${part.id} not found`,
               },
               partialOutput: undefined,
@@ -909,13 +908,13 @@ class DefaultStreamTextResult<
             part.providerMetadata ?? activeText.providerMetadata;
         }
 
-        if (part.type === 'text-end') {
+        if (part.type === "text-end") {
           const activeText = activeTextContent[part.id];
 
           if (activeText == null) {
             controller.enqueue({
               part: {
-                type: 'error',
+                type: "error",
                 error: `text part ${part.id} not found`,
               },
               partialOutput: undefined,
@@ -929,23 +928,23 @@ class DefaultStreamTextResult<
           delete activeTextContent[part.id];
         }
 
-        if (part.type === 'reasoning-start') {
+        if (part.type === "reasoning-start") {
           activeReasoningContent[part.id] = {
-            type: 'reasoning',
-            text: '',
+            type: "reasoning",
+            text: "",
             providerMetadata: part.providerMetadata,
           };
 
           recordedContent.push(activeReasoningContent[part.id]);
         }
 
-        if (part.type === 'reasoning-delta') {
+        if (part.type === "reasoning-delta") {
           const activeReasoning = activeReasoningContent[part.id];
 
           if (activeReasoning == null) {
             controller.enqueue({
               part: {
-                type: 'error',
+                type: "error",
                 error: `reasoning part ${part.id} not found`,
               },
               partialOutput: undefined,
@@ -958,13 +957,13 @@ class DefaultStreamTextResult<
             part.providerMetadata ?? activeReasoning.providerMetadata;
         }
 
-        if (part.type === 'reasoning-end') {
+        if (part.type === "reasoning-end") {
           const activeReasoning = activeReasoningContent[part.id];
 
           if (activeReasoning == null) {
             controller.enqueue({
               part: {
-                type: 'error',
+                type: "error",
                 error: `reasoning part ${part.id} not found`,
               },
               partialOutput: undefined,
@@ -978,9 +977,9 @@ class DefaultStreamTextResult<
           delete activeReasoningContent[part.id];
         }
 
-        if (part.type === 'file') {
+        if (part.type === "file") {
           recordedContent.push({
-            type: 'file',
+            type: "file",
             file: part.file,
             ...(part.providerMetadata != null
               ? { providerMetadata: part.providerMetadata }
@@ -988,27 +987,27 @@ class DefaultStreamTextResult<
           });
         }
 
-        if (part.type === 'source') {
+        if (part.type === "source") {
           recordedContent.push(part);
         }
 
-        if (part.type === 'tool-call') {
+        if (part.type === "tool-call") {
           recordedContent.push(part);
         }
 
-        if (part.type === 'tool-result' && !part.preliminary) {
+        if (part.type === "tool-result" && !part.preliminary) {
           recordedContent.push(part);
         }
 
-        if (part.type === 'tool-approval-request') {
+        if (part.type === "tool-approval-request") {
           recordedContent.push(part);
         }
 
-        if (part.type === 'tool-error') {
+        if (part.type === "tool-error") {
           recordedContent.push(part);
         }
 
-        if (part.type === 'start-step') {
+        if (part.type === "start-step") {
           // reset the recorded data when a new step starts:
           recordedContent = [];
           activeReasoningContent = {};
@@ -1018,7 +1017,7 @@ class DefaultStreamTextResult<
           recordedWarnings = part.warnings;
         }
 
-        if (part.type === 'finish-step') {
+        if (part.type === "finish-step") {
           const stepMessages = await toResponseMessages({
             content: recordedContent,
             tools,
@@ -1063,7 +1062,7 @@ class DefaultStreamTextResult<
           stepFinish.resolve();
         }
 
-        if (part.type === 'finish') {
+        if (part.type === "finish") {
           recordedTotalUsage = part.totalUsage;
           recordedFinishReason = part.finishReason;
           recordedRawFinishReason = part.rawFinishReason;
@@ -1076,7 +1075,7 @@ class DefaultStreamTextResult<
             const error = abortSignal?.aborted
               ? abortSignal.reason
               : new NoOutputGeneratedError({
-                  message: 'No output generated. Check the stream for errors.',
+                  message: "No output generated. Check the stream for errors.",
                 });
 
             self._finishReason.reject(error);
@@ -1088,7 +1087,7 @@ class DefaultStreamTextResult<
           }
 
           // derived:
-          const finishReason = recordedFinishReason ?? 'other';
+          const finishReason = recordedFinishReason ?? "other";
           const totalUsage =
             recordedTotalUsage ?? createNullLanguageModelUsage();
 
@@ -1145,36 +1144,36 @@ class DefaultStreamTextResult<
             await selectTelemetryAttributes({
               telemetry,
               attributes: {
-                'ai.response.finishReason': finishReason,
-                'ai.response.text': { output: () => finalStep.text },
-                'ai.response.reasoning': {
+                "ai.response.finishReason": finishReason,
+                "ai.response.text": { output: () => finalStep.text },
+                "ai.response.reasoning": {
                   output: () => finalStep.reasoningText,
                 },
-                'ai.response.toolCalls': {
+                "ai.response.toolCalls": {
                   output: () =>
                     finalStep.toolCalls?.length
                       ? JSON.stringify(finalStep.toolCalls)
                       : undefined,
                 },
-                'ai.response.providerMetadata': JSON.stringify(
+                "ai.response.providerMetadata": JSON.stringify(
                   finalStep.providerMetadata,
                 ),
-                'ai.usage.inputTokens': totalUsage.inputTokens,
-                'ai.usage.inputTokenDetails.noCacheTokens':
+                "ai.usage.inputTokens": totalUsage.inputTokens,
+                "ai.usage.inputTokenDetails.noCacheTokens":
                   totalUsage.inputTokenDetails?.noCacheTokens,
-                'ai.usage.inputTokenDetails.cacheReadTokens':
+                "ai.usage.inputTokenDetails.cacheReadTokens":
                   totalUsage.inputTokenDetails?.cacheReadTokens,
-                'ai.usage.inputTokenDetails.cacheWriteTokens':
+                "ai.usage.inputTokenDetails.cacheWriteTokens":
                   totalUsage.inputTokenDetails?.cacheWriteTokens,
-                'ai.usage.outputTokens': totalUsage.outputTokens,
-                'ai.usage.outputTokenDetails.textTokens':
+                "ai.usage.outputTokens": totalUsage.outputTokens,
+                "ai.usage.outputTokenDetails.textTokens":
                   totalUsage.outputTokenDetails?.textTokens,
-                'ai.usage.outputTokenDetails.reasoningTokens':
+                "ai.usage.outputTokenDetails.reasoningTokens":
                   totalUsage.outputTokenDetails?.reasoningTokens,
-                'ai.usage.totalTokens': totalUsage.totalTokens,
-                'ai.usage.reasoningTokens':
+                "ai.usage.totalTokens": totalUsage.totalTokens,
+                "ai.usage.reasoningTokens":
                   totalUsage.outputTokenDetails?.reasoningTokens,
-                'ai.usage.cachedInputTokens':
+                "ai.usage.cachedInputTokens":
                   totalUsage.inputTokenDetails?.cacheReadTokens,
               },
             }),
@@ -1197,7 +1196,7 @@ class DefaultStreamTextResult<
     let stream = new ReadableStream<TextStreamPart<TOOLS>>({
       async start(controller) {
         // send start event:
-        controller.enqueue({ type: 'start' });
+        controller.enqueue({ type: "start" });
       },
 
       async pull(controller) {
@@ -1205,7 +1204,7 @@ class DefaultStreamTextResult<
         function abort() {
           onAbort?.({ steps: recordedSteps });
           controller.enqueue({
-            type: 'abort',
+            type: "abort",
             // The `reason` is usually of type DOMException, but it can also be of any type,
             // so we use getErrorMessage for serialization because it is already designed to accept values of the unknown type.
             // See: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/reason
@@ -1286,21 +1285,21 @@ class DefaultStreamTextResult<
     };
 
     recordSpan({
-      name: 'ai.streamText',
+      name: "ai.streamText",
       attributes: selectTelemetryAttributes({
         telemetry,
         attributes: {
-          ...assembleOperationName({ operationId: 'ai.streamText', telemetry }),
+          ...assembleOperationName({ operationId: "ai.streamText", telemetry }),
           ...baseTelemetryAttributes,
           // specific settings that only make sense on the outer level:
-          'ai.prompt': {
+          "ai.prompt": {
             input: () => JSON.stringify({ system, prompt, messages }),
           },
         },
       }),
       tracer,
       endWhenDone: false,
-      fn: async rootSpanArg => {
+      fn: async (rootSpanArg) => {
         rootSpan = rootSpanArg;
 
         const initialPrompt = await standardizePrompt({
@@ -1357,15 +1356,15 @@ class DefaultStreamTextResult<
           approvedToolApprovals.length > 0
         ) {
           const localApprovedToolApprovals = approvedToolApprovals.filter(
-            toolApproval => !toolApproval.toolCall.providerExecuted,
+            (toolApproval) => !toolApproval.toolCall.providerExecuted,
           );
           const localDeniedToolApprovals = deniedToolApprovals.filter(
-            toolApproval => !toolApproval.toolCall.providerExecuted,
+            (toolApproval) => !toolApproval.toolCall.providerExecuted,
           );
 
           const deniedProviderExecutedToolApprovals =
             deniedToolApprovals.filter(
-              toolApproval => toolApproval.toolCall.providerExecuted,
+              (toolApproval) => toolApproval.toolCall.providerExecuted,
             );
 
           let toolExecutionStepStreamController:
@@ -1387,7 +1386,7 @@ class DefaultStreamTextResult<
               ...deniedProviderExecutedToolApprovals,
             ]) {
               toolExecutionStepStreamController?.enqueue({
-                type: 'tool-output-denied',
+                type: "tool-output-denied",
                 toolCallId: toolApproval.toolCall.toolCallId,
                 toolName: toolApproval.toolCall.toolName,
               } as StaticToolOutputDenied<TOOLS>);
@@ -1396,7 +1395,7 @@ class DefaultStreamTextResult<
             const toolOutputs: Array<ToolOutput<TOOLS>> = [];
 
             await Promise.all(
-              localApprovedToolApprovals.map(async toolApproval => {
+              localApprovedToolApprovals.map(async (toolApproval) => {
                 const result = await executeToolCall({
                   toolCall: toolApproval.toolCall,
                   tools,
@@ -1405,6 +1404,7 @@ class DefaultStreamTextResult<
                   messages: initialMessages,
                   abortSignal,
                   experimental_context,
+                  approvalData: toolApproval.approvalResponse.data,
                   stepNumber: recordedSteps.length,
                   model: modelInfo,
                   onToolCallStart: [
@@ -1417,7 +1417,7 @@ class DefaultStreamTextResult<
                     onToolCallFinish,
                     globalTelemetry.onToolCallFinish,
                   ],
-                  onPreliminaryToolResult: result => {
+                  onPreliminaryToolResult: (result) => {
                     toolExecutionStepStreamController?.enqueue(result);
                   },
                 });
@@ -1436,7 +1436,7 @@ class DefaultStreamTextResult<
               // add regular tool results for approved tool calls:
               for (const output of toolOutputs) {
                 localToolContent.push({
-                  type: 'tool-result' as const,
+                  type: "tool-result" as const,
                   toolCallId: output.toolCallId,
                   toolName: output.toolName,
                   output: await createToolModelOutput({
@@ -1444,10 +1444,10 @@ class DefaultStreamTextResult<
                     input: output.input,
                     tool: tools?.[output.toolName],
                     output:
-                      output.type === 'tool-result'
+                      output.type === "tool-result"
                         ? output.output
                         : output.error,
-                    errorMode: output.type === 'tool-error' ? 'text' : 'none',
+                    errorMode: output.type === "tool-error" ? "text" : "none",
                   }),
                 });
               }
@@ -1455,18 +1455,18 @@ class DefaultStreamTextResult<
               // add execution denied tool results for denied local tool approvals:
               for (const toolApproval of localDeniedToolApprovals) {
                 localToolContent.push({
-                  type: 'tool-result' as const,
+                  type: "tool-result" as const,
                   toolCallId: toolApproval.toolCall.toolCallId,
                   toolName: toolApproval.toolCall.toolName,
                   output: {
-                    type: 'execution-denied' as const,
+                    type: "execution-denied" as const,
                     reason: toolApproval.approvalResponse.reason,
                   },
                 });
               }
 
               initialResponseMessages.push({
-                role: 'tool',
+                role: "tool",
                 content: localToolContent,
               });
             }
@@ -1611,27 +1611,28 @@ class DefaultStreamTextResult<
               startTimestampMs,
             } = await retry(() =>
               recordSpan({
-                name: 'ai.streamText.doStream',
+                name: "ai.streamText.doStream",
                 attributes: selectTelemetryAttributes({
                   telemetry,
                   attributes: {
                     ...assembleOperationName({
-                      operationId: 'ai.streamText.doStream',
+                      operationId: "ai.streamText.doStream",
                       telemetry,
                     }),
                     ...baseTelemetryAttributes,
                     // model:
-                    'ai.model.provider': stepModel.provider,
-                    'ai.model.id': stepModel.modelId,
+                    "ai.model.provider": stepModel.provider,
+                    "ai.model.id": stepModel.modelId,
                     // prompt:
-                    'ai.prompt.messages': {
+                    "ai.prompt.messages": {
                       input: () => stringifyForTelemetry(promptMessages),
                     },
-                    'ai.prompt.tools': {
+                    "ai.prompt.tools": {
                       // convert the language model level tools:
-                      input: () => stepTools?.map(tool => JSON.stringify(tool)),
+                      input: () =>
+                        stepTools?.map((tool) => JSON.stringify(tool)),
                     },
-                    'ai.prompt.toolChoice': {
+                    "ai.prompt.toolChoice": {
                       input: () =>
                         stepToolChoice != null
                           ? JSON.stringify(stepToolChoice)
@@ -1639,22 +1640,22 @@ class DefaultStreamTextResult<
                     },
 
                     // standardized gen-ai llm span attributes:
-                    'gen_ai.system': stepModel.provider,
-                    'gen_ai.request.model': stepModel.modelId,
-                    'gen_ai.request.frequency_penalty':
+                    "gen_ai.system": stepModel.provider,
+                    "gen_ai.request.model": stepModel.modelId,
+                    "gen_ai.request.frequency_penalty":
                       callSettings.frequencyPenalty,
-                    'gen_ai.request.max_tokens': callSettings.maxOutputTokens,
-                    'gen_ai.request.presence_penalty':
+                    "gen_ai.request.max_tokens": callSettings.maxOutputTokens,
+                    "gen_ai.request.presence_penalty":
                       callSettings.presencePenalty,
-                    'gen_ai.request.stop_sequences': callSettings.stopSequences,
-                    'gen_ai.request.temperature': callSettings.temperature,
-                    'gen_ai.request.top_k': callSettings.topK,
-                    'gen_ai.request.top_p': callSettings.topP,
+                    "gen_ai.request.stop_sequences": callSettings.stopSequences,
+                    "gen_ai.request.temperature": callSettings.temperature,
+                    "gen_ai.request.top_k": callSettings.topK,
+                    "gen_ai.request.top_p": callSettings.topP,
                   },
                 }),
                 tracer,
                 endWhenDone: false,
-                fn: async doStreamSpan => ({
+                fn: async (doStreamSpan) => ({
                   startTimestampMs: now(), // get before the call
                   doStreamSpan,
                   result: await stepModel.doStream({
@@ -1709,7 +1710,7 @@ class DefaultStreamTextResult<
 
             const activeToolCallToolNames: Record<string, string> = {};
 
-            let stepFinishReason: FinishReason = 'other';
+            let stepFinishReason: FinishReason = "other";
             let stepRawFinishReason: string | undefined = undefined;
 
             let stepUsage: LanguageModelUsage = createNullLanguageModelUsage();
@@ -1723,7 +1724,7 @@ class DefaultStreamTextResult<
               };
 
             // raw text as it comes from the provider. recorded for telemetry.
-            let activeText = '';
+            let activeText = "";
 
             self.addStream(
               streamWithToolResults.pipeThrough(
@@ -1734,7 +1735,7 @@ class DefaultStreamTextResult<
                   async transform(chunk, controller): Promise<void> {
                     resetChunkTimeout();
 
-                    if (chunk.type === 'stream-start') {
+                    if (chunk.type === "stream-start") {
                       warnings = chunk.warnings;
                       return; // stream start chunks are sent immediately and do not count as first chunk
                     }
@@ -1745,17 +1746,17 @@ class DefaultStreamTextResult<
 
                       stepFirstChunk = false;
 
-                      doStreamSpan.addEvent('ai.stream.firstChunk', {
-                        'ai.response.msToFirstChunk': msToFirstChunk,
+                      doStreamSpan.addEvent("ai.stream.firstChunk", {
+                        "ai.response.msToFirstChunk": msToFirstChunk,
                       });
 
                       doStreamSpan.setAttributes({
-                        'ai.response.msToFirstChunk': msToFirstChunk,
+                        "ai.response.msToFirstChunk": msToFirstChunk,
                       });
 
                       // Step start:
                       controller.enqueue({
-                        type: 'start-step',
+                        type: "start-step",
                         request: stepRequest,
                         warnings: warnings ?? [],
                       });
@@ -1763,17 +1764,17 @@ class DefaultStreamTextResult<
 
                     const chunkType = chunk.type;
                     switch (chunkType) {
-                      case 'tool-approval-request':
-                      case 'text-start':
-                      case 'text-end': {
+                      case "tool-approval-request":
+                      case "text-start":
+                      case "text-end": {
                         controller.enqueue(chunk);
                         break;
                       }
 
-                      case 'text-delta': {
+                      case "text-delta": {
                         if (chunk.delta.length > 0) {
                           controller.enqueue({
-                            type: 'text-delta',
+                            type: "text-delta",
                             id: chunk.id,
                             text: chunk.delta,
                             providerMetadata: chunk.providerMetadata,
@@ -1783,15 +1784,15 @@ class DefaultStreamTextResult<
                         break;
                       }
 
-                      case 'reasoning-start':
-                      case 'reasoning-end': {
+                      case "reasoning-start":
+                      case "reasoning-end": {
                         controller.enqueue(chunk);
                         break;
                       }
 
-                      case 'reasoning-delta': {
+                      case "reasoning-delta": {
                         controller.enqueue({
-                          type: 'reasoning-delta',
+                          type: "reasoning-delta",
                           id: chunk.id,
                           text: chunk.delta,
                           providerMetadata: chunk.providerMetadata,
@@ -1799,14 +1800,14 @@ class DefaultStreamTextResult<
                         break;
                       }
 
-                      case 'tool-call': {
+                      case "tool-call": {
                         controller.enqueue(chunk);
                         // store tool calls for onFinish callback and toolCalls promise:
                         stepToolCalls.push(chunk);
                         break;
                       }
 
-                      case 'tool-result': {
+                      case "tool-result": {
                         controller.enqueue(chunk);
 
                         if (!chunk.preliminary) {
@@ -1816,13 +1817,13 @@ class DefaultStreamTextResult<
                         break;
                       }
 
-                      case 'tool-error': {
+                      case "tool-error": {
                         controller.enqueue(chunk);
                         stepToolOutputs.push(chunk);
                         break;
                       }
 
-                      case 'response-metadata': {
+                      case "response-metadata": {
                         stepResponse = {
                           id: chunk.id ?? stepResponse.id,
                           timestamp: chunk.timestamp ?? stepResponse.timestamp,
@@ -1831,7 +1832,7 @@ class DefaultStreamTextResult<
                         break;
                       }
 
-                      case 'finish': {
+                      case "finish": {
                         // Note: tool executions might not be finished yet when the finish event is emitted.
                         // store usage and finish reason for promises and onFinish callback:
                         stepUsage = chunk.usage;
@@ -1842,27 +1843,27 @@ class DefaultStreamTextResult<
                         // Telemetry for finish event timing
                         // (since tool executions can take longer and distort calculations)
                         const msToFinish = now() - startTimestampMs;
-                        doStreamSpan.addEvent('ai.stream.finish');
+                        doStreamSpan.addEvent("ai.stream.finish");
                         doStreamSpan.setAttributes({
-                          'ai.response.msToFinish': msToFinish,
-                          'ai.response.avgOutputTokensPerSecond':
+                          "ai.response.msToFinish": msToFinish,
+                          "ai.response.avgOutputTokensPerSecond":
                             (1000 * (stepUsage.outputTokens ?? 0)) / msToFinish,
                         });
 
                         break;
                       }
 
-                      case 'file': {
+                      case "file": {
                         controller.enqueue(chunk);
                         break;
                       }
 
-                      case 'source': {
+                      case "source": {
                         controller.enqueue(chunk);
                         break;
                       }
 
-                      case 'tool-input-start': {
+                      case "tool-input-start": {
                         activeToolCallToolNames[chunk.id] = chunk.toolName;
 
                         const tool = tools?.[chunk.toolName];
@@ -1877,19 +1878,19 @@ class DefaultStreamTextResult<
 
                         controller.enqueue({
                           ...chunk,
-                          dynamic: chunk.dynamic ?? tool?.type === 'dynamic',
+                          dynamic: chunk.dynamic ?? tool?.type === "dynamic",
                           title: tool?.title,
                         });
                         break;
                       }
 
-                      case 'tool-input-end': {
+                      case "tool-input-end": {
                         delete activeToolCallToolNames[chunk.id];
                         controller.enqueue(chunk);
                         break;
                       }
 
-                      case 'tool-input-delta': {
+                      case "tool-input-delta": {
                         const toolName = activeToolCallToolNames[chunk.id];
                         const tool = tools?.[toolName];
 
@@ -1907,13 +1908,13 @@ class DefaultStreamTextResult<
                         break;
                       }
 
-                      case 'error': {
+                      case "error": {
                         controller.enqueue(chunk);
-                        stepFinishReason = 'error';
+                        stepFinishReason = "error";
                         break;
                       }
 
-                      case 'raw': {
+                      case "raw": {
                         if (includeRawChunks) {
                           controller.enqueue(chunk);
                         }
@@ -1942,40 +1943,40 @@ class DefaultStreamTextResult<
                         await selectTelemetryAttributes({
                           telemetry,
                           attributes: {
-                            'ai.response.finishReason': stepFinishReason,
-                            'ai.response.toolCalls': {
+                            "ai.response.finishReason": stepFinishReason,
+                            "ai.response.toolCalls": {
                               output: () => stepToolCallsJson,
                             },
-                            'ai.response.id': stepResponse.id,
-                            'ai.response.model': stepResponse.modelId,
-                            'ai.response.timestamp':
+                            "ai.response.id": stepResponse.id,
+                            "ai.response.model": stepResponse.modelId,
+                            "ai.response.timestamp":
                               stepResponse.timestamp.toISOString(),
-                            'ai.usage.inputTokens': stepUsage.inputTokens,
-                            'ai.usage.inputTokenDetails.noCacheTokens':
+                            "ai.usage.inputTokens": stepUsage.inputTokens,
+                            "ai.usage.inputTokenDetails.noCacheTokens":
                               stepUsage.inputTokenDetails?.noCacheTokens,
-                            'ai.usage.inputTokenDetails.cacheReadTokens':
+                            "ai.usage.inputTokenDetails.cacheReadTokens":
                               stepUsage.inputTokenDetails?.cacheReadTokens,
-                            'ai.usage.inputTokenDetails.cacheWriteTokens':
+                            "ai.usage.inputTokenDetails.cacheWriteTokens":
                               stepUsage.inputTokenDetails?.cacheWriteTokens,
-                            'ai.usage.outputTokens': stepUsage.outputTokens,
-                            'ai.usage.outputTokenDetails.textTokens':
+                            "ai.usage.outputTokens": stepUsage.outputTokens,
+                            "ai.usage.outputTokenDetails.textTokens":
                               stepUsage.outputTokenDetails?.textTokens,
-                            'ai.usage.outputTokenDetails.reasoningTokens':
+                            "ai.usage.outputTokenDetails.reasoningTokens":
                               stepUsage.outputTokenDetails?.reasoningTokens,
-                            'ai.usage.totalTokens': stepUsage.totalTokens,
-                            'ai.usage.reasoningTokens':
+                            "ai.usage.totalTokens": stepUsage.totalTokens,
+                            "ai.usage.reasoningTokens":
                               stepUsage.outputTokenDetails?.reasoningTokens,
-                            'ai.usage.cachedInputTokens':
+                            "ai.usage.cachedInputTokens":
                               stepUsage.inputTokenDetails?.cacheReadTokens,
 
                             // standardized gen-ai llm span attributes:
-                            'gen_ai.response.finish_reasons': [
+                            "gen_ai.response.finish_reasons": [
                               stepFinishReason,
                             ],
-                            'gen_ai.response.id': stepResponse.id,
-                            'gen_ai.response.model': stepResponse.modelId,
-                            'gen_ai.usage.input_tokens': stepUsage.inputTokens,
-                            'gen_ai.usage.output_tokens':
+                            "gen_ai.response.id": stepResponse.id,
+                            "gen_ai.response.model": stepResponse.modelId,
+                            "gen_ai.usage.input_tokens": stepUsage.inputTokens,
+                            "gen_ai.usage.output_tokens":
                               stepUsage.outputTokens,
                           },
                         }),
@@ -1985,7 +1986,7 @@ class DefaultStreamTextResult<
                     }
 
                     controller.enqueue({
-                      type: 'finish-step',
+                      type: "finish-step",
                       finishReason: stepFinishReason,
                       rawFinishReason: stepRawFinishReason,
                       usage: stepUsage,
@@ -2014,13 +2015,13 @@ class DefaultStreamTextResult<
                         await selectTelemetryAttributes({
                           telemetry,
                           attributes: {
-                            'ai.response.text': {
+                            "ai.response.text": {
                               output: () => processedStep.text,
                             },
-                            'ai.response.reasoning': {
+                            "ai.response.reasoning": {
                               output: () => processedStep.reasoningText,
                             },
-                            'ai.response.providerMetadata': JSON.stringify(
+                            "ai.response.providerMetadata": JSON.stringify(
                               processedStep.providerMetadata,
                             ),
                           },
@@ -2033,10 +2034,10 @@ class DefaultStreamTextResult<
                     }
 
                     const clientToolCalls = stepToolCalls.filter(
-                      toolCall => toolCall.providerExecuted !== true,
+                      (toolCall) => toolCall.providerExecuted !== true,
                     );
                     const clientToolOutputs = stepToolOutputs.filter(
-                      toolOutput => toolOutput.providerExecuted !== true,
+                      (toolOutput) => toolOutput.providerExecuted !== true,
                     );
 
                     // Track provider-executed tool calls that support deferred results.
@@ -2047,14 +2048,14 @@ class DefaultStreamTextResult<
                       if (toolCall.providerExecuted !== true) continue;
                       const tool = tools?.[toolCall.toolName];
                       if (
-                        tool?.type === 'provider' &&
+                        tool?.type === "provider" &&
                         tool.supportsDeferredResults
                       ) {
                         // Check if this tool call already has a result in the current step
                         const hasResultInStep = stepToolOutputs.some(
-                          output =>
-                            (output.type === 'tool-result' ||
-                              output.type === 'tool-error') &&
+                          (output) =>
+                            (output.type === "tool-result" ||
+                              output.type === "tool-error") &&
                             output.toolCallId === toolCall.toolCallId,
                         );
                         if (!hasResultInStep) {
@@ -2068,8 +2069,8 @@ class DefaultStreamTextResult<
                     // Mark deferred tool calls as resolved when we receive their results
                     for (const output of stepToolOutputs) {
                       if (
-                        output.type === 'tool-result' ||
-                        output.type === 'tool-error'
+                        output.type === "tool-result" ||
+                        output.type === "tool-error"
                       ) {
                         pendingDeferredToolCalls.delete(output.toolCallId);
                       }
@@ -2110,7 +2111,7 @@ class DefaultStreamTextResult<
                         });
                       } catch (error) {
                         controller.enqueue({
-                          type: 'error',
+                          type: "error",
                           error,
                         });
 
@@ -2118,7 +2119,7 @@ class DefaultStreamTextResult<
                       }
                     } else {
                       controller.enqueue({
-                        type: 'finish',
+                        type: "finish",
                         finishReason: stepFinishReason,
                         rawFinishReason: stepRawFinishReason,
                         totalUsage: combinedUsage,
@@ -2143,12 +2144,12 @@ class DefaultStreamTextResult<
           usage: createNullLanguageModelUsage(),
         });
       },
-    }).catch(error => {
+    }).catch((error) => {
       // add an error stream part and close the streams:
       self.addStream(
         new ReadableStream({
           start(controller) {
-            controller.enqueue({ type: 'error', error });
+            controller.enqueue({ type: "error", error });
             controller.close();
           },
         }),
@@ -2166,75 +2167,75 @@ class DefaultStreamTextResult<
   }
 
   private get finalStep() {
-    return this.steps.then(steps => steps[steps.length - 1]);
+    return this.steps.then((steps) => steps[steps.length - 1]);
   }
 
   get content() {
-    return this.finalStep.then(step => step.content);
+    return this.finalStep.then((step) => step.content);
   }
 
   get warnings() {
-    return this.finalStep.then(step => step.warnings);
+    return this.finalStep.then((step) => step.warnings);
   }
 
   get providerMetadata() {
-    return this.finalStep.then(step => step.providerMetadata);
+    return this.finalStep.then((step) => step.providerMetadata);
   }
 
   get text() {
-    return this.finalStep.then(step => step.text);
+    return this.finalStep.then((step) => step.text);
   }
 
   get reasoningText() {
-    return this.finalStep.then(step => step.reasoningText);
+    return this.finalStep.then((step) => step.reasoningText);
   }
 
   get reasoning() {
-    return this.finalStep.then(step => step.reasoning);
+    return this.finalStep.then((step) => step.reasoning);
   }
 
   get sources() {
-    return this.finalStep.then(step => step.sources);
+    return this.finalStep.then((step) => step.sources);
   }
 
   get files() {
-    return this.finalStep.then(step => step.files);
+    return this.finalStep.then((step) => step.files);
   }
 
   get toolCalls() {
-    return this.finalStep.then(step => step.toolCalls);
+    return this.finalStep.then((step) => step.toolCalls);
   }
 
   get staticToolCalls() {
-    return this.finalStep.then(step => step.staticToolCalls);
+    return this.finalStep.then((step) => step.staticToolCalls);
   }
 
   get dynamicToolCalls() {
-    return this.finalStep.then(step => step.dynamicToolCalls);
+    return this.finalStep.then((step) => step.dynamicToolCalls);
   }
 
   get toolResults() {
-    return this.finalStep.then(step => step.toolResults);
+    return this.finalStep.then((step) => step.toolResults);
   }
 
   get staticToolResults() {
-    return this.finalStep.then(step => step.staticToolResults);
+    return this.finalStep.then((step) => step.staticToolResults);
   }
 
   get dynamicToolResults() {
-    return this.finalStep.then(step => step.dynamicToolResults);
+    return this.finalStep.then((step) => step.dynamicToolResults);
   }
 
   get usage() {
-    return this.finalStep.then(step => step.usage);
+    return this.finalStep.then((step) => step.usage);
   }
 
   get request() {
-    return this.finalStep.then(step => step.request);
+    return this.finalStep.then((step) => step.request);
   }
 
   get response() {
-    return this.finalStep.then(step => step.response);
+    return this.finalStep.then((step) => step.response);
   }
 
   get totalUsage() {
@@ -2283,7 +2284,7 @@ class DefaultStreamTextResult<
           string
         >({
           transform({ part }, controller) {
-            if (part.type === 'text-delta') {
+            if (part.type === "text-delta") {
               controller.enqueue(part.text);
             }
           },
@@ -2346,7 +2347,7 @@ class DefaultStreamTextResult<
 
     if (transform == null) {
       throw new UnsupportedFunctionalityError({
-        functionality: `element streams in ${this.outputSpecification?.name ?? 'text'} mode`,
+        functionality: `element streams in ${this.outputSpecification?.name ?? "text"} mode`,
       });
     }
 
@@ -2354,7 +2355,7 @@ class DefaultStreamTextResult<
   }
 
   get output(): Promise<InferCompleteOutput<OUTPUT>> {
-    return this.finalStep.then(step => {
+    return this.finalStep.then((step) => {
       const output = this.outputSpecification ?? text();
       return output.parseCompleteOutput(
         { text: step.text },
@@ -2397,7 +2398,7 @@ class DefaultStreamTextResult<
         return part.dynamic;
       }
 
-      return tool?.type === 'dynamic' ? true : undefined;
+      return tool?.type === "dynamic" ? true : undefined;
     };
 
     const baseStream = this.fullStream.pipeThrough(
@@ -2413,9 +2414,9 @@ class DefaultStreamTextResult<
 
           const partType = part.type;
           switch (partType) {
-            case 'text-start': {
+            case "text-start": {
               controller.enqueue({
-                type: 'text-start',
+                type: "text-start",
                 id: part.id,
                 ...(part.providerMetadata != null
                   ? { providerMetadata: part.providerMetadata }
@@ -2424,9 +2425,9 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'text-delta': {
+            case "text-delta": {
               controller.enqueue({
-                type: 'text-delta',
+                type: "text-delta",
                 id: part.id,
                 delta: part.text,
                 ...(part.providerMetadata != null
@@ -2436,9 +2437,9 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'text-end': {
+            case "text-end": {
               controller.enqueue({
-                type: 'text-end',
+                type: "text-end",
                 id: part.id,
                 ...(part.providerMetadata != null
                   ? { providerMetadata: part.providerMetadata }
@@ -2447,8 +2448,8 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'reasoning-start':
-            case 'reasoning-end': {
+            case "reasoning-start":
+            case "reasoning-end": {
               if (sendReasoning) {
                 controller.enqueue({
                   type: partType,
@@ -2461,10 +2462,10 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'reasoning-delta': {
+            case "reasoning-delta": {
               if (sendReasoning) {
                 controller.enqueue({
-                  type: 'reasoning-delta',
+                  type: "reasoning-delta",
                   id: part.id,
                   delta: part.text,
                   ...(part.providerMetadata != null
@@ -2475,9 +2476,9 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'file': {
+            case "file": {
               controller.enqueue({
-                type: 'file',
+                type: "file",
                 mediaType: part.file.mediaType,
                 url: `data:${part.file.mediaType};base64,${part.file.base64}`,
                 ...(part.providerMetadata != null
@@ -2487,10 +2488,10 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'source': {
-              if (sendSources && part.sourceType === 'url') {
+            case "source": {
+              if (sendSources && part.sourceType === "url") {
                 controller.enqueue({
-                  type: 'source-url',
+                  type: "source-url",
                   sourceId: part.id,
                   url: part.url,
                   title: part.title,
@@ -2500,9 +2501,9 @@ class DefaultStreamTextResult<
                 });
               }
 
-              if (sendSources && part.sourceType === 'document') {
+              if (sendSources && part.sourceType === "document") {
                 controller.enqueue({
-                  type: 'source-document',
+                  type: "source-document",
                   sourceId: part.id,
                   mediaType: part.mediaType,
                   title: part.title,
@@ -2515,11 +2516,11 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'tool-input-start': {
+            case "tool-input-start": {
               const dynamic = isDynamic(part);
 
               controller.enqueue({
-                type: 'tool-input-start',
+                type: "tool-input-start",
                 toolCallId: part.id,
                 toolName: part.toolName,
                 ...(part.providerExecuted != null
@@ -2534,21 +2535,21 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'tool-input-delta': {
+            case "tool-input-delta": {
               controller.enqueue({
-                type: 'tool-input-delta',
+                type: "tool-input-delta",
                 toolCallId: part.id,
                 inputTextDelta: part.delta,
               });
               break;
             }
 
-            case 'tool-call': {
+            case "tool-call": {
               const dynamic = isDynamic(part);
 
               if (part.invalid) {
                 controller.enqueue({
-                  type: 'tool-input-error',
+                  type: "tool-input-error",
                   toolCallId: part.toolCallId,
                   toolName: part.toolName,
                   input: part.input,
@@ -2564,7 +2565,7 @@ class DefaultStreamTextResult<
                 });
               } else {
                 controller.enqueue({
-                  type: 'tool-input-available',
+                  type: "tool-input-available",
                   toolCallId: part.toolCallId,
                   toolName: part.toolName,
                   input: part.input,
@@ -2582,20 +2583,20 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'tool-approval-request': {
+            case "tool-approval-request": {
               controller.enqueue({
-                type: 'tool-approval-request',
+                type: "tool-approval-request",
                 approvalId: part.approvalId,
                 toolCallId: part.toolCall.toolCallId,
               });
               break;
             }
 
-            case 'tool-result': {
+            case "tool-result": {
               const dynamic = isDynamic(part);
 
               controller.enqueue({
-                type: 'tool-output-available',
+                type: "tool-output-available",
                 toolCallId: part.toolCallId,
                 output: part.output,
                 ...(part.providerExecuted != null
@@ -2612,14 +2613,14 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'tool-error': {
+            case "tool-error": {
               const dynamic = isDynamic(part);
 
               controller.enqueue({
-                type: 'tool-output-error',
+                type: "tool-output-error",
                 toolCallId: part.toolCallId,
                 errorText: part.providerExecuted
-                  ? typeof part.error === 'string'
+                  ? typeof part.error === "string"
                     ? part.error
                     : JSON.stringify(part.error)
                   : onError(part.error),
@@ -2634,36 +2635,36 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'tool-output-denied': {
+            case "tool-output-denied": {
               controller.enqueue({
-                type: 'tool-output-denied',
+                type: "tool-output-denied",
                 toolCallId: part.toolCallId,
               });
               break;
             }
 
-            case 'error': {
+            case "error": {
               controller.enqueue({
-                type: 'error',
+                type: "error",
                 errorText: onError(part.error),
               });
               break;
             }
 
-            case 'start-step': {
-              controller.enqueue({ type: 'start-step' });
+            case "start-step": {
+              controller.enqueue({ type: "start-step" });
               break;
             }
 
-            case 'finish-step': {
-              controller.enqueue({ type: 'finish-step' });
+            case "finish-step": {
+              controller.enqueue({ type: "finish-step" });
               break;
             }
 
-            case 'start': {
+            case "start": {
               if (sendStart) {
                 controller.enqueue({
-                  type: 'start',
+                  type: "start",
                   ...(messageMetadataValue != null
                     ? { messageMetadata: messageMetadataValue }
                     : {}),
@@ -2675,10 +2676,10 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'finish': {
+            case "finish": {
               if (sendFinish) {
                 controller.enqueue({
-                  type: 'finish',
+                  type: "finish",
                   finishReason: part.finishReason,
                   ...(messageMetadataValue != null
                     ? { messageMetadata: messageMetadataValue }
@@ -2688,16 +2689,16 @@ class DefaultStreamTextResult<
               break;
             }
 
-            case 'abort': {
+            case "abort": {
               controller.enqueue(part);
               break;
             }
 
-            case 'tool-input-end': {
+            case "tool-input-end": {
               break;
             }
 
-            case 'raw': {
+            case "raw": {
               // Raw chunks are not included in UI message streams
               // as they contain provider-specific data for developer use
               break;
@@ -2713,11 +2714,11 @@ class DefaultStreamTextResult<
           // so we only need to send metadata for other parts
           if (
             messageMetadataValue != null &&
-            partType !== 'start' &&
-            partType !== 'finish'
+            partType !== "start" &&
+            partType !== "finish"
           ) {
             controller.enqueue({
-              type: 'message-metadata',
+              type: "message-metadata",
               messageMetadata: messageMetadataValue,
             });
           }

--- a/packages/ai/src/generate-text/tool-set.ts
+++ b/packages/ai/src/generate-text/tool-set.ts
@@ -1,14 +1,19 @@
-import { Tool } from '@ai-sdk/provider-utils';
+import { Tool } from "@ai-sdk/provider-utils";
 
 export type ToolSet = Record<
   string,
-  (Tool<never, never> | Tool<any, any> | Tool<any, never> | Tool<never, any>) &
+  (
+    | Tool<never, never, never>
+    | Tool<any, any, any>
+    | Tool<any, never, any>
+    | Tool<never, any, any>
+  ) &
     Pick<
-      Tool<any, any>,
-      | 'execute'
-      | 'onInputAvailable'
-      | 'onInputStart'
-      | 'onInputDelta'
-      | 'needsApproval'
+      Tool<any, any, any>,
+      | "execute"
+      | "onInputAvailable"
+      | "onInputStart"
+      | "onInputDelta"
+      | "needsApproval"
     >
 >;

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,5 +1,5 @@
 // re-exports:
-export { createGateway, gateway, type GatewayModelId } from '@ai-sdk/gateway';
+export { createGateway, gateway, type GatewayModelId } from "@ai-sdk/gateway";
 export {
   asSchema,
   createIdGenerator,
@@ -12,6 +12,7 @@ export {
   type FlexibleSchema,
   type IdGenerator,
   type InferSchema,
+  type InferToolApprovalData,
   type InferToolInput,
   type InferToolOutput,
   type Schema,
@@ -21,29 +22,29 @@ export {
   type ToolCallOptions,
   type ToolExecutionOptions,
   type ToolExecuteFunction,
-} from '@ai-sdk/provider-utils';
+} from "@ai-sdk/provider-utils";
 
 // directory exports
-export * from './agent';
-export * from './embed';
-export * from './error';
-export * from './generate-image';
-export * from './generate-object';
-export * from './generate-speech';
-export * from './generate-text';
-export * from './generate-video';
-export * from './logger';
-export * from './middleware';
-export * from './prompt';
-export * from './registry';
-export * from './rerank';
-export * from './text-stream';
-export * from './transcribe';
-export * from './types';
-export * from './ui';
-export * from './ui-message-stream';
-export * from './util';
-export * from './telemetry';
+export * from "./agent";
+export * from "./embed";
+export * from "./error";
+export * from "./generate-image";
+export * from "./generate-object";
+export * from "./generate-speech";
+export * from "./generate-text";
+export * from "./generate-video";
+export * from "./logger";
+export * from "./middleware";
+export * from "./prompt";
+export * from "./registry";
+export * from "./rerank";
+export * from "./text-stream";
+export * from "./transcribe";
+export * from "./types";
+export * from "./ui";
+export * from "./ui-message-stream";
+export * from "./util";
+export * from "./telemetry";
 
 // import globals
-import './global';
+import "./global";

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -2662,6 +2662,53 @@ describe('Chat', () => {
           ]
         `);
       });
+
+      it('should store approval data on the tool invocation', async () => {
+        const chat = new TestChat({
+          id: '123',
+          generateId: mockId({ prefix: 'newid' }),
+          transport: new DefaultChatTransport({
+            api: 'http://localhost:3000/api/chat',
+          }),
+          messages: [
+            {
+              id: 'id-0',
+              role: 'user',
+              parts: [{ text: 'What is the weather in Tokyo?', type: 'text' }],
+            },
+            {
+              id: 'id-1',
+              role: 'assistant',
+              parts: [
+                { type: 'step-start' },
+                {
+                  type: 'tool-weather',
+                  toolCallId: 'call-1',
+                  state: 'approval-requested',
+                  input: { city: 'Tokyo' },
+                  approval: { id: 'approval-1' },
+                },
+              ],
+            },
+          ],
+        });
+
+        await chat.addToolApprovalResponse({
+          id: 'approval-1',
+          approved: true,
+          data: { token: 'abc123', confirmedBy: 'user' },
+        });
+
+        expect(chat.messages[1].parts[1]).toMatchObject({
+          type: 'tool-weather',
+          state: 'approval-responded',
+          approval: {
+            id: 'approval-1',
+            approved: true,
+            data: { token: 'abc123', confirmedBy: 'user' },
+          },
+        });
+      });
     });
 
     describe('approved with automatic sending', () => {

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -3,19 +3,19 @@ import {
   generateId as generateIdFunc,
   IdGenerator,
   InferSchema,
-} from '@ai-sdk/provider-utils';
-import { FinishReason } from '../types/language-model';
-import { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
-import { consumeStream } from '../util/consume-stream';
-import { SerialJobExecutor } from '../util/serial-job-executor';
-import { ChatTransport } from './chat-transport';
-import { convertFileListToFileUIParts } from './convert-file-list-to-file-ui-parts';
-import { DefaultChatTransport } from './default-chat-transport';
+} from "@ai-sdk/provider-utils";
+import { FinishReason } from "../types/language-model";
+import { UIMessageChunk } from "../ui-message-stream/ui-message-chunks";
+import { consumeStream } from "../util/consume-stream";
+import { SerialJobExecutor } from "../util/serial-job-executor";
+import { ChatTransport } from "./chat-transport";
+import { convertFileListToFileUIParts } from "./convert-file-list-to-file-ui-parts";
+import { DefaultChatTransport } from "./default-chat-transport";
 import {
   createStreamingUIMessageState,
   processUIMessageStream,
   StreamingUIMessageState,
-} from './process-ui-message-stream';
+} from "./process-ui-message-stream";
 import {
   InferUIMessageToolCall,
   isToolUIPart,
@@ -28,14 +28,14 @@ import {
   type InferUIMessageTools,
   type UIDataTypes,
   type UIMessage,
-} from './ui-messages';
+} from "./ui-messages";
 
 export type CreateUIMessage<UI_MESSAGE extends UIMessage> = Omit<
   UI_MESSAGE,
-  'id' | 'role'
+  "id" | "role"
 > & {
-  id?: UI_MESSAGE['id'];
-  role?: UI_MESSAGE['role'];
+  id?: UI_MESSAGE["id"];
+  role?: UI_MESSAGE["role"];
 };
 
 export type UIDataPartSchemas = Record<string, FlexibleSchema>;
@@ -69,6 +69,7 @@ export type ChatAddToolApproveResponseFunction = ({
   id,
   approved,
   reason,
+  data,
   options,
 }: {
   id: string;
@@ -82,6 +83,13 @@ export type ChatAddToolApproveResponseFunction = ({
    * Optional reason for the approval or denial.
    */
   reason?: string;
+
+  /**
+   * Optional extra data to pass with the approval response.
+   * This data will be available in the tool's execute function via `options.approvalData`.
+   * Can be used for user input during approval (e.g., confirmation notes, selected options).
+   */
+  data?: unknown;
 
   /**
    * Optional request options to be used if `sendAutomaticallyWhen` callback returns true.
@@ -118,18 +126,18 @@ export type ChatAddToolOutputFunction<UI_MESSAGE extends UIMessage> = <
   options?: ChatRequestOptions;
 } & (
   | {
-      state?: 'output-available';
-      output: InferUIMessageTools<UI_MESSAGE>[TOOL]['output'];
+      state?: "output-available";
+      output: InferUIMessageTools<UI_MESSAGE>[TOOL]["output"];
       errorText?: never;
     }
   | {
-      state: 'output-error';
+      state: "output-error";
       output?: never;
       errorText: string;
     }
 )) => void | PromiseLike<void>;
 
-export type ChatStatus = 'submitted' | 'streaming' | 'ready' | 'error';
+export type ChatStatus = "submitted" | "streaming" | "ready" | "error";
 
 type ActiveResponse<UI_MESSAGE extends UIMessage> = {
   state: StreamingUIMessageState<UI_MESSAGE>;
@@ -248,11 +256,11 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     | UIDataTypesToSchemas<InferUIMessageData<UI_MESSAGE>>
     | undefined;
   private readonly transport: ChatTransport<UI_MESSAGE>;
-  private onError?: ChatInit<UI_MESSAGE>['onError'];
-  private onToolCall?: ChatInit<UI_MESSAGE>['onToolCall'];
-  private onFinish?: ChatInit<UI_MESSAGE>['onFinish'];
-  private onData?: ChatInit<UI_MESSAGE>['onData'];
-  private sendAutomaticallyWhen?: ChatInit<UI_MESSAGE>['sendAutomaticallyWhen'];
+  private onError?: ChatInit<UI_MESSAGE>["onError"];
+  private onToolCall?: ChatInit<UI_MESSAGE>["onToolCall"];
+  private onFinish?: ChatInit<UI_MESSAGE>["onFinish"];
+  private onData?: ChatInit<UI_MESSAGE>["onData"];
+  private sendAutomaticallyWhen?: ChatInit<UI_MESSAGE>["sendAutomaticallyWhen"];
 
   private activeResponse: ActiveResponse<UI_MESSAGE> | undefined = undefined;
   private jobExecutor = new SerialJobExecutor();
@@ -269,7 +277,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     onFinish,
     onData,
     sendAutomaticallyWhen,
-  }: Omit<ChatInit<UI_MESSAGE>, 'messages'> & {
+  }: Omit<ChatInit<UI_MESSAGE>, "messages"> & {
     state: ChatState<UI_MESSAGE>;
   }) {
     this.id = id;
@@ -356,7 +364,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
   ): Promise<void> => {
     if (message == null) {
       await this.makeRequest({
-        trigger: 'submit-message',
+        trigger: "submit-message",
         messageId: this.lastMessage?.id,
         ...options,
       });
@@ -365,7 +373,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
     let uiMessage: CreateUIMessage<UI_MESSAGE>;
 
-    if ('text' in message || 'files' in message) {
+    if ("text" in message || "files" in message) {
       const fileParts = Array.isArray(message.files)
         ? message.files
         : await convertFileListToFileUIParts(message.files);
@@ -373,8 +381,8 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       uiMessage = {
         parts: [
           ...fileParts,
-          ...('text' in message && message.text != null
-            ? [{ type: 'text' as const, text: message.text }]
+          ...("text" in message && message.text != null
+            ? [{ type: "text" as const, text: message.text }]
             : []),
         ],
       } as UI_MESSAGE;
@@ -384,14 +392,14 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
     if (message.messageId != null) {
       const messageIndex = this.state.messages.findIndex(
-        m => m.id === message.messageId,
+        (m) => m.id === message.messageId,
       );
 
       if (messageIndex === -1) {
         throw new Error(`message with id ${message.messageId} not found`);
       }
 
-      if (this.state.messages[messageIndex].role !== 'user') {
+      if (this.state.messages[messageIndex].role !== "user") {
         throw new Error(
           `message with id ${message.messageId} is not a user message`,
         );
@@ -404,20 +412,20 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       this.state.replaceMessage(messageIndex, {
         ...uiMessage,
         id: message.messageId,
-        role: uiMessage.role ?? 'user',
+        role: uiMessage.role ?? "user",
         metadata: message.metadata,
       } as UI_MESSAGE);
     } else {
       this.state.pushMessage({
         ...uiMessage,
         id: uiMessage.id ?? this.generateId(),
-        role: uiMessage.role ?? 'user',
+        role: uiMessage.role ?? "user",
         metadata: message.metadata,
       } as UI_MESSAGE);
     }
 
     await this.makeRequest({
-      trigger: 'submit-message',
+      trigger: "submit-message",
       messageId: message.messageId,
       ...options,
     });
@@ -436,7 +444,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     const messageIndex =
       messageId == null
         ? this.state.messages.length - 1
-        : this.state.messages.findIndex(message => message.id === messageId);
+        : this.state.messages.findIndex((message) => message.id === messageId);
 
     if (messageIndex === -1) {
       throw new Error(`message ${messageId} not found`);
@@ -446,13 +454,13 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     this.state.messages = this.state.messages.slice(
       0,
       // if the message is a user message, we need to include it in the request:
-      this.messages[messageIndex].role === 'assistant'
+      this.messages[messageIndex].role === "assistant"
         ? messageIndex
         : messageIndex + 1,
     );
 
     await this.makeRequest({
-      trigger: 'regenerate-message',
+      trigger: "regenerate-message",
       messageId,
       ...options,
     });
@@ -462,16 +470,16 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
    * Attempt to resume an ongoing streaming response.
    */
   resumeStream = async (options: ChatRequestOptions = {}): Promise<void> => {
-    await this.makeRequest({ trigger: 'resume-stream', ...options });
+    await this.makeRequest({ trigger: "resume-stream", ...options });
   };
 
   /**
    * Clear the error state and set the status to ready if the chat is in an error state.
    */
   clearError = () => {
-    if (this.status === 'error') {
+    if (this.status === "error") {
       this.state.error = undefined;
-      this.setStatus({ status: 'ready' });
+      this.setStatus({ status: "ready" });
     }
   };
 
@@ -479,6 +487,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     id,
     approved,
     reason,
+    data,
     options,
   }) =>
     this.jobExecutor.run(async () => {
@@ -489,12 +498,17 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         part: UIMessagePart<UIDataTypes, UITools>,
       ): UIMessagePart<UIDataTypes, UITools> =>
         isToolUIPart(part) &&
-        part.state === 'approval-requested' &&
+        part.state === "approval-requested" &&
         part.approval.id === id
           ? {
               ...part,
-              state: 'approval-responded',
-              approval: { id, approved, reason },
+              state: "approval-responded",
+              approval: {
+                id,
+                approved,
+                reason,
+                ...(data !== undefined ? { data } : {}),
+              },
             }
           : part;
 
@@ -512,15 +526,15 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
       // automatically send the message if the sendAutomaticallyWhen function returns true
       if (
-        this.status !== 'streaming' &&
-        this.status !== 'submitted' &&
+        this.status !== "streaming" &&
+        this.status !== "submitted" &&
         this.sendAutomaticallyWhen
       ) {
-        this.shouldSendAutomatically().then(shouldSend => {
+        this.shouldSendAutomatically().then((shouldSend) => {
           if (shouldSend) {
             // no await to avoid deadlocking
             this.makeRequest({
-              trigger: 'submit-message',
+              trigger: "submit-message",
               messageId: this.lastMessage?.id,
               ...options,
             });
@@ -530,7 +544,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     });
 
   addToolOutput: ChatAddToolOutputFunction<UI_MESSAGE> = async ({
-    state = 'output-available',
+    state = "output-available",
     toolCallId,
     output,
     errorText,
@@ -561,15 +575,15 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
       // automatically send the message if the sendAutomaticallyWhen function returns true
       if (
-        this.status !== 'streaming' &&
-        this.status !== 'submitted' &&
+        this.status !== "streaming" &&
+        this.status !== "submitted" &&
         this.sendAutomaticallyWhen
       ) {
-        this.shouldSendAutomatically().then(shouldSend => {
+        this.shouldSendAutomatically().then((shouldSend) => {
           if (shouldSend) {
             // no await to avoid deadlocking
             this.makeRequest({
-              trigger: 'submit-message',
+              trigger: "submit-message",
               messageId: this.lastMessage?.id,
               ...options,
             });
@@ -585,7 +599,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
    * Abort the current request immediately, keep the generated tokens if any.
    */
   stop = async () => {
-    if (this.status !== 'streaming' && this.status !== 'submitted') return;
+    if (this.status !== "streaming" && this.status !== "submitted") return;
 
     if (this.activeResponse?.abortController) {
       this.activeResponse.abortController.abort();
@@ -600,7 +614,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     });
 
     // Check if result is a promise
-    if (result && typeof result === 'object' && 'then' in result) {
+    if (result && typeof result === "object" && "then" in result) {
       return await result;
     }
 
@@ -614,14 +628,14 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     body,
     messageId,
   }: {
-    trigger: 'submit-message' | 'resume-stream' | 'regenerate-message';
+    trigger: "submit-message" | "resume-stream" | "regenerate-message";
     messageId?: string;
   } & ChatRequestOptions) {
     // For resume-stream, check if there's an active stream before
     // changing status. This avoids a brief flash of 'submitted' status
     // when there is no stream to resume (e.g. on page load).
     let resumeStream: ReadableStream<UIMessageChunk> | undefined;
-    if (trigger === 'resume-stream') {
+    if (trigger === "resume-stream") {
       try {
         const reconnect = await this.transport.reconnectToStream({
           chatId: this.id,
@@ -639,12 +653,12 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         if (this.onError && err instanceof Error) {
           this.onError(err);
         }
-        this.setStatus({ status: 'error', error: err as Error });
+        this.setStatus({ status: "error", error: err as Error });
         return;
       }
     }
 
-    this.setStatus({ status: 'submitted', error: undefined });
+    this.setStatus({ status: "submitted", error: undefined });
 
     const lastMessage = this.lastMessage;
 
@@ -661,7 +675,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         abortController: new AbortController(),
       } as ActiveResponse<UI_MESSAGE>;
 
-      activeResponse.abortController.signal.addEventListener('abort', () => {
+      activeResponse.abortController.signal.addEventListener("abort", () => {
         isAbort = true;
       });
 
@@ -669,7 +683,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
       let stream: ReadableStream<UIMessageChunk>;
 
-      if (trigger === 'resume-stream') {
+      if (trigger === "resume-stream") {
         stream = resumeStream!;
       } else {
         stream = await this.transport.sendMessages({
@@ -696,7 +710,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
             state: activeResponse.state,
             write: () => {
               // streaming is set on first write (before it should be "submitted")
-              this.setStatus({ status: 'streaming' });
+              this.setStatus({ status: "streaming" });
 
               const replaceLastMessage =
                 activeResponse.state.message.id === this.lastMessage?.id;
@@ -721,21 +735,21 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           messageMetadataSchema: this.messageMetadataSchema,
           dataPartSchemas: this.dataPartSchemas,
           runUpdateMessageJob,
-          onError: error => {
+          onError: (error) => {
             throw error;
           },
         }),
-        onError: error => {
+        onError: (error) => {
           throw error;
         },
       });
 
-      this.setStatus({ status: 'ready' });
+      this.setStatus({ status: "ready" });
     } catch (err) {
       // Ignore abort errors as they are expected.
-      if (isAbort || (err as any).name === 'AbortError') {
+      if (isAbort || (err as any).name === "AbortError") {
         isAbort = true;
-        this.setStatus({ status: 'ready' });
+        this.setStatus({ status: "ready" });
         return null;
       }
 
@@ -744,8 +758,8 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       // Network errors such as disconnected, timeout, etc.
       if (
         err instanceof TypeError &&
-        (err.message.toLowerCase().includes('fetch') ||
-          err.message.toLowerCase().includes('network'))
+        (err.message.toLowerCase().includes("fetch") ||
+          err.message.toLowerCase().includes("network"))
       ) {
         isDisconnect = true;
       }
@@ -754,7 +768,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         this.onError(err);
       }
 
-      this.setStatus({ status: 'error', error: err as Error });
+      this.setStatus({ status: "error", error: err as Error });
     } finally {
       try {
         this.onFinish?.({
@@ -775,7 +789,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     // automatically send the message if the sendAutomaticallyWhen function returns true
     if (!isError && (await this.shouldSendAutomatically())) {
       await this.makeRequest({
-        trigger: 'submit-message',
+        trigger: "submit-message",
         messageId: this.lastMessage?.id,
         metadata,
         headers,

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -1604,6 +1604,54 @@ describe('convertToModelMessages', () => {
       `);
     });
 
+    it('should include approval data in an approved tool approval response', async () => {
+      const result = await convertToModelMessages([
+        {
+          parts: [
+            {
+              text: 'What is the weather in Tokyo?',
+              type: 'text',
+            },
+          ],
+          role: 'user',
+        },
+        {
+          parts: [
+            {
+              type: 'step-start',
+            },
+            {
+              approval: {
+                approved: true,
+                data: { token: 'abc123', confirmedBy: 'user' },
+                id: 'approval-1',
+                reason: undefined,
+              },
+              input: {
+                city: 'Tokyo',
+              },
+              state: 'approval-responded',
+              toolCallId: 'call-1',
+              type: 'tool-weather',
+            },
+          ],
+          role: 'assistant',
+        },
+      ]);
+
+      expect(result[2]).toMatchObject({
+        role: 'tool',
+        content: [
+          {
+            approvalId: 'approval-1',
+            approved: true,
+            data: { token: 'abc123', confirmedBy: 'user' },
+            type: 'tool-approval-response',
+          },
+        ],
+      });
+    });
+
     it('should convert a denied tool approval request and follow up text (static tool)', async () => {
       const result = await convertToModelMessages([
         {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -6,10 +6,10 @@ import {
   TextPart,
   ToolApprovalResponse,
   ToolResultPart,
-} from '@ai-sdk/provider-utils';
-import { ToolSet } from '../generate-text/tool-set';
-import { createToolModelOutput } from '../prompt/create-tool-model-output';
-import { MessageConversionError } from '../prompt/message-conversion-error';
+} from "@ai-sdk/provider-utils";
+import { ToolSet } from "../generate-text/tool-set";
+import { createToolModelOutput } from "../prompt/create-tool-model-output";
+import { MessageConversionError } from "../prompt/message-conversion-error";
 import {
   DataUIPart,
   DynamicToolUIPart,
@@ -26,7 +26,7 @@ import {
   TextUIPart,
   ToolUIPart,
   UIMessage,
-} from './ui-messages';
+} from "./ui-messages";
 
 /**
  * Converts an array of UI messages from useChat into an array of ModelMessages that can be used
@@ -40,7 +40,7 @@ import {
  * @returns An array of ModelMessages.
  */
 export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
-  messages: Array<Omit<UI_MESSAGE, 'id'>>,
+  messages: Array<Omit<UI_MESSAGE, "id">>,
   options?: {
     tools?: ToolSet;
     ignoreIncompleteToolCalls?: boolean;
@@ -52,22 +52,22 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
   const modelMessages: ModelMessage[] = [];
 
   if (options?.ignoreIncompleteToolCalls) {
-    messages = messages.map(message => ({
+    messages = messages.map((message) => ({
       ...message,
       parts: message.parts.filter(
-        part =>
+        (part) =>
           !isToolUIPart(part) ||
-          (part.state !== 'input-streaming' &&
-            part.state !== 'input-available'),
+          (part.state !== "input-streaming" &&
+            part.state !== "input-available"),
       ),
     }));
   }
 
   for (const message of messages) {
     switch (message.role) {
-      case 'system': {
+      case "system": {
         const textParts = message.parts.filter(
-          (part): part is TextUIPart => part.type === 'text',
+          (part): part is TextUIPart => part.type === "text",
         );
 
         const providerMetadata = textParts.reduce((acc, part) => {
@@ -78,8 +78,8 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
         }, {});
 
         modelMessages.push({
-          role: 'system',
-          content: textParts.map(part => part.text).join(''),
+          role: "system",
+          content: textParts.map((part) => part.text).join(""),
           ...(Object.keys(providerMetadata).length > 0
             ? { providerOptions: providerMetadata }
             : {}),
@@ -87,15 +87,15 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
         break;
       }
 
-      case 'user': {
+      case "user": {
         modelMessages.push({
-          role: 'user',
+          role: "user",
           content: message.parts
             .map((part): TextPart | FilePart | undefined => {
               // Process text parts
               if (isTextUIPart(part)) {
                 return {
-                  type: 'text' as const,
+                  type: "text" as const,
                   text: part.text,
                   ...(part.providerMetadata != null
                     ? { providerOptions: part.providerMetadata }
@@ -106,7 +106,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
               // Process file parts
               if (isFileUIPart(part)) {
                 return {
-                  type: 'file' as const,
+                  type: "file" as const,
                   mediaType: part.mediaType,
                   filename: part.filename,
                   data: part.url,
@@ -129,7 +129,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
         break;
       }
 
-      case 'assistant': {
+      case "assistant": {
         if (message.parts != null) {
           let block: Array<
             | TextUIPart
@@ -150,7 +150,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
             for (const part of block) {
               if (isTextUIPart(part)) {
                 content.push({
-                  type: 'text' as const,
+                  type: "text" as const,
                   text: part.text,
                   ...(part.providerMetadata != null
                     ? { providerOptions: part.providerMetadata }
@@ -158,7 +158,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                 });
               } else if (isFileUIPart(part)) {
                 content.push({
-                  type: 'file' as const,
+                  type: "file" as const,
                   mediaType: part.mediaType,
                   filename: part.filename,
                   data: part.url,
@@ -168,22 +168,22 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                 });
               } else if (isReasoningUIPart(part)) {
                 content.push({
-                  type: 'reasoning' as const,
+                  type: "reasoning" as const,
                   text: part.text,
                   providerOptions: part.providerMetadata,
                 });
               } else if (isToolUIPart(part)) {
                 const toolName = getToolName(part);
 
-                if (part.state !== 'input-streaming') {
+                if (part.state !== "input-streaming") {
                   content.push({
-                    type: 'tool-call' as const,
+                    type: "tool-call" as const,
                     toolCallId: part.toolCallId,
                     toolName,
                     input:
-                      part.state === 'output-error'
+                      part.state === "output-error"
                         ? (part.input ??
-                          ('rawInput' in part ? part.rawInput : undefined))
+                          ("rawInput" in part ? part.rawInput : undefined))
                         : part.input,
                     providerExecuted: part.providerExecuted,
                     ...(part.callProviderMetadata != null
@@ -193,7 +193,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
 
                   if (part.approval != null) {
                     content.push({
-                      type: 'tool-approval-request' as const,
+                      type: "tool-approval-request" as const,
                       approvalId: part.approval.id,
                       toolCallId: part.toolCallId,
                     });
@@ -201,27 +201,27 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
 
                   if (
                     part.providerExecuted === true &&
-                    part.state !== 'approval-responded' &&
-                    (part.state === 'output-available' ||
-                      part.state === 'output-error')
+                    part.state !== "approval-responded" &&
+                    (part.state === "output-available" ||
+                      part.state === "output-error")
                   ) {
                     const resultProviderMetadata =
                       part.resultProviderMetadata ?? part.callProviderMetadata;
 
                     content.push({
-                      type: 'tool-result',
+                      type: "tool-result",
                       toolCallId: part.toolCallId,
                       toolName,
                       output: await createToolModelOutput({
                         toolCallId: part.toolCallId,
                         input: part.input,
                         output:
-                          part.state === 'output-error'
+                          part.state === "output-error"
                             ? part.errorText
                             : part.output,
                         tool: options?.tools?.[toolName],
                         errorMode:
-                          part.state === 'output-error' ? 'json' : 'none',
+                          part.state === "output-error" ? "json" : "none",
                       }),
                       ...(resultProviderMetadata != null
                         ? { providerOptions: resultProviderMetadata }
@@ -244,14 +244,14 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
             }
 
             modelMessages.push({
-              role: 'assistant',
+              role: "assistant",
               content,
             });
 
             // check if there are tool invocations with results in the block
             // Include non-provider-executed tools, OR provider-executed tools with approval responses
             const toolParts = block.filter(
-              part =>
+              (part) =>
                 isToolUIPart(part) &&
                 (part.providerExecuted !== true ||
                   part.approval?.approved != null),
@@ -269,11 +269,14 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                   // add approval response for approved tool calls:
                   if (toolPart.approval?.approved != null) {
                     content.push({
-                      type: 'tool-approval-response' as const,
+                      type: "tool-approval-response" as const,
                       approvalId: toolPart.approval.id,
                       approved: toolPart.approval.approved,
                       reason: toolPart.approval.reason,
                       providerExecuted: toolPart.providerExecuted,
+                      ...(toolPart.approval.data !== undefined
+                        ? { data: toolPart.approval.data }
+                        : {}),
                     });
                   }
 
@@ -285,16 +288,16 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                   }
 
                   switch (toolPart.state) {
-                    case 'output-denied': {
+                    case "output-denied": {
                       content.push({
-                        type: 'tool-result',
+                        type: "tool-result",
                         toolCallId: toolPart.toolCallId,
                         toolName: getToolName(toolPart),
                         output: {
-                          type: 'error-text' as const,
+                          type: "error-text" as const,
                           value:
                             toolPart.approval.reason ??
-                            'Tool execution denied.',
+                            "Tool execution denied.",
                         },
                         ...(toolPart.callProviderMetadata != null
                           ? { providerOptions: toolPart.callProviderMetadata }
@@ -303,23 +306,23 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                       break;
                     }
 
-                    case 'output-error':
-                    case 'output-available': {
+                    case "output-error":
+                    case "output-available": {
                       const toolName = getToolName(toolPart);
                       content.push({
-                        type: 'tool-result',
+                        type: "tool-result",
                         toolCallId: toolPart.toolCallId,
                         toolName,
                         output: await createToolModelOutput({
                           toolCallId: toolPart.toolCallId,
                           input: toolPart.input,
                           output:
-                            toolPart.state === 'output-error'
+                            toolPart.state === "output-error"
                               ? toolPart.errorText
                               : toolPart.output,
                           tool: options?.tools?.[toolName],
                           errorMode:
-                            toolPart.state === 'output-error' ? 'text' : 'none',
+                            toolPart.state === "output-error" ? "text" : "none",
                         }),
                         ...(toolPart.callProviderMetadata != null
                           ? { providerOptions: toolPart.callProviderMetadata }
@@ -332,7 +335,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
 
                 if (content.length > 0) {
                   modelMessages.push({
-                    role: 'tool',
+                    role: "tool",
                     content,
                   });
                 }
@@ -352,7 +355,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
               isDataUIPart(part)
             ) {
               block.push(part as (typeof block)[number]);
-            } else if (part.type === 'step-start') {
+            } else if (part.type === "step-start") {
               await processBlock();
             }
           }

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -3,11 +3,11 @@ import {
   InferToolOutput,
   Tool,
   ToolCall,
-} from '@ai-sdk/provider-utils';
-import { ToolSet } from '../generate-text';
-import { ProviderMetadata } from '../types/provider-metadata';
-import { DeepPartial } from '../util/deep-partial';
-import { ValueOf } from '../util/value-of';
+} from "@ai-sdk/provider-utils";
+import { ToolSet } from "../generate-text";
+import { ProviderMetadata } from "../types/provider-metadata";
+import { DeepPartial } from "../util/deep-partial";
+import { ValueOf } from "../util/value-of";
 
 /**
  * The data types that can be used in the UI message for the UI message data parts.
@@ -52,7 +52,7 @@ export interface UIMessage<
   /**
    * The role of the message.
    */
-  role: 'system' | 'user' | 'assistant';
+  role: "system" | "user" | "assistant";
 
   /**
    * The metadata of the message.
@@ -90,7 +90,7 @@ export type UIMessagePart<
  * A text part of a message.
  */
 export type TextUIPart = {
-  type: 'text';
+  type: "text";
 
   /**
    * The text content.
@@ -100,7 +100,7 @@ export type TextUIPart = {
   /**
    * The state of the text part.
    */
-  state?: 'streaming' | 'done';
+  state?: "streaming" | "done";
 
   /**
    * The provider metadata.
@@ -112,7 +112,7 @@ export type TextUIPart = {
  * A reasoning part of a message.
  */
 export type ReasoningUIPart = {
-  type: 'reasoning';
+  type: "reasoning";
 
   /**
    * The reasoning text.
@@ -122,7 +122,7 @@ export type ReasoningUIPart = {
   /**
    * The state of the reasoning part.
    */
-  state?: 'streaming' | 'done';
+  state?: "streaming" | "done";
 
   /**
    * The provider metadata.
@@ -134,7 +134,7 @@ export type ReasoningUIPart = {
  * A source part of a message.
  */
 export type SourceUrlUIPart = {
-  type: 'source-url';
+  type: "source-url";
   sourceId: string;
   url: string;
   title?: string;
@@ -145,7 +145,7 @@ export type SourceUrlUIPart = {
  * A document source part of a message.
  */
 export type SourceDocumentUIPart = {
-  type: 'source-document';
+  type: "source-document";
   sourceId: string;
   mediaType: string;
   title: string;
@@ -157,7 +157,7 @@ export type SourceDocumentUIPart = {
  * A file part of a message.
  */
 export type FileUIPart = {
-  type: 'file';
+  type: "file";
 
   /**
    * IANA media type of the file.
@@ -187,7 +187,7 @@ export type FileUIPart = {
  * A step boundary part of a message.
  */
 export type StepStartUIPart = {
-  type: 'step-start';
+  type: "step-start";
 };
 
 export type DataUIPart<DATA_TYPES extends UIDataTypes> = ValueOf<{
@@ -208,7 +208,7 @@ type asUITool<TOOL extends UITool | Tool> = TOOL extends Tool
 export function isDataUIPart<DATA_TYPES extends UIDataTypes>(
   part: UIMessagePart<DATA_TYPES, UITools>,
 ): part is DataUIPart<DATA_TYPES> {
-  return part.type.startsWith('data-');
+  return part.type.startsWith("data-");
 }
 
 /**
@@ -229,24 +229,24 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
   providerExecuted?: boolean;
 } & (
   | {
-      state: 'input-streaming';
-      input: DeepPartial<asUITool<TOOL>['input']> | undefined;
+      state: "input-streaming";
+      input: DeepPartial<asUITool<TOOL>["input"]> | undefined;
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;
       approval?: never;
     }
   | {
-      state: 'input-available';
-      input: asUITool<TOOL>['input'];
+      state: "input-available";
+      input: asUITool<TOOL>["input"];
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;
       approval?: never;
     }
   | {
-      state: 'approval-requested';
-      input: asUITool<TOOL>['input'];
+      state: "approval-requested";
+      input: asUITool<TOOL>["input"];
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;
@@ -257,8 +257,8 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
       };
     }
   | {
-      state: 'approval-responded';
-      input: asUITool<TOOL>['input'];
+      state: "approval-responded";
+      input: asUITool<TOOL>["input"];
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;
@@ -266,12 +266,13 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         id: string;
         approved: boolean;
         reason?: string;
+        data?: unknown;
       };
     }
   | {
-      state: 'output-available';
-      input: asUITool<TOOL>['input'];
-      output: asUITool<TOOL>['output'];
+      state: "output-available";
+      input: asUITool<TOOL>["input"];
+      output: asUITool<TOOL>["output"];
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;
       resultProviderMetadata?: ProviderMetadata;
@@ -280,11 +281,12 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         id: string;
         approved: true;
         reason?: string;
+        data?: unknown;
       };
     }
   | {
-      state: 'output-error'; // TODO AI SDK 6: change to 'error' state
-      input: asUITool<TOOL>['input'] | undefined;
+      state: "output-error"; // TODO AI SDK 6: change to 'error' state
+      input: asUITool<TOOL>["input"] | undefined;
       rawInput?: unknown; // TODO AI SDK 6: remove this field, input should be unknown
       output?: never;
       errorText: string;
@@ -294,11 +296,12 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         id: string;
         approved: true;
         reason?: string;
+        data?: unknown;
       };
     }
   | {
-      state: 'output-denied';
-      input: asUITool<TOOL>['input'];
+      state: "output-denied";
+      input: asUITool<TOOL>["input"];
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;
@@ -306,6 +309,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         id: string;
         approved: false;
         reason?: string;
+        data?: unknown;
       };
     }
 );
@@ -317,7 +321,7 @@ export type ToolUIPart<TOOLS extends UITools = UITools> = ValueOf<{
 }>;
 
 export type DynamicToolUIPart = {
-  type: 'dynamic-tool';
+  type: "dynamic-tool";
 
   /**
    * Name of the tool that is being called.
@@ -336,7 +340,7 @@ export type DynamicToolUIPart = {
   providerExecuted?: boolean;
 } & (
   | {
-      state: 'input-streaming';
+      state: "input-streaming";
       input: unknown | undefined;
       output?: never;
       errorText?: never;
@@ -344,7 +348,7 @@ export type DynamicToolUIPart = {
       approval?: never;
     }
   | {
-      state: 'input-available';
+      state: "input-available";
       input: unknown;
       output?: never;
       errorText?: never;
@@ -352,7 +356,7 @@ export type DynamicToolUIPart = {
       approval?: never;
     }
   | {
-      state: 'approval-requested';
+      state: "approval-requested";
       input: unknown;
       output?: never;
       errorText?: never;
@@ -364,7 +368,7 @@ export type DynamicToolUIPart = {
       };
     }
   | {
-      state: 'approval-responded';
+      state: "approval-responded";
       input: unknown;
       output?: never;
       errorText?: never;
@@ -373,10 +377,11 @@ export type DynamicToolUIPart = {
         id: string;
         approved: boolean;
         reason?: string;
+        data?: unknown;
       };
     }
   | {
-      state: 'output-available';
+      state: "output-available";
       input: unknown;
       output: unknown;
       errorText?: never;
@@ -387,10 +392,11 @@ export type DynamicToolUIPart = {
         id: string;
         approved: true;
         reason?: string;
+        data?: unknown;
       };
     }
   | {
-      state: 'output-error'; // TODO AI SDK 6: change to 'error' state
+      state: "output-error"; // TODO AI SDK 6: change to 'error' state
       input: unknown;
       output?: never;
       errorText: string;
@@ -400,10 +406,11 @@ export type DynamicToolUIPart = {
         id: string;
         approved: true;
         reason?: string;
+        data?: unknown;
       };
     }
   | {
-      state: 'output-denied';
+      state: "output-denied";
       input: unknown;
       output?: never;
       errorText?: never;
@@ -412,6 +419,7 @@ export type DynamicToolUIPart = {
         id: string;
         approved: false;
         reason?: string;
+        data?: unknown;
       };
     }
 );
@@ -422,7 +430,7 @@ export type DynamicToolUIPart = {
 export function isTextUIPart(
   part: UIMessagePart<UIDataTypes, UITools>,
 ): part is TextUIPart {
-  return part.type === 'text';
+  return part.type === "text";
 }
 
 /**
@@ -431,7 +439,7 @@ export function isTextUIPart(
 export function isFileUIPart(
   part: UIMessagePart<UIDataTypes, UITools>,
 ): part is FileUIPart {
-  return part.type === 'file';
+  return part.type === "file";
 }
 
 /**
@@ -440,7 +448,7 @@ export function isFileUIPart(
 export function isReasoningUIPart(
   part: UIMessagePart<UIDataTypes, UITools>,
 ): part is ReasoningUIPart {
-  return part.type === 'reasoning';
+  return part.type === "reasoning";
 }
 
 /**
@@ -451,7 +459,7 @@ export function isReasoningUIPart(
 export function isStaticToolUIPart<TOOLS extends UITools>(
   part: UIMessagePart<UIDataTypes, TOOLS>,
 ): part is ToolUIPart<TOOLS> {
-  return part.type.startsWith('tool-');
+  return part.type.startsWith("tool-");
 }
 
 /**
@@ -462,7 +470,7 @@ export function isStaticToolUIPart<TOOLS extends UITools>(
 export function isDynamicToolUIPart(
   part: UIMessagePart<UIDataTypes, UITools>,
 ): part is DynamicToolUIPart {
-  return part.type === 'dynamic-tool';
+  return part.type === "dynamic-tool";
 }
 
 /**
@@ -491,7 +499,7 @@ export const isToolOrDynamicToolUIPart = isToolUIPart;
 export function getStaticToolName<TOOLS extends UITools>(
   part: ToolUIPart<TOOLS>,
 ): keyof TOOLS {
-  return part.type.split('-').slice(1).join('-') as keyof TOOLS;
+  return part.type.split("-").slice(1).join("-") as keyof TOOLS;
 }
 
 /**
@@ -521,7 +529,7 @@ export type InferUIMessageTools<T extends UIMessage> =
   T extends UIMessage<unknown, UIDataTypes, infer TOOLS> ? TOOLS : UITools;
 
 export type InferUIMessageToolOutputs<UI_MESSAGE extends UIMessage> =
-  InferUIMessageTools<UI_MESSAGE>[keyof InferUIMessageTools<UI_MESSAGE>]['output'];
+  InferUIMessageTools<UI_MESSAGE>[keyof InferUIMessageTools<UI_MESSAGE>]["output"];
 
 export type InferUIMessageToolCall<UI_MESSAGE extends UIMessage> =
   | ValueOf<{

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -1,4 +1,4 @@
-import { TypeValidationContext, TypeValidationError } from '@ai-sdk/provider';
+import { TypeValidationContext, TypeValidationError } from "@ai-sdk/provider";
 import {
   FlexibleSchema,
   lazySchema,
@@ -6,17 +6,17 @@ import {
   Tool,
   validateTypes,
   zodSchema,
-} from '@ai-sdk/provider-utils';
-import { z } from 'zod/v4';
-import { InvalidArgumentError } from '../error';
-import { providerMetadataSchema } from '../types/provider-metadata';
+} from "@ai-sdk/provider-utils";
+import { z } from "zod/v4";
+import { InvalidArgumentError } from "../error";
+import { providerMetadataSchema } from "../types/provider-metadata";
 import {
   DataUIPart,
   InferUIMessageData,
   InferUIMessageTools,
   ToolUIPart,
   UIMessage,
-} from './ui-messages';
+} from "./ui-messages";
 
 const uiMessagesSchema = lazySchema(() =>
   zodSchema(
@@ -24,32 +24,32 @@ const uiMessagesSchema = lazySchema(() =>
       .array(
         z.object({
           id: z.string(),
-          role: z.enum(['system', 'user', 'assistant']),
+          role: z.enum(["system", "user", "assistant"]),
           metadata: z.unknown().optional(),
           parts: z
             .array(
               z.union([
                 z.object({
-                  type: z.literal('text'),
+                  type: z.literal("text"),
                   text: z.string(),
-                  state: z.enum(['streaming', 'done']).optional(),
+                  state: z.enum(["streaming", "done"]).optional(),
                   providerMetadata: providerMetadataSchema.optional(),
                 }),
                 z.object({
-                  type: z.literal('reasoning'),
+                  type: z.literal("reasoning"),
                   text: z.string(),
-                  state: z.enum(['streaming', 'done']).optional(),
+                  state: z.enum(["streaming", "done"]).optional(),
                   providerMetadata: providerMetadataSchema.optional(),
                 }),
                 z.object({
-                  type: z.literal('source-url'),
+                  type: z.literal("source-url"),
                   sourceId: z.string(),
                   url: z.string(),
                   title: z.string().optional(),
                   providerMetadata: providerMetadataSchema.optional(),
                 }),
                 z.object({
-                  type: z.literal('source-document'),
+                  type: z.literal("source-document"),
                   sourceId: z.string(),
                   mediaType: z.string(),
                   title: z.string(),
@@ -57,25 +57,25 @@ const uiMessagesSchema = lazySchema(() =>
                   providerMetadata: providerMetadataSchema.optional(),
                 }),
                 z.object({
-                  type: z.literal('file'),
+                  type: z.literal("file"),
                   mediaType: z.string(),
                   filename: z.string().optional(),
                   url: z.string(),
                   providerMetadata: providerMetadataSchema.optional(),
                 }),
                 z.object({
-                  type: z.literal('step-start'),
+                  type: z.literal("step-start"),
                 }),
                 z.object({
-                  type: z.string().startsWith('data-'),
+                  type: z.string().startsWith("data-"),
                   id: z.string().optional(),
                   data: z.unknown(),
                 }),
                 z.object({
-                  type: z.literal('dynamic-tool'),
+                  type: z.literal("dynamic-tool"),
                   toolName: z.string(),
                   toolCallId: z.string(),
-                  state: z.literal('input-streaming'),
+                  state: z.literal("input-streaming"),
                   input: z.unknown().optional(),
                   providerExecuted: z.boolean().optional(),
                   callProviderMetadata: providerMetadataSchema.optional(),
@@ -84,10 +84,10 @@ const uiMessagesSchema = lazySchema(() =>
                   approval: z.never().optional(),
                 }),
                 z.object({
-                  type: z.literal('dynamic-tool'),
+                  type: z.literal("dynamic-tool"),
                   toolName: z.string(),
                   toolCallId: z.string(),
-                  state: z.literal('input-available'),
+                  state: z.literal("input-available"),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
                   output: z.never().optional(),
@@ -96,10 +96,10 @@ const uiMessagesSchema = lazySchema(() =>
                   approval: z.never().optional(),
                 }),
                 z.object({
-                  type: z.literal('dynamic-tool'),
+                  type: z.literal("dynamic-tool"),
                   toolName: z.string(),
                   toolCallId: z.string(),
-                  state: z.literal('approval-requested'),
+                  state: z.literal("approval-requested"),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
                   output: z.never().optional(),
@@ -112,10 +112,10 @@ const uiMessagesSchema = lazySchema(() =>
                   }),
                 }),
                 z.object({
-                  type: z.literal('dynamic-tool'),
+                  type: z.literal("dynamic-tool"),
                   toolName: z.string(),
                   toolCallId: z.string(),
-                  state: z.literal('approval-responded'),
+                  state: z.literal("approval-responded"),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
                   output: z.never().optional(),
@@ -125,13 +125,14 @@ const uiMessagesSchema = lazySchema(() =>
                     id: z.string(),
                     approved: z.boolean(),
                     reason: z.string().optional(),
+                    data: z.unknown().optional(),
                   }),
                 }),
                 z.object({
-                  type: z.literal('dynamic-tool'),
+                  type: z.literal("dynamic-tool"),
                   toolName: z.string(),
                   toolCallId: z.string(),
-                  state: z.literal('output-available'),
+                  state: z.literal("output-available"),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
                   output: z.unknown(),
@@ -144,14 +145,15 @@ const uiMessagesSchema = lazySchema(() =>
                       id: z.string(),
                       approved: z.literal(true),
                       reason: z.string().optional(),
+                      data: z.unknown().optional(),
                     })
                     .optional(),
                 }),
                 z.object({
-                  type: z.literal('dynamic-tool'),
+                  type: z.literal("dynamic-tool"),
                   toolName: z.string(),
                   toolCallId: z.string(),
-                  state: z.literal('output-error'),
+                  state: z.literal("output-error"),
                   input: z.unknown(),
                   rawInput: z.unknown().optional(),
                   providerExecuted: z.boolean().optional(),
@@ -164,14 +166,15 @@ const uiMessagesSchema = lazySchema(() =>
                       id: z.string(),
                       approved: z.literal(true),
                       reason: z.string().optional(),
+                      data: z.unknown().optional(),
                     })
                     .optional(),
                 }),
                 z.object({
-                  type: z.literal('dynamic-tool'),
+                  type: z.literal("dynamic-tool"),
                   toolName: z.string(),
                   toolCallId: z.string(),
-                  state: z.literal('output-denied'),
+                  state: z.literal("output-denied"),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
                   output: z.never().optional(),
@@ -181,12 +184,13 @@ const uiMessagesSchema = lazySchema(() =>
                     id: z.string(),
                     approved: z.literal(false),
                     reason: z.string().optional(),
+                    data: z.unknown().optional(),
                   }),
                 }),
                 z.object({
-                  type: z.string().startsWith('tool-'),
+                  type: z.string().startsWith("tool-"),
                   toolCallId: z.string(),
-                  state: z.literal('input-streaming'),
+                  state: z.literal("input-streaming"),
                   providerExecuted: z.boolean().optional(),
                   callProviderMetadata: providerMetadataSchema.optional(),
                   input: z.unknown().optional(),
@@ -195,9 +199,9 @@ const uiMessagesSchema = lazySchema(() =>
                   approval: z.never().optional(),
                 }),
                 z.object({
-                  type: z.string().startsWith('tool-'),
+                  type: z.string().startsWith("tool-"),
                   toolCallId: z.string(),
-                  state: z.literal('input-available'),
+                  state: z.literal("input-available"),
                   providerExecuted: z.boolean().optional(),
                   input: z.unknown(),
                   output: z.never().optional(),
@@ -206,9 +210,9 @@ const uiMessagesSchema = lazySchema(() =>
                   approval: z.never().optional(),
                 }),
                 z.object({
-                  type: z.string().startsWith('tool-'),
+                  type: z.string().startsWith("tool-"),
                   toolCallId: z.string(),
-                  state: z.literal('approval-requested'),
+                  state: z.literal("approval-requested"),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
                   output: z.never().optional(),
@@ -221,9 +225,9 @@ const uiMessagesSchema = lazySchema(() =>
                   }),
                 }),
                 z.object({
-                  type: z.string().startsWith('tool-'),
+                  type: z.string().startsWith("tool-"),
                   toolCallId: z.string(),
-                  state: z.literal('approval-responded'),
+                  state: z.literal("approval-responded"),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
                   output: z.never().optional(),
@@ -233,12 +237,13 @@ const uiMessagesSchema = lazySchema(() =>
                     id: z.string(),
                     approved: z.boolean(),
                     reason: z.string().optional(),
+                    data: z.unknown().optional(),
                   }),
                 }),
                 z.object({
-                  type: z.string().startsWith('tool-'),
+                  type: z.string().startsWith("tool-"),
                   toolCallId: z.string(),
-                  state: z.literal('output-available'),
+                  state: z.literal("output-available"),
                   providerExecuted: z.boolean().optional(),
                   input: z.unknown(),
                   output: z.unknown(),
@@ -251,13 +256,14 @@ const uiMessagesSchema = lazySchema(() =>
                       id: z.string(),
                       approved: z.literal(true),
                       reason: z.string().optional(),
+                      data: z.unknown().optional(),
                     })
                     .optional(),
                 }),
                 z.object({
-                  type: z.string().startsWith('tool-'),
+                  type: z.string().startsWith("tool-"),
                   toolCallId: z.string(),
-                  state: z.literal('output-error'),
+                  state: z.literal("output-error"),
                   providerExecuted: z.boolean().optional(),
                   input: z.unknown(),
                   rawInput: z.unknown().optional(),
@@ -270,13 +276,14 @@ const uiMessagesSchema = lazySchema(() =>
                       id: z.string(),
                       approved: z.literal(true),
                       reason: z.string().optional(),
+                      data: z.unknown().optional(),
                     })
                     .optional(),
                 }),
                 z.object({
-                  type: z.string().startsWith('tool-'),
+                  type: z.string().startsWith("tool-"),
                   toolCallId: z.string(),
-                  state: z.literal('output-denied'),
+                  state: z.literal("output-denied"),
                   providerExecuted: z.boolean().optional(),
                   input: z.unknown(),
                   output: z.never().optional(),
@@ -286,14 +293,15 @@ const uiMessagesSchema = lazySchema(() =>
                     id: z.string(),
                     approved: z.literal(false),
                     reason: z.string().optional(),
+                    data: z.unknown().optional(),
                   }),
                 }),
               ]),
             )
-            .nonempty('Message must contain at least one part'),
+            .nonempty("Message must contain at least one part"),
         }),
       )
-      .nonempty('Messages array must not be empty'),
+      .nonempty("Messages array must not be empty"),
   ),
 );
 
@@ -319,7 +327,7 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
   tools,
 }: {
   messages: unknown;
-  metadataSchema?: FlexibleSchema<UIMessage['metadata']>;
+  metadataSchema?: FlexibleSchema<UIMessage["metadata"]>;
   dataSchemas?: {
     [NAME in keyof InferUIMessageData<UI_MESSAGE> & string]?: FlexibleSchema<
       InferUIMessageData<UI_MESSAGE>[NAME]
@@ -327,8 +335,8 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
   };
   tools?: {
     [NAME in keyof InferUIMessageTools<UI_MESSAGE> & string]?: Tool<
-      InferUIMessageTools<UI_MESSAGE>[NAME]['input'],
-      InferUIMessageTools<UI_MESSAGE>[NAME]['output']
+      InferUIMessageTools<UI_MESSAGE>[NAME]["input"],
+      InferUIMessageTools<UI_MESSAGE>[NAME]["output"]
     >;
   };
 }): Promise<SafeValidateUIMessagesResult<UI_MESSAGE>> {
@@ -337,9 +345,9 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
       return {
         success: false,
         error: new InvalidArgumentError({
-          parameter: 'messages',
+          parameter: "messages",
           value: messages,
-          message: 'messages parameter must be provided',
+          message: "messages parameter must be provided",
         }),
       };
     }
@@ -366,7 +374,7 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
       for (const [msgIdx, message] of validatedMessages.entries()) {
         for (const [partIdx, part] of message.parts.entries()) {
           // Data part validation
-          if (dataSchemas && part.type.startsWith('data-')) {
+          if (dataSchemas && part.type.startsWith("data-")) {
             const dataPart = part as DataUIPart<InferUIMessageData<UI_MESSAGE>>;
             const dataName = dataPart.type.slice(5);
             const dataSchema = dataSchemas[dataName];
@@ -398,7 +406,7 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
           }
 
           // Tool part validation
-          if (tools && part.type.startsWith('tool-')) {
+          if (tools && part.type.startsWith("tool-")) {
             const toolPart = part as ToolUIPart<
               InferUIMessageTools<UI_MESSAGE>
             >;
@@ -407,9 +415,9 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
 
             if (
               !tool &&
-              (toolPart.state === 'output-available' ||
-                toolPart.state === 'output-error' ||
-                toolPart.state === 'output-denied')
+              (toolPart.state === "output-available" ||
+                toolPart.state === "output-error" ||
+                toolPart.state === "output-denied")
             ) {
               continue;
             }
@@ -432,9 +440,9 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
 
             // Tool input validation
             if (
-              toolPart.state === 'input-available' ||
-              toolPart.state === 'output-available' ||
-              (toolPart.state === 'output-error' &&
+              toolPart.state === "input-available" ||
+              toolPart.state === "output-available" ||
+              (toolPart.state === "output-error" &&
                 toolPart.input !== undefined)
             ) {
               await validateTypes({
@@ -449,7 +457,7 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
             }
 
             // Tool output validation
-            if (toolPart.state === 'output-available' && tool.outputSchema) {
+            if (toolPart.state === "output-available" && tool.outputSchema) {
               await validateTypes({
                 value: toolPart.output,
                 schema: tool.outputSchema,
@@ -493,7 +501,7 @@ export async function validateUIMessages<UI_MESSAGE extends UIMessage>({
   tools,
 }: {
   messages: unknown;
-  metadataSchema?: FlexibleSchema<UIMessage['metadata']>;
+  metadataSchema?: FlexibleSchema<UIMessage["metadata"]>;
   dataSchemas?: {
     [NAME in keyof InferUIMessageData<UI_MESSAGE> & string]?: FlexibleSchema<
       InferUIMessageData<UI_MESSAGE>[NAME]
@@ -501,8 +509,8 @@ export async function validateUIMessages<UI_MESSAGE extends UIMessage>({
   };
   tools?: {
     [NAME in keyof InferUIMessageTools<UI_MESSAGE> & string]?: Tool<
-      InferUIMessageTools<UI_MESSAGE>[NAME]['input'],
-      InferUIMessageTools<UI_MESSAGE>[NAME]['output']
+      InferUIMessageTools<UI_MESSAGE>[NAME]["input"],
+      InferUIMessageTools<UI_MESSAGE>[NAME]["output"]
     >;
   };
 }): Promise<Array<UI_MESSAGE>> {

--- a/packages/provider-utils/src/types/index.ts
+++ b/packages/provider-utils/src/types/index.ts
@@ -1,7 +1,7 @@
 export type {
   AssistantContent,
   AssistantModelMessage,
-} from './assistant-model-message';
+} from "./assistant-model-message";
 export type {
   FilePart,
   ImagePart,
@@ -10,29 +10,30 @@ export type {
   ToolCallPart,
   ToolResultOutput,
   ToolResultPart,
-} from './content-part';
-export type { DataContent } from './data-content';
-export { executeTool } from './execute-tool';
-export type { ModelMessage } from './model-message';
-export type { ProviderOptions } from './provider-options';
-export type { SystemModelMessage } from './system-model-message';
+} from "./content-part";
+export type { DataContent } from "./data-content";
+export { executeTool } from "./execute-tool";
+export type { ModelMessage } from "./model-message";
+export type { ProviderOptions } from "./provider-options";
+export type { SystemModelMessage } from "./system-model-message";
 export {
   dynamicTool,
   tool,
+  type InferToolApprovalData,
   type InferToolInput,
   type InferToolOutput,
   type Tool,
   type ToolExecutionOptions,
   type ToolExecuteFunction,
   type ToolNeedsApprovalFunction,
-} from './tool';
-export type { ToolApprovalRequest } from './tool-approval-request';
-export type { ToolApprovalResponse } from './tool-approval-response';
-export type { ToolCall } from './tool-call';
-export type { ToolContent, ToolModelMessage } from './tool-model-message';
-export type { ToolResult } from './tool-result';
-export type { UserContent, UserModelMessage } from './user-model-message';
-import type { ToolExecutionOptions } from './tool';
+} from "./tool";
+export type { ToolApprovalRequest } from "./tool-approval-request";
+export type { ToolApprovalResponse } from "./tool-approval-response";
+export type { ToolCall } from "./tool-call";
+export type { ToolContent, ToolModelMessage } from "./tool-model-message";
+export type { ToolResult } from "./tool-result";
+export type { UserContent, UserModelMessage } from "./user-model-message";
+import type { ToolExecutionOptions } from "./tool";
 
 /**
  * @deprecated Use ToolExecutionOptions instead.

--- a/packages/provider-utils/src/types/tool-approval-response.ts
+++ b/packages/provider-utils/src/types/tool-approval-response.ts
@@ -1,8 +1,8 @@
 /**
  * Tool approval response prompt part.
  */
-export type ToolApprovalResponse = {
-  type: 'tool-approval-response';
+export type ToolApprovalResponse<DATA = unknown> = {
+  type: "tool-approval-response";
 
   /**
    * ID of the tool approval.
@@ -24,4 +24,11 @@ export type ToolApprovalResponse = {
    * Only provider-executed tool approval responses should be sent to the model.
    */
   providerExecuted?: boolean;
+
+  /**
+   * Optional extra data provided with the approval response.
+   * This data is passed to the tool's execute function when the tool is approved.
+   * Can be used for user input during approval (e.g., confirmation notes, options).
+   */
+  data?: DATA;
 };

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -1,13 +1,13 @@
-import { JSONValue } from '@ai-sdk/provider';
-import { FlexibleSchema } from '../schema';
-import { ToolResultOutput } from './content-part';
-import { ModelMessage } from './model-message';
-import { ProviderOptions } from './provider-options';
+import { JSONValue } from "@ai-sdk/provider";
+import { FlexibleSchema } from "../schema";
+import { ToolResultOutput } from "./content-part";
+import { ModelMessage } from "./model-message";
+import { ProviderOptions } from "./provider-options";
 
 /**
  * Additional options that are sent into each tool call.
  */
-export interface ToolExecutionOptions {
+export interface ToolExecutionOptions<APPROVAL_DATA = unknown> {
   /**
    * The ID of the tool call. You can use it e.g. when sending tool-call related information with stream data.
    */
@@ -37,6 +37,17 @@ export interface ToolExecutionOptions {
    * Experimental (can break in patch releases).
    */
   experimental_context?: unknown;
+
+  /**
+   * Extra data provided with the approval response when the tool required approval.
+   * This is `undefined` if the tool did not require approval or was auto-approved.
+   *
+   * Use this to pass user-provided data from the approval UI to the tool execution,
+   * such as confirmation notes, selected options, or other contextual information.
+   *
+   * When `approvalDataSchema` is defined on the tool, this will be typed accordingly.
+   */
+  approvalData?: APPROVAL_DATA;
 }
 
 /**
@@ -65,9 +76,9 @@ export type ToolNeedsApprovalFunction<INPUT> = (
   },
 ) => boolean | PromiseLike<boolean>;
 
-export type ToolExecuteFunction<INPUT, OUTPUT> = (
+export type ToolExecuteFunction<INPUT, OUTPUT, APPROVAL_DATA = unknown> = (
   input: INPUT,
-  options: ToolExecutionOptions,
+  options: ToolExecutionOptions<APPROVAL_DATA>,
 ) => AsyncIterable<OUTPUT> | PromiseLike<OUTPUT> | OUTPUT;
 
 // 0 extends 1 & N checks for any
@@ -78,7 +89,11 @@ type NeverOptional<N, T> = 0 extends 1 & N
     ? Partial<Record<keyof T, undefined>>
     : T;
 
-type ToolOutputProperties<INPUT, OUTPUT> = NeverOptional<
+type ToolOutputProperties<
+  INPUT,
+  OUTPUT,
+  APPROVAL_DATA = unknown,
+> = NeverOptional<
   OUTPUT,
   | {
       /**
@@ -88,7 +103,7 @@ type ToolOutputProperties<INPUT, OUTPUT> = NeverOptional<
        * @args is the input of the tool call.
        * @options.abortSignal is a signal that can be used to abort the tool call.
        */
-      execute: ToolExecuteFunction<INPUT, OUTPUT>;
+      execute: ToolExecuteFunction<INPUT, OUTPUT, APPROVAL_DATA>;
 
       outputSchema?: FlexibleSchema<OUTPUT>;
     }
@@ -108,6 +123,7 @@ type ToolOutputProperties<INPUT, OUTPUT> = NeverOptional<
 export type Tool<
   INPUT extends JSONValue | unknown | never = any,
   OUTPUT extends JSONValue | unknown | never = any,
+  APPROVAL_DATA extends JSONValue | unknown | never = unknown,
 > = {
   /**
    * An optional description of what the tool does.
@@ -151,6 +167,13 @@ export type Tool<
     | ToolNeedsApprovalFunction<[INPUT] extends [never] ? unknown : INPUT>;
 
   /**
+   * Schema for extra data that can be provided with the approval response.
+   * When defined, the approval data will be typed accordingly in the execute function.
+   * This allows users to pass structured, validated data during tool approval.
+   */
+  approvalDataSchema?: FlexibleSchema<APPROVAL_DATA>;
+
+  /**
    * Strict mode setting for the tool.
    *
    * Providers that support strict mode will use this setting to determine
@@ -182,7 +205,7 @@ export type Tool<
       input: [INPUT] extends [never] ? unknown : INPUT;
     } & ToolExecutionOptions,
   ) => void | PromiseLike<void>;
-} & ToolOutputProperties<INPUT, OUTPUT> & {
+} & ToolOutputProperties<INPUT, OUTPUT, APPROVAL_DATA> & {
     /**
      * Optional conversion function that maps the tool result to an output that can be used by the language model.
      *
@@ -213,20 +236,20 @@ export type Tool<
         /**
          * Tool with user-defined input and output schemas.
          */
-        type?: undefined | 'function';
+        type?: undefined | "function";
       }
     | {
         /**
          * Tool that is defined at runtime (e.g. an MCP tool).
          * The types of input and output are not known at development time.
          */
-        type: 'dynamic';
+        type: "dynamic";
       }
     | {
         /**
          * Tool with provider-defined input and output schemas.
          */
-        type: 'provider';
+        type: "provider";
 
         /**
          * The ID of the tool. Must follow the format `<provider-name>.<unique-tool-name>`.
@@ -259,18 +282,27 @@ export type Tool<
  * Infer the input type of a tool.
  */
 export type InferToolInput<TOOL extends Tool> =
-  TOOL extends Tool<infer INPUT, any> ? INPUT : never;
+  TOOL extends Tool<infer INPUT, any, any> ? INPUT : never;
 
 /**
  * Infer the output type of a tool.
  */
 export type InferToolOutput<TOOL extends Tool> =
-  TOOL extends Tool<any, infer OUTPUT> ? OUTPUT : never;
+  TOOL extends Tool<any, infer OUTPUT, any> ? OUTPUT : never;
+
+/**
+ * Infer the approval data type of a tool.
+ */
+export type InferToolApprovalData<TOOL extends Tool> =
+  TOOL extends Tool<any, any, infer APPROVAL_DATA> ? APPROVAL_DATA : never;
 
 /**
  * Helper function for inferring the execute args of a tool.
  */
 // Note: overload order is important for auto-completion
+export function tool<INPUT, OUTPUT, APPROVAL_DATA>(
+  tool: Tool<INPUT, OUTPUT, APPROVAL_DATA>,
+): Tool<INPUT, OUTPUT, APPROVAL_DATA>;
 export function tool<INPUT, OUTPUT>(
   tool: Tool<INPUT, OUTPUT>,
 ): Tool<INPUT, OUTPUT>;
@@ -318,7 +350,7 @@ export function dynamicTool(tool: {
    */
   needsApproval?: boolean | ToolNeedsApprovalFunction<unknown>;
 }): Tool<unknown, unknown> & {
-  type: 'dynamic';
+  type: "dynamic";
 } {
-  return { ...tool, type: 'dynamic' };
+  return { ...tool, type: "dynamic" };
 }


### PR DESCRIPTION
## Background

This brings the approval-data tool typing work forward onto the latest `main` so it can be reviewed against current AI SDK internals.

## Summary

- add a `data` field to `ToolApprovalResponse`
- thread `approvalData` through tool execution options
- add `approvalDataSchema` and the `APPROVAL_DATA` generic to tool definitions
- expose `InferToolApprovalData`
- update chat/UI approval flows to preserve approval data
- update the `ToolSet` typing to keep the extra generic parameter intact
- include a patch changeset

## Manual Verification

Rebased the branch onto the latest upstream `main` and verified the touched approval paths with targeted Vitest runs:

- `pnpm --filter ai exec vitest --config vitest.node.config.js --run src/generate-text/execute-tool-call.test.ts src/generate-text/generate-text.test.ts src/ui/chat.test.ts src/ui/convert-to-model-messages.test.ts src/ui/validate-ui-messages.test.ts`
- `pnpm --filter ai exec vitest --config vitest.node.config.js --run src/generate-text/stream-text.test.ts`

Note: `pnpm --filter ai test -- --runInBand` is currently failing on unrelated upstream issues in `generate-video` and package-type resolution, so I did not use that as the gating signal for this PR.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
