### PR TITLE
chore(provider/replicate): update provider to use v4 types

### DIFF
--- a/.changeset/slow-ghosts-draw.md
+++ b/.changeset/slow-ghosts-draw.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/replicate': patch
+---
+
+chore(provider/replicate): update provider to use v4 types

--- a/packages/replicate/src/replicate-image-model.ts
+++ b/packages/replicate/src/replicate-image-model.ts
@@ -1,4 +1,4 @@
-import type { ImageModelV3, SharedV3Warning } from '@ai-sdk/provider';
+import type { ImageModelV4, SharedV4Warning } from '@ai-sdk/provider';
 import type { Resolvable } from '@ai-sdk/provider-utils';
 import {
   combineHeaders,
@@ -32,8 +32,8 @@ interface ReplicateImageModelConfig {
 const FLUX_2_MODEL_PATTERN = /^black-forest-labs\/flux-2-/;
 const MAX_FLUX_2_INPUT_IMAGES = 8;
 
-export class ReplicateImageModel implements ImageModelV3 {
-  readonly specificationVersion = 'v3';
+export class ReplicateImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4';
 
   get maxImagesPerCall(): number {
     // Flux-2 models support up to 8 input images
@@ -64,10 +64,10 @@ export class ReplicateImageModel implements ImageModelV3 {
     abortSignal,
     files,
     mask,
-  }: Parameters<ImageModelV3['doGenerate']>[0]): Promise<
-    Awaited<ReturnType<ImageModelV3['doGenerate']>>
+  }: Parameters<ImageModelV4['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV4['doGenerate']>>
   > {
-    const warnings: Array<SharedV3Warning> = [];
+    const warnings: Array<SharedV4Warning> = [];
 
     const [modelId, version] = this.modelId.split(':');
 

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -1,7 +1,7 @@
 import {
-  Experimental_VideoModelV3,
+  Experimental_VideoModelV4,
   NoSuchModelError,
-  ProviderV3,
+  ProviderV4,
 } from '@ai-sdk/provider';
 import type { FetchFunction } from '@ai-sdk/provider-utils';
 import { loadApiKey, withUserAgentSuffix } from '@ai-sdk/provider-utils';
@@ -36,7 +36,7 @@ export interface ReplicateProviderSettings {
   fetch?: FetchFunction;
 }
 
-export interface ReplicateProvider extends ProviderV3 {
+export interface ReplicateProvider extends ProviderV4 {
   /**
    * Creates a Replicate image generation model.
    */
@@ -55,12 +55,12 @@ export interface ReplicateProvider extends ProviderV3 {
   /**
    * Creates a Replicate video generation model.
    */
-  video(modelId: ReplicateVideoModelId): Experimental_VideoModelV3;
+  video(modelId: ReplicateVideoModelId): Experimental_VideoModelV4;
 
   /**
    * Creates a Replicate video generation model.
    */
-  videoModel(modelId: ReplicateVideoModelId): Experimental_VideoModelV3;
+  videoModel(modelId: ReplicateVideoModelId): Experimental_VideoModelV4;
 }
 
 /**
@@ -106,7 +106,7 @@ export function createReplicate(
   };
 
   return {
-    specificationVersion: 'v3' as const,
+    specificationVersion: 'v4' as const,
     image: createImageModel,
     imageModel: createImageModel,
     languageModel: (modelId: string) => {

--- a/packages/replicate/src/replicate-video-model.test.ts
+++ b/packages/replicate/src/replicate-video-model.test.ts
@@ -143,7 +143,7 @@ describe('ReplicateVideoModel', () => {
 
       expect(model.provider).toBe('replicate.video');
       expect(model.modelId).toBe('minimax/video-01');
-      expect(model.specificationVersion).toBe('v3');
+      expect(model.specificationVersion).toBe('v4');
       expect(model.maxVideosPerCall).toBe(1);
     });
 

--- a/packages/replicate/src/replicate-video-model.ts
+++ b/packages/replicate/src/replicate-video-model.ts
@@ -1,7 +1,7 @@
 import {
   AISDKError,
-  type Experimental_VideoModelV3,
-  type SharedV3Warning,
+  type Experimental_VideoModelV4,
+  type SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -55,8 +55,8 @@ interface ReplicateVideoModelConfig {
   };
 }
 
-export class ReplicateVideoModel implements Experimental_VideoModelV3 {
-  readonly specificationVersion = 'v3';
+export class ReplicateVideoModel implements Experimental_VideoModelV4 {
+  readonly specificationVersion = 'v4';
   readonly maxVideosPerCall = 1; // Replicate video models support 1 video at a time
 
   get provider(): string {
@@ -69,10 +69,10 @@ export class ReplicateVideoModel implements Experimental_VideoModelV3 {
   ) {}
 
   async doGenerate(
-    options: Parameters<Experimental_VideoModelV3['doGenerate']>[0],
-  ): Promise<Awaited<ReturnType<Experimental_VideoModelV3['doGenerate']>>> {
+    options: Parameters<Experimental_VideoModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<Experimental_VideoModelV4['doGenerate']>>> {
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
-    const warnings: SharedV3Warning[] = [];
+    const warnings: SharedV4Warning[] = [];
 
     const replicateOptions = (await parseProviderOptions({
       provider: 'replicate',


### PR DESCRIPTION
## Background

Migrate the `replicate` provider to use V4 types from the `provider` package, aligning it with the ongoing spec version upgrade across all providers.

## Summary

Renamed all V3 type references to their V4 equivalents and updated `specificationVersion` from `'v3'` to `'v4'`. This is a pure rename — V3 and V4 types are currently identical.

Similar to e.g. #13375, #13417, etc.

## Manual Verification

N/A — pure type rename, verified via full type check and running tests.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
