### PR TITLE
Backport (v5): Add `LanguageModel` support to the Prodia provider

### DIFF
--- a/.changeset/tiny-meals-melt.md
+++ b/.changeset/tiny-meals-melt.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/prodia': patch
+---
+
+feat(provider/prodia): Add LanguageModel support to the Prodia provider.
+
+- **LanguageModel**: Supports Nano Banana (`inference.nano-banana.img2img.v2`) for img2img generation with text+image output via multipart form-data requests. Implements both `doGenerate` and `doStream`.
+- Extract shared multipart parsing and error handling infrastructure into `prodia-api.ts`.

--- a/examples/ai-core/src/generate-text/prodia-nano-banana.ts
+++ b/examples/ai-core/src/generate-text/prodia-nano-banana.ts
@@ -1,0 +1,40 @@
+import { type ProdiaLanguageModelOptions, prodia } from '@ai-sdk/prodia';
+import { generateText } from 'ai';
+import { presentImages } from '../lib/present-image';
+import { run } from '../lib/run';
+import 'dotenv/config';
+
+run(async () => {
+  const result = await generateText({
+    model: prodia.languageModel('inference.nano-banana.img2img.v2'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image',
+            image:
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+          },
+          {
+            type: 'text',
+            text: 'Make this image look like a watercolor painting',
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      prodia: {
+        aspectRatio: '1:1',
+      } satisfies ProdiaLanguageModelOptions,
+    },
+  });
+
+  console.log('Text response:', result.text);
+
+  for (const file of result.files) {
+    if (file.mediaType.startsWith('image/')) {
+      await presentImages([file]);
+    }
+  }
+});

--- a/packages/prodia/src/index.ts
+++ b/packages/prodia/src/index.ts
@@ -1,5 +1,7 @@
 export type { ProdiaImageProviderOptions } from './prodia-image-model';
 export type { ProdiaImageModelId } from './prodia-image-settings';
+export type { ProdiaLanguageModelOptions } from './prodia-language-model';
+export type { ProdiaLanguageModelId } from './prodia-language-model-settings';
 export type { ProdiaProvider, ProdiaProviderSettings } from './prodia-provider';
 export { createProdia, prodia } from './prodia-provider';
 export { VERSION } from './version';

