### PR TITLE
fix(ai): filter orphaned provider-executed tool calls without matching results

### DIFF
--- a/.changeset/fix-vertex-orphaned-tool-calls.md
+++ b/.changeset/fix-vertex-orphaned-tool-calls.md
@@ -1,0 +1,9 @@
+---
+'ai': patch
+---
+
+fix(ai): filter orphaned provider-executed tool calls without matching results
+
+When using Vertex Anthropic with provider-executed tools like web_search, the API sometimes omits the tool_result from the stream when both provider and client tools are called in the same turn. This causes orphaned tool-call parts to enter the conversation history, leading to API errors.
+
+This fix filters out provider-executed tool calls that have no matching tool-result or tool-error in the response, preventing the orphaned tool-call issue (see #13533).

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -937,30 +937,150 @@ describe('toResponseMessages', () => {
     });
   });
 
-  it('should include provider metadata in the text parts', async () => {
+  it('should filter out orphaned provider-executed tool calls without matching results or approval requests', async () => {
+    // This test covers the Vertex Anthropic case where web_search_tool_result
+    // is missing from the stream when both provider and client tools are called
+    // in the same turn (see https://github.com/vercel/ai/issues/13533)
     const result = await toResponseMessages({
       content: [
         {
           type: 'text',
-          text: 'Here is a text',
-          providerMetadata: { testProvider: { signature: 'sig' } },
+          text: 'Searching for information and calling client tool',
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'web-search-1',
+          toolName: 'web_search',
+          input: { query: 'latest AI standards' },
+          providerExecuted: true,
+          dynamic: true,
+        },
+        // Note: web_search_tool_result is missing (orphaned tool call)
+        {
+          type: 'tool-call',
+          toolCallId: 'client-tool-1',
+          toolName: 'clientTool',
+          input: { data: 'test' },
+          providerExecuted: false,
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'client-tool-1',
+          toolName: 'clientTool',
+          output: 'Client tool result',
+          providerExecuted: false,
         },
       ],
-      tools: {},
+      tools: {
+        clientTool: tool({
+          description: 'A client tool',
+          inputSchema: z.object({ data: z.string() }),
+        }),
+      },
     });
 
+    // The orphaned provider-executed tool call should be filtered out
     expect(result).toMatchInlineSnapshot(`
       [
         {
           "content": [
             {
-              "providerOptions": {
-                "testProvider": {
-                  "signature": "sig",
-                },
-              },
-              "text": "Here is a text",
+              "providerOptions": undefined,
+              "text": "Searching for information and calling client tool",
               "type": "text",
+            },
+            {
+              "input": {
+                "data": "test",
+              },
+              "providerExecuted": false,
+              "providerOptions": undefined,
+              "toolCallId": "client-tool-1",
+              "toolName": "clientTool",
+              "type": "tool-call",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "output": {
+                "type": "text",
+                "value": "Client tool result",
+              },
+              "toolCallId": "client-tool-1",
+              "toolName": "clientTool",
+              "type": "tool-result",
+            },
+          ],
+          "role": "tool",
+        },
+      ]
+    `);
+  });
+
+  it('should keep provider-executed tool calls that have matching results', async () => {
+    const result = await toResponseMessages({
+      content: [
+        {
+          type: 'text',
+          text: 'Search completed',
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'web-search-1',
+          toolName: 'web_search',
+          input: { query: 'test' },
+          providerExecuted: true,
+          dynamic: true,
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'web-search-1',
+          toolName: 'web_search',
+          output: [{ url: 'https://example.com', title: 'Example' }],
+          providerExecuted: true,
+          dynamic: true,
+        },
+      ],
+      tools: {},
+    });
+
+    // Provider-executed tool calls with results should be included
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "providerOptions": undefined,
+              "text": "Search completed",
+              "type": "text",
+            },
+            {
+              "input": {
+                "query": "test",
+              },
+              "providerExecuted": true,
+              "providerOptions": undefined,
+              "toolCallId": "web-search-1",
+              "toolName": "web_search",
+              "type": "tool-call",
+            },
+            {
+              "output": {
+                "type": "json",
+                "value": [
+                  {
+                    "title": "Example",
+                    "url": "https://example.com",
+                  },
+                ],
+              },
+              "providerOptions": undefined,
+              "toolCallId": "web-search-1",
+              "toolName": "web_search",
+              "type": "tool-result",
             },
           ],
           "role": "assistant",

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -20,6 +20,39 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
 }): Promise<Array<AssistantModelMessage | ToolModelMessage>> {
   const responseMessages: Array<AssistantModelMessage | ToolModelMessage> = [];
 
+  // Track provider-executed tool calls and their results to identify orphans
+  // (provider-executed tool calls without matching results, which can happen
+  // with Vertex Anthropic when web_search_tool_result is missing from the stream)
+  const providerToolCallIds = new Set<string>();
+  const providerToolResultIds = new Set<string>();
+  const toolApprovalRequestIds = new Set<string>();
+
+  for (const part of inputContent) {
+    if (part.type === 'tool-call' && part.providerExecuted) {
+      providerToolCallIds.add(part.toolCallId);
+    }
+    if (
+      (part.type === 'tool-result' || part.type === 'tool-error') &&
+      part.providerExecuted
+    ) {
+      providerToolResultIds.add(part.toolCallId);
+    }
+    if (part.type === 'tool-approval-request') {
+      toolApprovalRequestIds.add(part.toolCall.toolCallId);
+    }
+  }
+
+  // Identify orphaned provider-executed tool calls (no matching result or approval request)
+  const orphanedToolCallIds = new Set<string>();
+  for (const toolCallId of providerToolCallIds) {
+    if (
+      !providerToolResultIds.has(toolCallId) &&
+      !toolApprovalRequestIds.has(toolCallId)
+    ) {
+      orphanedToolCallIds.add(toolCallId);
+    }
+  }
+
   const content: AssistantContent = [];
   for (const part of inputContent) {
     // Skip sources - they are response-only content that no provider expects back
@@ -37,6 +70,12 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
 
     // Skip empty text
     if (part.type === 'text' && part.text.length === 0) {
+      continue;
+    }
+
+    // Skip orphaned provider-executed tool calls (no matching result/error)
+    // This can happen with Vertex Anthropic when web_search_tool_result is missing
+    if (part.type === 'tool-call' && orphanedToolCallIds.has(part.toolCallId)) {
       continue;
     }
 


### PR DESCRIPTION
## Description

Fixes #13533

When using Vertex Anthropic with provider-executed tools like `web_search`, the API sometimes omits the `tool_result` from the stream when both provider and client tools are called in the same turn. This causes orphaned `tool-call` parts to enter the conversation history via `toResponseMessages`, and the next API request fails with:

```
tool_use ids were found without tool_result blocks immediately after: srvtoolu_xxx
```

## Changes

This PR modifies `toResponseMessages` to filter out provider-executed tool calls that have no matching `tool-result` or `tool-error` in the response. Tool calls with approval requests are preserved (not considered orphaned).

### Implementation Details

1. First pass: collect all provider-executed tool call IDs and provider-executed tool result/error IDs, plus tool approval request IDs
2. Identify orphaned tool calls (provider-executed tool calls without matching results or approval requests)
3. Second pass: filter out the orphaned tool calls when building the content

## Testing

Added two new test cases:
1. `should filter out orphaned provider-executed tool calls without matching results or approval requests` - verifies the fix for #13533
2. `should keep provider-executed tool calls that have matching results` - ensures normal provider tool calls still work

All existing tests continue to pass.