### PR TITLE
fix: add output-denied to sendAutomaticallyWhen approval check

### DIFF
--- a/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.ts
+++ b/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.ts
@@ -38,6 +38,7 @@ export function lastAssistantMessageIsCompleteWithApprovalResponses({
       part =>
         part.state === 'output-available' ||
         part.state === 'output-error' ||
+        part.state === 'output-denied' ||
         part.state === 'approval-responded',
     )
   );


### PR DESCRIPTION
## Summary

Fixes #13670

The `lastAssistantMessageIsCompleteWithApprovalResponses` predicate was missing `output-denied` from its terminal state check. When a tool call was denied via `addToolApprovalResponse({ approved: false })`, the state became `output-denied` which was not recognized as terminal, causing `sendAutomaticallyWhen` to never fire and the chat to permanently stall.

## Changes

Added `part.state === 'output-denied'` to the `.every()` condition in `packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.ts` to properly recognize denied tool invocations as terminal states.

## Root Cause

The `.every()` check only listed three terminal states:
- `output-available` — tool completed successfully
- `output-error` — tool errored
- `approval-responded` — tool was approved

But `output-denied` (emitted when `approved: false` is passed to `addToolApprovalResponse`) was missing. This caused denied tool invocations to be treated as still-pending, making the predicate always return `false`.

## Related

A similar partial fix was applied for `createAgentUIStream` in #12209, but this predicate was not updated.