### PR TITLE
fix(provider-utils): retry on Node.js socket termination errors

### DIFF
--- a/packages/provider-utils/src/handle-fetch-error.test.ts
+++ b/packages/provider-utils/src/handle-fetch-error.test.ts
@@ -121,6 +121,59 @@ describe('handleFetchError', () => {
     });
   });
 
+  describe('node.js socket termination errors', () => {
+    it('should handle TypeError with "terminated" message', () => {
+      const terminatedError = new TypeError('terminated');
+
+      const result = handleFetchError({
+        error: terminatedError,
+        url: testUrl,
+        requestBodyValues: testRequestBodyValues,
+      });
+
+      expect(APICallError.isInstance(result)).toBe(true);
+      expect((result as APICallError).isRetryable).toBe(true);
+      expect((result as APICallError).message).toBe(
+        'Cannot connect to API: terminated',
+      );
+    });
+
+    it('should handle SocketError with "other side closed" message', () => {
+      const socketError = new Error('other side closed');
+      (socketError as any).code = 'UND_ERR_SOCKET';
+
+      const result = handleFetchError({
+        error: socketError,
+        url: testUrl,
+        requestBodyValues: testRequestBodyValues,
+      });
+
+      expect(APICallError.isInstance(result)).toBe(true);
+      expect((result as APICallError).isRetryable).toBe(true);
+      expect((result as APICallError).message).toBe(
+        'Cannot connect to API: other side closed',
+      );
+    });
+
+    it('should handle TypeError with "terminated" as cause of fetch error', () => {
+      const cause = new TypeError('terminated');
+      const fetchError = new TypeError('fetch failed');
+      (fetchError as any).cause = cause;
+
+      const result = handleFetchError({
+        error: fetchError,
+        url: testUrl,
+        requestBodyValues: testRequestBodyValues,
+      });
+
+      expect(APICallError.isInstance(result)).toBe(true);
+      expect((result as APICallError).isRetryable).toBe(true);
+      expect((result as APICallError).message).toBe(
+        'Cannot connect to API: terminated',
+      );
+    });
+  });
+
   describe('unknown errors', () => {
     it('should return unknown errors as-is', () => {
       const unknownError = new Error('Something unexpected');

--- a/packages/provider-utils/src/handle-fetch-error.ts
+++ b/packages/provider-utils/src/handle-fetch-error.ts
@@ -3,6 +3,11 @@ import { isAbortError } from './is-abort-error';
 
 const FETCH_FAILED_ERROR_MESSAGES = ['fetch failed', 'failed to fetch'];
 
+// Node.js undici errors thrown when TCP socket dies mid-response
+const SOCKET_ERROR_MESSAGES = ['terminated', 'other side closed'];
+
+const SOCKET_ERROR_CODES = ['UND_ERR_SOCKET'];
+
 const BUN_ERROR_CODES = [
   'ConnectionRefused',
   'ConnectionClosed',
@@ -20,6 +25,23 @@ function isBunNetworkError(error: unknown): error is Error & { code?: string } {
 
   const code = (error as any).code;
   if (typeof code === 'string' && BUN_ERROR_CODES.includes(code)) {
+    return true;
+  }
+
+  return false;
+}
+
+function isSocketError(error: unknown): error is Error {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if (SOCKET_ERROR_MESSAGES.includes(error.message.toLowerCase())) {
+    return true;
+  }
+
+  const code = (error as any).code;
+  if (typeof code === 'string' && SOCKET_ERROR_CODES.includes(code)) {
     return true;
   }
 
@@ -59,6 +81,18 @@ export function handleFetchError({
   }
 
   if (isBunNetworkError(error)) {
+    return new APICallError({
+      message: `Cannot connect to API: ${error.message}`,
+      cause: error,
+      url,
+      requestBodyValues,
+      isRetryable: true,
+    });
+  }
+
+  // Node.js undici socket errors (e.g. TypeError: terminated, SocketError: other side closed)
+  // These occur when the TCP connection is dropped mid-response and are transient.
+  if (isSocketError(error)) {
     return new APICallError({
       message: `Cannot connect to API: ${error.message}`,
       cause: error,


### PR DESCRIPTION
## Summary

`TypeError: terminated` and `SocketError: other side closed` are thrown by Node.js undici when the TCP socket dies mid-response (e.g. during long-running `generateText` calls with reasoning models). These are transient network errors, but `handleFetchError` only recognizes `"fetch failed"` / `"failed to fetch"`, so they fall through as raw errors and are **not retried** by the exponential backoff logic.

This adds detection for socket termination errors (`terminated`, `other side closed`, `UND_ERR_SOCKET` code) so they are properly wrapped as retryable `APICallError`s.

## Reproduction

When using `generateText` with models that have long response times (e.g. `gpt-5.2` with `reasoningEffort: "high"`), the TCP socket can be terminated by intermediate infrastructure. The error surfaces as:

```
AI_APICallError: Failed to process successful response
  cause: TypeError: terminated
    at Fetch.onAborted (node:internal/deps/undici/undici:12826:53)
```

or:

```
SocketError: other side closed
  code: 'UND_ERR_SOCKET'
    at TLSSocket.onHttpSocketEnd (node:internal/deps/undici/undici:6294:28)
```

Neither error is retried because `handleFetchError` returns them as-is.

## Changes

- Added `isSocketError()` helper that matches `terminated`, `other side closed` messages and `UND_ERR_SOCKET` error code
- Socket errors are now wrapped as `APICallError` with `isRetryable: true`
- Added 3 test cases covering both error shapes

## Test plan

- [x] `TypeError: terminated` → retryable `APICallError`
- [x] `SocketError: other side closed` (code `UND_ERR_SOCKET`) → retryable `APICallError`
- [x] `TypeError: terminated` as cause of `fetch failed` → retryable (existing path, confirmed)
- [x] All existing tests pass

Fixes #11265
Fixes #9775