### PR TITLE
feat(ai): defer tool execution until after LLM response completes

### DIFF
--- a/.changeset/defer-tool-execution.md
+++ b/.changeset/defer-tool-execution.md
@@ -1,0 +1,9 @@
+---
+'ai': patch
+---
+
+Defer tool execution until after the LLM response stream completes.
+
+Previously, tool calls were executed immediately (fire-and-forget) as `tool-call` chunks arrived from the provider stream. Now, tool calls are buffered during streaming and executed in parallel after the LLM response finishes. This cleanly separates the LLM generation phase from the tool execution phase.
+
+This is a **behavioral change**: tool results will no longer appear interleaved with provider stream chunks. They will always appear after the provider stream finishes.

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -310,7 +310,7 @@ exports[`streamText > options.transform > with base transformation > telemetry s
       "ai.toolCall.args": "{"value":"VALUE"}",
       "ai.toolCall.id": "call-1",
       "ai.toolCall.name": "tool1",
-      "ai.toolCall.result": ""value-result"",
+      "ai.toolCall.result": ""VALUE-result"",
       "operation.name": "ai.toolCall",
     },
     "events": [],

--- a/packages/ai/src/generate-text/execute-tools-transformation.ts
+++ b/packages/ai/src/generate-text/execute-tools-transformation.ts
@@ -81,6 +81,13 @@ export function executeToolsTransformation<TOOLS extends ToolSet>({
     }
   }
 
+  // Buffer tool calls for deferred execution after the generator stream finishes.
+  // This ensures tool execution happens after the LLM response completes,
+  // which is needed for clean separation of LLM calls from tool execution.
+  const deferredToolCalls: Array<
+    UglyTransformedStreamTextPart<TOOLS> & { type: 'tool-call' }
+  > = [];
+
   // forward stream
   const forwardStream = new TransformStream<
     UglyTransformedStreamTextPart<TOOLS>,
@@ -146,43 +153,8 @@ export function executeToolsTransformation<TOOLS extends ToolSet>({
 
             // Only execute tools that are not provider-executed:
             if (tool.execute != null && chunk.providerExecuted !== true) {
-              const toolExecutionId = generateId(); // use our own id to guarantee uniqueness
-              outstandingToolResults.add(toolExecutionId);
-
-              // Note: we don't await the tool execution here (by leaving out 'await' on recordSpan),
-              // because we want to process the next chunk as soon as possible.
-              // This is important for the case where the tool execution takes a long time.
-              executeToolCall({
-                toolCall: chunk,
-                tools,
-                telemetry,
-                callId,
-                messages,
-                abortSignal,
-                timeout,
-                experimental_context,
-                stepNumber,
-                model,
-                onToolCallStart,
-                onToolCallFinish,
-                executeToolInTelemetryContext,
-                onPreliminaryToolResult: result => {
-                  toolResultsStreamController!.enqueue(result);
-                },
-              })
-                .then(result => {
-                  toolResultsStreamController!.enqueue(result);
-                })
-                .catch(error => {
-                  toolResultsStreamController!.enqueue({
-                    type: 'error',
-                    error,
-                  });
-                })
-                .finally(() => {
-                  outstandingToolResults.delete(toolExecutionId);
-                  attemptClose();
-                });
+              // Buffer the tool call for deferred execution after the stream finishes
+              deferredToolCalls.push(chunk);
             }
           } catch (error) {
             toolResultsStreamController!.enqueue({ type: 'error', error });
@@ -198,7 +170,47 @@ export function executeToolsTransformation<TOOLS extends ToolSet>({
       }
     },
 
-    flush() {
+    async flush() {
+      // Execute all buffered tool calls in parallel after the generator stream finishes
+      if (deferredToolCalls.length > 0) {
+        for (const toolCall of deferredToolCalls) {
+          const toolExecutionId = generateId();
+          outstandingToolResults.add(toolExecutionId);
+
+          executeToolCall({
+            toolCall,
+            tools,
+            telemetry,
+            callId,
+            messages,
+            abortSignal,
+            timeout,
+            experimental_context,
+            stepNumber,
+            model,
+            onToolCallStart,
+            onToolCallFinish,
+            executeToolInTelemetryContext,
+            onPreliminaryToolResult: result => {
+              toolResultsStreamController!.enqueue(result);
+            },
+          })
+            .then(result => {
+              toolResultsStreamController!.enqueue(result);
+            })
+            .catch(error => {
+              toolResultsStreamController!.enqueue({
+                type: 'error',
+                error,
+              });
+            })
+            .finally(() => {
+              outstandingToolResults.delete(toolExecutionId);
+              attemptClose();
+            });
+        }
+      }
+
       canClose = true;
       attemptClose();
     },

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -18031,6 +18031,17 @@ describe('streamText', () => {
                 "warnings": [],
               },
               {
+                "input": {
+                  "value": "value",
+                },
+                "providerExecuted": undefined,
+                "providerMetadata": undefined,
+                "title": undefined,
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-call",
+              },
+              {
                 "reason": "This operation was aborted",
                 "type": "abort",
               },


### PR DESCRIPTION
## Summary

- Tool calls are now buffered during streaming and executed in parallel after the LLM response finishes
- This cleanly separates the LLM generation phase from the tool execution phase
- Implements the change described in #13570 (applying #13388 without the flag)

**Breaking change**: Tool results will no longer appear interleaved with provider stream chunks — they always appear after the provider stream finishes.

## AI notes

Here's what was done:

Core change in execute-tools-transformation.ts: Instead of executing tool calls immediately (fire-and-forget) as tool-call chunks arrive from the provider stream, tool calls are now
buffered in a deferredToolCalls array and executed in parallel in the flush() method after the generator stream finishes.

Test updates:
- stream-text.test.ts: Updated the "abort during tool call" inline snapshot — with deferred execution, the tool-call chunk now appears in the stream before the abort (since it's
forwarded during streaming, but execution is deferred)
- stream-text.test.ts.snap: Updated telemetry snapshot (tool result now reflects transformed input since execution happens after the transform completes)

## Test plan

- [x] All 15 `execute-tools-transformation` tests pass
- [x] All 867 `stream-text` tests pass (2 snapshot updates for changed behavior)
- [ ] Manual verification with example apps using tool calls