### PR TITLE
Allow external file URLs in @ai-sdk/google without inlining

### DIFF
--- a/packages/google/src/google-provider.test.ts
+++ b/packages/google/src/google-provider.test.ts
@@ -197,7 +197,7 @@ describe('google-provider', () => {
     expect(GoogleGenerativeAIEmbeddingModel).toHaveBeenCalledTimes(2);
   });
 
-  it('should include YouTube URLs in supportedUrls', () => {
+  it('should include arbitrary external URLs in supportedUrls', () => {
     const provider = createGoogleGenerativeAI({
       apiKey: 'test-api-key',
     });
@@ -217,18 +217,14 @@ describe('google-provider', () => {
     const testResults = {
       supportedUrls: [
         'https://generativelanguage.googleapis.com/v1beta/files/test123',
+        'https://example.com/signed.pdf?X-Amz-Signature=test',
         'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-        'https://youtube.com/watch?v=dQw4w9WgXcQ',
-        'https://youtu.be/dQw4w9WgXcQ',
+        'gs://bucket/path/to/file.pdf',
       ].map(url => ({
         url,
         isSupported: patterns.some((pattern: RegExp) => pattern.test(url)),
       })),
-      unsupportedUrls: [
-        'https://example.com',
-        'https://vimeo.com/123456789',
-        'https://youtube.com/channel/UCdQw4w9WgXcQ',
-      ].map(url => ({
+      unsupportedUrls: ['not-a-url'].map(url => ({
         url,
         isSupported: patterns.some((pattern: RegExp) => pattern.test(url)),
       })),
@@ -243,29 +239,21 @@ describe('google-provider', () => {
           },
           {
             "isSupported": true,
+            "url": "https://example.com/signed.pdf?X-Amz-Signature=test",
+          },
+          {
+            "isSupported": true,
             "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
           },
           {
             "isSupported": true,
-            "url": "https://youtube.com/watch?v=dQw4w9WgXcQ",
-          },
-          {
-            "isSupported": true,
-            "url": "https://youtu.be/dQw4w9WgXcQ",
+            "url": "gs://bucket/path/to/file.pdf",
           },
         ],
         "unsupportedUrls": [
           {
             "isSupported": false,
-            "url": "https://example.com",
-          },
-          {
-            "isSupported": false,
-            "url": "https://vimeo.com/123456789",
-          },
-          {
-            "isSupported": false,
-            "url": "https://youtube.com/channel/UCdQw4w9WgXcQ",
+            "url": "not-a-url",
           },
         ],
       }

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -17,6 +17,7 @@ import { GoogleGenerativeAIEmbeddingModel } from './google-generative-ai-embeddi
 import { GoogleGenerativeAIEmbeddingModelId } from './google-generative-ai-embedding-options';
 import { GoogleGenerativeAILanguageModel } from './google-generative-ai-language-model';
 import { GoogleGenerativeAIModelId } from './google-generative-ai-options';
+import { supportedFileUrlPattern } from './google-supported-file-url';
 import { googleTools } from './google-tools';
 
 import {
@@ -152,16 +153,7 @@ export function createGoogleGenerativeAI(
       headers: getHeaders,
       generateId: options.generateId ?? generateId,
       supportedUrls: () => ({
-        '*': [
-          // Google Generative Language "files" endpoint
-          // e.g. https://generativelanguage.googleapis.com/v1beta/files/...
-          new RegExp(`^${baseURL}/files/.*$`),
-          // YouTube URLs (public or unlisted videos)
-          new RegExp(
-            `^https://(?:www\\.)?youtube\\.com/watch\\?v=[\\w-]+(?:&[\\w=&.-]*)?$`,
-          ),
-          new RegExp(`^https://youtu\\.be/[\\w-]+(?:\\?[\\w=&.-]*)?$`),
-        ],
+        '*': [supportedFileUrlPattern],
       }),
       fetch: options.fetch,
     });

--- a/packages/google/src/google-supported-file-url.test.ts
+++ b/packages/google/src/google-supported-file-url.test.ts
@@ -1,57 +1,21 @@
 import { isSupportedFileUrl } from './google-supported-file-url';
 import { it, expect } from 'vitest';
 
-it('should return true for valid Google generative language file URLs', () => {
-  const validUrl = new URL(
-    'https://generativelanguage.googleapis.com/v1beta/files/00000000-00000000-00000000-00000000',
-  );
-  expect(isSupportedFileUrl(validUrl)).toBe(true);
-
-  const simpleValidUrl = new URL(
-    'https://generativelanguage.googleapis.com/v1beta/files/test123',
-  );
-  expect(isSupportedFileUrl(simpleValidUrl)).toBe(true);
-});
-
-it('should return true for valid YouTube URLs', () => {
-  const validYouTubeUrls = [
+it('should return true for absolute URLs across supported schemes', () => {
+  const validUrls = [
+    new URL(
+      'https://generativelanguage.googleapis.com/v1beta/files/00000000-00000000-00000000-00000000',
+    ),
+    new URL('https://example.com/signed.pdf?X-Amz-Signature=test'),
     new URL('https://www.youtube.com/watch?v=dQw4w9WgXcQ'),
-    new URL('https://youtube.com/watch?v=dQw4w9WgXcQ'),
-    new URL('https://youtu.be/dQw4w9WgXcQ'),
-    new URL('https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be'),
-    new URL('https://youtu.be/dQw4w9WgXcQ?t=42'),
+    new URL('gs://bucket/path/to/file.pdf'),
   ];
 
-  validYouTubeUrls.forEach(url => {
+  validUrls.forEach(url => {
     expect(isSupportedFileUrl(url)).toBe(true);
   });
 });
 
-it('should return false for invalid YouTube URLs', () => {
-  const invalidYouTubeUrls = [
-    new URL('https://youtube.com/channel/UCdQw4w9WgXcQ'),
-    new URL('https://youtube.com/playlist?list=PLdQw4w9WgXcQ'),
-    new URL('https://m.youtube.com/watch?v=dQw4w9WgXcQ'),
-    new URL('http://youtube.com/watch?v=dQw4w9WgXcQ'),
-    new URL('https://vimeo.com/123456789'),
-  ];
-
-  invalidYouTubeUrls.forEach(url => {
-    expect(isSupportedFileUrl(url)).toBe(false);
-  });
-});
-
-it('should return false for non-Google generative language file URLs', () => {
-  const testCases = [
-    new URL('https://example.com'),
-    new URL('https://example.com/foo/bar'),
-    new URL('https://generativelanguage.googleapis.com'),
-    new URL('https://generativelanguage.googleapis.com/v1/other'),
-    new URL('http://generativelanguage.googleapis.com/v1beta/files/test'),
-    new URL('https://api.googleapis.com/v1beta/files/test'),
-  ];
-
-  testCases.forEach(url => {
-    expect(isSupportedFileUrl(url)).toBe(false);
-  });
+it('should return true for any absolute URL scheme', () => {
+  expect(isSupportedFileUrl(new URL('mailto:test@example.com'))).toBe(true);
 });

--- a/packages/google/src/google-supported-file-url.ts
+++ b/packages/google/src/google-supported-file-url.ts
@@ -1,20 +1,5 @@
+export const supportedFileUrlPattern = /^[a-z][a-z0-9+.-]*:/i;
+
 export function isSupportedFileUrl(url: URL): boolean {
-  const urlString = url.toString();
-
-  // Google Generative Language files API
-  if (
-    urlString.startsWith(
-      'https://generativelanguage.googleapis.com/v1beta/files/',
-    )
-  ) {
-    return true;
-  }
-
-  // YouTube URLs (public or unlisted videos)
-  const youtubeRegexes = [
-    /^https:\/\/(?:www\.)?youtube\.com\/watch\?v=[\w-]+(?:&[\w=&.-]*)?$/,
-    /^https:\/\/youtu\.be\/[\w-]+(?:\?[\w=&.-]*)?$/,
-  ];
-
-  return youtubeRegexes.some(regex => regex.test(urlString));
+  return supportedFileUrlPattern.test(url.toString());
 }


### PR DESCRIPTION
## Summary
- broaden `@ai-sdk/google` supported URL handling to accept arbitrary absolute file URLs
- preserve external URLs as `fileData.fileUri` instead of forcing ai core to download and inline them
- update provider and URL-support tests to cover signed HTTPS URLs and `gs://` URLs

## Problem
`@ai-sdk/google` currently exposes a narrow `supportedUrls` list. In ai core, any user file URL outside that list is downloaded before the Google provider serializes the request. That turns external signed URLs into inline bytes, which breaks the use case where callers need Gemini to fetch the file from the original URL directly.

## Solution
This patch changes the Google provider to advertise any absolute URL as supported. That keeps URL-backed file parts as `URL` instances through prompt conversion, so `convertToGoogleGenerativeAIMessages` emits `fileData.fileUri` instead of `inlineData`.

## Verification
- `pnpm -C /tmp/vercel-ai --filter @ai-sdk/provider --filter @ai-sdk/provider-utils build`
- `pnpm -C /tmp/vercel-ai --filter @ai-sdk/google exec vitest --config vitest.node.config.js --run src/google-provider.test.ts src/google-supported-file-url.test.ts`
