### PR TITLE
feat(provider/xai): add reasoningSummary to responses API

### DIFF
--- a/.changeset/reasoning-summary.md
+++ b/.changeset/reasoning-summary.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+add reasoningSummary to responses API provider options

--- a/examples/ai-functions/src/generate-text/xai/responses-reasoning-summary.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-reasoning-summary.ts
@@ -1,0 +1,28 @@
+import { xai, type XaiLanguageModelResponsesOptions } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: xai.responses('grok-3-mini-latest'),
+    providerOptions: {
+      xai: {
+        reasoningEffort: 'low',
+        reasoningSummary: 'detailed',
+      } satisfies XaiLanguageModelResponsesOptions,
+    },
+    prompt: 'Explain quantum entanglement briefly.',
+  });
+
+  console.log(result.text);
+  console.log();
+
+  const reasoningParts = result.content.filter(
+    part => part.type === 'reasoning',
+  );
+  if (reasoningParts.length > 0) {
+    console.log('Reasoning summary:', reasoningParts[0].text?.slice(0, 200));
+  }
+
+  console.log('Usage:', result.usage);
+});

--- a/examples/ai-functions/src/generate-text/xai/responses-reasoning-summary.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-reasoning-summary.ts
@@ -11,18 +11,14 @@ run(async () => {
         reasoningSummary: 'detailed',
       } satisfies XaiLanguageModelResponsesOptions,
     },
-    prompt: 'Explain quantum entanglement briefly.',
+    prompt: 'What is 12 * 37?',
   });
 
-  console.log(result.text);
+  console.log('Response:', result.text);
   console.log();
-
-  const reasoningParts = result.content.filter(
-    part => part.type === 'reasoning',
+  console.log(
+    'Reasoning tokens:',
+    result.usage.outputTokenDetails?.reasoningTokens,
   );
-  if (reasoningParts.length > 0) {
-    console.log('Reasoning summary:', reasoningParts[0].text?.slice(0, 200));
-  }
-
-  console.log('Usage:', result.usage);
+  console.log('Text tokens:', result.usage.outputTokenDetails?.textTokens);
 });

--- a/examples/ai-functions/src/stream-text/xai/responses-reasoning-summary.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-reasoning-summary.ts
@@ -11,13 +11,37 @@ run(async () => {
         reasoningSummary: 'detailed',
       } satisfies XaiLanguageModelResponsesOptions,
     },
-    prompt: 'Explain quantum entanglement briefly.',
+    prompt: 'What is 12 * 37?',
   });
 
-  for await (const textPart of result.textStream) {
-    process.stdout.write(textPart);
+  let inReasoning = false;
+  let inText = false;
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'reasoning-delta') {
+      if (!inReasoning) {
+        console.log('Reasoning:');
+        inReasoning = true;
+      }
+      process.stdout.write(part.text);
+    }
+    if (part.type === 'text-delta') {
+      if (!inText) {
+        if (inReasoning) console.log('\n');
+        console.log('Response:');
+        inText = true;
+      }
+      process.stdout.write(part.text);
+    }
   }
 
-  console.log();
-  console.log('Usage:', await result.usage);
+  console.log('\n');
+  console.log(
+    'Reasoning tokens:',
+    (await result.usage).outputTokenDetails?.reasoningTokens,
+  );
+  console.log(
+    'Text tokens:',
+    (await result.usage).outputTokenDetails?.textTokens,
+  );
 });

--- a/examples/ai-functions/src/stream-text/xai/responses-reasoning-summary.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-reasoning-summary.ts
@@ -1,0 +1,23 @@
+import { xai, type XaiLanguageModelResponsesOptions } from '@ai-sdk/xai';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: xai.responses('grok-3-mini-latest'),
+    providerOptions: {
+      xai: {
+        reasoningEffort: 'low',
+        reasoningSummary: 'detailed',
+      } satisfies XaiLanguageModelResponsesOptions,
+    },
+    prompt: 'Explain quantum entanglement briefly.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Usage:', await result.usage);
+});

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -378,6 +378,56 @@ describe('XaiResponsesLanguageModel', () => {
           expect(requestBody.reasoning.effort).toBe('high');
         });
 
+        it('reasoningSummary', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                reasoningSummary: 'concise',
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.reasoning.summary).toBe('concise');
+        });
+
+        it('reasoningEffort and reasoningSummary together', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                reasoningEffort: 'high',
+                reasoningSummary: 'detailed',
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.reasoning).toStrictEqual({
+            effort: 'high',
+            summary: 'detailed',
+          });
+        });
+
         it('logprobs and topLogprobs', async () => {
           prepareJsonResponse({
             id: 'resp_123',

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -165,8 +165,16 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
               : { type: 'json_object' },
         },
       }),
-      ...(options.reasoningEffort != null && {
-        reasoning: { effort: options.reasoningEffort },
+      ...((options.reasoningEffort != null ||
+        options.reasoningSummary != null) && {
+        reasoning: {
+          ...(options.reasoningEffort != null && {
+            effort: options.reasoningEffort,
+          }),
+          ...(options.reasoningSummary != null && {
+            summary: options.reasoningSummary,
+          }),
+        },
       }),
       ...(options.store === false && {
         store: options.store,

--- a/packages/xai/src/responses/xai-responses-options.ts
+++ b/packages/xai/src/responses/xai-responses-options.ts
@@ -17,6 +17,7 @@ export const xaiLanguageModelResponsesOptions = z.object({
    * Possible values are `low` (uses fewer reasoning tokens), `medium` and `high` (uses more reasoning tokens).
    */
   reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+  reasoningSummary: z.enum(['auto', 'concise', 'detailed']).optional(),
   logprobs: z.boolean().optional(),
   topLogprobs: z.number().int().min(0).max(8).optional(),
   /**


### PR DESCRIPTION
## background

xAI responses API supports `reasoning.summary` to control how reasoning traces are presented, but the SDK only exposed `reasoning.effort`

## summary

- add `reasoningSummary` to responses provider options
- map to `reasoning.summary` in request body alongside existing `reasoning.effort`
- add tests for summary alone, and effort + summary together
- add generate-text and stream-text examples

## verification

<details>
<summary>reasoning.summary sent alongside reasoning.effort</summary>

```
pnpm tsx src/generate-text/xai/responses-reasoning-summary.ts
Quantum entanglement is a phenomenon in quantum mechanics where two or more
particles become interconnected...

Usage: {
  outputTokenDetails: { textTokens: 104, reasoningTokens: 299 },
  ...
}
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

part of #12825