### PR TITLE
fix(ai): make rerankingModel optional in Provider type

### DIFF
--- a/.changeset/tall-clouds-design.md
+++ b/.changeset/tall-clouds-design.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+make rerankingModel optional in Provider to match ProviderV4

--- a/packages/ai/src/types/provider.ts
+++ b/packages/ai/src/types/provider.ts
@@ -51,5 +51,5 @@ export type Provider = {
    *
    * @throws {NoSuchModelError} If no such model exists.
    */
-  rerankingModel(modelId: string): RerankingModel;
+  rerankingModel?(modelId: string): RerankingModel;
 };


### PR DESCRIPTION
## background

the `Provider` type exported from `ai` has `rerankingModel` as required, but `ProviderV4` from `@ai-sdk/provider` has it as optional. only 3 of ~30 providers (bedrock, cohere, togetherai) implement reranking, so assigning any other provider to a `Provider` variable causes a TS error

## summary

- add `?` to `rerankingModel` in the `Provider` type to match `ProviderV4`

## checklist

- [ ] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

fixes #13438