--- a/packages/prodia/src/prodia-api.ts
+++ b/packages/prodia/src/prodia-api.ts
@@ -1,0 +1,198 @@
+import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
+import type { FetchFunction, Resolvable } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export interface ProdiaModelConfig {
+  provider: string;
+  baseURL: string;
+  headers?: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+export const prodiaJobResultSchema = z.object({
+  id: z.string(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+  expires_at: z.string().optional(),
+  state: z
+    .object({
+      current: z.string(),
+    })
+    .optional(),
+  config: z
+    .object({
+      seed: z.number().optional(),
+    })
+    .passthrough()
+    .optional(),
+  metrics: z
+    .object({
+      elapsed: z.number().optional(),
+      ips: z.number().optional(),
+    })
+    .optional(),
+  price: z
+    .object({
+      product: z.string(),
+      dollars: z.number(),
+    })
+    .nullish(),
+});
+
+export type ProdiaJobResult = z.infer<typeof prodiaJobResultSchema>;
+
+export function buildProdiaProviderMetadata(jobResult: ProdiaJobResult) {
+  return {
+    jobId: jobResult.id,
+    ...(jobResult.config?.seed != null && {
+      seed: jobResult.config.seed,
+    }),
+    ...(jobResult.metrics?.elapsed != null && {
+      elapsed: jobResult.metrics.elapsed,
+    }),
+    ...(jobResult.metrics?.ips != null && {
+      iterationsPerSecond: jobResult.metrics.ips,
+    }),
+    ...(jobResult.created_at != null && {
+      createdAt: jobResult.created_at,
+    }),
+    ...(jobResult.updated_at != null && {
+      updatedAt: jobResult.updated_at,
+    }),
+    ...(jobResult.price?.dollars != null && {
+      dollars: jobResult.price.dollars,
+    }),
+  };
+}
+
+export interface MultipartPart {
+  headers: Record<string, string>;
+  body: Uint8Array;
+}
+
+export function parseMultipart(
+  data: Uint8Array,
+  boundary: string,
+): MultipartPart[] {
+  const parts: MultipartPart[] = [];
+  const boundaryBytes = new TextEncoder().encode(`--${boundary}`);
+  const endBoundaryBytes = new TextEncoder().encode(`--${boundary}--`);
+
+  const positions: number[] = [];
+  for (let i = 0; i <= data.length - boundaryBytes.length; i++) {
+    let match = true;
+    for (let j = 0; j < boundaryBytes.length; j++) {
+      if (data[i + j] !== boundaryBytes[j]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) {
+      positions.push(i);
+    }
+  }
+
+  for (let i = 0; i < positions.length - 1; i++) {
+    const start = positions[i] + boundaryBytes.length;
+    const end = positions[i + 1];
+
+    let isEndBoundary = true;
+    for (let j = 0; j < endBoundaryBytes.length && isEndBoundary; j++) {
+      if (data[positions[i] + j] !== endBoundaryBytes[j]) {
+        isEndBoundary = false;
+      }
+    }
+    if (
+      isEndBoundary &&
+      positions[i] + endBoundaryBytes.length <= data.length
+    ) {
+      continue;
+    }
+
+    let partStart = start;
+    if (data[partStart] === 0x0d && data[partStart + 1] === 0x0a) {
+      partStart += 2;
+    } else if (data[partStart] === 0x0a) {
+      partStart += 1;
+    }
+
+    let partEnd = end;
+    if (data[partEnd - 2] === 0x0d && data[partEnd - 1] === 0x0a) {
+      partEnd -= 2;
+    } else if (data[partEnd - 1] === 0x0a) {
+      partEnd -= 1;
+    }
+
+    const partData = data.slice(partStart, partEnd);
+
+    let headerEnd = -1;
+    for (let j = 0; j < partData.length - 3; j++) {
+      if (
+        partData[j] === 0x0d &&
+        partData[j + 1] === 0x0a &&
+        partData[j + 2] === 0x0d &&
+        partData[j + 3] === 0x0a
+      ) {
+        headerEnd = j;
+        break;
+      }
+      if (partData[j] === 0x0a && partData[j + 1] === 0x0a) {
+        headerEnd = j;
+        break;
+      }
+    }
+
+    if (headerEnd === -1) {
+      continue;
+    }
+
+    const headerBytes = partData.slice(0, headerEnd);
+    const headerStr = new TextDecoder().decode(headerBytes);
+    const headers: Record<string, string> = {};
+    for (const line of headerStr.split(/\r?\n/)) {
+      const colonIdx = line.indexOf(':');
+      if (colonIdx > 0) {
+        const key = line.slice(0, colonIdx).trim().toLowerCase();
+        const value = line.slice(colonIdx + 1).trim();
+        headers[key] = value;
+      }
+    }
+
+    let bodyStart = headerEnd + 2;
+    if (partData[headerEnd] === 0x0d) {
+      bodyStart = headerEnd + 4;
+    }
+    const body = partData.slice(bodyStart);
+
+    parts.push({ headers, body });
+  }
+
+  return parts;
+}
+
+const prodiaErrorSchema = z.object({
+  message: z.string().optional(),
+  detail: z.unknown().optional(),
+  error: z.string().optional(),
+});
+
+export const prodiaFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: prodiaErrorSchema,
+  errorToMessage: error => {
+    const parsed = prodiaErrorSchema.safeParse(error);
+    if (!parsed.success) return 'Unknown Prodia error';
+    const { message, detail, error: errorField } = parsed.data;
+    if (typeof detail === 'string') return detail;
+    if (detail != null) {
+      try {
+        return JSON.stringify(detail);
+      } catch {
+        // ignore
+      }
+    }
+    return errorField ?? message ?? 'Unknown Prodia error';
+  },
+});

--- a/packages/prodia/src/prodia-image-model.ts
+++ b/packages/prodia/src/prodia-image-model.ts
@@ -1,16 +1,23 @@
 import type { ImageModelV2, ImageModelV2CallWarning } from '@ai-sdk/provider';
-import type { InferSchema, Resolvable } from '@ai-sdk/provider-utils';
+import type { InferSchema } from '@ai-sdk/provider-utils';
 import {
   combineHeaders,
-  createJsonErrorResponseHandler,
-  type FetchFunction,
   lazySchema,
+  parseJSON,
   parseProviderOptions,
   postToApi,
   resolve,
   zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
+import type { ProdiaModelConfig } from './prodia-api';
+import {
+  buildProdiaProviderMetadata,
+  parseMultipart,
+  prodiaFailedResponseHandler,
+  prodiaJobResultSchema,
+} from './prodia-api';
+import type { ProdiaJobResult } from './prodia-api';
 import type { ProdiaImageModelId } from './prodia-image-settings';
 
 export class ProdiaImageModel implements ImageModelV2 {
@@ -23,7 +30,7 @@ export class ProdiaImageModel implements ImageModelV2 {
 
   constructor(
     readonly modelId: ProdiaImageModelId,
-    private readonly config: ProdiaImageModelConfig,
+    private readonly config: ProdiaModelConfig,
   ) {}
 
   private async getArgs({
@@ -137,29 +144,7 @@ export class ProdiaImageModel implements ImageModelV2 {
       warnings,
       providerMetadata: {
         prodia: {
-          images: [
-            {
-              jobId: jobResult.id,
-              ...(jobResult.config?.seed != null && {
-                seed: jobResult.config.seed,
-              }),
-              ...(jobResult.metrics?.elapsed != null && {
-                elapsed: jobResult.metrics.elapsed,
-              }),
-              ...(jobResult.metrics?.ips != null && {
-                iterationsPerSecond: jobResult.metrics.ips,
-              }),
-              ...(jobResult.created_at != null && {
-                createdAt: jobResult.created_at,
-              }),
-              ...(jobResult.updated_at != null && {
-                updatedAt: jobResult.updated_at,
-              }),
-              ...(jobResult.price?.dollars != null && {
-                dollars: jobResult.price.dollars,
-              }),
-            },
-          ],
+          images: [buildProdiaProviderMetadata(jobResult)],
         },
       },
       response: {
@@ -226,48 +211,6 @@ export type ProdiaImageProviderOptions = InferSchema<
   typeof prodiaImageProviderOptionsSchema
 >;
 
-interface ProdiaImageModelConfig {
-  provider: string;
-  baseURL: string;
-  headers?: Resolvable<Record<string, string | undefined>>;
-  fetch?: FetchFunction;
-  _internal?: {
-    currentDate?: () => Date;
-  };
-}
-
-const prodiaJobResultSchema = z.object({
-  id: z.string(),
-  created_at: z.string().optional(),
-  updated_at: z.string().optional(),
-  expires_at: z.string().optional(),
-  state: z
-    .object({
-      current: z.string(),
-    })
-    .optional(),
-  config: z
-    .object({
-      seed: z.number().optional(),
-    })
-    .passthrough()
-    .optional(),
-  metrics: z
-    .object({
-      elapsed: z.number().optional(),
-      ips: z.number().optional(),
-    })
-    .optional(),
-  price: z
-    .object({
-      product: z.string(),
-      dollars: z.number(),
-    })
-    .nullish(),
-});
-
-type ProdiaJobResult = z.infer<typeof prodiaJobResultSchema>;
-
 interface MultipartResult {
   jobResult: ProdiaJobResult;
   imageBytes: Uint8Array;
@@ -310,7 +253,10 @@ function createMultipartResponseHandler() {
 
       if (contentDisposition.includes('name="job"')) {
         const jsonStr = new TextDecoder().decode(part.body);
-        jobResult = prodiaJobResultSchema.parse(JSON.parse(jsonStr));
+        jobResult = await parseJSON({
+          text: jsonStr,
+          schema: zodSchema(prodiaJobResultSchema),
+        });
       } else if (contentDisposition.includes('name="output"')) {
         imageBytes = part.body;
       } else if (partContentType.startsWith('image/')) {
@@ -332,128 +278,3 @@ function createMultipartResponseHandler() {
   };
 }
 
-interface MultipartPart {
-  headers: Record<string, string>;
-  body: Uint8Array;
-}
-
-function parseMultipart(data: Uint8Array, boundary: string): MultipartPart[] {
-  const parts: MultipartPart[] = [];
-  const boundaryBytes = new TextEncoder().encode(`--${boundary}`);
-  const endBoundaryBytes = new TextEncoder().encode(`--${boundary}--`);
-
-  const positions: number[] = [];
-  for (let i = 0; i <= data.length - boundaryBytes.length; i++) {
-    let match = true;
-    for (let j = 0; j < boundaryBytes.length; j++) {
-      if (data[i + j] !== boundaryBytes[j]) {
-        match = false;
-        break;
-      }
-    }
-    if (match) {
-      positions.push(i);
-    }
-  }
-
-  for (let i = 0; i < positions.length - 1; i++) {
-    const start = positions[i] + boundaryBytes.length;
-    const end = positions[i + 1];
-
-    let isEndBoundary = true;
-    for (let j = 0; j < endBoundaryBytes.length && isEndBoundary; j++) {
-      if (data[positions[i] + j] !== endBoundaryBytes[j]) {
-        isEndBoundary = false;
-      }
-    }
-    if (
-      isEndBoundary &&
-      positions[i] + endBoundaryBytes.length <= data.length
-    ) {
-      continue;
-    }
-
-    let partStart = start;
-    if (data[partStart] === 0x0d && data[partStart + 1] === 0x0a) {
-      partStart += 2;
-    } else if (data[partStart] === 0x0a) {
-      partStart += 1;
-    }
-
-    let partEnd = end;
-    if (data[partEnd - 2] === 0x0d && data[partEnd - 1] === 0x0a) {
-      partEnd -= 2;
-    } else if (data[partEnd - 1] === 0x0a) {
-      partEnd -= 1;
-    }
-
-    const partData = data.slice(partStart, partEnd);
-
-    let headerEnd = -1;
-    for (let j = 0; j < partData.length - 3; j++) {
-      if (
-        partData[j] === 0x0d &&
-        partData[j + 1] === 0x0a &&
-        partData[j + 2] === 0x0d &&
-        partData[j + 3] === 0x0a
-      ) {
-        headerEnd = j;
-        break;
-      }
-      if (partData[j] === 0x0a && partData[j + 1] === 0x0a) {
-        headerEnd = j;
-        break;
-      }
-    }
-
-    if (headerEnd === -1) {
-      continue;
-    }
-
-    const headerBytes = partData.slice(0, headerEnd);
-    const headerStr = new TextDecoder().decode(headerBytes);
-    const headers: Record<string, string> = {};
-    for (const line of headerStr.split(/\r?\n/)) {
-      const colonIdx = line.indexOf(':');
-      if (colonIdx > 0) {
-        const key = line.slice(0, colonIdx).trim().toLowerCase();
-        const value = line.slice(colonIdx + 1).trim();
-        headers[key] = value;
-      }
-    }
-
-    let bodyStart = headerEnd + 2;
-    if (partData[headerEnd] === 0x0d) {
-      bodyStart = headerEnd + 4;
-    }
-    const body = partData.slice(bodyStart);
-
-    parts.push({ headers, body });
-  }
-
-  return parts;
-}
-
-const prodiaErrorSchema = z.object({
-  message: z.string().optional(),
-  detail: z.unknown().optional(),
-  error: z.string().optional(),
-});
-
-const prodiaFailedResponseHandler = createJsonErrorResponseHandler({
-  errorSchema: prodiaErrorSchema,
-  errorToMessage: error => {
-    const parsed = prodiaErrorSchema.safeParse(error);
-    if (!parsed.success) return 'Unknown Prodia error';
-    const { message, detail, error: errorField } = parsed.data;
-    if (typeof detail === 'string') return detail;
-    if (detail != null) {
-      try {
-        return JSON.stringify(detail);
-      } catch {
-        // ignore
-      }
-    }
-    return errorField ?? message ?? 'Unknown Prodia error';
-  },
-});

--- a/packages/prodia/src/prodia-image-model.ts
+++ b/packages/prodia/src/prodia-image-model.ts
@@ -277,4 +277,3 @@ function createMultipartResponseHandler() {
     };
   };
 }
-

--- a/packages/prodia/src/prodia-language-model-settings.ts
+++ b/packages/prodia/src/prodia-language-model-settings.ts
@@ -1,0 +1,6 @@
+/**
+ * Prodia job types for language model (multimodal img2img).
+ */
+export type ProdiaLanguageModelId =
+  | 'inference.nano-banana.img2img.v2'
+  | (string & {});

--- a/packages/prodia/src/prodia-language-model.test.ts
+++ b/packages/prodia/src/prodia-language-model.test.ts
@@ -1,0 +1,517 @@
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import { ProdiaLanguageModel } from './prodia-language-model';
+
+const prompt = 'Describe this image';
+
+function createBasicModel({
+  headers,
+  fetch,
+  currentDate,
+}: {
+  headers?: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+  currentDate?: () => Date;
+} = {}) {
+  return new ProdiaLanguageModel('inference.nano-banana.img2img.v2', {
+    provider: 'prodia.language',
+    baseURL: 'https://api.example.com/v2',
+    headers: headers ?? (() => ({ Authorization: 'Bearer test-key' })),
+    fetch,
+    _internal: {
+      currentDate,
+    },
+  });
+}
+
+function createLanguageMultipartResponse(
+  jobResult: Record<string, unknown>,
+  {
+    textContent,
+    imageContent,
+  }: {
+    textContent?: string;
+    imageContent?: string;
+  } = {},
+): { body: Buffer; contentType: string } {
+  const boundary = 'test-boundary-12345';
+  const jobJson = JSON.stringify(jobResult);
+
+  const partStrings = [
+    `--${boundary}\r\n`,
+    'Content-Disposition: form-data; name="job"; filename="job.json"\r\n',
+    'Content-Type: application/json\r\n',
+    '\r\n',
+    jobJson,
+    '\r\n',
+  ];
+
+  if (textContent !== undefined) {
+    partStrings.push(
+      `--${boundary}\r\n`,
+      'Content-Disposition: form-data; name="output"; filename="message.txt"\r\n',
+      'Content-Type: text/plain\r\n',
+      '\r\n',
+      textContent,
+      '\r\n',
+    );
+  }
+
+  const headerPart = Buffer.from(partStrings.join(''));
+  const buffers: Buffer[] = [headerPart];
+
+  if (imageContent !== undefined) {
+    const imageHeader = Buffer.from(
+      [
+        `--${boundary}\r\n`,
+        'Content-Disposition: form-data; name="output"; filename="image.png"\r\n',
+        'Content-Type: image/png\r\n',
+        '\r\n',
+      ].join(''),
+    );
+    buffers.push(imageHeader, Buffer.from(imageContent));
+    buffers.push(Buffer.from('\r\n'));
+  }
+
+  buffers.push(Buffer.from(`--${boundary}--\r\n`));
+
+  const body = Buffer.concat(buffers);
+
+  return {
+    body,
+    contentType: `multipart/form-data; boundary=${boundary}`,
+  };
+}
+
+const defaultJobResult = {
+  id: 'job-lang-123',
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:03Z',
+  state: { current: 'completed' },
+  config: { prompt, seed: 7 },
+  metrics: { elapsed: 1.5, ips: 20.0 },
+  price: { product: 'nano-banana', dollars: 0.01 },
+};
+
+describe('ProdiaLanguageModel', () => {
+  const multipartResponse = createLanguageMultipartResponse(defaultJobResult, {
+    textContent: 'This is a beautiful landscape.',
+    imageContent: 'test-image-bytes',
+  });
+
+  const server = createTestServer({
+    'https://api.example.com/v2/job?price=true': {
+      response: {
+        type: 'binary',
+        body: multipartResponse.body,
+        headers: {
+          'content-type': multipartResponse.contentType,
+        },
+      },
+    },
+  });
+
+  describe('constructor', () => {
+    it('exposes correct provider and model information', () => {
+      const model = createBasicModel();
+
+      expect(model.provider).toBe('prodia.language');
+      expect(model.modelId).toBe('inference.nano-banana.img2img.v2');
+      expect(model.specificationVersion).toBe('v2');
+      expect(model.supportedUrls).toStrictEqual({});
+    });
+  });
+
+  describe('doGenerate', () => {
+    it('extracts text from user message and sends correct request', async () => {
+      const model = createBasicModel();
+
+      await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                data: new Uint8Array([1, 2, 3]),
+              },
+              { type: 'text', text: 'Describe this image' },
+            ],
+          },
+        ],
+        providerOptions: {},
+      });
+
+      expect(server.calls[0].requestMethod).toBe('POST');
+      expect(server.calls[0].requestHeaders['content-type']).toContain(
+        'multipart/form-data',
+      );
+    });
+
+    it('includes system message in prompt', async () => {
+      const model = createBasicModel();
+
+      await model.doGenerate({
+        prompt: [
+          { role: 'system', content: 'You are an art critic.' },
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Describe this.' }],
+          },
+        ],
+        providerOptions: {},
+      });
+
+      expect(server.calls[0].requestMethod).toBe('POST');
+    });
+
+    it('sends include_messages: true in config', async () => {
+      let capturedFormData: FormData | undefined;
+      const model = createBasicModel({
+        fetch: async (url, init) => {
+          if (init?.body instanceof FormData) {
+            capturedFormData = init.body;
+          }
+          return globalThis.fetch(url, init);
+        },
+      });
+
+      await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+        ],
+        providerOptions: {},
+      });
+
+      expect(capturedFormData).toBeDefined();
+      const jobBlob = capturedFormData!.get('job') as Blob;
+      const jobText = await jobBlob.text();
+      const jobJson = JSON.parse(jobText);
+      expect(jobJson.config.include_messages).toBe(true);
+    });
+
+    it('returns text content from message.txt response part', async () => {
+      const model = createBasicModel();
+
+      const result = await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: prompt }],
+          },
+        ],
+        providerOptions: {},
+      });
+
+      const textParts = result.content.filter(p => p.type === 'text');
+      expect(textParts).toHaveLength(1);
+      expect(textParts[0].type).toBe('text');
+      if (textParts[0].type === 'text') {
+        expect(textParts[0].text).toBe('This is a beautiful landscape.');
+      }
+    });
+
+    it('returns image content from image.png response part', async () => {
+      const model = createBasicModel();
+
+      const result = await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: prompt }],
+          },
+        ],
+        providerOptions: {},
+      });
+
+      const fileParts = result.content.filter(p => p.type === 'file');
+      expect(fileParts).toHaveLength(1);
+      expect(fileParts[0].type).toBe('file');
+      if (fileParts[0].type === 'file') {
+        expect(fileParts[0].mediaType).toBe('image/png');
+        expect(
+          Buffer.from(
+            fileParts[0].data as Uint8Array<ArrayBufferLike>,
+          ).toString(),
+        ).toBe('test-image-bytes');
+      }
+    });
+
+    it('returns finish reason as stop', async () => {
+      const model = createBasicModel();
+
+      const result = await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: prompt }],
+          },
+        ],
+        providerOptions: {},
+      });
+
+      expect(result.finishReason).toBe('stop');
+    });
+
+    it('returns provider metadata', async () => {
+      const model = createBasicModel();
+
+      const result = await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: prompt }],
+          },
+        ],
+        providerOptions: {},
+      });
+
+      expect(result.providerMetadata?.prodia).toStrictEqual({
+        jobId: 'job-lang-123',
+        seed: 7,
+        elapsed: 1.5,
+        iterationsPerSecond: 20.0,
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:03Z',
+        dollars: 0.01,
+      });
+    });
+
+    it('emits warnings for unsupported LLM features', async () => {
+      const model = createBasicModel();
+
+      const result = await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: prompt }],
+          },
+        ],
+        temperature: 0.5,
+        topP: 0.9,
+        topK: 40,
+        maxOutputTokens: 1000,
+        stopSequences: ['stop'],
+        presencePenalty: 0.1,
+        frequencyPenalty: 0.2,
+        tools: [
+          {
+            type: 'function',
+            name: 'test',
+            inputSchema: {},
+          },
+        ],
+        toolChoice: { type: 'auto' },
+        responseFormat: { type: 'json' },
+        providerOptions: {},
+      });
+
+      const warningSettings = result.warnings.map(w =>
+        w.type === 'unsupported-setting' ? w.setting : undefined,
+      );
+      expect(warningSettings).toContain('temperature');
+      expect(warningSettings).toContain('topP');
+      expect(warningSettings).toContain('topK');
+      expect(warningSettings).toContain('maxOutputTokens');
+      expect(warningSettings).toContain('stopSequences');
+      expect(warningSettings).toContain('presencePenalty');
+      expect(warningSettings).toContain('frequencyPenalty');
+      expect(warningSettings).toContain('tools');
+      expect(warningSettings).toContain('toolChoice');
+      expect(warningSettings).toContain('responseFormat');
+    });
+
+    it('passes aspectRatio from provider options', async () => {
+      let capturedFormData: FormData | undefined;
+      const model = createBasicModel({
+        fetch: async (url, init) => {
+          if (init?.body instanceof FormData) {
+            capturedFormData = init.body;
+          }
+          return globalThis.fetch(url, init);
+        },
+      });
+
+      await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: prompt }],
+          },
+        ],
+        providerOptions: {
+          prodia: {
+            aspectRatio: '16:9',
+          },
+        },
+      });
+
+      const jobBlob = capturedFormData!.get('job') as Blob;
+      const jobText = await jobBlob.text();
+      const jobJson = JSON.parse(jobText);
+      expect(jobJson.config.aspect_ratio).toBe('16:9');
+    });
+
+    it('merges provider and request headers', async () => {
+      const model = createBasicModel({
+        headers: () => ({
+          'Custom-Provider-Header': 'provider-value',
+          Authorization: 'Bearer test-key',
+        }),
+      });
+
+      await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: prompt }],
+          },
+        ],
+        providerOptions: {},
+        headers: {
+          'Custom-Request-Header': 'request-value',
+        },
+      });
+
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        'custom-provider-header': 'provider-value',
+        'custom-request-header': 'request-value',
+        authorization: 'Bearer test-key',
+      });
+    });
+
+    it('includes timestamp and modelId in response', async () => {
+      const testDate = new Date('2025-06-01T00:00:00Z');
+      const model = createBasicModel({ currentDate: () => testDate });
+
+      const result = await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: prompt }],
+          },
+        ],
+        providerOptions: {},
+      });
+
+      expect(result.response).toStrictEqual({
+        timestamp: testDate,
+        modelId: 'inference.nano-banana.img2img.v2',
+        headers: expect.any(Object),
+      });
+    });
+
+    it('handles API errors', async () => {
+      server.urls['https://api.example.com/v2/job?price=true'].response = {
+        type: 'error',
+        status: 400,
+        body: JSON.stringify({
+          message: 'Bad request',
+          detail: 'Missing input image',
+        }),
+      };
+
+      const model = createBasicModel();
+
+      await expect(
+        model.doGenerate({
+          prompt: [
+            {
+              role: 'user',
+              content: [{ type: 'text', text: prompt }],
+            },
+          ],
+          providerOptions: {},
+        }),
+      ).rejects.toMatchObject({
+        message: 'Missing input image',
+        statusCode: 400,
+      });
+    });
+
+    it('handles response with text only (no image)', async () => {
+      const textOnlyResponse = createLanguageMultipartResponse(
+        defaultJobResult,
+        {
+          textContent: 'Just a text response',
+        },
+      );
+
+      server.urls['https://api.example.com/v2/job?price=true'].response = {
+        type: 'binary',
+        body: textOnlyResponse.body,
+        headers: {
+          'content-type': textOnlyResponse.contentType,
+        },
+      };
+
+      const model = createBasicModel();
+
+      const result = await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: prompt }],
+          },
+        ],
+        providerOptions: {},
+      });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+    });
+  });
+
+  describe('doStream', () => {
+    it('wraps doGenerate result into stream parts', async () => {
+      const response = createLanguageMultipartResponse(defaultJobResult, {
+        textContent: 'Stream test response',
+        imageContent: 'stream-image-bytes',
+      });
+
+      server.urls['https://api.example.com/v2/job?price=true'].response = {
+        type: 'binary',
+        body: response.body,
+        headers: {
+          'content-type': response.contentType,
+        },
+      };
+
+      const model = createBasicModel();
+
+      const result = await model.doStream({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: prompt }],
+          },
+        ],
+        providerOptions: {},
+      });
+
+      const parts: Array<Record<string, unknown>> = [];
+      const reader = result.stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        parts.push(value as unknown as Record<string, unknown>);
+      }
+
+      expect(parts[0].type).toBe('stream-start');
+      expect(parts[1].type).toBe('response-metadata');
+      expect(parts[2].type).toBe('text-start');
+      expect(parts[3].type).toBe('text-delta');
+      expect((parts[3] as any).delta).toBe('Stream test response');
+      expect(parts[4].type).toBe('text-end');
+      expect(parts[5].type).toBe('file');
+      expect((parts[5] as any).mediaType).toBe('image/png');
+      expect(parts[6].type).toBe('finish');
+      expect((parts[6] as any).finishReason).toBe('stop');
+    });
+  });
+});

