### PR TITLE
feat(xai): add encrypted content option for responses

### DIFF
--- a/.changeset/nasty-bulldogs-tease.md
+++ b/.changeset/nasty-bulldogs-tease.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/xai": major
+---
+
+add useEncryptedContent to xAI responses provider options

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -428,6 +428,10 @@ The following provider options are available:
 
   Specify additional output data to include in the model response. Use `['file_search_call.results']` to include file search results with scores and content.
 
+- **useEncryptedContent** _boolean_
+
+  Include xAI encrypted content for reasoning and multi-agent state in the response. This maps to xAI's `include: ['reasoning.encrypted_content']` mechanism and is useful for preserving encrypted context across multi-turn conversations. This encrypted content is also included automatically when `store` is set to `false`.
+
 - **store** _boolean_
 
   Whether to store the input message(s) and model response for later retrieval. Defaults to `true`.
@@ -435,6 +439,31 @@ The following provider options are available:
 - **previousResponseId** _string_
 
   The ID of the previous response from the model. You can use it to continue a conversation.
+
+### Encrypted Content for Multi-Agent Models
+
+Use `useEncryptedContent` with xAI's multi-agent Responses models when you want to preserve encrypted sub-agent state for follow-up turns:
+
+```ts
+import { xai, type XaiLanguageModelResponsesOptions } from '@ai-sdk/xai';
+import { streamText } from 'ai';
+
+const result = streamText({
+  model: xai.responses('grok-4.20-multi-agent'),
+  prompt:
+    'Research the latest breakthroughs in quantum computing and summarize the key findings.',
+  tools: {
+    web_search: xai.tools.webSearch(),
+    x_search: xai.tools.xSearch(),
+  },
+  providerOptions: {
+    xai: {
+      reasoningEffort: 'low',
+      useEncryptedContent: true,
+    } satisfies XaiLanguageModelResponsesOptions,
+  },
+});
+```
 
 <Note>
   The Responses API only supports server-side tools. You cannot mix server-side

--- a/examples/ai-functions/src/stream-text/xai/responses-encrypted-reasoning.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-encrypted-reasoning.ts
@@ -3,60 +3,64 @@ import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const models = ['grok-code-fast-1', 'grok-4-1-fast-reasoning'];
+  const modelId = 'grok-4.20-multi-agent';
 
-  for (const modelId of models) {
-    console.log(`\n=> ${modelId}`);
+  console.log(`\n=> ${modelId}`);
 
-    const result = streamText({
-      model: xai.responses(modelId),
-      prompt: 'What is 2+2? Think carefully.',
-      providerOptions: {
-        xai: {
-          store: false,
-        } satisfies XaiLanguageModelResponsesOptions,
-      },
-    });
+  const result = streamText({
+    model: xai.responses(modelId),
+    prompt:
+      'Research the latest breakthroughs in quantum computing and summarize the key findings.',
+    tools: {
+      web_search: xai.tools.webSearch(),
+      x_search: xai.tools.xSearch(),
+    },
+    providerOptions: {
+      xai: {
+        reasoningEffort: 'low',
+        useEncryptedContent: true,
+      } satisfies XaiLanguageModelResponsesOptions,
+    },
+  });
 
-    let textContent = '';
-    let reasoningSummary = '';
-    let encryptedContent: string | undefined;
-    let itemId: string | undefined;
+  let textContent = '';
+  let reasoningSummary = '';
+  let encryptedContent: string | undefined;
+  let itemId: string | undefined;
 
-    for await (const part of result.fullStream) {
-      if (part.type === 'text-delta') {
-        textContent += part.text || '';
-      }
-
-      if (part.type === 'reasoning-delta') {
-        reasoningSummary += part.text || '';
-      }
-
-      if (part.type === 'reasoning-end') {
-        const xaiMetadata = part.providerMetadata?.xai as {
-          itemId?: string;
-          reasoningEncryptedContent?: string;
-        };
-        if (xaiMetadata) {
-          encryptedContent = xaiMetadata?.reasoningEncryptedContent;
-          itemId = xaiMetadata.itemId;
-        }
-      }
+  for await (const part of result.fullStream) {
+    if (part.type === 'text-delta') {
+      textContent += part.text || '';
     }
 
-    console.log('Text:', textContent);
-    console.log('\nUsage:', await result.usage);
-    console.log('\nReasoning:');
-    console.log('  - Summary length:', reasoningSummary.length);
-    console.log('  - Item ID:', itemId);
-    console.log('  - Encrypted content length:', encryptedContent?.length || 0);
-    console.log('  - Has encrypted content:', !!encryptedContent);
-
-    if (encryptedContent) {
-      console.log(
-        '  - Encrypted content (first 100 chars):',
-        encryptedContent.substring(0, 100) + '...',
-      );
+    if (part.type === 'reasoning-delta') {
+      reasoningSummary += part.text || '';
     }
+
+    if (part.type === 'reasoning-end') {
+      const xaiMetadata = part.providerMetadata?.xai as {
+        itemId?: string;
+        reasoningEncryptedContent?: string;
+      };
+      if (xaiMetadata) {
+        encryptedContent = xaiMetadata?.reasoningEncryptedContent;
+        itemId = xaiMetadata.itemId;
+      }
+    }
+  }
+
+  console.log('Text:', textContent);
+  console.log('\nUsage:', await result.usage);
+  console.log('\nReasoning:');
+  console.log('  - Summary length:', reasoningSummary.length);
+  console.log('  - Item ID:', itemId);
+  console.log('  - Encrypted content length:', encryptedContent?.length || 0);
+  console.log('  - Has encrypted content:', !!encryptedContent);
+
+  if (encryptedContent) {
+    console.log(
+      '  - Encrypted content (first 100 chars):',
+      encryptedContent.substring(0, 100) + '...',
+    );
   }
 });

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -589,6 +589,86 @@ describe('XaiResponsesLanguageModel', () => {
           ]);
         });
 
