### PR TITLE
feat (provider/xai): support video extend and r2v

### DIFF
--- a/.changeset/light-pumpkins-smoke.md
+++ b/.changeset/light-pumpkins-smoke.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/xai": patch
+---
+
+feat (provider/xai): support video extend and r2v

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -584,7 +584,7 @@ const { images } = await generateImage({
 You can create xAI video models using the `.video()` factory method.
 For more on video generation with the AI SDK see [generateVideo()](/docs/reference/ai-sdk-core/generate-video).
 
-This provider supports three video generation modes: text-to-video, image-to-video, and video editing.
+This provider supports five video generation modes: text-to-video, image-to-video, video editing, video extension, and reference-to-video.
 
 ### Text-to-Video
 
@@ -654,6 +654,89 @@ const { videos } = await generateVideo({
   Video editing accepts input videos up to 8.7 seconds long. The `duration`,
   `aspectRatio`, and `resolution` parameters are not supported for editing - the
   output matches the input video's properties (capped at 720p).
+</Note>
+
+### Video Extension
+
+Extend an existing video by generating a seamless continuation from its last frame.
+Provide a source video URL via `extensionVideoUrl` and a prompt describing what should happen next:
+
+```ts
+import { xai, type XaiVideoModelOptions } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { videos } = await generateVideo({
+  model: xai.video('grok-imagine-video'),
+  prompt: 'The camera slowly zooms out to reveal the city skyline at sunset',
+  duration: 6,
+  providerOptions: {
+    xai: {
+      extensionVideoUrl: 'https://example.com/source-video.mp4',
+      pollTimeoutMs: 600000, // 10 minutes
+    } satisfies XaiVideoModelOptions,
+  },
+});
+```
+
+<Note>
+  The input video must be MP4 format (H.264, H.265, or AV1 codec) with a
+  duration of 2–15 seconds. The extension duration can be 2–10 seconds. The
+  output is the original video stitched together with the generated extension.
+  The `aspectRatio` and `resolution` parameters are not supported for extension
+  — the output matches the input video.
+</Note>
+
+### Reference-to-Video
+
+Generate videos guided by one or more reference images as style and content references.
+Unlike image-to-video (where the image is the starting frame), reference-to-video uses
+the images to influence the overall look and subject of the generated video:
+
+```ts
+import { xai, type XaiVideoModelOptions } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { videos } = await generateVideo({
+  model: xai.video('grok-imagine-video'),
+  prompt:
+    'A golden retriever running through a sunlit meadow, cinematic slow motion',
+  duration: 8,
+  aspectRatio: '16:9',
+  providerOptions: {
+    xai: {
+      referenceImages: ['https://example.com/my-dog-photo.jpg'],
+      pollTimeoutMs: 600000, // 10 minutes
+    } satisfies XaiVideoModelOptions,
+  },
+});
+```
+
+You can provide multiple reference images:
+
+```ts
+const { videos } = await generateVideo({
+  model: xai.video('grok-imagine-video'),
+  prompt: 'Two cats playing together on a cozy sofa, warm lighting',
+  duration: 10,
+  aspectRatio: '16:9',
+  providerOptions: {
+    xai: {
+      referenceImages: [
+        'https://example.com/cat1.jpg',
+        'https://example.com/cat2.jpg',
+      ],
+      pollTimeoutMs: 600000,
+    } satisfies XaiVideoModelOptions,
+  },
+});
+```
+
+<Note>
+  Reference-to-video supports `duration`, `aspectRatio`, and `resolution` just
+  like text-to-video. Reference images can be HTTPS URLs or base64-encoded data
+  URIs (e.g., `data:image/jpeg;base64,...`). You cannot combine
+  `referenceImages` with the `image` parameter (image-to-video) or `videoUrl`
+  (video editing).
 </Note>
 
 ### Chaining and Concurrent Edits
@@ -726,6 +809,18 @@ You can validate the provider options using the `XaiVideoModelOptions` type.
   URL of a source video for video editing. When provided, the prompt is used
   to describe the desired edits to the video.
 
+- **extensionVideoUrl** _string_
+
+  URL of a source video to extend. The model generates a seamless continuation
+  from the last frame of the input video. The input must be MP4 format,
+  2–15 seconds long.
+
+- **referenceImages** _string[]_
+
+  Array of reference image URLs (HTTPS or `data:` URIs) for reference-to-video
+  generation. The images guide the style and content of the generated video
+  rather than serving as a starting frame.
+
 <Note>
   Video generation is an asynchronous process that can take several minutes.
   Consider setting `pollTimeoutMs` to at least 10 minutes (600000ms) for
@@ -747,11 +842,18 @@ resolution. Custom `duration`, `aspectRatio`, and `resolution` are not
 supported - the output resolution is capped at 720p (e.g., a 1080p input
 will be downsized to 720p).
 
+For **video extension**, the output matches the input video's aspect ratio and
+resolution. Custom `aspectRatio` and `resolution` are not supported, but you
+can specify `duration` (2–10 seconds) for the extension length.
+
+For **reference-to-video**, you can specify `duration`, `aspectRatio`, and
+`resolution` just like text-to-video.
+
 ### Video Model Capabilities
 
-| Model                | Duration | Aspect Ratios                                     | Resolution     | Image-to-Video      | Video Editing       |
-| -------------------- | -------- | ------------------------------------------------- | -------------- | ------------------- | ------------------- |
-| `grok-imagine-video` | 1–15s    | `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:2`, `2:3` | `480p`, `720p` | <Check size={18} /> | <Check size={18} /> |
+| Model                | Duration | Aspect Ratios                                     | Resolution     | Image-to-Video      | Video Editing       | Video Extension     | Reference-to-Video  |
+| -------------------- | -------- | ------------------------------------------------- | -------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `grok-imagine-video` | 1–15s    | `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:2`, `2:3` | `480p`, `720p` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   You can also pass any available provider model ID as a string if needed.

--- a/examples/ai-functions/src/generate-video/xai/extend.ts
+++ b/examples/ai-functions/src/generate-video/xai/extend.ts
@@ -12,11 +12,11 @@ run(async () => {
         model: xai.video('grok-imagine-video'),
         prompt:
           'The camera slowly zooms out to reveal the city skyline at sunset',
-        duration: 6,
+        duration: 2,
         providerOptions: {
           xai: {
             extensionVideoUrl:
-              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/prudence.mp4',
+              'https://2ktyacfouk5yfxly.public.blob.vercel-storage.com/prudence-480p.mp4',
             pollTimeoutMs: 1200000, // 20 minutes
           } satisfies XaiVideoModelOptions,
         },

--- a/examples/ai-functions/src/generate-video/xai/extend.ts
+++ b/examples/ai-functions/src/generate-video/xai/extend.ts
@@ -1,0 +1,27 @@
+import { type XaiVideoModelOptions, xai } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner(
+    'Extending video with xAI grok-imagine-video...',
+    () =>
+      generateVideo({
+        model: xai.video('grok-imagine-video'),
+        prompt:
+          'The camera slowly zooms out to reveal the city skyline at sunset',
+        duration: 6,
+        providerOptions: {
+          xai: {
+            extensionVideoUrl:
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/prudence.mp4',
+            pollTimeoutMs: 1200000, // 20 minutes
+          } satisfies XaiVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos(videos);
+});

--- a/examples/ai-functions/src/generate-video/xai/r2v-multi.ts
+++ b/examples/ai-functions/src/generate-video/xai/r2v-multi.ts
@@ -1,0 +1,29 @@
+import { type XaiVideoModelOptions, xai } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner(
+    'Generating reference-to-video with multiple references...',
+    () =>
+      generateVideo({
+        model: xai.video('grok-imagine-video'),
+        prompt: 'Two cats playing together on a cozy sofa, warm lighting',
+        duration: 10,
+        aspectRatio: '16:9',
+        providerOptions: {
+          xai: {
+            referenceImages: [
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+            ],
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies XaiVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos(videos);
+});

--- a/examples/ai-functions/src/generate-video/xai/r2v-multi.ts
+++ b/examples/ai-functions/src/generate-video/xai/r2v-multi.ts
@@ -11,7 +11,7 @@ run(async () => {
       generateVideo({
         model: xai.video('grok-imagine-video'),
         prompt: 'Two cats playing together on a cozy sofa, warm lighting',
-        duration: 10,
+        duration: 2,
         aspectRatio: '16:9',
         providerOptions: {
           xai: {

--- a/examples/ai-functions/src/generate-video/xai/r2v-url.ts
+++ b/examples/ai-functions/src/generate-video/xai/r2v-url.ts
@@ -1,0 +1,29 @@
+import { type XaiVideoModelOptions, xai } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner(
+    'Generating reference-to-video with xAI grok-imagine-video...',
+    () =>
+      generateVideo({
+        model: xai.video('grok-imagine-video'),
+        prompt:
+          'A golden retriever running through a sunlit meadow, cinematic slow motion',
+        duration: 8,
+        aspectRatio: '16:9',
+        providerOptions: {
+          xai: {
+            referenceImages: [
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+            ],
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies XaiVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos(videos);
+});

--- a/examples/ai-functions/src/generate-video/xai/r2v-url.ts
+++ b/examples/ai-functions/src/generate-video/xai/r2v-url.ts
@@ -10,14 +10,13 @@ run(async () => {
     () =>
       generateVideo({
         model: xai.video('grok-imagine-video'),
-        prompt:
-          'A golden retriever running through a sunlit meadow, cinematic slow motion',
-        duration: 8,
+        prompt: 'A bee flying through a meadow',
+        duration: 2,
         aspectRatio: '16:9',
         providerOptions: {
           xai: {
             referenceImages: [
-              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+              'https://2ktyacfouk5yfxly.public.blob.vercel-storage.com/05-bee-macro.png',
             ],
             pollTimeoutMs: 600000, // 10 minutes
           } satisfies XaiVideoModelOptions,

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -632,6 +632,33 @@ describe('XaiVideoModel', () => {
       };
     });
 
+    it('should throw when status is failed', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: {
+          status: 'failed',
+          video: { url: '', duration: 0, respect_moderation: true },
+          model: '',
+          error: {
+            code: 'failed_precondition',
+            message: 'Unsupported video content-type.',
+          },
+        },
+      };
+
+      const model = createModel();
+
+      await expect(model.doGenerate({ ...defaultOptions })).rejects.toThrow(
+        'failed_precondition: Unsupported video content-type.',
+      );
+
+      // Reset
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: doneStatusResponse,
+      };
+    });
+
     it('should throw when no request_id is returned', async () => {
       server.urls[`${TEST_BASE_URL}/videos/generations`].response = {
         type: 'json-value',

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -68,6 +68,12 @@ describe('XaiVideoModel', () => {
         body: createVideoResponse,
       },
     },
+    [`${TEST_BASE_URL}/videos/extensions`]: {
+      response: {
+        type: 'json-value',
+        body: createVideoResponse,
+      },
+    },
     [`${TEST_BASE_URL}/videos/req-123`]: {
       response: {
         type: 'json-value',
@@ -721,6 +727,402 @@ describe('XaiVideoModel', () => {
         type: 'json-value',
         body: doneStatusResponse,
       };
+    });
+  });
+
+  describe('video extension', () => {
+    it('should POST to /videos/extensions endpoint', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            extensionVideoUrl: 'https://example.com/source.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(server.calls[0].requestMethod).toBe('POST');
+      expect(server.calls[0].requestUrl).toBe(
+        `${TEST_BASE_URL}/videos/extensions`,
+      );
+    });
+
+    it('should send video object in extension request body', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            extensionVideoUrl: 'https://example.com/source.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        model: 'grok-imagine-video',
+        prompt,
+        video: { url: 'https://example.com/source.mp4' },
+      });
+    });
+
+    it('should include duration in extension request body', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        duration: 8,
+        providerOptions: {
+          xai: {
+            extensionVideoUrl: 'https://example.com/source.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({ duration: 8 });
+    });
+
+    it('should warn about aspectRatio in extension mode', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        aspectRatio: '16:9',
+        providerOptions: {
+          xai: {
+            extensionVideoUrl: 'https://example.com/source.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'aspectRatio',
+        }),
+      );
+    });
+
+    it('should warn about resolution in extension mode', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1280x720',
+        providerOptions: {
+          xai: {
+            extensionVideoUrl: 'https://example.com/source.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'resolution',
+        }),
+      );
+    });
+
+    it('should omit aspect_ratio and resolution from extension body', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        aspectRatio: '16:9',
+        resolution: '1280x720',
+        providerOptions: {
+          xai: {
+            extensionVideoUrl: 'https://example.com/source.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).not.toHaveProperty('aspect_ratio');
+      expect(body).not.toHaveProperty('resolution');
+    });
+
+    it('should handle extension response with nested response object', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: {
+          status: 'done',
+          response: {
+            video: {
+              url: 'https://vidgen.x.ai/output/extended-001.mp4',
+              duration: 16,
+              respect_moderation: true,
+            },
+            model: 'grok-imagine-video',
+            usage: { cost_in_usd_ticks: 5200000000 },
+          },
+        },
+      };
+
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            extensionVideoUrl: 'https://example.com/source.mp4',
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(result.videos[0]).toStrictEqual({
+        type: 'url',
+        url: 'https://vidgen.x.ai/output/extended-001.mp4',
+        mediaType: 'video/mp4',
+      });
+
+      expect(result.providerMetadata).toStrictEqual({
+        xai: {
+          requestId: 'req-123',
+          videoUrl: 'https://vidgen.x.ai/output/extended-001.mp4',
+          duration: 16,
+          costInUsdTicks: 5200000000,
+        },
+      });
+
+      // Reset
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: doneStatusResponse,
+      };
+    });
+  });
+
+  describe('reference-to-video (R2V)', () => {
+    it('should POST to /videos/generations with reference_images', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            referenceImages: ['https://example.com/ref1.jpg'],
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      expect(server.calls[0].requestUrl).toBe(
+        `${TEST_BASE_URL}/videos/generations`,
+      );
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        model: 'grok-imagine-video',
+        prompt,
+        reference_images: [{ url: 'https://example.com/ref1.jpg' }],
+      });
+    });
+
+    it('should send multiple reference images', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            referenceImages: [
+              'https://example.com/cat1.jpg',
+              'https://example.com/cat2.jpg',
+            ],
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        reference_images: [
+          { url: 'https://example.com/cat1.jpg' },
+          { url: 'https://example.com/cat2.jpg' },
+        ],
+      });
+    });
+
+    it('should support data URIs in reference images', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            referenceImages: ['data:image/jpeg;base64,abc123'],
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        reference_images: [{ url: 'data:image/jpeg;base64,abc123' }],
+      });
+    });
+
+    it('should include duration, aspect_ratio, and resolution in R2V body', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        duration: 10,
+        aspectRatio: '16:9',
+        resolution: '1280x720',
+        providerOptions: {
+          xai: {
+            referenceImages: ['https://example.com/ref1.jpg'],
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        duration: 10,
+        aspect_ratio: '16:9',
+        resolution: '720p',
+      });
+    });
+
+    it('should not include image field in body for R2V', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            referenceImages: ['https://example.com/ref1.jpg'],
+            pollIntervalMs: 10,
+            pollTimeoutMs: 5000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).not.toHaveProperty('image');
+    });
+  });
+
+  describe('conflict validation', () => {
+    it('should throw when combining videoUrl and extensionVideoUrl', async () => {
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          providerOptions: {
+            xai: {
+              videoUrl: 'https://example.com/edit.mp4',
+              extensionVideoUrl: 'https://example.com/extend.mp4',
+              pollIntervalMs: 10,
+              pollTimeoutMs: 5000,
+            },
+          },
+        }),
+      ).rejects.toThrow('Cannot combine videoUrl');
+    });
+
+    it('should throw when combining referenceImages and image', async () => {
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          image: {
+            type: 'url',
+            url: 'https://example.com/image.png',
+          },
+          providerOptions: {
+            xai: {
+              referenceImages: ['https://example.com/ref1.jpg'],
+              pollIntervalMs: 10,
+              pollTimeoutMs: 5000,
+            },
+          },
+        }),
+      ).rejects.toThrow('Cannot combine referenceImages');
+    });
+
+    it('should throw when combining referenceImages and videoUrl', async () => {
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          providerOptions: {
+            xai: {
+              referenceImages: ['https://example.com/ref1.jpg'],
+              videoUrl: 'https://example.com/edit.mp4',
+              pollIntervalMs: 10,
+              pollTimeoutMs: 5000,
+            },
+          },
+        }),
+      ).rejects.toThrow('Cannot combine referenceImages');
+    });
+
+    it('should throw when combining referenceImages and extensionVideoUrl', async () => {
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          providerOptions: {
+            xai: {
+              referenceImages: ['https://example.com/ref1.jpg'],
+              extensionVideoUrl: 'https://example.com/extend.mp4',
+              pollIntervalMs: 10,
+              pollTimeoutMs: 5000,
+            },
+          },
+        }),
+      ).rejects.toThrow('Cannot combine referenceImages');
+    });
+
+    it('should throw when combining extensionVideoUrl and image', async () => {
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          image: {
+            type: 'url',
+            url: 'https://example.com/image.png',
+          },
+          providerOptions: {
+            xai: {
+              extensionVideoUrl: 'https://example.com/extend.mp4',
+              pollIntervalMs: 10,
+              pollTimeoutMs: 5000,
+            },
+          },
+        }),
+      ).rejects.toThrow('Cannot combine extensionVideoUrl');
     });
   });
 });

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -272,18 +272,33 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
         ? 'extensions'
         : 'generations';
 
