### PR TITLE
feat(ai): decouple otel from rerank function

### DIFF
--- a/.changeset/two-fireants-notice.md
+++ b/.changeset/two-fireants-notice.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): decouple otel from rerank function

--- a/packages/ai/src/rerank/index.ts
+++ b/packages/ai/src/rerank/index.ts
@@ -1,3 +1,8 @@
 export { rerank } from './rerank';
 export type { RerankResult } from './rerank-result';
-export type { RerankOnStartEvent, RerankOnFinishEvent } from './rerank-events';
+export type {
+  RerankOnStartEvent,
+  RerankOnFinishEvent,
+  RerankStartEvent,
+  RerankFinishEvent,
+} from './rerank-events';

--- a/packages/ai/src/rerank/rerank-events.ts
+++ b/packages/ai/src/rerank/rerank-events.ts
@@ -118,3 +118,72 @@ export interface RerankOnFinishEvent {
   /** Additional metadata from telemetry settings. */
   readonly metadata: Record<string, JSONValue> | undefined;
 }
+
+/**
+ * Event fired when an individual reranking model call (inner doRerank) begins.
+ */
+export interface RerankStartEvent {
+  /** Unique identifier for this rerank call, used to correlate events. */
+  readonly callId: string;
+
+  /** Identifies the inner operation ('ai.rerank.doRerank'). */
+  readonly operationId: string;
+
+  /** The provider identifier. */
+  readonly provider: string;
+
+  /** The specific model identifier. */
+  readonly modelId: string;
+
+  /** The documents being reranked. */
+  readonly documents: Array<JSONObject | string>;
+
+  /** The type of documents ('text' or 'object'). */
+  readonly documentsType: string;
+
+  /** The query to rerank against. */
+  readonly query: string;
+
+  /** Number of top documents to return. */
+  readonly topN: number | undefined;
+
+  /** Whether telemetry is enabled. */
+  readonly isEnabled: boolean | undefined;
+
+  /** Whether to record inputs in telemetry. Enabled by default. */
+  readonly recordInputs: boolean | undefined;
+
+  /** Whether to record outputs in telemetry. Enabled by default. */
+  readonly recordOutputs: boolean | undefined;
+
+  /** Identifier from telemetry settings for grouping related operations. */
+  readonly functionId: string | undefined;
+
+  /** Additional metadata from telemetry settings. */
+  readonly metadata: Record<string, JSONValue> | undefined;
+}
+
+/**
+ * Event fired when an individual reranking model call (doRerank) completes.
+ *
+ * Contains the ranking results from the model response.
+ */
+export interface RerankFinishEvent {
+  /** Unique identifier for this rerank call, used to correlate events. */
+  readonly callId: string;
+
+  /** Identifies the inner operation ('ai.rerank.doRerank'). */
+  readonly operationId: string;
+
+  /** The provider identifier. */
+  readonly provider: string;
+
+  /** The specific model identifier. */
+  readonly modelId: string;
+
+  /** The type of documents ('text' or 'object'). */
+  readonly documentsType: string;
+
+  /** The ranking results from the model. */
+  readonly ranking: Array<{ index: number; relevanceScore: number }>;
+}

--- a/packages/ai/src/rerank/rerank.test.ts
+++ b/packages/ai/src/rerank/rerank.test.ts
@@ -5,6 +5,7 @@ import { rerank } from './rerank';
 import type { RerankOnStartEvent, RerankOnFinishEvent } from './rerank-events';
 import { RerankResult } from './rerank-result';
 import { MockTracer } from '../test/mock-tracer';
