### PR TITLE
fix(ai): sanitize output-error tool inputs

### DIFF
--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -721,6 +721,130 @@ describe('convertToModelMessages', () => {
       `);
       });
 
+      it('should parse raw input strings into object tool-call input', async () => {
+        const result = await convertToModelMessages([
+          {
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'text',
+                text: 'Let me calculate that for you.',
+                state: 'done',
+              },
+              {
+                type: 'tool-calculator',
+                state: 'output-error',
+                toolCallId: 'call1',
+                errorText: 'Error: Invalid input',
+                input: undefined,
+                rawInput: '{"operation":"add","numbers":[1,2]}',
+              },
+            ],
+          },
+        ]);
+
+        expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Let me calculate that for you.",
+                "type": "text",
+              },
+              {
+                "input": {
+                  "numbers": [
+                    1,
+                    2,
+                  ],
+                  "operation": "add",
+                },
+                "providerExecuted": undefined,
+                "toolCallId": "call1",
+                "toolName": "calculator",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "error-text",
+                  "value": "Error: Invalid input",
+                },
+                "toolCallId": "call1",
+                "toolName": "calculator",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ]
+      `);
+      });
+
+      it('should fall back to an empty object for invalid raw input strings', async () => {
+        const result = await convertToModelMessages([
+          {
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'text',
+                text: 'Let me calculate that for you.',
+                state: 'done',
+              },
+              {
+                type: 'tool-calculator',
+                state: 'output-error',
+                toolCallId: 'call1',
+                errorText: 'Error: Invalid input',
+                input: undefined,
+                rawInput: '{"operation":"add"',
+              },
+            ],
+          },
+        ]);
+
+        expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Let me calculate that for you.",
+                "type": "text",
+              },
+              {
+                "input": {},
+                "providerExecuted": undefined,
+                "toolCallId": "call1",
+                "toolName": "calculator",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "error-text",
+                  "value": "Error: Invalid input",
+                },
+                "toolCallId": "call1",
+                "toolName": "calculator",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ]
+      `);
+      });
+
       it('should handle assistant message with tool output error that has no raw input', async () => {
         const result = await convertToModelMessages([
           {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -1,9 +1,11 @@
+import { isJSONObject } from '@ai-sdk/provider';
 import {
   AssistantContent,
   CustomPart,
   FilePart,
   isNonNullable,
   ModelMessage,
+  safeParseJSON,
   TextPart,
   ToolApprovalResponse,
   ToolResultPart,
@@ -32,6 +34,32 @@ import {
   ToolUIPart,
   UIMessage,
 } from './ui-messages';
+
+async function resolveToolInput(
+  part: ToolUIPart | DynamicToolUIPart,
+): Promise<unknown> {
+  if (part.input !== undefined) {
+    return part.input;
+  }
+
+  if (!('rawInput' in part)) {
+    return {};
+  }
+
+  if (isJSONObject(part.rawInput)) {
+    return part.rawInput;
+  }
+
+  if (typeof part.rawInput === 'string') {
+    const parsedRawInput = await safeParseJSON({ text: part.rawInput });
+
+    if (parsedRawInput.success && isJSONObject(parsedRawInput.value)) {
+      return parsedRawInput.value;
+    }
+  }
+
+  return {};
+}
 
 /**
  * Converts an array of UI messages from useChat into an array of ModelMessages that can be used
@@ -198,15 +226,16 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                 const toolName = getToolName(part);
 
                 if (part.state !== 'input-streaming') {
+                  const input =
+                    part.state === 'output-error'
+                      ? await resolveToolInput(part)
+                      : part.input;
+
                   content.push({
                     type: 'tool-call' as const,
                     toolCallId: part.toolCallId,
                     toolName,
-                    input:
-                      part.state === 'output-error'
-                        ? (part.input ??
-                          ('rawInput' in part ? part.rawInput : undefined))
-                        : part.input,
+                    input,
                     providerExecuted: part.providerExecuted,
                     ...(part.callProviderMetadata != null
                       ? { providerOptions: part.callProviderMetadata }


### PR DESCRIPTION
## Summary
- sanitize `output-error` tool-call inputs before converting UI messages to model messages
- parse JSON-string `rawInput` values into objects when possible
- fall back to `{}` for invalid string payloads so Anthropic retries do not receive a raw string in `tool_use.input`

## Testing
- `pnpm --dir packages/ai type-check`
- `pnpm --dir packages/anthropic type-check`
- `pnpm --dir packages/ai exec vitest --config vitest.node.config.js --run src/ui/convert-to-model-messages.test.ts`
- `pnpm --dir packages/anthropic exec vitest --config vitest.node.config.js --run src/convert-to-anthropic-messages-prompt.test.ts`
- `pnpm exec ultracite check packages/ai/src/ui/convert-to-model-messages.ts packages/ai/src/ui/convert-to-model-messages.test.ts`
- temporary proof test on this branch: invalid `rawInput` string becomes `{}` in both `convertToModelMessages` output and Anthropic `tool_use.input`
- temporary proof test on `origin/main`: the same invalid `rawInput` string is still forwarded as a raw string in both places

Closes #13645.


> ⚠️ This reopens #13752 which was accidentally closed due to fork deletion.