### PR TITLE
fix(gateway): expose gateway tools for ai v6 users

### DIFF
--- a/.changeset/angry-pianos-confess.md
+++ b/.changeset/angry-pianos-confess.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/gateway': patch
+'ai': patch
+---
+
+Fix 'tools' does not exist on type 'GatewayProvider' error after migrating to SDK 6. Export gatewayTools from @ai-sdk/gateway and re-export from ai. Use gatewayTools.parallelSearch() and gatewayTools.perplexitySearch() instead of gateway.tools.parallelSearch() and gateway.tools.perplexitySearch().

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -327,13 +327,13 @@ The AI Gateway provider includes built-in tools that are executed by the gateway
 The Perplexity Search tool enables models to search the web using [Perplexity's search API](https://docs.perplexity.ai/guides/search-quickstart). This tool is executed by the AI Gateway and returns web search results that the model can use to provide up-to-date information.
 
 ```ts
-import { gateway, generateText } from 'ai';
+import { gatewayTools, generateText } from 'ai';
 
 const result = await generateText({
   model: 'openai/gpt-5-nano',
   prompt: 'Search for news about AI regulations in January 2025.',
   tools: {
-    perplexity_search: gateway.tools.perplexitySearch(),
+    perplexity_search: gatewayTools.perplexitySearch(),
   },
 });
 
@@ -345,14 +345,14 @@ console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
 You can also configure the search with optional parameters:
 
 ```ts
-import { gateway, generateText } from 'ai';
+import { gatewayTools, generateText } from 'ai';
 
 const result = await generateText({
   model: 'openai/gpt-5-nano',
   prompt:
     'Search for news about AI regulations from the first week of January 2025.',
   tools: {
-    perplexity_search: gateway.tools.perplexitySearch({
+    perplexity_search: gatewayTools.perplexitySearch({
       maxResults: 5,
       searchLanguageFilter: ['en'],
       country: 'US',
@@ -399,13 +399,13 @@ The Perplexity Search tool supports the following optional configuration options
 The tool works with both `generateText` and `streamText`:
 
 ```ts
-import { gateway, streamText } from 'ai';
+import { gatewayTools, streamText } from 'ai';
 
 const result = streamText({
   model: 'openai/gpt-5-nano',
   prompt: 'Search for the latest news about AI regulations.',
   tools: {
-    perplexity_search: gateway.tools.perplexitySearch(),
+    perplexity_search: gatewayTools.perplexitySearch(),
   },
 });
 
@@ -429,13 +429,13 @@ for await (const part of result.fullStream) {
 The Parallel Search tool enables models to search the web using [Parallel AI's Search API](https://docs.parallel.ai/api-reference/search-beta/search). This tool is optimized for LLM consumption, returning relevant excerpts from web pages that can replace multiple keyword searches with a single call.
 
 ```ts
-import { gateway, generateText } from 'ai';
+import { gatewayTools, generateText } from 'ai';
 
 const result = await generateText({
   model: 'openai/gpt-5-nano',
   prompt: 'Research the latest developments in quantum computing.',
   tools: {
-    parallel_search: gateway.tools.parallelSearch(),
+    parallel_search: gatewayTools.parallelSearch(),
   },
 });
 
@@ -447,13 +447,13 @@ console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
 You can also configure the search with optional parameters:
 
 ```ts
-import { gateway, generateText } from 'ai';
+import { gatewayTools, generateText } from 'ai';
 
 const result = await generateText({
   model: 'openai/gpt-5-nano',
   prompt: 'Find detailed information about TypeScript 5.0 features.',
   tools: {
-    parallel_search: gateway.tools.parallelSearch({
+    parallel_search: gatewayTools.parallelSearch({
       mode: 'agentic',
       maxResults: 5,
       sourcePolicy: {
@@ -508,13 +508,13 @@ The Parallel Search tool supports the following optional configuration options:
 The tool works with both `generateText` and `streamText`:
 
 ```ts
-import { gateway, streamText } from 'ai';
+import { gatewayTools, streamText } from 'ai';
 
 const result = streamText({
   model: 'openai/gpt-5-nano',
   prompt: 'Research the latest AI safety guidelines.',
   tools: {
-    parallel_search: gateway.tools.parallelSearch(),
+    parallel_search: gatewayTools.parallelSearch(),
   },
 });
 

--- a/examples/ai-functions/src/generate-text/gateway/tool-parallel-search-params.ts
+++ b/examples/ai-functions/src/generate-text/gateway/tool-parallel-search-params.ts
@@ -1,4 +1,4 @@
-import { gateway, generateText } from 'ai';
+import { gatewayTools, generateText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -6,7 +6,7 @@ async function main() {
     model: 'openai/gpt-5-nano',
     prompt: `Search for the latest research on quantum computing breakthroughs.`,
     tools: {
-      parallel_search: gateway.tools.parallelSearch({
+      parallel_search: gatewayTools.parallelSearch({
         mode: 'agentic',
         maxResults: 5,
         sourcePolicy: {

--- a/examples/ai-functions/src/generate-text/gateway/tool-parallel-search.ts
+++ b/examples/ai-functions/src/generate-text/gateway/tool-parallel-search.ts
@@ -1,4 +1,4 @@
-import { gateway, generateText } from 'ai';
+import { gatewayTools, generateText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -7,7 +7,7 @@ async function main() {
     prompt:
       'Use the parallelSearch tool to find current information about renewable energy developments in 2025. You must search the web first before answering.',
     tools: {
-      parallel_search: gateway.tools.parallelSearch(),
+      parallel_search: gatewayTools.parallelSearch(),
     },
   });
 

--- a/examples/ai-functions/src/generate-text/gateway/tool-perplexity-search-params.ts
+++ b/examples/ai-functions/src/generate-text/gateway/tool-perplexity-search-params.ts
@@ -1,4 +1,4 @@
-import { gateway, generateText } from 'ai';
+import { gatewayTools, generateText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -6,7 +6,7 @@ async function main() {
     model: 'openai/gpt-5-nano',
     prompt: `Search for news about AI regulations from the first week of January 2025. `,
     tools: {
-      perplexity_search: gateway.tools.perplexitySearch({
+      perplexity_search: gatewayTools.perplexitySearch({
         maxResults: 5,
         searchLanguageFilter: ['en'],
         country: 'US',

--- a/examples/ai-functions/src/generate-text/gateway/tool-perplexity-search.ts
+++ b/examples/ai-functions/src/generate-text/gateway/tool-perplexity-search.ts
@@ -1,4 +1,4 @@
-import { gateway, generateText } from 'ai';
+import { gatewayTools, generateText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -7,7 +7,7 @@ async function main() {
     prompt:
       'Use the perplexitySearch tool to find current news about AI regulations in January 2025. You must search the web first before answering.',
     tools: {
-      perplexity_search: gateway.tools.perplexitySearch(),
+      perplexity_search: gatewayTools.perplexitySearch(),
     },
   });
 

--- a/examples/ai-functions/src/stream-text/gateway/tool-parallel-search-params.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-parallel-search-params.ts
@@ -1,4 +1,4 @@
-import { createGateway, streamText } from 'ai';
+import { createGateway, gatewayTools, streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -10,7 +10,7 @@ async function main() {
     model: gateway('openai/gpt-5-nano'),
     prompt: `Search for the latest research on quantum computing breakthroughs.`,
     tools: {
-      parallel_search: gateway.tools.parallelSearch({
+      parallel_search: gatewayTools.parallelSearch({
         mode: 'agentic',
         maxResults: 5,
         sourcePolicy: {

--- a/examples/ai-functions/src/stream-text/gateway/tool-parallel-search.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-parallel-search.ts
@@ -1,4 +1,4 @@
-import { gateway, streamText } from 'ai';
+import { gatewayTools, streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -6,7 +6,7 @@ async function main() {
     model: 'openai/gpt-5-nano',
     prompt: `Search for current information about renewable energy developments in 2025.`,
     tools: {
-      parallel_search: gateway.tools.parallelSearch(),
+      parallel_search: gatewayTools.parallelSearch(),
     },
   });
 

--- a/examples/ai-functions/src/stream-text/gateway/tool-perplexity-search-params.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-perplexity-search-params.ts
@@ -1,4 +1,4 @@
-import { createGateway, streamText } from 'ai';
+import { createGateway, gatewayTools, streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -10,7 +10,7 @@ async function main() {
     model: gateway('openai/gpt-5-nano'),
     prompt: `Search for news about AI regulations from the first week of January 2025.`,
     tools: {
-      perplexity_search: gateway.tools.perplexitySearch({
+      perplexity_search: gatewayTools.perplexitySearch({
         maxResults: 5,
         searchLanguageFilter: ['en'],
         country: 'US',

--- a/examples/ai-functions/src/stream-text/gateway/tool-perplexity-search.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-perplexity-search.ts
@@ -1,4 +1,4 @@
-import { gateway, streamText } from 'ai';
+import { gatewayTools, streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -6,7 +6,7 @@ async function main() {
     model: 'openai/gpt-5-nano',
     prompt: `Search for news about AI regulations from the first week of January 2025.`,
     tools: {
-      perplexity_search: gateway.tools.perplexitySearch(),
+      perplexity_search: gatewayTools.perplexitySearch(),
     },
   });
 

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,5 +1,10 @@
 // re-exports:
-export { createGateway, gateway, type GatewayModelId } from '@ai-sdk/gateway';
+export {
+  createGateway,
+  gateway,
+  gatewayTools,
+  type GatewayModelId,
+} from '@ai-sdk/gateway';
 export {
   asSchema,
   createIdGenerator,

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -11,6 +11,7 @@ export {
   createGatewayProvider as createGateway,
   gateway,
 } from './gateway-provider';
+export { gatewayTools } from './gateway-tools';
 export type {
   GatewayProvider,
   GatewayProviderSettings,


### PR DESCRIPTION
### background

- gateway.tools.* caused a TypeScript error ('tools' does not exist on type 'GatewayProvider') after upgrading to AI SDK 6.

### Summary

- Export gatewayTools from @ai-sdk/gateway, re-export it from ai, and update docs/examples to use gatewayTools.parallelSearch() and gatewayTools.perplexitySearch().

### Manual Verification

- Built @ai-sdk/gateway and ai, and ran pnpm test in packages/gateway.

### Checklist

[x] Documentation has been added / updated (for bug fixes / features)
[x] A patch changeset for relevant packages has been added (for bug fixes / features - run pnpm changeset in the project root)
[x] I have reviewed this pull request (self-review)

### Future Work

- Investigate why some setups still lose the tools property on GatewayProvider.

### Related Issues

Fixes #13252