### PR TITLE
fix(mcp): expose server instructions on MCP client

### DIFF
--- a/.changeset/fix-mcp-server-instructions-client.md
+++ b/.changeset/fix-mcp-server-instructions-client.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+fix(mcp): expose server instructions on MCP client
+
+`MCPClient` now exposes `serverInstructions` in addition to `serverCapabilities`, so both initialization fields can be accessed directly from the client instance.

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -896,6 +896,34 @@ describe('MCPClient', () => {
     await client.close();
   });
 
+  it('should expose server capabilities and instructions from initialize', async () => {
+    createMockTransport.mockImplementation(
+      () =>
+        new MockMCPTransport({
+          initializeResult: {
+            protocolVersion: '2025-11-25',
+            serverInfo: {
+              name: 'mock-mcp-server',
+              version: '1.0.0',
+            },
+            capabilities: {
+              tools: { listChanged: true },
+            },
+            instructions: 'Follow tool safety rules.',
+          },
+        }),
+    );
+
+    client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+    });
+
+    expect(client.serverCapabilities).toMatchObject({
+      tools: { listChanged: true },
+    });
+    expect(client.serverInstructions).toBe('Follow tool safety rules.');
+  });
+
   it('should accept server responding with older supported protocol versions', async () => {
     for (const version of ['2025-06-18', '2025-03-26', '2024-11-05']) {
       createMockTransport.mockImplementation(

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -119,6 +119,9 @@ export async function createMCPClient(
 }
 
 export interface MCPClient {
+  readonly serverCapabilities: ServerCapabilities;
+  readonly serverInstructions?: string;
+
   tools<TOOL_SCHEMAS extends ToolSchemas = 'automatic'>(options?: {
     schemas?: TOOL_SCHEMAS;
   }): Promise<McpToolSet<TOOL_SCHEMAS>>;
@@ -200,11 +203,20 @@ class DefaultMCPClient implements MCPClient {
     number,
     (response: JSONRPCResponse | Error) => void
   > = new Map();
-  private serverCapabilities: ServerCapabilities = {};
+  private _serverCapabilities: ServerCapabilities = {};
+  private _serverInstructions: string | undefined;
   private isClosed = true;
   private elicitationRequestHandler?: (
     request: ElicitationRequest,
   ) => Promise<ElicitResult> | ElicitResult;
+
+  get serverCapabilities(): ServerCapabilities {
+    return this._serverCapabilities;
+  }
+
+  get serverInstructions(): string | undefined {
+    return this._serverInstructions;
+  }
 
   constructor({
     transport: transportConfig,
@@ -276,7 +288,8 @@ class DefaultMCPClient implements MCPClient {
         });
       }
 
-      this.serverCapabilities = result.capabilities;
+      this._serverCapabilities = result.capabilities;
+      this._serverInstructions = result.instructions;
 
       // Complete initialization handshake:
       await this.notification({
@@ -302,7 +315,7 @@ class DefaultMCPClient implements MCPClient {
         break;
       case 'tools/list':
       case 'tools/call':
-        if (!this.serverCapabilities.tools) {
+        if (!this._serverCapabilities.tools) {
           throw new MCPClientError({
             message: `Server does not support tools`,
           });
@@ -311,7 +324,7 @@ class DefaultMCPClient implements MCPClient {
       case 'resources/list':
       case 'resources/read':
       case 'resources/templates/list':
-        if (!this.serverCapabilities.resources) {
+        if (!this._serverCapabilities.resources) {
           throw new MCPClientError({
             message: `Server does not support resources`,
           });
@@ -319,7 +332,7 @@ class DefaultMCPClient implements MCPClient {
         break;
       case 'prompts/list':
       case 'prompts/get':
-        if (!this.serverCapabilities.prompts) {
+        if (!this._serverCapabilities.prompts) {
           throw new MCPClientError({
             message: `Server does not support prompts`,
           });


### PR DESCRIPTION
## Background

`@ai-sdk/mcp` already parses both `capabilities` and `instructions` from the MCP initialize response, but only capabilities were retained on the client instance.

## Summary

- Expose `serverCapabilities` and `serverInstructions` as readonly properties on `MCPClient`.
- Persist both values during initialization (`result.capabilities` and `result.instructions`).
- Add a regression test verifying both fields are available from the created client.
- Add a patch changeset for `@ai-sdk/mcp`.

## Manual Verification

- Ran `pnpm test:node src/tool/mcp-client.test.ts` in `packages/mcp`.
- Ran `pnpm type-check` in `packages/mcp`.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)