### PR TITLE
feat: sync DurableAgent with latest workflow repo changes

### DIFF
--- a/packages/durable-agent/src/do-stream-step.ts
+++ b/packages/durable-agent/src/do-stream-step.ts
@@ -603,10 +603,7 @@ function chunksToStep(
     )
     .map(chunk => chunk);
 
-  const rawFinishReason =
-    typeof finish?.finishReason === 'object'
-      ? finish?.finishReason?.raw
-      : undefined;
+  const rawFinishReason = finish?.finishReason?.raw;
 
   const stepResult: StepResult<any> = {
     callId: 'durable-agent', // Placeholder; DurableAgent doesn't use multi-call IDs
@@ -654,7 +651,7 @@ function chunksToStep(
     toolResults: [],
     staticToolResults: [],
     dynamicToolResults: [],
-    finishReason: normalizeFinishReason(finish?.finishReason),
+    finishReason: finish?.finishReason?.unified ?? 'other',
     rawFinishReason,
     usage: finish?.usage
       ? {
@@ -710,25 +707,4 @@ function chunksToStep(
   };
 
   return stepResult;
-}
-
-/**
- * Normalize the finish reason to the AI SDK FinishReason type.
- * AI SDK v6 may return an object with a 'unified' property,
- * while AI SDK v5 returns a plain string. This function handles both.
- *
- * @internal Exported for testing
- */
-export function normalizeFinishReason(rawFinishReason: unknown): FinishReason {
-  if (rawFinishReason == null) return 'other';
-  if (typeof rawFinishReason === 'string')
-    return rawFinishReason as FinishReason;
-  if (typeof rawFinishReason === 'object') {
-    const obj = rawFinishReason as {
-      unified?: FinishReason;
-      type?: FinishReason;
-    };
-    return obj.unified ?? obj.type ?? 'other';
-  }
-  return 'other';
 }

--- a/packages/durable-agent/src/do-stream-step.ts
+++ b/packages/durable-agent/src/do-stream-step.ts
@@ -21,6 +21,7 @@ import type {
   StreamTextTransform,
   TelemetrySettings,
 } from './durable-agent.js';
+import { recordSpan } from './telemetry.js';
 import type { CompatibleLanguageModel } from './types.js';
 
 export type FinishPart = Extract<LanguageModelV4StreamPart, { type: 'finish' }>;
@@ -163,7 +164,38 @@ export async function doStreamStep(
     }),
   };
 
-  const result = await model.doStream(callOptions);
+  const result = await recordSpan({
+    name: 'ai.streamText.doStream',
+    telemetry: options?.experimental_telemetry,
+    attributes: {
+      'ai.model.provider': model.provider,
+      'ai.model.id': model.modelId,
+      'gen_ai.system': model.provider,
+      'gen_ai.request.model': model.modelId,
+      ...(options?.maxOutputTokens !== undefined && {
+        'gen_ai.request.max_tokens': options.maxOutputTokens,
+      }),
+      ...(options?.temperature !== undefined && {
+        'gen_ai.request.temperature': options.temperature,
+      }),
+      ...(options?.topP !== undefined && {
+        'gen_ai.request.top_p': options.topP,
+      }),
+      ...(options?.topK !== undefined && {
+        'gen_ai.request.top_k': options.topK,
+      }),
+      ...(options?.frequencyPenalty !== undefined && {
+        'gen_ai.request.frequency_penalty': options.frequencyPenalty,
+      }),
+      ...(options?.presencePenalty !== undefined && {
+        'gen_ai.request.presence_penalty': options.presencePenalty,
+      }),
+      ...(options?.stopSequences !== undefined && {
+        'gen_ai.request.stop_sequences': options.stopSequences,
+      }),
+    },
+    fn: () => model!.doStream(callOptions),
+  });
 
   let finish: FinishPart | undefined;
   const toolCalls: LanguageModelV4ToolCall[] = [];
@@ -571,7 +603,10 @@ function chunksToStep(
     )
     .map(chunk => chunk);
 
