### PR TITLE
docs: add QuiverAI community provider

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -92,6 +92,7 @@ The open-source community has created the following providers:
 - [Zhipu (Z.AI) Provider](/providers/community-providers/zhipu) (`zhipu-ai-provider`)
 - [OLLM Provider](/providers/community-providers/ollm) (`@ofoundation/ollm`)
 - [ZeroEntropy Provider](/providers/community-providers/zeroentropy) (`zeroentropy-ai-provider`)
+- [QuiverAI Provider](/providers/community-providers/quiverai) (`quiverai-ai-provider`)
 
 ## Self-Hosted Models
 

--- a/content/providers/03-community-providers/51-quiverai.mdx
+++ b/content/providers/03-community-providers/51-quiverai.mdx
@@ -68,7 +68,7 @@ import { quiverai } from 'quiverai-ai-provider';
 import { streamText } from 'ai';
 
 const result = streamText({
-  model: quiverai('arrow-preview'),
+  model: quiverai('arrow-1.1'),
   prompt: 'A red circle with a blue border',
 });
 
@@ -76,7 +76,7 @@ for await (const chunk of result.textStream) {
   process.stdout.write(chunk); // progressive SVG markup
 }
 
-console.log('Usage:', await result.usage);
+console.log('Credits:', (await result.experimental_providerMetadata)?.quiverai?.credits);
 ```
 
 ### Non-streaming
@@ -85,12 +85,13 @@ console.log('Usage:', await result.usage);
 import { quiverai } from 'quiverai-ai-provider';
 import { generateText } from 'ai';
 
-const { text, usage } = await generateText({
-  model: quiverai('arrow-preview'),
+const { text, experimental_providerMetadata } = await generateText({
+  model: quiverai('arrow-1.1'),
   prompt: 'A red circle with a blue border',
 });
 
 console.log(text); // complete SVG markup
+console.log(experimental_providerMetadata?.quiverai?.credits); // credits used
 ```
 
 ### Vectorization (image to SVG)
