### PR TITLE
fix(openai, openai-compatible): send null content for tool-only assistant messages

### DIFF
--- a/.changeset/tiny-planets-own.md
+++ b/.changeset/tiny-planets-own.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/openai-compatible": patch
+"@ai-sdk/openai": patch
+---
+
+patch - send content: null instead of empty string for tool-only assistant messages

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -457,7 +457,7 @@ describe('tool calls', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             type: 'function',
@@ -506,7 +506,7 @@ describe('tool calls', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             type: 'function',
@@ -632,7 +632,7 @@ describe('provider-specific metadata merging', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call1',
@@ -999,7 +999,7 @@ describe('provider-specific metadata merging', () => {
         role: 'assistant',
         cacheControl: { type: 'default' },
         sharedKey: 'assistantLevel',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'collisionToolCall',
@@ -1041,7 +1041,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'function-call-1',
@@ -1134,7 +1134,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
     // Verify both signatures are preserved
     expect(result[1]).toEqual({
       role: 'assistant',
-      content: '',
+      content: null,
       tool_calls: [
         {
           id: 'function-call-1',
@@ -1154,7 +1154,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
 
     expect(result[3]).toEqual({
       role: 'assistant',
-      content: '',
+      content: null,
       tool_calls: [
         {
           id: 'function-call-2',
@@ -1203,7 +1203,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'function-call-paris',
@@ -1250,7 +1250,7 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
     expect(result).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call-1',
@@ -1259,7 +1259,6 @@ describe('Google Gemini thought signatures (OpenAI compatibility)', () => {
               name: 'some_tool',
               arguments: JSON.stringify({ param: 'value' }),
             },
-            // No extra_content field
           },
         ],
       },

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -202,7 +202,7 @@ export function convertToOpenAICompatibleChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           ...(reasoning.length > 0 ? { reasoning_content: reasoning } : {}),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           ...metadata,

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
@@ -455,7 +455,7 @@ describe('tool calls', () => {
     expect(result.messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             type: 'function',

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -175,7 +175,7 @@ export function convertToOpenAIChatMessages({
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 


### PR DESCRIPTION
## background

when an assistant message contains only tool-call parts (no text), `convertToOpenAICompatibleChatMessages` and `convertToOpenAIChatMessages` send `content: ""`. providers backed by AWS Bedrock reject this with `ValidationException: messages: text content blocks must be non-empty`

## summary

- change `content: text` to `content: text || null` for assistant messages in both `@ai-sdk/openai-compatible` and `@ai-sdk/openai`
- update tests to expect `null` instead of `""` for tool-only assistant messages

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

fixes #13466

## Future work

The same `content: text` pattern exists in `@ai-sdk/xai`, `@ai-sdk/deepseek`, `@ai-sdk/groq`, and `@ai-sdk/mistral` and will hit the same Bedrock error under equivalent routing. Tracked separately in #14612.