### PR TITLE
refactoring: rename stream-start to model-call-init on createStreamTextPartTransform

### DIFF
--- a/packages/ai/src/generate-text/create-stream-text-part-transform.test.ts
+++ b/packages/ai/src/generate-text/create-stream-text-part-transform.test.ts
@@ -27,6 +27,86 @@ const testUsage: LanguageModelV4Usage = {
 };
 
 describe('createStreamTextPartTransform', () => {
+  describe('stream-start parts', () => {
+    it('should convert stream-start to init-model-call', async () => {
+      const inputStream: ReadableStream<LanguageModelV4StreamPart> =
+        convertArrayToReadableStream([
+          {
+            type: 'stream-start',
+            warnings: [
+              {
+                type: 'compatibility',
+                feature: 'tool-approval',
+                details: 'approval fallback is being used',
+              },
+              {
+                type: 'other',
+                message: 'custom warning',
+              },
+            ],
+          },
+          {
+            type: 'finish',
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage: testUsage,
+          },
+        ]);
+
+      const transformedStream = inputStream.pipeThrough(
+        createStreamTextPartTransform({
+          tools: undefined,
+          system: undefined,
+          messages: [],
+          repairToolCall: undefined,
+        }),
+      );
+
+      const result = await convertReadableStreamToArray(transformedStream);
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "init-model-call",
+            "warnings": [
+              {
+                "details": "approval fallback is being used",
+                "feature": "tool-approval",
+                "type": "compatibility",
+              },
+              {
+                "message": "custom warning",
+                "type": "other",
+              },
+            ],
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": undefined,
+            "rawFinishReason": "stop",
+            "type": "finish",
+            "usage": {
+              "cachedInputTokens": undefined,
+              "inputTokenDetails": {
+                "cacheReadTokens": undefined,
+                "cacheWriteTokens": undefined,
+                "noCacheTokens": 3,
+              },
+              "inputTokens": 3,
+              "outputTokenDetails": {
+                "reasoningTokens": undefined,
+                "textTokens": 10,
+              },
+              "outputTokens": 10,
+              "raw": undefined,
+              "reasoningTokens": undefined,
+              "totalTokens": 13,
+            },
+          },
+        ]
+      `);
+    });
+  });
+
   describe('text parts', () => {
     it('should convert text to delta', async () => {
       const inputStream: ReadableStream<LanguageModelV4StreamPart> =

--- a/packages/ai/src/generate-text/create-stream-text-part-transform.test.ts
+++ b/packages/ai/src/generate-text/create-stream-text-part-transform.test.ts
@@ -66,7 +66,7 @@ describe('createStreamTextPartTransform', () => {
       expect(result).toMatchInlineSnapshot(`
         [
           {
-            "type": "init-model-call",
+            "type": "model-call-init",
             "warnings": [
               {
                 "details": "approval fallback is being used",

--- a/packages/ai/src/generate-text/create-stream-text-part-transform.ts
+++ b/packages/ai/src/generate-text/create-stream-text-part-transform.ts
@@ -64,7 +64,7 @@ export type UglyTransformedStreamTextPart<TOOLS extends ToolSet> =
 
   // warnings from the model call initialization
   | {
-      type: 'init-model-call';
+      type: 'model-call-init';
       warnings: Array<SharedV4Warning>;
     }
   | ({ type: 'response-metadata' } & LanguageModelV4ResponseMetadata);
@@ -233,7 +233,7 @@ export function createStreamTextPartTransform<TOOLS extends ToolSet>({
 
         case 'stream-start': {
           controller.enqueue({
-            type: 'init-model-call',
+            type: 'model-call-init',
             warnings: chunk.warnings,
           });
           break;

--- a/packages/ai/src/generate-text/create-stream-text-part-transform.ts
+++ b/packages/ai/src/generate-text/create-stream-text-part-transform.ts
@@ -62,9 +62,9 @@ export type UglyTransformedStreamTextPart<TOOLS extends ToolSet> =
       providerMetadata?: ProviderMetadata;
     }
 
-  // TODO check if we need to transform these parts?
+  // warnings from the model call initialization
   | {
-      type: 'stream-start';
+      type: 'init-model-call';
       warnings: Array<SharedV4Warning>;
     }
   | ({ type: 'response-metadata' } & LanguageModelV4ResponseMetadata);
@@ -227,6 +227,14 @@ export function createStreamTextPartTransform<TOOLS extends ToolSet>({
             ...chunk,
             dynamic: chunk.dynamic ?? tool?.type === 'dynamic',
             title: tool?.title,
+          });
+          break;
+        }
+
+        case 'stream-start': {
+          controller.enqueue({
+            type: 'init-model-call',
+            warnings: chunk.warnings,
           });
           break;
         }

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1682,7 +1682,7 @@ class DefaultStreamTextResult<
                 async transform(chunk, controller): Promise<void> {
                   resetChunkTimeout();
 
-                  if (chunk.type === 'init-model-call') {
+                  if (chunk.type === 'model-call-init') {
                     warnings = chunk.warnings;
                     return; // stream start chunks are sent immediately and do not count as first chunk
                   }

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1682,7 +1682,7 @@ class DefaultStreamTextResult<
                 async transform(chunk, controller): Promise<void> {
                   resetChunkTimeout();
 
-                  if (chunk.type === 'stream-start') {
+                  if (chunk.type === 'init-model-call') {
                     warnings = chunk.warnings;
                     return; // stream start chunks are sent immediately and do not count as first chunk
                   }


### PR DESCRIPTION
## Background

We are introducing dedicated part types for the model call stream.

## Summary

Rename `stream-start` part to `model-call-init`.

## Future Work

#13803 related language model change

## Related Issues

Part of #13570