### PR TITLE
chore(docs): add The Context Company to observability integrations

### DIFF
--- a/content/providers/05-observability/index.mdx
+++ b/content/providers/05-observability/index.mdx
@@ -21,6 +21,7 @@ Several LLM observability providers offer integrations with the AI SDK telemetry
 - [Scorecard](/providers/observability/scorecard)
 - [Sentry](https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/integrations/vercelai/)
 - [SigNoz](/providers/observability/signoz)
+- [The Context Company](https://docs.thecontext.company/frameworks/vercel-ai-sdk)
 - [Traceloop](/providers/observability/traceloop)
 - [Weave](/providers/observability/weave)
 


### PR DESCRIPTION
## Summary

Adds The Context Company to the AI SDK observability integrations list.

Integration guide:
https://docs.thecontext.company/frameworks/vercel-ai-sdk