### PR TITLE
test(azure): remove unnecessary 6s timeout from image generation test

### DIFF
--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -1710,29 +1710,24 @@ describe('responses', () => {
     });
 
     describe('image generation tool', () => {
-      // Parsing the large fixture can sometimes exceed the default 5s timeout.
-      it(
-        'should stream image generation tool results include',
-        { timeout: 6000 },
-        async () => {
-          prepareChunksFixtureResponse('azure-image-generation-tool.1');
-          const result = await createModel('test-deployment').doStream({
-            prompt: TEST_PROMPT,
-            tools: [
-              {
-                type: 'provider',
-                id: 'openai.image_generation',
-                name: 'image_generation',
-                args: {},
-              },
-            ],
-          });
+      it('should stream image generation tool results include', async () => {
+        prepareChunksFixtureResponse('azure-image-generation-tool.1');
+        const result = await createModel('test-deployment').doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'openai.image_generation',
+              name: 'image_generation',
+              args: {},
+            },
+          ],
+        });
 
-          expect(
-            await convertReadableStreamToArray(result.stream),
-          ).toMatchSnapshot();
-        },
-      );
+        expect(
+          await convertReadableStreamToArray(result.stream),
+        ).toMatchSnapshot();
+      });
     });
   });
 });


### PR DESCRIPTION
## Background

PR #13483 added a 6s timeout to the `should stream image generation tool results include` test because the large fixture (6.9MB of base64 image data) caused it to exceed the default 5s timeout in CI.

PR #13486 fixed the root cause by replacing the large image with a minimal 1x1 pixel PNG, reducing the fixture from 6.9MB to 12.6KB. The test now runs in ~2ms locally, so the extended timeout is no longer needed.

## Summary

Reverts #13483 to remove the 6s timeout and restore the original test structure.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Related Issues

- Reverts #13483
- Follow-up to #13486