### PR TITLE
fix(ai): support legacy tool parameters during schema lookup

### DIFF
--- a/.changeset/five-horses-hug.md
+++ b/.changeset/five-horses-hug.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): support legacy tool parameters during schema lookup

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -191,6 +191,43 @@ describe('parseToolCall', () => {
     `);
   });
 
+  it('should parse tool calls that only provide the legacy parameters field', async () => {
+    const result = await parseToolCall({
+      toolCall: {
+        type: 'tool-call',
+        toolName: 'testTool',
+        toolCallId: '123',
+        input: '{"param1": "test", "param2": 42}',
+      },
+      tools: {
+        testTool: {
+          parameters: z.object({
+            param1: z.string(),
+            param2: z.number(),
+          }),
+        } as any,
+      } as const,
+      repairToolCall: undefined,
+      messages: [],
+      system: undefined,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "input": {
+          "param1": "test",
+          "param2": 42,
+        },
+        "providerExecuted": undefined,
+        "providerMetadata": undefined,
+        "title": undefined,
+        "toolCallId": "123",
+        "toolName": "testTool",
+        "type": "tool-call",
+      }
+    `);
+  });
+
   it('should throw NoSuchToolError when tools is null', async () => {
     const result = await parseToolCall({
       toolCall: {

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -9,6 +9,7 @@ import {
 import { InvalidToolInputError } from '../error/invalid-tool-input-error';
 import { NoSuchToolError } from '../error/no-such-tool-error';
 import { ToolCallRepairError } from '../error/tool-call-repair-error';
+import { getToolInputSchema } from '../util/get-tool-input-schema';
 import { DynamicToolCall, TypedToolCall } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair-function';
 import { ToolSet } from './tool-set';
@@ -56,8 +57,8 @@ export async function parseToolCall<TOOLS extends ToolSet>({
           toolCall,
           tools,
           inputSchema: async ({ toolName }) => {
-            const { inputSchema } = tools[toolName];
-            return await asSchema(inputSchema).jsonSchema;
+            return await asSchema(getToolInputSchema(tools[toolName]))
+              .jsonSchema;
           },
           system,
           messages,
@@ -148,7 +149,7 @@ async function doParseToolCall<TOOLS extends ToolSet>({
     });
   }
 
-  const schema = asSchema(tool.inputSchema);
+  const schema = asSchema(getToolInputSchema(tool));
 
   // when the tool call has no arguments, we try passing an empty object to the schema
   // (many LLMs generate empty strings for tool calls with no arguments)

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
@@ -220,6 +220,40 @@ describe('prepareToolsAndToolChoice', () => {
     `);
   });
 
+  it('should fall back to legacy parameters when inputSchema is absent', async () => {
+    const result = await prepareToolsAndToolChoice({
+      tools: {
+        legacyTool: {
+          description: 'Legacy tool description',
+          parameters: z.object({ city: z.string() }),
+        } as any,
+      },
+      toolChoice: undefined,
+      activeTools: undefined,
+    });
+
+    expect(result).toEqual({
+      toolChoice: { type: 'auto' },
+      tools: [
+        {
+          type: 'function',
+          name: 'legacyTool',
+          description: 'Legacy tool description',
+          inputSchema: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            properties: {
+              city: { type: 'string' },
+            },
+            required: ['city'],
+            additionalProperties: false,
+          },
+          providerOptions: undefined,
+        },
+      ],
+    });
+  });
+
   it('should correctly map tool properties', async () => {
     const result = await prepareToolsAndToolChoice({
       tools: mockTools,

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
@@ -5,6 +5,7 @@ import {
 } from '@ai-sdk/provider';
 import { asSchema } from '@ai-sdk/provider-utils';
 import { isNonEmptyObject } from '../util/is-non-empty-object';
+import { getToolInputSchema } from '../util/get-tool-input-schema';
 import { ToolSet } from '../generate-text';
 import { ToolChoice } from '../types/language-model';
 
@@ -51,7 +52,7 @@ export async function prepareToolsAndToolChoice<TOOLS extends ToolSet>({
           type: 'function' as const,
           name,
           description: tool.description,
-          inputSchema: await asSchema(tool.inputSchema).jsonSchema,
+          inputSchema: await asSchema(getToolInputSchema(tool)).jsonSchema,
           ...(tool.inputExamples != null
             ? { inputExamples: tool.inputExamples }
             : {}),

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -1216,6 +1216,37 @@ describe('validateUIMessages', () => {
       `);
     });
 
+    it('should validate tool input using the legacy parameters field', async () => {
+      const inputMessages: TestMessage[] = [
+        {
+          id: '1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-foo',
+              toolCallId: '1',
+              state: 'input-available',
+              input: { foo: 'bar' },
+              providerExecuted: true,
+            },
+          ],
+        },
+      ];
+
+      const result = await validateUIMessages<TestMessage>({
+        messages: inputMessages,
+        tools: {
+          foo: {
+            parameters: z.object({
+              foo: z.string(),
+            }),
+          } as any,
+        },
+      });
+
+      expect(result).toEqual(inputMessages);
+    });
+
     it('should throw error when tool input validation fails', async () => {
       await expect(
         validateUIMessages<TestMessage>({

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -10,6 +10,7 @@ import {
 import { z } from 'zod/v4';
 import { InvalidArgumentError } from '../error';
 import { providerMetadataSchema } from '../types/provider-metadata';
+import { getToolInputSchema } from '../util/get-tool-input-schema';
 import {
   DataUIPart,
   InferUIMessageData,
@@ -428,9 +429,26 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
               (toolPart.state === 'output-error' &&
                 toolPart.input !== undefined)
             ) {
+              const inputSchema = getToolInputSchema(tool);
+
+              if (!inputSchema) {
+                return {
+                  success: false,
+                  error: new TypeValidationError({
+                    value: toolPart.input,
+                    cause: `No tool schema found for tool part ${toolName}`,
+                    context: {
+                      field: `messages[${msgIdx}].parts[${partIdx}].input`,
+                      entityName: toolName,
+                      entityId: toolPart.toolCallId,
+                    },
+                  }),
+                };
+              }
+
               await validateTypes({
                 value: toolPart.input,
-                schema: tool.inputSchema,
+                schema: inputSchema,
                 context: {
                   field: `messages[${msgIdx}].parts[${partIdx}].input`,
                   entityName: toolName,

--- a/packages/ai/src/util/get-tool-input-schema.ts
+++ b/packages/ai/src/util/get-tool-input-schema.ts
@@ -1,0 +1,12 @@
+import type { FlexibleSchema } from '@ai-sdk/provider-utils';
+
+type ToolWithLegacyParameters<INPUT = unknown> = {
+  inputSchema?: FlexibleSchema<INPUT>;
+  parameters?: FlexibleSchema<INPUT>;
+};
+
+export function getToolInputSchema<INPUT>(
+  tool: ToolWithLegacyParameters<INPUT>,
+): FlexibleSchema<INPUT> | undefined {
+  return tool.inputSchema ?? tool.parameters;
+}


### PR DESCRIPTION
## Summary
- fall back to legacy `parameters` when looking up tool schemas for prompt preparation and tool-call parsing
- reuse the same fallback in UI message validation so tool inputs are validated consistently
- add focused regression tests and a patch changeset for `ai`

Fixes #13460

## Validation
- `pnpm exec eslint src/prompt/prepare-tools-and-tool-choice.ts src/prompt/prepare-tools-and-tool-choice.test.ts src/generate-text/parse-tool-call.ts src/generate-text/parse-tool-call.test.ts src/ui/validate-ui-messages.ts src/ui/validate-ui-messages.test.ts src/util/get-tool-input-schema.ts`
- `pnpm type-check`
- `pnpm exec vitest run src/prompt/prepare-tools-and-tool-choice.test.ts src/generate-text/parse-tool-call.test.ts src/ui/validate-ui-messages.test.ts --config vitest.node.config.js`

## Notes
- this keeps the current `inputSchema` path unchanged and only adds a fallback for legacy runtime tool objects that still carry `parameters`