### PR TITLE
fix(openai-compatible): preserve structured SSE error payloads

### DIFF
--- a/.changeset/nine-pianos-sip.md
+++ b/.changeset/nine-pianos-sip.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Preserve structured SSE error payloads from OpenAI-compatible chat streams instead of collapsing them to the error message string.

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2683,7 +2683,10 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
-          "error": "Incorrect API key provided: as***T7. You can obtain an API key from https://console.api.com.",
+          "error": {
+            "code": "Client specified an invalid argument",
+            "message": "Incorrect API key provided: as***T7. You can obtain an API key from https://console.api.com.",
+          },
           "type": "error",
         },
         {

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -429,7 +429,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
               finishReason = { unified: 'error', raw: undefined };
               controller.enqueue({
                 type: 'error',
-                error: chunk.value.error.message,
+                error: chunk.value.error,
               });
               return;
             }


### PR DESCRIPTION
## Summary
- preserve the parsed SSE error object in the OpenAI-compatible chat stream instead of collapsing it to `error.message`
- extend the existing chat stream regression to cover `error.code`
- add a patch changeset for `@ai-sdk/openai-compatible`

## Why
Issue #13506 points out that OpenAI-compatible providers can return structured stream errors with a machine-readable `code`, but the chat stream currently drops that field before it reaches consumers. The completion path already forwards the parsed error object, so this brings the chat path back in line with that behavior.

## Testing
- `pnpm --filter @ai-sdk/openai-compatible lint`
- `pnpm --filter @ai-sdk/openai-compatible type-check`
- `pnpm --filter @ai-sdk/openai-compatible test:node -- src/chat/openai-compatible-chat-language-model.test.ts`