### PR TITLE
fix(ai): skip schema validation for historical tool parts in terminal states

### DIFF
--- a/.changeset/fix-historical-tool-validation-13544.md
+++ b/.changeset/fix-historical-tool-validation-13544.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+fix(ai): skip schema validation for historical tool parts in terminal states
+
+Tool parts in terminal states (output-available, output-error, output-denied) no longer throw TypeValidationError when their schema is not registered. This fixes issues with MCP servers that disconnect between conversation turns, where historical tool parts from no-longer-registered tools would cause validation failures.

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -1216,6 +1216,154 @@ describe('validateUIMessages', () => {
       `);
     });
 
+    it('should skip validation for tool parts in output-available state when tool schema is not found', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-missing',
+                toolCallId: '1',
+                state: 'output-available',
+                input: { foo: 'bar' },
+                output: { result: 'success' },
+                providerExecuted: true,
+              },
+            ],
+          },
+        ],
+        tools: {
+          foo: testTool,
+        },
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "input": {
+                  "foo": "bar",
+                },
+                "output": {
+                  "result": "success",
+                },
+                "providerExecuted": true,
+                "state": "output-available",
+                "toolCallId": "1",
+                "type": "tool-missing",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
+    it('should skip validation for tool parts in output-error state when tool schema is not found', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-missing',
+                toolCallId: '1',
+                state: 'output-error',
+                input: { foo: 'bar' },
+                errorText: 'Tool execution failed',
+                providerExecuted: true,
+              },
+            ],
+          },
+        ],
+        tools: {
+          foo: testTool,
+        },
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "errorText": "Tool execution failed",
+                "input": {
+                  "foo": "bar",
+                },
+                "providerExecuted": true,
+                "state": "output-error",
+                "toolCallId": "1",
+                "type": "tool-missing",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
+    it('should skip validation for tool parts in output-denied state when tool schema is not found', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-missing',
+                toolCallId: '1',
+                state: 'output-denied',
+                input: { foo: 'bar' },
+                providerExecuted: true,
+                approval: {
+                  id: 'approval-1',
+                  approved: false,
+                  reason: 'User denied the tool call',
+                },
+              },
+            ],
+          },
+        ],
+        tools: {
+          foo: testTool,
+        },
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "approval": {
+                  "approved": false,
+                  "id": "approval-1",
+                  "reason": "User denied the tool call",
+                },
+                "input": {
+                  "foo": "bar",
+                },
+                "providerExecuted": true,
+                "state": "output-denied",
+                "toolCallId": "1",
+                "type": "tool-missing",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
     it('should throw error when tool input validation fails', async () => {
       await expect(
         validateUIMessages<TestMessage>({

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -413,6 +413,18 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
 
             // TODO support dynamic tools
             if (!tool) {
+              // Skip validation for tool parts in terminal states when the tool
+              // schema is no longer registered (e.g., MCP server disconnected).
+              // These tools have already executed and their results are stored.
+              const terminalStates = [
+                'output-available',
+                'output-error',
+                'output-denied',
+              ];
+              if (terminalStates.includes(toolPart.state)) {
+                continue;
+              }
+
               return {
                 success: false,
                 error: new TypeValidationError({


### PR DESCRIPTION
Fixes #13544 - Tool parts in terminal states (output-available, output-error, output-denied) no longer throw TypeValidationError when their schema is not registered. This fixes issues with MCP servers that disconnect between conversation turns.