### PR TITLE
fix(ai): lazily create text/reasoning parts when resumed stream starts with delta

### DIFF
--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -226,11 +226,15 @@ describe('processUIMessageStream', () => {
   });
 
   describe('malformed stream errors', () => {
-    it('should throw descriptive error when text-delta is received without text-start', async () => {
+    it('should lazily create text part when text-delta is received without text-start', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
         { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+        { type: 'text-delta', id: 'text-1', delta: ' world' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -238,30 +242,36 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      await expect(
-        consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
         }),
-      ).rejects.toThrow(
-        'Received text-delta for missing text part with ID "text-1". ' +
-          'Ensure a "text-start" chunk is sent before any "text-delta" chunks.',
-      );
+      });
+
+      expect(state.message.parts).toEqual([
+        { type: 'step-start' },
+        {
+          type: 'text',
+          text: 'Hello world',
+          providerMetadata: undefined,
+          state: 'done',
+        },
+      ]);
     });
 
-    it('should throw descriptive error when reasoning-delta is received without reasoning-start', async () => {
+    it('should lazily create reasoning part when reasoning-delta is received without reasoning-start', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
         { type: 'reasoning-delta', id: 'reasoning-1', delta: 'Thinking...' },
+        { type: 'reasoning-delta', id: 'reasoning-1', delta: ' more' },
+        { type: 'reasoning-end', id: 'reasoning-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -269,23 +279,25 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      await expect(
-        consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
         }),
-      ).rejects.toThrow(
-        'Received reasoning-delta for missing reasoning part with ID "reasoning-1". ' +
-          'Ensure a "reasoning-start" chunk is sent before any "reasoning-delta" chunks.',
-      );
+      });
+
+      expect(state.message.parts).toEqual([
+        { type: 'step-start' },
+        {
+          type: 'reasoning',
+          text: 'Thinking... more',
+          providerMetadata: undefined,
+          state: 'done',
+        },
+      ]);
     });
 
     it('should throw descriptive error when tool-input-delta is received without tool-input-start', async () => {
@@ -323,11 +335,13 @@ describe('processUIMessageStream', () => {
       );
     });
 
-    it('should throw descriptive error when text-end is received without text-start', async () => {
+    it('should silently ignore text-end received without text-start', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
         { type: 'text-end', id: 'text-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -335,30 +349,26 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      await expect(
-        consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
         }),
-      ).rejects.toThrow(
-        'Received text-end for missing text part with ID "text-1". ' +
-          'Ensure a "text-start" chunk is sent before any "text-end" chunks.',
-      );
+      });
+
+      expect(state.message.parts).toEqual([{ type: 'step-start' }]);
     });
 
-    it('should throw descriptive error when reasoning-end is received without reasoning-start', async () => {
+    it('should silently ignore reasoning-end received without reasoning-start', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
         { type: 'reasoning-end', id: 'reasoning-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -366,30 +376,27 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      await expect(
-        consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
         }),
-      ).rejects.toThrow(
-        'Received reasoning-end for missing reasoning part with ID "reasoning-1". ' +
-          'Ensure a "reasoning-start" chunk is sent before any "reasoning-end" chunks.',
-      );
+      });
+
+      expect(state.message.parts).toEqual([{ type: 'step-start' }]);
     });
 
-    it('should throw UIMessageStreamError with correct properties for text-delta without text-start', async () => {
+    it('should lazily create text part for text-delta without text-start', async () => {
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
         { type: 'text-delta', id: 'missing-id', delta: 'Hello' },
+        { type: 'text-end', id: 'missing-id' },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -397,29 +404,25 @@ describe('processUIMessageStream', () => {
         lastMessage: undefined,
       });
 
-      let caughtError: unknown;
-      try {
-        await consumeStream({
-          stream: processUIMessageStream({
-            stream,
-            runUpdateMessageJob,
-            onError: error => {
-              throw error;
-            },
-          }),
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
           onError: error => {
             throw error;
           },
-        });
-      } catch (error) {
-        caughtError = error;
-      }
+        }),
+      });
 
