### PR TITLE
feat(openai): upgrade v3 specs to v4

### DIFF
--- a/.changeset/eleven-avocados-rescue.md
+++ b/.changeset/eleven-avocados-rescue.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/openai': patch
+'@ai-sdk/azure': patch
+'@ai-sdk/rsc': patch
+---
+
+feat(openai): upgrade v3 specs to v4

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -1,8 +1,8 @@
 import {
-  EmbeddingModelV3Embedding,
-  LanguageModelV3,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3Prompt,
+  EmbeddingModelV4Embedding,
+  LanguageModelV4,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4Prompt,
 } from '@ai-sdk/provider';
 import {
   convertReadableStreamToArray,
@@ -18,7 +18,7 @@ vi.mock('./version', () => ({
   VERSION: '0.0.0-test',
 }));
 
-const TEST_PROMPT: LanguageModelV3Prompt = [
+const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 
@@ -484,7 +484,7 @@ describe('embedding', () => {
     function prepareJsonResponse({
       embeddings = dummyEmbeddings,
     }: {
-      embeddings?: EmbeddingModelV3Embedding[];
+      embeddings?: EmbeddingModelV4Embedding[];
     } = {}) {
       server.urls[
         'https://test-resource.openai.azure.com/openai/v1/embeddings'
@@ -893,7 +893,7 @@ describe('responses', () => {
     it('should handle Azure file IDs with assistant- prefix', async () => {
       prepareJsonFixtureResponse('azure-text.1');
 
-      const TEST_PROMPT_WITH_AZURE_FILE: LanguageModelV3Prompt = [
+      const TEST_PROMPT_WITH_AZURE_FILE: LanguageModelV4Prompt = [
         {
           role: 'user',
           content: [
@@ -926,7 +926,7 @@ describe('responses', () => {
     it('should handle PDF files with assistant- prefix', async () => {
       prepareJsonFixtureResponse('azure-text.1');
 
-      const TEST_PROMPT_WITH_AZURE_PDF: LanguageModelV3Prompt = [
+      const TEST_PROMPT_WITH_AZURE_PDF: LanguageModelV4Prompt = [
         {
           role: 'user',
           content: [
@@ -959,7 +959,7 @@ describe('responses', () => {
     it('should fall back to base64 for non-assistant file IDs', async () => {
       prepareJsonFixtureResponse('azure-text.1');
 
-      const TEST_PROMPT_WITH_OPENAI_FILE: LanguageModelV3Prompt = [
+      const TEST_PROMPT_WITH_OPENAI_FILE: LanguageModelV4Prompt = [
         {
           role: 'user',
           content: [
@@ -1086,7 +1086,7 @@ describe('responses', () => {
     });
 
     describe('code interpreter tool', () => {
-      let result: LanguageModelV3GenerateResult;
+      let result: LanguageModelV4GenerateResult;
 
       beforeEach(async () => {
         prepareJsonFixtureResponse('azure-code-interpreter-tool.1');
@@ -1140,7 +1140,7 @@ describe('responses', () => {
     });
 
     describe('file search tool', () => {
-      let result: LanguageModelV3GenerateResult;
+      let result: LanguageModelV4GenerateResult;
 
       describe('without results include', () => {
         beforeEach(async () => {
@@ -1294,7 +1294,7 @@ describe('responses', () => {
     });
 
     describe('web search preview tool', () => {
-      let result: LanguageModelV3GenerateResult;
+      let result: LanguageModelV4GenerateResult;
 
       beforeEach(async () => {
         prepareJsonFixtureResponse('azure-web-search-preview-tool.1');
@@ -1317,7 +1317,7 @@ describe('responses', () => {
     });
 
     describe('reasoning', async () => {
-      let result: Awaited<ReturnType<LanguageModelV3['doGenerate']>>;
+      let result: Awaited<ReturnType<LanguageModelV4['doGenerate']>>;
       beforeEach(async () => {
         prepareJsonFixtureResponse('azure-reasoning-encrypted-content.1');
 
@@ -1357,7 +1357,7 @@ describe('responses', () => {
     });
 
     describe('image generation tool', () => {
-      let result: LanguageModelV3GenerateResult;
+      let result: LanguageModelV4GenerateResult;
 
       beforeEach(async () => {
         prepareJsonFixtureResponse('azure-image-generation-tool.1');

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -8,12 +8,12 @@ import {
   OpenAITranscriptionModel,
 } from '@ai-sdk/openai/internal';
 import {
-  EmbeddingModelV3,
-  LanguageModelV3,
-  ProviderV3,
-  ImageModelV3,
-  SpeechModelV3,
-  TranscriptionModelV3,
+  EmbeddingModelV4,
+  LanguageModelV4,
+  ProviderV4,
+  ImageModelV4,
+  SpeechModelV4,
+  TranscriptionModelV4,
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
@@ -24,68 +24,68 @@ import {
 import { azureOpenaiTools } from './azure-openai-tools';
 import { VERSION } from './version';
 
-export interface AzureOpenAIProvider extends ProviderV3 {
-  (deploymentId: string): LanguageModelV3;
+export interface AzureOpenAIProvider extends ProviderV4 {
+  (deploymentId: string): LanguageModelV4;
 
   /**
    * Creates an Azure OpenAI responses API model for text generation.
    */
-  languageModel(deploymentId: string): LanguageModelV3;
+  languageModel(deploymentId: string): LanguageModelV4;
 
   /**
    * Creates an Azure OpenAI chat model for text generation.
    */
-  chat(deploymentId: string): LanguageModelV3;
+  chat(deploymentId: string): LanguageModelV4;
 
   /**
    * Creates an Azure OpenAI responses API model for text generation.
    */
-  responses(deploymentId: string): LanguageModelV3;
+  responses(deploymentId: string): LanguageModelV4;
 
   /**
    * Creates an Azure OpenAI completion model for text generation.
    */
-  completion(deploymentId: string): LanguageModelV3;
+  completion(deploymentId: string): LanguageModelV4;
 
   /**
    * Creates an Azure OpenAI model for text embeddings.
    */
-  embedding(deploymentId: string): EmbeddingModelV3;
+  embedding(deploymentId: string): EmbeddingModelV4;
 
   /**
    * Creates an Azure OpenAI model for text embeddings.
    */
-  embeddingModel(deploymentId: string): EmbeddingModelV3;
+  embeddingModel(deploymentId: string): EmbeddingModelV4;
 
   /**
    * @deprecated Use `embedding` instead.
    */
-  textEmbedding(deploymentId: string): EmbeddingModelV3;
+  textEmbedding(deploymentId: string): EmbeddingModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
    */
-  textEmbeddingModel(deploymentId: string): EmbeddingModelV3;
+  textEmbeddingModel(deploymentId: string): EmbeddingModelV4;
 
   /**
    * Creates an Azure OpenAI DALL-E model for image generation.
    */
-  image(deploymentId: string): ImageModelV3;
+  image(deploymentId: string): ImageModelV4;
 
   /**
    * Creates an Azure OpenAI DALL-E model for image generation.
    */
-  imageModel(deploymentId: string): ImageModelV3;
+  imageModel(deploymentId: string): ImageModelV4;
 
   /**
    * Creates an Azure OpenAI model for audio transcription.
    */
-  transcription(deploymentId: string): TranscriptionModelV3;
+  transcription(deploymentId: string): TranscriptionModelV4;
 
   /**
    * Creates an Azure OpenAI model for speech generation.
    */
-  speech(deploymentId: string): SpeechModelV3;
+  speech(deploymentId: string): SpeechModelV4;
 
   /**
    * AzureOpenAI-specific tools.
@@ -250,7 +250,7 @@ export function createAzure(
     return createResponsesModel(deploymentId);
   };
 
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.languageModel = createResponsesModel;
   provider.chat = createChatModel;
   provider.completion = createCompletionModel;

--- a/packages/openai/src/chat/convert-openai-chat-usage.ts
+++ b/packages/openai/src/chat/convert-openai-chat-usage.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV3Usage } from '@ai-sdk/provider';
+import { LanguageModelV4Usage } from '@ai-sdk/provider';
 
 export type OpenAIChatUsage = {
   prompt_tokens?: number | null;
@@ -16,7 +16,7 @@ export type OpenAIChatUsage = {
 
 export function convertOpenAIChatUsage(
   usage: OpenAIChatUsage | undefined | null,
-): LanguageModelV3Usage {
+): LanguageModelV4Usage {
   if (usage == null) {
     return {
       inputTokens: {

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -1,6 +1,6 @@
 import {
-  SharedV3Warning,
-  LanguageModelV3Prompt,
+  SharedV4Warning,
+  LanguageModelV4Prompt,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { OpenAIChatPrompt } from './openai-chat-prompt';
@@ -10,14 +10,14 @@ export function convertToOpenAIChatMessages({
   prompt,
   systemMessageMode = 'system',
 }: {
-  prompt: LanguageModelV3Prompt;
+  prompt: LanguageModelV4Prompt;
   systemMessageMode?: 'system' | 'developer' | 'remove';
 }): {
   messages: OpenAIChatPrompt;
-  warnings: Array<SharedV3Warning>;
+  warnings: Array<SharedV4Warning>;
 } {
   const messages: OpenAIChatPrompt = [];
-  const warnings: Array<SharedV3Warning> = [];
+  const warnings: Array<SharedV4Warning> = [];
 
   for (const { role, content } of prompt) {
     switch (role) {

--- a/packages/openai/src/chat/map-openai-finish-reason.ts
+++ b/packages/openai/src/chat/map-openai-finish-reason.ts
@@ -1,8 +1,8 @@
-import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
+import { LanguageModelV4FinishReason } from '@ai-sdk/provider';
 
 export function mapOpenAIFinishReason(
   finishReason: string | null | undefined,
-): LanguageModelV3FinishReason['unified'] {
+): LanguageModelV4FinishReason['unified'] {
   switch (finishReason) {
     case 'stop':
       return 'stop';

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -1,14 +1,14 @@
 import {
   InvalidResponseDataError,
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  LanguageModelV3Content,
-  LanguageModelV3FinishReason,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamPart,
-  LanguageModelV3StreamResult,
-  SharedV3ProviderMetadata,
-  SharedV3Warning,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4Content,
+  LanguageModelV4FinishReason,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamPart,
+  LanguageModelV4StreamResult,
+  SharedV4ProviderMetadata,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
@@ -48,8 +48,8 @@ type OpenAIChatConfig = {
   fetch?: FetchFunction;
 };
 
-export class OpenAIChatLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = 'v3';
+export class OpenAIChatLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4';
 
   readonly modelId: OpenAIChatModelId;
 
@@ -82,8 +82,8 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
     tools,
     toolChoice,
     providerOptions,
-  }: LanguageModelV3CallOptions) {
-    const warnings: SharedV3Warning[] = [];
+  }: LanguageModelV4CallOptions) {
+    const warnings: SharedV4Warning[] = [];
 
     // Parse provider options
     const openaiOptions =
@@ -314,8 +314,8 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
   }
 
   async doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3GenerateResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
     const { args: body, warnings } = await this.getArgs(options);
 
     const {
@@ -338,7 +338,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
     });
 
     const choice = response.choices[0];
-    const content: Array<LanguageModelV3Content> = [];
+    const content: Array<LanguageModelV4Content> = [];
 
     // text content:
     const text = choice.message.content;
@@ -370,7 +370,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
     // provider metadata:
     const completionTokenDetails = response.usage?.completion_tokens_details;
     const promptTokenDetails = response.usage?.prompt_tokens_details;
-    const providerMetadata: SharedV3ProviderMetadata = { openai: {} };
+    const providerMetadata: SharedV4ProviderMetadata = { openai: {} };
     if (completionTokenDetails?.accepted_prediction_tokens != null) {
       providerMetadata.openai.acceptedPredictionTokens =
         completionTokenDetails?.accepted_prediction_tokens;
@@ -402,8 +402,8 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
   }
 
   async doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3StreamResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
     const { args, warnings } = await this.getArgs(options);
 
     const body = {
@@ -439,7 +439,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
       hasFinished: boolean;
     }> = [];
 
-    let finishReason: LanguageModelV3FinishReason = {
+    let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
       raw: undefined,
     };
@@ -447,13 +447,13 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
     let metadataExtracted = false;
     let isActiveText = false;
 
-    const providerMetadata: SharedV3ProviderMetadata = { openai: {} };
+    const providerMetadata: SharedV4ProviderMetadata = { openai: {} };
 
     return {
       stream: response.pipeThrough(
         new TransformStream<
           ParseResult<OpenAIChatChunk>,
-          LanguageModelV3StreamPart
+          LanguageModelV4StreamPart
         >({
           start(controller) {
             controller.enqueue({ type: 'stream-start', warnings });

--- a/packages/openai/src/chat/openai-chat-prepare-tools.ts
+++ b/packages/openai/src/chat/openai-chat-prepare-tools.ts
@@ -1,6 +1,6 @@
 import {
-  LanguageModelV3CallOptions,
-  SharedV3Warning,
+  LanguageModelV4CallOptions,
+  SharedV4Warning,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import {
@@ -12,17 +12,17 @@ export function prepareChatTools({
   tools,
   toolChoice,
 }: {
-  tools: LanguageModelV3CallOptions['tools'];
-  toolChoice?: LanguageModelV3CallOptions['toolChoice'];
+  tools: LanguageModelV4CallOptions['tools'];
+  toolChoice?: LanguageModelV4CallOptions['toolChoice'];
 }): {
   tools?: OpenAIChatFunctionTool[];
   toolChoice?: OpenAIChatToolChoice;
-  toolWarnings: Array<SharedV3Warning>;
+  toolWarnings: Array<SharedV4Warning>;
 } {
   // when the tools array is empty, change it to undefined to prevent errors:
   tools = tools?.length ? tools : undefined;
 
-  const toolWarnings: SharedV3Warning[] = [];
+  const toolWarnings: SharedV4Warning[] = [];
 
   if (tools == null) {
     return { tools: undefined, toolChoice: undefined, toolWarnings };

--- a/packages/openai/src/completion/convert-openai-completion-usage.ts
+++ b/packages/openai/src/completion/convert-openai-completion-usage.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV3Usage } from '@ai-sdk/provider';
+import { LanguageModelV4Usage } from '@ai-sdk/provider';
 
 export type OpenAICompletionUsage = {
   prompt_tokens?: number | null;
@@ -8,7 +8,7 @@ export type OpenAICompletionUsage = {
 
 export function convertOpenAICompletionUsage(
   usage: OpenAICompletionUsage | undefined | null,
-): LanguageModelV3Usage {
+): LanguageModelV4Usage {
   if (usage == null) {
     return {
       inputTokens: {

--- a/packages/openai/src/completion/convert-to-openai-completion-prompt.ts
+++ b/packages/openai/src/completion/convert-to-openai-completion-prompt.ts
@@ -1,6 +1,6 @@
 import {
   InvalidPromptError,
-  LanguageModelV3Prompt,
+  LanguageModelV4Prompt,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 
@@ -9,7 +9,7 @@ export function convertToOpenAICompletionPrompt({
   user = 'user',
   assistant = 'assistant',
 }: {
-  prompt: LanguageModelV3Prompt;
+  prompt: LanguageModelV4Prompt;
   user?: string;
   assistant?: string;
 }): {

--- a/packages/openai/src/completion/map-openai-finish-reason.ts
+++ b/packages/openai/src/completion/map-openai-finish-reason.ts
@@ -1,8 +1,8 @@
-import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
+import { LanguageModelV4FinishReason } from '@ai-sdk/provider';
 
 export function mapOpenAIFinishReason(
   finishReason: string | null | undefined,
-): LanguageModelV3FinishReason['unified'] {
+): LanguageModelV4FinishReason['unified'] {
   switch (finishReason) {
     case 'stop':
       return 'stop';

--- a/packages/openai/src/completion/openai-completion-language-model.ts
+++ b/packages/openai/src/completion/openai-completion-language-model.ts
@@ -1,12 +1,12 @@
 import {
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  LanguageModelV3FinishReason,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamPart,
-  LanguageModelV3StreamResult,
-  SharedV3ProviderMetadata,
-  SharedV3Warning,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4FinishReason,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamPart,
+  LanguageModelV4StreamResult,
+  SharedV4ProviderMetadata,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -42,8 +42,8 @@ type OpenAICompletionConfig = {
   fetch?: FetchFunction;
 };
 
-export class OpenAICompletionLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = 'v3';
+export class OpenAICompletionLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4';
 
   readonly modelId: OpenAICompletionModelId;
 
@@ -83,8 +83,8 @@ export class OpenAICompletionLanguageModel implements LanguageModelV3 {
     toolChoice,
     seed,
     providerOptions,
-  }: LanguageModelV3CallOptions) {
-    const warnings: SharedV3Warning[] = [];
+  }: LanguageModelV4CallOptions) {
+    const warnings: SharedV4Warning[] = [];
 
     // Parse provider options
     const openaiOptions = {
@@ -161,8 +161,8 @@ export class OpenAICompletionLanguageModel implements LanguageModelV3 {
   }
 
   async doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3GenerateResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
     const { args, warnings } = await this.getArgs(options);
 
     const {
@@ -186,7 +186,7 @@ export class OpenAICompletionLanguageModel implements LanguageModelV3 {
 
     const choice = response.choices[0];
 
-    const providerMetadata: SharedV3ProviderMetadata = { openai: {} };
+    const providerMetadata: SharedV4ProviderMetadata = { openai: {} };
 
     if (choice.logprobs != null) {
       providerMetadata.openai.logprobs = choice.logprobs;
@@ -211,8 +211,8 @@ export class OpenAICompletionLanguageModel implements LanguageModelV3 {
   }
 
   async doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3StreamResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
     const { args, warnings } = await this.getArgs(options);
 
     const body = {
@@ -239,11 +239,11 @@ export class OpenAICompletionLanguageModel implements LanguageModelV3 {
       fetch: this.config.fetch,
     });
 
-    let finishReason: LanguageModelV3FinishReason = {
+    let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
       raw: undefined,
     };
-    const providerMetadata: SharedV3ProviderMetadata = { openai: {} };
+    const providerMetadata: SharedV4ProviderMetadata = { openai: {} };
     let usage: OpenAICompletionUsage | undefined = undefined;
     let isFirstChunk = true;
 
@@ -251,7 +251,7 @@ export class OpenAICompletionLanguageModel implements LanguageModelV3 {
       stream: response.pipeThrough(
         new TransformStream<
           ParseResult<OpenAICompletionChunk>,
-          LanguageModelV3StreamPart
+          LanguageModelV4StreamPart
         >({
           start(controller) {
             controller.enqueue({ type: 'stream-start', warnings });

--- a/packages/openai/src/embedding/openai-embedding-model.ts
+++ b/packages/openai/src/embedding/openai-embedding-model.ts
@@ -1,5 +1,5 @@
 import {
-  EmbeddingModelV3,
+  EmbeddingModelV4,
   TooManyEmbeddingValuesForCallError,
 } from '@ai-sdk/provider';
 import {
@@ -16,8 +16,8 @@ import {
 } from './openai-embedding-options';
 import { openaiTextEmbeddingResponseSchema } from './openai-embedding-api';
 
-export class OpenAIEmbeddingModel implements EmbeddingModelV3 {
-  readonly specificationVersion = 'v3';
+export class OpenAIEmbeddingModel implements EmbeddingModelV4 {
+  readonly specificationVersion = 'v4';
   readonly modelId: OpenAIEmbeddingModelId;
   readonly maxEmbeddingsPerCall = 2048;
   readonly supportsParallelCalls = true;
@@ -38,8 +38,8 @@ export class OpenAIEmbeddingModel implements EmbeddingModelV3 {
     headers,
     abortSignal,
     providerOptions,
-  }: Parameters<EmbeddingModelV3['doEmbed']>[0]): Promise<
-    Awaited<ReturnType<EmbeddingModelV3['doEmbed']>>
+  }: Parameters<EmbeddingModelV4['doEmbed']>[0]): Promise<
+    Awaited<ReturnType<EmbeddingModelV4['doEmbed']>>
   > {
     if (values.length > this.maxEmbeddingsPerCall) {
       throw new TooManyEmbeddingValuesForCallError({

--- a/packages/openai/src/image/openai-image-model.ts
+++ b/packages/openai/src/image/openai-image-model.ts
@@ -1,7 +1,7 @@
 import {
-  ImageModelV3,
-  ImageModelV3File,
-  SharedV3Warning,
+  ImageModelV4,
+  ImageModelV4File,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -27,8 +27,8 @@ interface OpenAIImageModelConfig extends OpenAIConfig {
   };
 }
 
-export class OpenAIImageModel implements ImageModelV3 {
-  readonly specificationVersion = 'v3';
+export class OpenAIImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4';
 
   get maxImagesPerCall(): number {
     return modelMaxImagesPerCall[this.modelId] ?? 1;
@@ -54,10 +54,10 @@ export class OpenAIImageModel implements ImageModelV3 {
     providerOptions,
     headers,
     abortSignal,
-  }: Parameters<ImageModelV3['doGenerate']>[0]): Promise<
-    Awaited<ReturnType<ImageModelV3['doGenerate']>>
+  }: Parameters<ImageModelV4['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV4['doGenerate']>>
   > {
-    const warnings: Array<SharedV3Warning> = [];
+    const warnings: Array<SharedV4Warning> = [];
 
     if (aspectRatio != null) {
       warnings.push({
@@ -332,7 +332,7 @@ type OpenAIImageEditInput = {
 };
 
 async function fileToBlob(
-  file: ImageModelV3File | undefined,
+  file: ImageModelV4File | undefined,
 ): Promise<Blob | undefined> {
   if (!file) return undefined;
 

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -1,10 +1,10 @@
 import {
-  EmbeddingModelV3,
-  ImageModelV3,
-  LanguageModelV3,
-  ProviderV3,
-  SpeechModelV3,
-  TranscriptionModelV3,
+  EmbeddingModelV4,
+  ImageModelV4,
+  LanguageModelV4,
+  ProviderV4,
+  SpeechModelV4,
+  TranscriptionModelV4,
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
@@ -30,68 +30,68 @@ import { OpenAITranscriptionModel } from './transcription/openai-transcription-m
 import { OpenAITranscriptionModelId } from './transcription/openai-transcription-options';
 import { VERSION } from './version';
 
-export interface OpenAIProvider extends ProviderV3 {
-  (modelId: OpenAIResponsesModelId): LanguageModelV3;
+export interface OpenAIProvider extends ProviderV4 {
+  (modelId: OpenAIResponsesModelId): LanguageModelV4;
 
   /**
    * Creates an OpenAI model for text generation.
    */
-  languageModel(modelId: OpenAIResponsesModelId): LanguageModelV3;
+  languageModel(modelId: OpenAIResponsesModelId): LanguageModelV4;
 
   /**
    * Creates an OpenAI chat model for text generation.
    */
-  chat(modelId: OpenAIChatModelId): LanguageModelV3;
+  chat(modelId: OpenAIChatModelId): LanguageModelV4;
 
   /**
    * Creates an OpenAI responses API model for text generation.
    */
-  responses(modelId: OpenAIResponsesModelId): LanguageModelV3;
+  responses(modelId: OpenAIResponsesModelId): LanguageModelV4;
 
   /**
    * Creates an OpenAI completion model for text generation.
    */
-  completion(modelId: OpenAICompletionModelId): LanguageModelV3;
+  completion(modelId: OpenAICompletionModelId): LanguageModelV4;
 
   /**
    * Creates a model for text embeddings.
    */
-  embedding(modelId: OpenAIEmbeddingModelId): EmbeddingModelV3;
+  embedding(modelId: OpenAIEmbeddingModelId): EmbeddingModelV4;
 
   /**
    * Creates a model for text embeddings.
    */
-  embeddingModel(modelId: OpenAIEmbeddingModelId): EmbeddingModelV3;
+  embeddingModel(modelId: OpenAIEmbeddingModelId): EmbeddingModelV4;
 
   /**
    * @deprecated Use `embedding` instead.
    */
-  textEmbedding(modelId: OpenAIEmbeddingModelId): EmbeddingModelV3;
+  textEmbedding(modelId: OpenAIEmbeddingModelId): EmbeddingModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
    */
-  textEmbeddingModel(modelId: OpenAIEmbeddingModelId): EmbeddingModelV3;
+  textEmbeddingModel(modelId: OpenAIEmbeddingModelId): EmbeddingModelV4;
 
   /**
    * Creates a model for image generation.
    */
-  image(modelId: OpenAIImageModelId): ImageModelV3;
+  image(modelId: OpenAIImageModelId): ImageModelV4;
 
   /**
    * Creates a model for image generation.
    */
-  imageModel(modelId: OpenAIImageModelId): ImageModelV3;
+  imageModel(modelId: OpenAIImageModelId): ImageModelV4;
 
   /**
    * Creates a model for transcription.
    */
-  transcription(modelId: OpenAITranscriptionModelId): TranscriptionModelV3;
+  transcription(modelId: OpenAITranscriptionModelId): TranscriptionModelV4;
 
   /**
    * Creates a model for speech generation.
    */
-  speech(modelId: OpenAISpeechModelId): SpeechModelV3;
+  speech(modelId: OpenAISpeechModelId): SpeechModelV4;
 
   /**
    * OpenAI-specific tools.
@@ -240,7 +240,7 @@ export function createOpenAI(
     return createLanguageModel(modelId);
   };
 
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.languageModel = createLanguageModel;
   provider.chat = createChatModel;
   provider.completion = createCompletionModel;

--- a/packages/openai/src/responses/convert-openai-responses-usage.ts
+++ b/packages/openai/src/responses/convert-openai-responses-usage.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV3Usage } from '@ai-sdk/provider';
+import { LanguageModelV4Usage } from '@ai-sdk/provider';
 
 export type OpenAIResponsesUsage = {
   input_tokens: number;
@@ -13,7 +13,7 @@ export type OpenAIResponsesUsage = {
 
 export function convertOpenAIResponsesUsage(
   usage: OpenAIResponsesUsage | undefined | null,
-): LanguageModelV3Usage {
+): LanguageModelV4Usage {
   if (usage == null) {
     return {
       inputTokens: {

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -1,7 +1,7 @@
 import {
-  LanguageModelV3Prompt,
-  LanguageModelV3ToolApprovalResponsePart,
-  SharedV3Warning,
+  LanguageModelV4Prompt,
+  LanguageModelV4ToolApprovalResponsePart,
+  SharedV4Warning,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import {
@@ -50,7 +50,7 @@ export async function convertToOpenAIResponsesInput({
   hasApplyPatchTool = false,
   customProviderToolNames,
 }: {
-  prompt: LanguageModelV3Prompt;
+  prompt: LanguageModelV4Prompt;
   toolNameMapping: ToolNameMapping;
   systemMessageMode: 'system' | 'developer' | 'remove';
   providerOptionsName: string;
@@ -63,10 +63,10 @@ export async function convertToOpenAIResponsesInput({
   customProviderToolNames?: Set<string>;
 }): Promise<{
   input: OpenAIResponsesInput;
-  warnings: Array<SharedV3Warning>;
+  warnings: Array<SharedV4Warning>;
 }> {
   let input: OpenAIResponsesInput = [];
-  const warnings: Array<SharedV3Warning> = [];
+  const warnings: Array<SharedV4Warning> = [];
   const processedApprovalIds = new Set<string>();
 
   for (const { role, content } of prompt) {
@@ -488,7 +488,7 @@ export async function convertToOpenAIResponsesInput({
         for (const part of content) {
           if (part.type === 'tool-approval-response') {
             const approvalResponse =
-              part as LanguageModelV3ToolApprovalResponsePart;
+              part as LanguageModelV4ToolApprovalResponsePart;
 
             if (processedApprovalIds.has(approvalResponse.approvalId)) {
               continue;

--- a/packages/openai/src/responses/map-openai-responses-finish-reason.ts
+++ b/packages/openai/src/responses/map-openai-responses-finish-reason.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
+import { LanguageModelV4FinishReason } from '@ai-sdk/provider';
 
 export function mapOpenAIResponseFinishReason({
   finishReason,
@@ -7,7 +7,7 @@ export function mapOpenAIResponseFinishReason({
   finishReason: string | null | undefined;
   // flag that checks if there have been client-side tool calls (not executed by openai)
   hasFunctionCall: boolean;
-}): LanguageModelV3FinishReason['unified'] {
+}): LanguageModelV4FinishReason['unified'] {
   switch (finishReason) {
     case undefined:
     case null:

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -1,18 +1,18 @@
 import {
   APICallError,
   JSONValue,
-  LanguageModelV3,
-  LanguageModelV3Prompt,
-  LanguageModelV3CallOptions,
-  LanguageModelV3Content,
-  LanguageModelV3FinishReason,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3ProviderTool,
-  LanguageModelV3StreamPart,
-  LanguageModelV3StreamResult,
-  LanguageModelV3ToolApprovalRequest,
-  SharedV3ProviderMetadata,
-  SharedV3Warning,
+  LanguageModelV4,
+  LanguageModelV4Prompt,
+  LanguageModelV4CallOptions,
+  LanguageModelV4Content,
+  LanguageModelV4FinishReason,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4ProviderTool,
+  LanguageModelV4StreamPart,
+  LanguageModelV4StreamResult,
+  LanguageModelV4ToolApprovalRequest,
+  SharedV4ProviderMetadata,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -77,7 +77,7 @@ import {
  * so that tool results reference the correct tool call.
  */
 function extractApprovalRequestIdToToolCallIdMapping(
-  prompt: LanguageModelV3Prompt,
+  prompt: LanguageModelV4Prompt,
 ): Record<string, string> {
   const mapping: Record<string, string> = {};
   for (const message of prompt) {
@@ -94,8 +94,8 @@ function extractApprovalRequestIdToToolCallIdMapping(
   return mapping;
 }
 
-export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = 'v3';
+export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4';
 
   readonly modelId: OpenAIResponsesModelId;
 
@@ -129,8 +129,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
     tools,
     toolChoice,
     responseFormat,
-  }: LanguageModelV3CallOptions) {
-    const warnings: SharedV3Warning[] = [];
+  }: LanguageModelV4CallOptions) {
+    const warnings: SharedV4Warning[] = [];
     const modelCapabilities = getOpenAILanguageModelCapabilities(this.modelId);
 
     if (topK != null) {
@@ -273,7 +273,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
           tool.type === 'provider' &&
           (tool.id === 'openai.web_search' ||
             tool.id === 'openai.web_search_preview'),
-      ) as LanguageModelV3ProviderTool | undefined
+      ) as LanguageModelV4ProviderTool | undefined
     )?.name;
 
     if (webSearchToolName) {
@@ -454,8 +454,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
   }
 
   async doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3GenerateResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
     const {
       args: body,
       warnings,
@@ -500,7 +500,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       });
     }
 
-    const content: Array<LanguageModelV3Content> = [];
+    const content: Array<LanguageModelV4Content> = [];
     const logprobs: Array<OpenAIResponsesLogprobs> = [];
 
     // flag that checks if there have been client-side tool calls (not executed by openai)
@@ -621,7 +621,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
               logprobs.push(contentPart.logprobs);
             }
 
-            const providerMetadata: SharedV3ProviderMetadata[string] = {
+            const providerMetadata: SharedV4ProviderMetadata[string] = {
               itemId: part.id,
               ...(part.phase != null && { phase: part.phase }),
               ...(contentPart.annotations.length > 0 && {
@@ -833,7 +833,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
             type: 'tool-approval-request',
             approvalId: approvalRequestId,
             toolCallId: dummyToolCallId,
-          } satisfies LanguageModelV3ToolApprovalRequest);
+          } satisfies LanguageModelV4ToolApprovalRequest);
           break;
         }
 
@@ -930,7 +930,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       }
     }
 
-    const providerMetadata: SharedV3ProviderMetadata = {
+    const providerMetadata: SharedV4ProviderMetadata = {
       [providerOptionsName]: {
         responseId: response.id,
         ...(logprobs.length > 0 ? { logprobs } : {}),
@@ -966,8 +966,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
   }
 
   async doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3StreamResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
     const {
       args: body,
       warnings,
@@ -1006,7 +1006,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       string
     >();
 
-    let finishReason: LanguageModelV3FinishReason = {
+    let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
       raw: undefined,
     };
@@ -1059,7 +1059,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       stream: response.pipeThrough(
         new TransformStream<
           ParseResult<OpenAIResponsesChunk>,
-          LanguageModelV3StreamPart
+          LanguageModelV4StreamPart
         >({
           start(controller) {
             controller.enqueue({ type: 'stream-start', warnings });
@@ -1941,7 +1941,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
           },
 
           flush(controller) {
-            const providerMetadata: SharedV3ProviderMetadata = {
+            const providerMetadata: SharedV4ProviderMetadata = {
               [providerOptionsName]: {
                 responseId: responseId,
                 ...(logprobs.length > 0 ? { logprobs } : {}),

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -1,6 +1,6 @@
 import {
-  LanguageModelV3CallOptions,
-  SharedV3Warning,
+  LanguageModelV4CallOptions,
+  SharedV4Warning,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { ToolNameMapping, validateTypes } from '@ai-sdk/provider-utils';
@@ -20,8 +20,8 @@ export async function prepareResponsesTools({
   toolNameMapping,
   customProviderToolNames,
 }: {
-  tools: LanguageModelV3CallOptions['tools'];
-  toolChoice: LanguageModelV3CallOptions['toolChoice'] | undefined;
+  tools: LanguageModelV4CallOptions['tools'];
+  toolChoice: LanguageModelV4CallOptions['toolChoice'] | undefined;
   toolNameMapping?: ToolNameMapping;
   customProviderToolNames?: Set<string>;
 }): Promise<{
@@ -39,12 +39,12 @@ export async function prepareResponsesTools({
     | { type: 'mcp' }
     | { type: 'image_generation' }
     | { type: 'apply_patch' };
-  toolWarnings: SharedV3Warning[];
+  toolWarnings: SharedV4Warning[];
 }> {
   // when the tools array is empty, change it to undefined to prevent errors:
   tools = tools?.length ? tools : undefined;
 
-  const toolWarnings: SharedV3Warning[] = [];
+  const toolWarnings: SharedV4Warning[] = [];
 
   if (tools == null) {
     return { tools: undefined, toolChoice: undefined, toolWarnings };

--- a/packages/openai/src/speech/openai-speech-model.ts
+++ b/packages/openai/src/speech/openai-speech-model.ts
@@ -1,4 +1,4 @@
-import { SpeechModelV3, SharedV3Warning } from '@ai-sdk/provider';
+import { SpeechModelV4, SharedV4Warning } from '@ai-sdk/provider';
 import {
   combineHeaders,
   createBinaryResponseHandler,
@@ -19,8 +19,8 @@ interface OpenAISpeechModelConfig extends OpenAIConfig {
   };
 }
 
-export class OpenAISpeechModel implements SpeechModelV3 {
-  readonly specificationVersion = 'v3';
+export class OpenAISpeechModel implements SpeechModelV4 {
+  readonly specificationVersion = 'v4';
 
   get provider(): string {
     return this.config.provider;
@@ -39,8 +39,8 @@ export class OpenAISpeechModel implements SpeechModelV3 {
     instructions,
     language,
     providerOptions,
-  }: Parameters<SpeechModelV3['doGenerate']>[0]) {
-    const warnings: SharedV3Warning[] = [];
+  }: Parameters<SpeechModelV4['doGenerate']>[0]) {
+    const warnings: SharedV4Warning[] = [];
 
     // Parse provider options
     const openAIOptions = await parseProviderOptions({
@@ -98,8 +98,8 @@ export class OpenAISpeechModel implements SpeechModelV3 {
   }
 
   async doGenerate(
-    options: Parameters<SpeechModelV3['doGenerate']>[0],
-  ): Promise<Awaited<ReturnType<SpeechModelV3['doGenerate']>>> {
+    options: Parameters<SpeechModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<SpeechModelV4['doGenerate']>>> {
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const { requestBody, warnings } = await this.getArgs(options);
 

--- a/packages/openai/src/transcription/openai-transcription-model.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.ts
@@ -1,7 +1,7 @@
 import {
-  TranscriptionModelV3,
-  TranscriptionModelV3CallOptions,
-  SharedV3Warning,
+  TranscriptionModelV4,
+  TranscriptionModelV4CallOptions,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -21,7 +21,7 @@ import {
 } from './openai-transcription-options';
 
 export type OpenAITranscriptionCallOptions = Omit<
-  TranscriptionModelV3CallOptions,
+  TranscriptionModelV4CallOptions,
   'providerOptions'
 > & {
   providerOptions?: {
@@ -96,8 +96,8 @@ const languageMap = {
   welsh: 'cy',
 };
 
-export class OpenAITranscriptionModel implements TranscriptionModelV3 {
-  readonly specificationVersion = 'v3';
+export class OpenAITranscriptionModel implements TranscriptionModelV4 {
+  readonly specificationVersion = 'v4';
 
   get provider(): string {
     return this.config.provider;
@@ -113,7 +113,7 @@ export class OpenAITranscriptionModel implements TranscriptionModelV3 {
     mediaType,
     providerOptions,
   }: OpenAITranscriptionCallOptions) {
-    const warnings: SharedV3Warning[] = [];
+    const warnings: SharedV4Warning[] = [];
 
     // Parse provider options
     const openAIOptions = await parseProviderOptions({
@@ -176,7 +176,7 @@ export class OpenAITranscriptionModel implements TranscriptionModelV3 {
 
   async doGenerate(
     options: OpenAITranscriptionCallOptions,
-  ): Promise<Awaited<ReturnType<TranscriptionModelV3['doGenerate']>>> {
+  ): Promise<Awaited<ReturnType<TranscriptionModelV4['doGenerate']>>> {
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const { formData, warnings } = await this.getArgs(options);
 

--- a/packages/rsc/src/stream-ui/stream-ui.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.tsx
@@ -1,7 +1,7 @@
 import {
-  LanguageModelV3,
-  LanguageModelV3StreamResult,
-  LanguageModelV3Usage,
+  LanguageModelV4,
+  LanguageModelV4StreamResult,
+  LanguageModelV4Usage,
   SharedV3Warning,
 } from '@ai-sdk/provider';
 import {
@@ -85,7 +85,7 @@ type RenderText = Renderer<
 
 type RenderResult = {
   value: ReactNode;
-} & LanguageModelV3StreamResult;
+} & LanguageModelV4StreamResult;
 
 const defaultTextRenderer: RenderText = ({ content }: { content: string }) =>
   content;
@@ -115,7 +115,7 @@ export async function streamUI<
     /**
      * The language model to use.
      */
-    model: LanguageModelV3;
+    model: LanguageModelV4;
 
     /**
      * The tools that the model can call. The model needs to support calling tools.
@@ -206,7 +206,7 @@ export async function streamUI<
 
   let finishEvent: {
     finishReason: FinishReason;
-    usage: LanguageModelV3Usage;
+    usage: LanguageModelV4Usage;
     warnings?: CallWarning[];
     response?: {
       headers?: Record<string, string>;

--- a/packages/rsc/src/stream-ui/stream-ui.ui.test.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.ui.test.tsx
@@ -1,8 +1,9 @@
-import { LanguageModelV3Usage } from '@ai-sdk/provider';
+import { LanguageModelV4Usage } from '@ai-sdk/provider';
 import { delay } from '@ai-sdk/provider-utils';
 import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
 import { asLanguageModelUsage } from 'ai/internal';
-import { MockLanguageModelV3 } from 'ai/test';
+import { MockLanguageModelV4 } from 'ai/test';
+import React from 'react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { streamUI } from './stream-ui';
@@ -53,7 +54,7 @@ async function simulateFlightServerRender(node: React.ReactNode) {
   return traverse(node);
 }
 
-const testUsage: LanguageModelV3Usage = {
+const testUsage: LanguageModelV4Usage = {
   inputTokens: {
     total: 3,
     noCache: 3,
@@ -67,7 +68,7 @@ const testUsage: LanguageModelV3Usage = {
   },
 };
 
-const mockTextModel = new MockLanguageModelV3({
+const mockTextModel = new MockLanguageModelV4({
   doStream: async () => {
     return {
       stream: convertArrayToReadableStream([
@@ -89,13 +90,12 @@ const mockTextModel = new MockLanguageModelV3({
   },
 });
 
-const mockToolModel = new MockLanguageModelV3({
+const mockToolModel = new MockLanguageModelV4({
   doStream: async () => {
     return {
       stream: convertArrayToReadableStream([
         {
           type: 'tool-call',
-          toolCallType: 'function',
           toolCallId: 'call-1',
           toolName: 'tool1',
           input: `{ "value": "value" }`,
@@ -245,7 +245,7 @@ describe('rsc - streamUI() onFinish callback', () => {
 describe('options.headers', () => {
   it('should pass headers to model', async () => {
     const result = await streamUI({
-      model: new MockLanguageModelV3({
+      model: new MockLanguageModelV4({
         doStream: async ({ headers }) => {
           expect(headers).toStrictEqual({
             'custom-request-header': 'request-header-value',
@@ -283,7 +283,7 @@ describe('options.headers', () => {
 describe('options.providerMetadata', () => {
   it('should pass provider metadata to model', async () => {
     const result = await streamUI({
-      model: new MockLanguageModelV3({
+      model: new MockLanguageModelV4({
         doStream: async ({ providerOptions }) => {
           expect(providerOptions).toStrictEqual({
             aProvider: { someKey: 'someValue' },


### PR DESCRIPTION
## Background

some of the packages/providers are still dependent on LangaugeModelV3 specs (among other V3 specs) 

this was a blocker for the change in https://github.com/vercel/ai/pull/13327 and thus needs to be addressed first

## Summary

- upgrade all types to LanguageModelV4 (V4 in general) for:
  - `openai`
  - `azure`
  - `rsc`

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

needs to be done for remaining providers