### PR TITLE
fix(provider-utils): prevent SSRF bypass via DNS resolution in validateDownloadUrl

### DIFF
--- a/.changeset/fix-ssrf-dns-bypass.md
+++ b/.changeset/fix-ssrf-dns-bypass.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+Fix SSRF bypass via DNS resolution: add missing private IPv4 ranges and validate resolved IP addresses to prevent DNS-based SSRF attacks where hostnames resolve to private/internal IPs.

--- a/packages/ai/src/util/download/download.ts
+++ b/packages/ai/src/util/download/download.ts
@@ -3,6 +3,7 @@ import {
   readResponseWithSizeLimit,
   DEFAULT_MAX_DOWNLOAD_SIZE,
   validateDownloadUrl,
+  validateResolvedUrl,
 } from '@ai-sdk/provider-utils';
 import {
   withUserAgentSuffix,
@@ -31,6 +32,7 @@ export const download = async ({
 }) => {
   const urlText = url.toString();
   validateDownloadUrl(urlText);
+  await validateResolvedUrl(urlText);
   try {
     const response = await fetch(urlText, {
       headers: withUserAgentSuffix(
@@ -44,6 +46,7 @@ export const download = async ({
     // Validate final URL after redirects to prevent SSRF via open redirect
     if (response.redirected) {
       validateDownloadUrl(response.url);
+      await validateResolvedUrl(response.url);
     }
 
     if (!response.ok) {

--- a/packages/provider-utils/src/download-blob.ts
+++ b/packages/provider-utils/src/download-blob.ts
@@ -3,7 +3,10 @@ import {
   readResponseWithSizeLimit,
   DEFAULT_MAX_DOWNLOAD_SIZE,
 } from './read-response-with-size-limit';
-import { validateDownloadUrl } from './validate-download-url';
+import {
+  validateDownloadUrl,
+  validateResolvedUrl,
+} from './validate-download-url';
 
 /**
  * Download a file from a URL and return it as a Blob.
@@ -21,6 +24,7 @@ export async function downloadBlob(
   options?: { maxBytes?: number; abortSignal?: AbortSignal },
 ): Promise<Blob> {
   validateDownloadUrl(url);
+  await validateResolvedUrl(url);
   try {
     const response = await fetch(url, {
       signal: options?.abortSignal,
@@ -29,6 +33,7 @@ export async function downloadBlob(
     // Validate final URL after redirects to prevent SSRF via open redirect
     if (response.redirected) {
       validateDownloadUrl(response.url);
+      await validateResolvedUrl(response.url);
     }
 
     if (!response.ok) {

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -61,7 +61,10 @@ export {
 } from './schema';
 export { stripFileExtension } from './strip-file-extension';
 export * from './uint8-utils';
-export { validateDownloadUrl } from './validate-download-url';
+export {
+  validateDownloadUrl,
+  validateResolvedUrl,
+} from './validate-download-url';
 export * from './validate-types';
 export { VERSION } from './version';
 export { withUserAgentSuffix } from './with-user-agent-suffix';

--- a/packages/provider-utils/src/validate-download-url.test.ts
+++ b/packages/provider-utils/src/validate-download-url.test.ts
@@ -1,6 +1,17 @@
-import { describe, it, expect } from 'vitest';
-import { validateDownloadUrl } from './validate-download-url';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  validateDownloadUrl,
+  validateResolvedUrl,
+} from './validate-download-url';
 import { DownloadError } from './download-error';
+
+vi.mock('node:dns', () => ({
+  default: {
+    promises: {
+      lookup: vi.fn(),
+    },
+  },
+}));
 
 describe('validateDownloadUrl', () => {
   describe('allowed URLs', () => {
@@ -137,6 +148,46 @@ describe('validateDownloadUrl', () => {
         DownloadError,
       );
     });
+
+    it('should block 100.64.0.0/10 (CGNAT, RFC 6598)', () => {
+      expect(() => validateDownloadUrl('http://100.64.0.0/file')).toThrow(
+        DownloadError,
+      );
+      expect(() => validateDownloadUrl('http://100.127.255.255/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should allow 100.128.0.0 (outside CGNAT range)', () => {
+      expect(() =>
+        validateDownloadUrl('http://100.128.0.0/file'),
+      ).not.toThrow();
+    });
+
+    it('should block 198.18.0.0/15 (Benchmarking, RFC 2544)', () => {
+      expect(() => validateDownloadUrl('http://198.18.0.0/file')).toThrow(
+        DownloadError,
+      );
+      expect(() => validateDownloadUrl('http://198.19.255.255/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should allow 198.20.0.0 (outside benchmarking range)', () => {
+      expect(() => validateDownloadUrl('http://198.20.0.0/file')).not.toThrow();
+    });
+
+    it('should block 240.0.0.0/4 (reserved)', () => {
+      expect(() => validateDownloadUrl('http://240.0.0.0/file')).toThrow(
+        DownloadError,
+      );
+    });
+
+    it('should block 255.255.255.255 (broadcast)', () => {
+      expect(() => validateDownloadUrl('http://255.255.255.255/file')).toThrow(
+        DownloadError,
+      );
+    });
   });
 
   describe('blocked IPv6 addresses', () => {
@@ -192,5 +243,72 @@ describe('validateDownloadUrl', () => {
         validateDownloadUrl('http://[::ffff:203.0.113.1]/file'),
       ).not.toThrow();
     });
+  });
+});
+
+describe('validateResolvedUrl', () => {
+  let mockLookup: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const dns = await import('node:dns');
+    mockLookup = dns.default.promises.lookup as ReturnType<typeof vi.fn>;
+    mockLookup.mockReset();
+  });
+
+  it('should block hostname resolving to 169.254.169.254 (cloud metadata SSRF)', async () => {
+    mockLookup.mockResolvedValue({ address: '169.254.169.254', family: 4 });
+    await expect(
+      validateResolvedUrl('http://evil.attacker.com/latest/meta-data/'),
+    ).rejects.toThrow(DownloadError);
+  });
+
+  it('should block hostname resolving to 10.0.0.1', async () => {
+    mockLookup.mockResolvedValue({ address: '10.0.0.1', family: 4 });
+    await expect(
+      validateResolvedUrl('http://evil.example.com/file'),
+    ).rejects.toThrow(DownloadError);
+  });
+
+  it('should block hostname resolving to 127.0.0.1', async () => {
+    mockLookup.mockResolvedValue({ address: '127.0.0.1', family: 4 });
+    await expect(
+      validateResolvedUrl('http://evil.example.com/file'),
+    ).rejects.toThrow(DownloadError);
+  });
+
+  it('should allow hostname resolving to public IP', async () => {
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    await expect(
+      validateResolvedUrl('http://example.com/file'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should skip DNS resolution for literal IPv4 addresses', async () => {
+    await validateResolvedUrl('http://93.184.216.34/file');
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it('should skip DNS resolution for literal IPv6 addresses', async () => {
+    await validateResolvedUrl('http://[2001:db8::1]/file');
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it('should skip DNS resolution for data: URLs', async () => {
+    await validateResolvedUrl('data:text/plain;base64,aGVsbG8=');
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it('should block hostname resolving to private IPv6 address', async () => {
+    mockLookup.mockResolvedValue({ address: '::1', family: 6 });
+    await expect(
+      validateResolvedUrl('http://evil.example.com/file'),
+    ).rejects.toThrow(DownloadError);
+  });
+
+  it('should allow hostname resolving to public IPv6 address', async () => {
+    mockLookup.mockResolvedValue({ address: '2001:db8::1', family: 6 });
+    await expect(
+      validateResolvedUrl('http://example.com/file'),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/provider-utils/src/validate-download-url.test.ts
+++ b/packages/provider-utils/src/validate-download-url.test.ts
@@ -6,10 +6,8 @@ import {
 import { DownloadError } from './download-error';
 
 vi.mock('node:dns', () => ({
-  default: {
-    promises: {
-      lookup: vi.fn(),
-    },
+  promises: {
+    lookup: vi.fn(),
   },
 }));
 
@@ -251,7 +249,7 @@ describe('validateResolvedUrl', () => {
 
   beforeEach(async () => {
     const dns = await import('node:dns');
-    mockLookup = dns.default.promises.lookup as ReturnType<typeof vi.fn>;
+    mockLookup = dns.promises.lookup as ReturnType<typeof vi.fn>;
     mockLookup.mockReset();
   });
 
@@ -306,7 +304,10 @@ describe('validateResolvedUrl', () => {
   });
 
   it('should allow hostname resolving to public IPv6 address', async () => {
-    mockLookup.mockResolvedValue({ address: '2001:db8::1', family: 6 });
+    mockLookup.mockResolvedValue({
+      address: '2607:f8b0:4004:800::200e',
+      family: 6,
+    });
     await expect(
       validateResolvedUrl('http://example.com/file'),
     ).resolves.toBeUndefined();

--- a/packages/provider-utils/src/validate-download-url.ts
+++ b/packages/provider-utils/src/validate-download-url.ts
@@ -1,3 +1,4 @@
+import dns from 'node:dns';
 import { DownloadError } from './download-error';
 
 /**
@@ -104,6 +105,12 @@ function isPrivateIPv4(ip: string): boolean {
   if (a === 172 && b >= 16 && b <= 31) return true;
   // 192.168.0.0/16
   if (a === 192 && b === 168) return true;
+  // 100.64.0.0/10 (Carrier-Grade NAT, RFC 6598)
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  // 198.18.0.0/15 (Benchmarking, RFC 2544)
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  // 240.0.0.0/4 (Reserved)
+  if (a >= 240) return true;
 
   return false;
 }
@@ -145,4 +152,58 @@ function isPrivateIPv6(ip: string): boolean {
   if (normalized.startsWith('fe80')) return true;
 
   return false;
+}
+
+/**
+ * Validates that a URL's DNS resolution does not point to a private/internal IP address,
+ * preventing DNS rebinding SSRF attacks where a hostname resolves to an internal IP.
+ *
+ * @param url - The URL string to validate.
+ * @throws DownloadError if the resolved IP is private.
+ */
+export async function validateResolvedUrl(url: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return; // Invalid URLs are handled by validateDownloadUrl
+  }
+
+  // data: URLs don't trigger network fetches
+  if (parsed.protocol === 'data:') {
+    return;
+  }
+
+  const hostname = parsed.hostname;
+
+  // Skip literal IP addresses — already validated by sync validateDownloadUrl
+  if (isIPv4(hostname)) {
+    return;
+  }
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    return;
+  }
+
+  let result: { address: string; family: number };
+  try {
+    result = await dns.promises.lookup(hostname);
+  } catch {
+    return; // DNS failure will be caught by fetch
+  }
+
+  const { address: resolvedIp, family } = result;
+
+  if (family === 4 && isPrivateIPv4(resolvedIp)) {
+    throw new DownloadError({
+      url,
+      message: `URL hostname ${hostname} resolves to private IP address ${resolvedIp}`,
+    });
+  }
+
+  if (family === 6 && isPrivateIPv6(resolvedIp)) {
+    throw new DownloadError({
+      url,
+      message: `URL hostname ${hostname} resolves to private IPv6 address ${resolvedIp}`,
+    });
+  }
 }

--- a/packages/provider-utils/src/validate-download-url.ts
+++ b/packages/provider-utils/src/validate-download-url.ts
@@ -1,4 +1,3 @@
-import dns from 'node:dns';
 import { DownloadError } from './download-error';
 
 /**
@@ -186,9 +185,12 @@ export async function validateResolvedUrl(url: string): Promise<void> {
 
   let result: { address: string; family: number };
   try {
-    result = await dns.promises.lookup(hostname);
+    const { promises } = await import('node:dns');
+    result = await promises.lookup(hostname);
   } catch {
-    return; // DNS failure will be caught by fetch
+    // DNS failure or unavailable node:dns (edge runtime) — skip validation.
+    // DNS errors will be caught by fetch; edge runtimes don't need this check.
+    return;
   }
 
   const { address: resolvedIp, family } = result;


### PR DESCRIPTION
## Background

`validateDownloadUrl()` only validates literal IP addresses against private ranges. When a hostname is provided, it skips IP validation entirely, allowing DNS-based SSRF bypass where an attacker-controlled domain resolves to internal IPs (e.g., `evil.com → 169.254.169.254`).

Additionally, several private IPv4 ranges were missing from the blocklist.

## Summary

**Part 1 — Add missing private IPv4 ranges to `isPrivateIPv4()`:**
- 100.64.0.0/10 (Carrier-Grade NAT, RFC 6598)
- 198.18.0.0/15 (Benchmarking, RFC 2544)
- 240.0.0.0/4 (Reserved)
- 255.255.255.255 (Broadcast)

**Part 2 — DNS resolution validation:**
- Add `validateResolvedUrl()` async function that resolves hostnames via `dns.promises.lookup()` and checks resolved IPs against private ranges
- Uses dynamic `import('node:dns')` to support edge runtimes (graceful skip when unavailable)
- Integrate into both `download-blob.ts` and `download.ts` after existing sync validation
- Keep existing sync `validateDownloadUrl` unchanged for backward compatibility

## Manual Verification

- Ran `pnpm test` in `packages/provider-utils` — all 477 tests pass (node + edge)
- Verified edge runtime tests pass (dynamic import gracefully skips DNS check)
- Confirmed new tests cover the core SSRF bypass scenario (hostname → private IP)

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #13510