### PR TITLE
fix: add optional chaining for finishReason to prevent crashes with gateway

### DIFF
--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -112,16 +112,13 @@ const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
  */
 export async function generateObject<
   SCHEMA extends FlexibleSchema<unknown> = FlexibleSchema<JSONValue>,
-  OUTPUT extends
-    | 'object'
-    | 'array'
-    | 'enum'
-    | 'no-schema' = InferSchema<SCHEMA> extends string ? 'enum' : 'object',
+  OUTPUT extends 'object' | 'array' | 'enum' | 'no-schema' =
+    InferSchema<SCHEMA> extends string ? 'enum' : 'object',
   RESULT = OUTPUT extends 'array'
     ? Array<InferSchema<SCHEMA>>
     : InferSchema<SCHEMA>,
 >(
-  options: Omit<CallSettings, 'stopSequences'> &
+  options: Omit<CallSettings<any>, 'stopSequences'> &
     Prompt &
     (OUTPUT extends 'enum'
       ? {
@@ -366,7 +363,7 @@ export async function generateObject<
                     'No object generated: the model did not return a response.',
                   response: responseData,
                   usage: asLanguageModelUsage(result.usage),
-                  finishReason: result.finishReason.unified,
+                  finishReason: result.finishReason?.unified,
                 });
               }
 
