### PR TITLE
fix(mcp): validate state param in oauth flow

### DIFF
--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -2143,3 +2143,164 @@ describe('auth function', () => {
     );
   });
 });
+
+describe('OAuth state validation', () => {
+  const validTokens = {
+    access_token: 'access123',
+    token_type: 'Bearer',
+    expires_in: 3600,
+    refresh_token: 'refresh123',
+  };
+
+  function createMockProvider(
+    overrides?: Partial<OAuthClientProvider>,
+  ): OAuthClientProvider {
+    return {
+      get redirectUrl() {
+        return 'http://localhost:3000/callback';
+      },
+      get clientMetadata() {
+        return {
+          redirect_uris: ['http://localhost:3000/callback'],
+          client_name: 'Test Client',
+        };
+      },
+      clientInformation: vi.fn().mockResolvedValue({
+        client_id: 'test-client',
+        client_secret: 'test-secret',
+      }),
+      tokens: vi.fn().mockResolvedValue(undefined),
+      saveTokens: vi.fn(),
+      redirectToAuthorization: vi.fn(),
+      saveCodeVerifier: vi.fn(),
+      codeVerifier: vi.fn().mockResolvedValue('test-verifier'),
+      ...overrides,
+    };
+  }
+
+  function mockMetadataAndTokenFetch() {
+    mockFetch.mockImplementation(url => {
+      const urlString = url.toString();
+      if (urlString.includes('/.well-known/oauth-protected-resource')) {
+        return Promise.resolve({ ok: false, status: 404 });
+      } else if (
+        urlString.includes('/.well-known/oauth-authorization-server')
+      ) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            issuer: 'https://auth.example.com',
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+          }),
+        });
+      } else if (urlString.includes('/token')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => validTokens,
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+  }
+
+  function mockMetadataWithRegistration() {
+    mockFetch.mockImplementation(url => {
+      const urlString = url.toString();
+      if (urlString.includes('/.well-known/oauth-protected-resource')) {
+        return Promise.resolve({ ok: false, status: 404 });
+      } else if (
+        urlString.includes('/.well-known/oauth-authorization-server')
+      ) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            issuer: 'https://auth.example.com',
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            registration_endpoint: 'https://auth.example.com/register',
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+          }),
+        });
+      } else if (urlString.includes('/register')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            client_id: 'new-client',
+            client_secret: 'new-secret',
+            client_id_issued_at: 1612137600,
+            client_secret_expires_at: 1612224000,
+            redirect_uris: ['http://localhost:3000/callback'],
+            client_name: 'Test Client',
+          }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+  }
+
+  it('should reject token exchange when callback state does not match stored state', async () => {
+    mockMetadataAndTokenFetch();
+
+    const provider = createMockProvider({
+      state: vi.fn().mockResolvedValue('LEGITIMATE_STATE'),
+      saveState: vi.fn(),
+      storedState: vi.fn().mockResolvedValue('LEGITIMATE_STATE'),
+    });
+
+    await expect(
+      auth(provider, {
+        serverUrl: 'https://resource.example.com',
+        authorizationCode: 'auth-code-from-attacker-flow',
+        callbackState: 'ATTACKER_STATE',
+      }),
+    ).rejects.toThrow(/state/i);
+
+    expect(provider.saveTokens).not.toHaveBeenCalled();
+  });
+
+  it('should allow token exchange when callback state matches stored state', async () => {
+    mockMetadataAndTokenFetch();
+
+    const provider = createMockProvider({
+      state: vi.fn().mockResolvedValue('CORRECT_STATE'),
+      saveState: vi.fn(),
+      storedState: vi.fn().mockResolvedValue('CORRECT_STATE'),
+    });
+
+    const result = await auth(provider, {
+      serverUrl: 'https://resource.example.com',
+      authorizationCode: 'valid-auth-code',
+      callbackState: 'CORRECT_STATE',
+    });
+
+    expect(result).toBe('AUTHORIZED');
+    expect(provider.saveTokens).toHaveBeenCalledWith(validTokens);
+  });
+
+  it('should save state when starting a new authorization flow', async () => {
+    mockMetadataWithRegistration();
+
+    const saveState = vi.fn();
+    const provider = createMockProvider({
+      clientInformation: vi.fn().mockResolvedValue(undefined),
+      saveClientInformation: vi.fn(),
+      state: vi.fn().mockResolvedValue('MY_STATE_VALUE'),
+      saveState,
+    });
+
+    const result = await auth(provider, {
+      serverUrl: 'https://resource.example.com',
+    });
+
+    expect(result).toBe('REDIRECT');
+    expect(saveState).toHaveBeenCalledWith('MY_STATE_VALUE');
+  });
+});

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -83,6 +83,8 @@ export interface OAuthClientProvider {
     clientInformation: OAuthClientInformation,
   ): void | Promise<void>;
   state?(): string | Promise<string>;
+  saveState?(state: string): void | Promise<void>;
+  storedState?(): string | undefined | Promise<string | undefined>;
   validateResourceURL?(
     serverUrl: string | URL,
     resource?: string,
@@ -827,6 +829,7 @@ export async function auth(
   options: {
     serverUrl: string | URL;
     authorizationCode?: string;
+    callbackState?: string;
     scope?: string;
     resourceMetadataUrl?: URL;
     fetchFn?: FetchFunction;
@@ -886,12 +889,14 @@ async function authInternal(
   {
     serverUrl,
     authorizationCode,
+    callbackState,
     scope,
     resourceMetadataUrl,
     fetchFn,
   }: {
     serverUrl: string | URL;
     authorizationCode?: string;
+    callbackState?: string;
     scope?: string;
     resourceMetadataUrl?: URL;
     fetchFn?: FetchFunction;
@@ -960,6 +965,15 @@ async function authInternal(
 
   // Exchange authorization code for tokens
   if (authorizationCode !== undefined) {
+    if (provider.storedState) {
+      const expectedState = await provider.storedState();
+      if (expectedState !== undefined && expectedState !== callbackState) {
+        throw new Error(
+          'OAuth state parameter mismatch - possible CSRF attack',
+        );
+      }
+    }
+
     const codeVerifier = await provider.codeVerifier();
     const tokens = await exchangeAuthorization(authorizationServerUrl, {
       metadata,
@@ -1008,6 +1022,9 @@ async function authInternal(
   }
 
   const state = provider.state ? await provider.state() : undefined;
+  if (state && provider.saveState) {
+    await provider.saveState(state);
+  }
 
   // Start new authorization flow
   const { authorizationUrl, codeVerifier } = await startAuthorization(


### PR DESCRIPTION
## Background

The oauth impl in `@ai-sdk/mcp` had a missing protection check / bug. 

the `state` parameter which exists to prevent cross-site request forgery during OAuth flows -- was generated and sent to the authorization server, but never validated when the callback came back.

this meant an application would accept the callback without noticing the state mismatch and potentially link the victim's tokens to an attacker's session.

in practice, `PKCE` (which we implement) would block the specific attack scenario demonstrated in the POC, as long as the OAuth server enforces PKCE validation. But state and PKCE protect against different threat models, and the OAuth spec recommends both.

## Summary

- added `saveState()` and `storedState()` to OAuthClientProvider
- added `callbackState` to `auth()` - applications can now pass the state they received from the OAuth callback URL
- state is saved when starting a flow
- state is validated before token exchange

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)