-      expect(UIMessageStreamError.isInstance(caughtError)).toBe(true);
-      expect((caughtError as UIMessageStreamError).chunkType).toBe(
-        'text-delta',
-      );
-      expect((caughtError as UIMessageStreamError).chunkId).toBe('missing-id');
+      expect(state.message.parts).toEqual([
+        { type: 'step-start' },
+        {
+          type: 'text',
+          text: 'Hello',
+          providerMetadata: undefined,
+          state: 'done',
+        },
+      ]);
     });
 
     it('should throw UIMessageStreamError with correct properties for tool-input-delta without tool-input-start', async () => {
@@ -8683,6 +8686,118 @@ describe('processUIMessageStream', () => {
             },
           },
         },
+      ]);
+    });
+  });
+
+  describe('stream resume – text-delta without prior text-start (#13160)', () => {
+    it('should lazily create a text part and append deltas when resumed stream starts with text-delta', async () => {
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-resume' },
+        { type: 'start-step' },
+        // Resumed stream begins mid-text — no text-start was sent
+        { type: 'text-delta', id: 'part-A', delta: ' and loved well' },
+        { type: 'text-delta', id: 'part-A', delta: ', and that' },
+        { type: 'text-delta', id: 'part-A', delta: ' thou depar' },
+        { type: 'text-end', id: 'part-A' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-resume',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+
+      expect(state.message.parts).toEqual([
+        { type: 'step-start' },
+        {
+          type: 'text',
+          text: ' and loved well, and that thou depar',
+          providerMetadata: undefined,
+          state: 'done',
+        },
+      ]);
+    });
+
+    it('should lazily create a reasoning part when resumed stream starts with reasoning-delta', async () => {
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-resume' },
+        { type: 'start-step' },
+        { type: 'reasoning-delta', id: 'r-1', delta: 'continued reasoning' },
+        { type: 'reasoning-end', id: 'r-1' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-resume',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+
+      expect(state.message.parts).toEqual([
+        { type: 'step-start' },
+        {
+          type: 'reasoning',
+          text: 'continued reasoning',
+          providerMetadata: undefined,
+          state: 'done',
+        },
+      ]);
+    });
+
+    it('should handle orphaned text-end gracefully on resume', async () => {
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-resume' },
+        { type: 'start-step' },
+        // The text-start and all deltas were sent before the disconnect;
+        // the resumed stream only contains the closing text-end.
+        { type: 'text-end', id: 'old-part' },
+        { type: 'text-start', id: 'new-part' },
+        { type: 'text-delta', id: 'new-part', delta: 'Fresh text' },
+        { type: 'text-end', id: 'new-part' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-resume',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+
+      expect(state.message.parts).toEqual([
+        { type: 'step-start' },
+        { type: 'text', text: 'Fresh text', state: 'done' },
       ]);
     });
   });

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -365,16 +365,22 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'text-delta': {
-              const textPart = state.activeTextParts[chunk.id];
+              let textPart = state.activeTextParts[chunk.id];
+
+              // On resume, the text-start may have been sent before the
+              // disconnect so activeTextParts won't contain the entry.
+              // Lazily create the part so the stream can continue.
               if (textPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'text-delta',
-                  chunkId: chunk.id,
-                  message:
-                    `Received text-delta for missing text part with ID "${chunk.id}". ` +
-                    `Ensure a "text-start" chunk is sent before any "text-delta" chunks.`,
-                });
+                textPart = {
+                  type: 'text',
+                  text: '',
+                  providerMetadata: undefined,
+                  state: 'streaming',
+                };
+                state.activeTextParts[chunk.id] = textPart;
+                state.message.parts.push(textPart);
               }
+
               textPart.text += chunk.delta;
               textPart.providerMetadata =
                 chunk.providerMetadata ?? textPart.providerMetadata;
@@ -384,15 +390,13 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
 
             case 'text-end': {
               const textPart = state.activeTextParts[chunk.id];
+
+              // On resume the text-start may have been sent before the
+              // disconnect – silently ignore the orphaned end.
               if (textPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'text-end',
-                  chunkId: chunk.id,
-                  message:
-                    `Received text-end for missing text part with ID "${chunk.id}". ` +
-                    `Ensure a "text-start" chunk is sent before any "text-end" chunks.`,
-                });
+                break;
               }
+
               textPart.state = 'done';
               textPart.providerMetadata =
                 chunk.providerMetadata ?? textPart.providerMetadata;
@@ -426,16 +430,21 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'reasoning-delta': {
-              const reasoningPart = state.activeReasoningParts[chunk.id];
+              let reasoningPart = state.activeReasoningParts[chunk.id];
+
+              // On resume, the reasoning-start may have been sent before
+              // the disconnect. Lazily create the part.
               if (reasoningPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'reasoning-delta',
-                  chunkId: chunk.id,
-                  message:
-                    `Received reasoning-delta for missing reasoning part with ID "${chunk.id}". ` +
-                    `Ensure a "reasoning-start" chunk is sent before any "reasoning-delta" chunks.`,
-                });
+                reasoningPart = {
+                  type: 'reasoning',
+                  text: '',
+                  providerMetadata: undefined,
+                  state: 'streaming',
+                };
+                state.activeReasoningParts[chunk.id] = reasoningPart;
+                state.message.parts.push(reasoningPart);
               }
