### PR TITLE
feat(ai): decouple otel from embed functions

### DIFF
--- a/.changeset/rude-llamas-drum.md
+++ b/.changeset/rude-llamas-drum.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): decouple otel from embed functions

--- a/packages/ai/src/embed/__snapshots__/embed-many.test.ts.snap
+++ b/packages/ai/src/embed/__snapshots__/embed-many.test.ts.snap
@@ -96,6 +96,8 @@ exports[`result.responses > should include responses in the result 1`] = `
 ]
 `;
 
+exports[`telemetry > should not record any telemetry data when not explicitly enabled 1`] = `[]`;
+
 exports[`telemetry > should not record telemetry inputs / outputs when disabled 1`] = `
 [
   {

--- a/packages/ai/src/embed/embed-events.ts
+++ b/packages/ai/src/embed/embed-events.ts
@@ -107,3 +107,69 @@ export interface EmbedOnFinishEvent {
   /** Additional metadata from telemetry settings. */
   readonly metadata: Record<string, JSONValue> | undefined;
 }
+
+/**
+ * Event fired when an individual embedding model call (inner operation doEmbed) begins.
+ *
+ * For `embed`, there is one call. For `embedMany`, there may be multiple
+ * calls when values are chunked.
+ */
+export interface EmbedStartEvent {
+  /** Unique identifier for this embed call, used to correlate events. */
+  readonly callId: string;
+
+  /** Identifies the inner operation (e.g. 'ai.embed.doEmbed' or 'ai.embedMany.doEmbed'). */
+  readonly operationId: string;
+
+  /** The provider identifier. */
+  readonly provider: string;
+
+  /** The specific model identifier. */
+  readonly modelId: string;
+
+  /** The values being embedded in this particular model call. */
+  readonly values: Array<string>;
+
+  /** Whether telemetry is enabled. */
+  readonly isEnabled: boolean | undefined;
+
+  /** Whether to record inputs in telemetry. Enabled by default. */
+  readonly recordInputs: boolean | undefined;
+
+  /** Whether to record outputs in telemetry. Enabled by default. */
+  readonly recordOutputs: boolean | undefined;
+
+  /** Identifier from telemetry settings for grouping related operations. */
+  readonly functionId: string | undefined;
+
+  /** Additional metadata from telemetry settings. */
+  readonly metadata: Record<string, JSONValue> | undefined;
+}
+
+/**
+ * Event fired when an individual embedding model call (doEmbed) completes.
+ *
+ * Contains the embeddings, usage, and any warnings from the model response.
+ */
+export interface EmbedFinishEvent {
+  /** Unique identifier for this embed call, used to correlate events. */
+  readonly callId: string;
+
+  /** Identifies the inner operation (e.g. 'ai.embed.doEmbed' or 'ai.embedMany.doEmbed'). */
+  readonly operationId: string;
+
+  /** The provider identifier. */
+  readonly provider: string;
+
+  /** The specific model identifier. */
+  readonly modelId: string;
+
+  /** The values that were embedded in this particular model call. */
+  readonly values: Array<string>;
+
+  /** The resulting embeddings from the model call. */
+  readonly embeddings: Array<Embedding>;
+
+  /** Token usage for this model call. */
+  readonly usage: EmbeddingModelUsage;
+}

--- a/packages/ai/src/embed/embed-events.ts
+++ b/packages/ai/src/embed/embed-events.ts
@@ -118,6 +118,9 @@ export interface EmbedStartEvent {
   /** Unique identifier for this embed call, used to correlate events. */
   readonly callId: string;
 
+  /** Unique identifier for this individual doEmbed invocation, used to correlate start/finish within parallel chunks. */
+  readonly embedCallId: string;
+
   /** Identifies the inner operation (e.g. 'ai.embed.doEmbed' or 'ai.embedMany.doEmbed'). */
   readonly operationId: string;
 
@@ -154,6 +157,9 @@ export interface EmbedStartEvent {
 export interface EmbedFinishEvent {
   /** Unique identifier for this embed call, used to correlate events. */
   readonly callId: string;
+
+  /** Unique identifier for this individual doEmbed invocation, used to correlate start/finish within parallel chunks. */
+  readonly embedCallId: string;
 
   /** Identifies the inner operation (e.g. 'ai.embed.doEmbed' or 'ai.embedMany.doEmbed'). */
   readonly operationId: string;

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -12,6 +12,7 @@ import {
 import * as logWarningsModule from '../logger/log-warnings';
 import { MockEmbeddingModelV4 } from '../test/mock-embedding-model-v4';
 import { MockTracer } from '../test/mock-tracer';
+import { OpenTelemetryIntegration } from '../telemetry/open-telemetry-integration';
 import { Embedding, EmbeddingModelUsage, Warning } from '../types';
 import { createResolvablePromise } from '../util/create-resolvable-promise';
 import { embedMany } from './embed-many';
@@ -388,9 +389,12 @@ describe('telemetry', () => {
         doEmbed: mockEmbed(testValues, dummyEmbeddings),
       }),
       values: testValues,
+      experimental_telemetry: {
+        integrations: [new OpenTelemetryIntegration({ tracer })],
+      },
     });
 
-    assert.deepStrictEqual(tracer.jsonSpans, []);
+    expect(tracer.jsonSpans).toMatchSnapshot();
   });
 
   it('should record telemetry data when enabled (multiple calls path)', async () => {
@@ -428,7 +432,7 @@ describe('telemetry', () => {
           test1: 'value1',
           test2: false,
         },
-        tracer,
+        integrations: [new OpenTelemetryIntegration({ tracer })],
       },
     });
 
@@ -449,7 +453,7 @@ describe('telemetry', () => {
           test1: 'value1',
           test2: false,
         },
-        tracer,
+        integrations: [new OpenTelemetryIntegration({ tracer })],
       },
     });
 
@@ -467,7 +471,7 @@ describe('telemetry', () => {
         isEnabled: true,
         recordInputs: false,
         recordOutputs: false,
-        tracer,
+        integrations: [new OpenTelemetryIntegration({ tracer })],
       },
     });
 

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -477,6 +477,53 @@ describe('telemetry', () => {
 
     expect(tracer.jsonSpans).toMatchSnapshot();
   });
+
+  it('should correctly track telemetry spans for parallel doEmbed calls', async () => {
+    const resolvables = [
+      createResolvablePromise<void>(),
+      createResolvablePromise<void>(),
+      createResolvablePromise<void>(),
+    ];
+
+    let callCount = 0;
+
+    const embedManyPromise = embedMany({
+      model: new MockEmbeddingModelV4({
+        supportsParallelCalls: true,
+        maxEmbeddingsPerCall: 1,
+        doEmbed: async () => {
+          const index = callCount++;
+          await resolvables[index].promise;
+          return {
+            embeddings: [dummyEmbeddings[index]],
+            usage: { tokens: (index + 1) * 10 },
+            warnings: [],
+          };
+        },
+      }),
+      values: testValues,
+      experimental_telemetry: {
+        isEnabled: true,
+        integrations: [new OpenTelemetryIntegration({ tracer })],
+      },
+    });
+
+    resolvables[0].resolve();
+    resolvables[1].resolve();
+    resolvables[2].resolve();
+
+    await embedManyPromise;
+
+    const doEmbedSpans = tracer.jsonSpans.filter(
+      s => s.name === 'ai.embedMany.doEmbed',
+    );
+
+    expect(doEmbedSpans).toHaveLength(3);
+
+    expect(doEmbedSpans[0].attributes['ai.usage.tokens']).toBe(10);
+    expect(doEmbedSpans[1].attributes['ai.usage.tokens']).toBe(20);
+    expect(doEmbedSpans[2].attributes['ai.usage.tokens']).toBe(30);
+  });
 });
 
 describe('result.providerMetadata', () => {

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -5,11 +5,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveEmbeddingModel } from '../model/resolve-model';
-import { assembleOperationName } from '../telemetry/assemble-operation-name';
-import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
-import { getTracer } from '../telemetry/get-tracer';
-import { recordSpan } from '../telemetry/record-span';
-import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
+import { getGlobalTelemetryIntegration } from '../telemetry/get-global-telemetry-integration';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { Embedding, EmbeddingModel, ProviderMetadata } from '../types';
 import { Warning } from '../types/warning';
@@ -143,6 +139,11 @@ export async function embedMany({
 
   const callId = generateCallId();
 
+  const createGlobalTelemetry = getGlobalTelemetryIntegration();
+  const globalTelemetry = createGlobalTelemetry({
+    integrations: telemetry?.integrations,
+  });
+
   await notify({
     event: {
       callId,
@@ -160,264 +161,65 @@ export async function embedMany({
       functionId: telemetry?.functionId,
       metadata: telemetry?.metadata,
     },
-    callbacks: [onStart],
+    callbacks: [onStart, globalTelemetry.onStart],
   });
 
-  const baseTelemetryAttributes = getBaseTelemetryAttributes({
-    model,
-    telemetry,
-    headers: headersWithUserAgent,
-    settings: { maxRetries },
-  });
+  try {
+    const [maxEmbeddingsPerCall, supportsParallelCalls] = await Promise.all([
+      model.maxEmbeddingsPerCall,
+      model.supportsParallelCalls,
+    ]);
 
-  const tracer = getTracer(telemetry);
-
-  return recordSpan({
-    name: 'ai.embedMany',
-    attributes: selectTelemetryAttributes({
-      telemetry,
-      attributes: {
-        ...assembleOperationName({ operationId: 'ai.embedMany', telemetry }),
-        ...baseTelemetryAttributes,
-        // specific settings that only make sense on the outer level:
-        'ai.values': {
-          input: () => values.map(value => JSON.stringify(value)),
-        },
-      },
-    }),
-    tracer,
-    fn: async span => {
-      const [maxEmbeddingsPerCall, supportsParallelCalls] = await Promise.all([
-        model.maxEmbeddingsPerCall,
-        model.supportsParallelCalls,
-      ]);
-
-      // the model has not specified limits on
-      // how many embeddings can be generated in a single call
-      if (maxEmbeddingsPerCall == null || maxEmbeddingsPerCall === Infinity) {
-        const { embeddings, usage, warnings, response, providerMetadata } =
-          await retry(() => {
-            // nested spans to align with the embedMany telemetry data:
-            return recordSpan({
-              name: 'ai.embedMany.doEmbed',
-              attributes: selectTelemetryAttributes({
-                telemetry,
-                attributes: {
-                  ...assembleOperationName({
-                    operationId: 'ai.embedMany.doEmbed',
-                    telemetry,
-                  }),
-                  ...baseTelemetryAttributes,
-                  // specific settings that only make sense on the outer level:
-                  'ai.values': {
-                    input: () => values.map(value => JSON.stringify(value)),
-                  },
-                },
-              }),
-              tracer,
-              fn: async doEmbedSpan => {
-                const modelResponse = await model.doEmbed({
-                  values,
-                  abortSignal,
-                  headers: headersWithUserAgent,
-                  providerOptions,
-                });
-
-                const embeddings = modelResponse.embeddings;
-                const usage = modelResponse.usage ?? { tokens: NaN };
-
-                doEmbedSpan.setAttributes(
-                  await selectTelemetryAttributes({
-                    telemetry,
-                    attributes: {
-                      'ai.embeddings': {
-                        output: () =>
-                          embeddings.map(embedding =>
-                            JSON.stringify(embedding),
-                          ),
-                      },
-                      'ai.usage.tokens': usage.tokens,
-                    },
-                  }),
-                );
-
-                return {
-                  embeddings,
-                  usage,
-                  warnings: modelResponse.warnings,
-                  providerMetadata: modelResponse.providerMetadata,
-                  response: modelResponse.response,
-                };
-              },
-            });
+    if (maxEmbeddingsPerCall == null || maxEmbeddingsPerCall === Infinity) {
+      const { embeddings, usage, warnings, response, providerMetadata } =
+        await retry(async () => {
+          await notify({
+            event: {
+              callId,
+              operationId: 'ai.embedMany.doEmbed',
+              provider: model.provider,
+              modelId: model.modelId,
+              values,
+              isEnabled: telemetry?.isEnabled,
+              recordInputs: telemetry?.recordInputs,
+              recordOutputs: telemetry?.recordOutputs,
+              functionId: telemetry?.functionId,
+              metadata: telemetry?.metadata,
+            },
+            callbacks: [globalTelemetry.onEmbedStart],
           });
 
-        span.setAttributes(
-          await selectTelemetryAttributes({
-            telemetry,
-            attributes: {
-              'ai.embeddings': {
-                output: () =>
-                  embeddings.map(embedding => JSON.stringify(embedding)),
-              },
-              'ai.usage.tokens': usage.tokens,
+          const modelResponse = await model.doEmbed({
+            values,
+            abortSignal,
+            headers: headersWithUserAgent,
+            providerOptions,
+          });
+
+          const embeddings = modelResponse.embeddings;
+          const usage = modelResponse.usage ?? { tokens: NaN };
+
+          await notify({
+            event: {
+              callId,
+              operationId: 'ai.embedMany.doEmbed',
+              provider: model.provider,
+              modelId: model.modelId,
+              values,
+              embeddings,
+              usage,
             },
-          }),
-        );
+            callbacks: [globalTelemetry.onEmbedFinish],
+          });
 
-        logWarnings({
-          warnings,
-          provider: model.provider,
-          model: model.modelId,
-        });
-
-        await notify({
-          event: {
-            callId,
-            operationId: 'ai.embedMany',
-            provider: model.provider,
-            modelId: model.modelId,
-            value: values,
-            embedding: embeddings,
+          return {
+            embeddings,
             usage,
-            warnings,
-            providerMetadata,
-            response: [response],
-            isEnabled: telemetry?.isEnabled,
-            recordInputs: telemetry?.recordInputs,
-            recordOutputs: telemetry?.recordOutputs,
-            functionId: telemetry?.functionId,
-            metadata: telemetry?.metadata,
-          },
-          callbacks: [onFinish],
+            warnings: modelResponse.warnings,
+            providerMetadata: modelResponse.providerMetadata,
+            response: modelResponse.response,
+          };
         });
-
-        return new DefaultEmbedManyResult({
-          values,
-          embeddings,
-          usage,
-          warnings,
-          providerMetadata,
-          responses: [response],
-        });
-      }
-
-      // split the values into chunks that are small enough for the model:
-      const valueChunks = splitArray(values, maxEmbeddingsPerCall);
-
-      // serially embed the chunks:
-      const embeddings: Array<Embedding> = [];
-      const warnings: Array<Warning> = [];
-      const responses: Array<
-        | {
-            headers?: Record<string, string>;
-            body?: unknown;
-          }
-        | undefined
-      > = [];
-      let tokens = 0;
-      let providerMetadata: ProviderMetadata | undefined;
-
-      const parallelChunks = splitArray(
-        valueChunks,
-        supportsParallelCalls ? maxParallelCalls : 1,
-      );
-
-      for (const parallelChunk of parallelChunks) {
-        const results = await Promise.all(
-          parallelChunk.map(chunk => {
-            return retry(() => {
-              // nested spans to align with the embedMany telemetry data:
-              return recordSpan({
-                name: 'ai.embedMany.doEmbed',
-                attributes: selectTelemetryAttributes({
-                  telemetry,
-                  attributes: {
-                    ...assembleOperationName({
-                      operationId: 'ai.embedMany.doEmbed',
-                      telemetry,
-                    }),
-                    ...baseTelemetryAttributes,
-                    // specific settings that only make sense on the outer level:
-                    'ai.values': {
-                      input: () => chunk.map(value => JSON.stringify(value)),
-                    },
-                  },
-                }),
-                tracer,
-                fn: async doEmbedSpan => {
-                  const modelResponse = await model.doEmbed({
-                    values: chunk,
-                    abortSignal,
-                    headers: headersWithUserAgent,
-                    providerOptions,
-                  });
-
-                  const embeddings = modelResponse.embeddings;
-                  const usage = modelResponse.usage ?? { tokens: NaN };
-
-                  doEmbedSpan.setAttributes(
-                    await selectTelemetryAttributes({
-                      telemetry,
-                      attributes: {
-                        'ai.embeddings': {
-                          output: () =>
-                            embeddings.map(embedding =>
-                              JSON.stringify(embedding),
-                            ),
-                        },
-                        'ai.usage.tokens': usage.tokens,
-                      },
-                    }),
-                  );
-
-                  return {
-                    embeddings,
-                    usage,
-                    warnings: modelResponse.warnings,
-                    providerMetadata: modelResponse.providerMetadata,
-                    response: modelResponse.response,
-                  };
-                },
-              });
-            });
-          }),
-        );
-
-        for (const result of results) {
-          embeddings.push(...result.embeddings);
-          warnings.push(...result.warnings);
-          responses.push(result.response);
-          tokens += result.usage.tokens;
-          if (result.providerMetadata) {
-            if (!providerMetadata) {
-              providerMetadata = { ...result.providerMetadata };
-            } else {
-              for (const [providerName, metadata] of Object.entries(
-                result.providerMetadata,
-              )) {
-                providerMetadata[providerName] = {
-                  ...(providerMetadata[providerName] ?? {}),
-                  ...metadata,
-                };
-              }
-            }
-          }
-        }
-      }
-
-      span.setAttributes(
-        await selectTelemetryAttributes({
-          telemetry,
-          attributes: {
-            'ai.embeddings': {
-              output: () =>
-                embeddings.map(embedding => JSON.stringify(embedding)),
-            },
-            'ai.usage.tokens': tokens,
-          },
-        }),
-      );
 
       logWarnings({
         warnings,
@@ -433,29 +235,163 @@ export async function embedMany({
           modelId: model.modelId,
           value: values,
           embedding: embeddings,
-          usage: { tokens },
+          usage,
           warnings,
           providerMetadata,
-          response: responses,
+          response: [response],
           isEnabled: telemetry?.isEnabled,
           recordInputs: telemetry?.recordInputs,
           recordOutputs: telemetry?.recordOutputs,
           functionId: telemetry?.functionId,
           metadata: telemetry?.metadata,
         },
-        callbacks: [onFinish],
+        callbacks: [onFinish, globalTelemetry.onFinish],
       });
 
       return new DefaultEmbedManyResult({
         values,
         embeddings,
+        usage,
+        warnings,
+        providerMetadata,
+        responses: [response],
+      });
+    }
+
+    const valueChunks = splitArray(values, maxEmbeddingsPerCall);
+
+    const embeddings: Array<Embedding> = [];
+    const warnings: Array<Warning> = [];
+    const responses: Array<
+      | {
+          headers?: Record<string, string>;
+          body?: unknown;
+        }
+      | undefined
+    > = [];
+    let tokens = 0;
+    let providerMetadata: ProviderMetadata | undefined;
+
+    const parallelChunks = splitArray(
+      valueChunks,
+      supportsParallelCalls ? maxParallelCalls : 1,
+    );
+
+    for (const parallelChunk of parallelChunks) {
+      const results = await Promise.all(
+        parallelChunk.map(chunk => {
+          return retry(async () => {
+            await notify({
+              event: {
+                callId,
+                operationId: 'ai.embedMany.doEmbed',
+                provider: model.provider,
+                modelId: model.modelId,
+                values: chunk,
+                isEnabled: telemetry?.isEnabled,
+                recordInputs: telemetry?.recordInputs,
+                recordOutputs: telemetry?.recordOutputs,
+                functionId: telemetry?.functionId,
+                metadata: telemetry?.metadata,
+              },
+              callbacks: [globalTelemetry.onEmbedStart],
+            });
+
+            const modelResponse = await model.doEmbed({
+              values: chunk,
+              abortSignal,
+              headers: headersWithUserAgent,
+              providerOptions,
+            });
+
+            const chunkEmbeddings = modelResponse.embeddings;
+            const usage = modelResponse.usage ?? { tokens: NaN };
+
+            await notify({
+              event: {
+                callId,
+                operationId: 'ai.embedMany.doEmbed',
+                provider: model.provider,
+                modelId: model.modelId,
+                values: chunk,
+                embeddings: chunkEmbeddings,
+                usage,
+              },
+              callbacks: [globalTelemetry.onEmbedFinish],
+            });
+
+            return {
+              embeddings: chunkEmbeddings,
+              usage,
+              warnings: modelResponse.warnings,
+              providerMetadata: modelResponse.providerMetadata,
+              response: modelResponse.response,
+            };
+          });
+        }),
+      );
+
+      for (const result of results) {
+        embeddings.push(...result.embeddings);
+        warnings.push(...result.warnings);
+        responses.push(result.response);
+        tokens += result.usage.tokens;
+        if (result.providerMetadata) {
+          if (!providerMetadata) {
+            providerMetadata = { ...result.providerMetadata };
+          } else {
+            for (const [providerName, metadata] of Object.entries(
+              result.providerMetadata,
+            )) {
+              providerMetadata[providerName] = {
+                ...(providerMetadata[providerName] ?? {}),
+                ...metadata,
+              };
+            }
+          }
+        }
+      }
+    }
+
+    logWarnings({
+      warnings,
+      provider: model.provider,
+      model: model.modelId,
+    });
+
+    await notify({
+      event: {
+        callId,
+        operationId: 'ai.embedMany',
+        provider: model.provider,
+        modelId: model.modelId,
+        value: values,
+        embedding: embeddings,
         usage: { tokens },
         warnings,
-        providerMetadata: providerMetadata,
-        responses,
-      });
-    },
-  });
+        providerMetadata,
+        response: responses,
+        isEnabled: telemetry?.isEnabled,
+        recordInputs: telemetry?.recordInputs,
+        recordOutputs: telemetry?.recordOutputs,
+        functionId: telemetry?.functionId,
+        metadata: telemetry?.metadata,
+      },
+      callbacks: [onFinish, globalTelemetry.onFinish],
+    });
+
+    return new DefaultEmbedManyResult({
+      values,
+      embeddings,
+      usage: { tokens },
+      warnings,
+      providerMetadata: providerMetadata,
+      responses,
+    });
+  } catch (error) {
+    await globalTelemetry.onError?.({ callId, error });
+    throw error;
+  }
 }
 
 class DefaultEmbedManyResult implements EmbedManyResult {

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -173,9 +173,12 @@ export async function embedMany({
     if (maxEmbeddingsPerCall == null || maxEmbeddingsPerCall === Infinity) {
       const { embeddings, usage, warnings, response, providerMetadata } =
         await retry(async () => {
+          const embedCallId = generateCallId();
+
           await notify({
             event: {
               callId,
+              embedCallId,
               operationId: 'ai.embedMany.doEmbed',
               provider: model.provider,
               modelId: model.modelId,
@@ -202,6 +205,7 @@ export async function embedMany({
           await notify({
             event: {
               callId,
+              embedCallId,
               operationId: 'ai.embedMany.doEmbed',
               provider: model.provider,
               modelId: model.modelId,
@@ -281,9 +285,12 @@ export async function embedMany({
       const results = await Promise.all(
         parallelChunk.map(chunk => {
           return retry(async () => {
+            const embedCallId = generateCallId();
+
             await notify({
               event: {
                 callId,
+                embedCallId,
                 operationId: 'ai.embedMany.doEmbed',
                 provider: model.provider,
                 modelId: model.modelId,
@@ -310,6 +317,7 @@ export async function embedMany({
             await notify({
               event: {
                 callId,
+                embedCallId,
                 operationId: 'ai.embedMany.doEmbed',
                 provider: model.provider,
                 modelId: model.modelId,

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi, vitest } from 'vitest';
 import * as logWarningsModule from '../logger/log-warnings';
 import { MockEmbeddingModelV4 } from '../test/mock-embedding-model-v4';
 import { MockTracer } from '../test/mock-tracer';
+import { OpenTelemetryIntegration } from '../telemetry/open-telemetry-integration';
 import { Embedding, EmbeddingModelUsage, Warning } from '../types';
 import { embed } from './embed';
 import type { EmbedOnStartEvent, EmbedOnFinishEvent } from './embed-events';
@@ -236,7 +237,9 @@ describe('telemetry', () => {
         doEmbed: mockEmbed([testValue], [dummyEmbedding]),
       }),
       value: testValue,
-      experimental_telemetry: { tracer },
+      experimental_telemetry: {
+        integrations: [new OpenTelemetryIntegration({ tracer })],
+      },
     });
 
     expect(tracer.jsonSpans).toMatchSnapshot();
@@ -255,7 +258,7 @@ describe('telemetry', () => {
           test1: 'value1',
           test2: false,
         },
-        tracer,
+        integrations: [new OpenTelemetryIntegration({ tracer })],
       },
     });
 
@@ -272,7 +275,7 @@ describe('telemetry', () => {
         isEnabled: true,
         recordInputs: false,
         recordOutputs: false,
-        tracer,
+        integrations: [new OpenTelemetryIntegration({ tracer })],
       },
     });
 

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -151,9 +151,12 @@ export async function embed({
   try {
     const { embedding, usage, warnings, response, providerMetadata } =
       await retry(async () => {
+        const embedCallId = generateCallId();
+
         await notify({
           event: {
             callId,
+            embedCallId,
             operationId: 'ai.embed.doEmbed',
             provider: model.provider,
             modelId: model.modelId,
@@ -180,6 +183,7 @@ export async function embed({
         await notify({
           event: {
             callId,
+            embedCallId,
             operationId: 'ai.embed.doEmbed',
             provider: model.provider,
             modelId: model.modelId,

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -5,11 +5,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveEmbeddingModel } from '../model/resolve-model';
-import { assembleOperationName } from '../telemetry/assemble-operation-name';
-import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
-import { getTracer } from '../telemetry/get-tracer';
-import { recordSpan } from '../telemetry/record-span';
-import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
+import { getGlobalTelemetryIntegration } from '../telemetry/get-global-telemetry-integration';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { EmbeddingModel } from '../types';
 import { notify } from '../util/notify';
@@ -127,6 +123,11 @@ export async function embed({
 
   const callId = generateCallId();
 
+  const createGlobalTelemetry = getGlobalTelemetryIntegration();
+  const globalTelemetry = createGlobalTelemetry({
+    integrations: telemetry?.integrations,
+  });
+
   await notify({
     event: {
       callId,
@@ -144,128 +145,95 @@ export async function embed({
       functionId: telemetry?.functionId,
       metadata: telemetry?.metadata,
     },
-    callbacks: [onStart],
+    callbacks: [onStart, globalTelemetry.onStart],
   });
 
-  const baseTelemetryAttributes = getBaseTelemetryAttributes({
-    model: model,
-    telemetry,
-    headers: headersWithUserAgent,
-    settings: { maxRetries },
-  });
-
-  const tracer = getTracer(telemetry);
-
-  return recordSpan({
-    name: 'ai.embed',
-    attributes: selectTelemetryAttributes({
-      telemetry,
-      attributes: {
-        ...assembleOperationName({ operationId: 'ai.embed', telemetry }),
-        ...baseTelemetryAttributes,
-        'ai.value': { input: () => JSON.stringify(value) },
-      },
-    }),
-    tracer,
-    fn: async span => {
-      const { embedding, usage, warnings, response, providerMetadata } =
-        await retry(() =>
-          // nested spans to align with the embedMany telemetry data:
-          recordSpan({
-            name: 'ai.embed.doEmbed',
-            attributes: selectTelemetryAttributes({
-              telemetry,
-              attributes: {
-                ...assembleOperationName({
-                  operationId: 'ai.embed.doEmbed',
-                  telemetry,
-                }),
-                ...baseTelemetryAttributes,
-                // specific settings that only make sense on the outer level:
-                'ai.values': { input: () => [JSON.stringify(value)] },
-              },
-            }),
-            tracer,
-            fn: async doEmbedSpan => {
-              const modelResponse = await model.doEmbed({
-                values: [value],
-                abortSignal,
-                headers: headersWithUserAgent,
-                providerOptions,
-              });
-
-              const embedding = modelResponse.embeddings[0];
-              const usage = modelResponse.usage ?? { tokens: NaN };
-
-              doEmbedSpan.setAttributes(
-                await selectTelemetryAttributes({
-                  telemetry,
-                  attributes: {
-                    'ai.embeddings': {
-                      output: () =>
-                        modelResponse.embeddings.map(embedding =>
-                          JSON.stringify(embedding),
-                        ),
-                    },
-                    'ai.usage.tokens': usage.tokens,
-                  },
-                }),
-              );
-
-              return {
-                embedding,
-                usage,
-                warnings: modelResponse.warnings,
-                providerMetadata: modelResponse.providerMetadata,
-                response: modelResponse.response,
-              };
-            },
-          }),
-        );
-
-      span.setAttributes(
-        await selectTelemetryAttributes({
-          telemetry,
-          attributes: {
-            'ai.embedding': { output: () => JSON.stringify(embedding) },
-            'ai.usage.tokens': usage.tokens,
+  try {
+    const { embedding, usage, warnings, response, providerMetadata } =
+      await retry(async () => {
+        await notify({
+          event: {
+            callId,
+            operationId: 'ai.embed.doEmbed',
+            provider: model.provider,
+            modelId: model.modelId,
+            values: [value],
+            isEnabled: telemetry?.isEnabled,
+            recordInputs: telemetry?.recordInputs,
+            recordOutputs: telemetry?.recordOutputs,
+            functionId: telemetry?.functionId,
+            metadata: telemetry?.metadata,
           },
-        }),
-      );
+          callbacks: [globalTelemetry.onEmbedStart],
+        });
 
-      logWarnings({ warnings, provider: model.provider, model: model.modelId });
+        const modelResponse = await model.doEmbed({
+          values: [value],
+          abortSignal,
+          headers: headersWithUserAgent,
+          providerOptions,
+        });
 
-      await notify({
-        event: {
-          callId,
-          operationId: 'ai.embed',
-          provider: model.provider,
-          modelId: model.modelId,
-          value,
+        const embedding = modelResponse.embeddings[0];
+        const usage = modelResponse.usage ?? { tokens: NaN };
+
+        await notify({
+          event: {
+            callId,
+            operationId: 'ai.embed.doEmbed',
+            provider: model.provider,
+            modelId: model.modelId,
+            values: [value],
+            embeddings: modelResponse.embeddings,
+            usage,
+          },
+          callbacks: [globalTelemetry.onEmbedFinish],
+        });
+
+        return {
           embedding,
           usage,
-          warnings,
-          providerMetadata,
-          response,
-          isEnabled: telemetry?.isEnabled,
-          recordInputs: telemetry?.recordInputs,
-          recordOutputs: telemetry?.recordOutputs,
-          functionId: telemetry?.functionId,
-          metadata: telemetry?.metadata,
-        },
-        callbacks: [onFinish],
+          warnings: modelResponse.warnings,
+          providerMetadata: modelResponse.providerMetadata,
+          response: modelResponse.response,
+        };
       });
 
-      return new DefaultEmbedResult({
+    logWarnings({ warnings, provider: model.provider, model: model.modelId });
+
+    await notify({
+      event: {
+        callId,
+        operationId: 'ai.embed',
+        provider: model.provider,
+        modelId: model.modelId,
         value,
         embedding,
         usage,
         warnings,
         providerMetadata,
         response,
-      });
-    },
-  });
+        isEnabled: telemetry?.isEnabled,
+        recordInputs: telemetry?.recordInputs,
+        recordOutputs: telemetry?.recordOutputs,
+        functionId: telemetry?.functionId,
+        metadata: telemetry?.metadata,
+      },
+      callbacks: [onFinish, globalTelemetry.onFinish],
+    });
+
+    return new DefaultEmbedResult({
+      value,
+      embedding,
+      usage,
+      warnings,
+      providerMetadata,
+      response,
+    });
+  } catch (error) {
+    await globalTelemetry.onError?.({ callId, error });
+    throw error;
+  }
 }
 
 class DefaultEmbedResult implements EmbedResult {

--- a/packages/ai/src/telemetry/get-global-telemetry-integration.ts
+++ b/packages/ai/src/telemetry/get-global-telemetry-integration.ts
@@ -24,6 +24,8 @@ export function bindTelemetryIntegration(
     onToolCallFinish: integration.onToolCallFinish?.bind(integration),
     onChunk: integration.onChunk?.bind(integration),
     onStepFinish: integration.onStepFinish?.bind(integration),
+    onEmbedStart: integration.onEmbedStart?.bind(integration),
+    onEmbedFinish: integration.onEmbedFinish?.bind(integration),
     onFinish: integration.onFinish?.bind(integration),
     onError: integration.onError?.bind(integration),
     executeTool: integration.executeTool?.bind(integration),
@@ -91,6 +93,12 @@ export function getGlobalTelemetryIntegration<
       onChunk: createTelemetryComposite(integration => integration.onChunk),
       onStepFinish: createTelemetryComposite(
         integration => integration.onStepFinish,
+      ),
+      onEmbedStart: createTelemetryComposite(
+        integration => integration.onEmbedStart,
+      ),
+      onEmbedFinish: createTelemetryComposite(
+        integration => integration.onEmbedFinish,
       ),
       onFinish: createTelemetryComposite(integration => integration.onFinish),
       onError: createTelemetryComposite(integration => integration.onError),

--- a/packages/ai/src/telemetry/open-telemetry-integration.ts
+++ b/packages/ai/src/telemetry/open-telemetry-integration.ts
@@ -10,6 +10,12 @@ import {
   Tracer,
 } from '@opentelemetry/api';
 import type {
+  EmbedOnStartEvent,
+  EmbedOnFinishEvent,
+  EmbedStartEvent,
+  EmbedFinishEvent,
+} from '../embed/embed-events';
+import type {
   OnChunkEvent,
   OnFinishEvent,
   OnStartEvent,
@@ -111,6 +117,8 @@ interface CallState {
   rootContext: Context | undefined;
   stepSpan: Span | undefined;
   stepContext: Context | undefined;
+  embedSpan: Span | undefined;
+  embedContext: Context | undefined;
   toolSpans: Map<string, { span: Span; context: Context }>;
   baseTelemetryAttributes: Attributes;
   settings: Record<string, unknown>;
@@ -158,9 +166,21 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
     return context.with(toolSpanEntry.context, execute);
   }
 
-  onStart(event: OnStartEvent<ToolSet, Output>): void {
+  onStart(event: OnStartEvent<ToolSet, Output> | EmbedOnStartEvent): void {
     if (event.isEnabled !== true) return;
 
+    if (
+      event.operationId === 'ai.embed' ||
+      event.operationId === 'ai.embedMany'
+    ) {
+      this.onEmbedOperationStart(event as EmbedOnStartEvent);
+      return;
+    }
+
+    this.onGenerateStart(event as OnStartEvent<ToolSet, Output>);
+  }
+
+  private onGenerateStart(event: OnStartEvent<ToolSet, Output>): void {
     const telemetry: TelemetrySettings = {
       isEnabled: event.isEnabled,
       recordInputs: event.recordInputs,
@@ -216,6 +236,68 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
       rootContext,
       stepSpan: undefined,
       stepContext: undefined,
+      embedSpan: undefined,
+      embedContext: undefined,
+      toolSpans: new Map(),
+      baseTelemetryAttributes,
+      settings,
+    });
+  }
+
+  private onEmbedOperationStart(event: EmbedOnStartEvent): void {
+    const telemetry: TelemetrySettings = {
+      isEnabled: event.isEnabled,
+      recordInputs: event.recordInputs,
+      recordOutputs: event.recordOutputs,
+      functionId: event.functionId,
+      metadata: event.metadata,
+    };
+
+    const settings: Record<string, unknown> = {
+      maxRetries: event.maxRetries,
+    };
+
+    const baseTelemetryAttributes = getBaseTelemetryAttributes({
+      model: { provider: event.provider, modelId: event.modelId },
+      telemetry,
+      headers: event.headers,
+      settings,
+    });
+
+    const value = event.value;
+    const isMany = event.operationId === 'ai.embedMany';
+
+    const attributes = selectAttributes(telemetry, {
+      ...assembleOperationName({
+        operationId: event.operationId,
+        telemetry,
+      }),
+      ...baseTelemetryAttributes,
+      ...(isMany
+        ? {
+            'ai.values': {
+              input: () => (value as string[]).map(v => JSON.stringify(v)),
+            },
+          }
+        : {
+            'ai.value': {
+              input: () => JSON.stringify(value),
+            },
+          }),
+    });
+
+    const rootSpan = this.tracer.startSpan(event.operationId, { attributes });
+    const rootContext = trace.setSpan(context.active(), rootSpan);
+
+    this.callStates.set(event.callId, {
+      operationId: event.operationId,
+      telemetry,
+      rootSpan,
+      rootContext,
+      stepSpan: undefined,
+      stepContext: undefined,
+      embedSpan: undefined,
+      embedContext: undefined,
       toolSpans: new Map(),
       baseTelemetryAttributes,
       settings,
@@ -418,7 +500,22 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
     state.stepContext = undefined;
   }
 
-  onFinish(event: OnFinishEvent<ToolSet>): void {
+  onFinish(event: OnFinishEvent<ToolSet> | EmbedOnFinishEvent): void {
+    const state = this.getCallState(event.callId);
+    if (!state?.rootSpan) return;
+
+    if (
+      state.operationId === 'ai.embed' ||
+      state.operationId === 'ai.embedMany'
+    ) {
+      this.onEmbedOperationFinish(event as EmbedOnFinishEvent);
+      return;
+    }
+
+    this.onGenerateFinish(event as OnFinishEvent<ToolSet>);
+  }
+
+  private onGenerateFinish(event: OnFinishEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 
@@ -477,6 +574,81 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
     this.cleanupCallState(event.callId);
   }
 
+  private onEmbedOperationFinish(event: EmbedOnFinishEvent): void {
+    const state = this.getCallState(event.callId);
+    if (!state?.rootSpan) return;
+
+    const { telemetry } = state;
+    const isMany = state.operationId === 'ai.embedMany';
+
+    state.rootSpan.setAttributes(
+      selectAttributes(telemetry, {
+        ...(isMany
+          ? {
+              'ai.embeddings': {
+                output: () =>
+                  (event.embedding as number[][]).map(e => JSON.stringify(e)),
+              },
+            }
+          : {
+              'ai.embedding': {
+                output: () => JSON.stringify(event.embedding),
+              },
+            }),
+        'ai.usage.tokens': event.usage.tokens,
+      }),
+    );
+
+    state.rootSpan.end();
+    this.cleanupCallState(event.callId);
+  }
+
+  onEmbedStart(event: EmbedStartEvent): void {
+    const state = this.getCallState(event.callId);
+    if (!state?.rootSpan || !state.rootContext) return;
+
+    const { telemetry } = state;
+
+    const attributes = selectAttributes(telemetry, {
+      ...assembleOperationName({
+        operationId: event.operationId,
+        telemetry,
+      }),
+      ...state.baseTelemetryAttributes,
+      'ai.values': {
+        input: () => event.values.map(v => JSON.stringify(v)),
+      },
+    });
+
+    state.embedSpan = this.tracer.startSpan(
+      event.operationId,
+      { attributes },
+      state.rootContext,
+    );
+    state.embedContext = trace.setSpan(state.rootContext, state.embedSpan);
+  }
+
+  onEmbedFinish(event: EmbedFinishEvent): void {
+    const state = this.getCallState(event.callId);
+    if (!state?.embedSpan) return;
+
+    const { telemetry } = state;
+
+    state.embedSpan.setAttributes(
+      selectAttributes(telemetry, {
+        'ai.embeddings': {
+          output: () =>
+            event.embeddings.map(embedding => JSON.stringify(embedding)),
+        },
+        'ai.usage.tokens': event.usage.tokens,
+      }),
+    );
+
+    state.embedSpan.end();
+    state.embedSpan = undefined;
+    state.embedContext = undefined;
+  }
+
   onChunk(event: OnChunkEvent<ToolSet>): void {
     const chunk = event.chunk as {
       type: string;
@@ -511,11 +683,6 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
   }
 
   onError(error: unknown): void {
-    // onError receives the raw error; we need callId to look up state.
-    // The callId is attached to the error event by generate-text.ts via
-    // the globalTelemetry.onError composite which wraps it.
-    // However, since TelemetryIntegration.onError is Listener<unknown>,
-    // we accept a { callId, error } shape here.
     const event = error as { callId?: string; error?: unknown };
     if (!event?.callId) return;
 
@@ -527,6 +694,11 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
     if (state.stepSpan) {
       recordSpanError(state.stepSpan, actualError);
       state.stepSpan.end();
+    }
+
+    if (state.embedSpan) {
+      recordSpanError(state.embedSpan, actualError);
+      state.embedSpan.end();
     }
 
     recordSpanError(state.rootSpan, actualError);

--- a/packages/ai/src/telemetry/open-telemetry-integration.ts
+++ b/packages/ai/src/telemetry/open-telemetry-integration.ts
@@ -117,8 +117,7 @@ interface CallState {
   rootContext: Context | undefined;
   stepSpan: Span | undefined;
   stepContext: Context | undefined;
-  embedSpan: Span | undefined;
-  embedContext: Context | undefined;
+  embedSpans: Map<string, { span: Span; context: Context }>;
   toolSpans: Map<string, { span: Span; context: Context }>;
   baseTelemetryAttributes: Attributes;
   settings: Record<string, unknown>;
@@ -236,8 +235,7 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
       rootContext,
       stepSpan: undefined,
       stepContext: undefined,
-      embedSpan: undefined,
-      embedContext: undefined,
+      embedSpans: new Map(),
       toolSpans: new Map(),
       baseTelemetryAttributes,
       settings,
@@ -296,8 +294,7 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
       rootContext,
       stepSpan: undefined,
       stepContext: undefined,
-      embedSpan: undefined,
-      embedContext: undefined,
+      embedSpans: new Map(),
       toolSpans: new Map(),
       baseTelemetryAttributes,
       settings,
@@ -620,21 +617,30 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
       },
     });
 
-    state.embedSpan = this.tracer.startSpan(
+    const embedSpan = this.tracer.startSpan(
       event.operationId,
       { attributes },
       state.rootContext,
     );
-    state.embedContext = trace.setSpan(state.rootContext, state.embedSpan);
+    const embedContext = trace.setSpan(state.rootContext, embedSpan);
+
+    state.embedSpans.set(event.embedCallId, {
+      span: embedSpan,
+      context: embedContext,
+    });
   }
 
   onEmbedFinish(event: EmbedFinishEvent): void {
     const state = this.getCallState(event.callId);
-    if (!state?.embedSpan) return;
+    if (!state) return;
 
+    const embedSpanEntry = state.embedSpans.get(event.embedCallId);
+    if (!embedSpanEntry) return;
+
+    const { span } = embedSpanEntry;
     const { telemetry } = state;
 
-    state.embedSpan.setAttributes(
+    span.setAttributes(
       selectAttributes(telemetry, {
         'ai.embeddings': {
           output: () =>
@@ -644,9 +650,8 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
       }),
     );
 
-    state.embedSpan.end();
-    state.embedSpan = undefined;
-    state.embedContext = undefined;
+    span.end();
+    state.embedSpans.delete(event.embedCallId);
   }
 
   onChunk(event: OnChunkEvent<ToolSet>): void {
@@ -696,10 +701,11 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
       state.stepSpan.end();
     }
 
-    if (state.embedSpan) {
-      recordSpanError(state.embedSpan, actualError);
-      state.embedSpan.end();
+    for (const { span: embedSpan } of state.embedSpans.values()) {
+      recordSpanError(embedSpan, actualError);
+      embedSpan.end();
     }
+    state.embedSpans.clear();
 
     recordSpanError(state.rootSpan, actualError);
 

--- a/packages/ai/src/telemetry/telemetry-integration.ts
+++ b/packages/ai/src/telemetry/telemetry-integration.ts
@@ -9,6 +9,12 @@ import type {
 } from '../generate-text/core-events';
 import type { Output } from '../generate-text/output';
 import type { ToolSet } from '../generate-text/tool-set';
+import type {
+  EmbedOnStartEvent,
+  EmbedOnFinishEvent,
+  EmbedStartEvent,
+  EmbedFinishEvent,
+} from '../embed/embed-events';
 import { Listener } from '../util/notify';
 
 /**
@@ -17,14 +23,12 @@ import { Listener } from '../util/notify';
  */
 export interface TelemetryIntegration {
   /**
-   * Called when the generation operation begins, before any LLM calls are made.
-   * Use this to initialize telemetry spans, record input parameters, or set up
-   * tracking state for the entire generation lifecycle.
+   * Called when an operation begins. Fired for both text generation
+   * (generateText/streamText) and embedding (embed/embedMany) operations.
    *
-   * The event includes the full configuration: model, messages, tools, sampling
-   * parameters, and telemetry settings.
+   * Use the `operationId` field to distinguish between operation types.
    */
-  onStart?: Listener<OnStartEvent<ToolSet, Output>>;
+  onStart?: Listener<OnStartEvent<ToolSet, Output> | EmbedOnStartEvent>;
 
   /**
    * Called when an individual step (single LLM invocation) begins.
@@ -67,12 +71,25 @@ export interface TelemetryIntegration {
   onStepFinish?: Listener<OnStepFinishEvent<ToolSet>>;
 
   /**
-   * Called when the entire generation completes (all steps finished).
-   * The event extends the final step's result with aggregated data: an array
-   * of all step results (`steps`) and total token usage across all steps
-   * (`totalUsage`).
+   * Called when an individual embedding model call (doEmbed) begins.
+   * For `embed`, there is one call. For `embedMany`, there may be multiple
+   * calls when values are chunked.
    */
-  onFinish?: Listener<OnFinishEvent<ToolSet>>;
+  onEmbedStart?: Listener<EmbedStartEvent>;
+
+  /**
+   * Called when an individual embedding model call (doEmbed) completes.
+   * Contains the embeddings, usage, and any warnings from the model response.
+   */
+  onEmbedFinish?: Listener<EmbedFinishEvent>;
+
+  /**
+   * Called when an operation completes. Fired for both text generation
+   * (generateText/streamText) and embedding (embed/embedMany) operations.
+   *
+   * Use the event shape or `operationId` to distinguish between operation types.
+   */
+  onFinish?: Listener<OnFinishEvent<ToolSet> | EmbedOnFinishEvent>;
 
   /**
    * Called when an unrecoverable error occurs during the generation lifecycle.


### PR DESCRIPTION
## Background

as an ongoing effort to decouple otel from the core functions, this PR is follow up work for https://github.com/vercel/ai/pull/13051

## Summary

- remove all span creation from the `embed.ts` file and `embed-many.ts`
- add 2 new event types `EmbedStartEvent` and `EmbedFinishEvent` (tracks the inner ai.embed.doEmbed)
- in the telemetry integration, make onStart generic over normal OnStartEvent and EmbedOnStartEvent + add 2 new callbacks 
- in open telemetry integration, add a conditional logic in the onStart callback to see if we should create a span for doGenerate or doEmbed

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)