### PR TITLE
chore(provider/prodia): update provider to use v4 types

### DIFF
--- a/.changeset/gorgeous-snails-sing.md
+++ b/.changeset/gorgeous-snails-sing.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/prodia': patch
+---
+
+chore(provider/prodia): update provider to use v4 types

--- a/packages/prodia/src/prodia-image-model.test.ts
+++ b/packages/prodia/src/prodia-image-model.test.ts
@@ -616,7 +616,7 @@ describe('ProdiaImageModel', () => {
 
       expect(model.provider).toBe('prodia.image');
       expect(model.modelId).toBe('inference.flux-fast.schnell.txt2img.v2');
-      expect(model.specificationVersion).toBe('v3');
+      expect(model.specificationVersion).toBe('v4');
       expect(model.maxImagesPerCall).toBe(1);
     });
   });

--- a/packages/prodia/src/prodia-image-model.ts
+++ b/packages/prodia/src/prodia-image-model.ts
@@ -1,4 +1,4 @@
-import type { ImageModelV3, SharedV3Warning } from '@ai-sdk/provider';
+import type { ImageModelV4, SharedV4Warning } from '@ai-sdk/provider';
 import type { InferSchema, Resolvable } from '@ai-sdk/provider-utils';
 import {
   combineHeaders,
@@ -13,8 +13,8 @@ import {
 import { z } from 'zod/v4';
 import type { ProdiaImageModelId } from './prodia-image-settings';
 
-export class ProdiaImageModel implements ImageModelV3 {
-  readonly specificationVersion = 'v3';
+export class ProdiaImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4';
   readonly maxImagesPerCall = 1;
 
   get provider(): string {
@@ -31,8 +31,8 @@ export class ProdiaImageModel implements ImageModelV3 {
     size,
     seed,
     providerOptions,
-  }: Parameters<ImageModelV3['doGenerate']>[0]) {
-    const warnings: Array<SharedV3Warning> = [];
+  }: Parameters<ImageModelV4['doGenerate']>[0]) {
+    const warnings: Array<SharedV4Warning> = [];
 
     const prodiaOptions = await parseProviderOptions({
       provider: 'prodia',
@@ -103,8 +103,8 @@ export class ProdiaImageModel implements ImageModelV3 {
   }
 
   async doGenerate(
-    options: Parameters<ImageModelV3['doGenerate']>[0],
-  ): Promise<Awaited<ReturnType<ImageModelV3['doGenerate']>>> {
+    options: Parameters<ImageModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<ImageModelV4['doGenerate']>>> {
     const { body, warnings } = await this.getArgs(options);
 
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();

--- a/packages/prodia/src/prodia-provider.test.ts
+++ b/packages/prodia/src/prodia-provider.test.ts
@@ -66,7 +66,7 @@ describe('Prodia provider', () => {
     expect(imageModel.provider).toBe('prodia.image');
     expect(imageModel.modelId).toBe('inference.flux-fast.schnell.txt2img.v2');
     expect(imageModel2.modelId).toBe('inference.flux.schnell.txt2img.v2');
-    expect(imageModel.specificationVersion).toBe('v3');
+    expect(imageModel.specificationVersion).toBe('v4');
   });
 
   it('configures baseURL and headers correctly', async () => {

--- a/packages/prodia/src/prodia-provider.ts
+++ b/packages/prodia/src/prodia-provider.ts
@@ -1,7 +1,7 @@
 import {
-  type ImageModelV3,
+  type ImageModelV4,
   NoSuchModelError,
-  type ProviderV3,
+  type ProviderV4,
 } from '@ai-sdk/provider';
 import type { FetchFunction } from '@ai-sdk/provider-utils';
 import {
@@ -36,16 +36,16 @@ export interface ProdiaProviderSettings {
   fetch?: FetchFunction;
 }
 
-export interface ProdiaProvider extends ProviderV3 {
+export interface ProdiaProvider extends ProviderV4 {
   /**
    * Creates a model for image generation.
    */
-  image(modelId: ProdiaImageModelId): ImageModelV3;
+  image(modelId: ProdiaImageModelId): ImageModelV4;
 
   /**
    * Creates a model for image generation.
    */
-  imageModel(modelId: ProdiaImageModelId): ImageModelV3;
+  imageModel(modelId: ProdiaImageModelId): ImageModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
@@ -95,7 +95,7 @@ export function createProdia(
   };
 
   return {
-    specificationVersion: 'v3',
+    specificationVersion: 'v4',
     imageModel: createImageModel,
     image: createImageModel,
     languageModel,


### PR DESCRIPTION
## Background

Migrate the `prodia` provider to use V4 types from the `provider` package, aligning it with the ongoing spec version upgrade across all providers.

## Summary

Renamed all V3 type references to their V4 equivalents and updated `specificationVersion` from `'v3'` to `'v4'`. This is a pure rename — V3 and V4 types are currently identical.

Similar to e.g. #13375, #13417, etc.

## Manual Verification

N/A — pure type rename, verified via full type check and running tests.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
