### PR TITLE
fix: narrow the lint-staged glob to handle only JS/TS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fix": "ultracite fix"
   },
   "lint-staged": {
-    "*": [
+    "*.{js,jsx,ts,tsx,mjs,cjs}": [
       "ultracite fix"
     ]
   },


### PR DESCRIPTION
## Background

The lint-staged config in package.json uses "*" which matches all files. When only a .md file (like a changeset) is staged, ultracite fix receives no JS/TS files it can process and exits with an error, blocking the commit

Error received: 

```sh
ai % git add .changeset/great-cows-rush.md && git commit -m "change cs"   
✔ Backed up original state in git stash (ea29d32ee)
⚠ Running tasks for staged files...
  ❯ package.json — 1 file
    ❯ * — 1 file
      ✖ ultracite fix [FAILED]
↓ Skipped because of errors from tasks.
✔ Reverting to original state because of errors...
✔ Cleaning up temporary files...

✖ ultracite fix:
Expected at least one target file
husky - pre-commit script failed (code 1)
```

## Summary

narrow the lint-staged glob to only match file types ultracite handles

## Manual Verification

na

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)