### PR TITLE
feat(provider/xai): add promptCacheKey to responses API

### DIFF
--- a/.changeset/prompt-cache-key.md
+++ b/.changeset/prompt-cache-key.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+add promptCacheKey to responses API provider options

--- a/examples/ai-functions/src/generate-text/xai/responses-prompt-cache-key.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-prompt-cache-key.ts
@@ -3,16 +3,39 @@ import { generateText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const result = await generateText({
+  const cacheKey = `demo-${Date.now()}`;
+
+  console.log('Request 1 (cold cache):');
+  const result1 = await generateText({
     model: xai.responses('grok-4-fast-non-reasoning'),
     providerOptions: {
       xai: {
-        promptCacheKey: 'my-conversation-123',
+        promptCacheKey: cacheKey,
       } satisfies XaiLanguageModelResponsesOptions,
     },
     prompt: 'What is the capital of France?',
   });
 
-  console.log(result.text);
-  console.log('Usage:', result.usage);
+  console.log(result1.text);
+  console.log(
+    'Cached tokens:',
+    result1.usage.inputTokenDetails?.cacheReadTokens,
+  );
+
+  console.log('\nRequest 2 (warm cache, same key):');
+  const result2 = await generateText({
+    model: xai.responses('grok-4-fast-non-reasoning'),
+    providerOptions: {
+      xai: {
+        promptCacheKey: cacheKey,
+      } satisfies XaiLanguageModelResponsesOptions,
+    },
+    prompt: 'What is the capital of France?',
+  });
+
+  console.log(result2.text);
+  console.log(
+    'Cached tokens:',
+    result2.usage.inputTokenDetails?.cacheReadTokens,
+  );
 });

--- a/examples/ai-functions/src/generate-text/xai/responses-prompt-cache-key.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-prompt-cache-key.ts
@@ -1,0 +1,18 @@
+import { xai, type XaiLanguageModelResponsesOptions } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: xai.responses('grok-4-fast-non-reasoning'),
+    providerOptions: {
+      xai: {
+        promptCacheKey: 'my-conversation-123',
+      } satisfies XaiLanguageModelResponsesOptions,
+    },
+    prompt: 'What is the capital of France?',
+  });
+
+  console.log(result.text);
+  console.log('Usage:', result.usage);
+});

--- a/examples/ai-functions/src/stream-text/xai/responses-prompt-cache-key.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-prompt-cache-key.ts
@@ -1,0 +1,22 @@
+import { xai, type XaiLanguageModelResponsesOptions } from '@ai-sdk/xai';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: xai.responses('grok-4-fast-non-reasoning'),
+    providerOptions: {
+      xai: {
+        promptCacheKey: 'my-conversation-123',
+      } satisfies XaiLanguageModelResponsesOptions,
+    },
+    prompt: 'What is the capital of France?',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Usage:', await result.usage);
+});

--- a/examples/ai-functions/src/stream-text/xai/responses-prompt-cache-key.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-prompt-cache-key.ts
@@ -3,20 +3,39 @@ import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const result = streamText({
+  const cacheKey = `demo-${Date.now()}`;
+
+  console.log('Request 1 (cold cache):');
+  const result1 = streamText({
     model: xai.responses('grok-4-fast-non-reasoning'),
     providerOptions: {
       xai: {
-        promptCacheKey: 'my-conversation-123',
+        promptCacheKey: cacheKey,
       } satisfies XaiLanguageModelResponsesOptions,
     },
     prompt: 'What is the capital of France?',
   });
 
-  for await (const textPart of result.textStream) {
+  for await (const textPart of result1.textStream) {
     process.stdout.write(textPart);
   }
+  const usage1 = await result1.usage;
+  console.log('\nCached tokens:', usage1.inputTokenDetails?.cacheReadTokens);
 
-  console.log();
-  console.log('Usage:', await result.usage);
+  console.log('\nRequest 2 (warm cache, same key):');
+  const result2 = streamText({
+    model: xai.responses('grok-4-fast-non-reasoning'),
+    providerOptions: {
+      xai: {
+        promptCacheKey: cacheKey,
+      } satisfies XaiLanguageModelResponsesOptions,
+    },
+    prompt: 'What is the capital of France?',
+  });
+
+  for await (const textPart of result2.textStream) {
+    process.stdout.write(textPart);
+  }
+  const usage2 = await result2.usage;
+  console.log('\nCached tokens:', usage2.inputTokenDetails?.cacheReadTokens);
 });

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -552,6 +552,47 @@ describe('XaiResponsesLanguageModel', () => {
             'reasoning.encrypted_content',
           ]);
         });
+
+        it('promptCacheKey', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                promptCacheKey: 'my-cache-key',
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.prompt_cache_key).toBe('my-cache-key');
+        });
+
+        it('promptCacheKey not sent when not provided', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.prompt_cache_key).toBeUndefined();
+        });
       });
 
       it('should warn about unsupported stopSequences', async () => {

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -177,6 +177,9 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
       ...(options.previousResponseId != null && {
         previous_response_id: options.previousResponseId,
       }),
+      ...(options.promptCacheKey != null && {
+        prompt_cache_key: options.promptCacheKey,
+      }),
     };
 
     if (xaiTools && xaiTools.length > 0) {

--- a/packages/xai/src/responses/xai-responses-options.ts
+++ b/packages/xai/src/responses/xai-responses-options.ts
@@ -33,6 +33,7 @@ export const xaiLanguageModelResponsesOptions = z.object({
    * Example values: 'file_search_call.results'.
    */
   include: z.array(z.enum(['file_search_call.results'])).nullish(),
+  promptCacheKey: z.string().optional(),
 });
 
 export type XaiLanguageModelResponsesOptions = z.infer<


### PR DESCRIPTION
## background

xAI responses API supports `prompt_cache_key` for routing optimization, but the SDK wasn't forwarding it

## summary

- add `promptCacheKey` to responses provider options
- map to `prompt_cache_key` in request body
- add tests
- add generate-text and stream-text examples

## verification

<details>
<summary>generate-text with promptCacheKey</summary>

```
$ pnpm tsx src/generate-text/xai/responses-prompt-cache-key.ts
Request 1 (cold cache):
Paris is the capital of France. It's the largest city in the country...
Cached tokens: 174

Request 2 (warm cache, same key):
Paris
Cached tokens: 174
```

</details>

<details>
<summary>stream-text with promptCacheKey</summary>

```
$ pnpm tsx src/stream-text/xai/responses-prompt-cache-key.ts
Request 1 (cold cache):
Paris
Cached tokens: 164

Request 2 (warm cache, same key):
Paris
Cached tokens: 174
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

part of #12825