### PR TITLE
fix(anthropic): skip passing beta header for tool search tools

### DIFF
--- a/.changeset/odd-oranges-sparkle.md
+++ b/.changeset/odd-oranges-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): skip passing beta header for tool search tools

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -3112,7 +3112,7 @@ describe('AnthropicMessagesLanguageModel', () => {
         it('should include advanced-tool-use beta header', async () => {
           expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
             {
-              "anthropic-beta": "advanced-tool-use-2025-11-20,structured-outputs-2025-11-13",
+              "anthropic-beta": "structured-outputs-2025-11-13",
               "anthropic-version": "2023-06-01",
               "content-type": "application/json",
               "x-api-key": "test-api-key",
@@ -3218,7 +3218,7 @@ describe('AnthropicMessagesLanguageModel', () => {
         it('should include advanced-tool-use beta header', async () => {
           expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
             {
-              "anthropic-beta": "advanced-tool-use-2025-11-20,structured-outputs-2025-11-13",
+              "anthropic-beta": "structured-outputs-2025-11-13",
               "anthropic-version": "2023-06-01",
               "content-type": "application/json",
               "x-api-key": "test-api-key",

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -861,9 +861,7 @@ describe('prepareTools', () => {
 
       expect(result).toMatchInlineSnapshot(`
         {
-          "betas": Set {
-            "advanced-tool-use-2025-11-20",
-          },
+          "betas": Set {},
           "toolChoice": undefined,
           "toolWarnings": [],
           "tools": [
@@ -923,9 +921,7 @@ describe('prepareTools', () => {
 
       expect(result).toMatchInlineSnapshot(`
         {
-          "betas": Set {
-            "advanced-tool-use-2025-11-20",
-          },
+          "betas": Set {},
           "toolChoice": undefined,
           "toolWarnings": [],
           "tools": [

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -322,7 +322,6 @@ export async function prepareTools({
           }
 
           case 'anthropic.tool_search_regex_20251119': {
-            betas.add('advanced-tool-use-2025-11-20');
             anthropicTools.push({
               type: 'tool_search_tool_regex_20251119',
               name: 'tool_search_tool_regex',
@@ -331,7 +330,6 @@ export async function prepareTools({
           }
 
           case 'anthropic.tool_search_bm25_20251119': {
-            betas.add('advanced-tool-use-2025-11-20');
             anthropicTools.push({
               type: 'tool_search_tool_bm25_20251119',
               name: 'tool_search_tool_bm25',


### PR DESCRIPTION
## Background

The tool search tools don't require the beta header to be passed anymore in the request ([removed from the documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool))

it was still passed in the request with AI SDK. When passed, it is rejected by providers such as Google Vertex (explored in PR https://github.com/vercel/ai/pull/13497 )

## Summary

remove the addition of the beta header `advanced-tool-use-2025-11-20` in the prepare tools file

## Manual Verification

verified by running the existing examples before and after the fix:
- `examples/ai-functions/src/generate-text/anthropic/tool-search-regex.ts`
- `examples/ai-functions/src/generate-text/anthropic/tool-search-deferred-bm25.ts`
- `examples/ai-functions/src/generate-text/anthropic/tool-search-bm25.ts`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)