### PR TITLE
chore(ai/core): remove `timeout` from `CallSettings` as it was effectively unused there

### DIFF
--- a/.changeset/sweet-squids-kick.md
+++ b/.changeset/sweet-squids-kick.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/rsc": patch
+"ai": patch
+---
+
+chore(ai/core): remove `timeout` from `CallSettings` as it was effectively unused there

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -17,7 +17,7 @@ import { PrepareStepFunction } from '../generate-text/prepare-step';
 import { StopCondition } from '../generate-text/stop-condition';
 import { ToolCallRepairFunction } from '../generate-text/tool-call-repair-function';
 import { ToolSet } from '../generate-text/tool-set';
-import { CallSettings } from '../prompt/call-settings';
+import { CallSettings, TimeoutConfiguration } from '../prompt/call-settings';
 import { Prompt } from '../prompt/prompt';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { LanguageModel, ToolChoice } from '../types/language-model';
@@ -57,7 +57,15 @@ export type ToolLoopAgentSettings<
   CALL_OPTIONS = never,
   TOOLS extends ToolSet = {},
   OUTPUT extends Output = never,
-> = Omit<CallSettings<TOOLS>, 'abortSignal'> & {
+> = Omit<CallSettings, 'abortSignal'> & {
+  /**
+   * Timeout in milliseconds. The call will be aborted if it takes longer
+   * than the specified timeout. Can be used alongside abortSignal.
+   *
+   * Can be specified as a number (milliseconds) or as an object with `totalMs`.
+   */
+  timeout?: TimeoutConfiguration<TOOLS>;
+
   /**
    * The id of the agent.
    */

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -118,7 +118,7 @@ export async function generateObject<
     ? Array<InferSchema<SCHEMA>>
     : InferSchema<SCHEMA>,
 >(
-  options: Omit<CallSettings<any>, 'stopSequences'> &
+  options: Omit<CallSettings, 'stopSequences'> &
     Prompt &
     (OUTPUT extends 'enum'
       ? {

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -179,7 +179,7 @@ export function streamObject<
     ? Array<InferSchema<SCHEMA>>
     : InferSchema<SCHEMA>,
 >(
-  options: Omit<CallSettings<any>, 'stopSequences'> &
+  options: Omit<CallSettings, 'stopSequences'> &
     Prompt &
     (OUTPUT extends 'enum'
       ? {
@@ -400,7 +400,7 @@ class DefaultStreamObjectResult<
     model: LanguageModel;
     telemetry: TelemetrySettings | undefined;
     headers: Record<string, string | undefined> | undefined;
-    settings: Omit<CallSettings<any>, 'abortSignal' | 'headers'>;
+    settings: Omit<CallSettings, 'abortSignal' | 'headers'>;
     maxRetries: number | undefined;
     abortSignal: AbortSignal | undefined;
     outputStrategy: OutputStrategy<PARTIAL, RESULT, ELEMENT_STREAM>;

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -279,12 +279,20 @@ export async function generateText<
   onStepFinish,
   onFinish,
   ...settings
-}: CallSettings<TOOLS> &
+}: CallSettings &
   Prompt & {
     /**
      * The language model to use.
      */
     model: LanguageModel;
+
+    /**
+     * Timeout in milliseconds. The call will be aborted if it takes longer
+     * than the specified timeout. Can be used alongside abortSignal.
+     *
+     * Can be specified as a number (milliseconds) or as an object with `totalMs`.
+     */
+    timeout?: TimeoutConfiguration<TOOLS>;
 
     /**
      * The tools that the model can call. The model needs to support calling tools.

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -334,12 +334,20 @@ export function streamText<
     generateCallId = originalGenerateCallId,
   } = {},
   ...settings
-}: CallSettings<TOOLS> &
+}: CallSettings &
   Prompt & {
     /**
      * The language model to use.
      */
     model: LanguageModel;
+
+    /**
+     * Timeout in milliseconds. The call will be aborted if it takes longer
+     * than the specified timeout. Can be used alongside abortSignal.
+     *
+     * Can be specified as a number (milliseconds) or as an object with `totalMs`.
+     */
+    timeout?: TimeoutConfiguration<TOOLS>;
 
     /**
      * The tools that the model can call. The model needs to support calling tools.
@@ -767,7 +775,7 @@ class DefaultStreamTextResult<
     model: LanguageModelV4;
     telemetry: TelemetrySettings | undefined;
     headers: Record<string, string | undefined> | undefined;
-    settings: Omit<CallSettings<TOOLS>, 'abortSignal' | 'headers'>;
+    settings: Omit<CallSettings, 'abortSignal' | 'headers'>;
     maxRetries: number | undefined;
     abortSignal: AbortSignal | undefined;
     stepTimeoutMs: number | undefined;

--- a/packages/ai/src/prompt/call-settings.ts
+++ b/packages/ai/src/prompt/call-settings.ts
@@ -1,5 +1,5 @@
 import { LanguageModelV4CallOptions } from '@ai-sdk/provider';
-import { ToolSet } from '../generate-text/tool-set';
+import type { ToolSet } from '../generate-text/tool-set';
 
 /**
  * Timeout configuration for API calls. Can be specified as:
@@ -78,7 +78,7 @@ export function getToolTimeoutMs<TOOLS extends ToolSet>(
   return timeout.tools?.[`${toolName}Ms`] ?? timeout.toolMs;
 }
 
-export type CallSettings<TOOLS extends ToolSet> = {
+export type CallSettings = {
   /**
    * Maximum number of tokens to generate.
    */
@@ -160,14 +160,6 @@ export type CallSettings<TOOLS extends ToolSet> = {
    * Abort signal.
    */
   abortSignal?: AbortSignal;
-
-  /**
-   * Timeout in milliseconds. The call will be aborted if it takes longer
-   * than the specified timeout. Can be used alongside abortSignal.
-   *
-   * Can be specified as a number (milliseconds) or as an object with `totalMs`.
-   */
-  timeout?: TimeoutConfiguration<TOOLS>;
 
   /**
    * Additional HTTP headers to be sent with the request.

--- a/packages/ai/src/prompt/prepare-call-settings.ts
+++ b/packages/ai/src/prompt/prepare-call-settings.ts
@@ -14,8 +14,8 @@ export function prepareCallSettings({
   seed,
   stopSequences,
   reasoning,
-}: Omit<CallSettings<any>, 'abortSignal' | 'headers' | 'maxRetries'>): Omit<
-  CallSettings<any>,
+}: Omit<CallSettings, 'abortSignal' | 'headers' | 'maxRetries'>): Omit<
+  CallSettings,
   'abortSignal' | 'headers' | 'maxRetries'
 > {
   if (maxOutputTokens != null) {

--- a/packages/ai/src/telemetry/get-base-telemetry-attributes.ts
+++ b/packages/ai/src/telemetry/get-base-telemetry-attributes.ts
@@ -1,5 +1,5 @@
 import { Attributes, AttributeValue } from '@opentelemetry/api';
-import { CallSettings, getTotalTimeoutMs } from '../prompt/call-settings';
+import { CallSettings } from '../prompt/call-settings';
 import { TelemetrySettings } from './telemetry-settings';
 
 export function getBaseTelemetryAttributes({
@@ -9,7 +9,7 @@ export function getBaseTelemetryAttributes({
   headers,
 }: {
   model: { modelId: string; provider: string };
-  settings: Omit<CallSettings<any>, 'abortSignal' | 'headers' | 'temperature'>;
+  settings: Omit<CallSettings, 'abortSignal' | 'headers' | 'temperature'>;
   telemetry: TelemetrySettings | undefined;
   headers: Record<string, string | undefined> | undefined;
 }): Attributes {
@@ -19,17 +19,7 @@ export function getBaseTelemetryAttributes({
 
     // settings:
     ...Object.entries(settings).reduce((attributes, [key, value]) => {
-      // Handle timeout specially since it can be a number or object
-      if (key === 'timeout') {
-        const totalTimeoutMs = getTotalTimeoutMs(
-          value as Parameters<typeof getTotalTimeoutMs>[0],
-        );
-        if (totalTimeoutMs != null) {
-          attributes[`ai.settings.${key}`] = totalTimeoutMs;
-        }
-      } else {
-        attributes[`ai.settings.${key}`] = value as AttributeValue;
-      }
+      attributes[`ai.settings.${key}`] = value as AttributeValue;
       return attributes;
     }, {} as Attributes),
 

--- a/packages/rsc/src/stream-ui/stream-ui.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.tsx
@@ -110,7 +110,7 @@ export async function streamUI<
   providerOptions,
   onFinish,
   ...settings
-}: CallSettings<any> &
+}: CallSettings &
   Prompt & {
     /**
      * The language model to use.


### PR DESCRIPTION
## Background

In #13536, `CallSettings<TOOLS>` was made generic solely because of `timeout` (`TimeoutConfiguration<TOOLS>` uses tool-specific keys). I looked into making `prepareCallSettings` generic too as a result (see https://github.com/vercel/ai/pull/13536/changes#r2961226981), but that led me to a more important finding: `timeout` is never accessed through a `CallSettings`-typed variable — it's always destructured independently and handled via standalone helper functions. This generic propagates through many files unnecessarily, and `timeout` being part of `CallSettings` is probably no longer relevant.

## Summary

- Remove `timeout` from `CallSettings` and make it non-generic. In `generateText`, `streamText`, and `ToolLoopAgentSettings`, `timeout` is added as a standalone property in the object literal type, preserving the public API while keeping the tool-specific generic only where it's actually needed.
- Remove dead timeout-handling code in `getBaseTelemetryAttributes` that was unreachable since no caller ever passed `timeout` in the settings object.

Given that `CallSettings` is exported, this can be considered a low-severity breaking change. But we're working in the v7 branch, so this is fine.

## Manual Verification

N/A — internal type refactor, verified via type checking and existing test suites.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- A few places didn't actually support passing through `timeout` which maybe should allow it (e.g. `streamUI()`)
    - before it wasn't possible because `prepareCallSettings` would strip `timeout`, now `timeout` is formally removed from `CallSettings`
    - possibly something to fix, but worth noting this PR doesn't make it worse
- Consider breaking out `abortSignal`, `headers`, and `maxRetries` from `CallSettings` as well.
- Potentially create a separate `RequestSettings` type that contains these 3, plus `timeout`. Could then also rename `CallSettings` to something more descriptive, e.g. `ModelCallSettings`.

## Related Issues

N/A
