### PR TITLE
feat(ai): add toolMs to timeout configuration

### DIFF
--- a/.changeset/orange-games-listen.md
+++ b/.changeset/orange-games-listen.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add toolMs to timeout configuration

--- a/examples/ai-e2e-next/app/api/chat/tool-timeout/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/tool-timeout/route.ts
@@ -1,0 +1,62 @@
+import { openai } from '@ai-sdk/openai';
+import {
+  convertToModelMessages,
+  InferUITools,
+  stepCountIs,
+  streamText,
+  tool,
+  UIDataTypes,
+  UIMessage,
+  validateUIMessages,
+} from 'ai';
+import { z } from 'zod';
+
+export const maxDuration = 30;
+
+const getWeatherTool = tool({
+  description: 'Get the weather for a city',
+  inputSchema: z.object({ city: z.string() }),
+  execute: async (_input, { abortSignal }) => {
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(resolve, 10000);
+      abortSignal?.addEventListener('abort', () => {
+        clearTimeout(timer);
+        reject(abortSignal.reason);
+      });
+    });
+    return { temperature: 72, condition: 'sunny' };
+  },
+});
+
+const tools = {
+  getWeather: getWeatherTool,
+} as const;
+
+export type ToolTimeoutMessage = UIMessage<
+  never,
+  UIDataTypes,
+  InferUITools<typeof tools>
+>;
+
+export async function POST(req: Request) {
+  const body = await req.json();
+
+  const messages = await validateUIMessages<ToolTimeoutMessage>({
+    messages: body.messages,
+    tools,
+  });
+
+  const result = streamText({
+    model: openai('gpt-5.4'),
+    messages: await convertToModelMessages(messages),
+    system:
+      'You are a helpful weather assistant. When a tool times out, explain to the user that the weather service is unavailable and suggest they try again later.',
+    tools,
+    timeout: {
+      toolMs: 1000,
+    },
+    stopWhen: stepCountIs(2),
+  });
+
+  return result.toUIMessageStreamResponse();
+}

