### PR TITLE
feat(provider/xai): add costInUsdTicks and moderation error to video model

### DIFF
--- a/.changeset/poor-insects-bake.md
+++ b/.changeset/poor-insects-bake.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(provider/xai): add moderation error, and costInUsdTicks to video model

--- a/examples/ai-functions/src/generate-video/xai/cost.ts
+++ b/examples/ai-functions/src/generate-video/xai/cost.ts
@@ -2,6 +2,7 @@ import { type XaiVideoModelOptions, xai } from '@ai-sdk/xai';
 import { experimental_generateVideo as generateVideo } from 'ai';
 import { run } from '../../lib/run';
 import { withSpinner } from '../../lib/spinner';
+import { presentVideos } from '../../lib/present-video';
 
 run(async () => {
   const result = await withSpinner('Generating xAI video...', () =>

--- a/examples/ai-functions/src/generate-video/xai/cost.ts
+++ b/examples/ai-functions/src/generate-video/xai/cost.ts
@@ -17,8 +17,8 @@ run(async () => {
     }),
   );
 
-  console.log('Video generated:', result.videos[0].mediaType);
-  console.log();
+  await presentVideos(result.videos);
+
   console.log(
     'Provider metadata:',
     JSON.stringify(result.providerMetadata, null, 2),

--- a/examples/ai-functions/src/generate-video/xai/cost.ts
+++ b/examples/ai-functions/src/generate-video/xai/cost.ts
@@ -1,0 +1,26 @@
+import { type XaiVideoModelOptions, xai } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const result = await withSpinner('Generating xAI video...', () =>
+    generateVideo({
+      model: xai.video('grok-imagine-video'),
+      prompt: 'A cat sitting on a windowsill watching rain.',
+      duration: 5,
+      providerOptions: {
+        xai: {
+          pollTimeoutMs: 600000,
+        } satisfies XaiVideoModelOptions,
+      },
+    }),
+  );
+
+  console.log('Video generated:', result.videos[0].mediaType);
+  console.log();
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(result.providerMetadata, null, 2),
+  );
+});

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -574,6 +574,33 @@ describe('XaiVideoModel', () => {
         },
       });
     });
+
+    it('should include costInUsdTicks when returned in usage', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: {
+          ...doneStatusResponse,
+          usage: { cost_in_usd_ticks: 4000000000 },
+        },
+      };
+
+      const model = createModel();
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(result.providerMetadata).toStrictEqual({
+        xai: {
+          requestId: 'req-123',
+          videoUrl: 'https://vidgen.x.ai/output/video-001.mp4',
+          duration: 5,
+          costInUsdTicks: 4000000000,
+        },
+      });
+
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: doneStatusResponse,
+      };
+    });
   });
 
   describe('error handling', () => {
@@ -635,6 +662,31 @@ describe('XaiVideoModel', () => {
       );
 
       // Reset
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: doneStatusResponse,
+      };
+    });
+
+    it('should throw when respect_moderation is false', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: {
+          status: 'done',
+          video: {
+            url: '',
+            respect_moderation: false,
+          },
+          model: 'grok-imagine-video',
+        },
+      };
+
+      const model = createModel();
+
+      await expect(model.doGenerate({ ...defaultOptions })).rejects.toThrow(
+        'content policy violation',
+      );
+
       server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
         type: 'json-value',
         body: doneStatusResponse,

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -239,6 +239,14 @@ export class XaiVideoModel implements Experimental_VideoModelV3 {
         statusResponse.status === 'done' ||
         (statusResponse.status == null && statusResponse.video?.url)
       ) {
+        if (statusResponse.video?.respect_moderation === false) {
+          throw new AISDKError({
+            name: 'XAI_VIDEO_MODERATION_ERROR',
+            message:
+              'Video generation was blocked due to a content policy violation.',
+          });
+        }
+
         if (!statusResponse.video?.url) {
           throw new AISDKError({
             name: 'XAI_VIDEO_GENERATION_ERROR',
@@ -267,6 +275,9 @@ export class XaiVideoModel implements Experimental_VideoModelV3 {
               videoUrl: statusResponse.video.url,
               ...(statusResponse.video.duration != null
                 ? { duration: statusResponse.video.duration }
+                : {}),
+              ...(statusResponse.usage?.cost_in_usd_ticks != null
+                ? { costInUsdTicks: statusResponse.usage.cost_in_usd_ticks }
                 : {}),
             },
           },
@@ -299,4 +310,9 @@ const xaiVideoStatusResponseSchema = z.object({
     })
     .nullish(),
   model: z.string().nullish(),
+  usage: z
+    .object({
+      cost_in_usd_ticks: z.number().nullish(),
+    })
+    .nullish(),
 });


### PR DESCRIPTION
## background

xAI's video API returns `usage.cost_in_usd_ticks` and `respect_moderation` in status responses but the SDK wasn't handling either

## summary

- add `usage` schema to video status response, expose `costInUsdTicks` in provider metadata
- check `respect_moderation: false` and throw `XAI_VIDEO_MODERATION_ERROR` instead of generic "no video URL" error
- add tests for both features
- add cost example

## verification

<details>
<summary>costInUsdTicks in provider metadata</summary>

```
$ pnpm tsx src/generate-video/xai/cost.ts
✔ Generating xAI video... (16.6s)
Video generated: video/mp4

Provider metadata: {
  "xai": {
    "requestId": "a9395fb9-4531-eb46-956c-a95219ada6d3",
    "videoUrl": "https://vidgen.x.ai/xai-vidgen-bucket/xai-video-...",
    "duration": 5,
    "costInUsdTicks": 2500000000
  }
}
```

</details>

<details>
<summary>moderation error</summary>

```
$ pnpm tsx src/generate-video/xai/moderation.ts
✖ Generating xAI video... (6.0s)
Video was blocked by content moderation.
Response: {"code":"Client specified an invalid argument","error":"Generated video rejected by content moderation.","usage":{"cost_in_usd_ticks":2500000000}}
```

</details>

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

part of #12829