+    const submitUrl = `${baseURL}/videos/${endpoint}`;
+
+    // DEBUG: log the submit request
+    console.error(
+      `[xai-video-debug] POST ${submitUrl}\n` +
+        `[xai-video-debug] request body: ${JSON.stringify(body, null, 2)}`,
+    );
+
     // Step 1: Create video generation/edit/extension request
-    const { value: createResponse } = await postJsonToApi({
-      url: `${baseURL}/videos/${endpoint}`,
-      headers: combineHeaders(this.config.headers(), options.headers),
-      body,
-      failedResponseHandler: xaiFailedResponseHandler,
-      successfulResponseHandler: createJsonResponseHandler(
-        xaiCreateVideoResponseSchema,
-      ),
-      abortSignal: options.abortSignal,
-      fetch: this.config.fetch,
-    });
+    const { value: createResponse, rawValue: createRawValue } =
+      await postJsonToApi({
+        url: submitUrl,
+        headers: combineHeaders(this.config.headers(), options.headers),
+        body,
+        failedResponseHandler: xaiFailedResponseHandler,
+        successfulResponseHandler: createJsonResponseHandler(
+          xaiCreateVideoResponseSchema,
+        ),
+        abortSignal: options.abortSignal,
+        fetch: this.config.fetch,
+      });
+
+    // DEBUG: log the raw submit response
+    console.error(
+      `[xai-video-debug] POST response (raw): ${JSON.stringify(createRawValue, null, 2)}\n` +
+        `[xai-video-debug] POST response (parsed): ${JSON.stringify(createResponse, null, 2)}`,
+    );
 
     const requestId = createResponse.request_id;
     if (!requestId) {
@@ -298,6 +313,13 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
     const pollTimeoutMs = xaiOptions?.pollTimeoutMs ?? 600000;
     const startTime = Date.now();
     let responseHeaders: Record<string, string> | undefined;
+    const pollUrl = `${baseURL}/videos/${requestId}`;
+    let pollCount = 0;
+
+    // DEBUG: log polling config
+    console.error(
+      `[xai-video-debug] Polling ${pollUrl} every ${pollIntervalMs}ms (timeout: ${pollTimeoutMs}ms)`,
+    );
 
     while (true) {
       await delay(pollIntervalMs, { abortSignal: options.abortSignal });
@@ -309,17 +331,33 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
         });
       }
 
