### PR TITLE
fix(openai-compatible): send null content for assistant messages with only tool calls

### DIFF
--- a/.changeset/fix-openai-compatible-content-null.md
+++ b/.changeset/fix-openai-compatible-content-null.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+fix(openai-compatible): send null content for assistant messages with only tool calls
+
+The @ai-sdk/openai-compatible provider was sending content: "" for assistant messages that contain only tool calls. This caused Bedrock's ValidationException because Bedrock requires content to be null when only tool calls are present.

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -457,7 +457,7 @@ describe('tool calls', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             type: 'function',
@@ -506,7 +506,7 @@ describe('tool calls', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             type: 'function',
@@ -632,7 +632,7 @@ describe('provider-specific metadata merging', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call1',
@@ -999,7 +999,7 @@ describe('provider-specific metadata merging', () => {
         role: 'assistant',
         cacheControl: { type: 'default' },
         sharedKey: 'assistantLevel',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'collisionToolCall',
@@ -1041,7 +1041,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'function-call-1',
@@ -1134,7 +1134,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
     // Verify both signatures are preserved
     expect(result[1]).toEqual({
       role: 'assistant',
-      content: '',
+      content: null,
       tool_calls: [
         {
           id: 'function-call-1',
@@ -1154,7 +1154,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
 
     expect(result[3]).toEqual({
       role: 'assistant',
-      content: '',
+      content: null,
       tool_calls: [
         {
           id: 'function-call-2',
@@ -1203,7 +1203,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'function-call-paris',
@@ -1250,7 +1250,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call-1',

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -202,7 +202,7 @@ export function convertToOpenAICompatibleChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          ...(text.length > 0 ? { content: text } : { content: null }),
           ...(reasoning.length > 0 ? { reasoning_content: reasoning } : {}),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           ...metadata,


### PR DESCRIPTION
## Background

The @ai-sdk/openai-compatible provider was sending "content": "" for assistant messages that contain only tool calls. This caused Bedrock's ValidationException because Bedrock requires content to be null when only tool calls are present.

Fixes #13466

## Summary

Changed the assistant message conversion logic to send "content": null instead of "content": "" when there is no text content but there are tool calls.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #13466