### PR TITLE
chore(provider/open-responses): update provider to use v4 types

### DIFF
--- a/.changeset/selfish-spoons-reflect.md
+++ b/.changeset/selfish-spoons-reflect.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/open-responses': patch
+---
+
+chore(provider/open-responses): update provider to use v4 types

--- a/packages/open-responses/src/open-responses-provider.ts
+++ b/packages/open-responses/src/open-responses-provider.ts
@@ -1,7 +1,7 @@
 import {
-  LanguageModelV3,
+  LanguageModelV4,
   NoSuchModelError,
-  ProviderV3,
+  ProviderV4,
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
@@ -12,8 +12,8 @@ import {
 import { OpenResponsesLanguageModel } from './responses/open-responses-language-model';
 import { VERSION } from './version';
 
-export interface OpenResponsesProvider extends ProviderV3 {
-  (modelId: string): LanguageModelV3;
+export interface OpenResponsesProvider extends ProviderV4 {
+  (modelId: string): LanguageModelV4;
 }
 
 export interface OpenResponsesProviderSettings {
@@ -86,7 +86,7 @@ export function createOpenResponses(
     return createLanguageModel(modelId);
   };
 
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.languageModel = createLanguageModel;
 
   provider.embeddingModel = (modelId: string) => {

--- a/packages/open-responses/src/responses/convert-to-open-responses-input.ts
+++ b/packages/open-responses/src/responses/convert-to-open-responses-input.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV3Prompt, SharedV3Warning } from '@ai-sdk/provider';
+import { LanguageModelV4Prompt, SharedV4Warning } from '@ai-sdk/provider';
 import { convertToBase64 } from '@ai-sdk/provider-utils';
 import {
   FunctionCallItemParam,
@@ -14,14 +14,14 @@ import {
 export async function convertToOpenResponsesInput({
   prompt,
 }: {
-  prompt: LanguageModelV3Prompt;
+  prompt: LanguageModelV4Prompt;
 }): Promise<{
   input: OpenResponsesRequestBody['input'];
   instructions: string | undefined;
-  warnings: Array<SharedV3Warning>;
+  warnings: Array<SharedV4Warning>;
 }> {
   const input: OpenResponsesRequestBody['input'] = [];
-  const warnings: Array<SharedV3Warning> = [];
+  const warnings: Array<SharedV4Warning> = [];
   const systemMessages: string[] = [];
 
   for (const { role, content } of prompt) {

--- a/packages/open-responses/src/responses/map-open-responses-finish-reason.ts
+++ b/packages/open-responses/src/responses/map-open-responses-finish-reason.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
+import { LanguageModelV4FinishReason } from '@ai-sdk/provider';
 
 export function mapOpenResponsesFinishReason({
   finishReason,
@@ -6,7 +6,7 @@ export function mapOpenResponsesFinishReason({
 }: {
   finishReason: string | null | undefined;
   hasToolCalls: boolean;
-}): LanguageModelV3FinishReason['unified'] {
+}): LanguageModelV4FinishReason['unified'] {
   switch (finishReason) {
     case undefined:
     case null:

--- a/packages/open-responses/src/responses/open-responses-language-model.test.ts
+++ b/packages/open-responses/src/responses/open-responses-language-model.test.ts
@@ -1,6 +1,6 @@
 import {
-  LanguageModelV3GenerateResult,
-  LanguageModelV3Prompt,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4Prompt,
 } from '@ai-sdk/provider';
 import {
   convertReadableStreamToArray,
@@ -12,7 +12,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { OpenResponsesLanguageModel } from './open-responses-language-model';
 
 describe('OpenResponsesLanguageModel', () => {
-  const TEST_PROMPT: LanguageModelV3Prompt = [
+  const TEST_PROMPT: LanguageModelV4Prompt = [
     { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
   ];
 
@@ -46,7 +46,7 @@ describe('OpenResponsesLanguageModel', () => {
     }
 
     describe('basic generation', () => {
-      let result: LanguageModelV3GenerateResult;
+      let result: LanguageModelV4GenerateResult;
 
       beforeEach(async () => {
         prepareJsonFixtureResponse('lmstudio-basic.1');
@@ -70,7 +70,7 @@ describe('OpenResponsesLanguageModel', () => {
     });
 
     describe('request parameters', () => {
-      let result: LanguageModelV3GenerateResult;
+      let result: LanguageModelV4GenerateResult;
 
       beforeEach(async () => {
         prepareJsonFixtureResponse('lmstudio-basic.1');
@@ -103,7 +103,7 @@ describe('OpenResponsesLanguageModel', () => {
     });
 
     describe('tools', () => {
-      let result: LanguageModelV3GenerateResult;
+      let result: LanguageModelV4GenerateResult;
 
       beforeEach(async () => {
         prepareJsonFixtureResponse('lmstudio-basic.1');
@@ -151,7 +151,7 @@ describe('OpenResponsesLanguageModel', () => {
     });
 
     describe('tool call parsing', () => {
-      let result: LanguageModelV3GenerateResult;
+      let result: LanguageModelV4GenerateResult;
 
       beforeEach(async () => {
         prepareJsonFixtureResponse('lmstudio-tool-call.1');
@@ -300,7 +300,7 @@ describe('OpenResponsesLanguageModel', () => {
       it('should send correct request body with user, assistant tool-call, and tool result', async () => {
         prepareJsonFixtureResponse('lmstudio-basic.1');
 
-        const toolConversationPrompt: LanguageModelV3Prompt = [
+        const toolConversationPrompt: LanguageModelV4Prompt = [
           {
             role: 'user',
             content: [{ type: 'text', text: 'What is the weather in Tokyo?' }],

--- a/packages/open-responses/src/responses/open-responses-language-model.ts
+++ b/packages/open-responses/src/responses/open-responses-language-model.ts
@@ -1,13 +1,13 @@
 import {
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  LanguageModelV3Content,
-  LanguageModelV3FinishReason,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamPart,
-  LanguageModelV3StreamResult,
-  LanguageModelV3Usage,
-  SharedV3Warning,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4Content,
+  LanguageModelV4FinishReason,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamPart,
+  LanguageModelV4StreamResult,
+  LanguageModelV4Usage,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -31,8 +31,8 @@ import {
 import { mapOpenResponsesFinishReason } from './map-open-responses-finish-reason';
 import { OpenResponsesConfig } from './open-responses-config';
 
-export class OpenResponsesLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = 'v3';
+export class OpenResponsesLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4';
 
   readonly modelId: string;
 
@@ -65,11 +65,11 @@ export class OpenResponsesLanguageModel implements LanguageModelV3 {
     tools,
     toolChoice,
     responseFormat,
-  }: LanguageModelV3CallOptions): Promise<{
+  }: LanguageModelV4CallOptions): Promise<{
     body: Omit<OpenResponsesRequestBody, 'stream' | 'stream_options'>;
-    warnings: SharedV3Warning[];
+    warnings: SharedV4Warning[];
   }> {
-    const warnings: SharedV3Warning[] = [];
+    const warnings: SharedV4Warning[] = [];
 
     if (stopSequences != null) {
       warnings.push({ type: 'unsupported', feature: 'stopSequences' });
@@ -146,8 +146,8 @@ export class OpenResponsesLanguageModel implements LanguageModelV3 {
   }
 
   async doGenerate(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3GenerateResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4GenerateResult> {
     const { body, warnings } = await this.getArgs(options);
 
     const {
@@ -172,7 +172,7 @@ export class OpenResponsesLanguageModel implements LanguageModelV3 {
       fetch: this.config.fetch,
     });
 
-    const content: Array<LanguageModelV3Content> = [];
+    const content: Array<LanguageModelV4Content> = [];
     let hasToolCalls = false;
 
     for (const part of response.output!) {
@@ -255,8 +255,8 @@ export class OpenResponsesLanguageModel implements LanguageModelV3 {
   }
 
   async doStream(
-    options: LanguageModelV3CallOptions,
-  ): Promise<LanguageModelV3StreamResult> {
+    options: LanguageModelV4CallOptions,
+  ): Promise<LanguageModelV4StreamResult> {
     const { body, warnings } = await this.getArgs(options);
 
     const { responseHeaders, value: response } = await postJsonToApi({
@@ -276,7 +276,7 @@ export class OpenResponsesLanguageModel implements LanguageModelV3 {
       fetch: this.config.fetch,
     });
 
-    const usage: LanguageModelV3Usage = {
+    const usage: LanguageModelV4Usage = {
       inputTokens: {
         total: undefined,
         noCache: undefined,
@@ -320,7 +320,7 @@ export class OpenResponsesLanguageModel implements LanguageModelV3 {
 
     let isActiveReasoning = false;
     let hasToolCalls = false;
-    let finishReason: LanguageModelV3FinishReason = {
+    let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
       raw: undefined,
     };
@@ -333,7 +333,7 @@ export class OpenResponsesLanguageModel implements LanguageModelV3 {
       stream: response.pipeThrough(
         new TransformStream<
           ParseResult<OpenResponsesChunk>,
-          LanguageModelV3StreamPart
+          LanguageModelV4StreamPart
         >({
           start(controller) {
             controller.enqueue({ type: 'stream-start', warnings });


### PR DESCRIPTION
## Background

Migrate the `open-responses` provider to use V4 types from the `provider` package, aligning it with the ongoing spec version upgrade across all providers.

## Summary

Renamed all V3 type references to their V4 equivalents and updated `specificationVersion` from `'v3'` to `'v4'`. This is a pure rename — V3 and V4 types are currently identical.

Similar to e.g. #13375, #13417, etc.

## Manual Verification

N/A — pure type rename, verified via full type check and running tests.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