-      const { value: statusResponse, responseHeaders: pollHeaders } =
-        await getFromApi({
-          url: `${baseURL}/videos/${requestId}`,
-          headers: combineHeaders(this.config.headers(), options.headers),
-          successfulResponseHandler: createJsonResponseHandler(
-            xaiVideoStatusResponseSchema,
-          ),
-          failedResponseHandler: xaiFailedResponseHandler,
-          abortSignal: options.abortSignal,
-          fetch: this.config.fetch,
-        });
+      pollCount++;
+
+      const {
+        value: statusResponse,
+        rawValue: statusRawValue,
+        responseHeaders: pollHeaders,
+      } = await getFromApi({
+        url: pollUrl,
+        headers: combineHeaders(this.config.headers(), options.headers),
+        successfulResponseHandler: createJsonResponseHandler(
+          xaiVideoStatusResponseSchema,
+        ),
+        failedResponseHandler: xaiFailedResponseHandler,
+        abortSignal: options.abortSignal,
+        fetch: this.config.fetch,
+      });
+
+      const elapsedMs = Date.now() - startTime;
+
+      // DEBUG: log each poll response
+      console.error(
+        `[xai-video-debug] Poll #${pollCount} (${(elapsedMs / 1000).toFixed(1)}s elapsed) GET ${pollUrl}\n` +
+          `[xai-video-debug] Poll raw response: ${JSON.stringify(statusRawValue, null, 2)}\n` +
+          `[xai-video-debug] Poll parsed status: "${statusResponse.status}" | ` +
+          `video: ${statusResponse.video ? 'present' : 'null'} | ` +
+          `response.video: ${statusResponse.response?.video ? 'present' : 'null'}`,
+      );
 
       responseHeaders = pollHeaders;
 
