### PR TITLE
fix(provider-utils): use io: 'output' in zod4Schema to preserve required fields

### DIFF
--- a/packages/provider-utils/src/__snapshots__/schema.test.ts.snap
+++ b/packages/provider-utils/src/__snapshots__/schema.test.ts.snap
@@ -98,7 +98,7 @@ exports[`zodSchema > zod/v4 > json schema conversion > should duplicate referenc
 }
 `;
 
-exports[`zodSchema > zod/v4 > json schema conversion > should generate JSON schema for input when transform is used 1`] = `
+exports[`zodSchema > zod/v4 > json schema conversion > should generate JSON schema for output when transform is used 1`] = `
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
@@ -107,7 +107,7 @@ exports[`zodSchema > zod/v4 > json schema conversion > should generate JSON sche
       "additionalProperties": false,
       "properties": {
         "id": {
-          "type": "string",
+          "type": "number",
         },
         "name": {
           "type": "string",

--- a/packages/provider-utils/src/schema.test.ts
+++ b/packages/provider-utils/src/schema.test.ts
@@ -156,7 +156,36 @@ describe('zodSchema', () => {
         expect(schema.jsonSchema).toMatchSnapshot();
       });
 
-      it('should generate JSON schema for input when transform is used', async () => {
+      it('should include default() fields in required array', () => {
+        const schema = zodSchema(
+          z4.object({
+            name: z4.string().optional(),
+            items: z4.array(z4.string()).optional().default([]),
+          }),
+        );
+
+        expect(schema.jsonSchema).toMatchObject({
+          required: expect.arrayContaining(['items']),
+        });
+      });
+
+      it('should include default() fields in required for nullish schemas', () => {
+        const schema = zodSchema(
+          z4.object({
+            email: z4.string().nullish(),
+            certificates: z4
+              .array(z4.object({ title: z4.string().nullish() }))
+              .nullish()
+              .default([]),
+          }),
+        );
+
+        expect(schema.jsonSchema).toMatchObject({
+          required: expect.arrayContaining(['certificates']),
+        });
+      });
+
+      it('should generate JSON schema for output when transform is used', async () => {
         const schema = zodSchema(
           z4.object({
             user: z4.object({

--- a/packages/provider-utils/src/schema.ts
+++ b/packages/provider-utils/src/schema.ts
@@ -223,7 +223,7 @@ export function zod4Schema<OBJECT>(
       addAdditionalPropertiesToJsonSchema(
         z4.toJSONSchema(zodSchema, {
           target: 'draft-7',
-          io: 'input',
+          io: 'output',
           reused: useReferences ? 'ref' : 'inline',
         }) as JSONSchema7,
       ),


### PR DESCRIPTION
## Summary

`zod4Schema()` calls `z4.toJSONSchema()` with `io: 'input'`, which excludes `.default()` fields from the `required` array. When this JSON Schema is sent to LLMs via `response_format`, the missing `required` causes models to return incomplete structured output.

This PR changes `io: 'input'` to `io: 'output'` since the schema describes what the **LLM should output**, not what the user provides as input.

## Root cause

```ts
// Before (broken)
z4.toJSONSchema(zodSchema, { target: 'draft-7', io: 'input', ... })
// → required: undefined (default fields are optional from input perspective)

// After (fixed)  
z4.toJSONSchema(zodSchema, { target: 'draft-7', io: 'output', ... })
// → required: ["certificates"] (default fields are guaranteed in output)
```

## Reproduction

With a schema where all fields are `.nullish()` and one has `.default([])`:

| Method | email | phone | skills | languages | certificates |
|--------|-------|-------|--------|-----------|-------------|
| Before (`io: 'input'`) | null | null | 10 | 0 | 0 |
| After (`io: 'output'`) | ✅ | ✅ | 10 | 3 | 2 |

Tested with Gemini 2.5 Flash and Claude Sonnet 4 via OpenRouter — same behavior on both.

## Changes

- `packages/provider-utils/src/schema.ts`: `io: 'input'` → `io: 'output'`
- `packages/provider-utils/src/schema.test.ts`: added 2 tests for `.default()` fields in `required`, renamed transform test
- Updated snapshot

## Test plan

- [x] Existing tests pass (24/24)
- [x] New tests verify `.default()` fields appear in `required`
- [x] Verified with real LLM calls (Gemini 2.5 Flash via OpenRouter)

Fixes #13732