### PR TITLE
feat(provider): add MiniMax provider (@ai-sdk/minimax)

### DIFF
--- a/.changeset/add-minimax-provider.md
+++ b/.changeset/add-minimax-provider.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/minimax': major
+---
+
+Add MiniMax provider (`@ai-sdk/minimax`) with support for MiniMax-M2, MiniMax-M2-Stable, MiniMax-M2.5, and MiniMax-M2.5-highspeed models. The provider uses MiniMax's OpenAI-compatible API endpoint.

--- a/content/providers/01-ai-sdk-providers/33-minimax.mdx
+++ b/content/providers/01-ai-sdk-providers/33-minimax.mdx
@@ -1,0 +1,108 @@
+---
+title: MiniMax
+description: Learn how to use MiniMax's models with the AI SDK.
+---
+
+# MiniMax Provider
+
+The [MiniMax](https://www.minimax.io) provider offers access to powerful language models through the MiniMax API, including the latest MiniMax-M2.5 model with 204K context window.
+
+API keys can be obtained from the [MiniMax Platform](https://platform.minimax.io/user-center/basic-information/interface-key).
+
+## Setup
+
+The MiniMax provider is available via the `@ai-sdk/minimax` module. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @ai-sdk/minimax" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @ai-sdk/minimax" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @ai-sdk/minimax" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @ai-sdk/minimax" dark />
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+You can import the default provider instance `minimax` from `@ai-sdk/minimax`:
+
+```ts
+import { minimax } from '@ai-sdk/minimax';
+```
+
+For custom configuration, you can import `createMiniMax` and create a provider instance with your settings:
+
+```ts
+import { createMiniMax } from '@ai-sdk/minimax';
+
+const minimax = createMiniMax({
+  apiKey: process.env.MINIMAX_API_KEY ?? '',
+});
+```
+
+You can use the following optional settings to customize the MiniMax provider instance:
+
+- **baseURL** _string_
+
+  Use a different URL prefix for API calls.
+  The default prefix is `https://api.minimax.io/v1`.
+
+- **apiKey** _string_
+
+  API key that is being sent using the `Authorization` header. It defaults to
+  the `MINIMAX_API_KEY` environment variable.
+
+- **headers** _Record&lt;string,string&gt;_
+
+  Custom headers to include in the requests.
+
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+
+## Language Models
+
+You can create language models using a provider instance:
+
+```ts
+import { minimax } from '@ai-sdk/minimax';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: minimax('MiniMax-M2.5'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+});
+```
+
+You can also use the `.chat()` or `.languageModel()` factory methods:
+
+```ts
+const model = minimax.chat('MiniMax-M2.5');
+// or
+const model = minimax.languageModel('MiniMax-M2.5');
+```
+
+MiniMax language models can be used in the `streamText` function
+(see [AI SDK Core](/docs/ai-sdk-core)).
+
+## Model Capabilities
+
+| Model                    | Text Generation     | Object Generation   | Image Input         | Tool Usage          | Tool Streaming      |
+| ------------------------ | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `MiniMax-M2.5`           | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `MiniMax-M2.5-highspeed` | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `MiniMax-M2`             | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `MiniMax-M2-Stable`      | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+
+<Note>
+  Please see the [MiniMax
+  docs](https://platform.minimax.io/docs/guides/text-generation) for a full list
+  of available models. You can also pass any available provider model ID as a
+  string if needed.
+</Note>

--- a/content/providers/03-community-providers/28-minimax.mdx
+++ b/content/providers/03-community-providers/28-minimax.mdx
@@ -1,9 +1,15 @@
 ---
-title: MiniMax
-description: Learn how to use MiniMax provider with the AI SDK.
+title: MiniMax (Community)
+description: Learn how to use MiniMax community provider with the AI SDK.
 ---
 
-# MiniMax Provider
+# MiniMax Community Provider
+
+<Note>
+  MiniMax is also available as a first-party provider. See the
+  [`@ai-sdk/minimax` provider
+  documentation](/providers/ai-sdk-providers/minimax) for the recommended setup.
+</Note>
 
 [vercel-minimax-ai-provider](https://github.com/MiniMax-AI/vercel-minimax-ai-provider) is a community provider that provides access to the latest [MiniMax-M2 model](https://platform.minimax.io/docs/guides/text-generation) from [MiniMax](https://www.minimax.io/).
 

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -16,6 +16,7 @@
     "@ai-sdk/deepgram": "workspace:*",
     "@ai-sdk/deepinfra": "workspace:*",
     "@ai-sdk/deepseek": "workspace:*",
+    "@ai-sdk/minimax": "workspace:*",
     "@ai-sdk/elevenlabs": "workspace:*",
     "@ai-sdk/fal": "workspace:*",
     "@ai-sdk/fireworks": "workspace:*",

--- a/examples/ai-functions/src/stream-text/minimax/basic.ts
+++ b/examples/ai-functions/src/stream-text/minimax/basic.ts
@@ -1,0 +1,13 @@
+import { minimax } from '@ai-sdk/minimax';
+import { streamText } from 'ai';
+import { printFullStream } from '../../lib/print-full-stream';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: minimax('MiniMax-M2.5'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  printFullStream({ result });
+});

--- a/packages/minimax/package.json
+++ b/packages/minimax/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@ai-sdk/minimax",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "docs/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "directories": {
+    "doc": "./docs"
+  },
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist docs *.tsbuildinfo",
+    "prepack": "mkdir -p docs && cp ../../content/providers/01-ai-sdk-providers/33-minimax.mdx ./docs/",
+    "postpack": "del-cli docs",
+    "lint": "eslint \"./**/*.ts*\"",
+    "type-check": "tsc --build",
+    "prettier-check": "prettier --check \"./**/*.ts*\"",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:update": "pnpm test:node -u",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@ai-sdk/test-server": "workspace:*",
+    "@types/node": "20.17.24",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8",
+    "typescript": "5.8.3",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel/ai.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai"
+  ]
+}

--- a/packages/minimax/src/chat/convert-to-minimax-chat-messages.ts
+++ b/packages/minimax/src/chat/convert-to-minimax-chat-messages.ts
@@ -1,0 +1,155 @@
+import {
+  LanguageModelV3CallOptions,
+  LanguageModelV3Prompt,
+  SharedV3Warning,
+} from '@ai-sdk/provider';
+import { MiniMaxChatPrompt } from './minimax-chat-api-types';
+
+export function convertToMiniMaxChatMessages({
+  prompt,
+  responseFormat,
+}: {
+  prompt: LanguageModelV3Prompt;
+  responseFormat: LanguageModelV3CallOptions['responseFormat'];
+}): {
+  messages: MiniMaxChatPrompt;
+  warnings: Array<SharedV3Warning>;
+} {
+  const messages: MiniMaxChatPrompt = [];
+  const warnings: Array<SharedV3Warning> = [];
+
+  // Inject system message if response format is JSON
+  if (responseFormat?.type === 'json') {
+    if (responseFormat.schema == null) {
+      messages.push({
+        role: 'system',
+        content: 'Return JSON.',
+      });
+    } else {
+      messages.push({
+        role: 'system',
+        content:
+          'Return JSON that conforms to the following schema: ' +
+          JSON.stringify(responseFormat.schema),
+      });
+      warnings.push({
+        type: 'compatibility',
+        feature: 'responseFormat JSON schema',
+        details: 'JSON response schema is injected into the system message.',
+      });
+    }
+  }
+
+  for (const { role, content } of prompt) {
+    switch (role) {
+      case 'system': {
+        messages.push({ role: 'system', content });
+        break;
+      }
+
+      case 'user': {
+        let userContent = '';
+        for (const part of content) {
+          if (part.type === 'text') {
+            userContent += part.text;
+          } else {
+            warnings.push({
+              type: 'unsupported',
+              feature: `user message part type: ${part.type}`,
+            });
+          }
+        }
+
+        messages.push({
+          role: 'user',
+          content: userContent,
+        });
+
+        break;
+      }
+      case 'assistant': {
+        let text = '';
+
+        const toolCalls: Array<{
+          id: string;
+          type: 'function';
+          function: { name: string; arguments: string };
+        }> = [];
+
+        for (const part of content) {
+          switch (part.type) {
+            case 'text': {
+              text += part.text;
+              break;
+            }
+            case 'reasoning': {
+              // MiniMax does not support reasoning content
+              break;
+            }
+            case 'tool-call': {
+              toolCalls.push({
+                id: part.toolCallId,
+                type: 'function',
+                function: {
+                  name: part.toolName,
+                  arguments: JSON.stringify(part.input),
+                },
+              });
+              break;
+            }
+          }
+        }
+
+        messages.push({
+          role: 'assistant',
+          content: text,
+          tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+        });
+
+        break;
+      }
+
+      case 'tool': {
+        for (const toolResponse of content) {
+          if (toolResponse.type === 'tool-approval-response') {
+            continue;
+          }
+          const output = toolResponse.output;
+
+          let contentValue: string;
+          switch (output.type) {
+            case 'text':
+            case 'error-text':
+              contentValue = output.value;
+              break;
+            case 'execution-denied':
+              contentValue = output.reason ?? 'Tool execution denied.';
+              break;
+            case 'content':
+            case 'json':
+            case 'error-json':
+              contentValue = JSON.stringify(output.value);
+              break;
+          }
+
+          messages.push({
+            role: 'tool',
+            tool_call_id: toolResponse.toolCallId,
+            content: contentValue,
+          });
+        }
+        break;
+      }
+
+      default: {
+        warnings.push({
+          type: 'unsupported',
+          feature: `message role: ${role}`,
+        });
+        break;
+      }
+    }
+  }
+
+  return { messages, warnings };
+}

--- a/packages/minimax/src/chat/convert-to-minimax-usage.ts
+++ b/packages/minimax/src/chat/convert-to-minimax-usage.ts
@@ -1,0 +1,46 @@
+import { LanguageModelV3Usage } from '@ai-sdk/provider';
+
+export function convertMiniMaxUsage(
+  usage:
+    | {
+        prompt_tokens?: number | null | undefined;
+        completion_tokens?: number | null | undefined;
+      }
+    | undefined
+    | null,
+): LanguageModelV3Usage {
+  if (usage == null) {
+    return {
+      inputTokens: {
+        total: undefined,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: undefined,
+        text: undefined,
+        reasoning: undefined,
+      },
+      raw: undefined,
+    };
+  }
+
+  const promptTokens = usage.prompt_tokens ?? 0;
+  const completionTokens = usage.completion_tokens ?? 0;
+
+  return {
+    inputTokens: {
+      total: promptTokens,
+      noCache: undefined,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+    },
+    outputTokens: {
+      total: completionTokens,
+      text: completionTokens,
+      reasoning: undefined,
+    },
+    raw: usage,
+  };
+}

--- a/packages/minimax/src/chat/get-response-metadata.ts
+++ b/packages/minimax/src/chat/get-response-metadata.ts
@@ -1,0 +1,15 @@
+export function getResponseMetadata({
+  id,
+  model,
+  created,
+}: {
+  id?: string | undefined | null;
+  created?: number | undefined | null;
+  model?: string | undefined | null;
+}) {
+  return {
+    id: id ?? undefined,
+    modelId: model ?? undefined,
+    timestamp: created != null ? new Date(created * 1000) : undefined,
+  };
+}

--- a/packages/minimax/src/chat/map-minimax-finish-reason.ts
+++ b/packages/minimax/src/chat/map-minimax-finish-reason.ts
@@ -1,0 +1,18 @@
+import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
+
+export function mapMiniMaxFinishReason(
+  finishReason: string | null | undefined,
+): LanguageModelV3FinishReason['unified'] {
+  switch (finishReason) {
+    case 'stop':
+      return 'stop';
+    case 'length':
+      return 'length';
+    case 'content_filter':
+      return 'content-filter';
+    case 'tool_calls':
+      return 'tool-calls';
+    default:
+      return 'other';
+  }
+}

--- a/packages/minimax/src/chat/minimax-chat-api-types.ts
+++ b/packages/minimax/src/chat/minimax-chat-api-types.ts
@@ -1,0 +1,147 @@
+import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export type MiniMaxChatPrompt = Array<MiniMaxMessage>;
+
+export type MiniMaxMessage =
+  | MiniMaxSystemMessage
+  | MiniMaxUserMessage
+  | MiniMaxAssistantMessage
+  | MiniMaxToolMessage;
+
+export interface MiniMaxSystemMessage {
+  role: 'system';
+  content: string;
+}
+
+export interface MiniMaxUserMessage {
+  role: 'user';
+  content: string;
+}
+
+export interface MiniMaxAssistantMessage {
+  role: 'assistant';
+  content?: string | null;
+  tool_calls?: Array<MiniMaxMessageToolCall>;
+}
+
+export interface MiniMaxMessageToolCall {
+  type: 'function';
+  id: string;
+  function: {
+    arguments: string;
+    name: string;
+  };
+}
+
+export interface MiniMaxToolMessage {
+  role: 'tool';
+  content: string;
+  tool_call_id: string;
+}
+
+export interface MiniMaxFunctionTool {
+  type: 'function';
+  function: {
+    name: string;
+    description: string | undefined;
+    parameters: unknown;
+    strict?: boolean;
+  };
+}
+
+export type MiniMaxToolChoice =
+  | { type: 'function'; function: { name: string } }
+  | 'auto'
+  | 'none'
+  | 'required'
+  | undefined;
+
+const tokenUsageSchema = z
+  .object({
+    prompt_tokens: z.number().nullish(),
+    completion_tokens: z.number().nullish(),
+    total_tokens: z.number().nullish(),
+  })
+  .nullish();
+
+export type MiniMaxChatTokenUsage = z.infer<typeof tokenUsageSchema>;
+
+export const minimaxErrorSchema = z.object({
+  error: z.object({
+    message: z.string(),
+    type: z.string().nullish(),
+    param: z.any().nullish(),
+    code: z.union([z.string(), z.number()]).nullish(),
+  }),
+});
+
+export type MiniMaxErrorData = z.infer<typeof minimaxErrorSchema>;
+
+// limited version of the schema, focussed on what is needed for the implementation
+// this approach limits breakages when the API changes and increases efficiency
+export const minimaxChatResponseSchema = z.object({
+  id: z.string().nullish(),
+  created: z.number().nullish(),
+  model: z.string().nullish(),
+  choices: z.array(
+    z.object({
+      message: z.object({
+        role: z.literal('assistant').nullish(),
+        content: z.string().nullish(),
+        tool_calls: z
+          .array(
+            z.object({
+              id: z.string().nullish(),
+              function: z.object({
+                name: z.string(),
+                arguments: z.string(),
+              }),
+            }),
+          )
+          .nullish(),
+      }),
+      finish_reason: z.string().nullish(),
+    }),
+  ),
+  usage: tokenUsageSchema,
+});
+
+// limited version of the schema, focussed on what is needed for the implementation
+// this approach limits breakages when the API changes and increases efficiency
+export const minimaxChatChunkSchema = lazySchema(() =>
+  zodSchema(
+    z.union([
+      z.object({
+        id: z.string().nullish(),
+        created: z.number().nullish(),
+        model: z.string().nullish(),
+        choices: z.array(
+          z.object({
+            delta: z
+              .object({
+                role: z.enum(['assistant']).nullish(),
+                content: z.string().nullish(),
+                tool_calls: z
+                  .array(
+                    z.object({
+                      index: z.number(),
+                      id: z.string().nullish(),
+                      function: z.object({
+                        name: z.string().nullish(),
+                        arguments: z.string().nullish(),
+                      }),
+                    }),
+                  )
+                  .nullish(),
+              })
+              .nullish(),
+            finish_reason: z.string().nullish(),
+          }),
+        ),
+        usage: tokenUsageSchema,
+      }),
+      minimaxErrorSchema,
+    ]),
+  ),
+);

--- a/packages/minimax/src/chat/minimax-chat-language-model.ts
+++ b/packages/minimax/src/chat/minimax-chat-language-model.ts
@@ -1,0 +1,464 @@
+import {
+  APICallError,
+  InvalidResponseDataError,
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3Content,
+  LanguageModelV3FinishReason,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamPart,
+  LanguageModelV3StreamResult,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createEventSourceResponseHandler,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  FetchFunction,
+  generateId,
+  InferSchema,
+  isParsableJson,
+  parseProviderOptions,
+  ParseResult,
+  postJsonToApi,
+  ResponseHandler,
+} from '@ai-sdk/provider-utils';
+import { convertToMiniMaxChatMessages } from './convert-to-minimax-chat-messages';
+import { convertMiniMaxUsage } from './convert-to-minimax-usage';
+import {
+  minimaxChatChunkSchema,
+  minimaxChatResponseSchema,
+  MiniMaxChatTokenUsage,
+  minimaxErrorSchema,
+} from './minimax-chat-api-types';
+import {
+  MiniMaxChatModelId,
+  minimaxLanguageModelOptions,
+} from './minimax-chat-options';
+import { prepareTools } from './minimax-prepare-tools';
+import { getResponseMetadata } from './get-response-metadata';
+import { mapMiniMaxFinishReason } from './map-minimax-finish-reason';
+
+export type MiniMaxChatConfig = {
+  provider: string;
+  headers: () => Record<string, string | undefined>;
+  url: (options: { modelId: string; path: string }) => string;
+  fetch?: FetchFunction;
+};
+
+export class MiniMaxChatLanguageModel implements LanguageModelV3 {
+  readonly specificationVersion = 'v3';
+
+  readonly modelId: MiniMaxChatModelId;
+  readonly supportedUrls = {};
+
+  private readonly config: MiniMaxChatConfig;
+  private readonly failedResponseHandler: ResponseHandler<APICallError>;
+
+  constructor(modelId: MiniMaxChatModelId, config: MiniMaxChatConfig) {
+    this.modelId = modelId;
+    this.config = config;
+
+    this.failedResponseHandler = createJsonErrorResponseHandler({
+      errorSchema: minimaxErrorSchema,
+      errorToMessage: (error: InferSchema<typeof minimaxErrorSchema>) =>
+        error.error.message,
+    });
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  private get providerOptionsName(): string {
+    return this.config.provider.split('.')[0].trim();
+  }
+
+  private async getArgs({
+    prompt,
+    maxOutputTokens,
+    temperature,
+    topP,
+    topK,
+    frequencyPenalty,
+    presencePenalty,
+    providerOptions,
+    stopSequences,
+    responseFormat,
+    seed,
+    toolChoice,
+    tools,
+  }: LanguageModelV3CallOptions) {
+    await parseProviderOptions({
+      provider: this.providerOptionsName,
+      providerOptions,
+      schema: minimaxLanguageModelOptions,
+    });
+
+    const { messages, warnings } = convertToMiniMaxChatMessages({
+      prompt,
+      responseFormat,
+    });
+
+    if (topK != null) {
+      warnings.push({ type: 'unsupported', feature: 'topK' });
+    }
+
+    if (seed != null) {
+      warnings.push({ type: 'unsupported', feature: 'seed' });
+    }
+
+    const {
+      tools: minimaxTools,
+      toolChoice: minimaxToolChoices,
+      toolWarnings,
+    } = prepareTools({
+      tools,
+      toolChoice,
+    });
+
+    return {
+      args: {
+        model: this.modelId,
+        max_tokens: maxOutputTokens,
+        temperature,
+        top_p: topP,
+        frequency_penalty: frequencyPenalty,
+        presence_penalty: presencePenalty,
+        response_format:
+          responseFormat?.type === 'json' ? { type: 'json_object' } : undefined,
+        stop: stopSequences,
+        messages,
+        tools: minimaxTools,
+        tool_choice: minimaxToolChoices,
+      },
+      warnings: [...warnings, ...toolWarnings],
+    };
+  }
+
+  async doGenerate(
+    options: LanguageModelV3CallOptions,
+  ): Promise<LanguageModelV3GenerateResult> {
+    const { args, warnings } = await this.getArgs({ ...options });
+
+    const {
+      responseHeaders,
+      value: responseBody,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: this.config.url({
+        path: '/chat/completions',
+        modelId: this.modelId,
+      }),
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body: args,
+      failedResponseHandler: this.failedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        minimaxChatResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const choice = responseBody.choices[0];
+    const content: Array<LanguageModelV3Content> = [];
+
+    // tool calls:
+    if (choice.message.tool_calls != null) {
+      for (const toolCall of choice.message.tool_calls) {
+        content.push({
+          type: 'tool-call',
+          toolCallId: toolCall.id ?? generateId(),
+          toolName: toolCall.function.name,
+          input: toolCall.function.arguments!,
+        });
+      }
+    }
+
+    // text content:
+    const text = choice.message.content;
+    if (text != null && text.length > 0) {
+      content.push({ type: 'text', text });
+    }
+
+    return {
+      content,
+      finishReason: {
+        unified: mapMiniMaxFinishReason(choice.finish_reason),
+        raw: choice.finish_reason ?? undefined,
+      },
+      usage: convertMiniMaxUsage(responseBody.usage),
+      request: { body: args },
+      response: {
+        ...getResponseMetadata(responseBody),
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+      warnings,
+    };
+  }
+
+  async doStream(
+    options: LanguageModelV3CallOptions,
+  ): Promise<LanguageModelV3StreamResult> {
+    const { args, warnings } = await this.getArgs({ ...options });
+
+    const body = {
+      ...args,
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+
+    const { responseHeaders, value: response } = await postJsonToApi({
+      url: this.config.url({
+        path: '/chat/completions',
+        modelId: this.modelId,
+      }),
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body,
+      failedResponseHandler: this.failedResponseHandler,
+      successfulResponseHandler: createEventSourceResponseHandler(
+        minimaxChatChunkSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const toolCalls: Array<{
+      id: string;
+      type: 'function';
+      function: {
+        name: string;
+        arguments: string;
+      };
+      hasFinished: boolean;
+    }> = [];
+
+    let finishReason: LanguageModelV3FinishReason = {
+      unified: 'other',
+      raw: undefined,
+    };
+    let usage: MiniMaxChatTokenUsage | undefined = undefined;
+    let isFirstChunk = true;
+    let isActiveText = false;
+
+    return {
+      stream: response.pipeThrough(
+        new TransformStream<
+          ParseResult<InferSchema<typeof minimaxChatChunkSchema>>,
+          LanguageModelV3StreamPart
+        >({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings });
+          },
+
+          transform(chunk, controller) {
+            // Emit raw chunk if requested (before anything else)
+            if (options.includeRawChunks) {
+              controller.enqueue({ type: 'raw', rawValue: chunk.rawValue });
+            }
+
+            // handle failed chunk parsing / validation:
+            if (!chunk.success) {
+              finishReason = { unified: 'error', raw: undefined };
+              controller.enqueue({ type: 'error', error: chunk.error });
+              return;
+            }
+            const value = chunk.value;
+
+            // handle error chunks:
+            if ('error' in value) {
+              finishReason = { unified: 'error', raw: undefined };
+              controller.enqueue({ type: 'error', error: value.error.message });
+              return;
+            }
+
+            if (isFirstChunk) {
+              isFirstChunk = false;
+
+              controller.enqueue({
+                type: 'response-metadata',
+                ...getResponseMetadata(value),
+              });
+            }
+
+            if (value.usage != null) {
+              usage = value.usage;
+            }
+
+            const choice = value.choices[0];
+
+            if (choice?.finish_reason != null) {
+              finishReason = {
+                unified: mapMiniMaxFinishReason(choice.finish_reason),
+                raw: choice.finish_reason,
+              };
+            }
+
+            if (choice?.delta == null) {
+              return;
+            }
+
+            const delta = choice.delta;
+
+            if (delta.content) {
+              if (!isActiveText) {
+                controller.enqueue({ type: 'text-start', id: 'txt-0' });
+                isActiveText = true;
+              }
+
+              controller.enqueue({
+                type: 'text-delta',
+                id: 'txt-0',
+                delta: delta.content,
+              });
+            }
+
+            if (delta.tool_calls != null) {
+              for (const toolCallDelta of delta.tool_calls) {
+                const index = toolCallDelta.index;
+
+                if (toolCalls[index] == null) {
+                  if (toolCallDelta.id == null) {
+                    throw new InvalidResponseDataError({
+                      data: toolCallDelta,
+                      message: `Expected 'id' to be a string.`,
+                    });
+                  }
+
+                  if (toolCallDelta.function?.name == null) {
+                    throw new InvalidResponseDataError({
+                      data: toolCallDelta,
+                      message: `Expected 'function.name' to be a string.`,
+                    });
+                  }
+
+                  controller.enqueue({
+                    type: 'tool-input-start',
+                    id: toolCallDelta.id,
+                    toolName: toolCallDelta.function.name,
+                  });
+
+                  toolCalls[index] = {
+                    id: toolCallDelta.id,
+                    type: 'function',
+                    function: {
+                      name: toolCallDelta.function.name,
+                      arguments: toolCallDelta.function.arguments ?? '',
+                    },
+                    hasFinished: false,
+                  };
+
+                  const toolCall = toolCalls[index];
+
+                  if (
+                    toolCall.function?.name != null &&
+                    toolCall.function?.arguments != null
+                  ) {
+                    // send delta if the argument text has already started:
+                    if (toolCall.function.arguments.length > 0) {
+                      controller.enqueue({
+                        type: 'tool-input-delta',
+                        id: toolCall.id,
+                        delta: toolCall.function.arguments,
+                      });
+                    }
+
+                    // check if tool call is complete
+                    // (some providers send the full tool call in one chunk):
+                    if (isParsableJson(toolCall.function.arguments)) {
+                      controller.enqueue({
+                        type: 'tool-input-end',
+                        id: toolCall.id,
+                      });
+
+                      controller.enqueue({
+                        type: 'tool-call',
+                        toolCallId: toolCall.id ?? generateId(),
+                        toolName: toolCall.function.name,
+                        input: toolCall.function.arguments,
+                      });
+                      toolCall.hasFinished = true;
+                    }
+                  }
+
+                  continue;
+                }
+
+                // existing tool call, merge if not finished
+                const toolCall = toolCalls[index];
+
+                if (toolCall.hasFinished) {
+                  continue;
+                }
+
+                if (toolCallDelta.function?.arguments != null) {
+                  toolCall.function!.arguments +=
+                    toolCallDelta.function?.arguments ?? '';
+                }
+
+                // send delta
+                controller.enqueue({
+                  type: 'tool-input-delta',
+                  id: toolCall.id,
+                  delta: toolCallDelta.function.arguments ?? '',
+                });
+
+                // check if tool call is complete
+                if (
+                  toolCall.function?.name != null &&
+                  toolCall.function?.arguments != null &&
+                  isParsableJson(toolCall.function.arguments)
+                ) {
+                  controller.enqueue({
+                    type: 'tool-input-end',
+                    id: toolCall.id,
+                  });
+
+                  controller.enqueue({
+                    type: 'tool-call',
+                    toolCallId: toolCall.id ?? generateId(),
+                    toolName: toolCall.function.name,
+                    input: toolCall.function.arguments,
+                  });
+                  toolCall.hasFinished = true;
+                }
+              }
+            }
+          },
+
+          flush(controller) {
+            if (isActiveText) {
+              controller.enqueue({ type: 'text-end', id: 'txt-0' });
+            }
+
+            // go through all tool calls and send the ones that are not finished
+            for (const toolCall of toolCalls.filter(
+              toolCall => !toolCall.hasFinished,
+            )) {
+              controller.enqueue({
+                type: 'tool-input-end',
+                id: toolCall.id,
+              });
+
+              controller.enqueue({
+                type: 'tool-call',
+                toolCallId: toolCall.id ?? generateId(),
+                toolName: toolCall.function.name,
+                input: toolCall.function.arguments,
+              });
+            }
+
+            controller.enqueue({
+              type: 'finish',
+              finishReason,
+              usage: convertMiniMaxUsage(usage),
+            });
+          },
+        }),
+      ),
+      request: { body },
+      response: { headers: responseHeaders },
+    };
+  }
+}

--- a/packages/minimax/src/chat/minimax-chat-options.ts
+++ b/packages/minimax/src/chat/minimax-chat-options.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod/v4';
+
+// https://platform.minimax.io/docs/guides/text-generation
+export type MiniMaxChatModelId =
+  | 'MiniMax-M2'
+  | 'MiniMax-M2-Stable'
+  | 'MiniMax-M2.5'
+  | 'MiniMax-M2.5-highspeed'
+  | (string & {});
+
+export const minimaxLanguageModelOptions = z.object({});
+
+export type MiniMaxLanguageModelOptions = z.infer<
+  typeof minimaxLanguageModelOptions
+>;

--- a/packages/minimax/src/chat/minimax-prepare-tools.ts
+++ b/packages/minimax/src/chat/minimax-prepare-tools.ts
@@ -1,0 +1,82 @@
+import { LanguageModelV3CallOptions, SharedV3Warning } from '@ai-sdk/provider';
+import {
+  MiniMaxFunctionTool,
+  MiniMaxToolChoice,
+} from './minimax-chat-api-types';
+
+export function prepareTools({
+  tools,
+  toolChoice,
+}: {
+  tools: LanguageModelV3CallOptions['tools'];
+  toolChoice?: LanguageModelV3CallOptions['toolChoice'];
+}): {
+  tools: undefined | Array<MiniMaxFunctionTool>;
+  toolChoice: MiniMaxToolChoice;
+  toolWarnings: SharedV3Warning[];
+} {
+  // when the tools array is empty, change it to undefined to prevent errors:
+  tools = tools?.length ? tools : undefined;
+
+  const toolWarnings: SharedV3Warning[] = [];
+
+  if (tools == null) {
+    return { tools: undefined, toolChoice: undefined, toolWarnings };
+  }
+
+  const minimaxTools: Array<MiniMaxFunctionTool> = [];
+
+  for (const tool of tools) {
+    if (tool.type === 'provider') {
+      toolWarnings.push({
+        type: 'unsupported',
+        feature: `provider-defined tool ${tool.id}`,
+      });
+    } else {
+      minimaxTools.push({
+        type: 'function',
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.inputSchema,
+          ...(tool.strict != null ? { strict: tool.strict } : {}),
+        },
+      });
+    }
+  }
+
+  if (toolChoice == null) {
+    return { tools: minimaxTools, toolChoice: undefined, toolWarnings };
+  }
+
+  const type = toolChoice?.type;
+
+  switch (type) {
+    case 'auto':
+    case 'none':
+    case 'required':
+      return { tools: minimaxTools, toolChoice: type, toolWarnings };
+    case 'tool':
+      return {
+        tools: minimaxTools,
+        toolChoice: {
+          type: 'function',
+          function: { name: toolChoice.toolName },
+        },
+        toolWarnings,
+      };
+    default: {
+      return {
+        tools: minimaxTools,
+        toolChoice: undefined,
+        toolWarnings: [
+          ...toolWarnings,
+          {
+            type: 'unsupported',
+            feature: `tool choice type: ${type}`,
+          },
+        ],
+      };
+    }
+  }
+}

--- a/packages/minimax/src/index.ts
+++ b/packages/minimax/src/index.ts
@@ -1,0 +1,8 @@
+export { createMiniMax, minimax } from './minimax-provider';
+export type {
+  MiniMaxProvider,
+  MiniMaxProviderSettings,
+} from './minimax-provider';
+export { VERSION } from './version';
+export type { MiniMaxLanguageModelOptions } from './chat/minimax-chat-options';
+export type { MiniMaxErrorData } from './chat/minimax-chat-api-types';

--- a/packages/minimax/src/minimax-provider.ts
+++ b/packages/minimax/src/minimax-provider.ts
@@ -1,0 +1,108 @@
+import {
+  LanguageModelV3,
+  NoSuchModelError,
+  ProviderV3,
+} from '@ai-sdk/provider';
+import {
+  FetchFunction,
+  loadApiKey,
+  withoutTrailingSlash,
+  withUserAgentSuffix,
+} from '@ai-sdk/provider-utils';
+import { MiniMaxChatModelId } from './chat/minimax-chat-options';
+import { MiniMaxChatLanguageModel } from './chat/minimax-chat-language-model';
+import { VERSION } from './version';
+
+export interface MiniMaxProviderSettings {
+  /**
+   * MiniMax API key.
+   */
+  apiKey?: string;
+
+  /**
+   * Base URL for the API calls.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept requests,
+   * or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+}
+
+export interface MiniMaxProvider extends ProviderV3 {
+  /**
+   * Creates a MiniMax model for text generation.
+   */
+  (modelId: MiniMaxChatModelId): LanguageModelV3;
+
+  /**
+   * Creates a MiniMax model for text generation.
+   */
+  languageModel(modelId: MiniMaxChatModelId): LanguageModelV3;
+
+  /**
+   * Creates a MiniMax chat model for text generation.
+   */
+  chat(modelId: MiniMaxChatModelId): LanguageModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
+}
+
+export function createMiniMax(
+  options: MiniMaxProviderSettings = {},
+): MiniMaxProvider {
+  const baseURL = withoutTrailingSlash(
+    options.baseURL ?? 'https://api.minimax.io/v1',
+  );
+
+  const getHeaders = () =>
+    withUserAgentSuffix(
+      {
+        Authorization: `Bearer ${loadApiKey({
+          apiKey: options.apiKey,
+          environmentVariableName: 'MINIMAX_API_KEY',
+          description: 'MiniMax API key',
+        })}`,
+        ...options.headers,
+      },
+      `ai-sdk/minimax/${VERSION}`,
+    );
+
+  const createLanguageModel = (modelId: MiniMaxChatModelId) => {
+    return new MiniMaxChatLanguageModel(modelId, {
+      provider: `minimax.chat`,
+      url: ({ path }) => `${baseURL}${path}`,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+  };
+
+  const provider = (modelId: MiniMaxChatModelId) =>
+    createLanguageModel(modelId);
+
+  provider.specificationVersion = 'v3' as const;
+  provider.languageModel = createLanguageModel;
+  provider.chat = createLanguageModel;
+
+  provider.embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
+  };
+  provider.textEmbeddingModel = provider.embeddingModel;
+  provider.imageModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+  };
+
+  return provider;
+}
+
+export const minimax = createMiniMax();

--- a/packages/minimax/src/version.ts
+++ b/packages/minimax/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/minimax/tsconfig.build.json
+++ b/packages/minimax/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Disable project configuration for tsup builds
+    "composite": false
+  }
+}

--- a/packages/minimax/tsconfig.json
+++ b/packages/minimax/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": ["dist", "build", "node_modules", "tsup.config.ts"],
+  "references": [
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    },
+    {
+      "path": "../test-server"
+    }
+  ]
+}