--- a/packages/prodia/src/prodia-language-model.ts
+++ b/packages/prodia/src/prodia-language-model.ts
@@ -1,0 +1,387 @@
+import type {
+  LanguageModelV2,
+  LanguageModelV2CallOptions,
+  LanguageModelV2CallWarning,
+  LanguageModelV2Content,
+  LanguageModelV2StreamPart,
+} from '@ai-sdk/provider';
+import type { InferSchema } from '@ai-sdk/provider-utils';
+import {
+  combineHeaders,
+  convertBase64ToUint8Array,
+  generateId,
+  lazySchema,
+  parseJSON,
+  parseProviderOptions,
+  postFormDataToApi,
+  resolve,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import type { ProdiaModelConfig } from './prodia-api';
+import {
+  buildProdiaProviderMetadata,
+  parseMultipart,
+  prodiaFailedResponseHandler,
+  prodiaJobResultSchema,
+} from './prodia-api';
+import type { ProdiaJobResult } from './prodia-api';
+import type { ProdiaLanguageModelId } from './prodia-language-model-settings';
+
+export class ProdiaLanguageModel implements LanguageModelV2 {
+  readonly specificationVersion = 'v2';
+  readonly supportedUrls = {};
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: ProdiaLanguageModelId,
+    private readonly config: ProdiaModelConfig,
+  ) {}
+
+  async doGenerate(options: LanguageModelV2CallOptions) {
+    const warnings: Array<LanguageModelV2CallWarning> = [];
+
+    if (options.temperature !== undefined) {
+      warnings.push({ type: 'unsupported-setting', setting: 'temperature' });
+    }
+    if (options.topP !== undefined) {
+      warnings.push({ type: 'unsupported-setting', setting: 'topP' });
+    }
+    if (options.topK !== undefined) {
+      warnings.push({ type: 'unsupported-setting', setting: 'topK' });
+    }
+    if (options.maxOutputTokens !== undefined) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'maxOutputTokens',
+      });
+    }
+    if (options.stopSequences !== undefined) {
+      warnings.push({ type: 'unsupported-setting', setting: 'stopSequences' });
+    }
+    if (options.presencePenalty !== undefined) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'presencePenalty',
+      });
+    }
+    if (options.frequencyPenalty !== undefined) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'frequencyPenalty',
+      });
+    }
+    if (options.tools !== undefined && options.tools.length > 0) {
+      warnings.push({ type: 'unsupported-setting', setting: 'tools' });
+    }
+    if (options.toolChoice !== undefined) {
+      warnings.push({ type: 'unsupported-setting', setting: 'toolChoice' });
+    }
+    if (
+      options.responseFormat !== undefined &&
+      options.responseFormat.type !== 'text'
+    ) {
+      warnings.push({ type: 'unsupported-setting', setting: 'responseFormat' });
+    }
+
+    const prodiaOptions = await parseProviderOptions({
+      provider: 'prodia',
+      providerOptions: options.providerOptions,
+      schema: prodiaLanguageModelOptionsSchema,
+    });
+
+    let prompt = '';
+    let systemMessage = '';
+    for (const message of options.prompt) {
+      if (message.role === 'system') {
+        systemMessage = message.content;
+      }
+    }
+    for (let i = options.prompt.length - 1; i >= 0; i--) {
+      const message = options.prompt[i];
+      if (message.role === 'user') {
+        for (const part of message.content) {
+          if (part.type === 'text') {
+            prompt += (prompt ? '\n' : '') + part.text;
+          }
+        }
+        break;
+      }
+    }
+    if (systemMessage) {
+      prompt = systemMessage + '\n' + prompt;
+    }
+
+    let imageBytes: Uint8Array | undefined;
+    let imageMediaType = 'image/png';
+    for (let i = options.prompt.length - 1; i >= 0; i--) {
+      const message = options.prompt[i];
+      if (message.role === 'user') {
+        for (const part of message.content) {
+          if (part.type === 'file' && part.mediaType.startsWith('image/')) {
+            if (part.data instanceof Uint8Array) {
+              imageBytes = part.data;
+            } else if (typeof part.data === 'string') {
+              imageBytes = convertBase64ToUint8Array(part.data);
+            } else if (part.data instanceof URL) {
+              const fetchFn = this.config.fetch ?? globalThis.fetch;
+              const response = await fetchFn(part.data.toString());
+              const arrayBuffer = await response.arrayBuffer();
+              imageBytes = new Uint8Array(arrayBuffer);
+            }
+            imageMediaType = part.mediaType;
+            break;
+          }
+        }
+        break;
+      }
+    }
+
+    const jobConfig: Record<string, unknown> = {
+      prompt,
+      include_messages: true,
+    };
+
+    if (prodiaOptions?.aspectRatio !== undefined) {
+      jobConfig.aspect_ratio = prodiaOptions.aspectRatio;
+    }
+
+    const body = {
+      type: this.modelId,
+      config: jobConfig,
+    };
+
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const combinedHeaders = combineHeaders(
+      await resolve(this.config.headers),
+      options.headers,
+    );
+
+    const formData = new FormData();
+    formData.append(
+      'job',
+      new Blob([JSON.stringify(body)], { type: 'application/json' }),
+      'job.json',
+    );
+    if (imageBytes) {
+      const ext =
+        imageMediaType === 'image/png'
+          ? '.png'
+          : imageMediaType === 'image/jpeg'
+            ? '.jpg'
+            : imageMediaType === 'image/webp'
+              ? '.webp'
+              : '';
+      formData.append(
+        'input',
+        new Blob([imageBytes], { type: imageMediaType }),
+        'input' + ext,
+      );
+    }
+
+    const { value: multipartResult, responseHeaders } = await postFormDataToApi(
+      {
+        url: `${this.config.baseURL}/job?price=true`,
+        headers: {
+          ...combinedHeaders,
+          Accept: 'multipart/form-data',
+        },
+        formData,
+        failedResponseHandler: prodiaFailedResponseHandler,
+        successfulResponseHandler: createLanguageMultipartResponseHandler(),
+        abortSignal: options.abortSignal,
+        fetch: this.config.fetch,
+      },
+    );
+
+    const { jobResult, textContent, fileContent } = multipartResult;
+
+    const content: Array<LanguageModelV2Content> = [];
+    if (textContent !== undefined) {
+      content.push({ type: 'text', text: textContent });
+    }
+    for (const file of fileContent) {
+      content.push({
+        type: 'file',
+        mediaType: file.mediaType,
+        data: file.data,
+      });
+    }
+
+    return {
+      content,
+      finishReason: 'stop' as const,
+      usage: {
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+      },
+      warnings,
+      providerMetadata: {
+        prodia: buildProdiaProviderMetadata(jobResult),
+      },
+      response: {
+        modelId: this.modelId,
+        timestamp: currentDate,
+        headers: responseHeaders,
+      },
+    };
+  }
+
+  async doStream(options: LanguageModelV2CallOptions) {
+    const result = await this.doGenerate(options);
+
+    const stream = new ReadableStream<LanguageModelV2StreamPart>({
+      start(controller) {
+        controller.enqueue({
+          type: 'stream-start',
+          warnings: result.warnings,
+        });
+
+        controller.enqueue({
+          type: 'response-metadata',
+          modelId: result.response?.modelId,
+          timestamp: result.response?.timestamp,
+        });
+
+        for (const part of result.content) {
+          if (part.type === 'text') {
+            const id = generateId();
+            controller.enqueue({ type: 'text-start', id });
+            controller.enqueue({
+              type: 'text-delta',
+              id,
+              delta: part.text,
+            });
+            controller.enqueue({ type: 'text-end', id });
+          } else if (part.type === 'file') {
+            controller.enqueue({
+              type: 'file',
+              mediaType: part.mediaType,
+              data: part.data,
+            });
+          }
+        }
+
+        controller.enqueue({
+          type: 'finish',
+          usage: result.usage,
+          finishReason: result.finishReason,
+          providerMetadata: result.providerMetadata,
+        });
+
+        controller.close();
+      },
+    });
+
+    return {
+      stream,
+      response: {
+        headers: result.response?.headers,
+      },
+    };
+  }
+}
+
+export const prodiaLanguageModelOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      aspectRatio: z
+        .enum([
+          '1:1',
+          '2:3',
+          '3:2',
+          '4:5',
+          '5:4',
+          '4:7',
+          '7:4',
+          '9:16',
+          '16:9',
+          '9:21',
+          '21:9',
+        ])
+        .optional(),
+    }),
+  ),
+);
+
+export type ProdiaLanguageModelOptions = InferSchema<
+  typeof prodiaLanguageModelOptionsSchema
+>;
+
+interface LanguageMultipartResult {
+  jobResult: ProdiaJobResult;
+  textContent: string | undefined;
+  fileContent: Array<{ mediaType: string; data: Uint8Array }>;
+}
+
+function createLanguageMultipartResponseHandler() {
+  return async ({
+    response,
+  }: {
+    response: Response;
+  }): Promise<{
+    value: LanguageMultipartResult;
+    responseHeaders: Record<string, string>;
+  }> => {
+    const contentType = response.headers.get('content-type') ?? '';
+    const responseHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+
+    const boundaryMatch = contentType.match(/boundary=([^\s;]+)/);
+    if (!boundaryMatch) {
+      throw new Error(
+        `Prodia response missing multipart boundary in content-type: ${contentType}`,
+      );
+    }
+    const boundary = boundaryMatch[1];
+
+    const arrayBuffer = await response.arrayBuffer();
+    const bytes = new Uint8Array(arrayBuffer);
+
+    const parts = parseMultipart(bytes, boundary);
+
+    let jobResult: ProdiaJobResult | undefined;
+    let textContent: string | undefined;
+    const fileContent: Array<{ mediaType: string; data: Uint8Array }> = [];
+
+    for (const part of parts) {
+      const contentDisposition = part.headers['content-disposition'] ?? '';
+      const partContentType = part.headers['content-type'] ?? '';
+
+      if (contentDisposition.includes('name="job"')) {
+        const jsonStr = new TextDecoder().decode(part.body);
+        jobResult = await parseJSON({
+          text: jsonStr,
+          schema: zodSchema(prodiaJobResultSchema),
+        });
+      } else if (contentDisposition.includes('name="output"')) {
+        if (
+          partContentType.startsWith('text/') ||
+          contentDisposition.includes('.txt')
+        ) {
+          textContent = new TextDecoder().decode(part.body);
+        } else if (partContentType.startsWith('image/')) {
+          fileContent.push({
+            mediaType: partContentType,
+            data: part.body,
+          });
+        }
+      }
+    }
+
+    if (!jobResult) {
+      throw new Error('Prodia multipart response missing job part');
+    }
+
+    return {
+      value: { jobResult, textContent, fileContent },
+      responseHeaders,
+    };
+  };
+}

