### PR TITLE
feat(ai): add preparedTools/preparedToolChoice to experimental_streamModelCall

### DIFF
--- a/examples/next-workflow/next-env.d.ts
+++ b/examples/next-workflow/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -37,6 +37,13 @@ export {
   streamModelCall as experimental_streamModelCall,
   type ModelCallStreamPart as Experimental_ModelCallStreamPart,
 } from './stream-model-call';
+export type {
+  FunctionToolDescriptor,
+  ProviderToolDescriptor,
+  ToolChoiceDescriptor,
+  ToolDescriptor,
+} from './tool-descriptor';
+export { prepareToolsAndToolChoice as experimental_prepareToolsAndToolChoice } from '../prompt/prepare-tools-and-tool-choice';
 export {
   streamText,
   type StreamTextOnChunkCallback,

--- a/packages/ai/src/generate-text/stream-model-call.ts
+++ b/packages/ai/src/generate-text/stream-model-call.ts
@@ -1,7 +1,10 @@
 import {
   getErrorMessage,
+  LanguageModelV4FunctionTool,
   LanguageModelV4Prompt,
+  LanguageModelV4ProviderTool,
   LanguageModelV4StreamPart,
+  LanguageModelV4ToolChoice,
   SharedV4Headers,
 } from '@ai-sdk/provider';
 import {
@@ -46,6 +49,7 @@ import {
 } from './stream-text-result';
 import { TypedToolCall } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair-function';
+import type { ToolChoiceDescriptor, ToolDescriptor } from './tool-descriptor';
 import { TypedToolError } from './tool-error';
 import { TypedToolResult } from './tool-result';
 import { ToolSet } from './tool-set';
@@ -111,6 +115,8 @@ export async function streamModelCall<
   output,
   toolChoice,
   activeTools,
+  preparedTools,
+  preparedToolChoice,
   prompt,
   system,
   messages,
@@ -129,6 +135,25 @@ export async function streamModelCall<
   output?: OUTPUT;
   toolChoice?: ToolChoice<TOOLS>;
   activeTools?: Array<keyof NoInfer<TOOLS>>;
+
+  /**
+   * Pre-prepared serializable tool descriptors. When provided, skips
+   * `prepareToolsAndToolChoice` and uses these directly.
+   *
+   * Use this when tools need to cross a serialization boundary (e.g.,
+   * Workflow step functions) where `ToolSet` (with Zod schemas and
+   * execute functions) cannot be serialized.
+   *
+   * Obtain these by calling `prepareToolsAndToolChoice()` from `ai/internal`
+   * before the serialization boundary.
+   */
+  preparedTools?: ToolDescriptor[];
+
+  /**
+   * Pre-prepared serializable tool choice. Used together with `preparedTools`.
+   */
+  preparedToolChoice?: ToolChoiceDescriptor;
+
   download?: DownloadFunction;
   headers?: Record<string, string | undefined>;
   includeRawChunks?: boolean;
@@ -181,12 +206,23 @@ export async function streamModelCall<
     download,
   });
 
