### PR TITLE
fix(@ai-sdk/anthropic): strip unsupported JSON Schema validation properties

### DIFF
--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -52,6 +52,7 @@ import {
 import { convertToAnthropicMessagesPrompt } from './convert-to-anthropic-messages-prompt';
 import { CacheControlValidator } from './get-cache-control';
 import { mapAnthropicStopReason } from './map-anthropic-stop-reason';
+import { sanitizeJsonSchema } from './sanitize-json-schema';
 
 function createCitationSource(
   citation: Citation,
@@ -284,7 +285,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
             type: 'function',
             name: 'json',
             description: 'Respond with a JSON object.',
-            inputSchema: responseFormat.schema,
+            inputSchema: sanitizeJsonSchema(responseFormat.schema),
           }
         : undefined;
 
@@ -367,7 +368,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
             responseFormat.schema != null && {
               format: {
                 type: 'json_schema',
-                schema: responseFormat.schema,
+                schema: sanitizeJsonSchema(responseFormat.schema),
               },
             }),
         },

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -5,6 +5,7 @@ import {
 } from '@ai-sdk/provider';
 import { AnthropicTool, AnthropicToolChoice } from './anthropic-messages-api';
 import { CacheControlValidator } from './get-cache-control';
+import { sanitizeJsonSchema } from './sanitize-json-schema';
 import { textEditor_20250728ArgsSchema } from './tool/text-editor_20250728';
 import { webSearch_20260209ArgsSchema } from './tool/web-search_20260209';
 import { webSearch_20250305ArgsSchema } from './tool/web-search_20250305';