+import { OpenTelemetryIntegration } from '../telemetry/open-telemetry-integration';
 
 describe('rerank', () => {
   describe('rerank with string documents', () => {
@@ -411,7 +412,7 @@ describe('rerank', () => {
             test1: 'value1',
             test2: false,
           },
-          tracer,
+          integrations: [new OpenTelemetryIntegration({ tracer })],
         },
       });
 
@@ -481,7 +482,7 @@ describe('rerank', () => {
           isEnabled: true,
           recordInputs: false,
           recordOutputs: false,
-          tracer,
+          integrations: [new OpenTelemetryIntegration({ tracer })],
         },
       });
 

--- a/packages/ai/src/rerank/rerank.ts
+++ b/packages/ai/src/rerank/rerank.ts
@@ -2,11 +2,7 @@ import { JSONObject, RerankingModelV4CallOptions } from '@ai-sdk/provider';
 import { createIdGenerator, ProviderOptions } from '@ai-sdk/provider-utils';
 import { prepareRetries } from '../../src/util/prepare-retries';
 import { logWarnings } from '../logger/log-warnings';
-import { assembleOperationName } from '../telemetry/assemble-operation-name';
-import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
-import { getTracer } from '../telemetry/get-tracer';
-import { recordSpan } from '../telemetry/record-span';
-import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
+import { getGlobalTelemetryIntegration } from '../telemetry/get-global-telemetry-integration';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { RerankingModel } from '../types';
 import { notify } from '../util/notify';
@@ -120,6 +116,11 @@ export async function rerank<VALUE extends JSONObject | string>({
 }): Promise<RerankResult<VALUE>> {
   const callId = generateCallId();
 
+  const createGlobalTelemetry = getGlobalTelemetryIntegration();
+  const globalTelemetry = createGlobalTelemetry({
+    integrations: telemetry?.integrations,
+  });
+
   if (documents.length === 0) {
     await notify({
       event: {
@@ -140,7 +141,7 @@ export async function rerank<VALUE extends JSONObject | string>({
         functionId: telemetry?.functionId,
         metadata: telemetry?.metadata,
       },
-      callbacks: [onStart],
+      callbacks: [onStart, globalTelemetry.onStart],
     });
 
     await notify({
@@ -164,7 +165,7 @@ export async function rerank<VALUE extends JSONObject | string>({
         functionId: telemetry?.functionId,
         metadata: telemetry?.metadata,
       },
-      callbacks: [onFinish],
+      callbacks: [onFinish, globalTelemetry.onFinish],
     });
 
     return new DefaultRerankResult({
@@ -182,6 +183,11 @@ export async function rerank<VALUE extends JSONObject | string>({
     maxRetries: maxRetriesArg,
     abortSignal,
   });
+
+  const documentsToSend: RerankingModelV4CallOptions['documents'] =
+    typeof documents[0] === 'string'
+      ? { type: 'text', values: documents as string[] }
+      : { type: 'object', values: documents as JSONObject[] };
 
   await notify({
     event: {
@@ -202,137 +208,83 @@ export async function rerank<VALUE extends JSONObject | string>({
       functionId: telemetry?.functionId,
       metadata: telemetry?.metadata,
     },
-    callbacks: [onStart],
+    callbacks: [onStart, globalTelemetry.onStart],
   });
 
-  // detect the type of the documents:
-  const documentsToSend: RerankingModelV4CallOptions['documents'] =
-    typeof documents[0] === 'string'
-      ? { type: 'text', values: documents as string[] }
-      : { type: 'object', values: documents as JSONObject[] };
-
-  const baseTelemetryAttributes = getBaseTelemetryAttributes({
-    model,
-    telemetry,
-    headers,
-    settings: { maxRetries },
-  });
-
-  const tracer = getTracer(telemetry);
-
-  return recordSpan({
-    name: 'ai.rerank',
-    attributes: selectTelemetryAttributes({
-      telemetry,
-      attributes: {
-        ...assembleOperationName({ operationId: 'ai.rerank', telemetry }),
-        ...baseTelemetryAttributes,
-        'ai.documents': {
-          input: () => documents.map(document => JSON.stringify(document)),
-        },
-      },
-    }),
-    tracer,
-    fn: async () => {
-      const { ranking, response, providerMetadata, warnings } = await retry(
-        () =>
-          recordSpan({
-            name: 'ai.rerank.doRerank',
-            attributes: selectTelemetryAttributes({
-              telemetry,
-              attributes: {
-                ...assembleOperationName({
-                  operationId: 'ai.rerank.doRerank',
-                  telemetry,
-                }),
-                ...baseTelemetryAttributes,
-                // specific settings that only make sense on the outer level:
-                'ai.documents': {
-                  input: () =>
-                    documents.map(document => JSON.stringify(document)),
-                },
-              },
-            }),
-            tracer,
-            fn: async doRerankSpan => {
-              const modelResponse = await model.doRerank({
-                documents: documentsToSend,
-                query,
-                topN,
-                providerOptions,
-                abortSignal,
-                headers,
-              });
-
-              const ranking = modelResponse.ranking;
-
-              doRerankSpan.setAttributes(
-                await selectTelemetryAttributes({
-                  telemetry,
-                  attributes: {
-                    'ai.ranking.type': documentsToSend.type,
-                    'ai.ranking': {
-                      output: () =>
-                        ranking.map(ranking => JSON.stringify(ranking)),
-                    },
-                  },
-                }),
-              );
-
-              return {
-                ranking,
-                providerMetadata: modelResponse.providerMetadata,
-                response: modelResponse.response,
-                warnings: modelResponse.warnings,
-              };
-            },
-          }),
-      );
-
-      logWarnings({
-        warnings: warnings ?? [],
-        provider: model.provider,
-        model: model.modelId,
-      });
-
-      await notify({
-        event: {
-          callId,
-          operationId: 'ai.rerank',
-          provider: model.provider,
-          modelId: model.modelId,
-          documents,
-          query,
-          ranking: ranking.map(r => ({
-            originalIndex: r.index,
-            score: r.relevanceScore,
-            document: documents[r.index],
-          })),
-          warnings: warnings ?? [],
-          providerMetadata,
-          response: {
-            id: response?.id,
-            timestamp: response?.timestamp ?? new Date(),
-            modelId: response?.modelId ?? model.modelId,
-            headers: response?.headers,
-            body: response?.body,
+  try {
+    const { ranking, response, providerMetadata, warnings } = await retry(
+      async () => {
+        await notify({
+          event: {
+            callId,
+            operationId: 'ai.rerank.doRerank',
+            provider: model.provider,
+            modelId: model.modelId,
+            documents,
+            documentsType: documentsToSend.type,
+            query,
+            topN,
+            isEnabled: telemetry?.isEnabled,
+            recordInputs: telemetry?.recordInputs,
+            recordOutputs: telemetry?.recordOutputs,
+            functionId: telemetry?.functionId,
+            metadata: telemetry?.metadata,
           },
-          isEnabled: telemetry?.isEnabled,
-          recordInputs: telemetry?.recordInputs,
-          recordOutputs: telemetry?.recordOutputs,
-          functionId: telemetry?.functionId,
-          metadata: telemetry?.metadata,
-        },
-        callbacks: [onFinish],
-      });
+          callbacks: [globalTelemetry.onRerankStart],
+        });
 
-      return new DefaultRerankResult({
-        originalDocuments: documents,
-        ranking: ranking.map(ranking => ({
-          originalIndex: ranking.index,
-          score: ranking.relevanceScore,
-          document: documents[ranking.index],
+        const modelResponse = await model.doRerank({
+          documents: documentsToSend,
+          query,
+          topN,
+          providerOptions,
+          abortSignal,
+          headers,
+        });
+
+        const ranking = modelResponse.ranking;
+
+        await notify({
+          event: {
+            callId,
+            operationId: 'ai.rerank.doRerank',
+            provider: model.provider,
+            modelId: model.modelId,
+            documentsType: documentsToSend.type,
+            ranking,
+          },
+          callbacks: [globalTelemetry.onRerankFinish],
+        });
+
+        return {
+          ranking,
+          providerMetadata: modelResponse.providerMetadata,
+          response: modelResponse.response,
+          warnings: modelResponse.warnings,
+        };
+      },
+    );
+
+    logWarnings({
+      warnings: warnings ?? [],
+      provider: model.provider,
+      model: model.modelId,
+    });
+
+    await notify({
+      event: {
+        callId,
+        operationId: 'ai.rerank',
+        provider: model.provider,
+        modelId: model.modelId,
+        documents,
+        query,
+        ranking: ranking.map(r => ({
+          originalIndex: r.index,
+          score: r.relevanceScore,
+          document: documents[r.index],
         })),
+        warnings: warnings ?? [],
         providerMetadata,
         response: {
           id: response?.id,
@@ -341,9 +293,35 @@ export async function rerank<VALUE extends JSONObject | string>({
           headers: response?.headers,
           body: response?.body,
         },
-      });
-    },
-  });
+        isEnabled: telemetry?.isEnabled,
+        recordInputs: telemetry?.recordInputs,
+        recordOutputs: telemetry?.recordOutputs,
+        functionId: telemetry?.functionId,
+        metadata: telemetry?.metadata,
+      },
+      callbacks: [onFinish, globalTelemetry.onFinish],
+    });
+
+    return new DefaultRerankResult({
+      originalDocuments: documents,
+      ranking: ranking.map(ranking => ({
+        originalIndex: ranking.index,
+        score: ranking.relevanceScore,
+        document: documents[ranking.index],
+      })),
+      providerMetadata,
+      response: {
+        id: response?.id,
+        timestamp: response?.timestamp ?? new Date(),
+        modelId: response?.modelId ?? model.modelId,
+        headers: response?.headers,
+        body: response?.body,
+      },
+    });
+  } catch (error) {
+    await globalTelemetry.onError?.({ callId, error });
+    throw error;
+  }
 }
 
 class DefaultRerankResult<VALUE> implements RerankResult<VALUE> {

--- a/packages/ai/src/telemetry/get-global-telemetry-integration.ts
+++ b/packages/ai/src/telemetry/get-global-telemetry-integration.ts
@@ -26,6 +26,8 @@ export function bindTelemetryIntegration(
     onStepFinish: integration.onStepFinish?.bind(integration),
     onEmbedStart: integration.onEmbedStart?.bind(integration),
     onEmbedFinish: integration.onEmbedFinish?.bind(integration),
+    onRerankStart: integration.onRerankStart?.bind(integration),
+    onRerankFinish: integration.onRerankFinish?.bind(integration),
     onFinish: integration.onFinish?.bind(integration),
     onError: integration.onError?.bind(integration),
     executeTool: integration.executeTool?.bind(integration),
@@ -99,6 +101,12 @@ export function getGlobalTelemetryIntegration<
       ),
       onEmbedFinish: createTelemetryComposite(
         integration => integration.onEmbedFinish,
+      ),
+      onRerankStart: createTelemetryComposite(
+        integration => integration.onRerankStart,
+      ),
+      onRerankFinish: createTelemetryComposite(
+        integration => integration.onRerankFinish,
       ),
       onFinish: createTelemetryComposite(integration => integration.onFinish),
       onError: createTelemetryComposite(integration => integration.onError),

--- a/packages/ai/src/telemetry/open-telemetry-integration.ts
+++ b/packages/ai/src/telemetry/open-telemetry-integration.ts
@@ -16,6 +16,12 @@ import type {
   EmbedFinishEvent,
 } from '../embed/embed-events';
 import type {
+  RerankOnStartEvent,
+  RerankOnFinishEvent,
+  RerankStartEvent,
+  RerankFinishEvent,
+} from '../rerank/rerank-events';
+import type {
   OnChunkEvent,
   OnFinishEvent,
   OnStartEvent,
@@ -118,6 +124,7 @@ interface CallState {
   stepSpan: Span | undefined;
   stepContext: Context | undefined;
   embedSpans: Map<string, { span: Span; context: Context }>;
+  rerankSpan: { span: Span; context: Context } | undefined;
   toolSpans: Map<string, { span: Span; context: Context }>;
   baseTelemetryAttributes: Attributes;
   settings: Record<string, unknown>;
@@ -165,7 +172,12 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
     return context.with(toolSpanEntry.context, execute);
   }
 
-  onStart(event: OnStartEvent<ToolSet, Output> | EmbedOnStartEvent): void {
+  onStart(
+    event:
+      | OnStartEvent<ToolSet, Output>
+      | EmbedOnStartEvent
+      | RerankOnStartEvent,
+  ): void {
     if (event.isEnabled !== true) return;
 
     if (
@@ -173,6 +185,11 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
       event.operationId === 'ai.embedMany'
     ) {
       this.onEmbedOperationStart(event as EmbedOnStartEvent);
+      return;
+    }
+
+    if (event.operationId === 'ai.rerank') {
+      this.onRerankOperationStart(event as RerankOnStartEvent);
       return;
     }
 
@@ -236,6 +253,7 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
       stepSpan: undefined,
       stepContext: undefined,
       embedSpans: new Map(),
+      rerankSpan: undefined,
       toolSpans: new Map(),
       baseTelemetryAttributes,
       settings,
@@ -295,6 +313,7 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
       stepSpan: undefined,
       stepContext: undefined,
       embedSpans: new Map(),
+      rerankSpan: undefined,
       toolSpans: new Map(),
       baseTelemetryAttributes,
       settings,
@@ -497,7 +516,9 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
     state.stepContext = undefined;
   }
 
-  onFinish(event: OnFinishEvent<ToolSet> | EmbedOnFinishEvent): void {
+  onFinish(
+    event: OnFinishEvent<ToolSet> | EmbedOnFinishEvent | RerankOnFinishEvent,
+  ): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 
@@ -506,6 +527,11 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
       state.operationId === 'ai.embedMany'
     ) {
       this.onEmbedOperationFinish(event as EmbedOnFinishEvent);
+      return;
+    }
+
+    if (state.operationId === 'ai.rerank') {
+      this.onRerankOperationFinish(event as RerankOnFinishEvent);
       return;
     }
 
@@ -654,6 +680,110 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
     state.embedSpans.delete(event.embedCallId);
   }
 
+  private onRerankOperationStart(event: RerankOnStartEvent): void {
+    const telemetry: TelemetrySettings = {
+      isEnabled: event.isEnabled,
+      recordInputs: event.recordInputs,
+      recordOutputs: event.recordOutputs,
+      functionId: event.functionId,
+      metadata: event.metadata,
+    };
+
+    const settings: Record<string, unknown> = {
+      maxRetries: event.maxRetries,
+    };
+
+    const baseTelemetryAttributes = getBaseTelemetryAttributes({
+      model: { provider: event.provider, modelId: event.modelId },
+      telemetry,
+      headers: event.headers,
+      settings,
+    });
+
+    const attributes = selectAttributes(telemetry, {
+      ...assembleOperationName({
+        operationId: event.operationId,
+        telemetry,
+      }),
+      ...baseTelemetryAttributes,
+      'ai.documents': {
+        input: () => event.documents.map(d => JSON.stringify(d)),
+      },
+    });
+
+    const rootSpan = this.tracer.startSpan(event.operationId, { attributes });
+    const rootContext = trace.setSpan(context.active(), rootSpan);
+
+    this.callStates.set(event.callId, {
+      operationId: event.operationId,
+      telemetry,
+      rootSpan,
+      rootContext,
+      stepSpan: undefined,
+      stepContext: undefined,
+      embedSpans: new Map(),
+      rerankSpan: undefined,
+      toolSpans: new Map(),
+      baseTelemetryAttributes,
+      settings,
+    });
+  }
+
+  private onRerankOperationFinish(event: RerankOnFinishEvent): void {
+    const state = this.getCallState(event.callId);
+    if (!state?.rootSpan) return;
+
+    state.rootSpan.end();
+    this.cleanupCallState(event.callId);
+  }
+
+  onRerankStart(event: RerankStartEvent): void {
+    const state = this.getCallState(event.callId);
+    if (!state?.rootSpan || !state.rootContext) return;
+
+    const { telemetry } = state;
+
+    const attributes = selectAttributes(telemetry, {
+      ...assembleOperationName({
+        operationId: event.operationId,
+        telemetry,
+      }),
+      ...state.baseTelemetryAttributes,
+      'ai.documents': {
+        input: () => event.documents.map(d => JSON.stringify(d)),
+      },
+    });
+
+    const rerankSpan = this.tracer.startSpan(
+      event.operationId,
+      { attributes },
+      state.rootContext,
+    );
+    const rerankContext = trace.setSpan(state.rootContext, rerankSpan);
+
+    state.rerankSpan = { span: rerankSpan, context: rerankContext };
+  }
+
+  onRerankFinish(event: RerankFinishEvent): void {
+    const state = this.getCallState(event.callId);
+    if (!state?.rerankSpan) return;
+
+    const { span } = state.rerankSpan;
+    const { telemetry } = state;
+
+    span.setAttributes(
+      selectAttributes(telemetry, {
+        'ai.ranking.type': event.documentsType,
+        'ai.ranking': {
+          output: () => event.ranking.map(r => JSON.stringify(r)),
+        },
+      }),
+    );
+
+    span.end();
+    state.rerankSpan = undefined;
+  }
+
   onChunk(event: OnChunkEvent<ToolSet>): void {
     const chunk = event.chunk as {
       type: string;
@@ -706,6 +836,12 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
       embedSpan.end();
     }
     state.embedSpans.clear();
+
+    if (state.rerankSpan) {
+      recordSpanError(state.rerankSpan.span, actualError);
+      state.rerankSpan.span.end();
+      state.rerankSpan = undefined;
+    }
 
     recordSpanError(state.rootSpan, actualError);
 

--- a/packages/ai/src/telemetry/telemetry-integration.ts
+++ b/packages/ai/src/telemetry/telemetry-integration.ts
@@ -15,6 +15,12 @@ import type {
   EmbedStartEvent,
   EmbedFinishEvent,
 } from '../embed/embed-events';
+import type {
+  RerankOnStartEvent,
+  RerankOnFinishEvent,
+  RerankStartEvent,
+  RerankFinishEvent,
+} from '../rerank/rerank-events';
 import { Listener } from '../util/notify';
 
 /**
@@ -28,7 +34,9 @@ export interface TelemetryIntegration {
    *
    * Use the `operationId` field to distinguish between operation types.
    */
-  onStart?: Listener<OnStartEvent<ToolSet, Output> | EmbedOnStartEvent>;
+  onStart?: Listener<
+    OnStartEvent<ToolSet, Output> | EmbedOnStartEvent | RerankOnStartEvent
+  >;
 
   /**
    * Called when an individual step (single LLM invocation) begins.
@@ -84,12 +92,26 @@ export interface TelemetryIntegration {
   onEmbedFinish?: Listener<EmbedFinishEvent>;
 
   /**
+   * Called when an individual reranking model call (doRerank) begins.
+   * There is one call per `rerank` invocation.
+   */
+  onRerankStart?: Listener<RerankStartEvent>;
+
+  /**
+   * Called when an individual reranking model call (doRerank) completes.
+   * Contains the ranking results from the model response.
+   */
+  onRerankFinish?: Listener<RerankFinishEvent>;
+
+  /**
    * Called when an operation completes. Fired for both text generation
    * (generateText/streamText) and embedding (embed/embedMany) operations.
    *
    * Use the event shape or `operationId` to distinguish between operation types.
    */
-  onFinish?: Listener<OnFinishEvent<ToolSet> | EmbedOnFinishEvent>;
+  onFinish?: Listener<
+    OnFinishEvent<ToolSet> | EmbedOnFinishEvent | RerankOnFinishEvent
+  >;
 
   /**
    * Called when an unrecoverable error occurs during the generation lifecycle.


### PR DESCRIPTION
## Background

as an ongoing effort to decouple otel from the core functions, this PR is follow up work for https://github.com/vercel/ai/pull/13051

## Summary

- introduced 2 new event types: `RerankStartEvent` and `RerankFinishEvent` for the inner spans
- expand the shape of `onStart` and `onFinish` callback to accept the rerank events
- move all otel logic within `rerank.ts` to `open-telemetry-integration.ts`

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)