### PR TITLE
fix: prevent rawInput string from causing Anthropic 400 in convertToModelMessages

### DIFF
--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -722,6 +722,118 @@ describe('convertToModelMessages', () => {
       });
     });
 
+    it('should handle tool output error with rawInput as invalid JSON string', async () => {
+      const result = await convertToModelMessages([
+        {
+          role: 'assistant',
+          parts: [
+            { type: 'step-start' },
+            {
+              type: 'text',
+              text: 'Sending email...',
+              state: 'done',
+            },
+            {
+              type: 'tool-sendEmail',
+              state: 'output-error',
+              toolCallId: 'call1',
+              errorText: 'Error: Invalid JSON in tool input',
+              input: undefined,
+              rawInput: 'to: John Doe <john@example.com>',
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Sending email...",
+                "type": "text",
+              },
+              {
+                "input": {},
+                "providerExecuted": undefined,
+                "toolCallId": "call1",
+                "toolName": "sendEmail",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "error-text",
+                  "value": "Error: Invalid JSON in tool input",
+                },
+                "toolCallId": "call1",
+                "toolName": "sendEmail",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ]
+      `);
+    });
+
+    it('should handle tool output error with rawInput as parseable JSON string', async () => {
+      const result = await convertToModelMessages([
+        {
+          role: 'assistant',
+          parts: [
+            { type: 'step-start' },
+            {
+              type: 'tool-sendEmail',
+              state: 'output-error',
+              toolCallId: 'call1',
+              errorText: 'Error: delivery failed',
+              input: undefined,
+              rawInput: '{"to":"john@example.com","subject":"Hi"}',
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "input": {
+                  "subject": "Hi",
+                  "to": "john@example.com",
+                },
+                "providerExecuted": undefined,
+                "toolCallId": "call1",
+                "toolName": "sendEmail",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "error-text",
+                  "value": "Error: delivery failed",
+                },
+                "toolCallId": "call1",
+                "toolName": "sendEmail",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ]
+      `);
+    });
+
     it('should handle assistant message with provider-executed tool output available', async () => {
       const result = await convertToModelMessages([
         {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -44,6 +44,33 @@ import {
  *
  * @returns An array of ModelMessages.
  */
+/**
+ * Safely extract tool input from a UI part, handling the case where
+ * rawInput is an invalid JSON string (e.g., when streaming JSON parsing failed).
+ * Anthropic and other providers require tool_use.input to be a valid object.
+ */
+function getSafeToolInput(
+  part: { input?: unknown; rawInput?: unknown },
+): unknown {
+  if (part.input !== undefined) {
+    return part.input;
+  }
+  if ('rawInput' in part && part.rawInput !== undefined) {
+    // rawInput may be a string if JSON parsing failed during streaming
+    if (typeof part.rawInput === 'string') {
+      try {
+        return JSON.parse(part.rawInput);
+      } catch {
+        // Invalid JSON string — return empty object to avoid provider rejection.
+        // The actual error is already captured in errorText.
+        return {};
+      }
+    }
+    return part.rawInput;
+  }
+  return undefined;
+}
+
 export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
   messages: Array<Omit<UI_MESSAGE, 'id'>>,
   options?: {
@@ -204,8 +231,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                     toolName,
                     input:
                       part.state === 'output-error'
-                        ? (part.input ??
-                          ('rawInput' in part ? part.rawInput : undefined))
+                        ? getSafeToolInput(part)
                         : part.input,
                     providerExecuted: part.providerExecuted,
                     ...(part.callProviderMetadata != null


### PR DESCRIPTION
## Problem

When a tool call has `state: "output-error"` with `input: undefined` and `rawInput` set to a string (because the model generated invalid JSON for the tool input), `convertToModelMessages` sends the raw string as the `tool_use.input` value to Anthropic.

Anthropic's API requires `tool_use.input` to be a JSON object/dictionary, so it rejects the request with:

```
400: messages.N.content.M.tool_use.input: Input should be a valid dictionary
```

This creates an **unrecoverable loop** in multi-turn conversations: the corrupted tool call is part of the message history, so every subsequent inference attempt replays the same invalid message and gets the same 400 error.

## Root Cause

In `convertToModelMessages`, when processing tool UI parts with `state === "output-error"`:

```js
input: part.state === "output-error"
  ? (part.input ?? ("rawInput" in part ? part.rawInput : undefined))
  : part.input,
```

When `part.input` is `undefined` (as set during streaming when JSON parsing fails), it falls back to `part.rawInput` — which is a **string**, not an object. Anthropic (and likely other providers) requires `input` to be a dict/object.

## Fix

Added a `getSafeToolInput()` helper function that:
1. Returns `part.input` directly if defined
2. If `rawInput` is a string, attempts to `JSON.parse()` it
3. If parsing fails (invalid JSON), returns `{}` instead of the raw string
4. The actual error is already captured in `errorText`, so an empty input object is safe
5. Passes through object `rawInput` values unchanged

## Testing

- Added test case for `rawInput` as an invalid JSON string (falls back to `{}`)
- Added test case for `rawInput` as a parseable JSON string (correctly parses)
- All 58 existing tests pass

Fixes #13645