### PR TITLE
fix: handle TypeValidationError on historical tool parts

### DIFF
--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -1216,6 +1216,150 @@ describe('validateUIMessages', () => {
       `);
     });
 
+    it('should skip validation for tool parts in terminal states when tool schema is not found', async () => {
+      // Test output-available state
+      const messagesOutputAvailable = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-bar',
+                toolCallId: '1',
+                state: 'output-available',
+                input: { foo: 'bar' },
+                output: { result: 'success' },
+                providerExecuted: true,
+              },
+            ],
+          },
+        ],
+        tools: {
+          foo: testTool,
+        },
+      });
+
+      expect(messagesOutputAvailable).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "input": {
+                  "foo": "bar",
+                },
+                "output": {
+                  "result": "success",
+                },
+                "providerExecuted": true,
+                "state": "output-available",
+                "toolCallId": "1",
+                "type": "tool-bar",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+
+      // Test output-error state
+      const messagesOutputError = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-bar',
+                toolCallId: '1',
+                state: 'output-error',
+                input: { foo: 'bar' },
+                errorText: 'Tool execution failed',
+                providerExecuted: true,
+              },
+            ],
+          },
+        ],
+        tools: {
+          foo: testTool,
+        },
+      });
+
+      expect(messagesOutputError).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "errorText": "Tool execution failed",
+                "input": {
+                  "foo": "bar",
+                },
+                "providerExecuted": true,
+                "state": "output-error",
+                "toolCallId": "1",
+                "type": "tool-bar",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+
+      // Test output-denied state
+      const messagesOutputDenied = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-bar',
+                toolCallId: '1',
+                state: 'output-denied',
+                input: { foo: 'bar' },
+                providerExecuted: true,
+                approval: {
+                  id: 'approval-1',
+                  approved: false,
+                  reason: 'Access denied',
+                },
+              },
+            ],
+          },
+        ],
+        tools: {
+          foo: testTool,
+        },
+      });
+
+      expect(messagesOutputDenied).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "approval": {
+                  "approved": false,
+                  "id": "approval-1",
+                  "reason": "Access denied",
+                },
+                "input": {
+                  "foo": "bar",
+                },
+                "providerExecuted": true,
+                "state": "output-denied",
+                "toolCallId": "1",
+                "type": "tool-bar",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
     it('should throw error when tool input validation fails', async () => {
       await expect(
         validateUIMessages<TestMessage>({

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -413,6 +413,19 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
 
             // TODO support dynamic tools
             if (!tool) {
+              // Skip validation for tool parts in terminal states - the tool
+              // already executed and results are stored. This handles cases
+              // where the tool schema is no longer registered (e.g., MCP
+              // server disconnected between turns).
+              const terminalStates = [
+                'output-available',
+                'output-error',
+                'output-denied',
+              ];
+              if (terminalStates.includes(toolPart.state)) {
+                continue;
+              }
+
               return {
                 success: false,
                 error: new TypeValidationError({


### PR DESCRIPTION
Fixes #13544

## Problem
When a conversation contains historical tool parts (from previous turns) and the tool schema is no longer registered (e.g., MCP server disconnected), the UI message validation throws <code>TypeValidationError</code> because it can't find the tool schema.

## Solution
Skip schema validation for tool parts in terminal states (output-available, output-error, output-denied) when the tool schema is not found. The tool has already executed and the results are stored, so schema validation is not needed for these completed states.

## Changes
- Modified validate-ui-messages.ts to check for terminal states before throwing schema not found error
- Added test coverage for all three terminal states (output-available, output-error, output-denied)

## Test Plan
- New unit tests verify that tool parts in terminal states pass validation without schema
- Existing tests verify that non-terminal states still require schema validation