### PR TITLE
fix(ai): include tool input on tool result for provider executed dynamic tools

### DIFF
--- a/.changeset/heavy-tables-fetch.md
+++ b/.changeset/heavy-tables-fetch.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): include tool input on tool result for provider executed dynamic tools

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -169,10 +169,8 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
   // keep track of outstanding tool results for stream closing:
   const outstandingToolResults = new Set<string>();
 
-  // keep track of tool inputs for provider-side tool results
-  const toolInputs = new Map<string, unknown>();
-
   // keep track of parsed tool calls so provider-emitted approval requests can reference them
+  // keep track of tool inputs for provider-side tool results
   const toolCallsByToolCallId = new Map<string, TypedToolCall<TOOLS>>();
 
   let canClose = false;
@@ -322,8 +320,6 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
               break;
             }
 
-            toolInputs.set(toolCall.toolCallId, toolCall.input);
-
             // Only execute tools that are not provider-executed:
             if (tool.execute != null && toolCall.providerExecuted !== true) {
               const toolExecutionId = generateId(); // use our own id to guarantee uniqueness
@@ -380,7 +376,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                   type: 'tool-error',
                   toolCallId: chunk.toolCallId,
                   toolName,
-                  input: toolInputs.get(chunk.toolCallId),
+                  input: toolCallsByToolCallId.get(chunk.toolCallId)?.input,
                   providerExecuted: true,
                   error: chunk.result,
                   dynamic: chunk.dynamic,
@@ -392,7 +388,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                   type: 'tool-result',
                   toolCallId: chunk.toolCallId,
                   toolName,
-                  input: toolInputs.get(chunk.toolCallId),
+                  input: toolCallsByToolCallId.get(chunk.toolCallId)?.input,
                   output: chunk.result,
                   providerExecuted: true,
                   dynamic: chunk.dynamic,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -18731,7 +18731,9 @@ describe('streamText', () => {
               },
               {
                 "dynamic": true,
-                "input": undefined,
+                "input": {
+                  "city": "San Francisco",
+                },
                 "output": {
                   "status": "success",
                   "text": "The weather in San Francisco is 72°F",
@@ -18888,7 +18890,9 @@ describe('streamText', () => {
             },
             {
               "dynamic": true,
-              "input": undefined,
+              "input": {
+                "city": "San Francisco",
+              },
               "output": {
                 "status": "success",
                 "text": "The weather in San Francisco is 72°F",


### PR DESCRIPTION
## Background

For provider-executed dynamic, the input of the tool was not available on stream text tool results parts because the tool is null and thus it did not get added to the bookkeeping object.

## Summary

Unify bookkeeping objects.

## Related issues

towards https://github.com/vercel/ai/issues/13570