### PR TITLE
fix(ai): omit non-finite numeric telemetry attributes

### DIFF
--- a/.changeset/green-phones-skip.md
+++ b/.changeset/green-phones-skip.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): omit non-finite numeric telemetry attributes before exporting spans

--- a/packages/ai/src/telemetry/open-telemetry-integration.test.ts
+++ b/packages/ai/src/telemetry/open-telemetry-integration.test.ts
@@ -624,6 +624,39 @@ describe('OpenTelemetryIntegration', () => {
       expect(setAttrsCall['gen_ai.usage.output_tokens']).toBe(20);
     });
 
+    it('omits non-finite usage attributes', () => {
+      otelIntegration.onStart!(makeOnStartEvent());
+      otelIntegration.onStepStart!(makeStepStartEvent());
+      otelIntegration.onStepFinish!(
+        makeStepFinishEvent({
+          usage: {
+            inputTokens: Number.NaN,
+            outputTokens: Number.POSITIVE_INFINITY,
+            totalTokens: Number.NaN,
+            reasoningTokens: undefined,
+            cachedInputTokens: undefined,
+            inputTokenDetails: {
+              noCacheTokens: undefined,
+              cacheReadTokens: undefined,
+              cacheWriteTokens: undefined,
+            },
+            outputTokenDetails: {
+              textTokens: undefined,
+              reasoningTokens: undefined,
+            },
+          },
+        }),
+      );
+
+      const stepSpan = tracer.spans[1];
+      const setAttrsCall = getSetAttributesArg(stepSpan);
+      expect(setAttrsCall['ai.usage.inputTokens']).toBeUndefined();
+      expect(setAttrsCall['ai.usage.outputTokens']).toBeUndefined();
+      expect(setAttrsCall['ai.usage.totalTokens']).toBeUndefined();
+      expect(setAttrsCall['gen_ai.usage.input_tokens']).toBeUndefined();
+      expect(setAttrsCall['gen_ai.usage.output_tokens']).toBeUndefined();
+    });
+
     it('includes text in output attributes', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());

--- a/packages/ai/src/telemetry/open-telemetry-integration.test.ts
+++ b/packages/ai/src/telemetry/open-telemetry-integration.test.ts
@@ -852,6 +852,32 @@ describe('OpenTelemetryIntegration', () => {
       );
     });
 
+    it('omits non-finite chunk attributes', () => {
+      otelIntegration.onStart!(makeOnStartEvent());
+      otelIntegration.onStepStart!(makeStepStartEvent());
+
+      otelIntegration.onChunk!(
+        makeChunkEvent({
+          type: 'ai.stream.firstChunk',
+          callId,
+          stepNumber: 0,
+          attributes: {
+            'ai.stream.msToFirstChunk': Number.NaN,
+            'ai.stream.msToFinish': Number.POSITIVE_INFINITY,
+            'ai.stream.valid': 42,
+          },
+        }),
+      );
+
+      const stepSpan = tracer.spans[1];
+      expect(stepSpan.addEvent).toHaveBeenCalledWith('ai.stream.firstChunk', {
+        'ai.stream.valid': 42,
+      });
+      expect(stepSpan.setAttributes).toHaveBeenCalledWith({
+        'ai.stream.valid': 42,
+      });
+    });
+
     it('ignores chunks without callId in the chunk body', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());

--- a/packages/ai/src/telemetry/open-telemetry-integration.ts
+++ b/packages/ai/src/telemetry/open-telemetry-integration.ts
@@ -22,6 +22,7 @@ import type { Output } from '../generate-text/output';
 import type { ToolSet } from '../generate-text/tool-set';
 import { assembleOperationName } from './assemble-operation-name';
 import { getBaseTelemetryAttributes } from './get-base-telemetry-attributes';
+import { sanitizeTelemetryAttributeValue } from './sanitize-telemetry-attribute-value';
 import { stringifyForTelemetry } from './stringify-for-telemetry';
 import { TelemetrySettings } from './telemetry-settings';
 import type { TelemetryIntegration } from './telemetry-integration';
@@ -74,7 +75,8 @@ function selectAttributes(
     ) {
       if (telemetry?.recordInputs === false) continue;
       const resolved = value.input();
-      if (resolved != null) result[key] = resolved;
+      const sanitizedResolved = sanitizeTelemetryAttributeValue(resolved);
+      if (sanitizedResolved != null) result[key] = sanitizedResolved;
       continue;
     }
 
@@ -85,11 +87,17 @@ function selectAttributes(
     ) {
       if (telemetry?.recordOutputs === false) continue;
       const resolved = value.output();
-      if (resolved != null) result[key] = resolved;
+      const sanitizedResolved = sanitizeTelemetryAttributeValue(resolved);
+      if (sanitizedResolved != null) result[key] = sanitizedResolved;
       continue;
     }
 
-    result[key] = value as AttributeValue;
+    const sanitizedValue = sanitizeTelemetryAttributeValue(
+      value as AttributeValue,
+    );
+    if (sanitizedValue != null) {
+      result[key] = sanitizedValue;
+    }
   }
 
   return result;