+        it('useEncryptedContent:true', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                useEncryptedContent: true,
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.store).toBe(undefined);
+          expect(requestBody.include).toStrictEqual([
+            'reasoning.encrypted_content',
+          ]);
+        });
+
+        it('useEncryptedContent:true with file_search_call.results', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                include: ['file_search_call.results'],
+                useEncryptedContent: true,
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.include).toStrictEqual([
+            'file_search_call.results',
+            'reasoning.encrypted_content',
+          ]);
+        });
+
+        it('useEncryptedContent:true with store:false dedupes encrypted content include', async () => {
+          prepareJsonResponse({
+            id: 'resp_123',
+            object: 'response',
+            status: 'completed',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          });
+
+          await createModel().doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              xai: {
+                store: false,
+                useEncryptedContent: true,
+              } satisfies XaiLanguageModelResponsesOptions,
+            },
+          });
+
+          const requestBody = await server.calls[0].requestBodyJson;
+          expect(requestBody.store).toBe(false);
+          expect(requestBody.include).toStrictEqual([
+            'reasoning.encrypted_content',
+          ]);
+        });
+
         it('previousResponseId', async () => {
           prepareJsonResponse({
             id: 'resp_123',

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -28,6 +28,7 @@ import { convertXaiResponsesUsage } from './convert-xai-responses-usage';
 import { mapXaiResponsesFinishReason } from './map-xai-responses-finish-reason';
 import {
   XaiResponsesIncludeOptions,
+  XaiResponsesIncludeValue,
   xaiResponsesChunkSchema,
   xaiResponsesResponseSchema,
 } from './xai-responses-api';
@@ -127,20 +128,17 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
     });
     warnings.push(...toolWarnings);
 
-    // Build include array based on provider options and store setting
-    let include: XaiResponsesIncludeOptions = options.include
-      ? [...options.include]
-      : undefined;
+    // Merge includes from raw provider options and ergonomic flags without duplicates.
+    const includeValues = new Set<XaiResponsesIncludeValue>(
+      options.include ?? [],
+    );
 
-    if (options.store === false) {
-      // When store is false, we need to include reasoning.encrypted_content
-      // to preserve reasoning tokens in the response
-      if (include == null) {
-        include = ['reasoning.encrypted_content'];
-      } else {
-        include = [...include, 'reasoning.encrypted_content'];
-      }
+    if (options.useEncryptedContent === true || options.store === false) {
+      includeValues.add('reasoning.encrypted_content');
     }
+
+    const include: XaiResponsesIncludeOptions =
+      includeValues.size > 0 ? [...includeValues] : undefined;
 
     const resolvedReasoningEffort =
       options.reasoningEffort ??

--- a/packages/xai/src/responses/xai-responses-options.ts
+++ b/packages/xai/src/responses/xai-responses-options.ts
@@ -21,6 +21,10 @@ export const xaiLanguageModelResponsesOptions = z.object({
   logprobs: z.boolean().optional(),
   topLogprobs: z.number().int().min(0).max(8).optional(),
   /**
+   * Include xAI encrypted content for reasoning and multi-agent state.
+   */
+  useEncryptedContent: z.boolean().optional(),
+  /**
    * Whether to store the input message(s) and model response for later retrieval.
    * @default true
    */


### PR DESCRIPTION

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

This PR adds support for the `use_encrypted_content` exposed by xAI's multi agent models. Allows the user to pass in context from the sub-agents in a multi-turn conversation.

## Summary

<!-- What did you change? -->

Support xAI multi-agent follow-up flows by exposing useEncryptedContent on Responses models and deduping encrypted reasoning includes. Document the option and cover it with request-body tests.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

I ran multiple live tests with changes and all worked.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->

Fixes #10542