### PR TITLE
feat: add runName for LLM calls and devtools run titles

### DIFF
--- a/.changeset/add-run-name-llm-invocation.md
+++ b/.changeset/add-run-name-llm-invocation.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+'@ai-sdk/provider': patch
+'@ai-sdk/devtools': patch
+---
+
+Add runName option to LLM invocations (generateText, streamText, generateObject, streamObject). Used by devtools and telemetry to display a descriptive title for the run instead of the prompt preview.

--- a/content/docs/03-ai-sdk-core/65-devtools.mdx
+++ b/content/docs/03-ai-sdk-core/65-devtools.mdx
@@ -54,6 +54,7 @@ import { generateText } from 'ai';
 const result = await generateText({
   model, // wrapped model with DevTools
   prompt: 'What cities are in the United States?',
+  runName: 'List US cities', // optional: displayed as run title in DevTools
 });
 ```
 
@@ -82,6 +83,8 @@ DevTools organizes captured data into runs and steps:
 
 - **Run**: A complete multi-step AI interaction, grouped by the initial prompt
 - **Step**: A single LLM call within a run (e.g., one `generateText` or `streamText` call)
+
+Use the optional `runName` parameter in `generateText`, `streamText`, `generateObject`, or `streamObject` to give your run a descriptive title (e.g. "Generate summary of document"). When set, DevTools displays this instead of the prompt preview in the run list.
 
 Multi-step interactions, such as those created by tool calling or agent loops, are grouped together as a single run with multiple steps.
 

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -183,6 +183,12 @@ export async function generateObject<
       providerOptions?: ProviderOptions;
 
       /**
+       * Optional name for the run. Used by devtools and telemetry to identify
+       * the run (e.g. "Generate summary of document").
+       */
+      runName?: string;
+
+      /**
        * Internal. For test use only. May change without notice.
        */
       _internal?: {
@@ -204,6 +210,7 @@ export async function generateObject<
     experimental_telemetry: telemetry,
     experimental_download: download,
     providerOptions,
+    runName,
     _internal: {
       generateId = originalGenerateId,
       currentDate = () => new Date(),
@@ -344,6 +351,7 @@ export async function generateObject<
                 providerOptions,
                 abortSignal,
                 headers: headersWithUserAgent,
+                runName,
               });
 
               const responseData = {

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -245,6 +245,12 @@ export function streamObject<
       providerOptions?: ProviderOptions;
 
       /**
+       * Optional name for the run. Used by devtools and telemetry to identify
+       * the run (e.g. "Generate summary of document").
+       */
+      runName?: string;
+
+      /**
        * Callback that is invoked when an error occurs during streaming.
        * You can use it to log errors.
        * The stream processing will pause until the callback promise is resolved.
@@ -291,6 +297,7 @@ export function streamObject<
     experimental_telemetry: telemetry,
     experimental_download: download,
     providerOptions,
+    runName,
     onError = ({ error }: { error: unknown }) => {
       console.error(error);
     },
@@ -347,6 +354,7 @@ export function streamObject<
     generateId,
     currentDate,
     now,
+    runName,
   });
 }
 
@@ -396,6 +404,7 @@ class DefaultStreamObjectResult<
     generateId,
     currentDate,
     now,
+    runName,
   }: {
     model: LanguageModel;
     telemetry: TelemetrySettings | undefined;
@@ -417,6 +426,7 @@ class DefaultStreamObjectResult<
     generateId: () => string;
     currentDate: () => Date;
     now: () => number;
+    runName: string | undefined;
   }) {
     const model = resolveLanguageModel(modelArg);
 
@@ -504,6 +514,7 @@ class DefaultStreamObjectResult<
           abortSignal,
           headers,
           includeRawChunks: false,
+          runName,
         };
 
         const transformer: Transformer<

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -278,6 +278,7 @@ export async function generateText<
   experimental_onToolCallFinish: onToolCallFinish,
   onStepFinish,
   onFinish,
+  runName,
   ...settings
 }: CallSettings &
   Prompt & {
@@ -409,6 +410,12 @@ export async function generateText<
      * Callback that is called when all steps are finished and the response is complete.
      */
     onFinish?: GenerateTextOnFinishCallback<NoInfer<TOOLS>>;
+
+    /**
+     * Optional name for the run. Used by devtools and telemetry to identify
+     * the run (e.g. "Generate summary of document").
+     */
+    runName?: string;
 
     /**
      * Context that is passed into tool execution.
@@ -763,6 +770,7 @@ export async function generateText<
             providerOptions: stepProviderOptions,
             abortSignal: mergedAbortSignal,
             headers: headersWithUserAgent,
+            runName,
           });
 
           const responseData = {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -329,6 +329,7 @@ export function streamText<
   experimental_onToolCallFinish: onToolCallFinish,
   experimental_context,
   experimental_include: include,
+  runName,
   _internal: {
     now = originalNow,
     generateId = originalGenerateId,
@@ -476,6 +477,12 @@ export function streamText<
     onStepFinish?: StreamTextOnStepFinishCallback<TOOLS>;
 
     /**
+     * Optional name for the run. Used by devtools and telemetry to identify
+     * the run (e.g. "Generate summary of document").
+     */
+    runName?: string;
+
+    /**
      * Callback that is called when the streamText operation begins,
      * before any LLM calls are made.
      */
@@ -592,6 +599,7 @@ export function streamText<
     experimental_context,
     download,
     include,
+    runName,
   });
 }
 
@@ -772,6 +780,7 @@ class DefaultStreamTextResult<
     experimental_context,
     download,
     include,
+    runName,
   }: {
     model: LanguageModelV4;
     telemetry: TelemetrySettings | undefined;
@@ -808,6 +817,7 @@ class DefaultStreamTextResult<
     experimental_context: unknown;
     download: DownloadFunction | undefined;
     include: { requestBody?: boolean } | undefined;
+    runName: string | undefined;
 
     // callbacks:
     onChunk: undefined | StreamTextOnChunkCallback<TOOLS>;
@@ -1606,6 +1616,7 @@ class DefaultStreamTextResult<
               abortSignal,
               headers,
               includeRawChunks,
+              runName,
             }),
           );
 

--- a/packages/devtools/src/db.ts
+++ b/packages/devtools/src/db.ts
@@ -36,6 +36,7 @@ export const notifyServerAsync = async (
 export interface Run {
   id: string;
   started_at: string;
+  run_name?: string;
 }
 
 export interface Step {
@@ -145,17 +146,19 @@ export const reloadDb = async (): Promise<void> => {
   dbCache = readDb();
 };
 
-export const createRun = async (id: string): Promise<Run> => {
+export const createRun = async (
+  id: string,
+  runName?: string,
+): Promise<Run> => {
   const db = getDb();
   const started_at = new Date().toISOString();
 
-  // Check if run already exists
   const existing = db.runs.find(r => r.id === id);
   if (existing) {
     return existing;
   }
 
-  const run: Run = { id, started_at };
+  const run: Run = { id, started_at, run_name: runName };
   db.runs.push(run);
   saveDb(db);
   notifyServer('run');

--- a/packages/devtools/src/middleware.ts
+++ b/packages/devtools/src/middleware.ts
@@ -112,9 +112,9 @@ export const devToolsMiddleware = (): LanguageModelV4Middleware => {
   let runCreated = false;
   let stepCounter = 0;
 
-  const ensureRunCreated = async () => {
+  const ensureRunCreated = async (runName?: string) => {
     if (!runCreated) {
-      await createRun(runId);
+      await createRun(runId, runName);
       runCreated = true;
     }
   };
@@ -131,7 +131,7 @@ export const devToolsMiddleware = (): LanguageModelV4Middleware => {
       const startTime = Date.now();
       const stepId = generateId();
       const stepNumber = getNextStepNumber();
-      await ensureRunCreated();
+      await ensureRunCreated(params.runName);
 
       // Log step start
       await createStep({
@@ -201,7 +201,7 @@ export const devToolsMiddleware = (): LanguageModelV4Middleware => {
       const startTime = Date.now();
       const stepId = generateId();
       const stepNumber = getNextStepNumber();
-      await ensureRunCreated();
+      await ensureRunCreated(params.runName);
 
       // Store original setting before overriding
       const userRequestedRawChunks = params.includeRawChunks === true;

--- a/packages/devtools/src/viewer/client/app.tsx
+++ b/packages/devtools/src/viewer/client/app.tsx
@@ -43,6 +43,7 @@ interface Run {
   started_at: string;
   stepCount: number;
   firstMessage?: string;
+  run_name?: string;
   hasError?: boolean;
   isInProgress?: boolean;
   type?: 'generate' | 'stream';
@@ -68,7 +69,12 @@ interface Step {
 }
 
 interface RunDetail {
-  run: { id: string; started_at: string; isInProgress?: boolean };
+  run: {
+    id: string;
+    started_at: string;
+    isInProgress?: boolean;
+    run_name?: string;
+  };
   steps: Step[];
 }
 
@@ -543,7 +549,7 @@ function App() {
                           <MessageSquare className="size-3.5 text-muted-foreground mt-0.5 shrink-0" />
                         )}
                         <span className="text-[13px] text-foreground leading-tight line-clamp-1 break-all">
-                          {run.firstMessage || 'Loading...'}
+                          {run.run_name || run.firstMessage || 'Loading...'}
                         </span>
                       </div>
                       <div className="flex items-center gap-2 ml-5.5 text-[11px] text-muted-foreground">
@@ -594,7 +600,8 @@ function App() {
                 <div className="flex items-center justify-between mb-5">
                   <div className="flex items-center gap-3">
                     <h2 className="text-sm font-medium text-foreground">
-                      {getFirstUserMessage(selectedRun.steps)}
+                      {selectedRun.run.run_name ||
+                        getFirstUserMessage(selectedRun.steps)}
                     </h2>
                     {selectedRun.run.isInProgress && (
                       <Badge

--- a/packages/provider/src/language-model/v4/language-model-v4-call-options.ts
+++ b/packages/provider/src/language-model/v4/language-model-v4-call-options.ts
@@ -135,4 +135,11 @@ export type LanguageModelV4CallOptions = {
    * functionality that can be fully encapsulated in the provider.
    */
   providerOptions?: SharedV4ProviderOptions;
+
+  /**
+   * Optional name for the run. Used by devtools and telemetry to identify
+   * the run (e.g. "Generate summary of document") instead of showing
+   * the beginning of the prompt.
+   */
+  runName?: string;
 };


### PR DESCRIPTION
## Summary

- Add optional `runName` on `generateText`, `streamText`, `generateObject`, `streamObject`.
- Extend `LanguageModelV4CallOptions` with `runName`; pass it through `doGenerate` / `doStream`.
- Persist `run_name` on devtools runs; show it in the viewer when set.
- Docs + patch changeset (`ai`, `@ai-sdk/provider`, `@ai-sdk/devtools`).
- Snapshot updates for model call params.

## Manual Verification

Wrap model with `devToolsMiddleware()`, call `generateText` / `streamText` with `runName`, open DevTools UI and confirm the run title matches `runName`.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)


## Future Work

Optional: surface `runName` in telemetry spans if desired.

## Related Issues

Fixes #13666