### PR TITLE
docs: Add Mermaid architecture diagrams for streaming and middleware

### DIFF
--- a/architecture/middleware-pipeline.md
+++ b/architecture/middleware-pipeline.md
@@ -1,0 +1,155 @@
+# Middleware Pipeline Architecture
+
+This document details how language model middleware works internally, covering the wrapping mechanism, execution order, and composition patterns.
+
+## Wrapping Mechanism
+
+`wrapLanguageModel()` takes a model and one or more middlewares, returning a new `LanguageModelV4` that intercepts `doGenerate` and `doStream` calls.
+
+```mermaid
+classDiagram
+    class LanguageModelV4 {
+        <<interface>>
+        +provider: string
+        +modelId: string
+        +doGenerate(params) GenerateResult
+        +doStream(params) StreamResult
+    }
+
+    class WrappedModel {
+        -innerModel: LanguageModelV4
+        -middleware: LanguageModelV4Middleware
+        +doGenerate(params) GenerateResult
+        +doStream(params) StreamResult
+    }
+
+    class LanguageModelV4Middleware {
+        <<interface>>
+        +transformParams(ctx)
+        +wrapGenerate(ctx)
+        +wrapStream(ctx)
+    }
+
+    class ConcreteProvider {
+        +doGenerate(params)
+        +doStream(params)
+    }
+
+    WrappedModel ..|> LanguageModelV4 : implements
+    WrappedModel --> LanguageModelV4 : wraps inner model
+    WrappedModel --> LanguageModelV4Middleware : uses
+    ConcreteProvider ..|> LanguageModelV4 : implements
+```
+
+The wrapped model satisfies the same `LanguageModelV4` interface, so it can be used anywhere a model is expected — including as input to another `wrapLanguageModel()` call.
+
+## Composition and Execution Order
+
+When an array of middlewares `[A, B, C]` is provided, the SDK reverses the array and reduces from the innermost wrapper outward:
+
+```
+wrapLanguageModel({ model, middleware: [A, B, C] })
+
+// Internally becomes:
+A( B( C( model ) ) )
+```
+
+This means:
+
+- **Parameter transforms** execute outside-in: A first, then B, then C
+- **Stream/generate wrappers** execute outside-in for the "before" phase: A wraps B wraps C wraps model
+- **Results** flow back inside-out: model result passes through C, then B, then A
+
+```mermaid
+flowchart TB
+    subgraph "Request Phase (outside → in)"
+        direction TB
+        R1["A.transformParams()"] --> R2["B.transformParams()"] --> R3["C.transformParams()"]
+    end
+
+    subgraph "Model Call"
+        direction TB
+        R3 --> M["model.doStream()"]
+    end
+
+    subgraph "Response Phase (inside → out)"
+        direction TB
+        M --> S3["C.wrapStream()"]
+        S3 --> S2["B.wrapStream()"]
+        S2 --> S1["A.wrapStream()"]
+    end
+
+    S1 --> Result["Final StreamResult"]
+```
+
+## Internal Call Flow
+
+For each `doGenerate` or `doStream` call on a wrapped model:
+
+```mermaid
+flowchart TD
+    Entry["wrappedModel.doGenerate(params)"]
+
+    Entry --> TP["transformParams(params, type='generate')"]
+    TP -->|transformed params| Decision{wrapGenerate defined?}
+
+    Decision -->|Yes| WG["wrapGenerate({ doGenerate, doStream, params, model })"]
+    Decision -->|No| DG["model.doGenerate(transformedParams)"]
+
+    WG -->|middleware calls doGenerate| DG
+    DG --> Result["GenerateResult"]
+    WG --> Result
+```
+
+The `wrapGenerate` and `wrapStream` callbacks receive both `doGenerate` and `doStream` functions, allowing a stream wrapper to fall back to non-streaming generation (or vice versa) if needed.
+
+## Middleware Hook Reference
+
+| Hook | Signature | Called During | Typical Uses |
+|------|-----------|--------------|-------------|
+| `transformParams` | `(ctx: { params, type, model }) => params` | Both generate and stream | Inject RAG context, rewrite prompts, add system instructions |
+| `wrapGenerate` | `(ctx: { doGenerate, doStream, params, model }) => result` | `doGenerate` only | Caching responses, applying guardrails, logging |
+| `wrapStream` | `(ctx: { doGenerate, doStream, params, model }) => result` | `doStream` only | Stream transforms, token counting, rate monitoring |
+| `overrideProvider` | `(ctx: { model }) => string` | Model construction | Dynamic provider routing |
+| `overrideModelId` | `(ctx: { model }) => string` | Model construction | Model aliasing, A/B testing |
+| `overrideSupportedUrls` | `(ctx: { model }) => urls` | Model construction | URL allowlist overrides |
+
+## Common Patterns
+
+### Layered Middleware Stack
+
+A typical production setup layers concerns:
+
+```mermaid
+flowchart LR
+    subgraph "Middleware Stack"
+        direction LR
+        Log["Logging"] --> Guard["Guardrails"] --> Cache["Caching"] --> RAG["RAG"] --> Model["Base Model"]
+    end
+
+    App["streamText()"] --> Log
+    Model --> Provider["Provider API"]
+```
+
+Each middleware handles one concern. The logging middleware records inputs and outputs. The guardrail middleware validates content. The caching middleware short-circuits repeated queries. The RAG middleware injects retrieved context into the prompt.
+
+### Stream Transformation
+
+Middleware can modify stream content by piping through a `TransformStream`:
+
+```mermaid
+flowchart LR
+    Original["Original stream"] --> Transform["TransformStream"]
+    Transform --> Modified["Modified stream"]
+
+    subgraph TransformStream
+        direction TB
+        Inspect["Inspect each chunk"]
+        Modify["Modify / filter / augment"]
+        Enqueue["Enqueue to output"]
+
+        Inspect --> Modify --> Enqueue
+    end
+```
+
+The `wrapStream` hook receives the original stream and can return a new stream that pipes through any number of transforms. This is how built-in middlewares like `extractReasoningMiddleware` parse reasoning tags from the text stream and re-emit them as structured reasoning parts.

