### PR TITLE
refactoring: move delta to text conversion into run-tool-transformation

### DIFF
--- a/packages/ai/src/generate-text/run-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.test.ts
@@ -63,8 +63,9 @@ describe('runToolsTransformation', () => {
           "type": "text-start",
         },
         {
-          "delta": "text",
           "id": "1",
+          "providerMetadata": undefined,
+          "text": "text",
           "type": "text-delta",
         },
         {

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -37,7 +37,7 @@ export type SingleRequestTextStreamPart<TOOLS extends ToolSet> =
       type: 'text-delta';
       id: string;
       providerMetadata?: ProviderMetadata;
-      delta: string;
+      text: string;
     }
   | {
       type: 'text-end';
@@ -55,7 +55,7 @@ export type SingleRequestTextStreamPart<TOOLS extends ToolSet> =
       type: 'reasoning-delta';
       id: string;
       providerMetadata?: ProviderMetadata;
-      delta: string;
+      text: string;
     }
   | {
       type: 'reasoning-end';
@@ -207,10 +207,8 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
         // forward:
         case 'stream-start':
         case 'text-start':
-        case 'text-delta':
         case 'text-end':
         case 'reasoning-start':
-        case 'reasoning-delta':
         case 'reasoning-end':
         case 'tool-input-start':
         case 'tool-input-delta':
@@ -222,6 +220,24 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
           controller.enqueue(chunk);
           break;
         }
+
+        case 'text-delta':
+          controller.enqueue({
+            type: 'text-delta',
+            id: chunk.id,
+            text: chunk.delta,
+            providerMetadata: chunk.providerMetadata,
+          });
+          break;
+
+        case 'reasoning-delta':
+          controller.enqueue({
+            type: 'reasoning-delta',
+            id: chunk.id,
+            text: chunk.delta,
+            providerMetadata: chunk.providerMetadata,
+          });
+          break;
 
         case 'file':
         case 'reasoning-file': {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1,7 +1,6 @@
 import {
   getErrorMessage,
   LanguageModelV4,
-  LanguageModelV4ToolChoice,
   SharedV4Warning,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
@@ -10,15 +9,12 @@ import {
   DelayedPromise,
   IdGenerator,
   isAbortError,
-  ModelMessage,
   ProviderOptions,
-  SystemModelMessage,
   ToolApprovalResponse,
   ToolContent,
 } from '@ai-sdk/provider-utils';
 import { ServerResponse } from 'node:http';
 import { NoOutputGeneratedError } from '../error';
-import { Listener, notify } from '../util/notify';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
 import {
@@ -73,9 +69,9 @@ import { createStitchableStream } from '../util/create-stitchable-stream';
 import { DownloadFunction } from '../util/download/download-function';
 import { mergeAbortSignals } from '../util/merge-abort-signals';
 import { mergeObjects } from '../util/merge-objects';
+import { notify } from '../util/notify';
 import { now as originalNow } from '../util/now';
 import { prepareRetries } from '../util/prepare-retries';
-import { collectToolApprovals } from './collect-tool-approvals';
 import type {
   OnFinishEvent,
   OnStartEvent,
@@ -84,6 +80,7 @@ import type {
   OnToolCallFinishEvent,
   OnToolCallStartEvent,
 } from './callback-events';
+import { collectToolApprovals } from './collect-tool-approvals';
 import { ContentPart } from './content-part';
 import { executeToolCall } from './execute-tool-call';
 import { Output, text } from './output';
@@ -1687,13 +1684,8 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                     }
 
                     case 'text-delta': {
-                      if (chunk.delta.length > 0) {
-                        controller.enqueue({
-                          type: 'text-delta',
-                          id: chunk.id,
-                          text: chunk.delta,
-                          providerMetadata: chunk.providerMetadata,
-                        });
+                      if (chunk.text.length > 0) {
+                        controller.enqueue(chunk);
                       }
                       break;
                     }
@@ -1705,12 +1697,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
                     }
 
                     case 'reasoning-delta': {
-                      controller.enqueue({
-                        type: 'reasoning-delta',
-                        id: chunk.id,
-                        text: chunk.delta,
-                        providerMetadata: chunk.providerMetadata,
-                      });
+                      controller.enqueue(chunk);
                       break;
                     }
 


### PR DESCRIPTION
## Background

We are working towards better support for custom loop control. For this, we are separating out individual reusable functions from streamText. As a first step, we need to separate transformation steps such that each transformation has a single responsibility.

## Summary

* move delta to text conversion to earlier transformation in pipeline
* organize imports

## Related issues

towards https://github.com/vercel/ai/issues/13570