### PR TITLE
fix(ai): prevent execution of disabled tools when activeTools is set

### DIFF
--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -806,6 +806,14 @@ export async function generateText<
             continue;
           }
 
+          // skip tool calls for tools that are not active
+          if (
+            stepActiveTools != null &&
+            !stepActiveTools.includes(toolCall.toolName as keyof TOOLS)
+          ) {
+            continue;
+          }
+
           if (tool?.onInputAvailable != null) {
             await tool.onInputAvailable({
               input: toolCall.input,
@@ -862,7 +870,9 @@ export async function generateText<
               toolCalls: clientToolCalls.filter(
                 toolCall =>
                   !toolCall.invalid &&
-                  toolApprovalRequests[toolCall.toolCallId] == null,
+                  toolApprovalRequests[toolCall.toolCallId] == null &&
+                  (stepActiveTools == null ||
+                    stepActiveTools.includes(toolCall.toolName as keyof TOOLS)),
               ),
               tools,
               telemetry,

--- a/packages/ai/src/generate-text/run-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.test.ts
@@ -42,6 +42,7 @@ describe('runToolsTransformation', () => {
       ]);
 
     const transformedStream = runToolsTransformation({
+      activeTools: undefined,
       generateId: mockId({ prefix: 'id' }),
       tools: undefined,
       generatorStream: inputStream,
@@ -114,6 +115,7 @@ describe('runToolsTransformation', () => {
       ]);
 
     const transformedStream = runToolsTransformation({
+      activeTools: undefined,
       generateId: mockId({ prefix: 'id' }),
       tools: undefined,
       generatorStream: inputStream,
@@ -185,6 +187,7 @@ describe('runToolsTransformation', () => {
       ]);
 
     const transformedStream = runToolsTransformation({
+      activeTools: undefined,
       generateId: mockId({ prefix: 'id' }),
       tools: undefined,
       generatorStream: inputStream,
@@ -259,6 +262,7 @@ describe('runToolsTransformation', () => {
       ]);
 
     const transformedStream = runToolsTransformation({
+      activeTools: undefined,
       generateId: mockId({ prefix: 'id' }),
       tools: {
         syncTool: {
@@ -345,6 +349,7 @@ describe('runToolsTransformation', () => {
       ]);
 
     const transformedStream = runToolsTransformation({
+      activeTools: undefined,
       generateId: mockId({ prefix: 'id' }),
       tools: {
         syncTool: {
@@ -431,6 +436,7 @@ describe('runToolsTransformation', () => {
       ]);
 
     const transformedStream = runToolsTransformation({
+      activeTools: undefined,
       generateId: mockId({ prefix: 'id' }),
       tools: {
         delayedTool: {
@@ -521,6 +527,7 @@ describe('runToolsTransformation', () => {
       ]);
 
     const transformedStream = runToolsTransformation({
+      activeTools: undefined,
       generateId: mockId({ prefix: 'id' }),
       generatorStream: inputStream,
       telemetry: undefined,
@@ -626,6 +633,7 @@ describe('runToolsTransformation', () => {
       ]);
 
     const transformedStream = runToolsTransformation({
+      activeTools: undefined,
       generateId: mockId({ prefix: 'id' }),
       tools: {
         providerTool: {
@@ -675,6 +683,7 @@ describe('runToolsTransformation', () => {
         ]);
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           mcp_tool: {
@@ -768,6 +777,7 @@ describe('runToolsTransformation', () => {
         ]);
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: undefined,
         generatorStream: inputStream,
@@ -850,6 +860,7 @@ describe('runToolsTransformation', () => {
         ]);
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           mcp_search: {
@@ -978,6 +989,7 @@ describe('runToolsTransformation', () => {
         ]);
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           onInputAvailableTool: tool({
@@ -1069,6 +1081,7 @@ describe('runToolsTransformation', () => {
         ]);
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           onInputAvailableTool: tool({
@@ -1179,6 +1192,7 @@ describe('runToolsTransformation', () => {
         ]);
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           testTool: {
@@ -1234,6 +1248,7 @@ describe('runToolsTransformation', () => {
         ]);
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           testTool: {
@@ -1304,6 +1319,7 @@ describe('runToolsTransformation', () => {
         ]);
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           testTool: {
@@ -1358,6 +1374,7 @@ describe('runToolsTransformation', () => {
         ]);
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           failingTool: {
@@ -1413,6 +1430,7 @@ describe('runToolsTransformation', () => {
         ]);
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           noExecuteTool: {
@@ -1467,6 +1485,7 @@ describe('runToolsTransformation', () => {
         ]);
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           testTool: {
@@ -1524,6 +1543,7 @@ describe('runToolsTransformation', () => {
         ]);
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           providerTool: {
@@ -1574,6 +1594,7 @@ describe('runToolsTransformation', () => {
       const toolError = new Error('Tool execution failed!');
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           failingTool: {
@@ -1640,6 +1661,7 @@ describe('runToolsTransformation', () => {
       const toolError = new Error('Sync tool failed!');
 
       const transformedStream = runToolsTransformation({
+        activeTools: undefined,
         generateId: mockId({ prefix: 'id' }),
         tools: {
           failingTool: {

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -110,6 +110,7 @@ export type SingleRequestTextStreamPart<TOOLS extends ToolSet> =
 
 export function runToolsTransformation<TOOLS extends ToolSet>({
   tools,
+  activeTools,
   generatorStream,
   telemetry,
   callId,
@@ -126,6 +127,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
   executeToolInTelemetryContext,
 }: {
   tools: TOOLS | undefined;
+  activeTools: Array<keyof TOOLS> | undefined;
   generatorStream: ReadableStream<LanguageModelV4StreamPart>;
   telemetry: TelemetrySettings | undefined;
   callId: string;
@@ -296,6 +298,14 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
             if (tool == null) {
               // ignore tool calls for tools that are not available,
               // e.g. provider-executed dynamic tools
+              break;
+            }
+
+            // skip tool calls for tools that are not active
+            if (
+              activeTools != null &&
+              !activeTools.includes(toolCall.toolName as keyof TOOLS)
+            ) {
               break;
             }
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1591,6 +1591,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
 
           const streamWithToolResults = runToolsTransformation({
             tools,
+            activeTools: stepActiveTools,
             generatorStream: stream,
             telemetry,
             callId,


### PR DESCRIPTION
## Problem

When using `activeTools: []` to disable tools, the tools were still being executed. While the provider call correctly received filtered tools, the tool parsing/execution logic in `runToolsTransformation` still validated against the full `tools` object instead of the filtered active subset.

## Changes

- Added `activeTools` parameter to `runToolsTransformation` function
- Added check to skip execution of tools not in the active set
- Updated call site in `stream-text.ts` to pass `stepActiveTools`
- Updated tests to include the new parameter

## Testing

All existing tests pass (2172 tests).

Fixes #13448

---
_This contribution was made by [ClawOSS](https://github.com/kevinlin/clawOSS), an autonomous codebase helper._