### PR TITLE
chore(openai-compat): update v3 specs to v4

### DIFF
--- a/.changeset/old-experts-happen.md
+++ b/.changeset/old-experts-happen.md
@@ -1,0 +1,12 @@
+---
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/moonshotai': patch
+'@ai-sdk/togetherai': patch
+'@ai-sdk/deepinfra': patch
+'@ai-sdk/fireworks': patch
+'@ai-sdk/cerebras': patch
+'@ai-sdk/baseten': patch
+'@ai-sdk/vercel': patch
+---
+
+chore(openai-compat): update v3 specs to v4

--- a/packages/baseten/src/baseten-provider.ts
+++ b/packages/baseten/src/baseten-provider.ts
@@ -4,10 +4,10 @@ import {
   ProviderErrorStructure,
 } from '@ai-sdk/openai-compatible';
 import {
-  EmbeddingModelV3,
-  LanguageModelV3,
+  EmbeddingModelV4,
+  LanguageModelV4,
   NoSuchModelError,
-  ProviderV3,
+  ProviderV4,
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
@@ -61,31 +61,31 @@ export interface BasetenProviderSettings {
   fetch?: FetchFunction;
 }
 
-export interface BasetenProvider extends ProviderV3 {
+export interface BasetenProvider extends ProviderV4 {
   /**
    * Creates a chat model for text generation.
    */
-  (modelId?: BasetenChatModelId): LanguageModelV3;
+  (modelId?: BasetenChatModelId): LanguageModelV4;
 
   /**
    * Creates a chat model for text generation.
    */
-  chatModel(modelId?: BasetenChatModelId): LanguageModelV3;
+  chatModel(modelId?: BasetenChatModelId): LanguageModelV4;
 
   /**
    * Creates a language model for text generation. Alias for chatModel.
    */
-  languageModel(modelId?: BasetenChatModelId): LanguageModelV3;
+  languageModel(modelId?: BasetenChatModelId): LanguageModelV4;
 
   /**
    * Creates a embedding model for text generation.
    */
-  embeddingModel(modelId?: BasetenEmbeddingModelId): EmbeddingModelV3;
+  embeddingModel(modelId?: BasetenEmbeddingModelId): EmbeddingModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
    */
-  textEmbeddingModel(modelId?: BasetenEmbeddingModelId): EmbeddingModelV3;
+  textEmbeddingModel(modelId?: BasetenEmbeddingModelId): EmbeddingModelV4;
 }
 
 // by default, we use the Model APIs
@@ -233,7 +233,7 @@ export function createBaseten(
 
   const provider = (modelId?: BasetenChatModelId) => createChatModel(modelId);
 
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.chatModel = createChatModel;
   provider.languageModel = createChatModel;
   provider.imageModel = (modelId: string) => {

--- a/packages/baseten/src/baseten-provider.unit.test.ts
+++ b/packages/baseten/src/baseten-provider.unit.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { createBaseten } from './baseten-provider';
 import {
-  LanguageModelV3,
-  EmbeddingModelV3,
+  LanguageModelV4,
+  EmbeddingModelV4,
   NoSuchModelError,
 } from '@ai-sdk/provider';
 import { loadApiKey } from '@ai-sdk/provider-utils';

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -1,8 +1,8 @@
 import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
 import {
-  LanguageModelV3,
+  LanguageModelV4,
   NoSuchModelError,
-  ProviderV3,
+  ProviderV4,
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
@@ -50,21 +50,21 @@ export interface CerebrasProviderSettings {
   fetch?: FetchFunction;
 }
 
-export interface CerebrasProvider extends ProviderV3 {
+export interface CerebrasProvider extends ProviderV4 {
   /**
    * Creates a Cerebras model for text generation.
    */
-  (modelId: CerebrasChatModelId): LanguageModelV3;
+  (modelId: CerebrasChatModelId): LanguageModelV4;
 
   /**
    * Creates a Cerebras model for text generation.
    */
-  languageModel(modelId: CerebrasChatModelId): LanguageModelV3;
+  languageModel(modelId: CerebrasChatModelId): LanguageModelV4;
 
   /**
    * Creates a Cerebras chat model for text generation.
    */
-  chat(modelId: CerebrasChatModelId): LanguageModelV3;
+  chat(modelId: CerebrasChatModelId): LanguageModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
@@ -105,7 +105,7 @@ export function createCerebras(
   const provider = (modelId: CerebrasChatModelId) =>
     createLanguageModel(modelId);
 
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.languageModel = createLanguageModel;
   provider.chat = createLanguageModel;
 

--- a/packages/deepinfra/src/deepinfra-chat-language-model.ts
+++ b/packages/deepinfra/src/deepinfra-chat-language-model.ts
@@ -1,7 +1,7 @@
 import {
-  LanguageModelV3CallOptions,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamResult,
+  LanguageModelV4CallOptions,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamResult,
 } from '@ai-sdk/provider';
 import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
 import { FetchFunction } from '@ai-sdk/provider-utils';
@@ -67,8 +67,8 @@ export class DeepInfraChatLanguageModel extends OpenAICompatibleChatLanguageMode
   }
 
   async doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3GenerateResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
     const result = await super.doGenerate(options);
 
     // Fix usage if needed
@@ -107,8 +107,8 @@ export class DeepInfraChatLanguageModel extends OpenAICompatibleChatLanguageMode
   }
 
   async doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3StreamResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
     const result = await super.doStream(options);
 
     // Wrap the stream to fix usage in the final chunk

--- a/packages/deepinfra/src/deepinfra-image-model.test.ts
+++ b/packages/deepinfra/src/deepinfra-image-model.test.ts
@@ -244,7 +244,7 @@ describe('DeepInfraImageModel', () => {
 
       expect(model.provider).toBe('deepinfra');
       expect(model.modelId).toBe('stability-ai/sdxl');
-      expect(model.specificationVersion).toBe('v3');
+      expect(model.specificationVersion).toBe('v4');
       expect(model.maxImagesPerCall).toBe(1);
     });
   });

--- a/packages/deepinfra/src/deepinfra-image-model.ts
+++ b/packages/deepinfra/src/deepinfra-image-model.ts
@@ -1,7 +1,7 @@
 import {
-  ImageModelV3,
-  ImageModelV3File,
-  SharedV3Warning,
+  ImageModelV4,
+  ImageModelV4File,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -27,8 +27,8 @@ interface DeepInfraImageModelConfig {
   };
 }
 
-export class DeepInfraImageModel implements ImageModelV3 {
-  readonly specificationVersion = 'v3';
+export class DeepInfraImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4';
   readonly maxImagesPerCall = 1;
 
   get provider(): string {
@@ -51,10 +51,10 @@ export class DeepInfraImageModel implements ImageModelV3 {
     abortSignal,
     files,
     mask,
-  }: Parameters<ImageModelV3['doGenerate']>[0]): Promise<
-    Awaited<ReturnType<ImageModelV3['doGenerate']>>
+  }: Parameters<ImageModelV4['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV4['doGenerate']>>
   > {
-    const warnings: Array<SharedV3Warning> = [];
+    const warnings: Array<SharedV4Warning> = [];
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
 
     // Image editing mode - use OpenAI-compatible /images/edits endpoint
@@ -180,7 +180,7 @@ type DeepInfraFormDataInput = {
   [key: string]: unknown;
 };
 
-async function fileToBlob(file: ImageModelV3File): Promise<Blob> {
+async function fileToBlob(file: ImageModelV4File): Promise<Blob> {
   if (file.type === 'url') {
     return downloadBlob(file.url);
   }

--- a/packages/deepinfra/src/deepinfra-provider.test.ts
+++ b/packages/deepinfra/src/deepinfra-provider.test.ts
@@ -5,7 +5,7 @@ import {
   OpenAICompatibleCompletionLanguageModel,
   OpenAICompatibleEmbeddingModel,
 } from '@ai-sdk/openai-compatible';
-import { LanguageModelV3, EmbeddingModelV3 } from '@ai-sdk/provider';
+import { LanguageModelV4, EmbeddingModelV4 } from '@ai-sdk/provider';
 import { loadApiKey } from '@ai-sdk/provider-utils';
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 
@@ -36,17 +36,17 @@ vi.mock('./deepinfra-image-model', () => ({
 }));
 
 describe('DeepInfraProvider', () => {
-  let mockLanguageModel: LanguageModelV3;
-  let mockEmbeddingModel: EmbeddingModelV3;
+  let mockLanguageModel: LanguageModelV4;
+  let mockEmbeddingModel: EmbeddingModelV4;
 
   beforeEach(() => {
     // Mock implementations of models
     mockLanguageModel = {
-      // Add any required methods for LanguageModelV3
-    } as LanguageModelV3;
+      // Add any required methods for LanguageModelV4
+    } as LanguageModelV4;
     mockEmbeddingModel = {
-      // Add any required methods for EmbeddingModelV3
-    } as EmbeddingModelV3;
+      // Add any required methods for EmbeddingModelV4
+    } as EmbeddingModelV4;
 
     // Reset mocks
     vi.clearAllMocks();

--- a/packages/deepinfra/src/deepinfra-provider.ts
+++ b/packages/deepinfra/src/deepinfra-provider.ts
@@ -1,8 +1,8 @@
 import {
-  LanguageModelV3,
-  EmbeddingModelV3,
-  ProviderV3,
-  ImageModelV3,
+  LanguageModelV4,
+  EmbeddingModelV4,
+  ProviderV4,
+  ImageModelV4,
 } from '@ai-sdk/provider';
 import {
   OpenAICompatibleCompletionLanguageModel,
@@ -42,46 +42,46 @@ export interface DeepInfraProviderSettings {
   fetch?: FetchFunction;
 }
 
-export interface DeepInfraProvider extends ProviderV3 {
+export interface DeepInfraProvider extends ProviderV4 {
   /**
    * Creates a model for text generation.
    */
-  (modelId: DeepInfraChatModelId): LanguageModelV3;
+  (modelId: DeepInfraChatModelId): LanguageModelV4;
 
   /**
    * Creates a chat model for text generation.
    */
-  chatModel(modelId: DeepInfraChatModelId): LanguageModelV3;
+  chatModel(modelId: DeepInfraChatModelId): LanguageModelV4;
 
   /**
    * Creates a model for image generation.
    */
-  image(modelId: DeepInfraImageModelId): ImageModelV3;
+  image(modelId: DeepInfraImageModelId): ImageModelV4;
 
   /**
    * Creates a model for image generation.
    */
-  imageModel(modelId: DeepInfraImageModelId): ImageModelV3;
+  imageModel(modelId: DeepInfraImageModelId): ImageModelV4;
 
   /**
    * Creates a chat model for text generation.
    */
-  languageModel(modelId: DeepInfraChatModelId): LanguageModelV3;
+  languageModel(modelId: DeepInfraChatModelId): LanguageModelV4;
 
   /**
    * Creates a completion model for text generation.
    */
-  completionModel(modelId: DeepInfraCompletionModelId): LanguageModelV3;
+  completionModel(modelId: DeepInfraCompletionModelId): LanguageModelV4;
 
   /**
    * Creates a embedding model for text generation.
    */
-  embeddingModel(modelId: DeepInfraEmbeddingModelId): EmbeddingModelV3;
+  embeddingModel(modelId: DeepInfraEmbeddingModelId): EmbeddingModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
    */
-  textEmbeddingModel(modelId: DeepInfraEmbeddingModelId): EmbeddingModelV3;
+  textEmbeddingModel(modelId: DeepInfraEmbeddingModelId): EmbeddingModelV4;
 }
 
 export function createDeepInfra(
@@ -146,7 +146,7 @@ export function createDeepInfra(
 
   const provider = (modelId: DeepInfraChatModelId) => createChatModel(modelId);
 
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.completionModel = createCompletionModel;
   provider.chatModel = createChatModel;
   provider.image = createImageModel;

--- a/packages/fireworks/src/fireworks-image-model.test.ts
+++ b/packages/fireworks/src/fireworks-image-model.test.ts
@@ -480,7 +480,7 @@ describe('FireworksImageModel', () => {
 
       expect(model.provider).toBe('fireworks');
       expect(model.modelId).toBe('accounts/fireworks/models/flux-1-dev-fp8');
-      expect(model.specificationVersion).toBe('v3');
+      expect(model.specificationVersion).toBe('v4');
       expect(model.maxImagesPerCall).toBe(1);
     });
   });

--- a/packages/fireworks/src/fireworks-image-model.ts
+++ b/packages/fireworks/src/fireworks-image-model.ts
@@ -1,4 +1,4 @@
-import { ImageModelV3, SharedV3Warning } from '@ai-sdk/provider';
+import { ImageModelV4, SharedV4Warning } from '@ai-sdk/provider';
 import {
   combineHeaders,
   convertImageModelFileToDataUri,
@@ -108,8 +108,8 @@ interface FireworksImageModelConfig {
   };
 }
 
-export class FireworksImageModel implements ImageModelV3 {
-  readonly specificationVersion = 'v3';
+export class FireworksImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4';
   readonly maxImagesPerCall = 1;
 
   get provider(): string {
@@ -132,10 +132,10 @@ export class FireworksImageModel implements ImageModelV3 {
     abortSignal,
     files,
     mask,
-  }: Parameters<ImageModelV3['doGenerate']>[0]): Promise<
-    Awaited<ReturnType<ImageModelV3['doGenerate']>>
+  }: Parameters<ImageModelV4['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV4['doGenerate']>>
   > {
-    const warnings: Array<SharedV3Warning> = [];
+    const warnings: Array<SharedV4Warning> = [];
 
     const backendConfig = modelToBackendConfig[this.modelId];
     if (!backendConfig?.supportsSize && size != null) {
@@ -244,9 +244,9 @@ export class FireworksImageModel implements ImageModelV3 {
     body: Record<string, unknown>;
     headers: Record<string, string | undefined>;
     abortSignal: AbortSignal | undefined;
-    warnings: Array<SharedV3Warning>;
+    warnings: Array<SharedV4Warning>;
     currentDate: Date;
-  }): Promise<Awaited<ReturnType<ImageModelV3['doGenerate']>>> {
+  }): Promise<Awaited<ReturnType<ImageModelV4['doGenerate']>>> {
     // Submit the generation request
     const { value: submitResponse } = await postJsonToApi({
       url: getUrlForModel(this.config.baseURL, this.modelId),

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -5,10 +5,10 @@ import {
   ProviderErrorStructure,
 } from '@ai-sdk/openai-compatible';
 import {
-  EmbeddingModelV3,
-  ImageModelV3,
-  LanguageModelV3,
-  ProviderV3,
+  EmbeddingModelV4,
+  ImageModelV4,
+  LanguageModelV4,
+  ProviderV4,
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
@@ -56,46 +56,46 @@ export interface FireworksProviderSettings {
   fetch?: FetchFunction;
 }
 
-export interface FireworksProvider extends ProviderV3 {
+export interface FireworksProvider extends ProviderV4 {
   /**
    * Creates a model for text generation.
    */
-  (modelId: FireworksChatModelId): LanguageModelV3;
+  (modelId: FireworksChatModelId): LanguageModelV4;
 
   /**
    * Creates a chat model for text generation.
    */
-  chatModel(modelId: FireworksChatModelId): LanguageModelV3;
+  chatModel(modelId: FireworksChatModelId): LanguageModelV4;
 
   /**
    * Creates a completion model for text generation.
    */
-  completionModel(modelId: FireworksCompletionModelId): LanguageModelV3;
+  completionModel(modelId: FireworksCompletionModelId): LanguageModelV4;
 
   /**
    * Creates a chat model for text generation.
    */
-  languageModel(modelId: FireworksChatModelId): LanguageModelV3;
+  languageModel(modelId: FireworksChatModelId): LanguageModelV4;
 
   /**
    * Creates a text embedding model for text generation.
    */
-  embeddingModel(modelId: FireworksEmbeddingModelId): EmbeddingModelV3;
+  embeddingModel(modelId: FireworksEmbeddingModelId): EmbeddingModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
    */
-  textEmbeddingModel(modelId: FireworksEmbeddingModelId): EmbeddingModelV3;
+  textEmbeddingModel(modelId: FireworksEmbeddingModelId): EmbeddingModelV4;
 
   /**
    * Creates a model for image generation.
    */
-  image(modelId: FireworksImageModelId): ImageModelV3;
+  image(modelId: FireworksImageModelId): ImageModelV4;
 
   /**
    * Creates a model for image generation.
    */
-  imageModel(modelId: FireworksImageModelId): ImageModelV3;
+  imageModel(modelId: FireworksImageModelId): ImageModelV4;
 }
 
 const defaultBaseURL = 'https://api.fireworks.ai/inference/v1';
@@ -181,7 +181,7 @@ export function createFireworks(
 
   const provider = (modelId: FireworksChatModelId) => createChatModel(modelId);
 
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.completionModel = createCompletionModel;
   provider.chatModel = createChatModel;
   provider.languageModel = createChatModel;

--- a/packages/moonshotai/src/convert-moonshotai-chat-usage.ts
+++ b/packages/moonshotai/src/convert-moonshotai-chat-usage.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV3Usage } from '@ai-sdk/provider';
+import { LanguageModelV4Usage } from '@ai-sdk/provider';
 
 export function convertMoonshotAIChatUsage(
   usage:
@@ -15,7 +15,7 @@ export function convertMoonshotAIChatUsage(
       }
     | undefined
     | null,
-): LanguageModelV3Usage {
+): LanguageModelV4Usage {
   if (usage == null) {
     return {
       inputTokens: {

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -1,10 +1,10 @@
 import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
 import { OpenAICompatibleChatConfig } from '@ai-sdk/openai-compatible/internal';
 import {
-  LanguageModelV3CallOptions,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamPart,
-  LanguageModelV3StreamResult,
+  LanguageModelV4CallOptions,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamPart,
+  LanguageModelV4StreamResult,
 } from '@ai-sdk/provider';
 import { convertMoonshotAIChatUsage } from './convert-moonshotai-chat-usage';
 import { MoonshotAIChatModelId } from './moonshotai-chat-options';
@@ -18,8 +18,8 @@ export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageMod
   }
 
   async doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3GenerateResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
     const result = await super.doGenerate(options);
 
     // @ts-expect-error accessing response body from parent result
@@ -32,16 +32,16 @@ export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageMod
   }
 
   async doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3StreamResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
     const result = await super.doStream(options);
 
     return {
       ...result,
       stream: result.stream.pipeThrough(
         new TransformStream<
-          LanguageModelV3StreamPart,
-          LanguageModelV3StreamPart
+          LanguageModelV4StreamPart,
+          LanguageModelV4StreamPart
         >({
           transform(chunk, controller) {
             if (chunk.type === 'finish' && chunk.usage) {

--- a/packages/moonshotai/src/moonshotai-provider.ts
+++ b/packages/moonshotai/src/moonshotai-provider.ts
@@ -1,8 +1,8 @@
 import { ProviderErrorStructure } from '@ai-sdk/openai-compatible';
 import {
-  LanguageModelV3,
+  LanguageModelV4,
   NoSuchModelError,
-  ProviderV3,
+  ProviderV4,
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
@@ -50,21 +50,21 @@ export interface MoonshotAIProviderSettings {
   fetch?: FetchFunction;
 }
 
-export interface MoonshotAIProvider extends ProviderV3 {
+export interface MoonshotAIProvider extends ProviderV4 {
   /**
    * Creates a model for text generation.
    */
-  (modelId: MoonshotAIChatModelId): LanguageModelV3;
+  (modelId: MoonshotAIChatModelId): LanguageModelV4;
 
   /**
    * Creates a chat model for text generation.
    */
-  chatModel(modelId: MoonshotAIChatModelId): LanguageModelV3;
+  chatModel(modelId: MoonshotAIChatModelId): LanguageModelV4;
 
   /**
    * Creates a language model for text generation.
    */
-  languageModel(modelId: MoonshotAIChatModelId): LanguageModelV3;
+  languageModel(modelId: MoonshotAIChatModelId): LanguageModelV4;
 }
 
 const defaultBaseURL = 'https://api.moonshot.ai/v1';
@@ -133,7 +133,7 @@ export function createMoonshotAI(
 
   const provider = (modelId: MoonshotAIChatModelId) => createChatModel(modelId);
 
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.chatModel = createChatModel;
   provider.languageModel = createChatModel;
 

--- a/packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.ts
+++ b/packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV3Usage } from '@ai-sdk/provider';
+import { LanguageModelV4Usage } from '@ai-sdk/provider';
 
 export function convertOpenAICompatibleChatUsage(
   usage:
@@ -14,7 +14,7 @@ export function convertOpenAICompatibleChatUsage(
       }
     | undefined
     | null,
-): LanguageModelV3Usage {
+): LanguageModelV4Usage {
   if (usage == null) {
     return {
       inputTokens: {

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -1,6 +1,6 @@
 import {
-  LanguageModelV3Prompt,
-  SharedV3ProviderMetadata,
+  LanguageModelV4Prompt,
+  SharedV4ProviderMetadata,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { OpenAICompatibleChatPrompt } from './openai-compatible-api-types';
@@ -10,7 +10,7 @@ import {
 } from '@ai-sdk/provider-utils';
 
 function getOpenAIMetadata(message: {
-  providerOptions?: SharedV3ProviderMetadata;
+  providerOptions?: SharedV4ProviderMetadata;
 }) {
   return message?.providerOptions?.openaiCompatible ?? {};
 }
@@ -28,7 +28,7 @@ function getAudioFormat(mediaType: string): 'wav' | 'mp3' | null {
 }
 
 export function convertToOpenAICompatibleChatMessages(
-  prompt: LanguageModelV3Prompt,
+  prompt: LanguageModelV4Prompt,
 ): OpenAICompatibleChatPrompt {
   const messages: OpenAICompatibleChatPrompt = [];
   for (const { role, content, ...message } of prompt) {

--- a/packages/openai-compatible/src/chat/map-openai-compatible-finish-reason.ts
+++ b/packages/openai-compatible/src/chat/map-openai-compatible-finish-reason.ts
@@ -1,8 +1,8 @@
-import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
+import { LanguageModelV4FinishReason } from '@ai-sdk/provider';
 
 export function mapOpenAICompatibleFinishReason(
   finishReason: string | null | undefined,
-): LanguageModelV3FinishReason['unified'] {
+): LanguageModelV4FinishReason['unified'] {
   switch (finishReason) {
     case 'stop':
       return 'stop';

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { LanguageModelV4Prompt } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import {
   convertReadableStreamToArray,
@@ -9,7 +9,7 @@ import {
 import { createOpenAICompatible } from '../openai-compatible-provider';
 import { OpenAICompatibleChatLanguageModel } from './openai-compatible-chat-language-model';
 
-const TEST_PROMPT: LanguageModelV3Prompt = [
+const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -1,15 +1,15 @@
 import {
   APICallError,
   InvalidResponseDataError,
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  LanguageModelV3Content,
-  LanguageModelV3FinishReason,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamPart,
-  LanguageModelV3StreamResult,
-  SharedV3ProviderMetadata,
-  SharedV3Warning,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4Content,
+  LanguageModelV4FinishReason,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamPart,
+  LanguageModelV4StreamResult,
+  SharedV4ProviderMetadata,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -57,7 +57,7 @@ export type OpenAICompatibleChatConfig = {
   /**
    * The supported URLs for the model.
    */
-  supportedUrls?: () => LanguageModelV3['supportedUrls'];
+  supportedUrls?: () => LanguageModelV4['supportedUrls'];
 
   /**
    * Optional function to transform the request body before sending it to the API.
@@ -67,8 +67,8 @@ export type OpenAICompatibleChatConfig = {
   transformRequestBody?: (args: Record<string, any>) => Record<string, any>;
 };
 
-export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = 'v3';
+export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4';
 
   readonly supportsStructuredOutputs: boolean;
 
@@ -125,8 +125,8 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
     seed,
     toolChoice,
     tools,
-  }: LanguageModelV3CallOptions) {
-    const warnings: SharedV3Warning[] = [];
+  }: LanguageModelV4CallOptions) {
+    const warnings: SharedV4Warning[] = [];
 
     // Parse provider options - check for deprecated 'openai-compatible' key
     const deprecatedOptions = await parseProviderOptions({
@@ -242,8 +242,8 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
   }
 
   async doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3GenerateResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
     const { args, warnings } = await this.getArgs({ ...options });
 
     const transformedBody = this.transformRequestBody(args);
@@ -269,7 +269,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
     });
 
     const choice = responseBody.choices[0];
-    const content: Array<LanguageModelV3Content> = [];
+    const content: Array<LanguageModelV4Content> = [];
 
     // text content:
     const text = choice.message.content;
@@ -309,7 +309,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
     }
 
     // provider metadata:
-    const providerMetadata: SharedV3ProviderMetadata = {
+    const providerMetadata: SharedV4ProviderMetadata = {
       [this.providerOptionsName]: {},
       ...(await this.config.metadataExtractor?.extractMetadata?.({
         parsedBody: rawResponse,
@@ -345,8 +345,8 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
   }
 
   async doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3StreamResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
     const { args, warnings } = await this.getArgs({ ...options });
 
     const body = this.transformRequestBody({
@@ -388,7 +388,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
       thoughtSignature?: string;
     }> = [];
 
-    let finishReason: LanguageModelV3FinishReason = {
+    let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
       raw: undefined,
     };
@@ -403,7 +403,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
       stream: response.pipeThrough(
         new TransformStream<
           ParseResult<z.infer<typeof this.chunkSchema>>,
-          LanguageModelV3StreamPart
+          LanguageModelV4StreamPart
         >({
           start(controller) {
             controller.enqueue({ type: 'stream-start', warnings });
@@ -684,7 +684,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
               });
             }
 
-            const providerMetadata: SharedV3ProviderMetadata = {
+            const providerMetadata: SharedV4ProviderMetadata = {
               [providerOptionsName]: {},
               ...metadataExtractor?.buildMetadata(),
             };

--- a/packages/openai-compatible/src/chat/openai-compatible-metadata-extractor.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-metadata-extractor.ts
@@ -1,4 +1,4 @@
-import { SharedV3ProviderMetadata } from '@ai-sdk/provider';
+import { SharedV4ProviderMetadata } from '@ai-sdk/provider';
 
 /**
  * Extracts provider-specific metadata from API responses.
@@ -18,7 +18,7 @@ export type MetadataExtractor = {
     parsedBody,
   }: {
     parsedBody: unknown;
-  }) => Promise<SharedV3ProviderMetadata | undefined>;
+  }) => Promise<SharedV4ProviderMetadata | undefined>;
 
   /**
    * Creates an extractor for handling streaming responses. The returned object provides
@@ -43,6 +43,6 @@ export type MetadataExtractor = {
      * @returns Provider-specific metadata or undefined if no metadata is available.
      *          The metadata should be under a key indicating the provider id.
      */
-    buildMetadata(): SharedV3ProviderMetadata | undefined;
+    buildMetadata(): SharedV4ProviderMetadata | undefined;
   };
 };

--- a/packages/openai-compatible/src/chat/openai-compatible-prepare-tools.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-prepare-tools.ts
@@ -1,6 +1,6 @@
 import {
-  LanguageModelV3CallOptions,
-  SharedV3Warning,
+  LanguageModelV4CallOptions,
+  SharedV4Warning,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 
@@ -8,8 +8,8 @@ export function prepareTools({
   tools,
   toolChoice,
 }: {
-  tools: LanguageModelV3CallOptions['tools'];
-  toolChoice?: LanguageModelV3CallOptions['toolChoice'];
+  tools: LanguageModelV4CallOptions['tools'];
+  toolChoice?: LanguageModelV4CallOptions['toolChoice'];
 }): {
   tools:
     | undefined
@@ -28,12 +28,12 @@ export function prepareTools({
     | 'none'
     | 'required'
     | undefined;
-  toolWarnings: SharedV3Warning[];
+  toolWarnings: SharedV4Warning[];
 } {
   // when the tools array is empty, change it to undefined to prevent errors:
   tools = tools?.length ? tools : undefined;
 
-  const toolWarnings: SharedV3Warning[] = [];
+  const toolWarnings: SharedV4Warning[] = [];
 
   if (tools == null) {
     return { tools: undefined, toolChoice: undefined, toolWarnings };

--- a/packages/openai-compatible/src/completion/convert-openai-compatible-completion-usage.ts
+++ b/packages/openai-compatible/src/completion/convert-openai-compatible-completion-usage.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV3Usage } from '@ai-sdk/provider';
+import { LanguageModelV4Usage } from '@ai-sdk/provider';
 
 export function convertOpenAICompatibleCompletionUsage(
   usage:
@@ -8,7 +8,7 @@ export function convertOpenAICompatibleCompletionUsage(
       }
     | undefined
     | null,
-): LanguageModelV3Usage {
+): LanguageModelV4Usage {
   if (usage == null) {
     return {
       inputTokens: {

--- a/packages/openai-compatible/src/completion/convert-to-openai-compatible-completion-prompt.ts
+++ b/packages/openai-compatible/src/completion/convert-to-openai-compatible-completion-prompt.ts
@@ -1,6 +1,6 @@
 import {
   InvalidPromptError,
-  LanguageModelV3Prompt,
+  LanguageModelV4Prompt,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 
@@ -9,7 +9,7 @@ export function convertToOpenAICompatibleCompletionPrompt({
   user = 'user',
   assistant = 'assistant',
 }: {
-  prompt: LanguageModelV3Prompt;
+  prompt: LanguageModelV4Prompt;
   user?: string;
   assistant?: string;
 }): {

--- a/packages/openai-compatible/src/completion/map-openai-compatible-finish-reason.ts
+++ b/packages/openai-compatible/src/completion/map-openai-compatible-finish-reason.ts
@@ -1,8 +1,8 @@
-import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
+import { LanguageModelV4FinishReason } from '@ai-sdk/provider';
 
 export function mapOpenAICompatibleFinishReason(
   finishReason: string | null | undefined,
-): LanguageModelV3FinishReason['unified'] {
+): LanguageModelV4FinishReason['unified'] {
   switch (finishReason) {
     case 'stop':
       return 'stop';

--- a/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.test.ts
+++ b/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { LanguageModelV4Prompt } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import {
   convertReadableStreamToArray,
@@ -8,7 +8,7 @@ import {
 import { createOpenAICompatible } from '../openai-compatible-provider';
 import { OpenAICompatibleCompletionLanguageModel } from './openai-compatible-completion-language-model';
 
-const TEST_PROMPT: LanguageModelV3Prompt = [
+const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 

--- a/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.ts
+++ b/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.ts
@@ -1,13 +1,13 @@
 import {
   APICallError,
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  LanguageModelV3Content,
-  LanguageModelV3FinishReason,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamPart,
-  LanguageModelV3StreamResult,
-  SharedV3Warning,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4Content,
+  LanguageModelV4FinishReason,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamPart,
+  LanguageModelV4StreamResult,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -45,13 +45,13 @@ type OpenAICompatibleCompletionConfig = {
   /**
    * The supported URLs for the model.
    */
-  supportedUrls?: () => LanguageModelV3['supportedUrls'];
+  supportedUrls?: () => LanguageModelV4['supportedUrls'];
 };
 
 export class OpenAICompatibleCompletionLanguageModel
-  implements LanguageModelV3
+  implements LanguageModelV4
 {
-  readonly specificationVersion = 'v3';
+  readonly specificationVersion = 'v4';
 
   readonly modelId: OpenAICompatibleCompletionModelId;
   private readonly config: OpenAICompatibleCompletionConfig;
@@ -100,8 +100,8 @@ export class OpenAICompatibleCompletionLanguageModel
     providerOptions,
     tools,
     toolChoice,
-  }: LanguageModelV3CallOptions) {
-    const warnings: SharedV3Warning[] = [];
+  }: LanguageModelV4CallOptions) {
+    const warnings: SharedV4Warning[] = [];
 
     // Parse provider options
     const completionOptions =
@@ -167,8 +167,8 @@ export class OpenAICompatibleCompletionLanguageModel
   }
 
   async doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3GenerateResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
     const { args, warnings } = await this.getArgs(options);
 
     const {
@@ -191,7 +191,7 @@ export class OpenAICompatibleCompletionLanguageModel
     });
 
     const choice = response.choices[0];
-    const content: Array<LanguageModelV3Content> = [];
+    const content: Array<LanguageModelV4Content> = [];
 
     // text content:
     if (choice.text != null && choice.text.length > 0) {
@@ -216,8 +216,8 @@ export class OpenAICompatibleCompletionLanguageModel
   }
 
   async doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3StreamResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
     const { args, warnings } = await this.getArgs(options);
 
     const body = {
@@ -245,7 +245,7 @@ export class OpenAICompatibleCompletionLanguageModel
       fetch: this.config.fetch,
     });
 
-    let finishReason: LanguageModelV3FinishReason = {
+    let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
       raw: undefined,
     };
@@ -262,7 +262,7 @@ export class OpenAICompatibleCompletionLanguageModel
       stream: response.pipeThrough(
         new TransformStream<
           ParseResult<z.infer<typeof this.chunkSchema>>,
-          LanguageModelV3StreamPart
+          LanguageModelV4StreamPart
         >({
           start(controller) {
             controller.enqueue({ type: 'stream-start', warnings });

--- a/packages/openai-compatible/src/embedding/openai-compatible-embedding-model.test.ts
+++ b/packages/openai-compatible/src/embedding/openai-compatible-embedding-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { EmbeddingModelV3Embedding } from '@ai-sdk/provider';
+import { EmbeddingModelV4Embedding } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { createOpenAICompatible } from '../openai-compatible-provider';
 
@@ -28,7 +28,7 @@ describe('doEmbed', () => {
     usage = { prompt_tokens: 8, total_tokens: 8 },
     headers,
   }: {
-    embeddings?: EmbeddingModelV3Embedding[];
+    embeddings?: EmbeddingModelV4Embedding[];
     usage?: { prompt_tokens: number; total_tokens: number };
     headers?: Record<string, string>;
   } = {}) {

--- a/packages/openai-compatible/src/embedding/openai-compatible-embedding-model.ts
+++ b/packages/openai-compatible/src/embedding/openai-compatible-embedding-model.ts
@@ -1,6 +1,6 @@
 import {
-  EmbeddingModelV3,
-  SharedV3Warning,
+  EmbeddingModelV4,
+  SharedV4Warning,
   TooManyEmbeddingValuesForCallError,
 } from '@ai-sdk/provider';
 import {
@@ -39,8 +39,8 @@ type OpenAICompatibleEmbeddingConfig = {
   errorStructure?: ProviderErrorStructure<any>;
 };
 
-export class OpenAICompatibleEmbeddingModel implements EmbeddingModelV3 {
-  readonly specificationVersion = 'v3';
+export class OpenAICompatibleEmbeddingModel implements EmbeddingModelV4 {
+  readonly specificationVersion = 'v4';
   readonly modelId: OpenAICompatibleEmbeddingModelId;
 
   private readonly config: OpenAICompatibleEmbeddingConfig;
@@ -74,10 +74,10 @@ export class OpenAICompatibleEmbeddingModel implements EmbeddingModelV3 {
     headers,
     abortSignal,
     providerOptions,
-  }: Parameters<EmbeddingModelV3['doEmbed']>[0]): Promise<
-    Awaited<ReturnType<EmbeddingModelV3['doEmbed']>>
+  }: Parameters<EmbeddingModelV4['doEmbed']>[0]): Promise<
+    Awaited<ReturnType<EmbeddingModelV4['doEmbed']>>
   > {
-    const warnings: SharedV3Warning[] = [];
+    const warnings: SharedV4Warning[] = [];
 
     // Parse provider options - check for deprecated 'openai-compatible' key
     const deprecatedOptions = await parseProviderOptions({

--- a/packages/openai-compatible/src/image/openai-compatible-image-model.test.ts
+++ b/packages/openai-compatible/src/image/openai-compatible-image-model.test.ts
@@ -4,7 +4,7 @@ import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { OpenAICompatibleImageModel } from './openai-compatible-image-model';
 import { z } from 'zod/v4';
 import { ProviderErrorStructure } from '../openai-compatible-error';
-import { ImageModelV3CallOptions } from '@ai-sdk/provider';
+import { ImageModelV4CallOptions } from '@ai-sdk/provider';
 
 const prompt = 'A photorealistic astronaut riding a horse';
 
@@ -31,7 +31,7 @@ function createBasicModel({
   });
 }
 
-function createDefaultGenerateParams(overrides = {}): ImageModelV3CallOptions {
+function createDefaultGenerateParams(overrides = {}): ImageModelV4CallOptions {
   return {
     prompt: 'A photorealistic astronaut riding a horse',
     files: undefined,
@@ -84,7 +84,7 @@ describe('OpenAICompatibleImageModel', () => {
 
       expect(model.provider).toBe('openai-compatible');
       expect(model.modelId).toBe('dall-e-3');
-      expect(model.specificationVersion).toBe('v3');
+      expect(model.specificationVersion).toBe('v4');
       expect(model.maxImagesPerCall).toBe(10);
     });
   });

--- a/packages/openai-compatible/src/image/openai-compatible-image-model.ts
+++ b/packages/openai-compatible/src/image/openai-compatible-image-model.ts
@@ -1,8 +1,8 @@
 import {
-  ImageModelV3,
-  ImageModelV3File,
-  SharedV3ProviderOptions,
-  SharedV3Warning,
+  ImageModelV4,
+  ImageModelV4File,
+  SharedV4ProviderOptions,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -33,8 +33,8 @@ export type OpenAICompatibleImageModelConfig = {
   };
 };
 
-export class OpenAICompatibleImageModel implements ImageModelV3 {
-  readonly specificationVersion = 'v3';
+export class OpenAICompatibleImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4';
   readonly maxImagesPerCall = 10;
 
   get provider(): string {
@@ -55,7 +55,7 @@ export class OpenAICompatibleImageModel implements ImageModelV3 {
 
   // TODO: deprecate non-camelCase keys and remove in future major version
   private getArgs(
-    providerOptions: SharedV3ProviderOptions,
+    providerOptions: SharedV4ProviderOptions,
   ): Record<string, unknown> {
     return {
       ...providerOptions[this.providerOptionsKey],
@@ -74,10 +74,10 @@ export class OpenAICompatibleImageModel implements ImageModelV3 {
     abortSignal,
     files,
     mask,
-  }: Parameters<ImageModelV3['doGenerate']>[0]): Promise<
-    Awaited<ReturnType<ImageModelV3['doGenerate']>>
+  }: Parameters<ImageModelV4['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV4['doGenerate']>>
   > {
-    const warnings: Array<SharedV3Warning> = [];
+    const warnings: Array<SharedV4Warning> = [];
 
     if (aspectRatio != null) {
       warnings.push({
@@ -187,7 +187,7 @@ type OpenAICompatibleFormDataInput = {
   [key: string]: unknown;
 };
 
-async function fileToBlob(file: ImageModelV3File): Promise<Blob> {
+async function fileToBlob(file: ImageModelV4File): Promise<Blob> {
   if (file.type === 'url') {
     return downloadBlob(file.url);
   }

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -1,8 +1,8 @@
 import {
-  EmbeddingModelV3,
-  ImageModelV3,
-  LanguageModelV3,
-  ProviderV3,
+  EmbeddingModelV4,
+  ImageModelV4,
+  LanguageModelV4,
+  ProviderV4,
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
@@ -24,26 +24,26 @@ export interface OpenAICompatibleProvider<
   COMPLETION_MODEL_IDS extends string = string,
   EMBEDDING_MODEL_IDS extends string = string,
   IMAGE_MODEL_IDS extends string = string,
-> extends Omit<ProviderV3, 'imageModel'> {
-  (modelId: CHAT_MODEL_IDS): LanguageModelV3;
+> extends Omit<ProviderV4, 'imageModel'> {
+  (modelId: CHAT_MODEL_IDS): LanguageModelV4;
 
   languageModel(
     modelId: CHAT_MODEL_IDS,
     config?: Partial<OpenAICompatibleChatConfig>,
-  ): LanguageModelV3;
+  ): LanguageModelV4;
 
-  chatModel(modelId: CHAT_MODEL_IDS): LanguageModelV3;
+  chatModel(modelId: CHAT_MODEL_IDS): LanguageModelV4;
 
-  completionModel(modelId: COMPLETION_MODEL_IDS): LanguageModelV3;
+  completionModel(modelId: COMPLETION_MODEL_IDS): LanguageModelV4;
 
-  embeddingModel(modelId: EMBEDDING_MODEL_IDS): EmbeddingModelV3;
+  embeddingModel(modelId: EMBEDDING_MODEL_IDS): EmbeddingModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
    */
-  textEmbeddingModel(modelId: EMBEDDING_MODEL_IDS): EmbeddingModelV3;
+  textEmbeddingModel(modelId: EMBEDDING_MODEL_IDS): EmbeddingModelV4;
 
-  imageModel(modelId: IMAGE_MODEL_IDS): ImageModelV3;
+  imageModel(modelId: IMAGE_MODEL_IDS): ImageModelV4;
 }
 
 export interface OpenAICompatibleProviderSettings {
@@ -181,7 +181,7 @@ export function createOpenAICompatible<
 
   const provider = (modelId: CHAT_MODEL_IDS) => createLanguageModel(modelId);
 
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.languageModel = createLanguageModel;
   provider.chatModel = createChatModel;
   provider.completionModel = createCompletionModel;

--- a/packages/togetherai/src/reranking/togetherai-reranking-model.ts
+++ b/packages/togetherai/src/reranking/togetherai-reranking-model.ts
@@ -1,4 +1,4 @@
-import { RerankingModelV3 } from '@ai-sdk/provider';
+import { RerankingModelV4 } from '@ai-sdk/provider';
 import {
   combineHeaders,
   createJsonErrorResponseHandler,
@@ -24,8 +24,8 @@ type TogetherAIRerankingConfig = {
   fetch?: FetchFunction;
 };
 
-export class TogetherAIRerankingModel implements RerankingModelV3 {
-  readonly specificationVersion = 'v3';
+export class TogetherAIRerankingModel implements RerankingModelV4 {
+  readonly specificationVersion = 'v4';
   readonly modelId: TogetherAIRerankingModelId;
 
   private readonly config: TogetherAIRerankingConfig;
@@ -50,8 +50,8 @@ export class TogetherAIRerankingModel implements RerankingModelV3 {
     topN,
     abortSignal,
     providerOptions,
-  }: Parameters<RerankingModelV3['doRerank']>[0]): Promise<
-    Awaited<ReturnType<RerankingModelV3['doRerank']>>
+  }: Parameters<RerankingModelV4['doRerank']>[0]): Promise<
+    Awaited<ReturnType<RerankingModelV4['doRerank']>>
   > {
     const rerankingOptions = await parseProviderOptions({
       provider: 'togetherai',

--- a/packages/togetherai/src/togetherai-image-model.test.ts
+++ b/packages/togetherai/src/togetherai-image-model.test.ts
@@ -281,7 +281,7 @@ describe('constructor', () => {
 
     expect(model.provider).toBe('togetherai');
     expect(model.modelId).toBe('stabilityai/stable-diffusion-xl');
-    expect(model.specificationVersion).toBe('v3');
+    expect(model.specificationVersion).toBe('v4');
     expect(model.maxImagesPerCall).toBe(1);
   });
 });

--- a/packages/togetherai/src/togetherai-image-model.ts
+++ b/packages/togetherai/src/togetherai-image-model.ts
@@ -1,4 +1,4 @@
-import { ImageModelV3, SharedV3Warning } from '@ai-sdk/provider';
+import { ImageModelV4, SharedV4Warning } from '@ai-sdk/provider';
 import {
   combineHeaders,
   convertImageModelFileToDataUri,
@@ -24,8 +24,8 @@ interface TogetherAIImageModelConfig {
   };
 }
 
-export class TogetherAIImageModel implements ImageModelV3 {
-  readonly specificationVersion = 'v3';
+export class TogetherAIImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4';
   readonly maxImagesPerCall = 1;
 
   get provider(): string {
@@ -47,10 +47,10 @@ export class TogetherAIImageModel implements ImageModelV3 {
     abortSignal,
     files,
     mask,
-  }: Parameters<ImageModelV3['doGenerate']>[0]): Promise<
-    Awaited<ReturnType<ImageModelV3['doGenerate']>>
+  }: Parameters<ImageModelV4['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV4['doGenerate']>>
   > {
-    const warnings: Array<SharedV3Warning> = [];
+    const warnings: Array<SharedV4Warning> = [];
 
     if (mask != null) {
       throw new Error(

--- a/packages/togetherai/src/togetherai-provider.test.ts
+++ b/packages/togetherai/src/togetherai-provider.test.ts
@@ -4,9 +4,9 @@ import {
   OpenAICompatibleEmbeddingModel,
 } from '@ai-sdk/openai-compatible';
 import {
-  EmbeddingModelV3,
-  LanguageModelV3,
-  RerankingModelV3,
+  EmbeddingModelV4,
+  LanguageModelV4,
+  RerankingModelV4,
 } from '@ai-sdk/provider';
 import { loadApiKey } from '@ai-sdk/provider-utils';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
@@ -44,21 +44,21 @@ vi.mock('./reranking/togetherai-reranking-model', () => ({
 describe('TogetherAIProvider', () => {
   const originalEnv = { ...process.env };
 
-  let mockLanguageModel: LanguageModelV3;
-  let mockEmbeddingModel: EmbeddingModelV3;
-  let mockRerankingModel: RerankingModelV3;
+  let mockLanguageModel: LanguageModelV4;
+  let mockEmbeddingModel: EmbeddingModelV4;
+  let mockRerankingModel: RerankingModelV4;
 
   beforeEach(() => {
     // Mock implementations of models
     mockLanguageModel = {
-      // Add any required methods for LanguageModelV3
-    } as LanguageModelV3;
+      // Add any required methods for LanguageModelV4
+    } as LanguageModelV4;
     mockEmbeddingModel = {
-      // Add any required methods for EmbeddingModelV3
-    } as EmbeddingModelV3;
+      // Add any required methods for EmbeddingModelV4
+    } as EmbeddingModelV4;
     mockRerankingModel = {
-      // Add any required methods for RerankingModelV3
-    } as RerankingModelV3;
+      // Add any required methods for RerankingModelV4
+    } as RerankingModelV4;
 
     vi.clearAllMocks();
     delete process.env.TOGETHER_API_KEY;

--- a/packages/togetherai/src/togetherai-provider.ts
+++ b/packages/togetherai/src/togetherai-provider.ts
@@ -4,11 +4,11 @@ import {
   OpenAICompatibleEmbeddingModel,
 } from '@ai-sdk/openai-compatible';
 import {
-  EmbeddingModelV3,
-  ImageModelV3,
-  LanguageModelV3,
-  ProviderV3,
-  RerankingModelV3,
+  EmbeddingModelV4,
+  ImageModelV4,
+  LanguageModelV4,
+  ProviderV4,
+  RerankingModelV4,
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
@@ -45,56 +45,56 @@ export interface TogetherAIProviderSettings {
   fetch?: FetchFunction;
 }
 
-export interface TogetherAIProvider extends ProviderV3 {
+export interface TogetherAIProvider extends ProviderV4 {
   /**
    * Creates a model for text generation.
    */
-  (modelId: TogetherAIChatModelId): LanguageModelV3;
+  (modelId: TogetherAIChatModelId): LanguageModelV4;
 
   /**
    * Creates a chat model for text generation.
    */
-  chatModel(modelId: TogetherAIChatModelId): LanguageModelV3;
+  chatModel(modelId: TogetherAIChatModelId): LanguageModelV4;
 
   /**
    * Creates a chat model for text generation.
    */
-  languageModel(modelId: TogetherAIChatModelId): LanguageModelV3;
+  languageModel(modelId: TogetherAIChatModelId): LanguageModelV4;
 
   /**
    * Creates a completion model for text generation.
    */
-  completionModel(modelId: TogetherAICompletionModelId): LanguageModelV3;
+  completionModel(modelId: TogetherAICompletionModelId): LanguageModelV4;
 
   /**
    * Creates a text embedding model for text generation.
    */
-  embeddingModel(modelId: TogetherAIEmbeddingModelId): EmbeddingModelV3;
+  embeddingModel(modelId: TogetherAIEmbeddingModelId): EmbeddingModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
    */
-  textEmbeddingModel(modelId: TogetherAIEmbeddingModelId): EmbeddingModelV3;
+  textEmbeddingModel(modelId: TogetherAIEmbeddingModelId): EmbeddingModelV4;
 
   /**
    * Creates a model for image generation.
    */
-  image(modelId: TogetherAIImageModelId): ImageModelV3;
+  image(modelId: TogetherAIImageModelId): ImageModelV4;
 
   /**
    * Creates a model for image generation.
    */
-  imageModel(modelId: TogetherAIImageModelId): ImageModelV3;
+  imageModel(modelId: TogetherAIImageModelId): ImageModelV4;
 
   /**
    * Creates a model for reranking.
    */
-  reranking(modelId: TogetherAIRerankingModelId): RerankingModelV3;
+  reranking(modelId: TogetherAIRerankingModelId): RerankingModelV4;
 
   /**
    * Creates a model for reranking.
    */
-  rerankingModel(modelId: TogetherAIRerankingModelId): RerankingModelV3;
+  rerankingModel(modelId: TogetherAIRerankingModelId): RerankingModelV4;
 }
 
 function loadDeprecatedApiKey(): string | undefined {
@@ -180,7 +180,7 @@ export function createTogetherAI(
 
   const provider = (modelId: TogetherAIChatModelId) => createChatModel(modelId);
 
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.completionModel = createCompletionModel;
   provider.languageModel = createChatModel;
   provider.chatModel = createChatModel;

--- a/packages/vercel/src/vercel-provider.test.ts
+++ b/packages/vercel/src/vercel-provider.test.ts
@@ -1,6 +1,6 @@
 import { createVercel } from './vercel-provider';
 import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
-import { LanguageModelV3 } from '@ai-sdk/provider';
+import { LanguageModelV4 } from '@ai-sdk/provider';
 import { loadApiKey } from '@ai-sdk/provider-utils';
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 
@@ -26,12 +26,12 @@ vi.mock('./vercel-image-model', () => ({
 }));
 
 describe('VercelProvider', () => {
-  let mockLanguageModel: LanguageModelV3;
+  let mockLanguageModel: LanguageModelV4;
 
   beforeEach(() => {
     mockLanguageModel = {
       // Add any required methods for LanguageModelV1
-    } as LanguageModelV3;
+    } as LanguageModelV4;
 
     // Reset mocks
     vi.clearAllMocks();

--- a/packages/vercel/src/vercel-provider.ts
+++ b/packages/vercel/src/vercel-provider.ts
@@ -1,7 +1,7 @@
 import {
-  LanguageModelV3,
+  LanguageModelV4,
   NoSuchModelError,
-  ProviderV3,
+  ProviderV4,
 } from '@ai-sdk/provider';
 import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
 import {
@@ -33,16 +33,16 @@ export interface VercelProviderSettings {
   fetch?: FetchFunction;
 }
 
-export interface VercelProvider extends ProviderV3 {
+export interface VercelProvider extends ProviderV4 {
   /**
    * Creates a model for text generation.
    */
-  (modelId: VercelChatModelId): LanguageModelV3;
+  (modelId: VercelChatModelId): LanguageModelV4;
 
   /**
    * Creates a language model for text generation.
    */
-  languageModel(modelId: VercelChatModelId): LanguageModelV3;
+  languageModel(modelId: VercelChatModelId): LanguageModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
@@ -91,7 +91,7 @@ export function createVercel(
 
   const provider = (modelId: VercelChatModelId) => createChatModel(modelId);
 
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.languageModel = createChatModel;
   provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });


### PR DESCRIPTION
## Background

the package providers still relied on V3 specs instead of the v4 ones (for main branch)

## Summary

following packages were updated to use v4 spec
- started for `baseten`
- relied on `openai-compat`, on which relied
  - `cerebras`
  - `deepinfra`
  - `fireworks`
  - `moonshotai`
  - `togetherai`
  - `vercel`

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)