### PR TITLE
fix(anthropic): skip empty/null compaction blocks to prevent re-send rejection

### DIFF
--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -605,7 +605,7 @@ export const anthropicMessagesResponseSchema = lazySchema(() =>
           }),
           z.object({
             type: z.literal('compaction'),
-            content: z.string(),
+            content: z.string().nullish(),
           }),
           z.object({
             type: z.literal('tool_use'),

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -5546,6 +5546,58 @@ describe('AnthropicMessagesLanguageModel', () => {
           raw: 'compaction',
         });
       });
+
+      it('should skip compaction blocks with empty content', async () => {
+        server.urls['https://api.anthropic.com/v1/messages'].response = {
+          type: 'json-value',
+          body: {
+            id: 'msg_123',
+            type: 'message',
+            role: 'assistant',
+            content: [
+              { type: 'compaction', content: '' },
+              { type: 'text', text: 'Hello' },
+            ],
+            model: 'claude-3-haiku-20240307',
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            usage: { input_tokens: 100, output_tokens: 50 },
+          },
+        };
+
+        const result = await model.doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        // Empty compaction block should be skipped, only text part remains
+        expect(result.content).toEqual([{ type: 'text', text: 'Hello' }]);
+      });
+
+      it('should skip compaction blocks with null content', async () => {
+        server.urls['https://api.anthropic.com/v1/messages'].response = {
+          type: 'json-value',
+          body: {
+            id: 'msg_123',
+            type: 'message',
+            role: 'assistant',
+            content: [
+              { type: 'compaction', content: null },
+              { type: 'text', text: 'World' },
+            ],
+            model: 'claude-3-haiku-20240307',
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            usage: { input_tokens: 100, output_tokens: 50 },
+          },
+        };
+
+        const result = await model.doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        // Null compaction block should be skipped, only text part remains
+        expect(result.content).toEqual([{ type: 'text', text: 'World' }]);
+      });
     });
   });
 

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -888,6 +888,12 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
           break;
         }
         case 'compaction': {
+          // Skip compaction blocks with empty/null content — they carry
+          // no information and would be rejected by the API on re-send
+          // (the request schema requires non-empty content).
+          if (!part.content) {
+            break;
+          }
           content.push({
             type: 'text',
             text: part.content,

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -3336,3 +3336,78 @@ describe('citations', () => {
     });
   });
 });
+
+describe('compaction', () => {
+  it('should skip compaction blocks with empty content', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: '',
+              providerOptions: {
+                anthropic: { type: 'compaction' },
+              },
+            },
+            {
+              type: 'text',
+              text: 'Hello',
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hi' }],
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    // Empty compaction block should be filtered out
+    expect(result.prompt.messages[0]!.content).toEqual([
+      {
+        type: 'text',
+        text: 'Hello',
+        cache_control: undefined,
+      },
+    ]);
+  });
+
+  it('should include compaction blocks with non-empty content', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'Summary of conversation...',
+              providerOptions: {
+                anthropic: { type: 'compaction' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hi' }],
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    expect(result.prompt.messages[0]!.content).toEqual([
+      {
+        type: 'compaction',
+        content: 'Summary of conversation...',
+        cache_control: undefined,
+      },
+    ]);
+  });
+});

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -486,11 +486,15 @@ export async function convertToAnthropicMessagesPrompt({
                   | undefined;
 
                 if (textMetadata?.type === 'compaction') {
-                  anthropicContent.push({
-                    type: 'compaction',
-                    content: part.text,
-                    cache_control: cacheControl,
-                  });
+                  // Skip compaction blocks with empty content — the API
+                  // rejects them with "content can't be empty".
+                  if (part.text) {
+                    anthropicContent.push({
+                      type: 'compaction',
+                      content: part.text,
+                      cache_control: cacheControl,
+                    });
+                  }
                 } else {
                   anthropicContent.push({
                     type: 'text',


### PR DESCRIPTION
## Problem

When Anthropic's compaction API returns a compaction block with empty or `null` content, the SDK persists it faithfully (the response schema allows it). However, when the message is re-sent on the next turn, the request schema requires non-empty content, causing the API to reject:

```
messages.67.content.0.compaction.content: content can't be empty
```

This is a **schema asymmetry** between response and request handling.

## Root Cause

1. **Response schema** (`anthropic-messages-api.ts`): The non-streaming compaction content block schema used `z.string()` which rejects `null` from the API. The streaming schema already had `z.string().nullish()`.
2. **Response parsing** (`doGenerate`): Empty/null compaction content was converted to a text part with `text: ''` and persisted.
3. **Request building** (`convert-to-anthropic-messages-prompt.ts`): Text parts with `anthropic.type === 'compaction'` were sent back as `{ type: 'compaction', content: '' }`, which the API rejects.

## Fix

Three-layer defense:

1. **Schema**: Update non-streaming response content schema to `z.string().nullish()` (matching the streaming schema) so null content doesn't cause a parse error.
2. **Response parsing**: Skip compaction blocks with falsy content in `doGenerate` — they carry no information.
3. **Request building**: Filter out compaction blocks with empty text before sending to the API.

## Tests

Added 4 new tests (all pass, 327/327 total):
- `should skip compaction blocks with empty content` (doGenerate)
- `should skip compaction blocks with null content` (doGenerate)
- `should skip compaction blocks with empty content` (request builder)
- `should include compaction blocks with non-empty content` (request builder)

Closes #13335

> ⚠️ This reopens #13382 which was accidentally closed due to fork deletion.