### PR TITLE
chore(ai): increase ai bundle size

### DIFF
--- a/packages/ai/scripts/check-bundle-size.ts
+++ b/packages/ai/scripts/check-bundle-size.ts
@@ -3,7 +3,7 @@ import { writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 // Bundle size limits in bytes
-const LIMIT = 580 * 1024;
+const LIMIT = 590 * 1024;
 
 interface BundleResult {
   size: number;


### PR DESCRIPTION
## Summary

`check-bundle-size` started failing on `main`: https://github.com/vercel/ai/actions/runs/23450889650

triggered by this more or less "random" PR: #13545 (shouldn't be a reason for worry)

## Manual Verification

N/A

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