--- a/architecture/streaming-data-flow.md
+++ b/architecture/streaming-data-flow.md
@@ -1,0 +1,175 @@
+# Streaming Data Flow Architecture
+
+This document describes how streaming data moves through the AI SDK, from the provider's HTTP response to the UI component rendering in the browser. It covers both the backend pipeline (`streamText` and its internal transforms) and the frontend consumption path (`useChat`, `useCompletion`).
+
+## End-to-End Overview
+
+```mermaid
+flowchart LR
+    subgraph Provider["AI Provider (e.g. OpenAI)"]
+        API["HTTP SSE / chunked response"]
+    end
+
+    subgraph Core["AI SDK Core (server)"]
+        LM["LanguageModelV4.doStream()"]
+        MW["Middleware pipeline"]
+        ST["streamText()"]
+        TP["Part transform stream"]
+        DR["DataStreamResponse"]
+    end
+
+    subgraph Transport["HTTP Transport"]
+        HTTP["Chunked HTTP response"]
+    end
+
+    subgraph UI["AI SDK UI (browser)"]
+        UC["useChat / useCompletion"]
+        PS["Stream parser"]
+        State["React / Vue / Svelte state"]
+        Render["Rendered UI"]
+    end
+
+    API -->|raw chunks| LM
+    LM -->|LanguageModelV4StreamPart| MW
+    MW -->|transformed parts| ST
+    ST -->|internal stream| TP
+    TP -->|formatted parts| DR
+    DR -->|data stream protocol| HTTP
+    HTTP -->|SSE chunks| PS
+    PS -->|parsed parts| UC
+    UC -->|state updates| State
+    State --> Render
+```
+
+## Provider to Core
+
+When `streamText()` is called, it resolves the model reference to a `LanguageModelV4` implementation (e.g. `OpenAIChatLanguageModel`). The model's `doStream()` method opens an HTTP connection to the provider API and returns a `ReadableStream<LanguageModelV4StreamPart>`.
+
+Stream part types include:
+
+- `text-start` / `text-delta` / `text-end` — incremental text generation
+- `tool-call-start` / `tool-call-delta` / `tool-call-end` — tool invocations
+- `reasoning` — model reasoning content
+- `source` — source attribution
+- `finish` / `error` — terminal events
+
+```mermaid
+sequenceDiagram
+    participant App as Application Code
+    participant ST as streamText()
+    participant MW as Middleware
+    participant Model as LanguageModelV4
+    participant API as Provider API
+
+    App->>ST: streamText({ model, prompt })
+    ST->>MW: doStream(params)
+    MW->>MW: transformParams()
+    MW->>Model: doStream(transformedParams)
+    Model->>API: HTTP POST (streaming)
+    API-->>Model: SSE chunks
+    Model-->>MW: LanguageModelV4StreamPart stream
+    MW-->>MW: wrapStream transform
+    MW-->>ST: transformed stream
+    ST-->>App: StreamTextResult
+```
+
+## Middleware Pipeline
+
+Middleware wraps the model using `wrapLanguageModel()`. When multiple middlewares are provided, they are applied in reverse order so the first middleware in the array is the outermost wrapper.
+
+For a call with `[middlewareA, middlewareB]`:
+
+```mermaid
+flowchart TB
+    subgraph Execution Order
+        direction TB
+        Call["streamText() call"]
+        A_transform["middlewareA.transformParams()"]
+        B_transform["middlewareB.transformParams()"]
+        Model["model.doStream()"]
+        B_wrap["middlewareB.wrapStream()"]
+        A_wrap["middlewareA.wrapStream()"]
+        Result["StreamTextResult"]
+
+        Call --> A_transform
+        A_transform --> B_transform
+        B_transform --> Model
+        Model --> B_wrap
+        B_wrap --> A_wrap
+        A_wrap --> Result
+    end
+```
+
+Each middleware can intercept at three points:
+
+| Hook | Phase | Use Case |
+|------|-------|----------|
+| `transformParams` | Before model call | RAG injection, prompt rewriting |
+| `wrapGenerate` | Around `doGenerate` | Caching, guardrails, logging |
+| `wrapStream` | Around `doStream` | Stream transformation, logging |
+
+## Core to UI
+
+The `streamText()` result provides multiple consumption methods:
+
+```mermaid
+flowchart LR
+    ST["StreamTextResult"]
+
+    ST -->|".textStream"| TS["AsyncIterable<string>"]
+    ST -->|".fullStream"| FS["AsyncIterable<StreamPart>"]
+    ST -->|".toDataStreamResponse()"| DSR["Data Stream HTTP Response"]
+    ST -->|".toTextStreamResponse()"| TSR["Text Stream HTTP Response"]
+    ST -->|".pipeDataStreamToResponse(res)"| Pipe["Pipe to Node response"]
+
+    DSR --> Browser["Browser fetch()"]
+    TSR --> Browser
+    Pipe --> Browser
+```
+
+### Data Stream Protocol
+
+The data stream protocol encodes typed parts as newline-delimited messages. Each line has a type prefix followed by the payload. This allows the frontend to distinguish between text chunks, tool calls, errors, and metadata without ambiguity.
+
+### Frontend Parsing
+
+On the frontend, `useChat` and `useCompletion` open a fetch request and parse the incoming stream using the appropriate protocol parser. Parsed parts update the hook's internal state, which triggers re-renders:
+
+```mermaid
+flowchart TB
+    subgraph Frontend Hook
+        Fetch["fetch() with streaming"]
+        Parse["Protocol parser"]
+        MsgState["messages[] state"]
+        Parts["message.parts[]"]
+
+        Fetch -->|ReadableStream| Parse
+        Parse -->|text part| MsgState
+        Parse -->|tool-call part| MsgState
+        Parse -->|tool-result part| MsgState
+        MsgState --> Parts
+    end
+
+    Parts --> TextPart["{ type: 'text', text }"]
+    Parts --> ToolPart["{ type: 'tool-invocation', ... }"]
+    Parts --> ReasonPart["{ type: 'reasoning', ... }"]
+```
+
+## Tool Call Round-Trip
+
+When the model produces a tool call, the SDK can execute it server-side and feed the result back into the model for another generation round. This loop continues until the model produces a final text response or hits the `maxSteps` limit.
+
+```mermaid
+sequenceDiagram
+    participant ST as streamText
+    participant Model as LanguageModelV4
+    participant Tool as Tool executor
+
+    ST->>Model: doStream(prompt)
+    Model-->>ST: tool-call stream parts
+    ST->>Tool: execute(toolName, args)
+    Tool-->>ST: tool result
+    ST->>Model: doStream(prompt + tool result)
+    Model-->>ST: text stream parts
+    ST-->>ST: emit final result
+```