--- a/packages/prodia/src/prodia-provider.test.ts
+++ b/packages/prodia/src/prodia-provider.test.ts
@@ -110,12 +110,19 @@ describe('Prodia provider', () => {
     expect(server.calls[0].requestUserAgent).toContain('ai-sdk/prodia/');
   });
 
+  it('creates language models via .languageModel', () => {
+    const provider = createProdia();
+
+    const model = provider.languageModel('inference.nano-banana.img2img.v2');
+
+    expect(model.provider).toBe('prodia.language');
+    expect(model.modelId).toBe('inference.nano-banana.img2img.v2');
+    expect(model.specificationVersion).toBe('v2');
+  });
+
   it('throws NoSuchModelError for unsupported model types', () => {
     const provider = createProdia();
 
-    expect(() => provider.languageModel('some-id')).toThrowError(
-      'No such languageModel',
-    );
     expect(() => provider.textEmbeddingModel('some-id')).toThrowError(
       'No such textEmbeddingModel',
     );

--- a/packages/prodia/src/prodia-provider.ts
+++ b/packages/prodia/src/prodia-provider.ts
@@ -1,5 +1,6 @@
 import {
   type ImageModelV2,
+  type LanguageModelV2,
   NoSuchModelError,
   type ProviderV2,
 } from '@ai-sdk/provider';
@@ -11,6 +12,8 @@ import {
 } from '@ai-sdk/provider-utils';
 import { ProdiaImageModel } from './prodia-image-model';
 import type { ProdiaImageModelId } from './prodia-image-settings';
+import { ProdiaLanguageModel } from './prodia-language-model';
+import type { ProdiaLanguageModelId } from './prodia-language-model-settings';
 import { VERSION } from './version';
 
 export interface ProdiaProviderSettings {
@@ -37,6 +40,11 @@ export interface ProdiaProviderSettings {
 }
 
 export interface ProdiaProvider extends ProviderV2 {
+  /**
+   * Creates a language model for multimodal generation (img2img with text+image output).
+   */
+  languageModel(modelId: ProdiaLanguageModelId): LanguageModelV2;
+
   /**
    * Creates a model for image generation.
    */
@@ -80,6 +88,14 @@ export function createProdia(
       fetch: options.fetch,
     });
 
+  const createLanguageModel = (modelId: ProdiaLanguageModelId) =>
+    new ProdiaLanguageModel(modelId, {
+      provider: 'prodia.language',
+      baseURL: baseURL ?? defaultBaseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
   const textEmbeddingModel = (modelId: string) => {
     throw new NoSuchModelError({
       modelId,
@@ -87,17 +103,10 @@ export function createProdia(
     });
   };
 
-  const languageModel = (modelId: string) => {
-    throw new NoSuchModelError({
-      modelId,
-      modelType: 'languageModel',
-    });
-  };
-
   return {
+    languageModel: createLanguageModel,
     imageModel: createImageModel,
     image: createImageModel,
-    languageModel,
     textEmbeddingModel,
   };
 }


### PR DESCRIPTION
## Background

Manual backport of #13597 (originally #13364) to `release-v5.0`. The original PR added `LanguageModel` and `VideoModel` support to the Prodia provider on `release-v6.0`. This backport covers **only the `LanguageModel` part** (since v5 does not support `VideoModel`), adapted from V3 provider spec to V2.

## Manual Verification

Use the new example.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
