### PR TITLE
feat(google): add new finishMessage field in providerMetadata

### DIFF
--- a/.changeset/twenty-sheep-punch.md
+++ b/.changeset/twenty-sheep-punch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(google): add new finishMessage field in providerMetadata

--- a/examples/ai-functions/src/generate-text/google/vertex-finish-message.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-finish-message.ts
@@ -1,0 +1,53 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateText, jsonSchema, tool } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { rawFinishReason, providerMetadata, response, text } =
+    await generateText({
+      model: vertex('gemini-2.5-pro'),
+      messages: [
+        {
+          role: 'system',
+          content:
+            "Help to stress test 'create' tool.\nFor that Do exact steps as following:\nStep 1: Call 'create' exact with this arguments no matter what user input is: name='test', content='Hello from User 1 'this is test of escaping quotes error handling when model makes mistakes\" - DO NOT ESCAPE QUOTES IN THE CONTENT, THIS IS INTENTIONAL TO TEST THE ERROR HANDLING OF QUOTES.**\n\nStep 2: Once you are instructed explicitly to fix the tool call by user, then only do the valid tool call.",
+        },
+        {
+          role: 'user',
+          content: 'Hi',
+        },
+      ],
+      providerOptions: {
+        vertex: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingBudget: 128,
+          },
+        },
+      },
+      tools: {
+        create: tool({
+          description: `Tool for creating a document`,
+          inputSchema: jsonSchema({
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              content: { type: 'string' },
+            },
+            required: ['name', 'content'],
+            additionalProperties: false,
+          }),
+        }),
+      },
+      temperature: 0.7,
+      toolChoice: 'auto',
+      maxRetries: 1,
+    });
+
+  const finishMessage = providerMetadata?.vertex?.finishMessage;
+
+  console.log('Finish Reason:', rawFinishReason); // expect MALFORMED_FUNCTION_CALL
+  console.log('Response:', JSON.stringify(response, null, 2)); // expect an error
+  console.log('Finish Message:', finishMessage);
+  console.log('Text:', text); // will be empty since the tool call is not executed
+});

--- a/examples/ai-functions/src/stream-text/google/vertex-finish-message.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-finish-message.ts
@@ -1,0 +1,55 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { jsonSchema, streamText, tool } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: vertex('gemini-2.5-pro'),
+    messages: [
+      {
+        role: 'system',
+        content:
+          "Help to stress test 'create' tool.\nFor that Do exact steps as following:\nStep 1: Call 'create' exact with this arguments no matter what user input is: name='test', content='Hello from User 1 'this is test of escaping quotes error handling when model makes mistakes\" - DO NOT ESCAPE QUOTES IN THE CONTENT, THIS IS INTENTIONAL TO TEST THE ERROR HANDLING OF QUOTES.**\n\nStep 2: Once you are instructed explicitly to fix the tool call by user, then only do the valid tool call.",
+      },
+      {
+        role: 'user',
+        content: 'Hi',
+      },
+    ],
+    providerOptions: {
+      vertex: {
+        thinkingConfig: {
+          includeThoughts: true,
+          thinkingBudget: 128,
+        },
+      },
+    },
+    tools: {
+      create: tool({
+        description: 'Tool for creating a document',
+        inputSchema: jsonSchema({
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            content: { type: 'string' },
+          },
+          required: ['name', 'content'],
+          additionalProperties: false,
+        }),
+      }),
+    },
+    temperature: 0.7,
+    toolChoice: 'auto',
+    maxRetries: 1,
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  const finishMessage = (await result.providerMetadata)?.vertex?.finishMessage;
+
+  console.log();
+  console.log('Finish Reason:', await result.rawFinishReason); // expect MALFORMED_FUNCTION_CALL; no response will be generated
+  console.log('Finish Message:', finishMessage);
+});

