### PR TITLE
fix(provider/amazon-bedrock): normalize tool call IDs for Mistral models to support multiturn

### DIFF
--- a/.changeset/silly-geckos-tie.md
+++ b/.changeset/silly-geckos-tie.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): normalize tool call IDs for MoonshotAI

--- a/examples/ai-functions/src/generate-text/bedrock/moonshotai-multiturn-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/bedrock/moonshotai-multiturn-tool-call.ts
@@ -1,0 +1,86 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { moonshotai } from '@ai-sdk/moonshotai';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+/**
+ * Real multi-turn: get a tool call from moonshotai (which generates IDs
+ * like "weather:0"), then send the tool call back to bedrock.
+ */
+run(async () => {
+  const tools = {
+    get_weather: tool({
+      description: 'Get the current weather for a given city.',
+      inputSchema: z.object({
+        location: z.string().describe('City name'),
+      }),
+      execute: async ({ location }) => ({
+        location,
+        temperature: 72,
+        condition: 'Sunny',
+      }),
+    }),
+  };
+
+  // Step 1: Get tool call from moonshotai
+  console.log('--- Step 1: Get tool call from moonshotai ---');
+  const step1 = await generateText({
+    model: moonshotai('kimi-k2.5'),
+    tools,
+    prompt: 'What is the weather in Tokyo? Use the get_weather tool.',
+  });
+
+  const tc = step1.steps[0]?.toolCalls?.[0];
+  if (!tc) {
+    console.error('No tool call returned — re-run.');
+    return;
+  }
+
+  console.log(`  Tool call ID: "${tc.toolCallId}"`);
+  console.log(`  Tool name: "${tc.toolName}"`);
+
+  // Step 2: Send that to bedrock
+  console.log('\n--- Step 2: Send moonshot tool call to bedrock ---');
+  try {
+    const step2 = await generateText({
+      model: bedrock('moonshotai.kimi-k2.5'),
+      tools,
+      messages: [
+        { role: 'user', content: 'What is the weather in Tokyo?' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call' as const,
+              toolCallId: tc.toolCallId,
+              toolName: tc.toolName,
+              input: tc.input,
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result' as const,
+              toolCallId: tc.toolCallId,
+              toolName: tc.toolName,
+              output: {
+                type: 'json' as const,
+                value: {
+                  location: 'Tokyo',
+                  temperature: 72,
+                  condition: 'Sunny',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+    console.log('PASS:', step2.text?.substring(0, 150));
+  } catch (e) {
+    console.log('FAIL:', e instanceof Error ? e.message.substring(0, 200) : e);
+  }
+});

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -39,7 +39,11 @@ import { prepareTools } from './bedrock-prepare-tools';
 import { BedrockUsage, convertBedrockUsage } from './convert-bedrock-usage';
 import { convertToBedrockChatMessages } from './convert-to-bedrock-chat-messages';
 import { mapBedrockFinishReason } from './map-bedrock-finish-reason';
-import { isMistralModel, normalizeToolCallId } from './normalize-tool-call-id';
+import {
+  isMistralModel,
+  isMoonshotaiModel,
+  normalizeToolCallId,
+} from './normalize-tool-call-id';
 
 type BedrockChatConfig = {
   baseUrl: () => string;
@@ -359,9 +363,11 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
     }
 
     const isMistral = isMistralModel(this.modelId);
+    const isMoonshotai = isMoonshotaiModel(this.modelId);
     const { system, messages } = await convertToBedrockChatMessages(
       filteredPrompt,
       isMistral,
+      isMoonshotai,
     );
 
     // Filter out reasoningConfig from providerOptions.bedrock to prevent sending it to Bedrock API
@@ -490,11 +496,16 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
           });
         } else {
           const isMistral = isMistralModel(this.modelId);
+          const isMoonshotai = isMoonshotaiModel(this.modelId);
           const rawToolCallId =
             part.toolUse?.toolUseId ?? this.config.generateId();
           content.push({
             type: 'tool-call' as const,
-            toolCallId: normalizeToolCallId(rawToolCallId, isMistral),
+            toolCallId: normalizeToolCallId(
+              rawToolCallId,
+              isMistral,
+              isMoonshotai,
+            ),
             toolName: part.toolUse?.name ?? `tool-${this.config.generateId()}`,
             input: JSON.stringify(part.toolUse?.input ?? {}),
           });
@@ -575,6 +586,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
     } = await this.getArgs(options);
     const modelId = this.modelId;
     const isMistral = isMistralModel(modelId);
+    const isMoonshotai = isMoonshotaiModel(modelId);
     const url = `${this.getUrl(modelId)}/converse-stream`;
 
     const { value: response, responseHeaders } = await postJsonToApi({
@@ -879,6 +891,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
               const normalizedToolCallId = normalizeToolCallId(
                 toolUse.toolUseId!,
                 isMistral,
+                isMoonshotai,
               );
               contentBlocks[blockIndex] = {
                 type: 'tool-call',

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -56,6 +56,7 @@ async function shouldEnableCitations(
 export async function convertToBedrockChatMessages(
   prompt: LanguageModelV3Prompt,
   isMistral: boolean = false,
+  isMoonshotai: boolean = false,
 ): Promise<{
   system: BedrockSystemMessages;
   messages: BedrockMessages;
@@ -220,7 +221,11 @@ export async function convertToBedrockChatMessages(
 
                 bedrockContent.push({
                   toolResult: {
-                    toolUseId: normalizeToolCallId(part.toolCallId, isMistral),
+                    toolUseId: normalizeToolCallId(
+                      part.toolCallId,
+                      isMistral,
+                      isMoonshotai,
+                    ),
                     content: toolResultContent,
                   },
                 });
@@ -322,7 +327,11 @@ export async function convertToBedrockChatMessages(
               case 'tool-call': {
                 bedrockContent.push({
                   toolUse: {
-                    toolUseId: normalizeToolCallId(part.toolCallId, isMistral),
+                    toolUseId: normalizeToolCallId(
+                      part.toolCallId,
+                      isMistral,
+                      isMoonshotai,
+                    ),
                     name: part.toolName,
                     input: part.input as JSONObject,
                   },

--- a/packages/amazon-bedrock/src/normalize-tool-call-id.test.ts
+++ b/packages/amazon-bedrock/src/normalize-tool-call-id.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { isMistralModel, normalizeToolCallId } from './normalize-tool-call-id';
+import {
+  isMistralModel,
+  isMoonshotaiModel,
+  normalizeToolCallId,
+} from './normalize-tool-call-id';
 
 describe('isMistralModel', () => {
   it('should return true for mistral models', () => {
@@ -28,45 +32,83 @@ describe('isMistralModel', () => {
 });
 
 describe('normalizeToolCallId', () => {
-  it('should return the original ID when not a Mistral model', () => {
+  it('should return the original ID when not a Mistral or Moonshotai model', () => {
     const originalId = 'tooluse_bpe71yCfRu2b5i-nKGDr5g';
-    expect(normalizeToolCallId(originalId, false)).toBe(originalId);
+    expect(normalizeToolCallId(originalId, false, false)).toBe(originalId);
   });
 
   it('should extract first 9 alphanumeric characters for Mistral models', () => {
-    // Bedrock format: tooluse_bpe71yCfRu2b5i-nKGDr5g
-    // After removing non-alphanumeric: toolusebpe71yCfRu2b5inKGDr5g
-    // First 9 chars: toolusebp
-    expect(normalizeToolCallId('tooluse_bpe71yCfRu2b5i-nKGDr5g', true)).toBe(
-      'toolusebp',
+    expect(
+      normalizeToolCallId('tooluse_bpe71yCfRu2b5i-nKGDr5g', true, false),
+    ).toBe('toolusebp');
+  });
+
+  it('should handle IDs with various special characters for Mistral', () => {
+    expect(normalizeToolCallId('tool-use_123ABC456', true, false)).toBe(
+      'tooluse12',
+    );
+    expect(normalizeToolCallId('___abc123DEF___', true, false)).toBe(
+      'abc123DEF',
     );
   });
 
-  it('should handle IDs with various special characters', () => {
-    expect(normalizeToolCallId('tool-use_123ABC456', true)).toBe('tooluse12');
-    expect(normalizeToolCallId('___abc123DEF___', true)).toBe('abc123DEF');
+  it('should handle IDs that are already alphanumeric for Mistral', () => {
+    expect(normalizeToolCallId('abcdefghi', true, false)).toBe('abcdefghi');
+    expect(normalizeToolCallId('abc123XYZ', true, false)).toBe('abc123XYZ');
   });
 
-  it('should handle IDs that are already alphanumeric', () => {
-    expect(normalizeToolCallId('abcdefghi', true)).toBe('abcdefghi');
-    expect(normalizeToolCallId('abc123XYZ', true)).toBe('abc123XYZ');
+  it('should handle short IDs for Mistral', () => {
+    expect(normalizeToolCallId('abc', true, false)).toBe('abc');
+    expect(normalizeToolCallId('12345', true, false)).toBe('12345');
   });
 
-  it('should handle short IDs', () => {
-    expect(normalizeToolCallId('abc', true)).toBe('abc');
-    expect(normalizeToolCallId('12345', true)).toBe('12345');
-  });
-
-  it('should handle IDs with only special characters', () => {
-    expect(normalizeToolCallId('___---___', true)).toBe('');
+  it('should handle IDs with only special characters for Mistral', () => {
+    expect(normalizeToolCallId('___---___', true, false)).toBe('');
   });
 
   it('should produce valid Mistral tool call IDs (9 alphanumeric chars)', () => {
     const normalizedId = normalizeToolCallId(
       'tooluse_bpe71yCfRu2b5i-nKGDr5g',
       true,
+      false,
     );
-    // Verify the ID matches Mistral's requirements: ^[a-zA-Z0-9]{1,9}$
     expect(normalizedId).toMatch(/^[a-zA-Z0-9]{1,9}$/);
+  });
+
+  it('should replace colons in Moonshotai tool call IDs', () => {
+    expect(normalizeToolCallId('get_weather:0', false, true)).toBe(
+      'get_weather_0',
+    );
+    expect(normalizeToolCallId('web_search:0', false, true)).toBe(
+      'web_search_0',
+    );
+  });
+
+  it('should replace multiple invalid characters for Moonshotai', () => {
+    expect(normalizeToolCallId('tool:name:1', false, true)).toBe('tool_name_1');
+  });
+
+  it('should preserve valid characters for Moonshotai', () => {
+    expect(normalizeToolCallId('tool_name-1', false, true)).toBe('tool_name-1');
+  });
+
+  it('should return original ID if already valid for Moonshotai', () => {
+    expect(normalizeToolCallId('tooluse_abc123', false, true)).toBe(
+      'tooluse_abc123',
+    );
+  });
+});
+
+describe('isMoonshotaiModel', () => {
+  it('should return true for moonshotai models', () => {
+    expect(isMoonshotaiModel('moonshotai.kimi-k2.5')).toBe(true);
+    expect(isMoonshotaiModel('moonshotai.kimi-k2')).toBe(true);
+  });
+
+  it('should return false for non-moonshotai models', () => {
+    expect(isMoonshotaiModel('anthropic.claude-3-5-sonnet-20241022-v2:0')).toBe(
+      false,
+    );
+    expect(isMoonshotaiModel('mistral.mistral-large-2402-v1:0')).toBe(false);
   });
 });

--- a/packages/amazon-bedrock/src/normalize-tool-call-id.ts
+++ b/packages/amazon-bedrock/src/normalize-tool-call-id.ts
@@ -7,6 +7,14 @@ export function isMistralModel(modelId: string): boolean {
 }
 
 /**
+ * Checks if the given model ID is a Moonshot AI model.
+ * Moonshot models on Bedrock are prefixed with 'moonshotai.'.
+ */
+export function isMoonshotaiModel(modelId: string): boolean {
+  return modelId.includes('moonshotai.');
+}
+
+/**
  * Normalizes a tool call ID for Mistral models.
  *
  * Mistral models require tool call IDs to match the regex `^[a-zA-Z0-9]{9}$`:
@@ -25,12 +33,19 @@ export function isMistralModel(modelId: string): boolean {
 export function normalizeToolCallId(
   toolCallId: string,
   isMistral: boolean,
+  isMoonshotai: boolean,
 ): string {
-  if (!isMistral) {
-    return toolCallId;
+  if (isMistral) {
+    // Mistral: extract only alphanumeric characters and take first 9
+    const alphanumericChars = toolCallId.replace(/[^a-zA-Z0-9]/g, '');
+    return alphanumericChars.slice(0, 9);
   }
 
-  // Extract only alphanumeric characters and take first 9
-  const alphanumericChars = toolCallId.replace(/[^a-zA-Z0-9]/g, '');
-  return alphanumericChars.slice(0, 9);
+  if (isMoonshotai) {
+    // Moonshot uses "name:index" format (e.g. "get_weather:0") which
+    // violates Bedrock Converse API constraint: [a-zA-Z0-9_-]+
+    return toolCallId.replace(/[^a-zA-Z0-9_-]/g, '_');
+  }
+
+  return toolCallId;
 }


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Bedrock's Converse API requires toolUseId to match [a-zA-Z0-9_-]+. MoonshotAI generates tool call IDs in `name:index` format (e.g. `get_weather:0`) for both custom and provider tools which are rejected by Bedrock.

When requests with moonshot-originated tool IDs are sent to bedrock, bedrock rejects them with a validation error.

## Summary

Extended normalizeToolCallId in @ai-sdk/amazon-bedrock to sanitize MoonshotAI tool call IDs

<!-- What did you change? -->

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

- Added a test script
- Updated unit tests

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

- backport to v6 
- backport to v5