### PR TITLE
fix(openai-compatible): include error.code in SSE stream error chunks

### DIFF
--- a/.changeset/fix-sse-error-code.md
+++ b/.changeset/fix-sse-error-code.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+fix(openai-compatible): include error.code in SSE stream error chunks

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2683,7 +2683,10 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
-          "error": "Incorrect API key provided: as***T7. You can obtain an API key from https://console.api.com.",
+          "error": {
+            "code": "Client specified an invalid argument",
+            "message": "Incorrect API key provided: as***T7. You can obtain an API key from https://console.api.com.",
+          },
           "type": "error",
         },
         {

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -429,7 +429,10 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
               finishReason = { unified: 'error', raw: undefined };
               controller.enqueue({
                 type: 'error',
-                error: chunk.value.error.message,
+                error: {
+                  message: chunk.value.error.message,
+                  code: chunk.value.error.code,
+                },
               });
               return;
             }


### PR DESCRIPTION
Fixes #13506

**Problem:**
When an OpenAI-compatible provider returns an SSE stream error event with both `error.message` and `error.code`, only the message was being forwarded to consumers. The error code was silently dropped.

**Root Cause:**
In the chat stream transform, the error part only included the message string:
```typescript
controller.enqueue({
  type: "error",
  error: chunk.value.error.message  // only message, code is dropped
});
```

**Fix:**
Changed to include both message and code:
```typescript
controller.enqueue({
  type: "error",
  error: {
    message: chunk.value.error.message,
    code: chunk.value.error.code,
  }
});
```

This allows consumers to programmatically distinguish between different error types using the code field.

**Testing:**
- Updated existing test case to expect the new error format with both `message` and `code` fields
- All 177 tests pass (node + edge environments)