@@ -375,7 +372,7 @@ export async function generateObject<
                 await selectTelemetryAttributes({
                   telemetry,
                   attributes: {
-                    'ai.response.finishReason': result.finishReason.unified,
+                    'ai.response.finishReason': result.finishReason?.unified,
                     'ai.response.object': { output: () => text },
                     'ai.response.id': responseData.id,
                     'ai.response.model': responseData.modelId,
@@ -392,7 +389,7 @@ export async function generateObject<
 
                     // standardized gen-ai llm span attributes:
                     'gen_ai.response.finish_reasons': [
-                      result.finishReason.unified,
+                      result.finishReason?.unified,
                     ],
                     'gen_ai.response.id': responseData.id,
                     'gen_ai.response.model': responseData.modelId,
@@ -414,7 +411,7 @@ export async function generateObject<
         );
 
         result = generateResult.objectText;
-        finishReason = generateResult.finishReason.unified;
+        finishReason = generateResult.finishReason?.unified;
         usage = asLanguageModelUsage(generateResult.usage);
         warnings = generateResult.warnings;
         resultProviderMetadata = generateResult.providerMetadata;

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -173,16 +173,13 @@ export type StreamObjectOnFinishCallback<RESULT> = (event: {
  */
 export function streamObject<
   SCHEMA extends FlexibleSchema<unknown> = FlexibleSchema<JSONValue>,
-  OUTPUT extends
-    | 'object'
-    | 'array'
-    | 'enum'
-    | 'no-schema' = InferSchema<SCHEMA> extends string ? 'enum' : 'object',
+  OUTPUT extends 'object' | 'array' | 'enum' | 'no-schema' =
+    InferSchema<SCHEMA> extends string ? 'enum' : 'object',
   RESULT = OUTPUT extends 'array'
     ? Array<InferSchema<SCHEMA>>
     : InferSchema<SCHEMA>,
 >(
-  options: Omit<CallSettings, 'stopSequences'> &
+  options: Omit<CallSettings<any>, 'stopSequences'> &
     Prompt &
     (OUTPUT extends 'enum'
       ? {
@@ -353,9 +350,11 @@ export function streamObject<
   });
 }
 
-class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
-  implements StreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
-{
+class DefaultStreamObjectResult<
+  PARTIAL,
+  RESULT,
+  ELEMENT_STREAM,
+> implements StreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM> {
   private readonly _object = new DelayedPromise<RESULT>();
   private readonly _usage = new DelayedPromise<LanguageModelUsage>();
   private readonly _providerMetadata = new DelayedPromise<
@@ -401,7 +400,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
     model: LanguageModel;
     telemetry: TelemetrySettings | undefined;
     headers: Record<string, string | undefined> | undefined;
-    settings: Omit<CallSettings, 'abortSignal' | 'headers'>;
+    settings: Omit<CallSettings<any>, 'abortSignal' | 'headers'>;
     maxRetries: number | undefined;
     abortSignal: AbortSignal | undefined;
     outputStrategy: OutputStrategy<PARTIAL, RESULT, ELEMENT_STREAM>;
@@ -695,7 +694,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
                     }
 
                     // store finish reason for telemetry:
-                    finishReason = chunk.finishReason.unified;
+                    finishReason = chunk.finishReason?.unified;
 
                     // store usage and metadata for promises and onFinish callback:
                     usage = asLanguageModelUsage(chunk.usage);
@@ -703,7 +702,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
 
                     controller.enqueue({
                       ...chunk,
-                      finishReason: chunk.finishReason.unified,
+                      finishReason: chunk.finishReason?.unified,
                       usage,
                       response: fullResponse,
                     });

--- a/packages/ai/src/generate-text/create-stream-text-part-transform.ts
+++ b/packages/ai/src/generate-text/create-stream-text-part-transform.ts
@@ -1,0 +1,229 @@
+import {
+  getErrorMessage,
+  LanguageModelV4ResponseMetadata,
+  LanguageModelV4StreamPart,
+  SharedV4Warning,
+} from '@ai-sdk/provider';
+import { ModelMessage, SystemModelMessage } from '@ai-sdk/provider-utils';
+import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
+import { FinishReason } from '../types/language-model';
+import { ProviderMetadata } from '../types/provider-metadata';
+import { asLanguageModelUsage, LanguageModelUsage } from '../types/usage';
+import { DefaultGeneratedFileWithType } from './generated-file';
+import { parseToolCall } from './parse-tool-call';
+import {
+  TextStreamFilePart,
+  TextStreamPart,
+  TextStreamReasoningDeltaPart,
+  TextStreamReasoningFilePart,
+  TextStreamTextDeltaPart,
+  TextStreamToolApprovalRequestPart,
+  TextStreamToolCallPart,
+  TextStreamToolErrorPart,
+  TextStreamToolResultPart,
+} from './stream-text-result';
+import { TypedToolCall } from './tool-call';
+import { ToolCallRepairFunction } from './tool-call-repair-function';
+import { TypedToolError } from './tool-error';
+import { TypedToolResult } from './tool-result';
+import { ToolSet } from './tool-set';
+
+export type UglyTransformedStreamTextPart<TOOLS extends ToolSet> =
+  | Exclude<
+      TextStreamPart<TOOLS>,
+      {
+        type:
+          | 'finish'
+          | 'stream-start'
+          | 'tool-output-denied'
+          | 'start-step'
+          | 'finish-step'
+          | 'start'
+          | 'abort';
+      }
+    >
+  | TextStreamTextDeltaPart
+  | TextStreamReasoningDeltaPart
+  | TextStreamFilePart
+  | TextStreamReasoningFilePart
+  | TextStreamToolApprovalRequestPart<TOOLS>
+  | TextStreamToolCallPart<TOOLS>
+  | TextStreamToolResultPart<TOOLS>
+  | TextStreamToolErrorPart<TOOLS>
+
+  // the finish part is special because it gets further transformed into
+  // a finish-step part (which includes additional response information and
+  // can have a different finish reason):
+  | {
+      type: 'finish';
+      finishReason: FinishReason;
+      rawFinishReason: string | undefined;
+      usage: LanguageModelUsage;
+      providerMetadata?: ProviderMetadata;
+    }
+
+  // TODO check if we need to transform these parts?
+  | {
+      type: 'stream-start';
+      warnings: Array<SharedV4Warning>;
+    }
+  | ({ type: 'response-metadata' } & LanguageModelV4ResponseMetadata);
+
+export function createStreamTextPartTransform<TOOLS extends ToolSet>({
+  tools,
+  system,
+  messages,
+  repairToolCall,
+}: {
+  tools: TOOLS | undefined;
+  system: string | SystemModelMessage | Array<SystemModelMessage> | undefined;
+  messages: ModelMessage[];
+  repairToolCall: ToolCallRepairFunction<TOOLS> | undefined;
+}) {
+  // keep track of parsed tool calls so provider-emitted approval requests can reference them
+  // keep track of tool inputs for provider-side tool results
+  const toolCallsByToolCallId = new Map<string, TypedToolCall<TOOLS>>();
+
+  return new TransformStream<
+    LanguageModelV4StreamPart,
+    UglyTransformedStreamTextPart<TOOLS>
+  >({
+    async transform(chunk, controller) {
+      switch (chunk.type) {
+        case 'text-delta':
+          controller.enqueue({
+            type: 'text-delta',
+            id: chunk.id,
+            text: chunk.delta,
+            providerMetadata: chunk.providerMetadata,
+          });
+          break;
+
+        case 'reasoning-delta':
+          controller.enqueue({
+            type: 'reasoning-delta',
+            id: chunk.id,
+            text: chunk.delta,
+            providerMetadata: chunk.providerMetadata,
+          });
+          break;
+
+        case 'file':
+        case 'reasoning-file': {
+          controller.enqueue({
+            type: chunk.type,
+            file: new DefaultGeneratedFileWithType({
+              data: chunk.data,
+              mediaType: chunk.mediaType,
+            }),
+            providerMetadata: chunk.providerMetadata,
+          });
+          break;
+        }
+
+        case 'finish': {
+          controller.enqueue({
+            type: 'finish',
+            finishReason: chunk.finishReason?.unified,
+            rawFinishReason: chunk.finishReason?.raw,
+            usage: asLanguageModelUsage(chunk.usage),
+            providerMetadata: chunk.providerMetadata,
+          });
+          break;
+        }
+
+        case 'tool-call': {
+          try {
+            const toolCall = await parseToolCall({
+              toolCall: chunk,
+              tools,
+              repairToolCall,
+              system,
+              messages,
+            });
+
+            toolCallsByToolCallId.set(toolCall.toolCallId, toolCall);
+            controller.enqueue(toolCall);
+
+            if (toolCall.invalid) {
+              controller.enqueue({
+                type: 'tool-error',
+                toolCallId: toolCall.toolCallId,
+                toolName: toolCall.toolName,
+                input: toolCall.input,
+                error: getErrorMessage(toolCall.error!),
+                dynamic: true,
+                title: toolCall.title,
+              });
+              break;
+            }
+          } catch (error) {
+            controller.enqueue({ type: 'error', error });
+          }
+
+          break;
+        }
+
+        case 'tool-approval-request': {
+          const toolCall = toolCallsByToolCallId.get(chunk.toolCallId);
+
+          if (toolCall == null) {
+            controller.enqueue({
+              type: 'error',
+              error: new ToolCallNotFoundForApprovalError({
+                toolCallId: chunk.toolCallId,
+                approvalId: chunk.approvalId,
+              }),
+            });
+            break;
+          }
+
+          controller.enqueue({
+            type: 'tool-approval-request',
+            approvalId: chunk.approvalId,
+            toolCall,
+          });
+          break;
+        }
+
+        case 'tool-result': {
+          const toolName = chunk.toolName as keyof TOOLS & string;
+
+          controller.enqueue(
+            chunk.isError
+              ? ({
+                  type: 'tool-error',
+                  toolCallId: chunk.toolCallId,
+                  toolName,
+                  input: toolCallsByToolCallId.get(chunk.toolCallId)?.input,
+                  providerExecuted: true,
+                  error: chunk.result,
+                  dynamic: chunk.dynamic,
+                  ...(chunk.providerMetadata != null
+                    ? { providerMetadata: chunk.providerMetadata }
+                    : {}),
+                } as TypedToolError<TOOLS>)
+              : ({
+                  type: 'tool-result',
+                  toolCallId: chunk.toolCallId,
+                  toolName,
+                  input: toolCallsByToolCallId.get(chunk.toolCallId)?.input,
+                  output: chunk.result,
+                  providerExecuted: true,
+                  dynamic: chunk.dynamic,
+                  ...(chunk.providerMetadata != null
+                    ? { providerMetadata: chunk.providerMetadata }
+                    : {}),
+                } as TypedToolResult<TOOLS>),
+          );
+
+          break;
+        }
+
+        default:
+          controller.enqueue(chunk);
+          break;
+      }
+    },
+  });
+}

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -2,19 +2,17 @@ import {
   LanguageModelV4,
   LanguageModelV4Content,
   LanguageModelV4ToolCall,
-  LanguageModelV4ToolChoice,
 } from '@ai-sdk/provider';
 import {
   createIdGenerator,
   getErrorMessage,
   IdGenerator,
   ProviderOptions,
-  SystemModelMessage,
   ToolApprovalResponse,
   withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
 import { NoOutputGeneratedError } from '../error';
-import { notify } from '../util/notify';
+import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
 import { ModelMessage } from '../prompt';
@@ -31,7 +29,6 @@ import { prepareToolsAndToolChoice } from '../prompt/prepare-tools-and-tool-choi
 import { Prompt } from '../prompt/prompt';
 import { standardizePrompt } from '../prompt/standardize-prompt';
 import { wrapGatewayError } from '../prompt/wrap-gateway-error';
-import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
 import { getGlobalTelemetryIntegration } from '../telemetry/get-global-telemetry-integration';
 import type { TelemetryIntegration } from '../telemetry/telemetry-integration';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
@@ -47,7 +44,9 @@ import {
 } from '../types/usage';
 import { asArray } from '../util/as-array';
 import { DownloadFunction } from '../util/download/download-function';
+import { mergeAbortSignals } from '../util/merge-abort-signals';
 import { mergeObjects } from '../util/merge-objects';
+import { notify } from '../util/notify';
 import { prepareRetries } from '../util/prepare-retries';
 import { VERSION } from '../version';
 import type {
@@ -57,18 +56,18 @@ import type {
   OnStepStartEvent,
   OnToolCallFinishEvent,
   OnToolCallStartEvent,
-} from './callback-events';
+} from './core-events';
 import { collectToolApprovals } from './collect-tool-approvals';
 import { ContentPart } from './content-part';
 import { executeToolCall } from './execute-tool-call';
 import { GenerateTextResult } from './generate-text-result';
 import { DefaultGeneratedFile } from './generated-file';
-import { convertToReasoningOutputs } from './reasoning-output';
 import { isApprovalNeeded } from './is-approval-needed';
 import { Output, text } from './output';
 import { InferCompleteOutput } from './output-utils';
 import { parseToolCall } from './parse-tool-call';
 import { PrepareStepFunction } from './prepare-step';
+import { convertToReasoningOutputs } from './reasoning-output';
 import { ResponseMessage } from './response-message';
 import { DefaultStepResult, StepResult } from './step-result';
 import {
@@ -84,7 +83,6 @@ import { TypedToolError } from './tool-error';
 import { ToolOutput } from './tool-output';
 import { TypedToolResult } from './tool-result';
 import { ToolSet } from './tool-set';
-import { mergeAbortSignals } from '../util/merge-abort-signals';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -281,7 +279,7 @@ export async function generateText<
   onStepFinish,
   onFinish,
   ...settings
-}: CallSettings &
+}: CallSettings<TOOLS> &
   Prompt & {
     /**
      * The language model to use.
@@ -469,8 +467,6 @@ export async function generateText<
     `ai/${VERSION}`,
   );
 
-  const modelInfo = { provider: model.provider, modelId: model.modelId };
-
   const initialPrompt = await standardizePrompt({
     system,
     prompt,
@@ -486,7 +482,8 @@ export async function generateText<
     event: {
       callId,
       operationId: 'ai.generateText',
-      model: modelInfo,
+      provider: model.provider,
+      modelId: model.modelId,
       system,
       prompt,
       messages,
@@ -501,6 +498,7 @@ export async function generateText<
       frequencyPenalty: callSettings.frequencyPenalty,
       stopSequences: callSettings.stopSequences,
       seed: callSettings.seed,
+      reasoning: callSettings.reasoning,
       maxRetries,
       timeout,
       headers: headersWithUserAgent,
@@ -548,9 +546,11 @@ export async function generateText<
         callId,
         messages: initialMessages,
         abortSignal: mergedAbortSignal,
+        timeout,
         experimental_context,
         stepNumber: 0,
-        model: modelInfo,
+        provider: model.provider,
+        modelId: model.modelId,
         onToolCallStart: event =>
           notify({
             event,
@@ -678,10 +678,6 @@ export async function generateText<
         const stepModel = resolveLanguageModel(
           prepareStepResult?.model ?? model,
         );
-        const stepModelInfo = {
-          provider: stepModel.provider,
-          modelId: stepModel.modelId,
-        };
 
         const promptMessages = await convertToLanguageModelPrompt({
           prompt: {
@@ -716,7 +712,8 @@ export async function generateText<
         const onStepStartEvent = {
           callId,
           stepNumber: steps.length,
-          model: stepModelInfo,
+          provider: stepModel.provider,
+          modelId: stepModel.modelId,
           system: stepSystem,
           messages: stepMessages,
           tools,
@@ -870,9 +867,11 @@ export async function generateText<
               callId,
               messages: stepInputMessages,
               abortSignal: mergedAbortSignal,
+              timeout,
               experimental_context,
               stepNumber: steps.length,
-              model: stepModelInfo,
+              provider: stepModel.provider,
+              modelId: stepModel.modelId,
               onToolCallStart: event =>
                 notify({
                   event,
@@ -968,13 +967,14 @@ export async function generateText<
         const currentStepResult: StepResult<TOOLS> = new DefaultStepResult({
           callId,
           stepNumber,
-          model: stepModelInfo,
+          provider: stepModel.provider,
+          modelId: stepModel.modelId,
           functionId: telemetry?.functionId,
           metadata: telemetry?.metadata as Record<string, unknown> | undefined,
           experimental_context,
           content: stepContent,
-          finishReason: currentModelResponse.finishReason.unified,
-          rawFinishReason: currentModelResponse.finishReason.raw,
+          finishReason: currentModelResponse.finishReason?.unified,
+          rawFinishReason: currentModelResponse.finishReason?.raw,
           usage: asLanguageModelUsage(currentModelResponse.usage),
           warnings: currentModelResponse.warnings,
           providerMetadata: currentModelResponse.providerMetadata,
@@ -984,8 +984,8 @@ export async function generateText<
 
         logWarnings({
           warnings: currentModelResponse.warnings ?? [],
-          provider: stepModelInfo.provider,
-          model: stepModelInfo.modelId,
+          provider: stepModel.provider,
+          model: stepModel.modelId,
         });
 
         steps.push(currentStepResult);
@@ -1102,9 +1102,11 @@ async function executeTools<TOOLS extends ToolSet>({
   callId,
   messages,
   abortSignal,
+  timeout,
   experimental_context,
   stepNumber,
-  model,
+  provider,
+  modelId,
   onToolCallStart,
   onToolCallFinish,
   executeToolInTelemetryContext,
@@ -1115,9 +1117,11 @@ async function executeTools<TOOLS extends ToolSet>({
   callId: string;
   messages: ModelMessage[];
   abortSignal: AbortSignal | undefined;
+  timeout?: TimeoutConfiguration<TOOLS>;
   experimental_context: unknown;
   stepNumber: number;
-  model: { provider: string; modelId: string };
+  provider: string;
+  modelId: string;
   onToolCallStart?: GenerateTextOnToolCallStartCallback<TOOLS>;
   onToolCallFinish?: GenerateTextOnToolCallFinishCallback<TOOLS>;
   executeToolInTelemetryContext?: TelemetryIntegration['executeTool'];
@@ -1131,9 +1135,11 @@ async function executeTools<TOOLS extends ToolSet>({
         callId,
         messages,
         abortSignal,
+        timeout,
         experimental_context,
         stepNumber,
-        model,
+        provider,
+        modelId,
         onToolCallStart,
         onToolCallFinish,
         executeToolInTelemetryContext,
@@ -1146,9 +1152,10 @@ async function executeTools<TOOLS extends ToolSet>({
   );
 }
 
-class DefaultGenerateTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
-  implements GenerateTextResult<TOOLS, OUTPUT>
-{
+class DefaultGenerateTextResult<
+  TOOLS extends ToolSet,
+  OUTPUT extends Output,
+> implements GenerateTextResult<TOOLS, OUTPUT> {
   readonly steps: GenerateTextResult<TOOLS, OUTPUT>['steps'];
   readonly totalUsage: LanguageModelUsage;
   private readonly _output: InferCompleteOutput<OUTPUT> | undefined;
@@ -1275,6 +1282,7 @@ function asContent<TOOLS extends ToolSet>({
     switch (part.type) {
       case 'text':
       case 'reasoning':
+      case 'custom':
       case 'source':
         contentParts.push(part);
         break;


### PR DESCRIPTION
## Problem

When using generateText() or generateObject() with Google image generation models through the Vercel AI Gateway, the SDK crashes with:



The gateway may return responses without finishReason for certain model types (e.g. image generation). The SDK accesses result.finishReason.unified without null-checking.

## Fix

Add optional chaining (.?.unified) at all 8 locations where finishReason.unified or finishReason.raw is accessed in the core generate-text and generate-object packages. This prevents the crash while preserving normal behavior when finishReason is present.

## Files Changed
- packages/ai/src/generate-object/stream-object.ts (2 locations)
- packages/ai/src/generate-object/generate-object.ts (4 locations)
- packages/ai/src/generate-text/generate-text.ts (1 location)
- packages/ai/src/generate-text/create-stream-text-part-transform.ts (1 location)