### PR TITLE
fix: filter tools by activeTools before parsing/executing tool calls

### DIFF
--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -771,6 +771,19 @@ export async function generateText<
         });
 
         // parse tool calls:
+        // Filter tools to only include active tools, so that tool calls
+        // for disabled tools are rejected as NoSuchToolError instead of
+        // being parsed and executed. When no activeTools filter is set,
+        // all tools are available.
+        const effectiveTools =
+          stepActiveTools != null && tools != null
+            ? (Object.fromEntries(
+                Object.entries(tools).filter(([name]) =>
+                  (stepActiveTools as string[]).includes(name),
+                ),
+              ) as TOOLS)
+            : tools;
+
         const stepToolCalls: TypedToolCall<TOOLS>[] = await Promise.all(
           currentModelResponse.content
             .filter(
@@ -780,7 +793,7 @@ export async function generateText<
             .map(toolCall =>
               parseToolCall({
                 toolCall,
-                tools,
+                tools: effectiveTools,
                 repairToolCall,
                 system,
                 messages: stepInputMessages,

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1589,8 +1589,19 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
             }),
           );
 
+          // Filter tools to only include active tools, so that tool calls
+          // for disabled tools are rejected instead of being executed.
+          const effectiveTools =
+            stepActiveTools != null && tools != null
+              ? (Object.fromEntries(
+                  Object.entries(tools).filter(([name]) =>
+                    (stepActiveTools as string[]).includes(name),
+                  ),
+                ) as TOOLS)
+              : tools;
+
           const streamWithToolResults = runToolsTransformation({
-            tools,
+            tools: effectiveTools,
             generatorStream: stream,
             telemetry,
             callId,


### PR DESCRIPTION
## Summary

Fixes #13448

When `activeTools` is set, tool calls from the model are correctly **filtered when sent to the provider** (`prepareToolsAndToolChoice`), but the **parsing and execution** still uses the full `tools` object. This means a model can return a tool call for a disabled tool and it will be parsed, validated, and executed.

## Root cause

`parseToolCall()` receives the unfiltered `tools` object:

```typescript
// Before (both generateText and streamText)
parseToolCall({ toolCall, tools, ... })
//                        ^^^^^ full tools object — disabled tools pass validation
```

## Fix

Filter `tools` down to only include active tools before passing to `parseToolCall` / `runToolsTransformation`:

```typescript
// After
const effectiveTools = stepActiveTools != null && tools != null
  ? Object.fromEntries(
      Object.entries(tools).filter(([name]) => stepActiveTools.includes(name))
    )
  : tools;

parseToolCall({ toolCall, tools: effectiveTools, ... })
```

Tool calls for disabled tools now throw `NoSuchToolError` and are marked as `invalid: true`.

## Changed files

| File | Path |
|------|------|
| generateText | `packages/ai/src/generate-text/generate-text.ts` |
| streamText | `packages/ai/src/generate-text/stream-text.ts` |

Both paths (sync and streaming) are fixed consistently.

## Verification

The minimal repro from #13448 should now produce:
- `executed === false`
- Tool call marked as `invalid: true` with `NoSuchToolError`
- `toolResults` does not contain the disabled tool's result