@@ -384,6 +422,17 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
         });
       }
 
+      if (statusResponse.status === 'failed') {
+        const errorInfo = statusResponse.error;
+        const errorMessage = errorInfo
+          ? `${errorInfo.code ?? 'unknown'}: ${errorInfo.message ?? 'unknown error'}`
+          : 'Unknown failure';
+        throw new AISDKError({
+          name: 'XAI_VIDEO_GENERATION_ERROR',
+          message: `Video generation failed: ${errorMessage}`,
+        });
+      }
+
       // 'pending' → continue polling
     }
   }
@@ -415,6 +464,13 @@ const xaiVideoStatusResponseSchema = z.object({
       video: xaiVideoDataSchema.nullish(),
       model: z.string().nullish(),
       usage: xaiUsageSchema.nullish(),
+    })
+    .nullish(),
+  // Error details returned when status is "failed"
+  error: z
+    .object({
+      code: z.string().nullish(),
+      message: z.string().nullish(),
     })
     .nullish(),
 });

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -272,33 +272,18 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
         ? 'extensions'
         : 'generations';
 
-    const submitUrl = `${baseURL}/videos/${endpoint}`;
-
-    // DEBUG: log the submit request
-    console.error(
-      `[xai-video-debug] POST ${submitUrl}\n` +
-        `[xai-video-debug] request body: ${JSON.stringify(body, null, 2)}`,
-    );
-
     // Step 1: Create video generation/edit/extension request
