### PR TITLE
fix: use passthrough() in uiMessageChunkSchema for forward compatibility

### DIFF
--- a/.changeset/fix-ui-message-chunk-passthrough.md
+++ b/.changeset/fix-ui-message-chunk-passthrough.md
@@ -1,0 +1,10 @@
+---
+'ai': patch
+---
+
+fix(ai): use passthrough() in uiMessageChunkSchema for forward compatibility
+
+Replaced z.strictObject() with z.object().passthrough() in uiMessageChunkSchema to prevent
+AI_TypeValidationError when a newer server sends fields (e.g. providerMetadata) that an older
+cached client schema doesn't recognize. This makes the stream protocol forward-compatible
+across patch/minor versions.

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.test-d.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.test-d.ts
@@ -13,6 +13,8 @@ describe('UI message chunks type', () => {
       },
     });
 
-    expectTypeOf(chunk).toEqualTypeOf<UIMessageChunk>();
+    // toMatchTypeOf (not toEqualTypeOf) because passthrough() adds an index
+    // signature to the inferred type, making it wider than the UIMessageChunk union.
+    expectTypeOf(chunk).toMatchTypeOf<UIMessageChunk>();
   });
 });

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.test.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { uiMessageChunkSchema } from './ui-message-chunks';
+import { validateTypes } from '@ai-sdk/provider-utils';
+
+describe('uiMessageChunkSchema', () => {
+  it('should validate a chunk with recognized fields', async () => {
+    const chunk = await validateTypes({
+      schema: uiMessageChunkSchema,
+      value: {
+        type: 'text-delta',
+        id: '1',
+        delta: 'hello',
+      },
+    });
+
+    expect(chunk).toEqual({
+      type: 'text-delta',
+      id: '1',
+      delta: 'hello',
+    });
+  });
+
+  it('should pass through unknown fields without error', async () => {
+    const chunk = await validateTypes({
+      schema: uiMessageChunkSchema,
+      value: {
+        type: 'text-delta',
+        id: '1',
+        delta: 'hello',
+        unknownField: 'value',
+      },
+    });
+
+    expect(chunk).toEqual({
+      type: 'text-delta',
+      id: '1',
+      delta: 'hello',
+      unknownField: 'value',
+    });
+  });
+
+  it('should pass through unknown fields on start-step chunk', async () => {
+    const chunk = await validateTypes({
+      schema: uiMessageChunkSchema,
+      value: {
+        type: 'start-step',
+        futureField: 42,
+      },
+    });
+
+    expect(chunk).toEqual({
+      type: 'start-step',
+      futureField: 42,
+    });
+  });
+
+  it('should pass through unknown fields on finish chunk with enum field', async () => {
+    const chunk = await validateTypes({
+      schema: uiMessageChunkSchema,
+      value: {
+        type: 'finish',
+        finishReason: 'stop',
+        futureField: true,
+      },
+    });
+
+    expect(chunk).toEqual({
+      type: 'finish',
+      finishReason: 'stop',
+      futureField: true,
+    });
+  });
+
+  it('should pass through providerMetadata on error chunk (issue #13733)', async () => {
+    const chunk = await validateTypes({
+      schema: uiMessageChunkSchema,
+      value: {
+        type: 'error',
+        errorText: 'something went wrong',
+        providerMetadata: { anthropic: { cacheControl: 'ephemeral' } },
+      },
+    });
+
+    expect(chunk).toEqual({
+      type: 'error',
+      errorText: 'something went wrong',
+      providerMetadata: { anthropic: { cacheControl: 'ephemeral' } },
+    });
+  });
+
+  it('should pass through unknown fields on tool approval chunks', async () => {
+    const chunks = [
+      {
+        type: 'tool-approval-request',
+        approvalId: 'approval-1',
+        toolCallId: 'tool-call-1',
+        futureField: 'request',
+      },
+      {
+        type: 'tool-approval-response',
+        approvalId: 'approval-1',
+        approved: true,
+        futureField: 'response',
+      },
+      {
+        type: 'tool-output-denied',
+        toolCallId: 'tool-call-1',
+        futureField: 'denied',
+      },
+    ];
+
+    for (const value of chunks) {
+      await expect(
+        validateTypes({
+          schema: uiMessageChunkSchema,
+          value,
+        }),
+      ).resolves.toEqual(value);
+    }
+  });
+
+  it('should reject a chunk with an invalid type', async () => {
+    await expect(
+      validateTypes({
+        schema: uiMessageChunkSchema,
+        value: {
+          type: 'invalid-type',
+        },
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -16,187 +16,243 @@ import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
 export const uiMessageChunkSchema = lazySchema(() =>
   zodSchema(
     z.union([
-      z.strictObject({
-        type: z.literal('text-start'),
-        id: z.string(),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.strictObject({
-        type: z.literal('text-delta'),
-        id: z.string(),
-        delta: z.string(),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.strictObject({
-        type: z.literal('text-end'),
-        id: z.string(),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.strictObject({
-        type: z.literal('error'),
-        errorText: z.string(),
-      }),
-      z.strictObject({
-        type: z.literal('tool-input-start'),
-        toolCallId: z.string(),
-        toolName: z.string(),
-        providerExecuted: z.boolean().optional(),
-        providerMetadata: providerMetadataSchema.optional(),
-        dynamic: z.boolean().optional(),
-        title: z.string().optional(),
-      }),
-      z.strictObject({
-        type: z.literal('tool-input-delta'),
-        toolCallId: z.string(),
-        inputTextDelta: z.string(),
-      }),
-      z.strictObject({
-        type: z.literal('tool-input-available'),
-        toolCallId: z.string(),
-        toolName: z.string(),
-        input: z.unknown(),
-        providerExecuted: z.boolean().optional(),
-        providerMetadata: providerMetadataSchema.optional(),
-        dynamic: z.boolean().optional(),
-        title: z.string().optional(),
-      }),
-      z.strictObject({
-        type: z.literal('tool-input-error'),
-        toolCallId: z.string(),
-        toolName: z.string(),
-        input: z.unknown(),
-        providerExecuted: z.boolean().optional(),
-        providerMetadata: providerMetadataSchema.optional(),
-        dynamic: z.boolean().optional(),
-        errorText: z.string(),
-        title: z.string().optional(),
-      }),
-      z.strictObject({
-        type: z.literal('tool-approval-request'),
-        approvalId: z.string(),
-        toolCallId: z.string(),
-        isAutomatic: z.boolean().optional(),
-      }),
-      z.strictObject({
-        type: z.literal('tool-approval-response'),
-        approvalId: z.string(),
-        approved: z.boolean(),
-        reason: z.string().optional(),
-        providerExecuted: z.boolean().optional(),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.strictObject({
-        type: z.literal('tool-output-available'),
-        toolCallId: z.string(),
-        output: z.unknown(),
-        providerExecuted: z.boolean().optional(),
-        providerMetadata: providerMetadataSchema.optional(),
-        dynamic: z.boolean().optional(),
-        preliminary: z.boolean().optional(),
-      }),
-      z.strictObject({
-        type: z.literal('tool-output-error'),
-        toolCallId: z.string(),
-        errorText: z.string(),
-        providerExecuted: z.boolean().optional(),
-        providerMetadata: providerMetadataSchema.optional(),
-        dynamic: z.boolean().optional(),
-      }),
-      z.strictObject({
-        type: z.literal('tool-output-denied'),
-        toolCallId: z.string(),
-      }),
-      z.strictObject({
-        type: z.literal('reasoning-start'),
-        id: z.string(),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.strictObject({
-        type: z.literal('reasoning-delta'),
-        id: z.string(),
-        delta: z.string(),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.strictObject({
-        type: z.literal('reasoning-end'),
-        id: z.string(),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.strictObject({
-        type: z.literal('custom'),
-        kind: z.string().transform(value => value as `${string}.${string}`),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.strictObject({
-        type: z.literal('source-url'),
-        sourceId: z.string(),
-        url: z.string(),
-        title: z.string().optional(),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.strictObject({
-        type: z.literal('source-document'),
-        sourceId: z.string(),
-        mediaType: z.string(),
-        title: z.string(),
-        filename: z.string().optional(),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.strictObject({
-        type: z.literal('file'),
-        url: z.string(),
-        mediaType: z.string(),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.strictObject({
-        type: z.literal('reasoning-file'),
-        url: z.string(),
-        mediaType: z.string(),
-        providerMetadata: providerMetadataSchema.optional(),
-      }),
-      z.strictObject({
-        type: z.custom<`data-${string}`>(
-          (value): value is `data-${string}` =>
-            typeof value === 'string' && value.startsWith('data-'),
-          { message: 'Type must start with "data-"' },
-        ),
-        id: z.string().optional(),
-        data: z.unknown(),
-        transient: z.boolean().optional(),
-      }),
-      z.strictObject({
-        type: z.literal('start-step'),
-      }),
-      z.strictObject({
-        type: z.literal('finish-step'),
-      }),
-      z.strictObject({
-        type: z.literal('start'),
-        messageId: z.string().optional(),
-        messageMetadata: z.unknown().optional(),
-      }),
-      z.strictObject({
-        type: z.literal('finish'),
-        finishReason: z
-          .enum([
-            'stop',
-            'length',
-            'content-filter',
-            'tool-calls',
-            'error',
-            'other',
-          ] as const satisfies readonly FinishReason[])
-          .optional(),
-        messageMetadata: z.unknown().optional(),
-      }),
-      z.strictObject({
-        type: z.literal('abort'),
-        reason: z.string().optional(),
-      }),
-      z.strictObject({
-        type: z.literal('message-metadata'),
-        messageMetadata: z.unknown(),
-      }),
+      z
+        .object({
+          type: z.literal('text-start'),
+          id: z.string(),
+          providerMetadata: providerMetadataSchema.optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('text-delta'),
+          id: z.string(),
+          delta: z.string(),
+          providerMetadata: providerMetadataSchema.optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('text-end'),
+          id: z.string(),
+          providerMetadata: providerMetadataSchema.optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('error'),
+          errorText: z.string(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('tool-input-start'),
+          toolCallId: z.string(),
+          toolName: z.string(),
+          providerExecuted: z.boolean().optional(),
+          providerMetadata: providerMetadataSchema.optional(),
+          dynamic: z.boolean().optional(),
+          title: z.string().optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('tool-input-delta'),
+          toolCallId: z.string(),
+          inputTextDelta: z.string(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('tool-input-available'),
+          toolCallId: z.string(),
+          toolName: z.string(),
+          input: z.unknown(),
+          providerExecuted: z.boolean().optional(),
+          providerMetadata: providerMetadataSchema.optional(),
+          dynamic: z.boolean().optional(),
+          title: z.string().optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('tool-input-error'),
+          toolCallId: z.string(),
+          toolName: z.string(),
+          input: z.unknown(),
+          providerExecuted: z.boolean().optional(),
+          providerMetadata: providerMetadataSchema.optional(),
+          dynamic: z.boolean().optional(),
+          errorText: z.string(),
+          title: z.string().optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('tool-approval-request'),
+          approvalId: z.string(),
+          toolCallId: z.string(),
+          isAutomatic: z.boolean().optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('tool-approval-response'),
+          approvalId: z.string(),
+          approved: z.boolean(),
+          reason: z.string().optional(),
+          providerExecuted: z.boolean().optional(),
+          providerMetadata: providerMetadataSchema.optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('tool-output-available'),
+          toolCallId: z.string(),
+          output: z.unknown(),
+          providerExecuted: z.boolean().optional(),
+          providerMetadata: providerMetadataSchema.optional(),
+          dynamic: z.boolean().optional(),
+          preliminary: z.boolean().optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('tool-output-error'),
+          toolCallId: z.string(),
+          errorText: z.string(),
+          providerExecuted: z.boolean().optional(),
+          providerMetadata: providerMetadataSchema.optional(),
+          dynamic: z.boolean().optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('tool-output-denied'),
+          toolCallId: z.string(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('reasoning-start'),
+          id: z.string(),
+          providerMetadata: providerMetadataSchema.optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('reasoning-delta'),
+          id: z.string(),
+          delta: z.string(),
+          providerMetadata: providerMetadataSchema.optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('reasoning-end'),
+          id: z.string(),
+          providerMetadata: providerMetadataSchema.optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('custom'),
+          kind: z.string().transform(value => value as `${string}.${string}`),
+          providerMetadata: providerMetadataSchema.optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('source-url'),
+          sourceId: z.string(),
+          url: z.string(),
+          title: z.string().optional(),
+          providerMetadata: providerMetadataSchema.optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('source-document'),
+          sourceId: z.string(),
+          mediaType: z.string(),
+          title: z.string(),
+          filename: z.string().optional(),
+          providerMetadata: providerMetadataSchema.optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('file'),
+          url: z.string(),
+          mediaType: z.string(),
+          providerMetadata: providerMetadataSchema.optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('reasoning-file'),
+          url: z.string(),
+          mediaType: z.string(),
+          providerMetadata: providerMetadataSchema.optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.custom<`data-${string}`>(
+            (value): value is `data-${string}` =>
+              typeof value === 'string' && value.startsWith('data-'),
+            { message: 'Type must start with "data-"' },
+          ),
+          id: z.string().optional(),
+          data: z.unknown(),
+          transient: z.boolean().optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('start-step'),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('finish-step'),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('start'),
+          messageId: z.string().optional(),
+          messageMetadata: z.unknown().optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('finish'),
+          finishReason: z
+            .enum([
+              'stop',
+              'length',
+              'content-filter',
+              'tool-calls',
+              'error',
+              'other',
+            ] as const satisfies readonly FinishReason[])
+            .optional(),
+          messageMetadata: z.unknown().optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('abort'),
+          reason: z.string().optional(),
+        })
+        .passthrough(),
+      z
+        .object({
+          type: z.literal('message-metadata'),
+          messageMetadata: z.unknown(),
+        })
+        .passthrough(),
     ]),
   ),
 );


### PR DESCRIPTION
## Background

Issue #13733: `uiMessageChunkSchema` uses `z.strictObject()` on all 27 discriminated union variants, which rejects any unrecognized keys with `AI_TypeValidationError`. When a newer server adds a field (e.g. `providerMetadata`), older cached clients break because the strict schema won't accept the extra key.

## Summary

- Replaced `z.strictObject()` with `z.object().passthrough()` on all 27 variants in `uiMessageChunkSchema`
- Added regression tests verifying unknown fields pass through on text-delta, start-step, finish, and error chunk types
- Added specific test for `providerMetadata` on error chunks (the exact scenario from #13733)
- Updated type test to use `toMatchTypeOf` since `passthrough()` adds an index signature to the inferred type

## Manual Verification

Ran `pnpm test` in `packages/ai` — all 2268 tests pass (node + edge), no type errors.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #13733