@@ -75,7 +76,7 @@ export async function prepareTools({
         anthropicTools.push({
           name: tool.name,
           description: tool.description,
-          input_schema: tool.inputSchema,
+          input_schema: sanitizeJsonSchema(tool.inputSchema),
           cache_control: cacheControl,
           ...(eagerInputStreaming ? { eager_input_streaming: true } : {}),
           ...(supportsStructuredOutput === true && tool.strict != null

--- a/packages/anthropic/src/sanitize-json-schema.test.ts
+++ b/packages/anthropic/src/sanitize-json-schema.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeJsonSchema } from './sanitize-json-schema';
+
+describe('sanitizeJsonSchema', () => {
+  it('should strip unsupported string validation properties', () => {
+    const schema = {
+      type: 'object' as const,
+      properties: {
+        name: {
+          type: 'string' as const,
+          minLength: 1,
+          maxLength: 100,
+          pattern: '^[a-z]+$',
+          format: 'email',
+        },
+      },
+      required: ['name'],
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+      },
+      required: ['name'],
+    });
+  });
+
+  it('should strip unsupported number validation properties', () => {
+    const schema = {
+      type: 'object' as const,
+      properties: {
+        count: {
+          type: 'number' as const,
+          minimum: 0,
+          maximum: 10,
+          exclusiveMinimum: 0,
+          exclusiveMaximum: 11,
+          multipleOf: 2,
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        count: {
+          type: 'number',
+        },
+      },
+    });
+  });
+
+  it('should strip unsupported array validation properties', () => {
+    const schema = {
+      type: 'object' as const,
+      properties: {
+        items: {
+          type: 'array' as const,
+          items: { type: 'string' as const, minLength: 1 },
+          minItems: 2,
+          maxItems: 5,
+          uniqueItems: true,
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+    });
+  });
+
+  it('should strip unsupported object validation properties', () => {
+    const schema = {
+      type: 'object' as const,
+      properties: {
+        data: {
+          type: 'object' as const,
+          minProperties: 1,
+          maxProperties: 10,
+          properties: {
+            key: { type: 'string' as const },
+          },
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        data: {
+          type: 'object',
+          properties: {
+            key: { type: 'string' },
+          },
+        },
+      },
+    });
+  });
+
+  it('should preserve supported properties', () => {
+    const schema = {
+      type: 'object' as const,
+      properties: {
+        name: { type: 'string' as const, description: 'The name' },
+        age: { type: 'integer' as const },
+      },
+      required: ['name', 'age'],
+      additionalProperties: false,
+      description: 'A person',
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual(schema);
+  });
+
+  it('should handle nested schemas recursively', () => {
+    const schema = {
+      type: 'object' as const,
+      properties: {
+        nested: {
+          type: 'object' as const,
+          properties: {
+            deep: {
+              type: 'string' as const,
+              minLength: 1,
+              maxLength: 50,
+            },
+          },
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        nested: {
+          type: 'object',
+          properties: {
+            deep: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('should handle allOf/anyOf/oneOf', () => {
+    const schema = {
+      type: 'object' as const,
+      properties: {
+        value: {
+          anyOf: [
+            { type: 'string' as const, minLength: 1 },
+            { type: 'number' as const, minimum: 0 },
+          ],
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        value: {
+          anyOf: [{ type: 'string' }, { type: 'number' }],
+        },
+      },
+    });
+  });
+
+  it('should not mutate the original schema', () => {
+    const original = {
+      type: 'object' as const,
+      properties: {
+        name: { type: 'string' as const, minLength: 1 },
+      },
+    };
+
+    const originalCopy = JSON.parse(JSON.stringify(original));
+    sanitizeJsonSchema(original);
+
+    expect(original).toEqual(originalCopy);
+  });
+
+  it('should handle additionalProperties as a schema', () => {
+    const schema = {
+      type: 'object' as const,
+      additionalProperties: {
+        type: 'string' as const,
+        minLength: 1,
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      additionalProperties: {
+        type: 'string',
+      },
+    });
+  });
+});

--- a/packages/anthropic/src/sanitize-json-schema.ts
+++ b/packages/anthropic/src/sanitize-json-schema.ts
@@ -1,0 +1,82 @@
+import { JSONSchema7 } from 'json-schema';
+
+/**
+ * JSON Schema validation properties that Anthropic's API does not support.
+ *
+ * @see https://docs.anthropic.com/en/docs/build-with-claude/structured-output
+ */
+const UNSUPPORTED_PROPERTIES = new Set([
+  'minLength',
+  'maxLength',
+  'pattern',
+  'format',
+  'minimum',
+  'maximum',
+  'exclusiveMinimum',
+  'exclusiveMaximum',
+  'multipleOf',
+  'minItems',
+  'maxItems',
+  'uniqueItems',
+  'minProperties',
+  'maxProperties',
+]);
+
+/**
+ * Recursively strip JSON Schema validation properties that are not supported
+ * by the Anthropic API. The original schema object is not mutated; a new
+ * schema object is returned with the unsupported properties removed.
+ */
+export function sanitizeJsonSchema(schema: JSONSchema7): JSONSchema7 {
+  if (typeof schema !== 'object' || schema === null) {
+    return schema;
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(schema)) {
+    if (UNSUPPORTED_PROPERTIES.has(key)) {
+      continue;
+    }
+
+    if (key === 'properties' && typeof value === 'object' && value !== null) {
+      const sanitizedProperties: Record<string, unknown> = {};
+      for (const [propKey, propValue] of Object.entries(value)) {
+        sanitizedProperties[propKey] = sanitizeJsonSchema(
+          propValue as JSONSchema7,
+        );
+      }
+      result[key] = sanitizedProperties;
+    } else if (key === 'items') {
+      if (Array.isArray(value)) {
+        result[key] = value.map(item =>
+          sanitizeJsonSchema(item as JSONSchema7),
+        );
+      } else if (typeof value === 'object' && value !== null) {
+        result[key] = sanitizeJsonSchema(value as JSONSchema7);
+      } else {
+        result[key] = value;
+      }
+    } else if (key === 'allOf' || key === 'anyOf' || key === 'oneOf') {
+      if (Array.isArray(value)) {
+        result[key] = value.map(item =>
+          sanitizeJsonSchema(item as JSONSchema7),
+        );
+      } else {
+        result[key] = value;
+      }
+    } else if (key === 'not' && typeof value === 'object' && value !== null) {
+      result[key] = sanitizeJsonSchema(value as JSONSchema7);
+    } else if (
+      key === 'additionalProperties' &&
+      typeof value === 'object' &&
+      value !== null
+    ) {
+      result[key] = sanitizeJsonSchema(value as JSONSchema7);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result as JSONSchema7;
+}


### PR DESCRIPTION
## Summary

Closes #13355

Anthropic's API rejects JSON Schema validation properties like `minLength`, `maxLength`, `minimum`, `maximum`, `minItems`, `maxItems`, `pattern`, `format`, `uniqueItems`, etc. When users define Zod schemas with constraints (e.g., `z.string().min(1)`, `z.number().int().min(0).max(10)`), the generated JSON Schema contains these properties and the API returns `400 Bad Request`.

This PR adds a `sanitizeJsonSchema()` utility that recursively strips unsupported properties before schemas are sent to the Anthropic API. It's applied to:
- Tool `inputSchema` (in `anthropic-prepare-tools.ts`)
- Structured output `json_schema` format (in `anthropic-messages-language-model.ts`)

The native Anthropic SDK (`@anthropic-ai/sdk`) handles this automatically; this brings the Vercel AI SDK Anthropic provider to parity.

## Changes

- **New**: `packages/anthropic/src/sanitize-json-schema.ts` — recursive schema sanitization utility
- **New**: `packages/anthropic/src/sanitize-json-schema.test.ts` — 9 tests covering strings, numbers, arrays, objects, nested schemas, allOf/anyOf/oneOf, additionalProperties, and immutability
- **Modified**: `anthropic-messages-language-model.ts` — apply sanitization to structured output and json response tool schemas
- **Modified**: `anthropic-prepare-tools.ts` — apply sanitization to tool input schemas

## Stripped properties

Per [Anthropic's structured output docs](https://docs.anthropic.com/en/docs/build-with-claude/structured-output):

`minLength`, `maxLength`, `pattern`, `format`, `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`, `minItems`, `maxItems`, `uniqueItems`, `minProperties`, `maxProperties`

## Test plan

- [x] 9 new tests for `sanitizeJsonSchema()` — all pass
- [x] Existing `anthropic-prepare-tools.test.ts` (48 tests) — all pass
- [x] No changes to existing test behavior