### PR TITLE
feat : allow async messageMetadata callback for UI message streams

### DIFF
--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -55,13 +55,17 @@ export type UIMessageStreamOptions<UI_MESSAGE extends UIMessage> = {
   onFinish?: UIMessageStreamOnFinishCallback<UI_MESSAGE>;
 
   /**
-   * Extracts message metadata that will be send to the client.
+   * Extracts message metadata that will be sent to the client.
    *
-   * Called on `start` and `finish` events.
+   * Called on `start` and `finish` events. May be async to support
+   * external stores (e.g. token usage tracking).
    */
   messageMetadata?: (options: {
     part: TextStreamPart<ToolSet>;
-  }) => InferUIMessageMetadata<UI_MESSAGE> | undefined;
+  }) =>
+    | InferUIMessageMetadata<UI_MESSAGE>
+    | undefined
+    | Promise<InferUIMessageMetadata<UI_MESSAGE> | undefined>;
 
   /**
    * Send reasoning parts to the client.

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -2804,6 +2804,41 @@ describe('streamText', () => {
         `);
     });
 
+    it('should support async messageMetadata callback', async () => {
+      const result = streamText({
+        model: createTestModel(),
+        ...defaultSettings(),
+      });
+
+      const uiMessageStream = result.toUIMessageStream({
+        messageMetadata: async ({ part }) => {
+          if (part.type === 'finish') {
+            await new Promise(resolve => setTimeout(resolve, 0));
+            return {
+              usage: {
+                tokens: (part.totalUsage.inputTokens ?? 0) + 100,
+                limit: 1000,
+                exceeded: false,
+              },
+            };
+          }
+        },
+      });
+
+      const chunks = await convertReadableStreamToArray(uiMessageStream);
+      const finishChunk = chunks.find(
+        (c): c is typeof c & { type: 'finish' } => c.type === 'finish',
+      );
+      expect(finishChunk).toBeDefined();
+      expect(finishChunk?.messageMetadata).toEqual({
+        usage: {
+          tokens: 100,
+          limit: 1000,
+          exceeded: false,
+        },
+      });
+    });
+
     it('should mask error messages by default', async () => {
       const result = streamText({
         model: createTestModel({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2243,7 +2243,9 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
         >
       >({
         transform: async (part, controller) => {
-          const messageMetadataValue = messageMetadata?.({ part });
+          const messageMetadataValue = messageMetadata
+            ? await Promise.resolve(messageMetadata({ part }))
+            : undefined;
 
           const partType = part.type;
           switch (partType) {


### PR DESCRIPTION
fix : #13427

### background

- Need to attach token-usage metadata from an external store during streaming without race conditions.

### Summary

- Made messageMetadata accept async callbacks and awaited it inside the UI stream transform.
- Added a test for an async messageMetadata using part.totalUsage on finish.

### Manual Verification

- Locally called streamText().toUIMessageStreamResponse with an async messageMetadata and confirmed the final UI chunk contained the expected usage metadata.