### PR TITLE
Backport: README updates and tags (v6.0)

### DIFF
--- a/.changeset/two-pens-teach.md
+++ b/.changeset/two-pens-teach.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+README updates

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -30,7 +30,7 @@ By default, the AI SDK uses the [Vercel AI Gateway](https://vercel.com/docs/ai-g
 
 ```ts
 const result = await generateText({
-  model: 'anthropic/claude-opus-4.5', // or 'openai/gpt-5.4', 'google/gemini-3-flash', etc.
+  model: 'anthropic/claude-opus-4.6', // or 'openai/gpt-5.4', 'google/gemini-3-flash', etc.
   prompt: 'Hello!',
 });
 ```
@@ -45,7 +45,7 @@ npm install @ai-sdk/openai @ai-sdk/anthropic @ai-sdk/google
 import { anthropic } from '@ai-sdk/anthropic';
 
 const result = await generateText({
-  model: anthropic('claude-opus-4-5-20250414'), // or openai('gpt-5.4'), google('gemini-3-flash'), etc.
+  model: anthropic('claude-opus-4-6'), // or openai('gpt-5.4'), google('gemini-3-flash'), etc.
   prompt: 'Hello!',
 });
 ```
@@ -58,17 +58,7 @@ const result = await generateText({
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: 'openai/gpt-5', // use Vercel AI Gateway
-  prompt: 'What is an agent?',
-});
-```
-
-```ts
-import { generateText } from 'ai';
-import { openai } from '@ai-sdk/openai';
-
-const { text } = await generateText({
-  model: openai('gpt-5'), // use OpenAI Responses API
+  model: 'openai/gpt-5.4', // use Vercel AI Gateway
   prompt: 'What is an agent?',
 });
 ```
@@ -80,7 +70,7 @@ import { generateText, Output } from 'ai';
 import { z } from 'zod';
 
 const { output } = await generateText({
-  model: 'openai/gpt-5',
+  model: 'openai/gpt-5.4',
   output: Output.object({
     schema: z.object({
       recipe: z.object({
@@ -102,7 +92,7 @@ const { output } = await generateText({
 import { ToolLoopAgent } from 'ai';
 
 const sandboxAgent = new ToolLoopAgent({
-  model: 'openai/gpt-5',
+  model: 'openai/gpt-5.4',
   system: 'You are an agent with access to a shell environment.',
   tools: {
     shell: openai.tools.localShell({
@@ -134,7 +124,7 @@ import { openai } from '@ai-sdk/openai';
 import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
 export const imageGenerationAgent = new ToolLoopAgent({
-  model: openai('gpt-5'),
+  model: 'openai/gpt-5.4',
   tools: {
     generateImage: openai.tools.imageGeneration({
       partialImages: 3,

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -100,6 +100,7 @@
     "ai",
     "vercel",
     "sdk",
+    "llm",
     "mcp",
     "tool-calling",
     "tools",
@@ -107,11 +108,17 @@
     "agent",
     "agentic",
     "generative",
+    "genai",
     "chatbot",
     "prompt",
     "inference",
-    "llm",
     "language-model",
-    "streaming"
+    "streaming",
+    "openai",
+    "anthropic",
+    "claude",
+    "gemini",
+    "xai",
+    "grok"
   ]
 }


### PR DESCRIPTION
## Summary

Backport of README updates and tag changes from `main` to `release-v6.0`:

- #13636: Update model names in README (claude-opus-4.5 -> claude-opus-4.6, gpt-5 -> gpt-5.4, etc.), remove duplicate code example, reorder and add keywords to package.json
- #13651: Add changeset for the README updates

## Test plan

- [ ] Verify README content is correct
- [ ] Verify package.json keywords are present
- [ ] Verify changeset file exists