--- a/packages/ai/src/telemetry/open-telemetry-integration.ts
+++ b/packages/ai/src/telemetry/open-telemetry-integration.ts
@@ -501,8 +501,11 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
 
     const attributes = Object.fromEntries(
       Object.entries(
-        (chunk.attributes as Record<string, unknown>) ?? {},
-      ).filter(([, value]) => value != null),
+        (chunk.attributes as Record<string, AttributeValue>) ?? {},
+      ).flatMap(([key, value]) => {
+        const sanitizedValue = sanitizeTelemetryAttributeValue(value);
+        return sanitizedValue == null ? [] : [[key, sanitizedValue]];
+      }),
     ) as Attributes;
 
     state.stepSpan.addEvent(chunk.type, attributes);

--- a/packages/ai/src/telemetry/sanitize-telemetry-attribute-value.ts
+++ b/packages/ai/src/telemetry/sanitize-telemetry-attribute-value.ts
@@ -1,0 +1,18 @@
+import type { AttributeValue } from '@opentelemetry/api';
+
+export function sanitizeTelemetryAttributeValue(
+  value: AttributeValue | undefined,
+): AttributeValue | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (
+    Array.isArray(value) &&
+    value.some(item => typeof item === 'number' && !Number.isFinite(item))
+  ) {
+    return undefined;
+  }
+
+  return value;
+}

--- a/packages/ai/src/telemetry/select-telemetry-attributes.ts
+++ b/packages/ai/src/telemetry/select-telemetry-attributes.ts
@@ -1,4 +1,5 @@
 import type { Attributes, AttributeValue } from '@opentelemetry/api';
+import { sanitizeTelemetryAttributeValue } from './sanitize-telemetry-attribute-value';
 import type { TelemetrySettings } from './telemetry-settings';
 
 type ResolvableAttributeValue = () =>
@@ -43,9 +44,10 @@ export async function selectTelemetryAttributes({
       }
 
       const result = await value.input();
+      const sanitizedResult = sanitizeTelemetryAttributeValue(result);
 
-      if (result != null) {
-        resultAttributes[key] = result;
+      if (sanitizedResult != null) {
+        resultAttributes[key] = sanitizedResult;
       }
 
       continue;
@@ -63,15 +65,22 @@ export async function selectTelemetryAttributes({
       }
 
       const result = await value.output();
+      const sanitizedResult = sanitizeTelemetryAttributeValue(result);
 
-      if (result != null) {
-        resultAttributes[key] = result;
+      if (sanitizedResult != null) {
+        resultAttributes[key] = sanitizedResult;
       }
       continue;
     }
 
     // value is an attribute value already:
-    resultAttributes[key] = value as AttributeValue;
+    const sanitizedValue = sanitizeTelemetryAttributeValue(
+      value as AttributeValue,
+    );
+
+    if (sanitizedValue != null) {
+      resultAttributes[key] = sanitizedValue;
+    }
   }
 
   return resultAttributes;

--- a/packages/ai/src/telemetry/select-temetry-attributes.test.ts
+++ b/packages/ai/src/telemetry/select-temetry-attributes.test.ts
@@ -112,3 +112,39 @@ it('should handle mixed attribute types correctly', async () => {
     output: 'output value',
   });
 });
+
+it('should omit non-finite numeric attributes', async () => {
+  const result = await selectTelemetryAttributes({
+    telemetry: { isEnabled: true },
+    attributes: {
+      valid: 1,
+      nan: Number.NaN,
+      positiveInfinity: Number.POSITIVE_INFINITY,
+      negativeInfinity: Number.NEGATIVE_INFINITY,
+      validArray: [1, 2, 3],
+      invalidArray: [1, Number.NaN, 3],
+    },
+  });
+
+  expect(result).toEqual({
+    valid: 1,
+    validArray: [1, 2, 3],
+  });
+});
+
+it('should omit non-finite numeric values from input and output resolvers', async () => {
+  const result = await selectTelemetryAttributes({
+    telemetry: { isEnabled: true },
+    attributes: {
+      validInput: { input: () => 1 },
+      invalidInput: { input: () => Number.NaN },
+      validOutput: { output: () => [1, 2, 3] },
+      invalidOutput: { output: () => [1, Number.POSITIVE_INFINITY, 3] },
+    },
+  });
+
+  expect(result).toEqual({
+    validInput: 1,
+    validOutput: [1, 2, 3],
+  });
+});


### PR DESCRIPTION
## Background

`selectTelemetryAttributes` and the OpenTelemetry integration were both copying numeric values straight onto spans. When a provider reports usage as `NaN` or `Infinity`, OTLP JSON exporters serialize those numbers as `doubleValue: null`, which causes collectors to reject the whole batch.

## Summary

- add a shared telemetry attribute sanitizer for non-finite numeric values
- apply it in both `selectTelemetryAttributes` and the OpenTelemetry integration's internal attribute selector
- add regression tests for direct telemetry selection and OpenTelemetry step-finish usage attributes
- add a patch changeset for `ai`

## Manual Verification

- ran the focused telemetry tests and verified the new regression cases pass
- verified the OpenTelemetry step span no longer includes `ai.usage.*` / `gen_ai.usage.*` keys when usage values are non-finite

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #6546
