### PR TITLE
refactoring(ai): introduce stream text part transform and move text part conversion

### DIFF
--- a/packages/ai/src/generate-text/create-stream-text-part-transform.test.ts
+++ b/packages/ai/src/generate-text/create-stream-text-part-transform.test.ts
@@ -1,5 +1,5 @@
 import {
-  LanguageModelV3Usage,
+  LanguageModelV4Usage,
   LanguageModelV4StreamPart,
 } from '@ai-sdk/provider';
 import {
@@ -9,7 +9,7 @@ import {
 import { describe, expect, it } from 'vitest';
 import { createStreamTextPartTransform } from './create-stream-text-part-transform';
 
-const testUsage: LanguageModelV3Usage = {
+const testUsage: LanguageModelV4Usage = {
   inputTokens: {
     total: 3,
     noCache: 3,

--- a/packages/ai/src/generate-text/create-stream-text-part-transform.test.ts
+++ b/packages/ai/src/generate-text/create-stream-text-part-transform.test.ts
@@ -1,0 +1,85 @@
+import {
+  LanguageModelV3Usage,
+  LanguageModelV4StreamPart,
+} from '@ai-sdk/provider';
+import {
+  convertArrayToReadableStream,
+  convertReadableStreamToArray,
+} from '@ai-sdk/provider-utils/test';
+import { describe, expect, it } from 'vitest';
+import { createStreamTextPartTransform } from './create-stream-text-part-transform';
+
+const testUsage: LanguageModelV3Usage = {
+  inputTokens: {
+    total: 3,
+    noCache: 3,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 10,
+    text: 10,
+    reasoning: undefined,
+  },
+};
+
+describe('createStreamTextPartTransform', () => {
+  it('should forward text parts', async () => {
+    const inputStream: ReadableStream<LanguageModelV4StreamPart> =
+      convertArrayToReadableStream([
+        { type: 'text-start', id: '1' },
+        { type: 'text-delta', id: '1', delta: 'text' },
+        { type: 'text-end', id: '1' },
+        {
+          type: 'finish',
+          finishReason: { unified: 'stop', raw: 'stop' },
+          usage: testUsage,
+        },
+      ]);
+
+    const transformedStream = inputStream.pipeThrough(
+      createStreamTextPartTransform(),
+    );
+
+    const result = await convertReadableStreamToArray(transformedStream);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "1",
+          "type": "text-start",
+        },
+        {
+          "id": "1",
+          "providerMetadata": undefined,
+          "text": "text",
+          "type": "text-delta",
+        },
+        {
+          "id": "1",
+          "type": "text-end",
+        },
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": undefined,
+              "cacheWrite": undefined,
+              "noCache": 3,
+              "total": 3,
+            },
+            "outputTokens": {
+              "reasoning": undefined,
+              "text": 10,
+              "total": 10,
+            },
+          },
+        },
+      ]
+    `);
+  });
+});

--- a/packages/ai/src/generate-text/create-stream-text-part-transform.ts
+++ b/packages/ai/src/generate-text/create-stream-text-part-transform.ts
@@ -1,0 +1,36 @@
+import { LanguageModelV4StreamPart } from '@ai-sdk/provider';
+import { ProviderMetadata } from '../types/provider-metadata';
+
+export type UglyTransformedStreamTextPart =
+  | Exclude<
+      LanguageModelV4StreamPart,
+      {
+        type: 'text-delta';
+      }
+    >
+  | {
+      type: 'text-delta';
+      id: string;
+      providerMetadata?: ProviderMetadata;
+      text: string;
+    };
+
+export function createStreamTextPartTransform() {
+  return new TransformStream<
+    LanguageModelV4StreamPart,
+    UglyTransformedStreamTextPart
+  >({
+    async transform(chunk, controller) {
+      if (chunk.type === 'text-delta') {
+        controller.enqueue({
+          type: 'text-delta',
+          id: chunk.id,
+          text: chunk.delta,
+          providerMetadata: chunk.providerMetadata,
+        });
+      } else {
+        controller.enqueue(chunk);
+      }
+    },
+  });
+}

--- a/packages/ai/src/generate-text/run-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.test.ts
@@ -1,7 +1,4 @@
-import {
-  LanguageModelV3StreamPart,
-  LanguageModelV3Usage,
-} from '@ai-sdk/provider';
+import { LanguageModelV4Usage } from '@ai-sdk/provider';
 import { delay, tool } from '@ai-sdk/provider-utils';
 import {
   convertArrayToReadableStream,
@@ -11,9 +8,10 @@ import {
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { NoSuchToolError } from '../error/no-such-tool-error';
+import { UglyTransformedStreamTextPart } from './create-stream-text-part-transform';
 import { runToolsTransformation } from './run-tools-transformation';
 
-const testUsage: LanguageModelV3Usage = {
+const testUsage: LanguageModelV4Usage = {
   inputTokens: {
     total: 3,
     noCache: 3,
@@ -29,10 +27,10 @@ const testUsage: LanguageModelV3Usage = {
 
 describe('runToolsTransformation', () => {
   it('should forward text parts', async () => {
-    const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+    const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
       convertArrayToReadableStream([
         { type: 'text-start', id: '1' },
-        { type: 'text-delta', id: '1', delta: 'text' },
+        { type: 'text-delta', id: '1', text: 'text' },
         { type: 'text-end', id: '1' },
         {
           type: 'finish',
@@ -64,7 +62,6 @@ describe('runToolsTransformation', () => {
         },
         {
           "id": "1",
-          "providerMetadata": undefined,
           "text": "text",
           "type": "text-delta",
         },
@@ -100,7 +97,7 @@ describe('runToolsTransformation', () => {
   });
 
   it('should forward file parts', async () => {
-    const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+    const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
       convertArrayToReadableStream([
         {
           type: 'file',
@@ -168,7 +165,7 @@ describe('runToolsTransformation', () => {
   });
 
   it('should forward file parts with providerMetadata', async () => {
-    const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+    const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
       convertArrayToReadableStream([
         {
           type: 'file',
@@ -244,7 +241,7 @@ describe('runToolsTransformation', () => {
   });
 
   it('should handle async tool execution', async () => {
-    const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+    const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
       convertArrayToReadableStream([
         {
           type: 'tool-call',
@@ -330,7 +327,7 @@ describe('runToolsTransformation', () => {
   });
 
   it('should handle sync tool execution', async () => {
-    const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+    const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
       convertArrayToReadableStream([
         {
           type: 'tool-call',
@@ -416,7 +413,7 @@ describe('runToolsTransformation', () => {
   });
 
   it('should hold off on sending finish until the delayed tool result is received', async () => {
-    const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+    const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
       convertArrayToReadableStream([
         {
           type: 'tool-call',
@@ -506,7 +503,7 @@ describe('runToolsTransformation', () => {
   });
 
   it('should try to repair tool call when the tool name is not found', async () => {
-    const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+    const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
       convertArrayToReadableStream([
         {
           type: 'tool-call',
@@ -603,7 +600,7 @@ describe('runToolsTransformation', () => {
   it('should not call execute for provider-executed tool calls', async () => {
     let toolExecuted = false;
 
-    const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+    const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
       convertArrayToReadableStream([
         {
           type: 'tool-call',
@@ -654,7 +651,7 @@ describe('runToolsTransformation', () => {
 
   describe('provider-emitted tool-approval-request (MCP flow)', () => {
     it('should forward provider-emitted tool-approval-request with the correct tool call', async () => {
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',
@@ -753,7 +750,7 @@ describe('runToolsTransformation', () => {
     });
 
     it('should emit error when tool call is not found for provider approval request', async () => {
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           // No tool-call part before the approval request
           {
@@ -817,7 +814,7 @@ describe('runToolsTransformation', () => {
     });
 
     it('should handle multiple provider-executed tool calls with approval requests', async () => {
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',
@@ -963,7 +960,7 @@ describe('runToolsTransformation', () => {
   describe('Tool.onInputAvailable', () => {
     it('should call onInputAvailable before the tool call is executed', async () => {
       const output: unknown[] = [];
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',
@@ -1054,7 +1051,7 @@ describe('runToolsTransformation', () => {
 
     it('should call onInputAvailable when the tool needs approval', async () => {
       const output: unknown[] = [];
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',
@@ -1164,7 +1161,7 @@ describe('runToolsTransformation', () => {
     it('should call onToolCallStart before tool execution and onToolCallFinish after', async () => {
       const callOrder: string[] = [];
 
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',
@@ -1219,7 +1216,7 @@ describe('runToolsTransformation', () => {
       const startEvents: unknown[] = [];
       const finishEvents: unknown[] = [];
 
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',
@@ -1289,7 +1286,7 @@ describe('runToolsTransformation', () => {
     it('should call onToolCallFinish with success data', async () => {
       const finishEvents: unknown[] = [];
 
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',
@@ -1343,7 +1340,7 @@ describe('runToolsTransformation', () => {
       const finishEvents: unknown[] = [];
       const toolError = new Error('tool failed');
 
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',
@@ -1398,7 +1395,7 @@ describe('runToolsTransformation', () => {
       const startEvents: unknown[] = [];
       const finishEvents: unknown[] = [];
 
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',
@@ -1446,7 +1443,7 @@ describe('runToolsTransformation', () => {
       const startEvents: unknown[] = [];
       const finishEvents: unknown[] = [];
 
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',
@@ -1501,7 +1498,7 @@ describe('runToolsTransformation', () => {
       const startEvents: unknown[] = [];
       const finishEvents: unknown[] = [];
 
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',
@@ -1557,7 +1554,7 @@ describe('runToolsTransformation', () => {
 
   describe('tool execution error handling', () => {
     it('should handle error thrown in async tool execution', async () => {
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',
@@ -1623,7 +1620,7 @@ describe('runToolsTransformation', () => {
     });
 
     it('should handle error thrown in sync tool execution', async () => {
-      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+      const inputStream: ReadableStream<UglyTransformedStreamTextPart> =
         convertArrayToReadableStream([
           {
             type: 'tool-call',

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV4StreamPart, SharedV4Warning } from '@ai-sdk/provider';
+import { SharedV4Warning } from '@ai-sdk/provider';
 import {
   getErrorMessage,
   IdGenerator,
@@ -11,14 +11,15 @@ import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { FinishReason, LanguageModelUsage, ProviderMetadata } from '../types';
 import { Source } from '../types/language-model';
 import { asLanguageModelUsage } from '../types/usage';
+import { UglyTransformedStreamTextPart } from './create-stream-text-part-transform';
 import { executeToolCall } from './execute-tool-call';
+import { DefaultGeneratedFileWithType, GeneratedFile } from './generated-file';
+import { isApprovalNeeded } from './is-approval-needed';
+import { parseToolCall } from './parse-tool-call';
 import {
   StreamTextOnToolCallFinishCallback,
   StreamTextOnToolCallStartCallback,
 } from './stream-text';
-import { DefaultGeneratedFileWithType, GeneratedFile } from './generated-file';
-import { isApprovalNeeded } from './is-approval-needed';
-import { parseToolCall } from './parse-tool-call';
 import { ToolApprovalRequestOutput } from './tool-approval-request-output';
 import { TypedToolCall } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair-function';
@@ -131,7 +132,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
   executeToolInTelemetryContext,
 }: {
   tools: TOOLS | undefined;
-  generatorStream: ReadableStream<LanguageModelV4StreamPart>;
+  generatorStream: ReadableStream<UglyTransformedStreamTextPart>;
   telemetry: TelemetrySettings | undefined;
   callId: string;
   system: string | SystemModelMessage | Array<SystemModelMessage> | undefined;
@@ -192,11 +193,11 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
 
   // forward stream
   const forwardStream = new TransformStream<
-    LanguageModelV4StreamPart,
+    UglyTransformedStreamTextPart,
     SingleRequestTextStreamPart<TOOLS>
   >({
     async transform(
-      chunk: LanguageModelV4StreamPart,
+      chunk: UglyTransformedStreamTextPart,
       controller: TransformStreamDefaultController<
         SingleRequestTextStreamPart<TOOLS>
       >,
@@ -207,6 +208,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
         // forward:
         case 'stream-start':
         case 'text-start':
+        case 'text-delta':
         case 'text-end':
         case 'reasoning-start':
         case 'reasoning-end':
@@ -220,15 +222,6 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
           controller.enqueue(chunk);
           break;
         }
-
-        case 'text-delta':
-          controller.enqueue({
-            type: 'text-delta',
-            id: chunk.id,
-            text: chunk.delta,
-            providerMetadata: chunk.providerMetadata,
-          });
-          break;
 
         case 'reasoning-delta':
           controller.enqueue({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -82,6 +82,7 @@ import type {
 } from './callback-events';
 import { collectToolApprovals } from './collect-tool-approvals';
 import { ContentPart } from './content-part';
+import { createStreamTextPartTransform } from './create-stream-text-part-transform';
 import { executeToolCall } from './execute-tool-call';
 import { Output, text } from './output';
 import {
@@ -1573,7 +1574,11 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
           });
 
           const stepStartTimestampMs = now();
-          const { stream, response, request } = await retry(async () =>
+          const {
+            stream: languageModelStream,
+            response,
+            request,
+          } = await retry(async () =>
             stepModel.doStream({
               ...callSettings,
               tools: stepTools,
@@ -1585,6 +1590,10 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
               headers,
               includeRawChunks,
             }),
+          );
+
+          const stream = languageModelStream.pipeThrough(
+            createStreamTextPartTransform(),
           );
 
           const streamWithToolResults = runToolsTransformation({


### PR DESCRIPTION
## Background

We are working towards better support for custom loop control. For this, we are separating out individual reusable functions from streamText. As a first step, we need to separate transformation steps such that each transformation has a single responsibility.

## Summary

* introduce transform for converting `LanguageModelV4StreamPart` to `StreamTextResult` parts
* move text part standardization

## Future Work

* move more part transformations into the new Transform

## Related Issues

Builds on #13530