### PR DESCRIPTION
## Summary

Adds two new architecture documents with Mermaid diagrams to the `architecture/` directory:

- **`streaming-data-flow.md`** — End-to-end streaming pipeline from provider HTTP response through `LanguageModelV4.doStream()`, middleware transforms, `streamText()`, data stream protocol, to frontend `useChat`/`useCompletion` state updates. Includes a tool call round-trip sequence diagram.
- **`middleware-pipeline.md`** — How `wrapLanguageModel()` composes middleware, execution order for `[A, B, C]` arrays, internal call flow for `doGenerate`/`doStream`, hook reference table, and common patterns (layered stacks, stream transformation).

## Why

The existing `architecture/` directory has `provider-abstraction.md` covering the model type hierarchy, but nothing covering:

1. How data actually flows through the streaming pipeline (provider → core → transport → UI)
2. How middleware wrapping and execution ordering works internally

These are the two most common questions when onboarding to the codebase or building custom middleware (related to #8059 which flags outdated middleware examples). The diagrams render natively on GitHub and in any Mermaid-compatible docs tooling.

## What changed

- `architecture/streaming-data-flow.md` (new) — 7 Mermaid diagrams covering the full streaming path
- `architecture/middleware-pipeline.md` (new) — 6 Mermaid diagrams covering middleware internals

No code changes. No dependency changes.

## Test plan

- [ ] Verify Mermaid diagrams render correctly on GitHub PR preview
- [ ] Cross-reference diagrams against source in `packages/ai/src/middleware/wrap-language-model.ts` and `packages/ai/src/generate-text/stream-text.ts`