-    const { value: createResponse, rawValue: createRawValue } =
-      await postJsonToApi({
-        url: submitUrl,
-        headers: combineHeaders(this.config.headers(), options.headers),
-        body,
-        failedResponseHandler: xaiFailedResponseHandler,
-        successfulResponseHandler: createJsonResponseHandler(
-          xaiCreateVideoResponseSchema,
-        ),
-        abortSignal: options.abortSignal,
-        fetch: this.config.fetch,
-      });
-
-    // DEBUG: log the raw submit response
-    console.error(
-      `[xai-video-debug] POST response (raw): ${JSON.stringify(createRawValue, null, 2)}\n` +
-        `[xai-video-debug] POST response (parsed): ${JSON.stringify(createResponse, null, 2)}`,
-    );
+    const { value: createResponse } = await postJsonToApi({
+      url: `${baseURL}/videos/${endpoint}`,
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body,
+      failedResponseHandler: xaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        xaiCreateVideoResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
 
     const requestId = createResponse.request_id;
     if (!requestId) {
@@ -313,13 +298,6 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
     const pollTimeoutMs = xaiOptions?.pollTimeoutMs ?? 600000;
     const startTime = Date.now();
     let responseHeaders: Record<string, string> | undefined;
-    const pollUrl = `${baseURL}/videos/${requestId}`;
-    let pollCount = 0;
-
-    // DEBUG: log polling config
-    console.error(
-      `[xai-video-debug] Polling ${pollUrl} every ${pollIntervalMs}ms (timeout: ${pollTimeoutMs}ms)`,
-    );
 
     while (true) {
       await delay(pollIntervalMs, { abortSignal: options.abortSignal });
@@ -331,33 +309,17 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
         });
       }
 
-      pollCount++;
-
-      const {
-        value: statusResponse,
-        rawValue: statusRawValue,
-        responseHeaders: pollHeaders,
-      } = await getFromApi({
-        url: pollUrl,
-        headers: combineHeaders(this.config.headers(), options.headers),
-        successfulResponseHandler: createJsonResponseHandler(
-          xaiVideoStatusResponseSchema,
-        ),
-        failedResponseHandler: xaiFailedResponseHandler,
-        abortSignal: options.abortSignal,
-        fetch: this.config.fetch,
-      });
-
-      const elapsedMs = Date.now() - startTime;
-
-      // DEBUG: log each poll response
-      console.error(
-        `[xai-video-debug] Poll #${pollCount} (${(elapsedMs / 1000).toFixed(1)}s elapsed) GET ${pollUrl}\n` +
-          `[xai-video-debug] Poll raw response: ${JSON.stringify(statusRawValue, null, 2)}\n` +
-          `[xai-video-debug] Poll parsed status: "${statusResponse.status}" | ` +
-          `video: ${statusResponse.video ? 'present' : 'null'} | ` +
-          `response.video: ${statusResponse.response?.video ? 'present' : 'null'}`,
-      );
+      const { value: statusResponse, responseHeaders: pollHeaders } =
+        await getFromApi({
+          url: `${baseURL}/videos/${requestId}`,
+          headers: combineHeaders(this.config.headers(), options.headers),
+          successfulResponseHandler: createJsonResponseHandler(
+            xaiVideoStatusResponseSchema,
+          ),
+          failedResponseHandler: xaiFailedResponseHandler,
+          abortSignal: options.abortSignal,
+          fetch: this.config.fetch,
+        });
 
       responseHeaders = pollHeaders;
 

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -63,6 +63,51 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
     })) as XaiVideoModelOptions | undefined;
 
     const isEdit = xaiOptions?.videoUrl != null;
