### PR TITLE
feat(provider/xai): add parallelToolCalls to responses API

### DIFF
--- a/.changeset/hip-pillows-pull.md
+++ b/.changeset/hip-pillows-pull.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(provider/xai): add parallelToolCalls to responses API

--- a/examples/ai-functions/src/generate-text/xai/responses-parallel-tool-calls.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-parallel-tool-calls.ts
@@ -1,0 +1,22 @@
+import { xai, type XaiLanguageModelResponsesOptions } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: xai.responses('grok-4-fast-non-reasoning'),
+    tools: { weather: weatherTool },
+    providerOptions: {
+      xai: {
+        parallelToolCalls: true,
+      } satisfies XaiLanguageModelResponsesOptions,
+    },
+    prompt:
+      'What is the weather in San Francisco and New York? Call the tool for each city separately.',
+  });
+
+  console.log('Text:', result.text);
+  console.log('Tool Calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Tool Results:', JSON.stringify(result.toolResults, null, 2));
+});

--- a/examples/ai-functions/src/stream-text/xai/responses-parallel-tool-calls.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-parallel-tool-calls.ts
@@ -1,0 +1,33 @@
+import { xai, type XaiLanguageModelResponsesOptions } from '@ai-sdk/xai';
+import { streamText } from 'ai';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: xai.responses('grok-4-fast-non-reasoning'),
+    tools: { weather: weatherTool },
+    providerOptions: {
+      xai: {
+        parallelToolCalls: true,
+      } satisfies XaiLanguageModelResponsesOptions,
+    },
+    prompt:
+      'What is the weather in San Francisco and New York? Call the tool for each city separately.',
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'tool-call') {
+      console.log('Tool call:', part.toolName, JSON.stringify(part.input));
+    }
+    if (part.type === 'tool-result') {
+      console.log('Tool result:', part.toolName, JSON.stringify(part.output));
+    }
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+
+  console.log();
+  console.log('Usage:', await result.usage);
+});

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -552,6 +552,47 @@ describe('XaiResponsesLanguageModel', () => {
             'reasoning.encrypted_content',
           ]);
         });
+
+        it('parallelToolCalls', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                parallelToolCalls: false,
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.parallel_tool_calls).toBe(false);
+        });
+
+        it('parallelToolCalls not sent when not provided', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.parallel_tool_calls).toBeUndefined();
+        });
       });
 
       it('should warn about unsupported stopSequences', async () => {

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -177,6 +177,9 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
       ...(options.previousResponseId != null && {
         previous_response_id: options.previousResponseId,
       }),
+      ...(options.parallelToolCalls != null && {
+        parallel_tool_calls: options.parallelToolCalls,
+      }),
     };
 
     if (xaiTools && xaiTools.length > 0) {

--- a/packages/xai/src/responses/xai-responses-options.ts
+++ b/packages/xai/src/responses/xai-responses-options.ts
@@ -33,6 +33,7 @@ export const xaiLanguageModelResponsesOptions = z.object({
    * Example values: 'file_search_call.results'.
    */
   include: z.array(z.enum(['file_search_call.results'])).nullish(),
+  parallelToolCalls: z.boolean().optional(),
 });
 
 export type XaiLanguageModelResponsesOptions = z.infer<


### PR DESCRIPTION
## background

xAI responses API supports `parallel_tool_calls` to control whether the model can make multiple tool calls at once, but the SDK wasn't forwarding it

## summary

- add `parallelToolCalls` to responses provider options
- map to `parallel_tool_calls` in request body
- add tests
- add generate-text and stream-text examples

## verification

<details>
<summary>parallelToolCalls: true</summary>

```
pnpm tsx src/generate-text/xai/responses-parallel-tool-calls.ts
Tool Calls: [
  { "toolName": "weather", "input": { "location": "San Francisco" } },
  { "toolName": "weather", "input": { "location": "New York" } }
]
```

</details>

<details>
<summary>parallelToolCalls: false (single call)</summary>

```
Tool Calls: [
  { "toolName": "weather", "input": { "location": "San Francisco" } }
]
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

part of #12825