### PR TITLE
fix(mcp): setting redirect: error for MCP transport

### DIFF
--- a/.changeset/cold-hats-cry.md
+++ b/.changeset/cold-hats-cry.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': major
+---
+
+fix(mcp): setting redirect: error for MCP transport

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -43,8 +43,8 @@ const mcpClient = await createMCPClient({
     // optional: provide an OAuth client provider for automatic authorization
     authProvider: myOAuthClientProvider,
 
-    // optional: reject redirect responses to prevent SSRF
-    redirect: 'error',
+    // optional: allow redirect responses (default is 'error' to prevent SSRF)
+    redirect: 'follow',
   },
 });
 ```
@@ -81,8 +81,8 @@ const mcpClient = await createMCPClient({
     // optional: provide an OAuth client provider for automatic authorization
     authProvider: myOAuthClientProvider,
 
-    // optional: reject redirect responses to prevent SSRF
-    redirect: 'error',
+    // optional: allow redirect responses (default is 'error' to prevent SSRF)
+    redirect: 'follow',
   },
 });
 ```

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -113,7 +113,7 @@ It currently does not support accepting notifications from an MCP server, and cu
                       type: "'follow' | 'error'",
                       isOptional: true,
                       description:
-                        "Controls how HTTP redirects are handled for transport requests. Set to 'error' to reject any redirect response, preventing servers from redirecting requests to unintended hosts. Defaults to 'follow'.",
+                        "Controls how HTTP redirects are handled for transport requests. Set to 'follow' to allow redirect responses. Defaults to 'error' to reject any redirect response, preventing servers from redirecting requests to unintended hosts.",
                     },
                   ],
                 },

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -64,3 +64,32 @@ const result = await generateText({
 This applies to all AI SDK functions that accept `experimental_telemetry`, including `streamText`, `generateObject`, `streamObject`, `embed`, and `embedMany`.
 
 If you were not passing a custom `tracer` (relying on the default global tracer), no changes are needed — the `OpenTelemetryIntegration` is registered globally by default and uses `trace.getTracer('ai')` when no custom tracer is provided.
+
+## MCP Package
+
+### MCP Transport: `redirect` Default Changed from `'follow'` to `'error'`
+
+The `redirect` option on `MCPTransportConfig` (used by both HTTP and SSE transports) now defaults to `'error'` instead of `'follow'`. This means HTTP redirects are rejected by default to prevent server-side request forgery (SSRF) attacks where an MCP server could redirect requests to unintended hosts.
+
+If your MCP server relies on HTTP redirects, explicitly set `redirect: 'follow'` in your transport configuration:
+
+```tsx filename="AI SDK 6"
+const mcpClient = await createMCPClient({
+  transport: {
+    type: 'http',
+    url: 'https://your-server.com/mcp',
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const mcpClient = await createMCPClient({
+  transport: {
+    type: 'http',
+    url: 'https://your-server.com/mcp',
+    redirect: 'follow',
+  },
+});
+```
+
+If the MCP server you use does not issue redirects, no changes are needed — the new default is more secure.

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -401,7 +401,7 @@ describe('HttpMCPTransport', () => {
       fetchSpy.mockRestore();
     });
 
-    it('should default redirect to follow', async () => {
+    it('should default redirect to error', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
       transport = new HttpMCPTransport({
@@ -421,7 +421,7 @@ describe('HttpMCPTransport', () => {
 
       expect(fetchSpy).toHaveBeenCalledWith(
         'http://localhost:4000/mcp',
-        expect.objectContaining({ redirect: 'follow', method: 'GET' }),
+        expect.objectContaining({ redirect: 'error', method: 'GET' }),
       );
 
       fetchSpy.mockRestore();

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -50,7 +50,7 @@ export class HttpMCPTransport implements MCPTransport {
     url,
     headers,
     authProvider,
-    redirect = 'follow',
+    redirect = 'error',
   }: {
     url: string;
     headers?: Record<string, string>;

--- a/packages/mcp/src/tool/mcp-sse-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.test.ts
@@ -353,7 +353,7 @@ describe('SseMCPTransport', () => {
       fetchSpy.mockRestore();
     });
 
-    it('should default redirect to follow', async () => {
+    it('should default redirect to error', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
       const controller = new TestResponseController();
@@ -374,7 +374,7 @@ describe('SseMCPTransport', () => {
 
       expect(fetchSpy).toHaveBeenCalledWith(
         'http://localhost:3000/sse',
-        expect.objectContaining({ redirect: 'follow' }),
+        expect.objectContaining({ redirect: 'error' }),
       );
 
       await transport.close();

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -36,7 +36,7 @@ export class SseMCPTransport implements MCPTransport {
     url,
     headers,
     authProvider,
-    redirect = 'follow',
+    redirect = 'error',
   }: {
     url: string;
     headers?: Record<string, string>;

--- a/packages/mcp/src/tool/mcp-transport.ts
+++ b/packages/mcp/src/tool/mcp-transport.ts
@@ -63,7 +63,7 @@ export type MCPTransportConfig = {
    * Controls how HTTP redirects are handled for transport requests.
    * - `'follow'`: Follow redirects automatically (standard fetch behavior).
    * - `'error'`: Reject any redirect response with an error.
-   * @default 'follow'
+   * @default 'error'
    */
   redirect?: 'follow' | 'error';
 };


### PR DESCRIPTION
## Background

As a follow up to the PR https://github.com/vercel/ai/pull/13525, the default behaviour for MCP transports (both http and sse) for their redirect behvaiour, allowed `follow` (less secure) instead of `error`

## Summary

- change the default behaviour to be set as `redirect: error` for both transports
- documented as a breaking change in the migration guide

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)