### PR TITLE
fix(ai): skip data: URLs in downloadAssets to prevent AI_DownloadError on inline base64 attachments (fixes #13103)

### DIFF
--- a/.changeset/fix-data-url-ssrf-bypass-download.md
+++ b/.changeset/fix-data-url-ssrf-bypass-download.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): skip download for data: URLs in downloadAssets to prevent AI_DownloadError on inline base64 attachments

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -231,6 +231,41 @@ describe('convertToLanguageModelPrompt', () => {
           },
         ]);
       });
+
+      it('should not download image data URLs (inline base64)', async () => {
+        const downloadFn = vi.fn();
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'image',
+                    image: 'data:image/png;base64,/9j/3Q==',
+                  },
+                ],
+              },
+            ],
+          },
+          supportedUrls: {},
+          download: createDefaultDownloadFunction(downloadFn),
+        });
+
+        expect(downloadFn).not.toHaveBeenCalled();
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'image/jpeg',
+                data: '/9j/3Q==',
+              },
+            ],
+          },
+        ]);
+      });
     });
 
     describe('file parts', () => {
@@ -506,6 +541,42 @@ describe('convertToLanguageModelPrompt', () => {
                 type: 'file',
                 mediaType: 'application/pdf',
                 data: new Uint8Array([0, 1, 2, 3]),
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should not download file data URLs (inline base64)', async () => {
+        const downloadFn = vi.fn();
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'file',
+                    data: 'data:application/pdf;base64,dGVzdA==',
+                    mediaType: 'application/pdf',
+                  },
+                ],
+              },
+            ],
+          },
+          supportedUrls: {},
+          download: createDefaultDownloadFunction(downloadFn),
+        });
+
+        expect(downloadFn).not.toHaveBeenCalled();
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'application/pdf',
+                data: 'dGVzdA==',
               },
             ],
           },

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -420,7 +420,7 @@ async function downloadAssets(
 
     .filter(
       (part): part is { mediaType: string | undefined; data: URL } =>
-        part.data instanceof URL,
+        part.data instanceof URL && part.data.protocol !== 'data:',
     )
     .map(part => ({
       url: part.data,


### PR DESCRIPTION
## Summary

Fixes #13103.

`downloadAssets()` in `packages/ai/src/prompt/convert-to-language-model-prompt.ts` incorrectly attempts to download `data:` URLs, causing `AI_DownloadError: URL scheme must be http or https, got data:` when users send inline base64 images or PDFs (e.g. `data:image/png;base64,...`).

---

## Root Cause

In `downloadAssets()` (~line 365), string data values are converted to `URL` objects via `new URL(data)`. Since `data:image/png;base64,...` is syntactically valid, `new URL(...)` succeeds, producing a `URL` with `protocol === 'data:'`. This object then passes the `.filter(part => part.data instanceof URL)` check on line 374, landing in `plannedDownloads`.

The default download function delegates to `download()` in `@ai-sdk/provider-utils`, which calls `validateDownloadUrl()`. That function rejects any URL where `protocol !== 'http:' && protocol !== 'https:'`, throwing:

```
AI_DownloadError: URL scheme must be http or https, got data:
```

The crash happens before `convertToLanguageModelV4DataContent()` ever runs — which **already handles `data:` URLs correctly** by extracting the base64 payload (line 53 in `data-content.ts`):

```ts
// data-content.ts:53 — this code path was never reached
if (content instanceof URL && content.protocol === 'data:') {
  const { mediaType: dataUrlMediaType, base64Content } = splitDataUrl(...);
  return { data: base64Content, mediaType: dataUrlMediaType };
}
```

---

## Solution

Add `&& part.data.protocol !== 'data:'` to the filter in `downloadAssets()`:

```ts
// Before
.filter(
  (part): part is { mediaType: string | undefined; data: URL } =>
    part.data instanceof URL,
)

// After
.filter(
  (part): part is { mediaType: string | undefined; data: URL } =>
    part.data instanceof URL && part.data.protocol !== 'data:',
)
```

`data:` URLs are self-contained inline assets — they don't need downloading. By excluding them from `plannedDownloads`, they fall through to `convertPartToLanguageModelPart()`, where `convertToLanguageModelV4DataContent()` correctly extracts the base64 content and media type.

---

## Testing

- Added `should not download image data URLs (inline base64)` test: asserts the download function is never called and the result contains the extracted base64 content
- Added `should not download file data URLs (inline base64)` test: same assertion for `file` parts with a PDF data URL
- All 2177 existing tests continue to pass
- Run with: `pnpm test:node -- --run src/prompt/convert-to-language-model-prompt.test.ts`

---

## Checklist

- [x] Fixes the root cause (not just the symptom)
- [x] New tests cover the exact failing scenario from the issue
- [x] All existing tests pass
- [x] No unrelated changes
- [x] Code style matches project conventions
- [x] Changeset added (`patch` for `ai` package)