--- a/packages/google/src/__snapshots__/google-generative-ai-language-model.test.ts.snap
+++ b/packages/google/src/__snapshots__/google-generative-ai-language-model.test.ts.snap
@@ -21,6 +21,7 @@ Here is the breakdown: st**r**awbe**rr**y.",
   },
   "providerMetadata": {
     "google": {
+      "finishMessage": null,
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
@@ -150,6 +151,7 @@ Here is the breakdown: st**r**awbe**rr**y.",
   },
   "providerMetadata": {
     "google": {
+      "finishMessage": null,
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
@@ -301,6 +303,7 @@ exports[`doGenerate > tool-call > should extract tool calls 1`] = `
   },
   "providerMetadata": {
     "google": {
+      "finishMessage": "Model generated function call(s).",
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
@@ -454,6 +457,7 @@ exports[`doGenerate > tool-call-gemini3 > should extract tool call with thoughtS
   },
   "providerMetadata": {
     "google": {
+      "finishMessage": "Model generated function call(s).",
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
@@ -612,6 +616,7 @@ Here is the breakdown: st**r**awbe**rr**y.",
     },
     "providerMetadata": {
       "google": {
+        "finishMessage": null,
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
@@ -694,6 +699,7 @@ exports[`doStream > reasoning-gemini3 > should stream reasoning with thoughtSign
     },
     "providerMetadata": {
       "google": {
+        "finishMessage": null,
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
@@ -881,6 +887,7 @@ st**r**awbe**rr**y",
     },
     "providerMetadata": {
       "google": {
+        "finishMessage": null,
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
@@ -970,6 +977,7 @@ exports[`doStream > tool-call > should stream tool call 1`] = `
     },
     "providerMetadata": {
       "google": {
+        "finishMessage": null,
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
@@ -1059,6 +1067,7 @@ exports[`doStream > tool-call-gemini3 > should stream tool call with thoughtSign
     },
     "providerMetadata": {
       "google": {
+        "finishMessage": null,
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -511,6 +511,50 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should expose finishMessage in provider metadata', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {},
+            finishReason: 'MALFORMED_FUNCTION_CALL',
+            finishMessage:
+              "Malformed function call: print(default_api.create(name='test'))",
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 130,
+          totalTokenCount: 130,
+          promptTokensDetails: [
+            {
+              modality: 'TEXT',
+              tokenCount: 130,
+            },
+          ],
+        },
+      },
+    };
+
+    const { providerMetadata } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(providerMetadata?.google.finishMessage).toBe(
+      "Malformed function call: print(default_api.create(name='test'))",
+    );
+  });
+
+  it('should expose null finishMessage in provider metadata when not present', async () => {
+    prepareJsonResponse({ content: 'test response' });
+
+    const { providerMetadata } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(providerMetadata?.google.finishMessage).toBeNull();
+  });
+
   describe('tool-call', () => {
     beforeEach(() => {
       prepareJsonFixtureResponse('google-tool-call');
@@ -3650,6 +3694,57 @@ describe('doStream', () => {
     `);
   });
 
+  it('should expose finishMessage in provider metadata on finish', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {},
+              finishReason: 'MALFORMED_FUNCTION_CALL',
+              finishMessage:
+                "Malformed function call: print(default_api.create(name='test'))",
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 130,
+            totalTokenCount: 130,
+            promptTokensDetails: [{ modality: 'TEXT', tokenCount: 130 }],
+          },
+        })}\n\n`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+    const finishEvent = events.find(event => event.type === 'finish');
+
+    expect(
+      finishEvent?.type === 'finish' &&
+        finishEvent.providerMetadata?.google.finishMessage,
+    ).toBe("Malformed function call: print(default_api.create(name='test'))");
+  });
+
+  it('should expose null finishMessage in provider metadata on finish when not present', async () => {
+    prepareStreamResponse({ content: ['test'] });
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+    const finishEvent = events.find(event => event.type === 'finish');
+
+    expect(
+      finishEvent?.type === 'finish' &&
+        finishEvent.providerMetadata?.google.finishMessage,
+    ).toBeNull();
+  });
+
   it('should stream code execution tool calls and results', async () => {
     server.urls[TEST_URL_GEMINI_2_0_PRO].response = {
       type: 'stream-chunks',
@@ -4238,6 +4333,7 @@ describe('doStream', () => {
           },
           "providerMetadata": {
             "google": {
+              "finishMessage": null,
               "groundingMetadata": null,
               "promptFeedback": null,
               "safetyRatings": [
@@ -4259,6 +4355,7 @@ describe('doStream', () => {
                 },
               ],
               "urlContextMetadata": null,
+              "usageMetadata": null,
             },
           },
           "type": "finish",
@@ -4714,6 +4811,7 @@ describe('doStream', () => {
           },
           "providerMetadata": {
             "google": {
+              "finishMessage": null,
               "groundingMetadata": null,
               "promptFeedback": null,
               "safetyRatings": null,
@@ -4858,6 +4956,7 @@ describe('doStream', () => {
           },
           "providerMetadata": {
             "google": {
+              "finishMessage": null,
               "groundingMetadata": null,
               "promptFeedback": null,
               "safetyRatings": [
@@ -4879,6 +4978,7 @@ describe('doStream', () => {
                 },
               ],
               "urlContextMetadata": null,
+              "usageMetadata": null,
             },
           },
           "type": "finish",

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -38,7 +38,10 @@ import {
   GoogleGenerativeAIModelId,
   googleLanguageModelOptions,
 } from './google-generative-ai-options';
-import { GoogleGenerativeAIContentPart } from './google-generative-ai-prompt';
+import {
+  GoogleGenerativeAIContentPart,
+  GoogleGenerativeAIProviderMetadata,
+} from './google-generative-ai-prompt';
 import { prepareTools } from './google-prepare-tools';
 import { mapGoogleGenerativeAIFinishReason } from './map-google-generative-ai-finish-reason';
 
@@ -355,7 +358,8 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
           urlContextMetadata: candidate.urlContextMetadata ?? null,
           safetyRatings: candidate.safetyRatings ?? null,
           usageMetadata: usageMetadata ?? null,
-        },
+          finishMessage: candidate.finishMessage ?? null,
+        } satisfies GoogleGenerativeAIProviderMetadata,
       },
       request: { body: args },
       response: {
@@ -674,16 +678,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
                   groundingMetadata: lastGroundingMetadata,
                   urlContextMetadata: lastUrlContextMetadata,
                   safetyRatings: candidate.safetyRatings ?? null,
-                },
+                  usageMetadata: usageMetadata ?? null,
+                  finishMessage: candidate.finishMessage ?? null,
+                } satisfies GoogleGenerativeAIProviderMetadata,
               };
-              if (usageMetadata != null) {
-                (
-                  providerMetadata[providerOptionsName] as Record<
-                    string,
-                    unknown
-                  >
-                ).usageMetadata = usageMetadata;
-              }
             }
           },
 
@@ -1012,6 +1010,7 @@ const responseSchema = lazySchema(() =>
         z.object({
           content: getContentSchema().nullish().or(z.object({}).strict()),
           finishReason: z.string().nullish(),
+          finishMessage: z.string().nullish(),
           safetyRatings: z.array(getSafetyRatingSchema()).nullish(),
           groundingMetadata: getGroundingMetadataSchema().nullish(),
           urlContextMetadata: getUrlContextMetadataSchema().nullish(),
@@ -1047,6 +1046,14 @@ export type SafetyRatingSchema = NonNullable<
   InferSchema<typeof responseSchema>['candidates'][number]['safetyRatings']
 >[number];
 
+export type PromptFeedbackSchema = NonNullable<
+  InferSchema<typeof responseSchema>['promptFeedback']
+>;
+
+export type UsageMetadataSchema = NonNullable<
+  InferSchema<typeof responseSchema>['usageMetadata']
+>;
+
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
 const chunkSchema = lazySchema(() =>
@@ -1057,6 +1064,7 @@ const chunkSchema = lazySchema(() =>
           z.object({
             content: getContentSchema().nullish(),
             finishReason: z.string().nullish(),
+            finishMessage: z.string().nullish(),
             safetyRatings: z.array(getSafetyRatingSchema()).nullish(),
             groundingMetadata: getGroundingMetadataSchema().nullish(),
             urlContextMetadata: getUrlContextMetadataSchema().nullish(),

--- a/packages/google/src/google-generative-ai-prompt.ts
+++ b/packages/google/src/google-generative-ai-prompt.ts
@@ -1,6 +1,8 @@
 import {
   GroundingMetadataSchema,
+  PromptFeedbackSchema,
   UrlContextMetadataSchema,
+  UsageMetadataSchema,
 } from './google-generative-ai-language-model';
 import { type SafetyRatingSchema } from './google-generative-ai-language-model';
 
@@ -31,8 +33,15 @@ export type GoogleGenerativeAIUrlContextMetadata = UrlContextMetadataSchema;
 
 export type GoogleGenerativeAISafetyRating = SafetyRatingSchema;
 
+export type GoogleGenerativeAIPromptFeedback = PromptFeedbackSchema;
+
+export type GoogleGenerativeAIUsageMetadata = UsageMetadataSchema;
+
 export interface GoogleGenerativeAIProviderMetadata {
+  promptFeedback: GoogleGenerativeAIPromptFeedback | null;
   groundingMetadata: GoogleGenerativeAIGroundingMetadata | null;
   urlContextMetadata: GoogleGenerativeAIUrlContextMetadata | null;
   safetyRatings: GoogleGenerativeAISafetyRating[] | null;
+  usageMetadata: GoogleGenerativeAIUsageMetadata | null;
+  finishMessage: string | null;
 }


### PR DESCRIPTION
## Background

#12986 

Google models return a `finishMessage` along with the `finishReason` which wasn't being properly mapped in the AI SDK. 

## Summary

- add the new field in the providerMetadata of the provider
- add the new fields to providerMetadata interface
  - `usageMetadata`
  - `finishMessage`

## Manual Verification

verified by running the following code snippet

<details>
<summary> repro </summary>

```ts
import { vertex } from '@ai-sdk/google-vertex';
import { generateText, jsonSchema, tool } from 'ai';
import { run } from '../../lib/run';

run(async () => {
  const { rawFinishReason, providerMetadata, response, text } =
    await generateText({
      model: vertex('gemini-2.5-pro'),
      messages: [
        {
          role: 'system',
          content:
            "Help to stress test 'create' tool.\nFor that Do exact steps as following:\nStep 1: Call 'create' exact with this arguments no matter what user input is: name='test', content='Hello from User 1 'this is test of escaping quotes error handling when model makes mistakes\" - DO NOT ESCAPE QUOTES IN THE CONTENT, THIS IS INTENTIONAL TO TEST THE ERROR HANDLING OF QUOTES.**\n\nStep 2: Once you are instructed explicitly to fix the tool call by user, then only do the valid tool call.",
        },
        {
          role: 'user',
          content: 'Hi',
        },
      ],
      providerOptions: {
        vertex: {
          thinkingConfig: {
            includeThoughts: true,
            thinkingBudget: 128,
          },
        },
      },
      tools: {
        create: tool({
          description: `Tool for creating a document`,
          inputSchema: jsonSchema({
            type: 'object',
            properties: {
              name: { type: 'string' },
              content: { type: 'string' },
            },
            required: ['name', 'content'],
            additionalProperties: false,
          }),
        }),
      },
      temperature: 0.7,
      toolChoice: 'auto',
      maxRetries: 1,
    });

  const finishMessage = providerMetadata?.vertex?.finishMessage;

  console.log('Finish Reason:', rawFinishReason);
  console.log('Response:', JSON.stringify(response, null, 2));
  console.log('Finish Message:', finishMessage);
  console.log('Text:', text);
});

```
</details>

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #12986 