--- a/packages/minimax/tsup.config.ts
+++ b/packages/minimax/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/minimax/turbo.json
+++ b/packages/minimax/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["**/dist/**"]
+    }
+  }
+}

--- a/packages/minimax/vitest.edge.config.js
+++ b/packages/minimax/vitest.edge.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/packages/minimax/vitest.node.config.js
+++ b/packages/minimax/vitest.node.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
       '@ai-sdk/mcp':
         specifier: workspace:*
         version: link:../../packages/mcp
+      '@ai-sdk/minimax':
+        specifier: workspace:*
+        version: link:../../packages/minimax
       '@ai-sdk/mistral':
         specifier: workspace:*
         version: link:../../packages/mistral
@@ -2517,6 +2520,34 @@ importers:
       vitest:
         specifier: 2.1.4
         version: 2.1.4(@edge-runtime/vm@5.0.0)(@types/node@20.17.24)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
+  packages/minimax:
+    dependencies:
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+    devDependencies:
+      '@ai-sdk/test-server':
+        specifier: workspace:*
+        version: link:../test-server
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.7.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -31828,7 +31859,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -31842,13 +31873,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
-      css-loader: 7.1.2(webpack@5.105.0)
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
+      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -31856,22 +31887,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
-      license-webpack-plugin: 4.0.2(webpack@5.105.0)
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
+      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0)
+      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -31881,7 +31912,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -31911,7 +31942,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -37348,7 +37379,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -42454,7 +42485,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -43255,7 +43286,7 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -43362,7 +43393,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0):
+  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -44449,7 +44480,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.1)
       eslint-plugin-react: 7.34.1(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -44539,8 +44570,8 @@ snapshots:
       debug: 4.4.3(supports-color@9.4.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       fast-glob: 3.3.3
       get-tsconfig: 4.8.1
       is-core-module: 2.16.1
@@ -44590,7 +44621,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -44666,7 +44697,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -44676,7 +44707,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -47574,7 +47605,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -47601,7 +47632,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0):
+  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -48693,7 +48724,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -50222,7 +50253,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -51310,7 +51341,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -51760,7 +51791,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0):
+  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -54184,7 +54215,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     { "path": "packages/llamaindex" },
     { "path": "packages/lmnt" },
     { "path": "packages/luma" },
