### PR TITLE
feat(google): support external URLs natively for gemini-2.5+ models

### DIFF
--- a/packages/google/src/google-provider.test.ts
+++ b/packages/google/src/google-provider.test.ts
@@ -271,6 +271,37 @@ describe('google-provider', () => {
       }
     `);
   });
+
+  it('should include http(s) URLs in supportedUrls for newer models (gemini-2.5+)', () => {
+    const provider = createGoogleGenerativeAI({
+      apiKey: 'test-api-key',
+    });
+    provider('gemini-2.5-pro');
+
+    const calls = vi.mocked(GoogleGenerativeAILanguageModel).mock.calls;
+    const call = calls[calls.length - 1]; // get the latest call
+    const supportedUrlsFunction = call[1].supportedUrls;
+
+    expect(supportedUrlsFunction).toBeDefined();
+
+    const supportedUrls = supportedUrlsFunction!() as Record<string, RegExp[]>;
+    const patterns = supportedUrls['*'];
+
+    expect(patterns).toBeDefined();
+    expect(Array.isArray(patterns)).toBe(true);
+
+    const testResults = {
+      supportedUrls: [
+        'https://example.com/image.jpg',
+        'http://example.com/audio.mp3',
+      ].map(url => ({
+        url,
+        isSupported: patterns.some((pattern: RegExp) => pattern.test(url)),
+      })),
+    };
+
+    expect(testResults.supportedUrls.every(r => r.isSupported)).toBe(true);
+  });
 });
 
 describe('google provider - custom provider name', () => {

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -151,18 +151,24 @@ export function createGoogleGenerativeAI(
       baseURL,
       headers: getHeaders,
       generateId: options.generateId ?? generateId,
-      supportedUrls: () => ({
-        '*': [
-          // Google Generative Language "files" endpoint
-          // e.g. https://generativelanguage.googleapis.com/v1beta/files/...
-          new RegExp(`^${baseURL}/files/.*$`),
-          // YouTube URLs (public or unlisted videos)
-          new RegExp(
-            `^https://(?:www\\.)?youtube\\.com/watch\\?v=[\\w-]+(?:&[\\w=&.-]*)?$`,
-          ),
-          new RegExp(`^https://youtu\\.be/[\\w-]+(?:\\?[\\w=&.-]*)?$`),
-        ],
-      }),
+      supportedUrls: () => {
+        const isUrlSupported =
+          modelId.includes('gemini-2.5') || modelId.includes('gemini-3');
+
+        return {
+          '*': [
+            // Google Generative Language "files" endpoint
+            // e.g. https://generativelanguage.googleapis.com/v1beta/files/...
+            new RegExp(`^${baseURL}/files/.*$`),
+            // YouTube URLs (public or unlisted videos)
+            new RegExp(
+              `^https://(?:www\\.)?youtube\\.com/watch\\?v=[\\w-]+(?:&[\\w=&.-]*)?$`,
+            ),
+            new RegExp(`^https://youtu\\.be/[\\w-]+(?:\\?[\\w=&.-]*)?$`),
+            ...(isUrlSupported ? [new RegExp('^https?://')] : []),
+          ],
+        };
+      },
       fetch: options.fetch,
     });
 


### PR DESCRIPTION
Fixes #13007

Google's Gemini 2.5+ and 3.0 models natively accept standard `https://` URLs in `file_uri`. This PR adjusts the provider mapping for `supportedUrls` to include standard HTTP(S) URLs for these models.