### PR TITLE
fix(provider/xai): extract reasoning text from content in responses doGenerate

### DIFF
--- a/.changeset/six-schools-enjoy.md
+++ b/.changeset/six-schools-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix reasoning text extraction from content in responses doGenerate

--- a/examples/ai-functions/src/generate-text/xai/responses-reasoning.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-reasoning.ts
@@ -1,0 +1,26 @@
+import { xai } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: xai.responses('grok-3-mini-latest'),
+    prompt: 'How many "r"s are in the word "strawberry"?',
+  });
+
+  for (const part of result.content) {
+    switch (part.type) {
+      case 'reasoning': {
+        console.log('--- reasoning ---');
+        console.log(part.text);
+        break;
+      }
+      case 'text': {
+        console.log('--- text ---');
+        console.log(part.text);
+        break;
+      }
+    }
+    console.log();
+  }
+});

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -223,6 +223,9 @@ const outputItemSchema = z.discriminatedUnion('type', [
     type: z.literal('reasoning'),
     id: z.string(),
     summary: z.array(reasoningSummaryPartSchema),
+    content: z
+      .array(z.object({ type: z.string(), text: z.string() }))
+      .nullish(),
     status: z.string(),
     encrypted_content: z.string().nullish(),
   }),

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -306,6 +306,68 @@ describe('XaiResponsesLanguageModel', () => {
           ]
         `);
       });
+
+      it('should extract reasoning from content when summary is empty', async () => {
+        prepareJsonResponse({
+          id: 'resp_123',
+          object: 'response',
+          status: 'completed',
+          model: 'grok-3-mini',
+          output: [
+            {
+              type: 'reasoning',
+              id: 'rs_456',
+              status: 'completed',
+              summary: [],
+              content: [
+                {
+                  type: 'reasoning_text',
+                  text: 'Let me think step by step.',
+                },
+              ],
+            },
+            {
+              type: 'message',
+              id: 'msg_123',
+              status: 'completed',
+              role: 'assistant',
+              content: [
+                {
+                  type: 'output_text',
+                  text: 'The answer is 444.',
+                  annotations: [],
+                },
+              ],
+            },
+          ],
+          usage: {
+            input_tokens: 10,
+            output_tokens: 15,
+          },
+        });
+
+        const result = await createModel('grok-3-mini').doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(result.content).toMatchInlineSnapshot(`
+          [
+            {
+              "providerMetadata": {
+                "xai": {
+                  "itemId": "rs_456",
+                },
+              },
+              "text": "Let me think step by step.",
+              "type": "reasoning",
+            },
+            {
+              "text": "The answer is 444.",
+              "type": "text",
+            },
+          ]
+        `);
+      });
     });
 
     describe('settings and options', () => {

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -369,7 +369,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
             .filter(text => text && text.length > 0)
             .join('');
 
-          if (reasoningText.length > 0) {
+          if (reasoningText) {
             if (part.encrypted_content || part.id) {
               content.push({
                 type: 'reasoning',

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -360,12 +360,16 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
         }
 
         case 'reasoning': {
-          const summaryTexts = part.summary
-            .map(s => s.text)
-            .filter(text => text && text.length > 0);
+          const texts =
+            part.summary.length > 0
+              ? part.summary.map(s => s.text)
+              : (part.content ?? []).map(c => c.text);
 
-          if (summaryTexts.length > 0) {
-            const reasoningText = summaryTexts.join('');
+          const reasoningText = texts
+            .filter(text => text && text.length > 0)
+            .join('');
+
+          if (reasoningText.length > 0) {
             if (part.encrypted_content || part.id) {
               content.push({
                 type: 'reasoning',


### PR DESCRIPTION
## background

xAI's non-streaming responses API returns reasoning text in the `content` field on reasoning output items (as `reasoning_text` parts), not in the `summary` field. the SDK only read from `summary`, so reasoning was silently dropped in `generateText` - streaming worked fine since it uses `reasoning_summary_text.delta` events

## summary

- add `content` field to the reasoning output item schema in `xai-responses-api.ts`
- read reasoning text from `content` when `summary` is empty in doGenerate
- add test for the content fallback path
- add generate-text reasoning example

## verification

<details>
<summary>before: no reasoning shown</summary>

```
$ pnpm tsx src/generate-text/xai/responses-reasoning.ts
--- text ---
The word "strawberry" contains **3** instances of the letter "r".
```

</details>

<details>
<summary>after: reasoning properly extracted</summary>

```
$ pnpm tsx src/generate-text/xai/responses-reasoning.ts
--- reasoning ---
First, the user asked: "How many 'r's are in the word 'strawberry'?"

I need to count the number of times the letter 'r' appears in the word "strawberry".

Let me spell out the word: S-T-R-A-W-B-E-R-R-Y.

Now, let's go through each letter:

1. S - Not an 'r'
2. T - Not an 'r'
3. R - This is an 'r' (first one)
4. A - Not an 'r'
5. W - Not an 'r'
6. B - Not an 'r'
7. E - Not an 'r'
8. R - This is an 'r' (second one)
9. R - This is an 'r' (third one)
10. Y - Not an 'r'

So, the 'r's are at positions 3, 8, and 9.
That means there are 3 'r's in "strawberry".

--- text ---
The word "strawberry" contains **3** instances of the letter "r".
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)