### PR TITLE
fix(provider/alibaba): single-item array cache control edge case

### DIFF
--- a/.changeset/hip-cats-rule.md
+++ b/.changeset/hip-cats-rule.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/alibaba': patch
+---
+
+fix(provider/alibaba): handle single-item content array cache control

--- a/examples/ai-functions/src/generate-text/alibaba/explicit-cache-single-array.ts
+++ b/examples/ai-functions/src/generate-text/alibaba/explicit-cache-single-array.ts
@@ -1,0 +1,61 @@
+import { alibaba, AlibabaUsage } from '@ai-sdk/alibaba';
+import { generateText } from 'ai';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { run } from '../../lib/run';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+run(async () => {
+  const longUserContent = readFileSync(
+    join(__dirname, '../../../data/anthropic-compaction-data.txt'),
+    'utf-8',
+  );
+
+  console.log('Request with part-level cache_control on user message...\n');
+
+  const result = await generateText({
+    model: alibaba('qwen-plus'),
+    messages: [
+      {
+        role: 'system',
+        content: 'You are a helpful assistant.',
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: longUserContent + '\n\nSummarize the above in one sentence.',
+            providerOptions: {
+              alibaba: {
+                cache_control: { type: 'ephemeral' },
+              },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log('Text:', result.text.substring(0, 50) + '...');
+  console.log('Usage:', result.usage);
+
+  const raw = result.usage.raw as AlibabaUsage;
+  const cacheCreated =
+    raw.prompt_tokens_details?.cache_creation_input_tokens || 0;
+  const cacheHit = raw.prompt_tokens_details?.cached_tokens || 0;
+
+  console.log();
+  if (cacheCreated > 0 || cacheHit > 0) {
+    console.log(
+      `SUCCESS: Part-level cache_control was applied (created: ${cacheCreated}, hit: ${cacheHit})`,
+    );
+  } else {
+    console.log(
+      'FAILED: Part-level cache_control was not applied - cache_control likely dropped by shortcut path',
+    );
+  }
+});

--- a/packages/alibaba/src/__snapshots__/alibaba-chat-language-model.test.ts.snap
+++ b/packages/alibaba/src/__snapshots__/alibaba-chat-language-model.test.ts.snap
@@ -98,7 +98,7 @@ So final answer: 3.",
     "unified": "stop",
   },
   "request": {
-    "body": "{"model":"qwen-plus","messages":[{"role":"user","content":"Hello"}]}",
+    "body": "{"model":"qwen-plus","messages":[{"role":"user","content":[{"type":"text","text":"Hello"}]}]}",
   },
   "response": {
     "body": {
@@ -302,7 +302,7 @@ Obsidiana is a quiet, reflective holiday that offers a profound antidote to mode
     "unified": "stop",
   },
   "request": {
-    "body": "{"model":"qwen-plus","messages":[{"role":"user","content":"Hello"}]}",
+    "body": "{"model":"qwen-plus","messages":[{"role":"user","content":[{"type":"text","text":"Hello"}]}]}",
   },
   "response": {
     "body": {
@@ -420,7 +420,7 @@ exports[`doGenerate > tool call > should extract tool call content 1`] = `
     "unified": "tool-calls",
   },
   "request": {
-    "body": "{"model":"qwen-plus","messages":[{"role":"user","content":"Hello"}]}",
+    "body": "{"model":"qwen-plus","messages":[{"role":"user","content":[{"type":"text","text":"Hello"}]}]}",
   },
   "response": {
     "body": {

--- a/packages/alibaba/src/alibaba-chat-language-model.test.ts
+++ b/packages/alibaba/src/alibaba-chat-language-model.test.ts
@@ -57,7 +57,12 @@ describe('doGenerate', () => {
         {
           "messages": [
             {
-              "content": "Hello",
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
               "role": "user",
             },
           ],

--- a/packages/alibaba/src/convert-to-alibaba-chat-messages.test.ts
+++ b/packages/alibaba/src/convert-to-alibaba-chat-messages.test.ts
@@ -3,7 +3,7 @@ import { convertToAlibabaChatMessages } from './convert-to-alibaba-chat-messages
 import { CacheControlValidator } from './get-cache-control';
 
 describe('convertToAlibabaChatMessages', () => {
-  it('should use string format for single text user message', () => {
+  it('should use array format for single text user message', () => {
     const result = convertToAlibabaChatMessages({
       prompt: [
         {
@@ -16,7 +16,12 @@ describe('convertToAlibabaChatMessages', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "Hello",
+          "content": [
+            {
+              "text": "Hello",
+              "type": "text",
+            },
+          ],
           "role": "user",
         },
       ]
@@ -201,6 +206,93 @@ describe('convertToAlibabaChatMessages', () => {
     `);
   });
 
+  it('should use part-level cache control for single-part user message', () => {
+    const validator = new CacheControlValidator();
+
+    const result = convertToAlibabaChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Hello',
+              providerOptions: {
+                alibaba: {
+                  cacheControl: { type: 'ephemeral' },
+                },
+              },
+            },
+          ],
+        },
+      ],
+      cacheControlValidator: validator,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "cache_control": {
+                "type": "ephemeral",
+              },
+              "text": "Hello",
+              "type": "text",
+            },
+          ],
+          "role": "user",
+        },
+      ]
+    `);
+  });
+
+  it('should prefer part-level over message-level cache control for single-part user message', () => {
+    const validator = new CacheControlValidator();
+
+    const result = convertToAlibabaChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Hello',
+              providerOptions: {
+                alibaba: {
+                  cacheControl: { type: 'ephemeral' },
+                },
+              },
+            },
+          ],
+          providerOptions: {
+            alibaba: {
+              cacheControl: { type: 'should-not-use' },
+            },
+          },
+        },
+      ],
+      cacheControlValidator: validator,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "cache_control": {
+                "type": "ephemeral",
+              },
+              "text": "Hello",
+              "type": "text",
+            },
+          ],
+          "role": "user",
+        },
+      ]
+    `);
+  });
+
   it('should use part-level cache control for multi-part user message', () => {
     const validator = new CacheControlValidator();
 
@@ -308,6 +400,105 @@ describe('convertToAlibabaChatMessages', () => {
           providerOptions: {
             alibaba: {
               cacheControl: { type: 'ephemeral' },
+            },
+          },
+        },
+      ],
+      cacheControlValidator: validator,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "cache_control": {
+                "type": "ephemeral",
+              },
+              "text": "{"temperature":72,"condition":"sunny"}",
+              "type": "text",
+            },
+          ],
+          "role": "tool",
+          "tool_call_id": "call-1",
+        },
+      ]
+    `);
+  });
+
+  it('should use part-level cache control for single-part tool message', () => {
+    const validator = new CacheControlValidator();
+
+    const result = convertToAlibabaChatMessages({
+      prompt: [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'get_weather',
+              output: {
+                type: 'json',
+                value: { temperature: 72, condition: 'sunny' },
+              },
+              providerOptions: {
+                alibaba: {
+                  cacheControl: { type: 'ephemeral' },
+                },
+              },
+            },
+          ],
+        },
+      ],
+      cacheControlValidator: validator,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "cache_control": {
+                "type": "ephemeral",
+              },
+              "text": "{"temperature":72,"condition":"sunny"}",
+              "type": "text",
+            },
+          ],
+          "role": "tool",
+          "tool_call_id": "call-1",
+        },
+      ]
+    `);
+  });
+
+  it('should prefer part-level over message-level cache control for single-part tool message', () => {
+    const validator = new CacheControlValidator();
+
+    const result = convertToAlibabaChatMessages({
+      prompt: [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'get_weather',
+              output: {
+                type: 'json',
+                value: { temperature: 72, condition: 'sunny' },
+              },
+              providerOptions: {
+                alibaba: {
+                  cacheControl: { type: 'ephemeral' },
+                },
+              },
+            },
+          ],
+          providerOptions: {
+            alibaba: {
+              cacheControl: { type: 'should-not-use' },
             },
           },
         },

--- a/packages/alibaba/src/convert-to-alibaba-chat-messages.test.ts
+++ b/packages/alibaba/src/convert-to-alibaba-chat-messages.test.ts
@@ -342,6 +342,55 @@ describe('convertToAlibabaChatMessages', () => {
     `);
   });
 
+  it('should apply message-level cache control to last part of multi-part user message', () => {
+    const validator = new CacheControlValidator();
+
+    const result = convertToAlibabaChatMessages({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is in this image?' },
+            {
+              type: 'file',
+              data: new Uint8Array([0, 1, 2, 3]),
+              mediaType: 'image/png',
+            },
+          ],
+          providerOptions: {
+            alibaba: {
+              cacheControl: { type: 'ephemeral' },
+            },
+          },
+        },
+      ],
+      cacheControlValidator: validator,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "text": "What is in this image?",
+              "type": "text",
+            },
+            {
+              "cache_control": {
+                "type": "ephemeral",
+              },
+              "image_url": {
+                "url": "data:image/png;base64,AAECAw==",
+              },
+              "type": "image_url",
+            },
+          ],
+          "role": "user",
+        },
+      ]
+    `);
+  });
+
   it('should inject cache control into assistant message', () => {
     const validator = new CacheControlValidator();
 
@@ -520,6 +569,67 @@ describe('convertToAlibabaChatMessages', () => {
           ],
           "role": "tool",
           "tool_call_id": "call-1",
+        },
+      ]
+    `);
+  });
+
+  it('should apply message-level cache control to last part of multi-part tool message', () => {
+    const validator = new CacheControlValidator();
+
+    const result = convertToAlibabaChatMessages({
+      prompt: [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'get_weather',
+              output: {
+                type: 'json',
+                value: { temperature: 72, condition: 'sunny' },
+              },
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'call-2',
+              toolName: 'get_time',
+              output: {
+                type: 'text',
+                value: '2:30 PM',
+              },
+            },
+          ],
+          providerOptions: {
+            alibaba: {
+              cacheControl: { type: 'ephemeral' },
+            },
+          },
+        },
+      ],
+      cacheControlValidator: validator,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "{"temperature":72,"condition":"sunny"}",
+          "role": "tool",
+          "tool_call_id": "call-1",
+        },
+        {
+          "content": [
+            {
+              "cache_control": {
+                "type": "ephemeral",
+              },
+              "text": "2:30 PM",
+              "type": "text",
+            },
+          ],
+          "role": "tool",
+          "tool_call_id": "call-2",
         },
       ]
     `);

--- a/packages/alibaba/src/convert-to-alibaba-chat-messages.ts
+++ b/packages/alibaba/src/convert-to-alibaba-chat-messages.ts
@@ -55,24 +55,12 @@ export function convertToAlibabaChatMessages({
       case 'user': {
         const isSinglePart = content.length === 1;
 
-        if (
-          isSinglePart &&
-          content[0].type === 'text' &&
-          !messageCacheControl
-        ) {
-          messages.push({
-            role: 'user',
-            content: content[0].text,
-          });
-          break;
-        }
-
         messages.push({
           role: 'user',
           content: content.map(part => {
-            const partCacheControl = isSinglePart
-              ? messageCacheControl
-              : cacheControlValidator?.getCacheControl(part.providerOptions);
+            const partCacheControl =
+              cacheControlValidator?.getCacheControl(part.providerOptions) ??
+              (isSinglePart ? messageCacheControl : undefined);
 
             switch (part.type) {
               case 'text': {
@@ -169,11 +157,10 @@ export function convertToAlibabaChatMessages({
           const toolResponse = toolResponses[i];
           const output = toolResponse.output;
 
-          const partCacheControl = isSinglePart
-            ? messageCacheControl
-            : cacheControlValidator?.getCacheControl(
-                (toolResponse as any).providerOptions,
-              );
+          const partCacheControl =
+            cacheControlValidator?.getCacheControl(
+              toolResponse.providerOptions,
+            ) ?? (isSinglePart ? messageCacheControl : undefined);
 
           let contentValue: string;
           switch (output.type) {

--- a/packages/alibaba/src/convert-to-alibaba-chat-messages.ts
+++ b/packages/alibaba/src/convert-to-alibaba-chat-messages.ts
@@ -53,14 +53,13 @@ export function convertToAlibabaChatMessages({
       }
 
       case 'user': {
-        const isSinglePart = content.length === 1;
-
         messages.push({
           role: 'user',
-          content: content.map(part => {
+          content: content.map((part, index) => {
+            const isLastPart = index === content.length - 1;
             const partCacheControl =
               cacheControlValidator?.getCacheControl(part.providerOptions) ??
-              (isSinglePart ? messageCacheControl : undefined);
+              (isLastPart ? messageCacheControl : undefined);
 
             switch (part.type) {
               case 'text': {
@@ -151,16 +150,15 @@ export function convertToAlibabaChatMessages({
           r => r.type !== 'tool-approval-response',
         );
 
-        const isSinglePart = toolResponses.length === 1;
-
         for (let i = 0; i < toolResponses.length; i++) {
           const toolResponse = toolResponses[i];
           const output = toolResponse.output;
+          const isLastPart = i === toolResponses.length - 1;
 
           const partCacheControl =
             cacheControlValidator?.getCacheControl(
               toolResponse.providerOptions,
-            ) ?? (isSinglePart ? messageCacheControl : undefined);
+            ) ?? (isLastPart ? messageCacheControl : undefined);
 
           let contentValue: string;
           switch (output.type) {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

When a single-part message is sent as an array, part-level `cache_control` is ignored and only message-level is checked. We should retain the part-level `cache_control` too.

AI SDK normalizes content: `content = 'Hello'` into `content: [{ type: 'text', text: 'Hello' }]` before it reaches the provider. This case was already handled by Alibaba provider: 
```ts
  messages: [{
    role: 'user',                                                       
    content: [{ type: 'text', text: '...' }],
    providerOptions: {                                                  
      alibaba: { cache_control: { type: 'ephemeral' } },                
    },                                                                  
  }]                                                                    
```

But when content is already a single-item array, part-level `cache_control` is ignored.
```ts
  messages: [{
    role: 'user',
    content: [{
      type: 'text',
      text: '...',
      providerOptions: {
        alibaba: { cache_control: { type: 'ephemeral' } },
      },
    }],
  }]
```

## Summary

<!-- What did you change? -->

`convert-to-alibaba-chat-messages.ts` 
Cache control now checks part-level first, falls back to message-level for single-part messages.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

- Added script and unit tests

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

- backport to v6
- backport to v5

