### PR TITLE
fix(openai): handle response.failed stream event and set finishReason to error (fixes #6534)

### DIFF
--- a/.changeset/fix-openai-responses-failed-chunk.md
+++ b/.changeset/fix-openai-responses-failed-chunk.md
@@ -1,0 +1,18 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): handle `response.failed` stream event and set `finishReason` to `error` for Responses API errors
+
+Previously, when the OpenAI Responses API returned an `error` event or a
+`response.failed` event (e.g. on rate-limit exceeded), the stream would
+complete with `finishReason: "other"` and the `response.failed` chunk was
+silently ignored (treated as an unknown chunk). This made it impossible to
+distinguish a successful response from a failed one.
+
+- Added `response.failed` to the chunk schema
+- Handle `response.failed` chunks in the stream processor: enqueue an error
+  event and set `finishReason` to `"error"`
+- When an `error` chunk is received, also set `finishReason` to `"error"`
+
+Fixes #6534

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -987,6 +987,30 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
           param: z.string().nullish(),
         }),
       }),
+      z.object({
+        type: z.literal('response.failed'),
+        response: z.object({
+          error: z
+            .object({
+              type: z.string().nullish(),
+              code: z.string().nullish(),
+              message: z.string(),
+            })
+            .nullish(),
+          usage: z
+            .object({
+              input_tokens: z.number(),
+              input_tokens_details: z
+                .object({ cached_tokens: z.number().nullish() })
+                .nullish(),
+              output_tokens: z.number(),
+              output_tokens_details: z
+                .object({ reasoning_tokens: z.number().nullish() })
+                .nullish(),
+            })
+            .nullish(),
+        }),
+      }),
       z
         .object({ type: z.string() })
         .loose()

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -6911,9 +6911,22 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "type": "error",
               },
               {
+                "error": {
+                  "response": {
+                    "error": {
+                      "code": "insufficient_quota",
+                      "message": "You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.",
+                    },
+                    "usage": null,
+                  },
+                  "type": "response.failed",
+                },
+                "type": "error",
+              },
+              {
                 "finishReason": {
-                  "raw": undefined,
-                  "unified": "other",
+                  "raw": "response.failed",
+                  "unified": "error",
                 },
                 "providerMetadata": {
                   "openai": {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -2070,7 +2070,14 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                   },
                 });
               }
+            } else if (isResponseFailedChunk(value)) {
+              finishReason = { unified: 'error', raw: 'response.failed' };
+              if (value.response.usage) {
+                usage = value.response.usage;
+              }
+              controller.enqueue({ type: 'error', error: value });
             } else if (isErrorChunk(value)) {
+              finishReason = { unified: 'error', raw: 'error' };
               controller.enqueue({ type: 'error', error: value });
             }
           },
@@ -2191,6 +2198,12 @@ function isResponseAnnotationAddedChunk(
   type: 'response.output_text.annotation.added';
 } {
   return chunk.type === 'response.output_text.annotation.added';
+}
+
+function isResponseFailedChunk(
+  chunk: OpenAIResponsesChunk,
+): chunk is OpenAIResponsesChunk & { type: 'response.failed' } {
+  return chunk.type === 'response.failed';
 }
 
 function isErrorChunk(


### PR DESCRIPTION
## Summary

Fixes #6534.

When the OpenAI Responses API returns a rate-limit or other server error during streaming, it sends two terminal events:

1. `event: error` — carries the error details (`type`, `code`, `message`)
2. `event: response.failed` — terminates the response (similar to `response.completed`)

Before this fix, both problems existed:
- **`response.failed` was silently ignored** — the chunk type was not in the schema, so it fell through to the `unknown_chunk` fallback and was discarded
- **`error` events did not update `finishReason`** — the stream completed with `finishReason: "other"` instead of `"error"`, making it impossible for callers to detect a failed response

---

## Root Cause

In `openai-responses-api.ts`, `response.failed` was absent from the chunk schema union, so the Zod discriminated union matched the final `z.object({ type: z.string() }).loose()` fallback and transformed it to `{ type: 'unknown_chunk' }`.

In `openai-responses-language-model.ts`, the `isErrorChunk` handler enqueued the error event but never updated the `finishReason` variable. The `isResponseFinishedChunk` guard only matches `response.completed` and `response.incomplete`, so `response.failed` was never processed and `finishReason` stayed at the initial `"other"` value.

---

## Solution

1. **`openai-responses-api.ts`**: Add `response.failed` to the chunk schema with its `response.error` and optional `response.usage` fields
2. **`openai-responses-language-model.ts`**:
   - Add `isResponseFailedChunk` guard function
   - Handle `response.failed`: enqueue an error event + set `finishReason = { unified: 'error', raw: 'response.failed' }` + capture usage if present
   - On `error` chunks: also set `finishReason = { unified: 'error', raw: 'error' }`

---

## Testing

- Updated the existing `should stream error parts` snapshot test: the fixture already contained both `error` and `response.failed` events, so it now correctly reflects the two error events emitted and the `finishReason: "error"` finish
- All 592 existing tests pass: `pnpm test:node --run`

---

## Checklist

- [x] Fixes the root cause (not just the symptom)
- [x] Updated test covers the exact failing scenario from the issue
- [x] All existing tests pass
- [x] No unrelated changes
- [x] Code style matches project conventions
- [x] Changeset added