### PR TITLE
refactoring: stream init part

### DIFF
--- a/packages/provider/src/language-model/v4/language-model-v4-stream-part.ts
+++ b/packages/provider/src/language-model/v4/language-model-v4-stream-part.ts
@@ -79,7 +79,14 @@ export type LanguageModelV4StreamPart =
   | LanguageModelV4ReasoningFile
   | LanguageModelV4Source
 
-  // stream start event with warnings for the call, e.g. unsupported settings:
+  // Stream start event with warnings for the call, e.g. unsupported settings.
+  //
+  // The stream-start part is returned immediately by the provider,
+  // even before the first LLM chunk is received.
+  // This is required to receive warnings from remote models
+  // when streaming.
+  //
+  // TODO rename to init
   | {
       type: 'stream-start';
       warnings: Array<SharedV4Warning>;


### PR DESCRIPTION
## Background

We have a `stream-start` part that contains the warnings. The name is inconsistent with our other part names and also slightly misleading, because it is returned immediately, i.e. before the first token from the llm.

## Summary

Rename `stream-start` to `init`

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

- [ ] rename stream part
- [ ] add transformation for language model v2 and v3 (in ai package)
- [ ] update providers
- [ ] update docs
- [ ] add changeset 

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
