### PR TITLE
fix(openai-compatible): send null instead of empty string for assistant messages with only tool calls

### DIFF
--- a/.changeset/fix-bedrock-empty-content.md
+++ b/.changeset/fix-bedrock-empty-content.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+fix(openai-compatible): send null instead of empty string for assistant messages with only tool calls
+
+When assistant messages contain only tool-call parts and no text parts, the content field was being sent as an empty string ("") instead of null. This caused AWS Bedrock to reject the request with a ValidationException.
+
+The fix changes `content: text` to `content: text || null` so that empty text content is sent as null, which matches the OpenAI API spec and is accepted by Bedrock.

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -457,7 +457,7 @@ describe('tool calls', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             type: 'function',
@@ -506,7 +506,7 @@ describe('tool calls', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             type: 'function',
@@ -632,7 +632,7 @@ describe('provider-specific metadata merging', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call1',
@@ -999,7 +999,7 @@ describe('provider-specific metadata merging', () => {
         role: 'assistant',
         cacheControl: { type: 'default' },
         sharedKey: 'assistantLevel',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'collisionToolCall',
@@ -1041,7 +1041,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'function-call-1',
@@ -1134,7 +1134,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
     // Verify both signatures are preserved
     expect(result[1]).toEqual({
       role: 'assistant',
-      content: '',
+      content: null,
       tool_calls: [
         {
           id: 'function-call-1',
@@ -1154,7 +1154,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
 
     expect(result[3]).toEqual({
       role: 'assistant',
-      content: '',
+      content: null,
       tool_calls: [
         {
           id: 'function-call-2',
@@ -1203,7 +1203,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'function-call-paris',
@@ -1250,7 +1250,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call-1',

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -202,7 +202,7 @@ export function convertToOpenAICompatibleChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           ...(reasoning.length > 0 ? { reasoning_content: reasoning } : {}),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           ...metadata,


### PR DESCRIPTION
## Description

Fixes #13466

When assistant messages contain only tool-call parts and no text parts, the content field was being sent as an empty string ("") instead of null. This caused AWS Bedrock to reject the request with:

> ValidationException: messages: text content blocks must be non-empty

## Changes

Changed \"content: text\" to \"content: text || null\" in convertToOpenAICompatibleChatMessages so that empty text content is sent as null, which matches the OpenAI API spec and is accepted by Bedrock.

## Testing

- Updated test expectations from \"content: ''\" to \"content: null\" for assistant messages with only tool calls
- All 36 tests in convert-to-openai-compatible-chat-messages.test.ts pass

---
_Disclosure: This contribution was made autonomously by [ClawOSS](https://github.com/billion-token-one-task/ClawOSS), an autonomous codebase helper._