### PR TITLE
fix(ai): support parameters as alias for inputSchema in tool definitions

### DIFF
--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -148,7 +148,7 @@ async function doParseToolCall<TOOLS extends ToolSet>({
     });
   }
 
-  const schema = asSchema(tool.inputSchema);
+  const schema = asSchema(tool.inputSchema ?? tool.parameters);
 
   // when the tool call has no arguments, we try passing an empty object to the schema
   // (many LLMs generate empty strings for tool calls with no arguments)

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
@@ -458,4 +458,32 @@ describe('prepareToolsAndToolChoice', () => {
       }
     `);
   });
+
+  it('should support parameters as alias for inputSchema', async () => {
+    const result = await prepareToolsAndToolChoice({
+      tools: {
+        tool1: tool({
+          description: 'Tool 1 description',
+          parameters: z.object({ city: z.string() }),
+        } as any),
+      },
+      toolChoice: undefined,
+      activeTools: undefined,
+    });
+
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools?.[0]).toMatchObject({
+      name: 'tool1',
+      description: 'Tool 1 description',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          city: {
+            type: 'string',
+          },
+        },
+        required: ['city'],
+      },
+    });
+  });
 });

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
@@ -51,7 +51,8 @@ export async function prepareToolsAndToolChoice<TOOLS extends ToolSet>({
           type: 'function' as const,
           name,
           description: tool.description,
-          inputSchema: await asSchema(tool.inputSchema).jsonSchema,
+          inputSchema: await asSchema(tool.inputSchema ?? tool.parameters)
+            .jsonSchema,
           ...(tool.inputExamples != null
             ? { inputExamples: tool.inputExamples }
             : {}),

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -428,15 +428,17 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
             }
 
             // Tool input validation
+            const inputSchema = tool.inputSchema ?? tool.parameters;
             if (
-              toolPart.state === 'input-available' ||
-              toolPart.state === 'output-available' ||
-              (toolPart.state === 'output-error' &&
-                toolPart.input !== undefined)
+              inputSchema != null &&
+              (toolPart.state === 'input-available' ||
+                toolPart.state === 'output-available' ||
+                (toolPart.state === 'output-error' &&
+                  toolPart.input !== undefined))
             ) {
               await validateTypes({
                 value: toolPart.input,
-                schema: tool.inputSchema,
+                schema: inputSchema,
                 context: {
                   field: `messages[${msgIdx}].parts[${partIdx}].input`,
                   entityName: toolName,

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -135,7 +135,13 @@ export type Tool<
    *
    * You can use descriptions on the schema properties to make the input understandable for the language model.
    */
-  inputSchema: FlexibleSchema<INPUT>;
+  inputSchema?: FlexibleSchema<INPUT>;
+
+  /**
+   * Alias for inputSchema. The schema of the input that the tool expects.
+   * Use either inputSchema or parameters, not both.
+   */
+  parameters?: FlexibleSchema<INPUT>;
 
   /**
    * An optional list of input examples that show the language


### PR DESCRIPTION
Fixes #13460

The tool() function allows users to define tools with either 'inputSchema' or 'parameters' as the schema property name. However, `prepareToolsAndToolChoice` and `doParseToolCall` only read from `inputSchema`, causing undefined schema errors when users use the `parameters` alias.

## Changes
- Updated Tool type to include optional `parameters` property as alias
- Updated prepareToolsAndToolChoice to use `tool.inputSchema ?? tool.parameters`
- Updated doParseToolCall to use `tool.inputSchema ?? tool.parameters`
- Updated validate-ui-messages to use `tool.inputSchema ?? tool.parameters`
- Added test case for parameters alias support

## Testing
All existing tests pass, and a new test was added to verify the fix works when using `parameters` instead of `inputSchema`.