+
               reasoningPart.text += chunk.delta;
               reasoningPart.providerMetadata =
                 chunk.providerMetadata ?? reasoningPart.providerMetadata;
@@ -445,15 +454,13 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
 
             case 'reasoning-end': {
               const reasoningPart = state.activeReasoningParts[chunk.id];
+
+              // On resume the reasoning-start may have been sent before
+              // the disconnect – silently ignore the orphaned end.
               if (reasoningPart == null) {
-                throw new UIMessageStreamError({
-                  chunkType: 'reasoning-end',
-                  chunkId: chunk.id,
-                  message:
-                    `Received reasoning-end for missing reasoning part with ID "${chunk.id}". ` +
-                    `Ensure a "reasoning-start" chunk is sent before any "reasoning-end" chunks.`,
-                });
+                break;
               }
+
               reasoningPart.providerMetadata =
                 chunk.providerMetadata ?? reasoningPart.providerMetadata;
               reasoningPart.state = 'done';


### PR DESCRIPTION
## Summary

Fixes #13160

When `useChat({ resume: true })` reconnects, the resumed SSE stream may begin with a `text-delta` (or `reasoning-delta`) whose matching `text-start` was sent before the disconnect. Because `createStreamingUIMessageState` initializes `activeTextParts` / `activeReasoningParts` as empty maps, the lookup fails and throws a `UIMessageStreamError`, sending the app into a reconnect loop.

## Changes

**`packages/ai/src/ui/process-ui-message-stream.ts`**

- **`text-delta`**: instead of throwing when the active part is missing, lazily create a new `TextUIPart` and register it in `activeTextParts`, then continue appending.
- **`text-end`**: silently ignore orphaned end chunks (the part was already \ended\ implicitly on disconnect).
- **`reasoning-delta`**: same lazy-creation strategy as `text-delta`.
- **`reasoning-end`**: same silent-ignore strategy as `text-end`.

**`packages/ai/src/ui/process-ui-message-stream.test.ts`**

- Updated existing error-expectation tests to reflect the new tolerant behavior.
- Added a dedicated `stream resume` describe block with three scenarios:
  - Resumed text-delta without prior text-start
  - Resumed reasoning-delta without prior reasoning-start
  - Orphaned text-end followed by a fresh text part

## How to verify

All 90 tests in `process-ui-message-stream.test.ts` pass.

> ⚠️ This reopens #13238 which was accidentally closed due to fork deletion.