### PR TITLE
fix :  AI Gateway tool input streaming buffering

### DIFF
--- a/.changeset/fix-ai-gateway-tool-input-delta-streaming.md
+++ b/.changeset/fix-ai-gateway-tool-input-delta-streaming.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(gateway): add Accept: text/event-stream header for streaming requests
+
+Ensures the AI Gateway and any intermediate proxies recognize the request as an SSE stream, which can prevent buffering of tool input deltas for long string fields. Without this header, proxies may buffer the response before forwarding, causing delayed delivery of tool input deltas compared to direct provider connections.

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -638,6 +638,7 @@ describe('GatewayLanguageModel', () => {
         'ai-language-model-specification-version': '3',
         'ai-language-model-id': 'test-model',
         'ai-language-model-streaming': 'true',
+        accept: 'text/event-stream',
       });
     });
 

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -108,6 +108,7 @@ export class GatewayLanguageModel implements LanguageModelV3 {
           options.headers,
           this.getModelConfigHeaders(this.modelId, true),
           await resolve(this.config.o11yHeaders),
+          { accept: 'text/event-stream' },
         ),
         body: args,
         successfulResponseHandler: createEventSourceResponseHandler(z.any()),


### PR DESCRIPTION
### background

- AI Gateway sometimes buffered tool input deltas for long string fields, causing those fields to stream much later than with the Vertex provider.

### Summary

- Added Accept: text/event-stream to gateway language model streaming requests so tool input deltas are forwarded incrementally instead of being buffered.

### Manual Verification

- Locally ran a streamText flow with a long-string tool input via AI Gateway and confirmed onInputDelta logs show long fields streaming incrementally instead of in a delayed burst.

fix : #13429