### PR TITLE
Backport: README updates and tags (v5.0)

### DIFF
--- a/.changeset/two-pens-teach.md
+++ b/.changeset/two-pens-teach.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+README updates

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -18,11 +18,29 @@ npm install ai
 
 The AI SDK provides a [unified API](https://ai-sdk.dev/docs/foundations/providers-and-models) to interact with model providers like [OpenAI](https://ai-sdk.dev/providers/ai-sdk-providers/openai), [Anthropic](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic), [Google](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai), and [more](https://ai-sdk.dev/providers/ai-sdk-providers).
 
+By default, the AI SDK uses the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) to give you access to all major providers out of the box. Just pass a model string for any supported model:
+
+```ts
+const result = await generateText({
+  model: 'anthropic/claude-opus-4.6', // or 'openai/gpt-5.4', 'google/gemini-3-flash', etc.
+  prompt: 'Hello!',
+});
+```
+
+You can also connect to providers directly using their SDK packages:
+
 ```shell
 npm install @ai-sdk/openai @ai-sdk/anthropic @ai-sdk/google
 ```
 
-Alternatively you can use the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway).
+```ts
+import { anthropic } from '@ai-sdk/anthropic';
+
+const result = await generateText({
+  model: anthropic('claude-opus-4-6'), // or openai('gpt-5.4'), google('gemini-3-flash'), etc.
+  prompt: 'Hello!',
+});
+```
 
 ## Usage
 
@@ -32,17 +50,7 @@ Alternatively you can use the [Vercel AI Gateway](https://vercel.com/docs/ai-gat
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: 'openai/gpt-5', // use Vercel AI Gateway
-  prompt: 'What is an agent?',
-});
-```
-
-```ts
-import { generateText } from 'ai';
-import { openai } from '@ai-sdk/openai';
-
-const { text } = await generateText({
-  model: openai('gpt-5'), // use OpenAI Responses API directly
+  model: 'openai/gpt-5.4', // use Vercel AI Gateway
   prompt: 'What is an agent?',
 });
 ```
@@ -54,7 +62,7 @@ import { generateObject } from 'ai';
 import { z } from 'zod';
 
 const { object } = await generateObject({
-  model: 'openai/gpt-5',
+  model: 'openai/gpt-5.4',
   schema: z.object({
     recipe: z.object({
       name: z.string(),

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -88,6 +88,7 @@
     "ai",
     "vercel",
     "sdk",
+    "llm",
     "mcp",
     "tool-calling",
     "tools",
@@ -95,11 +96,17 @@
     "agent",
     "agentic",
     "generative",
+    "genai",
     "chatbot",
     "prompt",
     "inference",
-    "llm",
     "language-model",
-    "streaming"
+    "streaming",
+    "openai",
+    "anthropic",
+    "claude",
+    "gemini",
+    "xai",
+    "grok"
   ]
 }


### PR DESCRIPTION
## Summary

Backport of README and package.json updates from main to `release-v5.0`:

- **#13636**: Update model names in README examples (claude-opus-4.6, gpt-5.4, etc.), add Vercel AI Gateway usage examples, and reorder/add keywords in package.json
- **#13651**: Add changeset for README updates

Conflicts in `packages/ai/README.md` were resolved manually — the v5.0 branch uses `generateObject` (not `generateText` with `Output.object`) and has a simpler UI section without the agents examples from main. Model name updates and the new AI Gateway examples were applied on top of the v5.0 content.