### PR TITLE
chore(provider/google): remove obsolete Google image model

### DIFF
--- a/.changeset/calm-bugs-pull.md
+++ b/.changeset/calm-bugs-pull.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+chore(provider/google): remove obsolete Google image model

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -7,7 +7,6 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-2.0-flash'
   | 'gemini-2.0-flash-001'
   | 'gemini-2.0-flash-lite'
-  | 'gemini-2.0-flash-exp-image-generation'
   | 'gemini-2.0-flash-lite-001'
   | 'gemini-2.5-pro'
   | 'gemini-2.5-flash'


### PR DESCRIPTION
## Background

The `gemini-2.0-flash-exp-image-generation` model has been marked as obsolete by Google and should be removed from the provider's model ID type union.

## Summary

- Remove `gemini-2.0-flash-exp-image-generation` from `GoogleGenerativeAIModelId` type union in the `google` package

## Manual Verification

N/A

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Fixes #13325
