### PR TITLE
chore: backport CI fixes from main

### DIFF
--- a/examples/sveltekit-openai/eslint.config.js
+++ b/examples/sveltekit-openai/eslint.config.js
@@ -18,6 +18,7 @@ export default ts.config(
   {
     rules: {
       'no-undef': 'off',
+      'svelte/no-navigation-without-resolve': 'off',
       '@typescript-eslint/no-unused-vars': [
         'error',
         {

--- a/packages/codemod/src/test/__testfixtures__/rename-addtoolresult-to-addtooloutput.output.tsx
+++ b/packages/codemod/src/test/__testfixtures__/rename-addtoolresult-to-addtooloutput.output.tsx
@@ -36,8 +36,8 @@ function ChatComponent3() {
   const chat = useChat();
 
   return (
-    (<button onClick={() => chat.addToolOutput({ tool: 'test', toolCallId: 'id', output: 'out' })}>Submit
-                </button>)
+    <button onClick={() => chat.addToolOutput({ tool: 'test', toolCallId: 'id', output: 'out' })}>Submit
+                </button>
   );
 }
 

--- a/packages/codemod/src/test/__testfixtures__/rename-addtoolresult-to-addtooloutput.output.tsx
+++ b/packages/codemod/src/test/__testfixtures__/rename-addtoolresult-to-addtooloutput.output.tsx
@@ -36,8 +36,8 @@ function ChatComponent3() {
   const chat = useChat();
 
   return (
-    <button onClick={() => chat.addToolOutput({ tool: 'test', toolCallId: 'id', output: 'out' })}>Submit
-                </button>
+    (<button onClick={() => chat.addToolOutput({ tool: 'test', toolCallId: 'id', output: 'out' })}>Submit
+                </button>)
   );
 }
 

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -128,6 +128,11 @@ describe('HttpMCPTransport', () => {
       params: {},
     });
 
+    // openInboundSse() is fire-and-forget, so wait for the GET request to appear
+    await vi.waitFor(() => {
+      expect(server.calls[2]).toBeDefined();
+    });
+
     expect(server.calls[2].requestMethod).toBe('GET');
     expect(server.calls[2].requestHeaders.accept).toBe('text/event-stream');
   });


### PR DESCRIPTION
## Summary

- Backport ESLint config fix for `sveltekit-openai` example (disable `svelte/no-navigation-without-resolve`)
- Backport updated codemod test fixture (`rename-addtoolresult-to-addtooloutput.output.tsx`)
- Backport `vi.waitFor` fix in MCP HTTP transport test

These are minor fixes cherry-picked from main to keep CI green on the `release-v6.0` branch.