+    { "path": "packages/minimax" },
     { "path": "packages/mistral" },
     { "path": "packages/moonshotai" },
     { "path": "packages/openai" },


### PR DESCRIPTION
## Summary

- Add first-party MiniMax provider (`@ai-sdk/minimax`) with support for MiniMax-M2, MiniMax-M2-Stable, MiniMax-M2.5, and MiniMax-M2.5-highspeed models
- The provider uses MiniMax's OpenAI-compatible API endpoint (`https://api.minimax.io/v1`) and follows the same architecture pattern as existing providers (e.g., DeepSeek)
- Updated the existing community provider docs to reference the new first-party package

## What's Included

- **Provider package** (`packages/minimax/`): Full provider implementation with chat language model, streaming, and tool calling support
- **Documentation** (`content/providers/01-ai-sdk-providers/33-minimax.mdx`): First-party provider docs with setup instructions and model capabilities
- **Example** (`examples/ai-functions/src/stream-text/minimax/basic.ts`): Stream text example
- **Changeset**: Initial major release changeset
- **Community docs update**: Added note pointing to the new first-party package

## MiniMax Models

| Model | Context Window | Description |
|-------|---------------|-------------|
| `MiniMax-M2.5` | 204K | Latest flagship model |
| `MiniMax-M2.5-highspeed` | 204K | Optimized for speed |
| `MiniMax-M2` | - | Previous generation |
| `MiniMax-M2-Stable` | - | Stable version of M2 |

## Test plan

- [x] Package builds successfully (`pnpm build` in `packages/minimax/`)
- [x] TypeScript type checking passes (`pnpm type-check`)
- [ ] CI passes on all checks
- [ ] Manual testing with MiniMax API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)