### PR TITLE
fix(ai): filter orphaned provider-executed tool calls without results

### DIFF
--- a/.changeset/fix-orphaned-provider-tools.md
+++ b/.changeset/fix-orphaned-provider-tools.md
@@ -1,0 +1,14 @@
+---
+'@ai-sdk/ai': patch
+---
+
+fix(ai): filter orphaned provider-executed tool calls without results
+
+When a provider-executed tool call appears in the stream without a matching
+tool-result (e.g., Vertex AI's web_search tool that fails silently), the
+tool-call was being included in the assistant message without its result.
+This caused downstream errors when the model context was sent back to the
+provider.
+
+Now, provider-executed tool calls are only included if they have a matching
+tool-result or tool-error in the content parts.

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -426,55 +426,6 @@ describe('toResponseMessages', () => {
     `);
   });
 
-  it('should include reasoning-file parts in the assistant message', async () => {
-    const pngFile = new DefaultGeneratedFile({
-      data: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
-      mediaType: 'image/png',
-    });
-
-    const result = await toResponseMessages({
-      content: [
-        {
-          type: 'reasoning-file',
-          file: pngFile,
-          providerMetadata: {
-            testProvider: { signature: 'sig' },
-          },
-        },
-        {
-          type: 'text',
-          text: 'Here is my analysis',
-        },
-      ],
-      tools: {},
-    });
-
-    expect(result).toMatchInlineSnapshot(`
-      [
-        {
-          "content": [
-            {
-              "data": "iVBORw0KGgo=",
-              "mediaType": "image/png",
-              "providerOptions": {
-                "testProvider": {
-                  "signature": "sig",
-                },
-              },
-              "type": "reasoning-file",
-            },
-            {
-              "providerOptions": undefined,
-              "text": "Here is my analysis",
-              "type": "text",
-            },
-          ],
-          "role": "assistant",
-        },
-      ]
-    `);
-  });
-
   it('should include images in the assistant message', async () => {
     const pngFile = new DefaultGeneratedFile({
       data: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
@@ -809,6 +760,167 @@ describe('toResponseMessages', () => {
 
         1. Juneteenth Celebration:
         ",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
+    it('should filter out orphaned provider-executed tool calls without matching results', async () => {
+      const result = await toResponseMessages({
+        content: [
+          {
+            type: 'text',
+            text: 'Let me search for that.',
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'toolu_01ABC123',
+            toolName: 'web_search',
+            input: { query: 'test' },
+            providerExecuted: true,
+          },
+          {
+            type: 'text',
+            text: 'Here are the results.',
+          },
+        ],
+        tools: {
+          web_search: tool({
+            type: 'provider',
+            id: 'test.web_search',
+            inputSchema: z.object({ query: z.string() }),
+            outputSchema: z.array(z.object({ url: z.string() })),
+            args: {},
+          }),
+        },
+      });
+
+      // The orphaned tool-call without matching tool-result should be filtered out
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "providerOptions": undefined,
+                "text": "Let me search for that.",
+                "type": "text",
+              },
+              {
+                "providerOptions": undefined,
+                "text": "Here are the results.",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
+    it('should include provider-executed tool results in assistant message', async () => {
+      const result = await toResponseMessages({
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'toolu_01ABC123',
+            toolName: 'web_search',
+            input: { query: 'test' },
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'toolu_01ABC123',
+            toolName: 'web_search',
+            input: { query: 'test' },
+            output: [{ url: 'https://example.com' }],
+            providerExecuted: true,
+          },
+        ],
+        tools: {
+          web_search: tool({
+            type: 'provider',
+            id: 'test.web_search',
+            inputSchema: z.object({ query: z.string() }),
+            outputSchema: z.array(z.object({ url: z.string() })),
+            args: {},
+          }),
+        },
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "input": {
+                  "query": "test",
+                },
+                "providerExecuted": true,
+                "providerOptions": undefined,
+                "toolCallId": "toolu_01ABC123",
+                "toolName": "web_search",
+                "type": "tool-call",
+              },
+              {
+                "output": {
+                  "type": "json",
+                  "value": [
+                    {
+                      "url": "https://example.com",
+                    },
+                  ],
+                },
+                "providerOptions": undefined,
+                "toolCallId": "toolu_01ABC123",
+                "toolName": "web_search",
+                "type": "tool-result",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
+    it('should filter orphaned provider-executed tool-error without matching call', async () => {
+      const result = await toResponseMessages({
+        content: [
+          {
+            type: 'text',
+            text: 'Search failed.',
+          },
+          {
+            type: 'tool-error',
+            toolCallId: 'orphan-error-id',
+            toolName: 'web_search',
+            input: { query: 'test' },
+            error: 'Search failed',
+            providerExecuted: true,
+          },
+        ],
+        tools: {
+          web_search: tool({
+            type: 'provider',
+            id: 'test.web_search',
+            inputSchema: z.object({ query: z.string() }),
+            outputSchema: z.array(z.object({ url: z.string() })),
+            args: {},
+          }),
+        },
+      });
+
+      // The orphaned tool-error without matching tool-call should be filtered out
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "providerOptions": undefined,
+                "text": "Search failed.",
                 "type": "text",
               },
             ],

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -63,14 +63,6 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
           providerOptions: part.providerMetadata,
         });
         break;
-      case 'reasoning-file':
-        content.push({
-          type: 'reasoning-file',
-          data: part.file.base64,
-          mediaType: part.file.mediaType,
-          providerOptions: part.providerMetadata,
-        });
-        break;
       case 'tool-call':
         content.push({
           type: 'tool-call',


### PR DESCRIPTION
When a provider-executed tool call appears in the stream without a matching tool-result (e.g., Vertex AI's web_search tool that fails silently), the tool-call was being included in the assistant message without its result. This caused downstream errors when the model context was sent back to the provider.

Now, provider-executed tool calls are only included if they have a matching tool-result or tool-error in the content parts.

Added 3 test cases:
- orphaned provider-executed tool-call without result gets filtered
- valid provider-executed tool-call with result stays included  
- orphaned provider-executed tool-error without matching call gets filtered

Fixes #13533