### PR TITLE
fix(openai-compatible): handle thinking content arrays

### DIFF
--- a/.changeset/fix-openai-compatible-thinking-content-arrays.md
+++ b/.changeset/fix-openai-compatible-thinking-content-arrays.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+fix(openai-compatible): support chat completion content arrays with thinking parts
+
+OpenAI-compatible chat parsing now accepts `content` as either a string or an array of content parts for both non-stream and stream responses. When `thinking` parts are present, their text is mapped to reasoning output while text parts continue to stream as normal text deltas.

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -345,6 +345,105 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should extract text and reasoning from content arrays with thinking parts', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'json-value',
+      body: {
+        id: 'chatcmpl-thinking-array',
+        object: 'chat.completion',
+        created: 1711115037,
+        model: 'grok-3',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'thinking',
+                  thinking: [
+                    { type: 'text', text: 'Step 1. ' },
+                    { type: 'text', text: 'Step 2.' },
+                  ],
+                },
+                { type: 'text', text: 'Final answer.' },
+              ],
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 1,
+          completion_tokens: 1,
+          total_tokens: 2,
+        },
+      },
+    };
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Final answer.",
+          "type": "text",
+        },
+        {
+          "text": "Step 1. Step 2.",
+          "type": "reasoning",
+        },
+      ]
+    `);
+  });
+
+  it('should ignore unknown content array parts in non-stream responses', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'json-value',
+      body: {
+        id: 'chatcmpl-thinking-array-unknown-part',
+        object: 'chat.completion',
+        created: 1711115037,
+        model: 'grok-3',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: [
+                { type: 'metadata', foo: 'bar' },
+                {
+                  type: 'thinking',
+                  thinking: [{ type: 'text', text: 'Reasoning.' }],
+                },
+                { type: 'text', text: 'Answer.' },
+              ],
+            },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+    };
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Answer.",
+          "type": "text",
+        },
+        {
+          "text": "Reasoning.",
+          "type": "reasoning",
+        },
+      ]
+    `);
+  });
+
   it('should support partial usage', async () => {
     prepareJsonResponse({
       usage: { prompt_tokens: 20, total_tokens: 20 },
@@ -1719,6 +1818,194 @@ describe('doStream', () => {
             "raw": {
               "completion_tokens": 439,
               "prompt_tokens": 18,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should stream content arrays with thinking parts', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-thinking-array","object":"chat.completion.chunk","created":1711357598,"model":"grok-3","choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":[{"type":"text","text":"Considering "},{"type":"text","text":"options"}]},{"type":"text","text":"Answer"}]},"finish_reason":null}]}` +
+          `\n\n`,
+        `data: {"id":"chatcmpl-thinking-array","object":"chat.completion.chunk","created":1711357598,"model":"grok-3","choices":[{"index":0,"delta":{"content":" ready"},"finish_reason":null}]}` +
+          `\n\n`,
+        `data: {"id":"chatcmpl-thinking-array","object":"chat.completion.chunk","created":1711357598,"model":"grok-3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}` +
+          `\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-thinking-array",
+          "modelId": "grok-3",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-start",
+        },
+        {
+          "delta": "Considering options",
+          "id": "reasoning-0",
+          "type": "reasoning-delta",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-end",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-start",
+        },
+        {
+          "delta": "Answer",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "delta": " ready",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-end",
+        },
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 1,
+              "total": 1,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 2,
+              "total": 2,
+            },
+            "raw": {
+              "completion_tokens": 2,
+              "prompt_tokens": 1,
+              "total_tokens": 3,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should ignore unknown content array parts in stream responses', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-thinking-array-unknown-part","object":"chat.completion.chunk","created":1711357598,"model":"grok-3","choices":[{"index":0,"delta":{"content":[{"type":"metadata","foo":"bar"},{"type":"thinking","thinking":[{"type":"text","text":"Reasoning."}]},{"type":"text","text":"Answer"}]},"finish_reason":null}]}` +
+          `\n\n`,
+        `data: {"id":"chatcmpl-thinking-array-unknown-part","object":"chat.completion.chunk","created":1711357598,"model":"grok-3","choices":[{"index":0,"delta":{"content":" done"},"finish_reason":null}]}` +
+          `\n\n`,
+        `data: {"id":"chatcmpl-thinking-array-unknown-part","object":"chat.completion.chunk","created":1711357598,"model":"grok-3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}` +
+          `\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-thinking-array-unknown-part",
+          "modelId": "grok-3",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-start",
+        },
+        {
+          "delta": "Reasoning.",
+          "id": "reasoning-0",
+          "type": "reasoning-delta",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-end",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-start",
+        },
+        {
+          "delta": "Answer",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "delta": " done",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-end",
+        },
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 1,
+              "total": 1,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 2,
+              "total": 2,
+            },
+            "raw": {
+              "completion_tokens": 2,
+              "prompt_tokens": 1,
+              "total_tokens": 3,
             },
           },
         },

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -41,6 +41,68 @@ import {
 import { MetadataExtractor } from './openai-compatible-metadata-extractor';
 import { prepareTools } from './openai-compatible-prepare-tools';
 
+const openAICompatibleContentSchema = z.union([
+  z.string(),
+  z.array(z.unknown()),
+]);
+
+function normalizeOpenAICompatibleContent(content: unknown): {
+  text?: string;
+  reasoning?: string;
+} {
+  if (typeof content === 'string') {
+    return { text: content };
+  }
+
+  if (!Array.isArray(content)) {
+    return {};
+  }
+
+  const textParts: string[] = [];
+  const reasoningParts: string[] = [];
+
+  for (const part of content) {
+    if (part == null || typeof part !== 'object') {
+      continue;
+    }
+
+    if (
+      'type' in part &&
+      part.type === 'text' &&
+      'text' in part &&
+      typeof part.text === 'string'
+    ) {
+      textParts.push(part.text);
+      continue;
+    }
+
+    if (
+      'type' in part &&
+      part.type === 'thinking' &&
+      'thinking' in part &&
+      Array.isArray(part.thinking)
+    ) {
+      for (const thinkingPart of part.thinking) {
+        if (
+          thinkingPart != null &&
+          typeof thinkingPart === 'object' &&
+          'type' in thinkingPart &&
+          thinkingPart.type === 'text' &&
+          'text' in thinkingPart &&
+          typeof thinkingPart.text === 'string'
+        ) {
+          reasoningParts.push(thinkingPart.text);
+        }
+      }
+    }
+  }
+
+  return {
+    text: textParts.length > 0 ? textParts.join('') : undefined,
+    reasoning: reasoningParts.length > 0 ? reasoningParts.join('') : undefined,
+  };
+}
+
 export type OpenAICompatibleChatConfig = {
   provider: string;
   headers: () => Record<string, string | undefined>;
@@ -278,14 +340,19 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
     const content: Array<LanguageModelV4Content> = [];
 
     // text content:
-    const text = choice.message.content;
+    const normalizedMessageContent = normalizeOpenAICompatibleContent(
+      choice.message.content,
+    );
+    const text = normalizedMessageContent.text;
     if (text != null && text.length > 0) {
       content.push({ type: 'text', text });
     }
 
     // reasoning content:
     const reasoning =
-      choice.message.reasoning_content ?? choice.message.reasoning;
+      choice.message.reasoning_content ??
+      choice.message.reasoning ??
+      normalizedMessageContent.reasoning;
     if (reasoning != null && reasoning.length > 0) {
       content.push({
         type: 'reasoning',
@@ -471,9 +538,15 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
             }
 
             const delta = choice.delta;
+            const normalizedDeltaContent = normalizeOpenAICompatibleContent(
+              delta.content,
+            );
 
             // enqueue reasoning before text deltas:
-            const reasoningContent = delta.reasoning_content ?? delta.reasoning;
+            const reasoningContent =
+              delta.reasoning_content ??
+              delta.reasoning ??
+              normalizedDeltaContent.reasoning;
             if (reasoningContent) {
               if (!isActiveReasoning) {
                 controller.enqueue({
@@ -490,7 +563,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
               });
             }
 
-            if (delta.content) {
+            if (normalizedDeltaContent.text) {
               // end active reasoning block before text starts
               if (isActiveReasoning) {
                 controller.enqueue({
@@ -508,7 +581,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
               controller.enqueue({
                 type: 'text-delta',
                 id: 'txt-0',
-                delta: delta.content,
+                delta: normalizedDeltaContent.text,
               });
             }
 
@@ -754,7 +827,7 @@ const OpenAICompatibleChatResponseSchema = z.looseObject({
     z.object({
       message: z.object({
         role: z.literal('assistant').nullish(),
-        content: z.string().nullish(),
+        content: openAICompatibleContentSchema.nullish(),
         reasoning_content: z.string().nullish(),
         reasoning: z.string().nullish(),
         tool_calls: z
@@ -794,7 +867,7 @@ const chunkBaseSchema = z.looseObject({
       delta: z
         .object({
           role: z.enum(['assistant']).nullish(),
-          content: z.string().nullish(),
+          content: openAICompatibleContentSchema.nullish(),
           // Most openai-compatible models set `reasoning_content`, but some
           // providers serving `gpt-oss` set `reasoning`. See #7866
           reasoning_content: z.string().nullish(),


### PR DESCRIPTION
## Background
Some OpenAI-compatible providers (see #13703) return structured content arrays (including `thinking` parts) in chat responses/chunks, while the current implementation expected string-only content in key paths. This caused validation failures (`expected string, received array`) and broke generate/stream flows.

## Summary
- Add support for array-shaped `content` in OpenAI-compatible chat response/chunk schemas.
- Normalize known content-part types:
  - `text` parts -> text output
  - `thinking` parts -> reasoning output
- Keep compatibility precedence:
  - `reasoning_content` > `reasoning` > reasoning extracted from `thinking`
- Keep schema future-proof by allowing unknown array part types without failing validation.
- Add regression tests for:
  - non-stream content arrays with thinking
  - stream content arrays with thinking
  - unknown content part types in both paths
- Add patch changeset.

## Manual Verification
- Ran package tests:
  - `corepack pnpm --filter @ai-sdk/openai-compatible test:node -- src/chat/openai-compatible-chat-language-model.test.ts`
  - Result: all tests passed (including new regression tests)
- Ran package type-check:
  - `corepack pnpm --filter @ai-sdk/openai-compatible type-check`
  - Result: passed

## Checklist
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work
- Consider extracting the content normalization helper for reuse if similar parsing logic is needed in other OpenAI-compatible surfaces.

## Related Issues
https://github.com/vercel/ai/issues/13703
