### PR TITLE
fix(provider/amazon-bedrock): fix bedrock anthropic base64 decoding

### DIFF
--- a/.changeset/perfect-cycles-camp.md
+++ b/.changeset/perfect-cycles-camp.md
@@ -2,4 +2,4 @@
 '@ai-sdk/amazon-bedrock': patch
 ---
 
-fix(amazon-bedrock): fix base64 decoding
+fix(provider/amazon-bedrock): fix base64 decoding

--- a/.changeset/perfect-cycles-camp.md
+++ b/.changeset/perfect-cycles-camp.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): fix base64 decoding

--- a/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-utf8.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-utf8.ts
@@ -27,9 +27,13 @@ async function testStream(label: string, prompt: string) {
   console.log();
 
   if (corruptionPattern.test(fullText)) {
-    console.log(`\x1b[34mFAIL test ${testNumber}: detected corrupted UTF-8 characters\x1b[0m`);
+    console.log(
+      `\x1b[34mFAIL test ${testNumber}: detected corrupted UTF-8 characters\x1b[0m`,
+    );
   } else {
-    console.log(`\x1b[34mPASS test ${testNumber}: no corrupted characters detected\x1b[0m`);
+    console.log(
+      `\x1b[34mPASS test ${testNumber}: no corrupted characters detected\x1b[0m`,
+    );
   }
   console.log();
 }

--- a/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-utf8.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-anthropic-utf8.ts
@@ -1,0 +1,46 @@
+import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { streamText } from 'ai';
+import { run } from '../lib/run';
+
+// Known corrupted forms from the bug report (UTF-8 bytes misread as Latin-1)
+// German: ö→Ã¶, ü→Ã¼, é→Ã©, ß→ÃŸ
+// Japanese: 日→æ¥, 本→æ¬, で→ã§
+const corruptionPattern = /Ã¶|Ã¼|Ã©|ÃŸ|æ¥æ¬|ã§|ä¸ç/;
+
+let testNumber = 0;
+
+async function testStream(label: string, prompt: string) {
+  testNumber++;
+  console.log(`--- ${label} ---`);
+  const result = streamText({
+    model: bedrockAnthropic('us.anthropic.claude-haiku-4-5-20251001-v1:0'),
+    prompt,
+  });
+
+  let fullText = '';
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+    fullText += textPart;
+  }
+
+  console.log();
+  console.log();
+
+  if (corruptionPattern.test(fullText)) {
+    console.log(`\x1b[34mFAIL test ${testNumber}: detected corrupted UTF-8 characters\x1b[0m`);
+  } else {
+    console.log(`\x1b[34mPASS test ${testNumber}: no corrupted characters detected\x1b[0m`);
+  }
+  console.log();
+}
+
+run(async () => {
+  await testStream(
+    'German',
+    'Gib mir eine Liste der größten Städte in Deutschland!',
+  );
+  await testStream(
+    'Japanese',
+    '日本で一番大きい都市のリストを教えてください！',
+  );
+});

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-fetch.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-fetch.ts
@@ -1,4 +1,8 @@
-import { FetchFunction, safeParseJSON } from '@ai-sdk/provider-utils';
+import {
+  convertBase64ToUint8Array,
+  FetchFunction,
+  safeParseJSON,
+} from '@ai-sdk/provider-utils';
 import { createBedrockEventStreamDecoder } from '../bedrock-event-stream-decoder';
 
 export function createBedrockAnthropicFetch(
@@ -43,7 +47,9 @@ function transformBedrockEventStreamToSSE(
         }
         const bytes = (parsed.value as { bytes?: string }).bytes;
         if (bytes) {
-          const anthropicEvent = atob(bytes);
+          const anthropicEvent = new TextDecoder().decode(
+            convertBase64ToUint8Array(bytes),
+          );
           controller.enqueue(textEncoder.encode(`data: ${anthropicEvent}\n\n`));
         } else {
           controller.enqueue(textEncoder.encode(`data: ${event.data}\n\n`));


### PR DESCRIPTION
## Background

the code used `atob()` which corrupts multi-byte UTF-8 characters (like German, Japanese, Emojis)

## Summary

- Basically the same to this PR #12168 (maybe just missing backport to `v5`), I couldn't use backport label cleanly to `v5` so just copying a lot of the logic over.
- Added a script for verification

## Manual Verification

Verified by adding a new script to try a couple non-English languages

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)