### PR TITLE
fix(provider-utils): chunk array when converting to base64 to avoid excessive memory usage

### DIFF
--- a/.changeset/giant-camels-burn.md
+++ b/.changeset/giant-camels-burn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Improve memory usage when converting to base64

--- a/packages/provider-utils/src/uint8-utils.test.ts
+++ b/packages/provider-utils/src/uint8-utils.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  convertBase64ToUint8Array,
+  convertUint8ArrayToBase64,
+  convertToBase64,
+} from './uint8-utils';
+
+// Creates a Uint8Array of the given length filled with cycling byte values
+// (0, 1, 2, ..., 255, 0, 1, ...) to produce varied, non-trivial test data.
+function makeBytes(length: number): Uint8Array {
+  const array = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    array[i] = i % 256;
+  }
+  return array;
+}
+
+describe('convertUint8ArrayToBase64', () => {
+  it('should convert a basic byte array to base64', () => {
+    expect(
+      convertUint8ArrayToBase64(new Uint8Array([72, 101, 108, 108, 111])),
+    ).toBe('SGVsbG8=');
+  });
+
+  it('should handle empty array', () => {
+    expect(convertUint8ArrayToBase64(new Uint8Array([]))).toBe('');
+  });
+
+  it('should handle all byte values (0-255)', () => {
+    const allBytes = makeBytes(256);
+    const result = convertUint8ArrayToBase64(allBytes);
+    // round-trip should recover original bytes
+    expect(convertBase64ToUint8Array(result)).toEqual(allBytes);
+  });
+
+  it('should correctly round-trip large arrays', () => {
+    const large = makeBytes(100000);
+    expect(convertBase64ToUint8Array(convertUint8ArrayToBase64(large))).toEqual(
+      large,
+    );
+  });
+});
+
+describe('convertBase64ToUint8Array', () => {
+  it('should convert a base64 string to a byte array', () => {
+    expect(convertBase64ToUint8Array('SGVsbG8=')).toEqual(
+      new Uint8Array([72, 101, 108, 108, 111]),
+    );
+  });
+
+  it('should handle base64url encoding (- and _ characters)', () => {
+    // [251, 255] encodes to '+/8=' in standard base64, '-_8=' in base64url
+    expect(convertBase64ToUint8Array('-_8=')).toEqual(
+      new Uint8Array([251, 255]),
+    );
+  });
+
+  it('should handle empty string', () => {
+    expect(convertBase64ToUint8Array('')).toEqual(new Uint8Array([]));
+  });
+});
+
+describe('convertToBase64', () => {
+  it('should pass through a string unchanged', () => {
+    expect(convertToBase64('SGVsbG8=')).toBe('SGVsbG8=');
+  });
+
+  it('should convert a Uint8Array to base64', () => {
+    expect(convertToBase64(new Uint8Array([72, 101, 108, 108, 111]))).toBe(
+      'SGVsbG8=',
+    );
+  });
+});

--- a/packages/provider-utils/src/uint8-utils.ts
+++ b/packages/provider-utils/src/uint8-utils.ts
@@ -12,12 +12,13 @@ export function convertBase64ToUint8Array(base64String: string) {
 export function convertUint8ArrayToBase64(array: Uint8Array): string {
   let latin1string = '';
 
+  const chunkSize = 4096;
+
   // Note: regular for loop to support older JavaScript versions that
   // do not support for..of on Uint8Array
-  for (let i = 0; i < array.length; i++) {
-    latin1string += String.fromCodePoint(array[i]);
+  for (let i = 0; i < array.length; i += chunkSize) {
+    latin1string += String.fromCodePoint(...array.subarray(i, i + chunkSize));
   }
-
   return btoa(latin1string);
 }
 

--- a/packages/provider-utils/src/uint8-utils.ts
+++ b/packages/provider-utils/src/uint8-utils.ts
@@ -10,16 +10,15 @@ export function convertBase64ToUint8Array(base64String: string) {
 }
 
 export function convertUint8ArrayToBase64(array: Uint8Array): string {
-  let latin1string = '';
-
+  const chunks: string[] = [];
   const chunkSize = 4096;
 
   // Note: regular for loop to support older JavaScript versions that
   // do not support for..of on Uint8Array
   for (let i = 0; i < array.length; i += chunkSize) {
-    latin1string += String.fromCodePoint(...array.subarray(i, i + chunkSize));
+    chunks.push(String.fromCodePoint(...array.subarray(i, i + chunkSize)));
   }
-  return btoa(latin1string);
+  return btoa(chunks.join(''));
 }
 
 export function convertToBase64(value: string | Uint8Array): string {


### PR DESCRIPTION
## Background

With a recent issue disabling passing files as base64 encoded data (https://github.com/vercel/ai/issues/13103), we switched to passing a Buffer and let the library handle base64 encoding.

However we noticed very high memory usage with this method.

## Summary

### Problem
The previous implementation built the latin1 string character by character in a loop, creating a new string allocation on every iteration. For large arrays this causes O(n²) memory pressure due to repeated string concatenation.

### Solution
Replace with a chunked approach (4096 bytes per chunk, matching [`js-base64`](https://github.com/dankogai/js-base64/blob/main/base64.ts#L65-L75)) that converts each chunk in a single `String.fromCodePoint` call and collects results into an array, joining once at the end before passing to btoa. This avoids both per-byte allocations and the O(n²) string concatenation cost.

## Manual Verification

### Tests
Added `uint8-utils.test.ts` covering basic encoding/decoding. The suite passes against both the old and new implementations.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