-  const { toolChoice: stepToolChoice, tools: stepTools } =
-    await prepareToolsAndToolChoice({
-      tools,
-      toolChoice,
-      activeTools,
-    });
+  // Use pre-prepared tools if provided (for serialization boundary scenarios),
+  // otherwise prepare from the ToolSet.
+  const { toolChoice: stepToolChoice, tools: stepTools } = preparedTools
+    ? {
+        // ToolDescriptor is structurally compatible with V4 tool types
+        tools: preparedTools as Array<
+          LanguageModelV4FunctionTool | LanguageModelV4ProviderTool
+        >,
+        toolChoice: (preparedToolChoice ?? {
+          type: 'auto' as const,
+        }) as LanguageModelV4ToolChoice,
+      }
+    : await prepareToolsAndToolChoice({
+        tools,
+        toolChoice,
+        activeTools,
+      });
 
   await notify({
     event: { promptMessages },

--- a/packages/ai/src/generate-text/tool-descriptor.ts
+++ b/packages/ai/src/generate-text/tool-descriptor.ts
@@ -1,0 +1,51 @@
+import type { JSONSchema7 } from '@ai-sdk/provider';
+import type { ProviderOptions } from '@ai-sdk/provider-utils';
+
+/**
+ * A serializable descriptor for a function tool, containing only the
+ * information needed by the model to understand and call the tool.
+ *
+ * This is the serializable output of `prepareToolsAndToolChoice` —
+ * it contains JSON schemas (not Zod objects) and no execute functions,
+ * making it safe to pass across serialization boundaries (e.g., Workflow
+ * step functions).
+ *
+ * This type intentionally aliases the internal LanguageModelV4FunctionTool
+ * to shield consumers from provider spec version changes.
+ */
+export interface FunctionToolDescriptor {
+  type: 'function';
+  name: string;
+  description?: string;
+  inputSchema: JSONSchema7;
+  inputExamples?: Array<Record<string, unknown>>;
+  providerOptions?: ProviderOptions;
+  strict?: boolean;
+}
+
+/**
+ * A serializable descriptor for a provider-managed tool.
+ */
+export interface ProviderToolDescriptor {
+  type: 'provider';
+  name: string;
+  id: string;
+  args?: Record<string, unknown>;
+}
+
+/**
+ * A serializable tool descriptor — either a function tool or a provider tool.
+ */
+export type ToolDescriptor = FunctionToolDescriptor | ProviderToolDescriptor;
+
+/**
+ * A serializable tool choice descriptor.
+ *
+ * This type intentionally aliases the internal LanguageModelV4ToolChoice
+ * to shield consumers from provider spec version changes.
+ */
+export type ToolChoiceDescriptor =
+  | { type: 'auto' }
+  | { type: 'none' }
+  | { type: 'required' }
+  | { type: 'tool'; toolName: string };


### PR DESCRIPTION
## Summary

Add support for pre-prepared serializable tool descriptors in `experimental_streamModelCall`. When `preparedTools` is provided, the function skips `prepareToolsAndToolChoice` and uses the descriptors directly. This is needed to unblock #13820.

Alternative approach: https://github.com/vercel/ai/pull/13824

## Problem

`experimental_streamModelCall` requires `ToolSet` for its `tools` parameter. `ToolSet` contains Zod schemas and `execute` functions — neither of which are serializable. When `streamModelCall` is called inside a Workflow `'use step'` function, the `ToolSet` crosses the step serialization boundary and fails:

```
[Workflow] Serialization failed {
  context: 'step arguments',
  problematicValue: ZodObject { ... }
}
```

## Solution

Allow callers to pre-prepare tools **outside** the serialization boundary and pass the serializable result through:

```ts
// Outside the step boundary:
const { tools: preparedTools, toolChoice: preparedToolChoice } =
  await experimental_prepareToolsAndToolChoice({ tools, toolChoice });

// Inside the step (serialization boundary):
const { stream } = await experimental_streamModelCall({
  model,
  messages,
  preparedTools,      // JSON schemas, no Zod
  preparedToolChoice, // plain object
});
```

## New types

Intentionally alias internal `LanguageModelV4*` types to shield consumers from provider spec version changes:

- **`FunctionToolDescriptor`** — serializable function tool descriptor (JSON schema, name, description)
- **`ProviderToolDescriptor`** — serializable provider tool descriptor
- **`ToolDescriptor`** — union of the above
- **`ToolChoiceDescriptor`** — serializable tool choice (`auto` | `none` | `required` | `{ tool: name }`)

## New exports from `ai`

- `FunctionToolDescriptor`, `ProviderToolDescriptor`, `ToolDescriptor`, `ToolChoiceDescriptor` (types)
- `experimental_prepareToolsAndToolChoice` (function — extracts serializable descriptors from `ToolSet`)

## Test plan

- [x] `pnpm build` in packages/ai — passes
- [x] `pnpm test:node` in packages/ai — 2266 tests pass
- [x] Existing tests unaffected (preparedTools is optional, no behavior change when not provided)