### PR TITLE
feat(perplexity): expose provider-reported cost in providerMetadata

### DIFF
--- a/.changeset/gentle-buttons-retire.md
+++ b/.changeset/gentle-buttons-retire.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/perplexity": patch
+---
+
+feat(perplexity): expose provider-reported cost in providerMetadata

--- a/packages/perplexity/src/__snapshots__/perplexity-language-model.test.ts.snap
+++ b/packages/perplexity/src/__snapshots__/perplexity-language-model.test.ts.snap
@@ -64,6 +64,7 @@ These reflect post-2020 Census trends (873,965 in 2020), with population declini
   },
   "providerMetadata": {
     "perplexity": {
+      "cost": null,
       "images": null,
       "usage": {
         "citationTokens": null,
@@ -220,6 +221,7 @@ This holiday scales for individuals (home setups) or communities (pop-up parks),
   },
   "providerMetadata": {
     "perplexity": {
+      "cost": null,
       "images": null,
       "usage": {
         "citationTokens": null,
@@ -426,6 +428,7 @@ exports[`doStream > citations > should stream citations 1`] = `
     },
     "providerMetadata": {
       "perplexity": {
+        "cost": null,
         "images": null,
         "usage": {
           "citationTokens": null,
@@ -553,6 +556,7 @@ exports[`doStream > text > should stream text 1`] = `
     },
     "providerMetadata": {
       "perplexity": {
+        "cost": null,
         "images": null,
         "usage": {
           "citationTokens": null,

--- a/packages/perplexity/src/perplexity-language-model.test.ts
+++ b/packages/perplexity/src/perplexity-language-model.test.ts
@@ -326,6 +326,7 @@ describe('doGenerate', () => {
     expect(result.providerMetadata).toMatchInlineSnapshot(`
       {
         "perplexity": {
+          "cost": null,
           "images": [
             {
               "height": 100,
@@ -399,6 +400,7 @@ describe('doGenerate', () => {
     expect(result.providerMetadata).toMatchInlineSnapshot(`
       {
         "perplexity": {
+          "cost": null,
           "images": null,
           "usage": {
             "citationTokens": 30,
@@ -597,6 +599,7 @@ describe('doStream', () => {
     expect(finish?.providerMetadata).toMatchInlineSnapshot(`
       {
         "perplexity": {
+          "cost": null,
           "images": [
             {
               "height": 100,
@@ -686,6 +689,7 @@ describe('doStream', () => {
     expect(finish?.providerMetadata).toMatchInlineSnapshot(`
       {
         "perplexity": {
+          "cost": null,
           "images": null,
           "usage": {
             "citationTokens": 30,
@@ -864,6 +868,7 @@ describe('doStream', () => {
           },
           "providerMetadata": {
             "perplexity": {
+              "cost": null,
               "images": null,
               "usage": {
                 "citationTokens": null,

--- a/packages/perplexity/src/perplexity-language-model.ts
+++ b/packages/perplexity/src/perplexity-language-model.ts
@@ -191,6 +191,15 @@ export class PerplexityLanguageModel implements LanguageModelV4 {
             citationTokens: response.usage?.citation_tokens ?? null,
             numSearchQueries: response.usage?.num_search_queries ?? null,
           },
+          cost: response.usage?.cost
+            ? {
+                inputTokensCost: response.usage.cost.input_tokens_cost ?? null,
+                outputTokensCost:
+                  response.usage.cost.output_tokens_cost ?? null,
+                requestCost: response.usage.cost.request_cost ?? null,
+                totalCost: response.usage.cost.total_cost ?? null,
+              }
+            : null,
         },
       },
     };
@@ -236,6 +245,12 @@ export class PerplexityLanguageModel implements LanguageModelV4 {
           citationTokens: number | null;
           numSearchQueries: number | null;
         };
+        cost: {
+          inputTokensCost: number | null;
+          outputTokensCost: number | null;
+          requestCost: number | null;
+          totalCost: number | null;
+        } | null;
         images: Array<{
           imageUrl: string;
           originUrl: string;
@@ -249,6 +264,7 @@ export class PerplexityLanguageModel implements LanguageModelV4 {
           citationTokens: null,
           numSearchQueries: null,
         },
+        cost: null,
         images: null,
       },
     };
@@ -305,6 +321,16 @@ export class PerplexityLanguageModel implements LanguageModelV4 {
                 citationTokens: value.usage.citation_tokens ?? null,
                 numSearchQueries: value.usage.num_search_queries ?? null,
               };
+
+              providerMetadata.perplexity.cost = value.usage.cost
+                ? {
+                    inputTokensCost: value.usage.cost.input_tokens_cost ?? null,
+                    outputTokensCost:
+                      value.usage.cost.output_tokens_cost ?? null,
+                    requestCost: value.usage.cost.request_cost ?? null,
+                    totalCost: value.usage.cost.total_cost ?? null,
+                  }
+                : null;
             }
 
             if (value.images != null) {
@@ -381,6 +407,13 @@ function getResponseMetadata({
   };
 }
 
+const perplexityCostSchema = z.object({
+  input_tokens_cost: z.number().nullish(),
+  output_tokens_cost: z.number().nullish(),
+  request_cost: z.number().nullish(),
+  total_cost: z.number().nullish(),
+});
+
 const perplexityUsageSchema = z.object({
   prompt_tokens: z.number(),
   completion_tokens: z.number(),
@@ -388,6 +421,7 @@ const perplexityUsageSchema = z.object({
   citation_tokens: z.number().nullish(),
   num_search_queries: z.number().nullish(),
   reasoning_tokens: z.number().nullish(),
+  cost: perplexityCostSchema.nullish(),
 });
 
 export const perplexityImageSchema = z.object({


### PR DESCRIPTION
## Summary

- Perplexity's API returns a `cost` object in the usage response with `input_tokens_cost`, `output_tokens_cost`, `request_cost`, and `total_cost`
- This data is critical for accurate billing — Perplexity charges a per-request fee based on `search_context_size` (low/medium/high) that isn't captured by token-based pricing alone
- Parse the cost object and expose it at `providerMetadata.perplexity.cost`, following the same flat structure used by Prodia (`providerMetadata.prodia.images[].dollars`) and BFL (`providerMetadata.blackForestLabs.images[].cost`)

Without this, the ai-gateway undercharges by ~97% on typical Perplexity requests (e.g. $0.00015 billed vs $0.00515 actual cost for a simple sonar query).

Companion PR: https://github.com/vercel/ai-gateway/pull/new/feat/perplexity-provider-reported-cost

## Test plan
- [x] Existing unit tests pass (26/26) with updated snapshots
- [x] Verified against live Perplexity API — `providerMetadata.perplexity.cost.totalCost` matches the raw response `usage.cost.total_cost`
- [x] Tested all three context sizes (low/medium/high) and models (sonar, sonar-pro, sonar-reasoning-pro)