+    const isExtension = xaiOptions?.extensionVideoUrl != null;
+    const isR2V =
+      xaiOptions?.referenceImages != null &&
+      xaiOptions.referenceImages.length > 0;
+
+    // Conflict validation
+    if (isEdit && isExtension) {
+      throw new AISDKError({
+        name: 'XAI_VIDEO_GENERATION_ERROR',
+        message:
+          'Cannot combine videoUrl (edit mode) with extensionVideoUrl (extension mode). Use one or the other.',
+      });
+    }
+
+    if (isR2V && options.image != null) {
+      throw new AISDKError({
+        name: 'XAI_VIDEO_GENERATION_ERROR',
+        message:
+          'Cannot combine referenceImages (R2V mode) with image (I2V mode). Use one or the other.',
+      });
+    }
+
+    if (isR2V && isEdit) {
+      throw new AISDKError({
+        name: 'XAI_VIDEO_GENERATION_ERROR',
+        message:
+          'Cannot combine referenceImages (R2V mode) with videoUrl (edit mode). Use one or the other.',
+      });
+    }
+
+    if (isR2V && isExtension) {
+      throw new AISDKError({
+        name: 'XAI_VIDEO_GENERATION_ERROR',
+        message:
+          'Cannot combine referenceImages (R2V mode) with extensionVideoUrl (extension mode). Use one or the other.',
+      });
+    }
+
+    if (isExtension && options.image != null) {
+      throw new AISDKError({
+        name: 'XAI_VIDEO_GENERATION_ERROR',
+        message:
+          'Cannot combine extensionVideoUrl (extension mode) with image (I2V mode). Use one or the other.',
+      });
+    }
 
     if (options.fps != null) {
       warnings.push({
@@ -117,22 +162,44 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
       });
     }
 
