### PR TITLE
fix(anthropic): handle vertex_event SSE event from Vertex AI proxies (#13436)

### DIFF
--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -1320,6 +1320,12 @@ export const anthropicMessagesChunkSchema = lazySchema(() =>
       z.object({
         type: z.literal('ping'),
       }),
+      // Vertex AI returns a vertex_event with usage metadata that should be ignored
+      // by clients streaming through the Anthropic API proxy.
+      z.object({
+        type: z.literal('vertex_event'),
+        usage: z.looseObject({}).optional(),
+      }),
     ]),
   ),
 );

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -2201,6 +2201,12 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
               return;
             }
 
+            case 'vertex_event': {
+              // Vertex AI proxies emit vertex_event chunks with usage metadata.
+              // No content to process; safely ignore.
+              return;
+            }
+
             default: {
               const _exhaustiveCheck: never = value;
               throw new Error(`Unsupported chunk type: ${_exhaustiveCheck}`);


### PR DESCRIPTION
## Problem

When using the Anthropic API proxy with Vertex AI as the upstream provider, Vertex returns an additional SSE event called `vertex_event` containing usage metadata. This event type is not in the streaming schema, causing a `TypeValidationError` that breaks streaming.

## Root Cause

The `anthropicMessagesChunkSchema` uses a `discriminatedUnion("type", [...])` that does not include `vertex_event`.

## Fix

Add `vertex_event` as an accepted event type in the schema. The event is handled the same way as `ping` - accepted by the schema but does not produce any stream output.

## Related

Fixes #13436