--- a/examples/ai-e2e-next/app/chat/tool-timeout/page.tsx
+++ b/examples/ai-e2e-next/app/chat/tool-timeout/page.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useState } from 'react';
+import ChatInput from '@/components/chat-input';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import { ToolTimeoutMessage } from '@/app/api/chat/tool-timeout/route';
+
+function ErrorDetails({
+  errorText,
+  toolName,
+  query,
+  timeoutMs,
+}: {
+  errorText: string;
+  toolName: string;
+  query: string;
+  timeoutMs: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const timestamp = new Date().toISOString();
+
+  return (
+    <div className="flex flex-col my-1 text-sm rounded-lg border border-red-200 overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-2.5 bg-red-50">
+        <div className="flex items-center gap-2 text-red-700">
+          <svg
+            aria-hidden="true"
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+            />
+          </svg>
+          Tool execution timed out
+        </div>
+        <button
+          onClick={() => setOpen(!open)}
+          className="flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-red-500 hover:text-red-700 bg-red-100 hover:bg-red-200 rounded transition-colors"
+        >
+          <svg
+            aria-hidden="true"
+            className={`w-3 h-3 transition-transform ${open ? 'rotate-180' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
+          </svg>
+          {open ? 'hide' : 'logs'}
+        </button>
+      </div>
+      {open && (
+        <div className="px-3 py-3 bg-gray-950 text-gray-300 font-mono text-xs leading-relaxed">
+          <div className="text-gray-500">{timestamp}</div>
+          <div className="mt-1">
+            <span className="text-blue-400">tool</span>
+            <span className="text-gray-500">.</span>
+            <span className="text-yellow-300">{toolName}</span>
+            <span className="text-gray-500">(</span>
+            <span className="text-green-400">&quot;{query}&quot;</span>
+            <span className="text-gray-500">)</span>
+          </div>
+          <div className="mt-1 text-gray-500">timeout: {timeoutMs}ms</div>
+          <div className="mt-2 flex items-center gap-1.5">
+            <span className="text-red-400">ERR</span>
+            <span className="text-red-300">{errorText}</span>
+          </div>
+          <div className="mt-1 text-gray-500">
+            Tool aborted - error sent to model as context
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Chat() {
+  const { messages, status, sendMessage } = useChat<ToolTimeoutMessage>({
+    transport: new DefaultChatTransport({ api: '/api/chat/tool-timeout' }),
+  });
+
+  return (
+    <div className="flex flex-col gap-4 p-8 mx-auto max-w-md min-h-screen">
+      <h1 className="text-2xl font-semibold tracking-tight">
+        Tool Timeout Demo
+      </h1>
+      <p className="text-sm text-gray-500">
+        Tools abort after 1 second. Try &quot;what is the weather in
+        tokyo&quot;.
+      </p>
+
+      <div className="flex-1 flex flex-col gap-3 pb-20">
+        {messages?.map(m => (
+          <div
+            key={m.id}
+            className={`flex flex-col gap-1 ${
+              m.role === 'user' ? 'items-end' : 'items-start'
+            }`}
+          >
+            <span className="text-xs font-medium text-gray-400 uppercase">
+              {m.role}
+            </span>
+            <div
+              className={`rounded-lg px-4 py-3 max-w-[80%] ${
+                m.role === 'user'
+                  ? 'bg-black text-white'
+                  : 'bg-gray-100 text-gray-900'
+              }`}
+            >
+              {m.parts.map((part, index) => {
+                switch (part.type) {
+                  case 'text':
+                    return (
+                      <span key={index} className="whitespace-pre-wrap">
+                        {part.text}
+                      </span>
+                    );
+
+                  case 'step-start':
+                    return index > 0 ? (
+                      <hr key={index} className="my-2 border-gray-300" />
+                    ) : null;
+
+                  case 'tool-getWeather': {
+                    switch (part.state) {
+                      case 'input-streaming':
+                        return (
+                          <div
+                            key={index}
+                            className="flex items-center gap-2 px-3 py-2 my-1 text-sm text-gray-500 bg-white border border-gray-200 rounded-md"
+                          >
+                            <span className="inline-block w-2 h-2 bg-yellow-400 rounded-full animate-pulse" />
+                            Getting weather...
+                          </div>
+                        );
+                      case 'input-available':
+                        return (
+                          <div
+                            key={index}
+                            className="flex items-center gap-2 px-3 py-2 my-1 text-sm text-gray-500 bg-white border border-gray-200 rounded-md"
+                          >
+                            <span className="inline-block w-2 h-2 bg-yellow-400 rounded-full animate-pulse" />
+                            Getting weather for {part.input.city}...
+                          </div>
+                        );
+                      case 'output-available':
+                        return (
+                          <div
+                            key={index}
+                            className="flex items-center gap-2 px-3 py-2 my-1 text-sm text-green-700 bg-green-50 border border-green-200 rounded-md"
+                          >
+                            <span className="inline-block w-2 h-2 bg-green-500 rounded-full" />
+                            Result: {JSON.stringify(part.output)}
+                          </div>
+                        );
+                      case 'output-error':
+                        return (
+                          <ErrorDetails
+                            key={index}
+                            errorText={part.errorText}
+                            toolName="getWeather"
+                            query={part.input?.city ?? 'unknown'}
+                            timeoutMs={1000}
+                          />
+                        );
+                    }
+                    break;
+                  }
+                }
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <ChatInput status={status} onSubmit={text => sendMessage({ text })} />
+    </div>
+  );
+}

--- a/examples/ai-functions/src/generate-text/openai/tool-timeout-error.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-timeout-error.ts
@@ -1,0 +1,47 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: openai('gpt-5.4'),
+    tools: {
+      slowApi: tool({
+        description: 'Fetch data from an API',
+        inputSchema: z.object({ query: z.string() }),
+        execute: async (_input, { abortSignal }) => {
+          await new Promise((resolve, reject) => {
+            const timer = setTimeout(resolve, 10000);
+            abortSignal?.addEventListener('abort', () => {
+              clearTimeout(timer);
+              reject(abortSignal.reason);
+            });
+          });
+          return { data: 'this will never resolve' };
+        },
+      }),
+    },
+    timeout: {
+      toolMs: 500,
+    },
+    stopWhen: stepCountIs(2),
+    prompt: 'Search for "hello world"',
+  });
+
+  for (const step of result.steps) {
+    for (const part of step.content) {
+      if (part.type === 'tool-call') {
+        console.log(
+          `tool-call: ${part.toolName}(${JSON.stringify(part.input)})`,
+        );
+      }
+      if (part.type === 'tool-error') {
+        console.log(`tool-error: ${part.toolName} timed out`);
+      }
+    }
+  }
+
+  console.log();
+  console.log(result.text);
+});

--- a/examples/ai-functions/src/generate-text/openai/tool-timeout.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-timeout.ts
@@ -1,0 +1,35 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: openai('gpt-5.4'),
+    tools: {
+      weather: weatherTool,
+      slowApi: tool({
+        description: 'Fetch data from a slow API',
+        inputSchema: z.object({ query: z.string() }),
+        execute: async ({ query }, { abortSignal }) => {
+          await new Promise((resolve, reject) => {
+            const timer = setTimeout(resolve, 10000);
+            abortSignal?.addEventListener('abort', () => {
+              clearTimeout(timer);
+              reject(new Error('tool timed out'));
+            });
+          });
+          return { result: query };
+        },
+      }),
+    },
+    timeout: {
+      toolMs: 2000,
+    },
+    stopWhen: stepCountIs(3),
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  console.log(JSON.stringify(result.text, null, 2));
+});

--- a/examples/ai-functions/src/stream-text/openai/tool-timeout-error.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-timeout-error.ts
@@ -1,0 +1,45 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: openai('gpt-5.4'),
+    tools: {
+      slowApi: tool({
+        description: 'Fetch data from an API',
+        inputSchema: z.object({ query: z.string() }),
+        execute: async (_input, { abortSignal }) => {
+          await new Promise((resolve, reject) => {
+            const timer = setTimeout(resolve, 10000);
+            abortSignal?.addEventListener('abort', () => {
+              clearTimeout(timer);
+              reject(abortSignal.reason);
+            });
+          });
+          return { data: 'this will never resolve' };
+        },
+      }),
+    },
+    timeout: {
+      toolMs: 500,
+    },
+    stopWhen: stepCountIs(2),
+    prompt: 'Search for "hello world"',
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'tool-call') {
+      console.log(`tool-call: ${part.toolName}(${JSON.stringify(part.input)})`);
+    }
+    if (part.type === 'tool-error') {
+      console.log(`tool-error: ${part.toolName} timed out`);
+    }
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+
+  console.log();
+});

--- a/examples/ai-functions/src/stream-text/openai/tool-timeout.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-timeout.ts
@@ -1,0 +1,39 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: openai('gpt-5.4'),
+    tools: {
+      weather: weatherTool,
+      slowApi: tool({
+        description: 'Fetch data from a slow API',
+        inputSchema: z.object({ query: z.string() }),
+        execute: async ({ query }, { abortSignal }) => {
+          await new Promise((resolve, reject) => {
+            const timer = setTimeout(resolve, 10000);
+            abortSignal?.addEventListener('abort', () => {
+              clearTimeout(timer);
+              reject(new Error('tool timed out'));
+            });
+          });
+          return { result: query };
+        },
+      }),
+    },
+    timeout: {
+      toolMs: 2000,
+    },
+    stopWhen: stepCountIs(3),
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  for await (const part of result.textStream) {
+    process.stdout.write(part);
+  }
+
+  console.log();
+});

--- a/packages/ai/src/generate-text/execute-tool-call.test.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.test.ts
@@ -671,6 +671,110 @@ describe('executeToolCall', () => {
     });
   });
 
+  describe('toolTimeoutMs', () => {
+    it('should return tool-result when tool completes before timeout', async () => {
+      const result = await executeToolCall({
+        toolCall: createToolCall(),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        telemetry: undefined,
+        callId: 'test-telemetry-call-id',
+        messages: [],
+        abortSignal: undefined,
+        toolTimeoutMs: 5000,
+        experimental_context: undefined,
+      });
+
+      expect(result).toMatchObject({
+        type: 'tool-result',
+        output: 'test-result',
+      });
+    });
+
+    it('should pass an abort signal to tool when toolTimeoutMs is set', async () => {
+      let receivedSignal: AbortSignal | undefined;
+
+      await executeToolCall({
+        toolCall: createToolCall(),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }, { abortSignal }) => {
+              receivedSignal = abortSignal;
+              return `${value}-result`;
+            },
+          }),
+        },
+        telemetry: undefined,
+        callId: 'test-telemetry-call-id',
+        messages: [],
+        abortSignal: undefined,
+        toolTimeoutMs: 5000,
+        experimental_context: undefined,
+      });
+
+      expect(receivedSignal).toBeDefined();
+      expect(receivedSignal!.aborted).toBe(false);
+    });
+
+    it('should not override abort signal when toolTimeoutMs is undefined', async () => {
+      let receivedSignal: AbortSignal | undefined;
+
+      await executeToolCall({
+        toolCall: createToolCall(),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }, { abortSignal }) => {
+              receivedSignal = abortSignal;
+              return `${value}-result`;
+            },
+          }),
+        },
+        telemetry: undefined,
+        callId: 'test-telemetry-call-id',
+        messages: [],
+        abortSignal: undefined,
+        toolTimeoutMs: undefined,
+        experimental_context: undefined,
+      });
+
+      expect(receivedSignal).toBeUndefined();
+    });
+
+    it('should merge toolTimeoutMs with existing abort signal', async () => {
+      const controller = new AbortController();
+      let receivedSignal: AbortSignal | undefined;
+
+      await executeToolCall({
+        toolCall: createToolCall(),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }, { abortSignal }) => {
+              receivedSignal = abortSignal;
+              return `${value}-result`;
+            },
+          }),
+        },
+        telemetry: undefined,
+        callId: 'test-telemetry-call-id',
+        messages: [],
+        abortSignal: controller.signal,
+        toolTimeoutMs: 5000,
+        experimental_context: undefined,
+      });
+
+      expect(receivedSignal).toBeDefined();
+      expect(receivedSignal).not.toBe(controller.signal);
+      expect(receivedSignal!.aborted).toBe(false);
+    });
+  });
+
   describe('dynamic tools', () => {
     it('should set dynamic: true for dynamic tools on success', async () => {
       const { dynamicTool } = await import('@ai-sdk/provider-utils');

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -30,6 +30,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   callId,
   messages,
   abortSignal,
+  toolTimeoutMs,
   experimental_context,
   stepNumber,
   model,
@@ -44,6 +45,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   callId: string;
   messages: ModelMessage[];
   abortSignal: AbortSignal | undefined;
+  toolTimeoutMs?: number | undefined;
   experimental_context: unknown;
   stepNumber?: number;
   model?: { provider: string; modelId: string };
@@ -83,6 +85,13 @@ export async function executeToolCall<TOOLS extends ToolSet>({
 
   await notify({ event: baseCallbackEvent, callbacks: onToolCallStart });
 
+  const toolAbortSignal =
+    toolTimeoutMs != null
+      ? abortSignal != null
+        ? AbortSignal.any([abortSignal, AbortSignal.timeout(toolTimeoutMs)])
+        : AbortSignal.timeout(toolTimeoutMs)
+      : abortSignal;
+
   const startTime = now();
 
   try {
@@ -101,7 +110,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
           options: {
             toolCallId,
             messages,
-            abortSignal,
+            abortSignal: toolAbortSignal,
             experimental_context,
           },
         });

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -21,6 +21,7 @@ import { ModelMessage } from '../prompt';
 import {
   CallSettings,
   getStepTimeoutMs,
+  getToolTimeoutMs,
   getTotalTimeoutMs,
   TimeoutConfiguration,
 } from '../prompt/call-settings';
@@ -449,6 +450,7 @@ export async function generateText<
 
   const totalTimeoutMs = getTotalTimeoutMs(timeout);
   const stepTimeoutMs = getStepTimeoutMs(timeout);
+  const toolTimeoutMs = getToolTimeoutMs(timeout);
   const stepAbortController =
     stepTimeoutMs != null ? new AbortController() : undefined;
   const mergedAbortSignal = mergeAbortSignals(
@@ -548,6 +550,7 @@ export async function generateText<
         callId,
         messages: initialMessages,
         abortSignal: mergedAbortSignal,
+        toolTimeoutMs,
         experimental_context,
         stepNumber: 0,
         model: modelInfo,
@@ -870,6 +873,7 @@ export async function generateText<
               callId,
               messages: stepInputMessages,
               abortSignal: mergedAbortSignal,
+              toolTimeoutMs,
               experimental_context,
               stepNumber: steps.length,
               model: stepModelInfo,
@@ -1102,6 +1106,7 @@ async function executeTools<TOOLS extends ToolSet>({
   callId,
   messages,
   abortSignal,
+  toolTimeoutMs,
   experimental_context,
   stepNumber,
   model,
@@ -1115,6 +1120,7 @@ async function executeTools<TOOLS extends ToolSet>({
   callId: string;
   messages: ModelMessage[];
   abortSignal: AbortSignal | undefined;
+  toolTimeoutMs?: number | undefined;
   experimental_context: unknown;
   stepNumber: number;
   model: { provider: string; modelId: string };
@@ -1131,6 +1137,7 @@ async function executeTools<TOOLS extends ToolSet>({
         callId,
         messages,
         abortSignal,
+        toolTimeoutMs,
         experimental_context,
         stepNumber,
         model,

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -122,6 +122,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
   messages,
   abortSignal,
   repairToolCall,
+  toolTimeoutMs,
   experimental_context,
   generateId,
   stepNumber,
@@ -138,6 +139,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
   messages: ModelMessage[];
   abortSignal: AbortSignal | undefined;
   repairToolCall: ToolCallRepairFunction<TOOLS> | undefined;
+  toolTimeoutMs?: number | undefined;
   experimental_context: unknown;
   generateId: IdGenerator;
   stepNumber?: number;
@@ -348,6 +350,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                 callId,
                 messages,
                 abortSignal,
+                toolTimeoutMs,
                 experimental_context,
                 stepNumber,
                 model,

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -25,6 +25,7 @@ import {
   CallSettings,
   getChunkTimeoutMs,
   getStepTimeoutMs,
+  getToolTimeoutMs,
   getTotalTimeoutMs,
   TimeoutConfiguration,
 } from '../prompt/call-settings';
@@ -533,6 +534,7 @@ export function streamText<
   const totalTimeoutMs = getTotalTimeoutMs(timeout);
   const stepTimeoutMs = getStepTimeoutMs(timeout);
   const chunkTimeoutMs = getChunkTimeoutMs(timeout);
+  const toolTimeoutMs = getToolTimeoutMs(timeout);
   const stepAbortController =
     stepTimeoutMs != null ? new AbortController() : undefined;
   const chunkAbortController =
@@ -553,6 +555,7 @@ export function streamText<
     stepAbortController,
     chunkTimeoutMs,
     chunkAbortController,
+    toolTimeoutMs,
     system,
     prompt,
     messages,
@@ -732,6 +735,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
     stepAbortController,
     chunkTimeoutMs,
     chunkAbortController,
+    toolTimeoutMs,
     system,
     prompt,
     messages,
@@ -774,6 +778,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
     stepAbortController: AbortController | undefined;
     chunkTimeoutMs: number | undefined;
     chunkAbortController: AbortController | undefined;
+    toolTimeoutMs: number | undefined;
     system: Prompt['system'];
     prompt: Prompt['prompt'];
     messages: Prompt['messages'];
@@ -1355,6 +1360,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                 callId,
                 messages: initialMessages,
                 abortSignal,
+                toolTimeoutMs,
                 experimental_context,
                 stepNumber: recordedSteps.length,
                 model: modelInfo,
@@ -1599,6 +1605,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
             messages: stepInputMessages,
             repairToolCall,
             abortSignal,
+            toolTimeoutMs,
             experimental_context,
             generateId,
             stepNumber: recordedSteps.length,

--- a/packages/ai/src/prompt/call-settings.ts
+++ b/packages/ai/src/prompt/call-settings.ts
@@ -7,7 +7,7 @@
  */
 export type TimeoutConfiguration =
   | number
-  | { totalMs?: number; stepMs?: number; chunkMs?: number };
+  | { totalMs?: number; stepMs?: number; chunkMs?: number; toolMs?: number };
 
 /**
  * Extracts the total timeout value in milliseconds from a TimeoutConfiguration.
@@ -56,6 +56,15 @@ export function getChunkTimeoutMs(
     return undefined;
   }
   return timeout.chunkMs;
+}
+
+export function getToolTimeoutMs(
+  timeout: TimeoutConfiguration | undefined,
+): number | undefined {
+  if (timeout == null || typeof timeout === 'number') {
+    return undefined;
+  }
+  return timeout.toolMs;
 }
 
 export type CallSettings = {

--- a/packages/ai/src/prompt/prepare-call-settings.test.ts
+++ b/packages/ai/src/prompt/prepare-call-settings.test.ts
@@ -1,5 +1,11 @@
 import { InvalidArgumentError } from '../error/invalid-argument-error';
 import { prepareCallSettings } from './prepare-call-settings';
+import {
+  getToolTimeoutMs,
+  getTotalTimeoutMs,
+  getStepTimeoutMs,
+  getChunkTimeoutMs,
+} from './call-settings';
 import { describe, it, expect } from 'vitest';
 
 describe('prepareCallSettings', () => {
@@ -133,6 +139,30 @@ describe('prepareCallSettings', () => {
           }),
         );
       });
+    });
+  });
+
+  describe('getToolTimeoutMs', () => {
+    it('should return undefined when timeout is undefined', () => {
+      expect(getToolTimeoutMs(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined when timeout is a number', () => {
+      expect(getToolTimeoutMs(5000)).toBeUndefined();
+    });
+
+    it('should return undefined when toolMs is not set', () => {
+      expect(getToolTimeoutMs({ totalMs: 10000 })).toBeUndefined();
+    });
+
+    it('should return toolMs when set', () => {
+      expect(getToolTimeoutMs({ toolMs: 3000 })).toBe(3000);
+    });
+
+    it('should return toolMs alongside other timeout values', () => {
+      expect(
+        getToolTimeoutMs({ totalMs: 30000, stepMs: 10000, toolMs: 5000 }),
+      ).toBe(5000);
     });
   });
 


### PR DESCRIPTION
## background

tools can hang indefinitely with no way to abort them independently of the overall request. users deploying to environments with strict execution limits need per-tool-execution timeouts

related discussion in #12037

## summary

- add `toolMs` to `TimeoutConfiguration` alongside existing `totalMs`, `stepMs`, `chunkMs`
- add `getToolTimeoutMs()` helper
- wire through `generateText`, `streamText`, and `runToolsTransformation` to `executeToolCall`
- merge `AbortSignal.timeout(toolMs)` with existing abort signal using `AbortSignal.any()`
- timed out tools return `tool-error` so the model can respond or retry

```ts
const result = await generateText({
  model: openai('gpt-5.4'),
  tools: { weather: weatherTool },
  timeout: {
    toolMs: 5000,
  },
  prompt: 'What is the weather in tokyo?',
});
```

## verification

<details>
<summary>generate text - tool times out, model responds</summary>

```
$ pnpm tsx src/generate-text/openai/tool-timeout-error.ts
tool-call: slowApi({"query":"hello world"})
tool-error: slowApi timed out

I searched for "hello world," but the search timed out.
```

</details>

<details>
<summary>stream text - tool times out, model responds</summary>

```
$ pnpm tsx src/stream-text/openai/tool-timeout-error.ts
tool-call: slowApi({"query":"hello world"})
tool-error: slowApi timed out
Search failed due to a timeout. Please try again.
```

</details>

<details>
<summary>e2e - tool timeout with chat ui</summary>

page at `/chat/tool-timeout` - tool times out after 1s, error shown with expandable logs, model explains the timeout to the user

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

fixes #13279