@@ -103,7 +104,7 @@ import { generateText } from 'ai';
 import { readFileSync } from 'node:fs';
 
 const { text } = await generateText({
-  model: quiverai('arrow-preview'),
+  model: quiverai('arrow-1.1'),
   messages: [
     {
       role: 'user',
@@ -123,9 +124,11 @@ console.log(text); // SVG markup of the vectorized image
 
 ### Model Capabilities
 
-| Model            | Text-to-SVG | Image-to-SVG | Streaming |
-| ---------------- | :---------: | :----------: | :-------: |
-| `arrow-preview`  |      +      |      +       |     +     |
+| Model          | Text-to-SVG | Image-to-SVG | Streaming |
+| -------------- | :---------: | :----------: | :-------: |
+| `arrow-1`      |      +      |      +       |     +     |
+| `arrow-1.1`    |      +      |      +       |     +     |
+| `arrow-1.1-max`|      +      |      +       |     +     |
 
 ## Image Models
 
@@ -139,7 +142,7 @@ import { generateImage } from 'ai';
 import { writeFileSync } from 'node:fs';
 
 const { images } = await generateImage({
-  model: quiverai.image('arrow-preview'),
+  model: quiverai.image('arrow-1.1'),
   prompt: 'A red circle with a blue border',
 });
 
@@ -158,7 +161,7 @@ import { generateImage } from 'ai';
 import { readFileSync } from 'node:fs';
 
 const { images } = await generateImage({
-  model: quiverai.image('arrow-preview'),
+  model: quiverai.image('arrow-1.1'),
   prompt: '',
   files: [
     {
@@ -188,7 +191,7 @@ import {
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: quiverai('arrow-preview'),
+  model: quiverai('arrow-1.1'),
   prompt: 'A minimalist logo for a coffee shop',
   providerOptions: {
     quiverai: {
@@ -200,29 +203,30 @@ const { text } = await generateText({
 });
 ```
 
-| Option            | Type      | Description                                                               |
-| ----------------- | --------- | ------------------------------------------------------------------------- |
-| `instructions`    | `string`  | Additional style/quality instructions appended to the prompt (text-to-SVG only). |
-| `temperature`     | `number`  | Controls randomness.                                                      |
-| `topP`            | `number`  | Nucleus sampling threshold.                                               |
-| `maxOutputTokens` | `number`  | Maximum tokens to generate.                                               |
-| `autoCrop`        | `boolean` | Auto-crop source image before vectorization.                              |
-| `targetSize`      | `number`  | Target output size in pixels (vectorization only).                        |
+| Option             | Type      | Description                                                               |
+| ------------------ | --------- | ------------------------------------------------------------------------- |
+| `instructions`     | `string`  | Additional style/quality instructions appended to the prompt (text-to-SVG only). |
+| `temperature`      | `number`  | Controls randomness.                                                      |
+| `topP`             | `number`  | Nucleus sampling threshold.                                               |
+| `presencePenalty`  | `number`  | Penalizes tokens already present in the output.                           |
+| `maxOutputTokens`  | `number`  | Maximum tokens to generate.                                               |
+| `autoCrop`         | `boolean` | Auto-crop source image before vectorization.                              |
+| `targetSize`       | `number`  | Target output size in pixels (vectorization only).                        |
 
-## Token Usage
+## Credits Billing
 
-QuiverAI returns `0` for all token counts (`inputTokens`, `outputTokens`, `totalTokens`). Pricing is a fixed cost per generation, not token-based.
+QuiverAI uses credits-based billing rather than token-based billing. Credits consumed per request are exposed via `providerMetadata.quiverai.credits`.
 
 ```ts
 const { images, providerMetadata } = await generateImage({
-  model: quiverai.image('arrow-preview'),
+  model: quiverai.image('arrow-1.1'),
   prompt: 'A red circle with a blue border',
 });
 
 console.log(providerMetadata?.quiverai);
 // {
 //   images: [{ mimeType: 'image/svg+xml' }],
-//   usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 }
+//   credits: { used: 1 }
 // }
 ```
 

--- a/content/providers/03-community-providers/51-quiverai.mdx
+++ b/content/providers/03-community-providers/51-quiverai.mdx
@@ -230,4 +230,4 @@ console.log(providerMetadata?.quiverai);
 
 - [QuiverAI](https://quiver.ai/)
 - [quiverai-ai-provider on npm](https://www.npmjs.com/package/quiverai-ai-provider)
-- [GitHub Repository](https://github.com/nichochar/quiverai-ai-provider)
+- [GitHub Repository](https://github.com/pmontp19/quiverai-ai-sdk-provider)

--- a/content/providers/03-community-providers/51-quiverai.mdx
+++ b/content/providers/03-community-providers/51-quiverai.mdx
@@ -1,0 +1,233 @@
+---
+title: QuiverAI
+description: Learn how to use the QuiverAI provider for the AI SDK.
+---
+
+# QuiverAI Provider
+
+The [QuiverAI](https://quiver.ai/) provider generates scalable vector graphics (SVG) from text prompts and images. SVG is an interesting edge case in AI generation: it is plain text (XML markup) that renders as a vector image. That duality means you can use it through two different AI SDK interfaces — `streamText` / `generateText` if you want a progressive streaming UX where the SVG builds up character by character, or `generateImage` if you prefer the conventional "give me an image" API.
+
+## Setup
+
+The QuiverAI provider is available via the `quiverai-ai-provider` module. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add quiverai-ai-provider" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install quiverai-ai-provider" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add quiverai-ai-provider" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add quiverai-ai-provider" dark />
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+You can import the default `quiverai` instance directly:
+
+```ts
+import { quiverai } from 'quiverai-ai-provider';
+```
+
+For a customized setup, use the `createQuiverAI` factory function:
+
+```ts
+import { createQuiverAI } from 'quiverai-ai-provider';
+
+const quiverai = createQuiverAI({
+  apiKey: 'your-api-key', // defaults to QUIVERAI_API_KEY env var
+  baseURL: 'custom-url', // optional
+  headers: {
+    /* custom headers */
+  }, // optional
+});
+```
+
+### Settings
+
+| Option    | Type                     | Description                                                      |
+| --------- | ------------------------ | ---------------------------------------------------------------- |
+| `apiKey`  | `string`                 | API key sent as `Authorization: Bearer`. Defaults to `QUIVERAI_API_KEY`. |
+| `baseURL` | `string`                 | Override the API base URL.                                       |
+| `headers` | `Record<string, string>` | Extra headers included in every request.                         |
+| `fetch`   | `FetchFunction`          | Custom fetch implementation (useful for testing/proxying).       |
+
+## Language Models
+
+Use `streamText` or `generateText` to receive SVG markup as text output. Streaming is especially useful for progressive rendering — each token is a small SVG fragment you can render live in the browser as it arrives.
+
+### Streaming
+
+```ts
+import { quiverai } from 'quiverai-ai-provider';
+import { streamText } from 'ai';
+
+const result = streamText({
+  model: quiverai('arrow-preview'),
+  prompt: 'A red circle with a blue border',
+});
+
+for await (const chunk of result.textStream) {
+  process.stdout.write(chunk); // progressive SVG markup
+}
+
+console.log('Usage:', await result.usage);
+```
+
+### Non-streaming
+
+```ts
+import { quiverai } from 'quiverai-ai-provider';
+import { generateText } from 'ai';
+
+const { text, usage } = await generateText({
+  model: quiverai('arrow-preview'),
+  prompt: 'A red circle with a blue border',
+});
+
+console.log(text); // complete SVG markup
+```
+
+### Vectorization (image to SVG)
+
+Include an image file part in the prompt to convert a raster image to SVG:
+
+```ts
+import { quiverai } from 'quiverai-ai-provider';
+import { generateText } from 'ai';
+import { readFileSync } from 'node:fs';
+
+const { text } = await generateText({
+  model: quiverai('arrow-preview'),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'file',
+          data: readFileSync('logo.png'),
+          mediaType: 'image/png',
+        },
+      ],
+    },
+  ],
+});
+
+console.log(text); // SVG markup of the vectorized image
+```
+
+### Model Capabilities
+
+| Model            | Text-to-SVG | Image-to-SVG | Streaming |
+| ---------------- | :---------: | :----------: | :-------: |
+| `arrow-preview`  |      +      |      +       |     +     |
+
+## Image Models
+
+Use `generateImage` for a conventional image generation workflow. The SVG is returned as a `Uint8Array` containing UTF-8 encoded markup — write it directly to a `.svg` file or decode it to a string.
+
+### Basic Usage
+
+```ts
+import { quiverai } from 'quiverai-ai-provider';
+import { generateImage } from 'ai';
+import { writeFileSync } from 'node:fs';
+
+const { images } = await generateImage({
+  model: quiverai.image('arrow-preview'),
+  prompt: 'A red circle with a blue border',
+});
+
+const decoder = new TextDecoder();
+for (const image of images) {
+  console.log(decoder.decode(image.uint8Array)); // SVG markup
+  writeFileSync(`output-${Date.now()}.svg`, image.uint8Array);
+}
+```
+
+### Vectorization (image to SVG)
+
+```ts
+import { quiverai } from 'quiverai-ai-provider';
+import { generateImage } from 'ai';
+import { readFileSync } from 'node:fs';
+
+const { images } = await generateImage({
+  model: quiverai.image('arrow-preview'),
+  prompt: '',
+  files: [
+    {
+      type: 'file',
+      data: readFileSync('logo.png'),
+      mediaType: 'image/png',
+    },
+  ],
+  providerOptions: {
+    quiverai: {
+      autoCrop: true,
+      targetSize: 512,
+    },
+  },
+});
+```
+
+## Provider Options
+
+Pass QuiverAI-specific options via `providerOptions.quiverai` on any call:
+
+```ts
+import {
+  quiverai,
+  type QuiverAILanguageProviderOptions,
+} from 'quiverai-ai-provider';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: quiverai('arrow-preview'),
+  prompt: 'A minimalist logo for a coffee shop',
+  providerOptions: {
+    quiverai: {
+      instructions: 'flat design, monochrome, geometric shapes only',
+      temperature: 0.7,
+      maxOutputTokens: 4096,
+    } satisfies QuiverAILanguageProviderOptions,
+  },
+});
+```
+
+| Option            | Type      | Description                                                               |
+| ----------------- | --------- | ------------------------------------------------------------------------- |
+| `instructions`    | `string`  | Additional style/quality instructions appended to the prompt (text-to-SVG only). |
+| `temperature`     | `number`  | Controls randomness.                                                      |
+| `topP`            | `number`  | Nucleus sampling threshold.                                               |
+| `maxOutputTokens` | `number`  | Maximum tokens to generate.                                               |
+| `autoCrop`        | `boolean` | Auto-crop source image before vectorization.                              |
+| `targetSize`      | `number`  | Target output size in pixels (vectorization only).                        |
+
+## Token Usage
+
+QuiverAI returns `0` for all token counts (`inputTokens`, `outputTokens`, `totalTokens`). Pricing is a fixed cost per generation, not token-based.
+
+```ts
+const { images, providerMetadata } = await generateImage({
+  model: quiverai.image('arrow-preview'),
+  prompt: 'A red circle with a blue border',
+});
+
+console.log(providerMetadata?.quiverai);
+// {
+//   images: [{ mimeType: 'image/svg+xml' }],
+//   usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 }
+// }
+```
+
+## Additional Resources
+
+- [QuiverAI](https://quiver.ai/)
+- [quiverai-ai-provider on npm](https://www.npmjs.com/package/quiverai-ai-provider)
+- [GitHub Repository](https://github.com/nichochar/quiverai-ai-provider)


### PR DESCRIPTION
## Summary

Add documentation page for [QuiverAI](https://quiver.ai/), a community provider for SVG generation from text prompts and images.

- Supports both language model (`streamText`/`generateText`) and image model (`generateImage`) interfaces
- Includes streaming SVG generation and image-to-SVG vectorization examples
- Documents provider options, settings, and token usage

## Changes

- Added `content/providers/03-community-providers/51-quiverai.mdx`

## Links

- [QuiverAI](https://quiver.ai/)
- [NPM Package](https://www.npmjs.com/package/quiverai-ai-provider)
- [GitHub Repository](https://github.com/nichochar/quiverai-ai-provider)

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)