### PR TITLE
feat : added scribe_v2 to the ElevenLabs updated the call signature from mod…

### DIFF
--- a/packages/elevenlabs/src/elevenlabs-provider.ts
+++ b/packages/elevenlabs/src/elevenlabs-provider.ts
@@ -17,7 +17,7 @@ import { VERSION } from './version';
 
 export interface ElevenLabsProvider extends ProviderV4 {
   (
-    modelId: 'scribe_v1',
+    modelId: ElevenLabsTranscriptionModelId,
     settings?: {},
   ): {
     transcription: ElevenLabsTranscriptionModel;

--- a/packages/elevenlabs/src/elevenlabs-transcription-options.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-options.ts
@@ -1,4 +1,5 @@
 export type ElevenLabsTranscriptionModelId =
   | 'scribe_v1'
   | 'scribe_v1_experimental'
+  | 'scribe_v2'
   | (string & {});


### PR DESCRIPTION
### summary

- Add ElevenLabs scribe_v2 to transcription model IDs

### Changes

- Include scribe_v2 in ElevenLabsTranscriptionModelId union
- Allow scribe_v2 in ElevenLabsProvider transcription signature

### Verification

- @ai-sdk/elevenlabs tests pass


fix : #13556