### PR TITLE
feat(provider/google): add `gemini-embedding-2-preview` and fix multimodal embedding support with `embedMany`

### DIFF
--- a/.changeset/new-walls-poke.md
+++ b/.changeset/new-walls-poke.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/google': patch
+---
+
+feat(provider/google): add `gemini-embedding-2-preview` and fix multimodal embedding support with `embedMany`

--- a/content/docs/03-ai-sdk-core/30-embeddings.mdx
+++ b/content/docs/03-ai-sdk-core/30-embeddings.mdx
@@ -227,19 +227,20 @@ const embeddingModelWithDefaults = wrapEmbeddingModel({
 
 Several providers offer embedding models:
 
-| Provider                                                                                  | Model                           | Embedding Dimensions |
-| ----------------------------------------------------------------------------------------- | ------------------------------- | -------------------- |
-| [OpenAI](/providers/ai-sdk-providers/openai#embedding-models)                             | `text-embedding-3-large`        | 3072                 |
-| [OpenAI](/providers/ai-sdk-providers/openai#embedding-models)                             | `text-embedding-3-small`        | 1536                 |
-| [OpenAI](/providers/ai-sdk-providers/openai#embedding-models)                             | `text-embedding-ada-002`        | 1536                 |
-| [Google Generative AI](/providers/ai-sdk-providers/google-generative-ai#embedding-models) | `gemini-embedding-001`          | 3072                 |
-| [Mistral](/providers/ai-sdk-providers/mistral#embedding-models)                           | `mistral-embed`                 | 1024                 |
-| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-english-v3.0`            | 1024                 |
-| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-multilingual-v3.0`       | 1024                 |
-| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-english-light-v3.0`      | 384                  |
-| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-multilingual-light-v3.0` | 384                  |
-| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-english-v2.0`            | 4096                 |
-| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-english-light-v2.0`      | 1024                 |
-| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-multilingual-v2.0`       | 768                  |
-| [Amazon Bedrock](/providers/ai-sdk-providers/amazon-bedrock#embedding-models)             | `amazon.titan-embed-text-v1`    | 1536                 |
-| [Amazon Bedrock](/providers/ai-sdk-providers/amazon-bedrock#embedding-models)             | `amazon.titan-embed-text-v2:0`  | 1024                 |
+| Provider                                                                                  | Model                           | Embedding Dimensions | Multimodal          |
+| ----------------------------------------------------------------------------------------- | ------------------------------- | -------------------- | ------------------- |
+| [OpenAI](/providers/ai-sdk-providers/openai#embedding-models)                             | `text-embedding-3-large`        | 3072                 | <Cross size={18} /> |
+| [OpenAI](/providers/ai-sdk-providers/openai#embedding-models)                             | `text-embedding-3-small`        | 1536                 | <Cross size={18} /> |
+| [OpenAI](/providers/ai-sdk-providers/openai#embedding-models)                             | `text-embedding-ada-002`        | 1536                 | <Cross size={18} /> |
+| [Google Generative AI](/providers/ai-sdk-providers/google-generative-ai#embedding-models) | `gemini-embedding-001`          | 3072                 | <Cross size={18} /> |
+| [Google Generative AI](/providers/ai-sdk-providers/google-generative-ai#embedding-models) | `gemini-embedding-2-preview`    | 3072                 | <Check size={18} /> |
+| [Mistral](/providers/ai-sdk-providers/mistral#embedding-models)                           | `mistral-embed`                 | 1024                 | <Cross size={18} /> |
+| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-english-v3.0`            | 1024                 | <Cross size={18} /> |
+| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-multilingual-v3.0`       | 1024                 | <Cross size={18} /> |
+| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-english-light-v3.0`      | 384                  | <Cross size={18} /> |
+| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-multilingual-light-v3.0` | 384                  | <Cross size={18} /> |
+| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-english-v2.0`            | 4096                 | <Cross size={18} /> |
+| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-english-light-v2.0`      | 1024                 | <Cross size={18} /> |
+| [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-multilingual-v2.0`       | 768                  | <Cross size={18} /> |
+| [Amazon Bedrock](/providers/ai-sdk-providers/amazon-bedrock#embedding-models)             | `amazon.titan-embed-text-v1`    | 1536                 | <Cross size={18} /> |
+| [Amazon Bedrock](/providers/ai-sdk-providers/amazon-bedrock#embedding-models)             | `amazon.titan-embed-text-v2:0`  | 1024                 | <Cross size={18} /> |

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -1131,7 +1131,28 @@ const { embedding } = await embed({
     google: {
       outputDimensionality: 512, // optional, number of dimensions for the embedding
       taskType: 'SEMANTIC_SIMILARITY', // optional, specifies the task type for generating embeddings
-      content: [{ text: 'additional context' }], // optional, multimodal content parts
+      content: [[{ text: 'additional context' }]], // optional, per-value multimodal content (only 1 here, since `value` is only a single one)
+    } satisfies GoogleEmbeddingModelOptions,
+  },
+});
+```
+
+When using `embedMany`, provide per-value multimodal content via the `content` option. Each entry corresponds to a value at the same index; use `null` for text-only entries:
+
+```ts
+import { google, type GoogleEmbeddingModelOptions } from '@ai-sdk/google';
+import { embedMany } from 'ai';
+
+const { embeddings } = await embedMany({
+  model: google.embedding('gemini-embedding-2-preview'),
+  values: ['sunny day at the beach', 'rainy afternoon in the city'],
+  providerOptions: {
+    google: {
+      // content array must have the same length as values
+      content: [
+        [{ inlineData: { mimeType: 'image/png', data: '<base64>' } }], // pairs with values[0]
+        null, // text-only, pairs with values[1]
+      ],
     } satisfies GoogleEmbeddingModelOptions,
   },
 });
@@ -1158,7 +1179,7 @@ The following optional provider options are available for Google Generative AI e
 
 - **content**: _array_
 
-  Optional. Multimodal content parts for embedding non-text content (images, video, PDF, audio). When provided, these parts are merged with the text values in the embedding request. Each part can be either `{ text: string }` or `{ inlineData: { mimeType: string, data: string } }`. Supported by `gemini-embedding-2-preview`.
+  Optional. Per-value multimodal content parts for embedding non-text content (images, video, PDF, audio). Each entry corresponds to the embedding value at the same index — its parts are merged with the text value in the request. Use `null` for entries that are text-only. The array length must match the number of values being embedded. Each non-null entry is an array of parts, where each part can be either `{ text: string }` or `{ inlineData: { mimeType: string, data: string } }`. Supported by `gemini-embedding-2-preview`.
 
 ### Model Capabilities
 

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -1131,6 +1131,7 @@ const { embedding } = await embed({
     google: {
       outputDimensionality: 512, // optional, number of dimensions for the embedding
       taskType: 'SEMANTIC_SIMILARITY', // optional, specifies the task type for generating embeddings
+      content: [{ text: 'additional context' }], // optional, multimodal content parts
     } satisfies GoogleEmbeddingModelOptions,
   },
 });
@@ -1155,11 +1156,16 @@ The following optional provider options are available for Google Generative AI e
   - `FACT_VERIFICATION`: Optimized for verifying factual information.
   - `CODE_RETRIEVAL_QUERY`: Optimized for retrieving code blocks based on natural language queries.
 
+- **content**: _array_
+
+  Optional. Multimodal content parts for embedding non-text content (images, video, PDF, audio). When provided, these parts are merged with the text values in the embedding request. Each part can be either `{ text: string }` or `{ inlineData: { mimeType: string, data: string } }`. Supported by `gemini-embedding-2-preview`.
+
 ### Model Capabilities
 
-| Model                  | Default Dimensions | Custom Dimensions   |
-| ---------------------- | ------------------ | ------------------- |
-| `gemini-embedding-001` | 3072               | <Check size={18} /> |
+| Model                        | Default Dimensions | Custom Dimensions   | Multimodal          |
+| ---------------------------- | ------------------ | ------------------- | ------------------- |
+| `gemini-embedding-001`       | 3072               | <Check size={18} /> | <Cross size={18} /> |
+| `gemini-embedding-2-preview` | 3072               | <Check size={18} /> | <Check size={18} /> |
 
 ## Image Models
 

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -829,9 +829,10 @@ The following optional provider options are available for Google Vertex AI embed
 
 #### Model Capabilities
 
-| Model                | Max Values Per Call | Parallel Calls      |
-| -------------------- | ------------------- | ------------------- |
-| `text-embedding-005` | 2048                | <Check size={18} /> |
+| Model                        | Max Values Per Call | Parallel Calls      | Multimodal          |
+| ---------------------------- | ------------------- | ------------------- | ------------------- |
+| `text-embedding-005`         | 2048                | <Check size={18} /> | <Cross size={18} /> |
+| `gemini-embedding-2-preview` | 2048                | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   The table above lists popular models. You can also pass any available provider

--- a/examples/ai-functions/src/e2e/google.test.ts
+++ b/examples/ai-functions/src/e2e/google.test.ts
@@ -64,6 +64,9 @@ createFeatureTestSuite({
       createEmbeddingModelWithCapabilities(
         provider.embeddingModel('gemini-embedding-001'),
       ),
+      createEmbeddingModelWithCapabilities(
+        provider.embeddingModel('gemini-embedding-2-preview'),
+      ),
     ],
     imageModels: [createImageModel('imagen-3.0-generate-002')],
   },

--- a/examples/ai-functions/src/embed-many/google/gemini-embedding-2-preview-multimodal.ts
+++ b/examples/ai-functions/src/embed-many/google/gemini-embedding-2-preview-multimodal.ts
@@ -1,0 +1,44 @@
+import { google, type GoogleEmbeddingModelOptions } from '@ai-sdk/google';
+import { embedMany } from 'ai';
+import { readFileSync } from 'fs';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const imageData = readFileSync('../../data/comic-cat.png').toString('base64');
+
+  const { embeddings, usage, warnings } = await embedMany({
+    model: google.embeddingModel('gemini-embedding-2-preview'),
+    values: [
+      'sunny day at the beach',
+      'rainy afternoon in the city',
+      'snowy night in the mountains',
+    ],
+    providerOptions: {
+      google: {
+        content: [
+          [
+            {
+              inlineData: {
+                mimeType: 'image/png',
+                data: imageData,
+              },
+            },
+          ],
+          null,
+          [
+            {
+              inlineData: {
+                mimeType: 'image/png',
+                data: imageData,
+              },
+            },
+          ],
+        ],
+      } satisfies GoogleEmbeddingModelOptions,
+    },
+  });
+
+  console.log(embeddings);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/examples/ai-functions/src/embed-many/google/gemini-embedding-2-preview-multimodal.ts
+++ b/examples/ai-functions/src/embed-many/google/gemini-embedding-2-preview-multimodal.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const imageData = readFileSync('../../data/comic-cat.png').toString('base64');
+  const imageData = readFileSync('./data/comic-cat.png').toString('base64');
 
   const { embeddings, usage, warnings } = await embedMany({
     model: google.embeddingModel('gemini-embedding-2-preview'),

--- a/examples/ai-functions/src/embed-many/google/gemini-embedding-2-preview.ts
+++ b/examples/ai-functions/src/embed-many/google/gemini-embedding-2-preview.ts
@@ -1,0 +1,18 @@
+import { google } from '@ai-sdk/google';
+import { embedMany } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { embeddings, usage, warnings } = await embedMany({
+    model: google.embeddingModel('gemini-embedding-2-preview'),
+    values: [
+      'sunny day at the beach',
+      'rainy afternoon in the city',
+      'snowy night in the mountains',
+    ],
+  });
+
+  console.log(embeddings);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/examples/ai-functions/src/embed/google/gemini-embedding-2-preview-multimodal.ts
+++ b/examples/ai-functions/src/embed/google/gemini-embedding-2-preview-multimodal.ts
@@ -1,0 +1,29 @@
+import { google, type GoogleEmbeddingModelOptions } from '@ai-sdk/google';
+import { embed } from 'ai';
+import { readFileSync } from 'fs';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const imageData = readFileSync('../../data/comic-cat.png').toString('base64');
+
+  const { embedding, usage, warnings } = await embed({
+    model: google.embeddingModel('gemini-embedding-2-preview'),
+    value: 'sunny day at the beach',
+    providerOptions: {
+      google: {
+        content: [
+          {
+            inlineData: {
+              mimeType: 'image/png',
+              data: imageData,
+            },
+          },
+        ],
+      } satisfies GoogleEmbeddingModelOptions,
+    },
+  });
+
+  console.log(embedding);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/examples/ai-functions/src/embed/google/gemini-embedding-2-preview-multimodal.ts
+++ b/examples/ai-functions/src/embed/google/gemini-embedding-2-preview-multimodal.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const imageData = readFileSync('../../data/comic-cat.png').toString('base64');
+  const imageData = readFileSync('./data/comic-cat.png').toString('base64');
 
   const { embedding, usage, warnings } = await embed({
     model: google.embeddingModel('gemini-embedding-2-preview'),

--- a/examples/ai-functions/src/embed/google/gemini-embedding-2-preview-multimodal.ts
+++ b/examples/ai-functions/src/embed/google/gemini-embedding-2-preview-multimodal.ts
@@ -12,12 +12,14 @@ run(async () => {
     providerOptions: {
       google: {
         content: [
-          {
-            inlineData: {
-              mimeType: 'image/png',
-              data: imageData,
+          [
+            {
+              inlineData: {
+                mimeType: 'image/png',
+                data: imageData,
+              },
             },
-          },
+          ],
         ],
       } satisfies GoogleEmbeddingModelOptions,
     },

--- a/examples/ai-functions/src/embed/google/gemini-embedding-2-preview.ts
+++ b/examples/ai-functions/src/embed/google/gemini-embedding-2-preview.ts
@@ -1,0 +1,14 @@
+import { google } from '@ai-sdk/google';
+import { embed } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { embedding, usage, warnings } = await embed({
+    model: google.embeddingModel('gemini-embedding-2-preview'),
+    value: 'sunny day at the beach',
+  });
+
+  console.log(embedding);
+  console.log(usage);
+  console.log(warnings);
+});

--- a/packages/gateway/src/gateway-embedding-model-settings.ts
+++ b/packages/gateway/src/gateway-embedding-model-settings.ts
@@ -5,6 +5,7 @@ export type GatewayEmbeddingModelId =
   | 'amazon/titan-embed-text-v2'
   | 'cohere/embed-v4.0'
   | 'google/gemini-embedding-001'
+  | 'google/gemini-embedding-2-preview'
   | 'google/text-embedding-005'
   | 'google/text-multilingual-embedding-002'
   | 'mistral/codestral-embed'

--- a/packages/google-vertex/src/google-vertex-embedding-options.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-options.ts
@@ -10,6 +10,8 @@ export type GoogleVertexEmbeddingModelId =
   | 'text-multilingual-embedding-002'
   | 'text-embedding-004'
   | 'text-embedding-005'
+  | 'gemini-embedding-001'
+  | 'gemini-embedding-2-preview'
   | (string & {});
 
 export const googleVertexEmbeddingModelOptions = z.object({

--- a/packages/google/src/google-generative-ai-embedding-model.test.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.test.ts
@@ -287,4 +287,165 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
       'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:embedContent',
     );
   });
+
+  it('should merge multimodal content for single embedding', async () => {
+    prepareSingleJsonResponse();
+
+    await model.doEmbed({
+      values: [testValues[0]],
+      providerOptions: {
+        google: {
+          content: [
+            [{ inlineData: { mimeType: 'image/png', data: 'abc123' } }],
+          ],
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "content": {
+          "parts": [
+            {
+              "text": "sunny day at the beach",
+            },
+            {
+              "inlineData": {
+                "data": "abc123",
+                "mimeType": "image/png",
+              },
+            },
+          ],
+        },
+        "model": "models/gemini-embedding-001",
+      }
+    `);
+  });
+
+  it('should merge per-value multimodal content for batch embedding', async () => {
+    prepareBatchJsonResponse();
+
+    await model.doEmbed({
+      values: testValues,
+      providerOptions: {
+        google: {
+          content: [
+            [{ inlineData: { mimeType: 'image/png', data: 'img1' } }],
+            [{ inlineData: { mimeType: 'image/jpeg', data: 'img2' } }],
+          ],
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "requests": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "sunny day at the beach",
+                },
+                {
+                  "inlineData": {
+                    "data": "img1",
+                    "mimeType": "image/png",
+                  },
+                },
+              ],
+              "role": "user",
+            },
+            "model": "models/gemini-embedding-001",
+          },
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "rainy day in the city",
+                },
+                {
+                  "inlineData": {
+                    "data": "img2",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+              ],
+              "role": "user",
+            },
+            "model": "models/gemini-embedding-001",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should handle null entries as text-only in batch embedding', async () => {
+    prepareBatchJsonResponse();
+
+    await model.doEmbed({
+      values: testValues,
+      providerOptions: {
+        google: {
+          content: [
+            [{ inlineData: { mimeType: 'image/png', data: 'img1' } }],
+            null,
+          ],
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "requests": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "sunny day at the beach",
+                },
+                {
+                  "inlineData": {
+                    "data": "img1",
+                    "mimeType": "image/png",
+                  },
+                },
+              ],
+              "role": "user",
+            },
+            "model": "models/gemini-embedding-001",
+          },
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "rainy day in the city",
+                },
+              ],
+              "role": "user",
+            },
+            "model": "models/gemini-embedding-001",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should throw error when content length does not match values length', async () => {
+    prepareBatchJsonResponse();
+
+    await expect(
+      model.doEmbed({
+        values: testValues,
+        providerOptions: {
+          google: {
+            content: [
+              [{ inlineData: { mimeType: 'image/png', data: 'img1' } }],
+            ],
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      'The number of multimodal content entries (1) must match the number of values (2).',
+    );
+  });
 });

--- a/packages/google/src/google-generative-ai-embedding-model.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.ts
@@ -74,14 +74,24 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV3 {
       headers,
     );
 
-    const multimodalContent = googleOptions?.content ?? [];
+    const multimodalContent = googleOptions?.content;
+
+    if (
+      multimodalContent != null &&
+      multimodalContent.length !== values.length
+    ) {
+      throw new Error(
+        `The number of multimodal content entries (${multimodalContent.length}) must match the number of values (${values.length}).`,
+      );
+    }
 
     // For single embeddings, use the single endpoint
     if (values.length === 1) {
+      const valueParts = multimodalContent?.[0];
       const textPart = values[0] ? [{ text: values[0] }] : [];
       const parts =
-        multimodalContent.length > 0
-          ? [...textPart, ...multimodalContent]
+        valueParts != null
+          ? [...textPart, ...valueParts]
           : [{ text: values[0] }];
 
       const {
@@ -116,7 +126,6 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV3 {
     }
 
     // For multiple values, use the batch endpoint
-    // If multimodal content is provided, merge it into each request's parts
     const {
       responseHeaders,
       value: response,
@@ -125,15 +134,16 @@ export class GoogleGenerativeAIEmbeddingModel implements EmbeddingModelV3 {
       url: `${this.config.baseURL}/models/${this.modelId}:batchEmbedContents`,
       headers: mergedHeaders,
       body: {
-        requests: values.map(value => {
+        requests: values.map((value, index) => {
+          const valueParts = multimodalContent?.[index];
           const textPart = value ? [{ text: value }] : [];
           return {
             model: `models/${this.modelId}`,
             content: {
               role: 'user',
               parts:
-                multimodalContent.length > 0
-                  ? [...textPart, ...multimodalContent]
+                valueParts != null
+                  ? [...textPart, ...valueParts]
                   : [{ text: value }],
             },
             outputDimensionality: googleOptions?.outputDimensionality,

--- a/packages/google/src/google-generative-ai-embedding-options.ts
+++ b/packages/google/src/google-generative-ai-embedding-options.ts
@@ -55,11 +55,17 @@ export const googleEmbeddingModelOptions = lazySchema(() =>
         .optional(),
 
       /**
-       * Optional. Multimodal content parts for embedding non-text content
-       * (images, video, PDF, audio). When provided, these parts are merged
-       * with the text values in the embedding request.
+       * Optional. Per-value multimodal content parts for embedding non-text
+       * content (images, video, PDF, audio). Each entry corresponds to the
+       * embedding value at the same index and its parts are merged with the
+       * text value in the request. Use `null` for entries that are text-only.
+       *
+       * The array length must match the number of values being embedded. In
+       * the case of a single embedding, the array length must be 1.
        */
-      content: z.array(googleEmbeddingContentPartSchema).min(1).optional(),
+      content: z
+        .array(z.array(googleEmbeddingContentPartSchema).min(1).nullable())
+        .optional(),
     }),
   ),
 );

--- a/packages/google/src/google-generative-ai-embedding-options.ts
+++ b/packages/google/src/google-generative-ai-embedding-options.ts
@@ -7,6 +7,7 @@ import { z } from 'zod/v4';
 
 export type GoogleGenerativeAIEmbeddingModelId =
   | 'gemini-embedding-001'
+  | 'gemini-embedding-2-preview'
   | (string & {});
 
 const googleEmbeddingContentPartSchema = z.union([


### PR DESCRIPTION
## Background

Google launched its `gemini-embedding-2-preview` model which supports multimodal embeddings (text + images, video, PDF, audio).

This is a follow-up to #13290.

## Summary

- Adds the `gemini-embedding-2-preview` model ID to google, google-vertex, and gateway packages.
- Fixes the `content` provider option so that it works correctly with `embedMany` by changing it from a flat array of parts to a per-value array — each entry corresponds to the value at the same index, with `null` for text-only entries. A validation error is thrown when the `content` array length doesn't match the number of values.

## Manual Verification

Run the new `embed` and `embedMany` examples.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Fixes #13313
