### PR TITLE
fix(openai): deduplicate tool call items in Responses API input

### DIFF
--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -4634,4 +4634,163 @@ describe('convertToOpenAIResponsesInput', () => {
       `);
     });
   });
+
+  describe('duplicate item deduplication', () => {
+    it('should deduplicate function_call items with the same toolCallId across messages', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallType: 'function',
+                toolCallId: 'fc_duplicate_123',
+                toolName: 'get_weather',
+                input: { city: 'NYC' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallType: 'function',
+                toolCallId: 'fc_duplicate_123',
+                toolName: 'get_weather',
+                output: { type: 'text', value: 'Sunny' },
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallType: 'function',
+                toolCallId: 'fc_duplicate_123',
+                toolName: 'get_weather',
+                input: { city: 'NYC' },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        toolNameMapping: testToolNameMapping,
+        providerOptionsName: 'openai',
+        store: false,
+      });
+
+      const functionCalls = result.input.filter(
+        (item: any) =>
+          item.type === 'function_call' && item.call_id === 'fc_duplicate_123',
+      );
+      expect(functionCalls).toHaveLength(1);
+    });
+
+    it('should deduplicate item_reference entries with the same id when store is true', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallType: 'function',
+                toolCallId: 'fc_stored_456',
+                toolName: 'search',
+                input: { q: 'test' },
+                providerOptions: {
+                  openai: { itemId: 'item_abc' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallType: 'function',
+                toolCallId: 'fc_stored_456',
+                toolName: 'search',
+                output: { type: 'text', value: 'results' },
+                providerOptions: {
+                  openai: { itemId: 'item_def' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallType: 'function',
+                toolCallId: 'fc_stored_456',
+                toolName: 'search',
+                input: { q: 'test' },
+                providerOptions: {
+                  openai: { itemId: 'item_abc' },
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        toolNameMapping: testToolNameMapping,
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      const itemRefs = result.input.filter(
+        (item: any) => item.type === 'item_reference' && item.id === 'item_abc',
+      );
+      expect(itemRefs).toHaveLength(1);
+    });
+
+    it('should deduplicate custom_tool_call items with the same toolCallId', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallType: 'function',
+                toolCallId: 'call_custom_dup',
+                toolName: 'my_tool',
+                input: { data: 'test' },
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallType: 'function',
+                toolCallId: 'call_custom_dup',
+                toolName: 'my_tool',
+                input: { data: 'test' },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        toolNameMapping: testToolNameMapping,
+        providerOptionsName: 'openai',
+        store: false,
+        customProviderToolNames: new Set(['my_tool']),
+      });
+
+      const customCalls = result.input.filter(
+        (item: any) =>
+          item.type === 'custom_tool_call' &&
+          item.call_id === 'call_custom_dup',
+      );
+      expect(customCalls).toHaveLength(1);
+    });
+  });
 });

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -4644,7 +4644,6 @@ describe('convertToOpenAIResponsesInput', () => {
             content: [
               {
                 type: 'tool-call',
-                toolCallType: 'function',
                 toolCallId: 'fc_duplicate_123',
                 toolName: 'get_weather',
                 input: { city: 'NYC' },
@@ -4656,7 +4655,6 @@ describe('convertToOpenAIResponsesInput', () => {
             content: [
               {
                 type: 'tool-result',
-                toolCallType: 'function',
                 toolCallId: 'fc_duplicate_123',
                 toolName: 'get_weather',
                 output: { type: 'text', value: 'Sunny' },
@@ -4668,7 +4666,6 @@ describe('convertToOpenAIResponsesInput', () => {
             content: [
               {
                 type: 'tool-call',
-                toolCallType: 'function',
                 toolCallId: 'fc_duplicate_123',
                 toolName: 'get_weather',
                 input: { city: 'NYC' },
@@ -4697,7 +4694,6 @@ describe('convertToOpenAIResponsesInput', () => {
             content: [
               {
                 type: 'tool-call',
-                toolCallType: 'function',
                 toolCallId: 'fc_stored_456',
                 toolName: 'search',
                 input: { q: 'test' },
@@ -4712,7 +4708,6 @@ describe('convertToOpenAIResponsesInput', () => {
             content: [
               {
                 type: 'tool-result',
-                toolCallType: 'function',
                 toolCallId: 'fc_stored_456',
                 toolName: 'search',
                 output: { type: 'text', value: 'results' },
@@ -4727,7 +4722,6 @@ describe('convertToOpenAIResponsesInput', () => {
             content: [
               {
                 type: 'tool-call',
-                toolCallType: 'function',
                 toolCallId: 'fc_stored_456',
                 toolName: 'search',
                 input: { q: 'test' },
@@ -4758,7 +4752,6 @@ describe('convertToOpenAIResponsesInput', () => {
             content: [
               {
                 type: 'tool-call',
-                toolCallType: 'function',
                 toolCallId: 'call_custom_dup',
                 toolName: 'my_tool',
                 input: { data: 'test' },
@@ -4770,7 +4763,6 @@ describe('convertToOpenAIResponsesInput', () => {
             content: [
               {
                 type: 'tool-call',
-                toolCallType: 'function',
                 toolCallId: 'call_custom_dup',
                 toolName: 'my_tool',
                 input: { data: 'test' },

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -79,6 +79,7 @@ export async function convertToOpenAIResponsesInput({
   let input: OpenAIResponsesInput = [];
   const warnings: Array<SharedV4Warning> = [];
   const processedApprovalIds = new Set<string>();
+  const processedItemIds = new Set<string>();
 
   for (const { role, content } of prompt) {
     switch (role) {
@@ -210,7 +211,10 @@ export async function convertToOpenAIResponsesInput({
 
               // item references reduce the payload size
               if (store && id != null) {
-                input.push({ type: 'item_reference', id });
+                if (!processedItemIds.has(id)) {
+                  processedItemIds.add(id);
+                  input.push({ type: 'item_reference', id });
+                }
                 break;
               }
 
@@ -276,13 +280,19 @@ export async function convertToOpenAIResponsesInput({
 
               if (part.providerExecuted) {
                 if (store && id != null) {
-                  input.push({ type: 'item_reference', id });
+                  if (!processedItemIds.has(id)) {
+                    processedItemIds.add(id);
+                    input.push({ type: 'item_reference', id });
+                  }
                 }
                 break;
               }
 
               if (store && id != null) {
-                input.push({ type: 'item_reference', id });
+                if (!processedItemIds.has(id)) {
+                  processedItemIds.add(id);
+                  input.push({ type: 'item_reference', id });
+                }
                 break;
               }
 
@@ -345,26 +355,32 @@ export async function convertToOpenAIResponsesInput({
               }
 
               if (customProviderToolNames?.has(resolvedToolName)) {
-                input.push({
-                  type: 'custom_tool_call',
-                  call_id: part.toolCallId,
-                  name: resolvedToolName,
-                  input:
-                    typeof part.input === 'string'
-                      ? part.input
-                      : JSON.stringify(part.input),
-                  id,
-                });
+                if (!processedItemIds.has(part.toolCallId)) {
+                  processedItemIds.add(part.toolCallId);
+                  input.push({
+                    type: 'custom_tool_call',
+                    call_id: part.toolCallId,
+                    name: resolvedToolName,
+                    input:
+                      typeof part.input === 'string'
+                        ? part.input
+                        : JSON.stringify(part.input),
+                    id,
+                  });
+                }
                 break;
               }
 
-              input.push({
-                type: 'function_call',
-                call_id: part.toolCallId,
-                name: resolvedToolName,
-                arguments: JSON.stringify(part.input),
-                id,
-              });
+              if (!processedItemIds.has(part.toolCallId)) {
+                processedItemIds.add(part.toolCallId);
+                input.push({
+                  type: 'function_call',
+                  call_id: part.toolCallId,
+                  name: resolvedToolName,
+                  arguments: JSON.stringify(part.input),
+                  id,
+                });
+              }
               break;
             }
 
@@ -460,7 +476,10 @@ export async function convertToOpenAIResponsesInput({
                       | { itemId?: string }
                       | undefined
                   )?.itemId ?? part.toolCallId;
-                input.push({ type: 'item_reference', id: itemId });
+                if (!processedItemIds.has(itemId)) {
+                  processedItemIds.add(itemId);
+                  input.push({ type: 'item_reference', id: itemId });
+                }
               } else {
                 warnings.push({
                   type: 'other',
@@ -619,10 +638,13 @@ export async function convertToOpenAIResponsesInput({
             processedApprovalIds.add(approvalResponse.approvalId);
 
             if (store) {
-              input.push({
-                type: 'item_reference',
-                id: approvalResponse.approvalId,
-              });
+              if (!processedItemIds.has(approvalResponse.approvalId)) {
+                processedItemIds.add(approvalResponse.approvalId);
+                input.push({
+                  type: 'item_reference',
+                  id: approvalResponse.approvalId,
+                });
+              }
             }
 
             input.push({

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -155,7 +155,9 @@ export async function convertToOpenAIResponsesInput({
                           isFileId(part.data, fileIdPrefixes)
                         ? { file_id: part.data }
                         : {
-                            image_url: `data:${mediaType};base64,${convertToBase64(part.data)}`,
+                            image_url: `data:${mediaType};base64,${convertToBase64(
+                              part.data,
+                            )}`,
                           }),
                     detail:
                       part.providerOptions?.[providerOptionsName]?.imageDetail,
@@ -174,7 +176,9 @@ export async function convertToOpenAIResponsesInput({
                       ? { file_id: part.data }
                       : {
                           filename: part.filename ?? `part-${index}.pdf`,
-                          file_data: `data:application/pdf;base64,${convertToBase64(part.data)}`,
+                          file_data: `data:application/pdf;base64,${convertToBase64(
+                            part.data,
+                          )}`,
                         }),
                   };
                 } else {
@@ -533,7 +537,9 @@ export async function convertToOpenAIResponsesInput({
                   } else if (reasoningMessage !== undefined) {
                     warnings.push({
                       type: 'other',
-                      message: `Cannot append empty reasoning part to existing reasoning sequence. Skipping reasoning part: ${JSON.stringify(part)}.`,
+                      message: `Cannot append empty reasoning part to existing reasoning sequence. Skipping reasoning part: ${JSON.stringify(
+                        part,
+                      )}.`,
                     });
                   }
 
@@ -584,7 +590,9 @@ export async function convertToOpenAIResponsesInput({
                 } else {
                   warnings.push({
                     type: 'other',
-                    message: `Non-OpenAI reasoning parts are not supported. Skipping reasoning part: ${JSON.stringify(part)}.`,
+                    message: `Non-OpenAI reasoning parts are not supported. Skipping reasoning part: ${JSON.stringify(
+                      part,
+                    )}.`,
                   });
                 }
               }


### PR DESCRIPTION
## Summary

Fixes #13307

When using HITL tools (`needsApproval: true`) with the OpenAI Responses API, the same `toolCallId` can appear across multiple messages in the prompt history — in the tool-call request, the approval response, and the tool output. When these messages are persisted and rehydrated into the next request, `convertToOpenAIResponsesInput` pushes duplicate items (e.g. multiple `function_call` or `item_reference` entries with the same `call_id`/`id`), causing the Responses API to reject with:

```
Error [AI_APICallError]: Duplicate item found with id fc_****
```

## Changes

Added a `processedItemIds` set (similar to the existing `processedApprovalIds`) that tracks all pushed item identifiers across:

- `function_call` items (by `call_id`)
- `custom_tool_call` items (by `call_id`)
- `item_reference` items (by `id`) — for both text parts, tool-call parts, and tool-result parts
- `mcp_approval_response` item references (by approval ID)

When a duplicate identifier is encountered, the item is silently skipped, preventing the API rejection while preserving the correct conversation semantics (only the first occurrence matters since items are immutable in the Responses API).

## Tests

Added 3 new test cases covering:
1. Duplicate `function_call` deduplication (same `toolCallId` across messages, `store: false`)
2. Duplicate `item_reference` deduplication (same `itemId` across messages, `store: true`)
3. Duplicate `custom_tool_call` deduplication

All 85 tests in the convert-to-openai-responses-input test suite pass.

> ⚠️ This reopens #13383 which was accidentally closed due to fork deletion.