### PR TITLE
feat(provider-utils): add getAbortReason function to extract abort reasons

### DIFF
--- a/packages/provider-utils/src/is-abort-error.ts
+++ b/packages/provider-utils/src/is-abort-error.ts
@@ -1,3 +1,8 @@
+/**
+ * Checks if the given error is an abort error (AbortError, ResponseAborted, or TimeoutError).
+ * @param error - The error to check
+ * @returns True if the error is an abort error
+ */
 export function isAbortError(error: unknown): error is Error {
   return (
     (error instanceof Error || error instanceof DOMException) &&
@@ -5,4 +10,17 @@ export function isAbortError(error: unknown): error is Error {
       error.name === 'ResponseAborted' || // Next.js
       error.name === 'TimeoutError')
   );
+}
+
+/**
+ * Extracts the abort reason from an abort error if available.
+ * When AbortController.abort(reason) is called, the reason is passed as the message.
+ * @param error - The abort error
+ * @returns The abort reason if available, otherwise undefined
+ */
+export function getAbortReason(error: unknown): string | undefined {
+  if (isAbortError(error) && error.message && error.message !== 'The operation was aborted.') {
+    return error.message;
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary

When `AbortController.abort(reason)` is called, the reason is passed as the error message. This adds a helper function to extract the abort reason from an abort error, enabling better handling of different abortion scenarios.

## Problem

Currently, the `isAbortError` function only checks if an error is an abort error, but doesn't provide access to the abort reason. When users call `abortController.abort('user_request')` or `abortController.abort('server_restart')`, the internal code has no way to access these reasons.

## Solution

Add a new `getAbortReason(error)` function that:
- Returns the abort reason string if available
- Returns `undefined` if no custom reason was provided (i.e., just `abort()` was called)
- Handles the default message 'The operation was aborted.' by ignoring it

## Usage

```typescript
import { isAbortError, getAbortReason } from '@ai-sdk/provider-utils';

try {
  // ... some operation that might be aborted
} catch (error) {
  if (isAbortError(error)) {
    const reason = getAbortReason(error);
    console.log(Aborted with reason:, reason);
    // Handle different reasons appropriately
  }
}
```

Closes #13411