### PR TITLE
fix: convertToModelMessages handles string rawInput in output-error tool calls

### DIFF
--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -720,6 +720,130 @@ describe('convertToModelMessages', () => {
         ]
       `);
       });
+
+      it('should handle tool output error with rawInput as string by returning empty object', async () => {
+        const result = await convertToModelMessages([
+          {
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'text',
+                text: 'Let me send an email.',
+                state: 'done',
+              },
+              {
+                type: 'tool-send-email',
+                state: 'output-error',
+                toolCallId: 'call1',
+                errorText: 'SyntaxError: Unexpected token',
+                input: undefined,
+                rawInput: '{"to": "John Doe <john@example.com>"',
+              },
+            ],
+          },
+        ]);
+
+        expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Let me send an email.",
+                "type": "text",
+              },
+              {
+                "input": {},
+                "providerExecuted": undefined,
+                "toolCallId": "call1",
+                "toolName": "send-email",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "error-text",
+                  "value": "SyntaxError: Unexpected token",
+                },
+                "toolCallId": "call1",
+                "toolName": "send-email",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ]
+      `);
+      });
+
+      it('should handle tool output error with valid JSON string rawInput by parsing it', async () => {
+        const result = await convertToModelMessages([
+          {
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'text',
+                text: 'Let me calculate that for you.',
+                state: 'done',
+              },
+              {
+                type: 'tool-calculator',
+                state: 'output-error',
+                toolCallId: 'call1',
+                errorText: 'Execution error',
+                input: undefined,
+                rawInput: '{"operation":"add","numbers":[1,2]}',
+              },
+            ],
+          },
+        ]);
+
+        expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Let me calculate that for you.",
+                "type": "text",
+              },
+              {
+                "input": {
+                  "numbers": [
+                    1,
+                    2,
+                  ],
+                  "operation": "add",
+                },
+                "providerExecuted": undefined,
+                "toolCallId": "call1",
+                "toolName": "calculator",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "error-text",
+                  "value": "Execution error",
+                },
+                "toolCallId": "call1",
+                "toolName": "calculator",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ]
+      `);
+      });
     });
 
     it('should handle assistant message with provider-executed tool output available', async () => {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -204,8 +204,20 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                     toolName,
                     input:
                       part.state === 'output-error'
-                        ? (part.input ??
-                          ('rawInput' in part ? part.rawInput : undefined))
+                        ? (() => {
+                            if (part.input != null) return part.input;
+                            if ('rawInput' in part && part.rawInput != null) {
+                              if (typeof part.rawInput === 'string') {
+                                try {
+                                  return JSON.parse(part.rawInput);
+                                } catch {
+                                  return {};
+                                }
+                              }
+                              return part.rawInput;
+                            }
+                            return undefined;
+                          })()
                         : part.input,
                     providerExecuted: part.providerExecuted,
                     ...(part.callProviderMetadata != null


### PR DESCRIPTION
## Problem

When a tool call has `state: "output-error"` with `input: undefined` and `rawInput` set to a string (because the model generated invalid JSON for the tool input), `convertToModelMessages` passes the raw string as `tool_use.input` to providers like Anthropic.

Anthropic's API requires `tool_use.input` to be a JSON object/dictionary, so it rejects with:

```
400: messages.N.content.M.tool_use.input: Input should be a valid dictionary
```

This creates an **unrecoverable loop** in multi-turn conversations: the corrupted tool call is in the message history, so every subsequent inference attempt replays the same invalid message and gets the same 400 error.

Fixes #13645

## Root Cause

In `convertToModelMessages`, when processing tool parts with `state === "output-error"`:

```js
input: part.state === "output-error"
  ? (part.input ?? ("rawInput" in part ? part.rawInput : undefined))
  : part.input,
```

When `part.input` is undefined and `rawInput` is a string (from failed JSON parsing during streaming), the string is passed directly as `input`.

## Fix

- When `rawInput` is a string, attempt `JSON.parse()` first
- If parsing fails (invalid JSON), fall back to `{}` (empty object)
- If `rawInput` is already an object, preserve existing behavior

## Testing

- Added 2 new test cases covering:
  1. String rawInput with invalid JSON → falls back to `{}`
  2. String rawInput with valid JSON → parses it correctly
- All 58 existing tests continue to pass