### PR TITLE
fix(amazon-bedrock): do not trim reasoning text when signature is present

### DIFF
--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -292,15 +292,11 @@ export async function convertToBedrockChatMessages(
                     bedrockContent.push({
                       reasoningContent: {
                         reasoningText: {
-                          // trim the last text part if it's the last message in the block
-                          // because Bedrock does not allow trailing whitespace
-                          // in pre-filled assistant responses
-                          text: trimIfLast(
-                            isLastBlock,
-                            isLastMessage,
-                            isLastContentPart,
-                            part.text,
-                          ),
+                          // Do NOT trim text when a signature is present — the signature
+                          // is a cryptographic hash of the original (untrimmed) text.
+                          // Trimming corrupts the text/signature pair, causing Bedrock
+                          // to reject the request with a ValidationException.
+                          text: part.text,
                           signature: reasoningMetadata.signature,
                         },
                       },


### PR DESCRIPTION
## Summary

Fixes #13583

`trimIfLast()` was applied to reasoning block text even when a cryptographic `signature` was present. Since the signature is computed over the original (untrimmed) text, trimming corrupts the text/signature pair, causing Bedrock to reject the request:

```
ValidationException: thinking blocks in the latest assistant message
cannot be modified. These blocks must remain as they were in the original response.
```

## Change

Skip `trimIfLast()` when `reasoningMetadata.signature` is set. The trailing-whitespace trim is still applied to reasoning blocks **without** a signature (unchanged behavior).

**Before:**
```ts
text: trimIfLast(isLastBlock, isLastMessage, isLastContentPart, part.text),
signature: reasoningMetadata.signature,
```

**After:**
```ts
text: part.text,  // preserve original text that signature was computed over
signature: reasoningMetadata.signature,
```

## Why

The signature is a cryptographic hash of the exact text content. Any modification (including whitespace trimming) invalidates the signature, causing Bedrock to reject the request.