-  const rawFinishReason = finish?.finishReason?.raw;
+  const rawFinishReason =
+    typeof finish?.finishReason === 'object'
+      ? finish?.finishReason?.raw
+      : undefined;
 
   const stepResult: StepResult<any> = {
     callId: 'durable-agent', // Placeholder; DurableAgent doesn't use multi-call IDs
@@ -619,7 +654,7 @@ function chunksToStep(
     toolResults: [],
     staticToolResults: [],
     dynamicToolResults: [],
-    finishReason: finish?.finishReason?.unified ?? 'other',
+    finishReason: normalizeFinishReason(finish?.finishReason),
     rawFinishReason,
     usage: finish?.usage
       ? {
@@ -675,4 +710,25 @@ function chunksToStep(
   };
 
   return stepResult;
+}
+
+/**
+ * Normalize the finish reason to the AI SDK FinishReason type.
+ * AI SDK v6 may return an object with a 'unified' property,
+ * while AI SDK v5 returns a plain string. This function handles both.
+ *
+ * @internal Exported for testing
+ */
+export function normalizeFinishReason(rawFinishReason: unknown): FinishReason {
+  if (rawFinishReason == null) return 'other';
+  if (typeof rawFinishReason === 'string')
+    return rawFinishReason as FinishReason;
+  if (typeof rawFinishReason === 'object') {
+    const obj = rawFinishReason as {
+      unified?: FinishReason;
+      type?: FinishReason;
+    };
+    return obj.unified ?? obj.type ?? 'other';
+  }
+  return 'other';
 }

--- a/packages/durable-agent/src/durable-agent.ts
+++ b/packages/durable-agent/src/durable-agent.ts
@@ -25,11 +25,26 @@ import {
   type UIMessageChunk,
 } from 'ai';
 import { convertToLanguageModelPrompt, standardizePrompt } from 'ai/internal';
+import { recordSpan } from './telemetry.js';
 import { streamTextIterator } from './stream-text-iterator.js';
 import type { CompatibleLanguageModel } from './types.js';
 
 // Re-export for consumers
 export type { CompatibleLanguageModel } from './types.js';
+
+/**
+ * Infer the type of the tools of a durable agent.
+ */
+export type InferDurableAgentTools<DURABLE_AGENT> =
+  DURABLE_AGENT extends DurableAgent<infer TOOLS> ? TOOLS : never;
+
+/**
+ * Infer the UI message type of a durable agent.
+ */
+export type InferDurableAgentUIMessage<
+  DURABLE_AGENT,
+  MESSAGE_METADATA = unknown,
+> = UIMessage<MESSAGE_METADATA>;
 
 /**
  * Re-export the Output helper for structured output specifications.
@@ -88,6 +103,22 @@ export interface TelemetrySettings {
     | null
     | undefined
   >;
+
+  /**
+   * Enable or disable input recording. Enabled by default.
+   *
+   * You might want to disable input recording to avoid recording sensitive
+   * information, to reduce data transfers, or to increase performance.
+   */
+  recordInputs?: boolean;
+
+  /**
+   * Enable or disable output recording. Enabled by default.
+   *
+   * You might want to disable output recording to avoid recording sensitive
+   * information, to reduce data transfers, or to increase performance.
+   */
+  recordOutputs?: boolean;
 
   /**
    * Custom tracer for the telemetry.
@@ -294,7 +325,9 @@ export type PrepareStepCallback<TTools extends ToolSet = ToolSet> = (
 /**
  * Configuration options for creating a {@link DurableAgent} instance.
  */
-export interface DurableAgentOptions extends GenerationSettings {
+export interface DurableAgentOptions<
+  TTools extends ToolSet = ToolSet,
+> extends GenerationSettings {
   /**
    * The model provider to use for the agent.
    *
@@ -308,7 +341,7 @@ export interface DurableAgentOptions extends GenerationSettings {
    * Tools can be implemented as workflow steps for automatic retries and persistence,
    * or as regular workflow-level logic using core library features like sleep() and Hooks.
    */
-  tools?: ToolSet;
+  tools?: TTools;
 
   /**
    * Agent instructions. Can be a string, a SystemModelMessage, or an array of SystemModelMessages.
@@ -325,12 +358,21 @@ export interface DurableAgentOptions extends GenerationSettings {
   /**
    * The tool choice strategy. Default: 'auto'.
    */
-  toolChoice?: ToolChoice<ToolSet>;
+  toolChoice?: ToolChoice<TTools>;
 
   /**
    * Optional telemetry configuration (experimental).
    */
   experimental_telemetry?: TelemetrySettings;
+
+  /**
+   * Default callback function called before each step in the agent loop.
+   * Use this to modify settings, manage context, or inject messages dynamically
+   * for every stream call on this agent instance.
+   *
+   * Per-stream `prepareStep` values passed to `stream()` override this default.
+   */
+  prepareStep?: PrepareStepCallback<TTools>;
 
   /**
    * Callback function to be called after each step completes.
@@ -435,8 +477,12 @@ export interface DurableAgentStreamOptions<
   preventClose?: boolean;
 
   /**
-   * If true, sends a 'start' chunk at the beginning of the stream.
-   * Defaults to true.
+   * If true, sends a 'start' chunk (with an auto-generated messageId) at the
+   * beginning of the stream. Defaults to true.
+   *
+   * Set to `false` when you write custom UIMessageChunks to the writable
+   * stream **before** calling `agent.stream()`. The auto-generated start
+   * chunk would overwrite your custom message metadata.
    */
   sendStart?: boolean;
 
@@ -723,16 +769,18 @@ export class DurableAgent<TBaseTools extends ToolSet = ToolSet> {
   private generationSettings: GenerationSettings;
   private toolChoice?: ToolChoice<TBaseTools>;
   private telemetry?: TelemetrySettings;
+  private prepareStep?: PrepareStepCallback<TBaseTools>;
   private constructorOnStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
   private constructorOnFinish?: StreamTextOnFinishCallback<ToolSet>;
 
-  constructor(options: DurableAgentOptions & { tools?: TBaseTools }) {
+  constructor(options: DurableAgentOptions<TBaseTools>) {
     this.model = options.model;
     this.tools = (options.tools ?? {}) as TBaseTools;
     // `instructions` takes precedence over deprecated `system`
     this.instructions = options.instructions ?? options.system;
-    this.toolChoice = options.toolChoice as ToolChoice<TBaseTools>;
+    this.toolChoice = options.toolChoice;
     this.telemetry = options.experimental_telemetry;
+    this.prepareStep = options.prepareStep;
     this.constructorOnStepFinish = options.onStepFinish;
     this.constructorOnFinish = options.onFinish;
 
@@ -875,6 +923,9 @@ export class DurableAgent<TBaseTools extends ToolSet = ToolSet> {
     // Determine effective tool choice
     const effectiveToolChoice = options.toolChoice ?? this.toolChoice;
 
+    // Merge telemetry settings
+    const effectiveTelemetry = options.experimental_telemetry ?? this.telemetry;
+
     // Filter tools if activeTools is specified
     const effectiveTools =
       options.activeTools && options.activeTools.length > 0
@@ -919,11 +970,13 @@ export class DurableAgent<TBaseTools extends ToolSet = ToolSet> {
       sendStart: options.sendStart ?? true,
       onStepFinish: mergedOnStepFinish,
       onError: options.onError,
-      prepareStep: options.prepareStep,
+      prepareStep:
+        options.prepareStep ??
+        (this.prepareStep as PrepareStepCallback<ToolSet> | undefined),
       generationSettings: mergedGenerationSettings,
       toolChoice: effectiveToolChoice as ToolChoice<ToolSet>,
       experimental_context: experimentalContext,
-      experimental_telemetry: options.experimental_telemetry ?? this.telemetry,
+      experimental_telemetry: effectiveTelemetry,
       includeRawChunks: options.includeRawChunks ?? false,
       experimental_transform: options.experimental_transform as
         | StreamTextTransform<ToolSet>
@@ -1004,6 +1057,7 @@ export class DurableAgent<TBaseTools extends ToolSet = ToolSet> {
                     iterMessages,
                     experimentalContext,
                     options.experimental_repairToolCall as ToolCallRepairFunction<ToolSet>,
+                    effectiveTelemetry,
                   ),
               ),
             );
@@ -1469,6 +1523,7 @@ async function executeTool(
   messages: LanguageModelV4Prompt,
   experimentalContext?: unknown,
   repairToolCall?: ToolCallRepairFunction<ToolSet>,
+  telemetry?: TelemetrySettings,
 ): Promise<LanguageModelV4ToolResultPart> {
   const tool = tools[toolCall.toolName];
   if (!tool) throw new Error(`Tool "${toolCall.toolName}" not found`);

--- a/packages/durable-agent/src/index.ts
+++ b/packages/durable-agent/src/index.ts
@@ -7,6 +7,8 @@ export {
   type DurableAgentStreamOptions,
   type DurableAgentStreamResult,
   type GenerationSettings,
+  type InferDurableAgentTools,
+  type InferDurableAgentUIMessage,
   type OutputSpecification,
   type PrepareStepCallback,
   type PrepareStepInfo,

--- a/packages/durable-agent/src/stream-text-iterator.ts
+++ b/packages/durable-agent/src/stream-text-iterator.ts
@@ -5,7 +5,6 @@ import type {
   LanguageModelV4ToolResultPart,
 } from '@ai-sdk/provider';
 import type {
-  FinishReason,
   StepResult,
   StreamTextOnStepFinishCallback,
   ToolChoice,
@@ -294,8 +293,7 @@ export async function* streamTextIterator({
         ...(stepUIChunks ?? []),
       ];
 
-      // Normalize finishReason - AI SDK v6 returns { unified, raw }, v5 returns a string
-      const finishReason = normalizeFinishReason(finish?.finishReason);
+      const finishReason = finish?.finishReason?.unified;
 
       if (finishReason === 'tool-calls') {
         lastStepWasToolCalls = true;
@@ -503,19 +501,4 @@ function sanitizeProviderMetadataForToolCall(
   }
 
   return meta;
-}
-
-/**
- * Normalize finishReason from different AI SDK versions.
- * - AI SDK v6: returns { unified: 'tool-calls', raw: 'tool_use' }
- * - AI SDK v5: returns 'tool-calls' string directly
- */
-function normalizeFinishReason(raw: unknown): FinishReason | undefined {
-  if (raw == null) return undefined;
-  if (typeof raw === 'string') return raw as FinishReason;
-  if (typeof raw === 'object') {
-    const obj = raw as { unified?: FinishReason; type?: FinishReason };
-    return obj.unified ?? obj.type ?? 'other';
-  }
-  return undefined;
 }

--- a/packages/durable-agent/src/stream-text-iterator.ts
+++ b/packages/durable-agent/src/stream-text-iterator.ts
@@ -5,6 +5,7 @@ import type {
   LanguageModelV4ToolResultPart,
 } from '@ai-sdk/provider';
 import type {
+  FinishReason,
   StepResult,
   StreamTextOnStepFinishCallback,
   ToolChoice,
@@ -147,8 +148,15 @@ export async function* streamTextIterator({
       if (prepareResult.model !== undefined) {
         currentModel = prepareResult.model;
       }
+      // Apply messages override BEFORE system so the system message
+      // isn't lost when messages replaces the prompt.
+      if (prepareResult.messages !== undefined) {
+        conversationPrompt = [...prepareResult.messages];
+      }
       if (prepareResult.system !== undefined) {
-        // Update or prepend system message in the conversation prompt
+        // Update or prepend system message in the conversation prompt.
+        // Applied AFTER messages override so the system message isn't
+        // lost when messages replaces the prompt.
         if (
           conversationPrompt.length > 0 &&
           conversationPrompt[0].role === 'system'
@@ -165,9 +173,6 @@ export async function* streamTextIterator({
             content: prepareResult.system,
           });
         }
-      }
-      if (prepareResult.messages !== undefined) {
-        conversationPrompt = [...prepareResult.messages];
       }
       if (prepareResult.experimental_context !== undefined) {
         currentContext = prepareResult.experimental_context;
@@ -289,7 +294,8 @@ export async function* streamTextIterator({
         ...(stepUIChunks ?? []),
       ];
 
-      const finishReason = finish?.finishReason?.unified;
+      // Normalize finishReason - AI SDK v6 returns { unified, raw }, v5 returns a string
+      const finishReason = normalizeFinishReason(finish?.finishReason);
 
       if (finishReason === 'tool-calls') {
         lastStepWasToolCalls = true;
@@ -497,4 +503,19 @@ function sanitizeProviderMetadataForToolCall(
   }
 
   return meta;
+}
+
+/**
+ * Normalize finishReason from different AI SDK versions.
+ * - AI SDK v6: returns { unified: 'tool-calls', raw: 'tool_use' }
+ * - AI SDK v5: returns 'tool-calls' string directly
+ */
+function normalizeFinishReason(raw: unknown): FinishReason | undefined {
+  if (raw == null) return undefined;
+  if (typeof raw === 'string') return raw as FinishReason;
+  if (typeof raw === 'object') {
+    const obj = raw as { unified?: FinishReason; type?: FinishReason };
+    return obj.unified ?? obj.type ?? 'other';
+  }
+  return undefined;
 }

--- a/packages/durable-agent/src/telemetry.ts
+++ b/packages/durable-agent/src/telemetry.ts
@@ -1,0 +1,199 @@
+import type { TelemetrySettings } from './durable-agent.js';
+
+// Minimal OTel type shims so we don't depend on @opentelemetry/api at compile time.
+type Attributes = Record<string, unknown>;
+
+type Span = {
+  setAttributes(attributes: Attributes): void;
+  setStatus(status: { code: number; message?: string }): void;
+  recordException(exception: {
+    name: string;
+    message: string;
+    stack?: string;
+  }): void;
+  end(): void;
+};
+
+type Context = unknown;
+
+type Tracer = {
+  startActiveSpan<T>(
+    name: string,
+    options: Attributes,
+    fn: (span: Span) => T,
+  ): T;
+};
+
+// Full OTel API surface we use
+interface OtelApi {
+  trace: {
+    getTracer(name: string): Tracer;
+    setSpan(context: Context, span: Span): Context;
+  };
+  context: {
+    active(): Context;
+    with<T>(ctx: Context, fn: () => T): T;
+  };
+  SpanStatusCode: { ERROR: number };
+}
+
+// Lazy-loaded OTel API — self-initializes on first use (item 5)
+let otelApi: OtelApi | null = null;
+let otelLoadAttempted = false;
+
+async function ensureOtelApi(): Promise<OtelApi | null> {
+  if (otelLoadAttempted) return otelApi;
+  otelLoadAttempted = true;
+  try {
+    // Dynamic import — @opentelemetry/api is an optional peer dependency.
+    // Use Function() to hide the import from bundlers that would fail at
+    // compile time when the package is absent.
+    otelApi = await (Function(
+      'return import("@opentelemetry/api")',
+    )() as Promise<OtelApi>);
+  } catch {
+    otelApi = null;
+  }
+  return otelApi;
+}
+
+/**
+ * Stateless tracer accessor matching AI SDK's `getTracer` pattern (item 5).
+ * Returns a no-op–equivalent `null` when telemetry is disabled, so callers
+ * don't need a separate init step.
+ */
+function getTracer(telemetry?: TelemetrySettings): Tracer | null {
+  if (!telemetry?.isEnabled || !otelApi) return null;
+  if (telemetry.tracer) return telemetry.tracer as Tracer;
+  return otelApi.trace.getTracer('ai');
+}
+
+// ── Attribute helpers ──────────────────────────────────────────────────
+
+/**
+ * Assemble `operation.name` / `resource.name` following the AI SDK convention
+ * (items 1 + 2): separator is a **space**, not a dot.
+ */
+function assembleOperationName(
+  operationId: string,
+  telemetry?: TelemetrySettings,
+): Attributes {
+  return {
+    'operation.name': `${operationId}${
+      telemetry?.functionId != null ? ` ${telemetry.functionId}` : ''
+    }`,
+    'resource.name': telemetry?.functionId,
+    'ai.operationId': operationId,
+    'ai.telemetry.functionId': telemetry?.functionId,
+  };
+}
+
+/**
+ * Build the full attribute bag for a span, merging operation name,
+ * caller-supplied attributes, and user-defined telemetry metadata.
+ */
+function buildAttributes(
+  operationId: string,
+  telemetry: TelemetrySettings | undefined,
+  extra?: Attributes,
+): Attributes {
+  if (!telemetry?.isEnabled) return {};
+
+  const attrs: Attributes = {
+    ...assembleOperationName(operationId, telemetry),
+    ...extra,
+  };
+
+  if (telemetry.metadata) {
+    for (const [key, value] of Object.entries(telemetry.metadata)) {
+      if (value != null) {
+        attrs[`ai.telemetry.metadata.${key}`] = value;
+      }
+    }
+  }
+
+  return attrs;
+}
+
+// ── Error recording (item 3) ───────────────────────────────────────────
+
+/**
+ * Record an error on a span following the AI SDK pattern:
+ * `recordException` (with name / message / stack) + `setStatus`.
+ */
+function recordErrorOnSpan(span: Span, error: unknown): void {
+  if (error instanceof Error) {
+    span.recordException({
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    });
+    span.setStatus({
+      code: otelApi?.SpanStatusCode.ERROR ?? 2,
+      message: error.message,
+    });
+  } else {
+    span.setStatus({ code: otelApi?.SpanStatusCode.ERROR ?? 2 });
+  }
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+/**
+ * Record a span around an async function.
+ *
+ * Self-initialising: the first call lazily loads `@opentelemetry/api`.
+ * If telemetry is disabled or OTel is unavailable the `fn` runs without
+ * instrumentation (no-op fast path).
+ *
+ * Matches the AI SDK's `recordSpan`:
+ * - Uses `context.with()` for proper context propagation (item 4)
+ * - Calls `recordException` + `setStatus` on errors (item 3)
+ * - Uses space separator in `operation.name` (item 1)
+ * - Sets `resource.name` (item 2)
+ */
+export async function recordSpan<T>(options: {
+  name: string;
+  telemetry?: TelemetrySettings;
+  attributes?: Attributes;
+  fn: (span?: Span) => PromiseLike<T> | T;
+}): Promise<T> {
+  // Self-initialise on first call (item 5)
+  if (!otelLoadAttempted) {
+    await ensureOtelApi();
+  }
+
+  const tracer = getTracer(options.telemetry);
+  if (!tracer || !otelApi) {
+    return options.fn(undefined);
+  }
+
+  const attrs = buildAttributes(
+    options.name,
+    options.telemetry,
+    options.attributes,
+  );
+
+  return tracer.startActiveSpan(
+    options.name,
+    { attributes: attrs },
+    async span => {
+      // Capture current context so nested spans parent correctly (item 4).
+      // otelApi is guaranteed non-null here (checked before startActiveSpan).
+      const ctx = otelApi!.context.active();
+
+      try {
+        const result = await otelApi!.context.with(ctx, () => options.fn(span));
+        span.end();
+        return result;
+      } catch (error) {
+        try {
+          recordErrorOnSpan(span, error);
+        } finally {
+          span.end();
+        }
+        throw error;
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Syncs DurableAgent code with changes from [vercel/workflow](https://github.com/vercel/workflow/tree/main/packages/ai/src/agent) since PR #12165 was opened (Jan 30, 2026). Key workflow PRs incorporated:

- [#1362](https://github.com/vercel/workflow/pull/1362) — AI SDK v6 migration, compat tests
- [#1385](https://github.com/vercel/workflow/pull/1385) — Various compatibility fixes
- [#1389](https://github.com/vercel/workflow/pull/1389) — Fix prepareStep system message lost when messages also returned
- [#1329](https://github.com/vercel/workflow/pull/1329) — Client-side tools support

## Changes

- **Telemetry**: Add `recordSpan` wrapper around `model.doStream()` with OTel span attributes (provider, model, generation settings). New `telemetry.ts` module with lazy OTel API loading.
- **`normalizeFinishReason`**: Handle both v5 string (`'stop'`) and v6 object (`{ unified: 'stop', raw: 'stop' }`) finish reason formats
- **prepareStep ordering fix**: Apply `messages` override before `system` so the system message isn't lost when messages replaces the prompt
- **Generic `DurableAgentOptions<TTools>`**: Tools and toolChoice properly typed through the generic parameter
- **Constructor `prepareStep`**: New field on `DurableAgentOptions` for default step preparation across all `stream()` calls
- **`TelemetrySettings`**: Add `recordInputs`/`recordOutputs` options
- **Type helpers**: Export `InferDurableAgentTools` and `InferDurableAgentUIMessage`
- **`sendStart` docs**: Explain when to set `false` (custom pre-stream UIMessageChunks)
- **Telemetry threading**: Pass telemetry settings through to `executeTool` calls

## Test plan

- [x] `pnpm type-check` — zero production code errors
- [x] `pnpm check` — lint passes
- [x] `pnpm build` in packages/durable-agent — builds
- [x] `pnpm test:node` in packages/durable-agent — 60 passed, 22 expected fail (same as before)