### PR TITLE
fix(openai, openai-compatible): use null instead of empty string for assistant content with tool calls

### DIFF
--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -829,6 +829,39 @@ describe('provider-specific metadata merging', () => {
     ]);
   });
 
+  it('should set content to null for assistant messages with only tool calls and no text', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call1',
+            toolName: 'searchTool',
+            input: { query: 'Weather' },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call1',
+            type: 'function',
+            function: {
+              name: 'searchTool',
+              arguments: JSON.stringify({ query: 'Weather' }),
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should handle a single tool role message with multiple tool-result parts', () => {
     const result = convertToOpenAICompatibleChatMessages([
       {

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -202,7 +202,7 @@ export function convertToOpenAICompatibleChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           ...(reasoning.length > 0 ? { reasoning_content: reasoning } : {}),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           ...metadata,

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
@@ -514,3 +514,40 @@ describe('tool calls', () => {
     `);
   });
 });
+
+describe('assistant messages', () => {
+  it('should set content to null for assistant messages with only tool calls and no text', () => {
+    const result = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call1',
+              toolName: 'searchTool',
+              input: { query: 'Weather' },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.messages).toEqual([
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call1',
+            type: 'function',
+            function: {
+              name: 'searchTool',
+              arguments: JSON.stringify({ query: 'Weather' }),
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -175,7 +175,7 @@ export function convertToOpenAIChatMessages({
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 


### PR DESCRIPTION
## Summary

Fixes assistant messages with only `tool-call` parts sending `content: ""` instead of `content: null`, which causes AWS Bedrock to reject with `ValidationException: messages: text content blocks must be non-empty`.

## Root Cause

In both `@ai-sdk/openai` and `@ai-sdk/openai-compatible`, the assistant message conversion initializes `text = ""` and only appends to it when `text` parts exist. When the assistant message contains only `tool-call` parts, `text` remains `""` and the output is `content: ""`.

```ts
// Before (both packages)
messages.push({
  role: 'assistant',
  content: text,  // "" when no text parts exist
  tool_calls: ...
});
```

## Fix

```ts
// After
messages.push({
  role: 'assistant',
  content: text || null,  // null instead of empty string
  tool_calls: ...
});
```

This matches the [OpenAI API spec](https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages) where `content` is nullable for assistant messages with tool calls.

## Changes

- `packages/openai/src/chat/convert-to-openai-chat-messages.ts` — `content: text` → `content: text || null`
- `packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts` — same fix
- Added regression tests in both packages verifying `content: null` when assistant has only tool calls

## Test plan
- [x] Added test: assistant message with only tool-call parts → `content: null`
- [x] Prettier/lint-staged passed
- [ ] CI will verify all existing tests still pass

Fixes #13466