### PR TITLE
fix(google-vertex): disable fine-grained tool streaming for Anthropic provider

### DIFF
--- a/.changeset/vertex-tool-streaming.md
+++ b/.changeset/vertex-tool-streaming.md
@@ -1,0 +1,10 @@
+---
+"@ai-sdk/anthropic": patch
+"@ai-sdk/google-vertex": patch
+---
+
+fix(google-vertex): disable fine-grained tool streaming for Anthropic provider
+
+Added `supportsFineGrainedToolStreaming` config option to AnthropicMessagesConfig
+to allow Google Vertex provider to disable the problematic beta header that
+causes malformed tool call JSON responses.

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -135,6 +135,12 @@ type AnthropicMessagesConfig = {
    * Defaults to true.
    */
   supportsStrictTools?: boolean;
+
+  /**
+   * When false, the fine-grained tool streaming beta header will not be sent.
+   * Defaults to true.
+   */
+  supportsFineGrainedToolStreaming?: boolean;
 };
 
 export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
@@ -607,7 +613,11 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
     }
 
     // only when streaming: enable fine-grained tool streaming
-    if (stream && (anthropicOptions?.toolStreaming ?? true)) {
+    if (
+      stream &&
+      (anthropicOptions?.toolStreaming ?? true) &&
+      (this.config.supportsFineGrainedToolStreaming ?? true)
+    ) {
       betas.add('fine-grained-tool-streaming-2025-05-14');
     }
 

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -52,6 +52,7 @@ describe('google-vertex-anthropic-provider', () => {
         transformRequestBody: expect.any(Function),
         supportsNativeStructuredOutput: false,
         supportsStrictTools: false,
+        supportsFineGrainedToolStreaming: false,
       }),
     );
   });

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -204,6 +204,8 @@ export function createVertexAnthropic(
       supportsNativeStructuredOutput: false,
       // Vertex Anthropic doesn't support strict mode on tool definitions.
       supportsStrictTools: false,
+      // Google Vertex doesn't support fine-grained tool streaming beta header
+      supportsFineGrainedToolStreaming: false,
     });
 
   const provider = function (modelId: GoogleVertexAnthropicMessagesModelId) {


### PR DESCRIPTION
## Background

Google Vertex Anthropic provider was sending the &#39;fine-grained-tool-streaming-2025-05-14&#39; beta header, which is not supported by the Vertex API. This caused malformed tool call JSON responses when streaming was enabled.

Fixes #13514

## Summary

- Added `supportsFineGrainedToolStreaming` config option to `AnthropicMessagesConfig`
- Set `supportsFineGrainedToolStreaming: false` in Google Vertex Anthropic provider
- Updated tests to verify the new config option

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added