+    if (isExtension && options.aspectRatio != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'aspectRatio',
+        details: 'xAI video extension does not support custom aspect ratio.',
+      });
+    }
+
+    if (
+      isExtension &&
+      (xaiOptions?.resolution != null || options.resolution != null)
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'resolution',
+        details: 'xAI video extension does not support custom resolution.',
+      });
+    }
+
     const body: Record<string, unknown> = {
       model: this.modelId,
       prompt: options.prompt,
     };
 
+    // Duration: supported for generation, extension, and R2V — not edit
     if (!isEdit && options.duration != null) {
       body.duration = options.duration;
     }
 
-    if (!isEdit && options.aspectRatio != null) {
+    // Aspect ratio: supported for generation and R2V — not edit or extension
+    if (!isEdit && !isExtension && options.aspectRatio != null) {
       body.aspect_ratio = options.aspectRatio;
     }
 
-    if (!isEdit && xaiOptions?.resolution != null) {
+    // Resolution: supported for generation and R2V — not edit or extension
+    if (!isEdit && !isExtension && xaiOptions?.resolution != null) {
       body.resolution = xaiOptions.resolution;
-    } else if (!isEdit && options.resolution != null) {
+    } else if (!isEdit && !isExtension && options.resolution != null) {
       const mapped = RESOLUTION_MAP[options.resolution];
       if (mapped != null) {
         body.resolution = mapped;
@@ -147,9 +214,21 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
       }
     }
 
-    // Video editing: pass source video URL (nested object like image)
+    // Video editing: pass source video URL
     if (xaiOptions?.videoUrl != null) {
       body.video = { url: xaiOptions.videoUrl };
+    }
+
+    // Video extension: pass source video URL
+    if (xaiOptions?.extensionVideoUrl != null) {
+      body.video = { url: xaiOptions.extensionVideoUrl };
+    }
+
+    // Reference-to-video: pass reference images
+    if (isR2V) {
+      body.reference_images = xaiOptions!.referenceImages!.map(url => ({
+        url,
+      }));
     }
 
     // Image-to-video: convert SDK image to nested image object
@@ -175,6 +254,8 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
             'pollTimeoutMs',
             'resolution',
             'videoUrl',
+            'extensionVideoUrl',
+            'referenceImages',
           ].includes(key)
         ) {
           body[key] = value;
@@ -184,9 +265,16 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
 
     const baseURL = this.config.baseURL ?? 'https://api.x.ai/v1';
 
-    // Step 1: Create video generation/edit request
+    // Determine endpoint based on mode
+    const endpoint = isEdit
+      ? 'edits'
+      : isExtension
+        ? 'extensions'
+        : 'generations';
+
+    // Step 1: Create video generation/edit/extension request
     const { value: createResponse } = await postJsonToApi({
-      url: `${baseURL}/videos/${isEdit ? 'edits' : 'generations'}`,
+      url: `${baseURL}/videos/${endpoint}`,
       headers: combineHeaders(this.config.headers(), options.headers),
       body,
       failedResponseHandler: xaiFailedResponseHandler,
@@ -235,11 +323,16 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
 
       responseHeaders = pollHeaders;
 
+      // Extension API nests video/usage inside a `response` object;
+      // generation/edit APIs have them at the top level. Normalize here.
+      const videoData = statusResponse.video ?? statusResponse.response?.video;
+      const usageData = statusResponse.usage ?? statusResponse.response?.usage;
+
       if (
         statusResponse.status === 'done' ||
-        (statusResponse.status == null && statusResponse.video?.url)
+        (statusResponse.status == null && videoData?.url)
       ) {
-        if (statusResponse.video?.respect_moderation === false) {
+        if (videoData?.respect_moderation === false) {
           throw new AISDKError({
             name: 'XAI_VIDEO_MODERATION_ERROR',
             message:
@@ -247,7 +340,7 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
           });
         }
 
-        if (!statusResponse.video?.url) {
+        if (!videoData?.url) {
           throw new AISDKError({
             name: 'XAI_VIDEO_GENERATION_ERROR',
             message:
@@ -259,7 +352,7 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
           videos: [
             {
               type: 'url' as const,
-              url: statusResponse.video.url,
+              url: videoData.url,
               mediaType: 'video/mp4',
             },
           ],
@@ -272,12 +365,12 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
           providerMetadata: {
             xai: {
               requestId,
-              videoUrl: statusResponse.video.url,
-              ...(statusResponse.video.duration != null
-                ? { duration: statusResponse.video.duration }
+              videoUrl: videoData.url,
+              ...(videoData.duration != null
+                ? { duration: videoData.duration }
                 : {}),
-              ...(statusResponse.usage?.cost_in_usd_ticks != null
-                ? { costInUsdTicks: statusResponse.usage.cost_in_usd_ticks }
+              ...(usageData?.cost_in_usd_ticks != null
+                ? { costInUsdTicks: usageData.cost_in_usd_ticks }
                 : {}),
             },
           },
@@ -300,19 +393,28 @@ const xaiCreateVideoResponseSchema = z.object({
   request_id: z.string().nullish(),
 });
 
+const xaiVideoDataSchema = z.object({
+  url: z.string(),
+  duration: z.number().nullish(),
+  respect_moderation: z.boolean().nullish(),
+});
+
+const xaiUsageSchema = z.object({
+  cost_in_usd_ticks: z.number().nullish(),
+});
+
 const xaiVideoStatusResponseSchema = z.object({
   status: z.string().nullish(),
-  video: z
-    .object({
-      url: z.string(),
-      duration: z.number().nullish(),
-      respect_moderation: z.boolean().nullish(),
-    })
-    .nullish(),
+  // Generation/edit APIs: video and usage at top level
+  video: xaiVideoDataSchema.nullish(),
   model: z.string().nullish(),
-  usage: z
+  usage: xaiUsageSchema.nullish(),
+  // Extension API: video and usage nested under response
+  response: z
     .object({
-      cost_in_usd_ticks: z.number().nullish(),
+      video: xaiVideoDataSchema.nullish(),
+      model: z.string().nullish(),
+      usage: xaiUsageSchema.nullish(),
     })
     .nullish(),
 });

--- a/packages/xai/src/xai-video-options.ts
+++ b/packages/xai/src/xai-video-options.ts
@@ -6,6 +6,8 @@ export type XaiVideoModelOptions = {
   pollTimeoutMs?: number | null;
   resolution?: '480p' | '720p' | null;
   videoUrl?: string | null;
+  extensionVideoUrl?: string | null;
+  referenceImages?: Array<string> | null;
   [key: string]: unknown;
 };
 
@@ -17,6 +19,8 @@ export const xaiVideoModelOptionsSchema = lazySchema(() =>
         pollTimeoutMs: z.number().positive().nullish(),
         resolution: z.enum(['480p', '720p']).nullish(),
         videoUrl: z.string().nullish(),
+        extensionVideoUrl: z.string().nullish(),
+        referenceImages: z.array(z.string()).nullish(),
       })
       .passthrough(),
   ),


### PR DESCRIPTION
## Background

The xAI provider previously supported three video generation modes: text-to-video, image-to-video, and video editing. This change adds support for two additional modes to provide more comprehensive video generation capabilities.

## Changes

Added support for **video extension** and **reference-to-video (R2V)** modes to the xAI provider:

### Video Extension
- Extends existing videos by generating seamless continuations from the last frame
- Uses `/videos/extensions` endpoint with `extensionVideoUrl` parameter
- Supports duration specification but not aspect ratio or resolution (inherits from source video)
- Handles nested response format specific to extension API

### Reference-to-Video (R2V)
- Generates videos guided by reference images for style and content influence
- Uses existing `/videos/generations` endpoint with `referenceImages` parameter
- Supports multiple reference images and data URI format
- Maintains full parameter support (duration, aspect ratio, resolution)

### Additional Improvements
- Added comprehensive conflict validation between different generation modes
- Enhanced error handling for failed video generation status
- Updated documentation with detailed examples and parameter explanations
- Added capability comparison table showing all five supported modes
- Included example scripts demonstrating the new functionality

## Manual Verification

Tested both new modes with the provided example scripts:
- Video extension successfully generates continuations from source videos
- Reference-to-video generates videos influenced by single and multiple reference images
- Conflict validation properly prevents incompatible parameter combinations
- Error handling correctly surfaces API failure messages

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)