### PR TITLE
fix(anthropic): handle vertex_event SSE events from Vertex AI Anthropic provider

### DIFF
--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -1320,6 +1320,16 @@ export const anthropicMessagesChunkSchema = lazySchema(() =>
       z.object({
         type: z.literal('ping'),
       }),
+      // Vertex AI sends additional events for Anthropic models that need to be handled
+      z.object({
+        type: z.literal('vertex_event'),
+        usage: z.looseObject({
+          input_tokens: z.number(),
+          output_tokens: z.number(),
+          cache_creation_input_tokens: z.number().nullish(),
+          cache_read_input_tokens: z.number().nullish(),
+        }),
+      }),
     ]),
   ),
 );

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -1358,6 +1358,11 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
               return; // ignored
             }
 
+            case 'vertex_event': {
+              // Vertex AI sends additional usage events that should be ignored
+              return;
+            }
+
             case 'content_block_start': {
               const part = value.content_block;
               const contentBlockType = part.type;


### PR DESCRIPTION
## Problem

When using streamText with the Vertex AI Anthropic provider, streaming fails immediately because Vertex sends additional `vertex_event` SSE events that aren't recognized by the SDK.

These events contain usage information that cause type validation errors, resulting in the stream finishing immediately instead of properly streaming.

## Solution

1. Added `vertex_event` to the `anthropicMessagesChunkSchema` with the usage field structure
2. Handle `vertex_event` in the transform stream (ignored like ping events)

This follows the same pattern used by other providers that handle provider-specific SSE events.

## Changes

- packages/anthropic/src/anthropic-messages-api.ts: Added vertex_event schema definition
- packages/anthropic/src/anthropic-messages-language-model.ts: Added handler for vertex_event type

Fixes #13350