### PR TITLE
fix: skip validation for output-error tool parts

### DIFF
--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -435,9 +435,7 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
             // Tool input validation
             if (
               toolPart.state === 'input-available' ||
-              toolPart.state === 'output-available' ||
-              (toolPart.state === 'output-error' &&
-                toolPart.input !== undefined)
+              toolPart.state === 'output-available'
             ) {
               await validateTypes({
                 value: toolPart.input,


### PR DESCRIPTION
## Summary

Re-validating known-bad input (output-error state) permanently bricks conversations. The input already failed validation - that's why the part is in output-error state.

## Fix

Remove the `output-error` condition from the validation check in `validate-ui-messages.ts`. The tool input validation should only run for `input-available` and `output-available` states.

## Root Cause

When an LLM produces a tool call with invalid input:
1. SDK correctly rejects it → sets state: 'output-error' with error text
2. LLM receives the error, retries or moves on
3. User sends the next message
4. `validateUIMessages` re-validates .input on output-error parts
5. Throws TypeValidationError - conversation permanently bricked

## Testing

This fix ensures that known-bad input in output-error state is not re-validated, preventing the conversation from being permanently broken.

Closes: #13591