### PR TITLE
feat(xai): add reasoning.encrypted_content to include option schema

### DIFF
--- a/.changeset/xai-include-reasoning-encrypted-content.md
+++ b/.changeset/xai-include-reasoning-encrypted-content.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(xai): add reasoning.encrypted_content to include option schema

--- a/examples/ai-functions/src/generate-text/xai/responses-include-reasoning-encrypted-content.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-include-reasoning-encrypted-content.ts
@@ -1,0 +1,48 @@
+import { xai, type XaiLanguageModelResponsesOptions } from '@ai-sdk/xai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+// Test that we can explicitly pass include: ['reasoning.encrypted_content']
+// This verifies the schema change allows this value
+run(async () => {
+  console.log(
+    'Testing explicit include option with reasoning.encrypted_content...\n',
+  );
+
+  const result = await generateText({
+    model: xai.responses('grok-4-1-fast-reasoning'),
+    prompt: 'How many "r"s are in the word "strawberry"',
+    providerOptions: {
+      xai: {
+        store: false,
+        // Explicitly passing include - this would fail before the schema fix
+        include: ['reasoning.encrypted_content'],
+      } satisfies XaiLanguageModelResponsesOptions,
+    },
+  });
+
+  console.log('✅ Schema validation passed!\n');
+  console.log('Text:', result.text);
+  console.log('Usage:', result.usage);
+
+  const reasoningParts = result.content.filter(
+    part => part.type === 'reasoning',
+  );
+
+  if (reasoningParts.length > 0) {
+    const reasoning = reasoningParts[0];
+    const xaiMetadata = reasoning.providerMetadata?.xai as {
+      reasoningEncryptedContent?: string;
+    };
+    console.log(
+      '\nReasoning encrypted content received:',
+      !!xaiMetadata?.reasoningEncryptedContent,
+    );
+    if (xaiMetadata?.reasoningEncryptedContent) {
+      console.log(
+        'Encrypted content length:',
+        xaiMetadata.reasoningEncryptedContent.length,
+      );
+    }
+  }
+});

--- a/packages/xai/src/responses/xai-responses-options.ts
+++ b/packages/xai/src/responses/xai-responses-options.ts
@@ -30,9 +30,11 @@ export const xaiLanguageModelResponsesOptions = z.object({
   previousResponseId: z.string().optional(),
   /**
    * Specify additional output data to include in the model response.
-   * Example values: 'file_search_call.results'.
+   * Example values: 'file_search_call.results', 'reasoning.encrypted_content'.
    */
-  include: z.array(z.enum(['file_search_call.results'])).nullish(),
+  include: z
+    .array(z.enum(['file_search_call.results', 'reasoning.encrypted_content']))
+    .nullish(),
 });
 
 export type XaiLanguageModelResponsesOptions = z.infer<


### PR DESCRIPTION
## Fixes

https://github.com/vercel/ai/issues/10542

## Background

`reasoning.encrypted_content` is now available as an option for reasoning Grok models.

## Summary

Added `reasoning.encrypted_content` to the schema for `xai-response-options`. You can manually validated that this option is available. It is also stated in the xAI docs.

```
curl https://api.x.ai/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $XAI_API_KEY" \
  -m 3600 \
  -d '{
    "model": "grok-4.20-beta-latest-reasoning",
    "input": [
        {
            "role": "system",
            "content": "You are Grok, a chatbot inspired by the Hitchhiker'\''s Guide to the Galaxy."
        },
        {
            "role": "user",
            "content": "What is the meaning of life, the universe, and everything?"
        }
    ],
    "include": ["reasoning.encrypted_content"]
}'
```

## Checklist

- [ x] Tests have been added / updated (for bug fixes / features)
- [ x] Documentation has been added / updated (for bug fixes / features)
- [ x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ x] I have reviewed this pull request (self-review)