### PR TITLE
feat(google-vertex): add the anthropic tool search tools

### DIFF
--- a/.changeset/rude-horses-end.md
+++ b/.changeset/rude-horses-end.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+feat(google-vertex): add the anthropic tool search tools

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-bm25.ts
@@ -6,17 +6,17 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = await generateText({
     model: vertexAnthropic('claude-sonnet-4-5'),
-    prompt: 'Find out weather data in SF',
+    prompt: 'What is the weather in San Francisco?',
     stopWhen: stepCountIs(10),
     onStepFinish: step => {
       console.log(`\n=== Step Response ===`);
       console.dir(step.response.body, { depth: Infinity });
     },
     tools: {
-      toolSearch: vertexAnthropic.tools.toolSearchRegex_20251119(),
+      toolSearch: vertexAnthropic.tools.toolSearchBm25_20251119(),
 
-      get_temp_data: tool({
-        description: 'For a location',
+      get_weather: tool({
+        description: 'Get the current weather at a specific location',
         inputSchema: z.object({
           location: z
             .string()

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-deferred-bm25.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-deferred-bm25.ts
@@ -1,0 +1,81 @@
+import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
+import { generateText, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  let stepNumber = 0;
+
+  const result = await generateText({
+    model: vertexAnthropic('claude-sonnet-4-5'),
+    prompt: `You have access to a note-taking system. Please:
+            1. First read the note tree to see the current structure
+            2. Then add "bye" as a new bullet after "hi"
+
+            The noteId is "d10aa585-982b-4bd9-984e-420f9b3717f7".
+            Remember, you may need to search for the right tools to perform editor operations.`,
+    stopWhen: stepCountIs(20),
+    onStepFinish: step => {
+      stepNumber++;
+      console.log(`\n========== STEP ${stepNumber} ==========`);
+      console.log('Response body (JSON):');
+      console.log(JSON.stringify(step.response.body, null, 2));
+      console.log(
+        '\nTool calls:',
+        step.toolCalls.map(tc => tc.toolName),
+      );
+      console.log(
+        'Tool results:',
+        step.toolResults.map(tr => tr.toolName),
+      );
+      console.log(`========== END STEP ${stepNumber} ==========\n`);
+    },
+    tools: {
+      toolSearch: vertexAnthropic.tools.toolSearchBm25_20251119(),
+
+      readNoteTree: tool({
+        description:
+          'Read the note tree structure to see all notes and their content',
+        inputSchema: z.object({
+          noteId: z.string().describe('The note ID to read'),
+        }),
+        execute: async ({ noteId }) => ({
+          noteId,
+          content: [{ type: 'bulletedListItem', text: 'hi' }],
+        }),
+      }),
+
+      executeEditorOperation: tool({
+        description:
+          'Execute operations on the editor like inserting blocks, text, etc.',
+        inputSchema: z.object({
+          noteId: z.string().describe('The note ID'),
+          operations: z.array(
+            z.object({
+              op: z.string(),
+              at: z
+                .object({
+                  type: z.string(),
+                  path: z.array(z.number()),
+                })
+                .optional(),
+              type: z.string().optional(),
+              text: z.string().optional(),
+            }),
+          ),
+        }),
+        execute: async ({ noteId, operations }) => ({
+          success: true,
+          noteId,
+          appliedOperations: operations.length,
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+    },
+  });
+
+  console.log('\n=== FINAL RESULT ===');
+  console.log('Text:', result.text);
+});

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-regex.ts
@@ -1,0 +1,88 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { createVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
+import { generateText, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const vertexAnthropic = createVertexAnthropic({
+    fetch: async (url, init) => {
+      console.log('\n=== Request URL ===');
+      console.log(url);
+      console.log('\n=== Request Headers ===');
+      console.log(JSON.stringify(init?.headers, null, 2));
+      return fetch(url, init);
+    },
+  });
+
+  const result = await generateText({
+    model: vertexAnthropic('claude-sonnet-4-5'),
+    prompt: 'Find out weather data in SF',
+    stopWhen: stepCountIs(10),
+    onStepFinish: step => {
+      console.log(`\n=== Step Response ===`);
+      console.dir(step.response.body, { depth: Infinity });
+    },
+    tools: {
+      toolSearch: vertexAnthropic.tools.toolSearchRegex_20251119(),
+
+      get_temp_data: tool({
+        description: 'For a location',
+        inputSchema: z.object({
+          location: z
+            .string()
+            .describe('The city and state, e.g. San Francisco, CA'),
+          unit: z
+            .enum(['celsius', 'fahrenheit'])
+            .optional()
+            .describe('Temperature unit'),
+        }),
+        execute: async ({ location, unit = 'fahrenheit' }) => ({
+          location,
+          temperature: unit === 'celsius' ? 18 : 64,
+          condition: 'Partly cloudy',
+          humidity: 65,
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+
+      search_files: tool({
+        description: 'Search through files in the workspace',
+        inputSchema: z.object({
+          query: z.string().describe('The search query'),
+          file_types: z
+            .array(z.string())
+            .optional()
+            .describe('Filter by file types'),
+        }),
+        execute: async ({ query }) => ({
+          results: [`Found 3 files matching "${query}"`],
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+
+      send_email: tool({
+        description: 'Send an email to a recipient',
+        inputSchema: z.object({
+          to: z.string().describe('Recipient email address'),
+          subject: z.string().describe('Email subject'),
+          body: z.string().describe('Email body content'),
+        }),
+        execute: async ({ to, subject }) => ({
+          success: true,
+          message: `Email sent to ${to} with subject: ${subject}`,
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+    },
+  });
+
+  console.log('\n=== Final Result ===');
+  console.log('Text:', result.text);
+});

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-search-bm25.ts
@@ -1,22 +1,18 @@
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, tool, stepCountIs } from 'ai';
+import { streamText, tool, stepCountIs } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const result = await generateText({
+  const result = streamText({
     model: vertexAnthropic('claude-sonnet-4-5'),
-    prompt: 'Find out weather data in SF',
+    prompt: 'What is the weather in San Francisco?',
     stopWhen: stepCountIs(10),
-    onStepFinish: step => {
-      console.log(`\n=== Step Response ===`);
-      console.dir(step.response.body, { depth: Infinity });
-    },
     tools: {
-      toolSearch: vertexAnthropic.tools.toolSearchRegex_20251119(),
+      toolSearch: vertexAnthropic.tools.toolSearchBm25_20251119(),
 
-      get_temp_data: tool({
-        description: 'For a location',
+      get_weather: tool({
+        description: 'Get the current weather at a specific location',
         inputSchema: z.object({
           location: z
             .string()
@@ -72,6 +68,34 @@ run(async () => {
     },
   });
 
-  console.log('\n=== Final Result ===');
-  console.log('Text:', result.text);
+  for await (const chunk of result.fullStream) {
+    switch (chunk.type) {
+      case 'text-delta': {
+        process.stdout.write(chunk.text);
+        break;
+      }
+
+      case 'tool-call': {
+        console.log(
+          `\n\x1b[32m\x1b[1mTool call:\x1b[22m ${chunk.toolName}\x1b[0m`,
+        );
+        console.log(JSON.stringify(chunk.input, null, 2));
+        break;
+      }
+
+      case 'tool-result': {
+        console.log(
+          `\x1b[32m\x1b[1mTool result:\x1b[22m ${chunk.toolName}\x1b[0m`,
+        );
+        console.log(JSON.stringify(chunk.output, null, 2));
+        break;
+      }
+
+      case 'error':
+        console.error('Error:', chunk.error);
+        break;
+    }
+  }
+
+  console.log('\n');
 });

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-search-regex.ts
@@ -1,22 +1,18 @@
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, tool, stepCountIs } from 'ai';
+import { streamText, tool, stepCountIs } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const result = await generateText({
+  const result = streamText({
     model: vertexAnthropic('claude-sonnet-4-5'),
     prompt: 'Find out weather data in SF',
     stopWhen: stepCountIs(10),
-    onStepFinish: step => {
-      console.log(`\n=== Step Response ===`);
-      console.dir(step.response.body, { depth: Infinity });
-    },
     tools: {
       toolSearch: vertexAnthropic.tools.toolSearchRegex_20251119(),
 
       get_temp_data: tool({
-        description: 'For a location',
+        description: 'Get the current weather at a specific location',
         inputSchema: z.object({
           location: z
             .string()
@@ -72,6 +68,34 @@ run(async () => {
     },
   });
 
-  console.log('\n=== Final Result ===');
-  console.log('Text:', result.text);
+  for await (const chunk of result.fullStream) {
+    switch (chunk.type) {
+      case 'text-delta': {
+        process.stdout.write(chunk.text);
+        break;
+      }
+
+      case 'tool-call': {
+        console.log(
+          `\n\x1b[32m\x1b[1mTool call:\x1b[22m ${chunk.toolName}\x1b[0m`,
+        );
+        console.log(JSON.stringify(chunk.input, null, 2));
+        break;
+      }
+
+      case 'tool-result': {
+        console.log(
+          `\x1b[32m\x1b[1mTool result:\x1b[22m ${chunk.toolName}\x1b[0m`,
+        );
+        console.log(JSON.stringify(chunk.output, null, 2));
+        break;
+      }
+
+      case 'error':
+        console.error('Error:', chunk.error);
+        break;
+    }
+  }
+
+  console.log('\n');
 });

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -101,6 +101,8 @@ describe('google-vertex-anthropic-provider', () => {
     expect(provider.tools).toHaveProperty('textEditor_20250728');
     expect(provider.tools).toHaveProperty('computer_20241022');
     expect(provider.tools).toHaveProperty('webSearch_20250305');
+    expect(provider.tools).toHaveProperty('toolSearchRegex_20251119');
+    expect(provider.tools).toHaveProperty('toolSearchBm25_20251119');
     expect(provider.tools).not.toHaveProperty('codeExecution_20250825');
     expect(provider.tools).not.toHaveProperty('codeExecution_20260120');
   });

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -78,6 +78,28 @@ export const vertexAnthropicTools = {
    * Creates a web search tool that gives Claude direct access to real-time web content.
    */
   webSearch_20250305: anthropicTools.webSearch_20250305,
+
+  /**
+   * Creates a tool search tool that uses regex patterns to find tools.
+   *
+   * The tool search tool enables Claude to work with hundreds or thousands of tools
+   * by dynamically discovering and loading them on-demand.
+   *
+   * Use `providerOptions: { anthropic: { deferLoading: true } }` on other tools
+   * to mark them for deferred loading.
+   */
+  toolSearchRegex_20251119: anthropicTools.toolSearchRegex_20251119,
+
+  /**
+   * Creates a tool search tool that uses BM25 (natural language) to find tools.
+   *
+   * The tool search tool enables Claude to work with hundreds or thousands of tools
+   * by dynamically discovering and loading them on-demand.
+   *
+   * Use `providerOptions: { anthropic: { deferLoading: true } }` on other tools
+   * to mark them for deferred loading.
+   */
+  toolSearchBm25_20251119: anthropicTools.toolSearchBm25_20251119,
 };
 export interface GoogleVertexAnthropicProvider extends ProviderV4 {
   /**
@@ -95,7 +117,8 @@ export interface GoogleVertexAnthropicProvider extends ProviderV4 {
    * Note: Only a subset of Anthropic tools are available on Vertex.
    * Supported tools: bash_20241022, bash_20250124, textEditor_20241022,
    * textEditor_20250124, textEditor_20250429, textEditor_20250728,
-   * computer_20241022, webSearch_20250305
+   * computer_20241022, webSearch_20250305, toolSearchRegex_20251119,
+   * toolSearchBm25_20251119
    */
   tools: typeof vertexAnthropicTools;
 


### PR DESCRIPTION
## Background

#13337

We currently did not include the Tool Search tools exposed in the anthropic provider for the vertex provider.

For this change to be added, we first needed to ensure we are not passing the beta header since vertex rejects it.

## Summary

include the `toolSearchRegex_20251119` and `toolSearchBm25_20251119` in `vertexAnthropicTools` 

## Manual Verification

verified by running the examples: 
- `examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-regex.ts`
- `examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-bm25.ts`
- `examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-deferred-bm25.ts`

along with the streaming examples

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #13337 