### PR TITLE
chore(provider/revai): update provider to use v4 types

### DIFF
--- a/.changeset/thirty-spoons-eat.md
+++ b/.changeset/thirty-spoons-eat.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/revai': patch
+---
+
+chore(provider/revai): update provider to use v4 types

--- a/packages/revai/src/revai-provider.ts
+++ b/packages/revai/src/revai-provider.ts
@@ -1,6 +1,6 @@
 import {
-  TranscriptionModelV3,
-  ProviderV3,
+  TranscriptionModelV4,
+  ProviderV4,
   NoSuchModelError,
 } from '@ai-sdk/provider';
 import {
@@ -12,7 +12,7 @@ import { RevaiTranscriptionModel } from './revai-transcription-model';
 import { RevaiTranscriptionModelId } from './revai-transcription-options';
 import { VERSION } from './version';
 
-export interface RevaiProvider extends ProviderV3 {
+export interface RevaiProvider extends ProviderV4 {
   (
     modelId: 'machine',
     settings?: {},
@@ -23,7 +23,7 @@ export interface RevaiProvider extends ProviderV3 {
   /**
    * Creates a model for transcription.
    */
-  transcription(modelId: RevaiTranscriptionModelId): TranscriptionModelV3;
+  transcription(modelId: RevaiTranscriptionModelId): TranscriptionModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
@@ -82,7 +82,7 @@ export function createRevai(
     };
   };
 
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.transcription = createTranscriptionModel;
   provider.transcriptionModel = createTranscriptionModel;
 

--- a/packages/revai/src/revai-transcription-model.ts
+++ b/packages/revai/src/revai-transcription-model.ts
@@ -1,7 +1,7 @@
 import {
   AISDKError,
-  TranscriptionModelV3,
-  SharedV3Warning,
+  TranscriptionModelV4,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -220,8 +220,8 @@ interface RevaiTranscriptionModelConfig extends RevaiConfig {
   };
 }
 
-export class RevaiTranscriptionModel implements TranscriptionModelV3 {
-  readonly specificationVersion = 'v3';
+export class RevaiTranscriptionModel implements TranscriptionModelV4 {
+  readonly specificationVersion = 'v4';
 
   get provider(): string {
     return this.config.provider;
@@ -236,8 +236,8 @@ export class RevaiTranscriptionModel implements TranscriptionModelV3 {
     audio,
     mediaType,
     providerOptions,
-  }: Parameters<TranscriptionModelV3['doGenerate']>[0]) {
-    const warnings: SharedV3Warning[] = [];
+  }: Parameters<TranscriptionModelV4['doGenerate']>[0]) {
+    const warnings: SharedV4Warning[] = [];
 
     // Parse provider options
     const revaiOptions = await parseProviderOptions({
@@ -314,8 +314,8 @@ export class RevaiTranscriptionModel implements TranscriptionModelV3 {
   }
 
   async doGenerate(
-    options: Parameters<TranscriptionModelV3['doGenerate']>[0],
-  ): Promise<Awaited<ReturnType<TranscriptionModelV3['doGenerate']>>> {
+    options: Parameters<TranscriptionModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<TranscriptionModelV4['doGenerate']>>> {
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const { formData, warnings } = await this.getArgs(options);
 


### PR DESCRIPTION
## Background

Migrate the `revai` provider to use V4 types from the `provider` package, aligning it with the ongoing spec version upgrade across all providers.

## Summary

Renamed all V3 type references to their V4 equivalents and updated `specificationVersion` from `'v3'` to `'v4'`. This is a pure rename — V3 and V4 types are currently identical.

Similar to e.g. #13375, #13417, etc.

## Manual Verification

N/A — pure type rename, verified via full type check and running tests.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
