### PR TITLE
refactor(ai): simplify types for stream text parts

### DIFF
--- a/architecture/stream-text-loop-control.md
+++ b/architecture/stream-text-loop-control.md
@@ -9,10 +9,9 @@ do {
 
  stream = doStream (with language model v4 messages)
 
- // new transform function for user friendly format
+ transform function for user friendly format
 
  run tools transformation on stream
-   transforms spec format to user friendly format
    executes tools and injects tool results into stream
    tool approval?
 

--- a/packages/ai/src/error/invalid-stream-part-error.ts
+++ b/packages/ai/src/error/invalid-stream-part-error.ts
@@ -1,5 +1,5 @@
 import { AISDKError } from '@ai-sdk/provider';
-import { SingleRequestTextStreamPart } from '../generate-text/execute-tools-transformation';
+import { UglyTransformedStreamTextPart } from '../generate-text/create-stream-text-part-transform';
 
 const name = 'AI_InvalidStreamPartError';
 const marker = `vercel.ai.error.${name}`;
@@ -8,13 +8,13 @@ const symbol = Symbol.for(marker);
 export class InvalidStreamPartError extends AISDKError {
   private readonly [symbol] = true; // used in isInstance
 
-  readonly chunk: SingleRequestTextStreamPart<any>;
+  readonly chunk: UglyTransformedStreamTextPart<any>;
 
   constructor({
     chunk,
     message,
   }: {
-    chunk: SingleRequestTextStreamPart<any>;
+    chunk: UglyTransformedStreamTextPart<any>;
     message: string;
   }) {
     super({ name, message });

--- a/packages/ai/src/generate-text/create-stream-text-part-transform.ts
+++ b/packages/ai/src/generate-text/create-stream-text-part-transform.ts
@@ -1,4 +1,9 @@
-import { getErrorMessage, LanguageModelV4StreamPart } from '@ai-sdk/provider';
+import {
+  getErrorMessage,
+  LanguageModelV4ResponseMetadata,
+  LanguageModelV4StreamPart,
+  SharedV4Warning,
+} from '@ai-sdk/provider';
 import { ModelMessage, SystemModelMessage } from '@ai-sdk/provider-utils';
 import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
 import { FinishReason } from '../types/language-model';
@@ -8,6 +13,7 @@ import { DefaultGeneratedFileWithType } from './generated-file';
 import { parseToolCall } from './parse-tool-call';
 import {
   TextStreamFilePart,
+  TextStreamPart,
   TextStreamReasoningDeltaPart,
   TextStreamReasoningFilePart,
   TextStreamTextDeltaPart,
@@ -24,31 +30,17 @@ import { ToolSet } from './tool-set';
 
 export type UglyTransformedStreamTextPart<TOOLS extends ToolSet> =
   | Exclude<
-      LanguageModelV4StreamPart,
-      | {
-          type: 'text-delta';
-        }
-      | {
-          type: 'reasoning-delta';
-        }
-      | {
-          type: 'file';
-        }
-      | {
-          type: 'reasoning-file';
-        }
-      | {
-          type: 'tool-approval-request';
-        }
-      | {
-          type: 'tool-result';
-        }
-      | {
-          type: 'tool-call';
-        }
-      | {
-          type: 'finish';
-        }
+      TextStreamPart<TOOLS>,
+      {
+        type:
+          | 'finish'
+          | 'stream-start'
+          | 'tool-output-denied'
+          | 'start-step'
+          | 'finish-step'
+          | 'start'
+          | 'abort';
+      }
     >
   | TextStreamTextDeltaPart
   | TextStreamReasoningDeltaPart
@@ -58,13 +50,24 @@ export type UglyTransformedStreamTextPart<TOOLS extends ToolSet> =
   | TextStreamToolCallPart<TOOLS>
   | TextStreamToolResultPart<TOOLS>
   | TextStreamToolErrorPart<TOOLS>
+
+  // the finish part is special because it gets further transformed into
+  // a finish-step part (which includes additional response information and
+  // can have a different finish reason):
   | {
       type: 'finish';
       finishReason: FinishReason;
       rawFinishReason: string | undefined;
       usage: LanguageModelUsage;
       providerMetadata?: ProviderMetadata;
-    };
+    }
+
+  // TODO check if we need to transform these parts?
+  | {
+      type: 'stream-start';
+      warnings: Array<SharedV4Warning>;
+    }
+  | ({ type: 'response-metadata' } & LanguageModelV4ResponseMetadata);
 
 export function createStreamTextPartTransform<TOOLS extends ToolSet>({
   tools,

--- a/packages/ai/src/generate-text/create-stream-text-part-transform.ts
+++ b/packages/ai/src/generate-text/create-stream-text-part-transform.ts
@@ -4,9 +4,18 @@ import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-f
 import { FinishReason } from '../types/language-model';
 import { ProviderMetadata } from '../types/provider-metadata';
 import { asLanguageModelUsage, LanguageModelUsage } from '../types/usage';
-import { DefaultGeneratedFileWithType, GeneratedFile } from './generated-file';
+import { DefaultGeneratedFileWithType } from './generated-file';
 import { parseToolCall } from './parse-tool-call';
-import { ToolApprovalRequestOutput } from './tool-approval-request-output';
+import {
+  TextStreamFilePart,
+  TextStreamReasoningDeltaPart,
+  TextStreamReasoningFilePart,
+  TextStreamTextDeltaPart,
+  TextStreamToolApprovalRequestPart,
+  TextStreamToolCallPart,
+  TextStreamToolErrorPart,
+  TextStreamToolResultPart,
+} from './stream-text-result';
 import { TypedToolCall } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair-function';
 import { TypedToolError } from './tool-error';
@@ -41,32 +50,14 @@ export type UglyTransformedStreamTextPart<TOOLS extends ToolSet> =
           type: 'finish';
         }
     >
-  | {
-      type: 'text-delta';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-      text: string;
-    }
-  | {
-      type: 'reasoning-delta';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-      text: string;
-    }
-  | {
-      type: 'file';
-      file: GeneratedFile;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'reasoning-file';
-      file: GeneratedFile;
-      providerMetadata?: ProviderMetadata;
-    }
-  | ToolApprovalRequestOutput<TOOLS>
-  | ({ type: 'tool-call' } & TypedToolCall<TOOLS>)
-  | ({ type: 'tool-result' } & TypedToolResult<TOOLS>)
-  | ({ type: 'tool-error' } & TypedToolError<TOOLS>)
+  | TextStreamTextDeltaPart
+  | TextStreamReasoningDeltaPart
+  | TextStreamFilePart
+  | TextStreamReasoningFilePart
+  | TextStreamToolApprovalRequestPart<TOOLS>
+  | TextStreamToolCallPart<TOOLS>
+  | TextStreamToolResultPart<TOOLS>
+  | TextStreamToolErrorPart<TOOLS>
   | {
       type: 'finish';
       finishReason: FinishReason;

--- a/packages/ai/src/generate-text/execute-tools-transformation.ts
+++ b/packages/ai/src/generate-text/execute-tools-transformation.ts
@@ -1,115 +1,15 @@
-import { SharedV4Warning } from '@ai-sdk/provider';
 import { IdGenerator, ModelMessage } from '@ai-sdk/provider-utils';
 import { TimeoutConfiguration } from '../prompt/call-settings';
 import type { TelemetryIntegration } from '../telemetry/telemetry-integration';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
-import { FinishReason, LanguageModelUsage, ProviderMetadata } from '../types';
-import { Source } from '../types/language-model';
 import { UglyTransformedStreamTextPart } from './create-stream-text-part-transform';
 import { executeToolCall } from './execute-tool-call';
-import { GeneratedFile } from './generated-file';
 import { isApprovalNeeded } from './is-approval-needed';
 import {
   StreamTextOnToolCallFinishCallback,
   StreamTextOnToolCallStartCallback,
 } from './stream-text';
-import { ToolApprovalRequestOutput } from './tool-approval-request-output';
-import { TypedToolCall } from './tool-call';
-import { TypedToolError } from './tool-error';
-import { TypedToolResult } from './tool-result';
 import { ToolSet } from './tool-set';
-
-export type SingleRequestTextStreamPart<TOOLS extends ToolSet> =
-  // Text blocks:
-  | {
-      type: 'text-start';
-      providerMetadata?: ProviderMetadata;
-      id: string;
-    }
-  | {
-      type: 'text-delta';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-      text: string;
-    }
-  | {
-      type: 'text-end';
-      providerMetadata?: ProviderMetadata;
-      id: string;
-    }
-
-  // Reasoning blocks:
-  | {
-      type: 'reasoning-start';
-      providerMetadata?: ProviderMetadata;
-      id: string;
-    }
-  | {
-      type: 'reasoning-delta';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-      text: string;
-    }
-  | {
-      type: 'reasoning-end';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'custom';
-      kind: string;
-      providerMetadata?: ProviderMetadata;
-    }
-
-  // Tool calls:
-  | {
-      type: 'tool-input-start';
-      id: string;
-      toolName: string;
-      providerMetadata?: ProviderMetadata;
-      dynamic?: boolean;
-      title?: string;
-    }
-  | {
-      type: 'tool-input-delta';
-      id: string;
-      delta: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'tool-input-end';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | ToolApprovalRequestOutput<TOOLS>
-
-  // Other types:
-  | ({ type: 'source' } & Source)
-  | { type: 'file'; file: GeneratedFile; providerMetadata?: ProviderMetadata }
-  | {
-      type: 'reasoning-file';
-      file: GeneratedFile;
-      providerMetadata?: ProviderMetadata;
-    }
-  | ({ type: 'tool-call' } & TypedToolCall<TOOLS>)
-  | ({ type: 'tool-result' } & TypedToolResult<TOOLS>)
-  | ({ type: 'tool-error' } & TypedToolError<TOOLS>)
-  | { type: 'stream-start'; warnings: SharedV4Warning[] }
-  | {
-      type: 'response-metadata';
-      id?: string;
-      timestamp?: Date;
-      modelId?: string;
-    }
-  | {
-      type: 'finish';
-      finishReason: FinishReason;
-      rawFinishReason: string | undefined;
-      usage: LanguageModelUsage;
-      providerMetadata?: ProviderMetadata;
-    }
-  | { type: 'error'; error: unknown }
-  | { type: 'raw'; rawValue: unknown };
 
 export function executeToolsTransformation<TOOLS extends ToolSet>({
   tools,
@@ -145,14 +45,14 @@ export function executeToolsTransformation<TOOLS extends ToolSet>({
     | StreamTextOnToolCallFinishCallback<TOOLS>
     | Array<StreamTextOnToolCallFinishCallback<TOOLS> | undefined | null>;
   executeToolInTelemetryContext?: TelemetryIntegration['executeTool'];
-}): ReadableStream<SingleRequestTextStreamPart<TOOLS>> {
+}): ReadableStream<UglyTransformedStreamTextPart<TOOLS>> {
   // there is a separate stream for tool results, because
   // tool results might be emitted after the generator stream has finished
   let toolResultsStreamController: ReadableStreamDefaultController<
-    SingleRequestTextStreamPart<TOOLS>
+    UglyTransformedStreamTextPart<TOOLS>
   > | null = null;
   const toolResultsStream = new ReadableStream<
-    SingleRequestTextStreamPart<TOOLS>
+    UglyTransformedStreamTextPart<TOOLS>
   >({
     start(controller) {
       toolResultsStreamController = controller;
@@ -164,7 +64,7 @@ export function executeToolsTransformation<TOOLS extends ToolSet>({
 
   let canClose = false;
   let finishChunk:
-    | (SingleRequestTextStreamPart<TOOLS> & { type: 'finish' })
+    | (UglyTransformedStreamTextPart<TOOLS> & { type: 'finish' })
     | undefined = undefined;
 
   function attemptClose() {
@@ -184,12 +84,12 @@ export function executeToolsTransformation<TOOLS extends ToolSet>({
   // forward stream
   const forwardStream = new TransformStream<
     UglyTransformedStreamTextPart<TOOLS>,
-    SingleRequestTextStreamPart<TOOLS>
+    UglyTransformedStreamTextPart<TOOLS>
   >({
     async transform(
       chunk: UglyTransformedStreamTextPart<TOOLS>,
       controller: TransformStreamDefaultController<
-        SingleRequestTextStreamPart<TOOLS>
+        UglyTransformedStreamTextPart<TOOLS>
       >,
     ) {
       const chunkType = chunk.type;
@@ -305,7 +205,7 @@ export function executeToolsTransformation<TOOLS extends ToolSet>({
   });
 
   // combine the generator stream and the tool results stream
-  return new ReadableStream<SingleRequestTextStreamPart<TOOLS>>({
+  return new ReadableStream<UglyTransformedStreamTextPart<TOOLS>>({
     async start(controller) {
       // need to wait for both pipes so there are no dangling promises that
       // can cause uncaught promise rejections when the stream is aborted

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -367,107 +367,170 @@ export interface StreamTextResult<
   toTextStreamResponse(init?: ResponseInit): Response;
 }
 
+export type TextStreamTextDeltaPart = {
+  type: 'text-delta';
+  id: string;
+  providerMetadata?: ProviderMetadata;
+  text: string;
+};
+
+export type TextStreamTextStartPart = {
+  type: 'text-start';
+  id: string;
+  providerMetadata?: ProviderMetadata;
+};
+
+export type TextStreamTextEndPart = {
+  type: 'text-end';
+  id: string;
+  providerMetadata?: ProviderMetadata;
+};
+
+export type TextStreamReasoningStartPart = {
+  type: 'reasoning-start';
+  id: string;
+  providerMetadata?: ProviderMetadata;
+};
+
+export type TextStreamReasoningEndPart = {
+  type: 'reasoning-end';
+  id: string;
+  providerMetadata?: ProviderMetadata;
+};
+
+export type TextStreamReasoningDeltaPart = {
+  type: 'reasoning-delta';
+  providerMetadata?: ProviderMetadata;
+  id: string;
+  text: string;
+};
+
+export type TextStreamCustomPart = {
+  type: 'custom';
+  kind: string;
+  providerMetadata?: ProviderMetadata;
+};
+
+export type TextStreamToolInputStartPart = {
+  type: 'tool-input-start';
+  id: string;
+  toolName: string;
+  providerMetadata?: ProviderMetadata;
+  providerExecuted?: boolean;
+  dynamic?: boolean;
+  title?: string;
+};
+
+export type TextStreamToolInputEndPart = {
+  type: 'tool-input-end';
+  id: string;
+  providerMetadata?: ProviderMetadata;
+};
+
+export type TextStreamToolInputDeltaPart = {
+  type: 'tool-input-delta';
+  id: string;
+  delta: string;
+  providerMetadata?: ProviderMetadata;
+};
+
+export type TextStreamSourcePart = { type: 'source' } & Source;
+
+export type TextStreamFilePart = {
+  type: 'file';
+  file: GeneratedFile;
+  providerMetadata?: ProviderMetadata;
+};
+
+export type TextStreamReasoningFilePart = {
+  type: 'reasoning-file';
+  file: GeneratedFile;
+  providerMetadata?: ProviderMetadata;
+};
+
+export type TextStreamToolCallPart<TOOLS extends ToolSet> = {
+  type: 'tool-call';
+} & TypedToolCall<TOOLS>;
+
+export type TextStreamToolResultPart<TOOLS extends ToolSet> = {
+  type: 'tool-result';
+} & TypedToolResult<TOOLS>;
+
+export type TextStreamToolErrorPart<TOOLS extends ToolSet> = {
+  type: 'tool-error';
+} & TypedToolError<TOOLS>;
+
+export type TextStreamToolOutputDeniedPart<TOOLS extends ToolSet> = {
+  type: 'tool-output-denied';
+} & StaticToolOutputDenied<TOOLS>;
+
+export type TextStreamToolApprovalRequestPart<TOOLS extends ToolSet> =
+  ToolApprovalRequestOutput<TOOLS>;
+
+export type TextStreamStartStepPart = {
+  type: 'start-step';
+  request: LanguageModelRequestMetadata;
+  warnings: CallWarning[];
+};
+
+export type TextStreamFinishStepPart = {
+  type: 'finish-step';
+  response: LanguageModelResponseMetadata;
+  usage: LanguageModelUsage;
+  finishReason: FinishReason;
+  rawFinishReason: string | undefined;
+  providerMetadata: ProviderMetadata | undefined;
+};
+
+export type TextStreamStartPart = {
+  type: 'start';
+};
+
+export type TextStreamFinishPart = {
+  type: 'finish';
+  finishReason: FinishReason;
+  rawFinishReason: string | undefined;
+  totalUsage: LanguageModelUsage;
+};
+
+export type TextStreamAbortPart = {
+  type: 'abort';
+  reason?: string;
+};
+
+export type TextStreamErrorPart = {
+  type: 'error';
+  error: unknown;
+};
+
+export type TextStreamRawPart = {
+  type: 'raw';
+  rawValue: unknown;
+};
+
 export type TextStreamPart<TOOLS extends ToolSet> =
-  | {
-      type: 'text-start';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'text-end';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'text-delta';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-      text: string;
-    }
-  | {
-      type: 'reasoning-start';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'reasoning-end';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'reasoning-delta';
-      providerMetadata?: ProviderMetadata;
-      id: string;
-      text: string;
-    }
-  | {
-      type: 'custom';
-      kind: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'tool-input-start';
-      id: string;
-      toolName: string;
-      providerMetadata?: ProviderMetadata;
-      providerExecuted?: boolean;
-      dynamic?: boolean;
-      title?: string;
-    }
-  | {
-      type: 'tool-input-end';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'tool-input-delta';
-      id: string;
-      delta: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | ({ type: 'source' } & Source)
-  | { type: 'file'; file: GeneratedFile; providerMetadata?: ProviderMetadata }
-  | {
-      type: 'reasoning-file';
-      file: GeneratedFile;
-      providerMetadata?: ProviderMetadata;
-    }
-  | ({ type: 'tool-call' } & TypedToolCall<TOOLS>)
-  | ({ type: 'tool-result' } & TypedToolResult<TOOLS>)
-  | ({ type: 'tool-error' } & TypedToolError<TOOLS>)
-  | ({ type: 'tool-output-denied' } & StaticToolOutputDenied<TOOLS>)
-  | ToolApprovalRequestOutput<TOOLS>
-  | {
-      type: 'start-step';
-      request: LanguageModelRequestMetadata;
-      warnings: CallWarning[];
-    }
-  | {
-      type: 'finish-step';
-      response: LanguageModelResponseMetadata;
-      usage: LanguageModelUsage;
-      finishReason: FinishReason;
-      rawFinishReason: string | undefined;
-      providerMetadata: ProviderMetadata | undefined;
-    }
-  | {
-      type: 'start';
-    }
-  | {
-      type: 'finish';
-      finishReason: FinishReason;
-      rawFinishReason: string | undefined;
-      totalUsage: LanguageModelUsage;
-    }
-  | {
-      type: 'abort';
-      reason?: string;
-    }
-  | {
-      type: 'error';
-      error: unknown;
-    }
-  | {
-      type: 'raw';
-      rawValue: unknown;
-    };
+  | TextStreamTextStartPart
+  | TextStreamTextEndPart
+  | TextStreamTextDeltaPart
+  | TextStreamReasoningStartPart
+  | TextStreamReasoningEndPart
+  | TextStreamReasoningDeltaPart
+  | TextStreamCustomPart
+  | TextStreamToolInputStartPart
+  | TextStreamToolInputEndPart
+  | TextStreamToolInputDeltaPart
+  | TextStreamSourcePart
+  | TextStreamFilePart
+  | TextStreamReasoningFilePart
+  | TextStreamToolCallPart<TOOLS>
+  | TextStreamToolResultPart<TOOLS>
+  | TextStreamToolErrorPart<TOOLS>
+  | TextStreamToolOutputDeniedPart<TOOLS>
+  | TextStreamToolApprovalRequestPart<TOOLS>
+  | TextStreamStartStepPart
+  | TextStreamFinishStepPart
+  | TextStreamStartPart
+  | TextStreamFinishPart
+  | TextStreamAbortPart
+  | TextStreamErrorPart
+  | TextStreamRawPart;

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1683,6 +1683,10 @@ class DefaultStreamTextResult<
                       warnings: warnings ?? [],
                     });
 
+                    // TODO considering changing to onStreamPart listener
+                    // which receives all stream parts as they are
+                    // (and add necessary information to the stream parts
+                    // where needed)
                     void globalTelemetry.onChunk?.({
                       chunk: {
                         type: 'ai.stream.firstChunk',

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -82,12 +82,12 @@ import type {
 } from './callback-events';
 import { collectToolApprovals } from './collect-tool-approvals';
 import { ContentPart } from './content-part';
-import { createStreamTextPartTransform } from './create-stream-text-part-transform';
-import { executeToolCall } from './execute-tool-call';
 import {
-  executeToolsTransformation,
-  SingleRequestTextStreamPart,
-} from './execute-tools-transformation';
+  createStreamTextPartTransform,
+  UglyTransformedStreamTextPart,
+} from './create-stream-text-part-transform';
+import { executeToolCall } from './execute-tool-call';
+import { executeToolsTransformation } from './execute-tools-transformation';
 import { Output, text } from './output';
 import {
   InferCompleteOutput,
@@ -1661,7 +1661,7 @@ class DefaultStreamTextResult<
           self.addStream(
             streamWithToolResults.pipeThrough(
               new TransformStream<
-                SingleRequestTextStreamPart<TOOLS>,
+                UglyTransformedStreamTextPart<TOOLS>,
                 TextStreamPart<TOOLS>
               >({
                 async transform(chunk, controller): Promise<void> {


### PR DESCRIPTION
## Background

We are working towards better support for custom loop control. For this, we are separating out individual reusable functions from streamText. As a first step, we need to separate transformation steps such that each transformation has a single responsibility.

## Summary

- replace `SingleRequestTextStreamPart` with `UglyTransformedStreamTextPart`
- simplify `UglyTransformedStreamTextPart` type
- introduce separate `TextStream*Part` types

## Related Issues

Towards #13570