### PR TITLE
fix(provider/google): preserve minItems, maxItems, minimum, maximum, maxLength in schema conversion

### DIFF
--- a/.changeset/preserve-array-numeric-constraints.md
+++ b/.changeset/preserve-array-numeric-constraints.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Preserve `minItems`, `maxItems`, `minimum`, `maximum`, and `maxLength` JSON Schema properties when converting to OpenAPI schema for Google Generative AI. These properties are supported by the Gemini API but were previously silently dropped during schema conversion, preventing users from enforcing array length and numeric range constraints in structured outputs.

--- a/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
@@ -682,3 +682,129 @@ it('should convert type arrays without null to anyOf', () => {
 
   expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
 });
+
+it('should preserve minItems and maxItems on arrays', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      tags: {
+        type: 'array',
+        items: { type: 'string' },
+        minItems: 1,
+        maxItems: 5,
+      },
+    },
+  };
+
+  const expected = {
+    type: 'object',
+    properties: {
+      tags: {
+        type: 'array',
+        items: { type: 'string' },
+        minItems: 1,
+        maxItems: 5,
+      },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
+});
+
+it('should preserve exact array length (minItems === maxItems)', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      answers: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            text: { type: 'string' },
+          },
+        },
+        minItems: 10,
+        maxItems: 10,
+      },
+    },
+  };
+
+  const expected = {
+    type: 'object',
+    properties: {
+      answers: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            text: { type: 'string' },
+          },
+        },
+        minItems: 10,
+        maxItems: 10,
+      },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
+});
+
+it('should preserve minimum and maximum on numbers', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      score: {
+        type: 'number',
+        minimum: 0,
+        maximum: 100,
+      },
+      count: {
+        type: 'integer',
+        minimum: 1,
+      },
+    },
+  };
+
+  const expected = {
+    type: 'object',
+    properties: {
+      score: {
+        type: 'number',
+        minimum: 0,
+        maximum: 100,
+      },
+      count: {
+        type: 'integer',
+        minimum: 1,
+      },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
+});
+
+it('should preserve maxLength on strings', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        minLength: 1,
+        maxLength: 255,
+      },
+    },
+  };
+
+  const expected = {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        minLength: 1,
+        maxLength: 255,
+      },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
+});

--- a/packages/google/src/convert-json-schema-to-openapi-schema.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.ts
@@ -38,8 +38,13 @@ export function convertJSONSchemaToOpenAPISchema(
     oneOf,
     format,
     const: constValue,
-    minLength,
     enum: enumValues,
+    minLength,
+    maxLength,
+    minimum,
+    maximum,
+    minItems,
+    maxItems,
   } = jsonSchema;
 
   const result: Record<string, unknown> = {};
@@ -141,6 +146,25 @@ export function convertJSONSchemaToOpenAPISchema(
 
   if (minLength !== undefined) {
     result.minLength = minLength;
+  }
+  if (maxLength !== undefined) {
+    result.maxLength = maxLength;
+  }
+
+  // numeric constraints
+  if (minimum !== undefined) {
+    result.minimum = minimum;
+  }
+  if (maximum !== undefined) {
+    result.maximum = maximum;
+  }
+
+  // array length constraints
+  if (minItems !== undefined) {
+    result.minItems = minItems;
+  }
+  if (maxItems !== undefined) {
+    result.maxItems = maxItems;
   }
 
   return result;


### PR DESCRIPTION
## Summary

The `convertJSONSchemaToOpenAPISchema` function silently drops several JSON Schema properties that are [documented as supported](https://ai.google.dev/gemini-api/docs/json-mode) by the Gemini API:

- **`minItems` / `maxItems`** — array length constraints
- **`minimum` / `maximum`** — numeric range constraints
- **`maxLength`** — string length constraint (`minLength` was already preserved)

This prevents users from enforcing exact array lengths in structured outputs. For example, `z.array(schema).length(10)` generates `minItems: 10, maxItems: 10` in JSON Schema, but both are stripped before reaching the Gemini API.

### Gemini API support

From the [official docs](https://ai.google.dev/gemini-api/docs/json-mode) (Type-specific properties section):

> For `array` values, you can specify `items`, `prefixItems` for tuple-like structures, and constraints on the number of items using `minItems` and `maxItems`.

> `number` and `integer` types allow for `enum` values as well as `minimum` and `maximum` constraints.

### The fix

Added the missing properties to the destructuring whitelist in `convertJSONSchemaToOpenAPISchema` and pass them through to the result object. This is consistent with how `minLength` is already handled.

## Test plan

- [x] Added test: `should preserve minItems and maxItems on arrays`
- [x] Added test: `should preserve exact array length (minItems === maxItems)`
- [x] Added test: `should preserve minimum and maximum on numbers`
- [x] Added test: `should preserve maxLength on strings`
- [x] All 23 tests in `convert-json-schema-to-openapi-schema.test.ts` pass
- [x] Changeset added (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)