### PR TITLE
feat: add @ai-sdk/phota provider

### DIFF
--- a/.changeset/add-phota-provider.md
+++ b/.changeset/add-phota-provider.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/phota": major
+---
+
+feat: add @ai-sdk/phota provider for Phota Labs image API

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -36,6 +36,7 @@
     "@ai-sdk/openai": "workspace:*",
     "@ai-sdk/openai-compatible": "workspace:*",
     "@ai-sdk/perplexity": "workspace:*",
+    "@ai-sdk/phota": "workspace:*",
     "@ai-sdk/prodia": "workspace:*",
     "@ai-sdk/provider": "workspace:*",
     "@ai-sdk/replicate": "workspace:*",

--- a/examples/ai-functions/src/generate-image/phota/basic.ts
+++ b/examples/ai-functions/src/generate-image/phota/basic.ts
@@ -1,0 +1,23 @@
+import { PhotaImageModelOptions, phota } from '@ai-sdk/phota';
+import { generateImage } from 'ai';
+import { presentImages } from '../../lib/present-image';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { images, providerMetadata } = await generateImage({
+    model: phota.image('generate'),
+    prompt:
+      'A cat wearing an intricate robe while gesticulating wildly, in the style of 80s pop art',
+    aspectRatio: '1:1',
+    providerOptions: {
+      phota: {
+        proMode: true,
+        resolution: '4K',
+      } satisfies PhotaImageModelOptions,
+    },
+  });
+
+  await presentImages(images);
+
+  console.log('providerMetadata', JSON.stringify(providerMetadata, null, 2));
+});

--- a/examples/ai-functions/src/generate-image/phota/edit.ts
+++ b/examples/ai-functions/src/generate-image/phota/edit.ts
@@ -1,0 +1,22 @@
+import { PhotaImageModelOptions, phota } from '@ai-sdk/phota';
+import { generateImage } from 'ai';
+import { presentImages } from '../../lib/present-image';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { images } = await generateImage({
+    model: phota.image('edit'),
+    prompt: {
+      text: 'Make the sun shine through the trees',
+      images: ['https://avatars.githubusercontent.com/in/1765080'],
+    },
+    providerOptions: {
+      phota: {
+        proMode: true,
+      } satisfies PhotaImageModelOptions,
+    },
+  });
+
+  console.log('OUTPUT IMAGE:');
+  await presentImages(images);
+});

--- a/examples/ai-functions/src/generate-image/phota/edit.ts
+++ b/examples/ai-functions/src/generate-image/phota/edit.ts
@@ -7,8 +7,8 @@ run(async () => {
   const { images } = await generateImage({
     model: phota.image('edit'),
     prompt: {
-      text: 'Make the sun shine through the trees',
-      images: ['https://avatars.githubusercontent.com/in/1765080'],
+      text: 'Add a sunset sky in the background',
+      images: ['https://picsum.photos/id/16/512/512'],
     },
     providerOptions: {
       phota: {

--- a/examples/ai-functions/src/generate-image/phota/enhance.ts
+++ b/examples/ai-functions/src/generate-image/phota/enhance.ts
@@ -1,0 +1,18 @@
+import { phota } from '@ai-sdk/phota';
+import { generateImage } from 'ai';
+import { presentImages } from '../../lib/present-image';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { images, providerMetadata } = await generateImage({
+    model: phota.image('enhance'),
+    prompt: {
+      images: ['https://avatars.githubusercontent.com/in/1765080'],
+    },
+  });
+
+  console.log('ENHANCED IMAGE:');
+  await presentImages(images);
+
+  console.log('providerMetadata', JSON.stringify(providerMetadata, null, 2));
+});

--- a/examples/ai-functions/src/generate-image/phota/train.ts
+++ b/examples/ai-functions/src/generate-image/phota/train.ts
@@ -1,4 +1,8 @@
-import { phota } from '@ai-sdk/phota';
+import {
+  getPhotaStatusResult,
+  getPhotaTrainResult,
+  phota,
+} from '@ai-sdk/phota';
 import { generateImage } from 'ai';
 import { run } from '../../lib/run';
 
@@ -16,10 +20,7 @@ run(async () => {
     },
   });
 
-  const photaTrainMeta = trainResult.providerMetadata!.phota as {
-    profileId: string;
-  };
-  const profileId = photaTrainMeta.profileId;
+  const { profileId } = getPhotaTrainResult(trainResult.providerMetadata);
   console.log('Profile created:', profileId);
 
   // Step 2: Poll training status
@@ -29,10 +30,7 @@ run(async () => {
     providerOptions: { phota: { profileId } },
   });
 
-  const photaStatusMeta = statusResult.providerMetadata!.phota as {
-    status: string;
-  };
-  const status = photaStatusMeta.status;
+  const { status } = getPhotaStatusResult(statusResult.providerMetadata);
   console.log('Training status:', status);
 
   // Step 3: Once READY, generate images using the profile

--- a/examples/ai-functions/src/generate-image/phota/train.ts
+++ b/examples/ai-functions/src/generate-image/phota/train.ts
@@ -11,10 +11,12 @@ run(async () => {
   const trainResult = await generateImage({
     model: phota.image('train'),
     prompt: {
-      images: Array.from(
-        { length: 30 },
-        (_, i) => `https://picsum.photos/id/${i + 10}/512/512`,
-      ),
+      images: [
+        'https://example.com/photo1.jpg',
+        'https://example.com/photo2.jpg',
+        'https://example.com/photo3.jpg',
+        // Phota requires 30-100 publicly accessible image URLs
+      ],
     },
   });
 

--- a/examples/ai-functions/src/generate-image/phota/train.ts
+++ b/examples/ai-functions/src/generate-image/phota/train.ts
@@ -1,0 +1,47 @@
+import { phota } from '@ai-sdk/phota';
+import { generateImage } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  // Step 1: Train a profile from reference images (returns immediately)
+  const trainResult = await generateImage({
+    model: phota.image('train'),
+    prompt: {
+      images: [
+        'https://example.com/photo1.jpg',
+        'https://example.com/photo2.jpg',
+        'https://example.com/photo3.jpg',
+        // Phota requires 30-100 publicly accessible image URLs
+      ],
+    },
+  });
+
+  const photaTrainMeta = trainResult.providerMetadata!.phota as {
+    profileId: string;
+  };
+  const profileId = photaTrainMeta.profileId;
+  console.log('Profile created:', profileId);
+
+  // Step 2: Poll training status
+  const statusResult = await generateImage({
+    model: phota.image('status'),
+    prompt: '',
+    providerOptions: { phota: { profileId } },
+  });
+
+  const photaStatusMeta = statusResult.providerMetadata!.phota as {
+    status: string;
+  };
+  const status = photaStatusMeta.status;
+  console.log('Training status:', status);
+
+  // Step 3: Once READY, generate images using the profile
+  if (status === 'READY') {
+    const { images } = await generateImage({
+      model: phota.image('generate'),
+      prompt: `A photo of [[${profileId}]] at a dinner party`,
+    });
+
+    console.log('Generated', images.length, 'image(s) with profile');
+  }
+});

--- a/examples/ai-functions/src/generate-image/phota/train.ts
+++ b/examples/ai-functions/src/generate-image/phota/train.ts
@@ -11,12 +11,10 @@ run(async () => {
   const trainResult = await generateImage({
     model: phota.image('train'),
     prompt: {
-      images: [
-        'https://example.com/photo1.jpg',
-        'https://example.com/photo2.jpg',
-        'https://example.com/photo3.jpg',
-        // Phota requires 30-100 publicly accessible image URLs
-      ],
+      images: Array.from(
+        { length: 30 },
+        (_, i) => `https://picsum.photos/id/${i + 10}/512/512`,
+      ),
     },
   });
 

--- a/packages/phota/package.json
+++ b/packages/phota/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@ai-sdk/phota",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist *.tsbuildinfo",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:update": "pnpm test:node -u",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@ai-sdk/test-server": "workspace:*",
+    "@types/node": "20.17.24",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8",
+    "typescript": "5.8.3",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel/ai.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai"
+  ]
+}

--- a/packages/phota/src/index.ts
+++ b/packages/phota/src/index.ts
@@ -2,4 +2,14 @@ export { createPhota, phota } from './phota-provider';
 export type { PhotaProvider, PhotaProviderSettings } from './phota-provider';
 export type { PhotaImageModelId } from './phota-image-settings';
 export type { PhotaImageModelOptions } from './phota-image-model';
+export {
+  getPhotaTrainResult,
+  getPhotaStatusResult,
+  getPhotaImageMetadata,
+} from './phota-metadata';
+export type {
+  PhotaTrainMetadata,
+  PhotaStatusMetadata,
+  PhotaImageMetadata,
+} from './phota-metadata';
 export { VERSION } from './version';

--- a/packages/phota/src/index.ts
+++ b/packages/phota/src/index.ts
@@ -1,0 +1,5 @@
+export { createPhota, phota } from './phota-provider';
+export type { PhotaProvider, PhotaProviderSettings } from './phota-provider';
+export type { PhotaImageModelId } from './phota-image-settings';
+export type { PhotaImageModelOptions } from './phota-image-model';
+export { VERSION } from './version';

--- a/packages/phota/src/phota-image-model.test.ts
+++ b/packages/phota/src/phota-image-model.test.ts
@@ -157,9 +157,13 @@ describe('PhotaImageModel', () => {
       });
 
       expect(result.providerMetadata?.phota).toMatchObject({
-        knownSubjects: {
-          counts: { 'profile-abc': 1 },
-        },
+        images: [
+          {
+            knownSubjects: {
+              counts: { 'profile-abc': 1 },
+            },
+          },
+        ],
       });
     });
 
@@ -366,7 +370,7 @@ describe('PhotaImageModel', () => {
       });
 
       expect(result.providerMetadata?.phota).toMatchObject({
-        profileId: 'trained-profile-abc',
+        images: [{ profileId: 'trained-profile-abc' }],
       });
       // Placeholder image returned so generateImage does not throw
       expect(result.images).toHaveLength(1);
@@ -436,9 +440,13 @@ describe('PhotaImageModel', () => {
       );
 
       expect(result.providerMetadata?.phota).toMatchObject({
-        profileId: 'my-profile-id',
-        status: 'READY',
-        message: 'Training complete',
+        images: [
+          {
+            profileId: 'my-profile-id',
+            status: 'READY',
+            message: 'Training complete',
+          },
+        ],
       });
       expect(result.images).toHaveLength(1);
     });

--- a/packages/phota/src/phota-image-model.test.ts
+++ b/packages/phota/src/phota-image-model.test.ts
@@ -514,16 +514,6 @@ describe('PhotaImageModel', () => {
       expect(model.provider).toBe('phota.image');
       expect(model.modelId).toBe('generate');
       expect(model.specificationVersion).toBe('v4');
-      expect(model.maxImagesPerCall).toBe(4);
-    });
-
-    it('sets maxImagesPerCall to 1 for train model', () => {
-      const model = createBasicModel({ modelId: 'train' });
-      expect(model.maxImagesPerCall).toBe(1);
-    });
-
-    it('sets maxImagesPerCall to 1 for status model', () => {
-      const model = createBasicModel({ modelId: 'status' });
       expect(model.maxImagesPerCall).toBe(1);
     });
   });

--- a/packages/phota/src/phota-image-model.test.ts
+++ b/packages/phota/src/phota-image-model.test.ts
@@ -1,0 +1,522 @@
+import { FetchFunction } from '@ai-sdk/provider-utils';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import { PhotaImageModel } from './phota-image-model';
+
+const prompt = 'A cute baby sea otter';
+
+function createBasicModel({
+  modelId = 'generate' as string,
+  headers,
+  fetch,
+  currentDate,
+}: {
+  modelId?: string;
+  headers?: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+  currentDate?: () => Date;
+} = {}) {
+  return new PhotaImageModel(modelId, {
+    provider: 'phota.image',
+    baseURL: 'https://api.example.com/v1/phota',
+    headers: headers ?? (() => ({ 'X-API-Key': 'test-key' })),
+    fetch,
+    _internal: {
+      currentDate,
+    },
+  });
+}
+
+describe('PhotaImageModel', () => {
+  describe('generate', () => {
+    const server = createTestServer({
+      'https://api.example.com/v1/phota/generate': {
+        response: {
+          type: 'json-value',
+          body: {
+            images: ['dGVzdC1pbWFnZS0x', 'dGVzdC1pbWFnZS0y'],
+            known_subjects: null,
+          },
+        },
+      },
+    });
+
+    it('passes prompt and n as num_output_images', async () => {
+      const model = createBasicModel();
+
+      await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 2,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        prompt,
+        num_output_images: 2,
+      });
+    });
+
+    it('passes aspect ratio and provider options', async () => {
+      const model = createBasicModel();
+
+      await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: '16:9',
+        seed: undefined,
+        providerOptions: {
+          phota: {
+            proMode: true,
+            resolution: '4K',
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        prompt,
+        num_output_images: 1,
+        aspect_ratio: '16:9',
+        pro_mode: true,
+        resolution: '4K',
+      });
+    });
+
+    it('returns base64 images from the API response', async () => {
+      const model = createBasicModel();
+
+      const result = await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 2,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.images).toStrictEqual([
+        'dGVzdC1pbWFnZS0x',
+        'dGVzdC1pbWFnZS0y',
+      ]);
+    });
+
+    it('warns when size is provided', async () => {
+      const model = createBasicModel();
+
+      const result = await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: '1024x1024',
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported',
+          feature: 'size',
+          details: 'Phota does not support size. Use aspectRatio instead.',
+        },
+      ]);
+    });
+
+    it('includes known_subjects in providerMetadata when present', async () => {
+      server.urls['https://api.example.com/v1/phota/generate'].response = {
+        type: 'json-value',
+        body: {
+          images: ['dGVzdA=='],
+          known_subjects: {
+            counts: { 'profile-abc': 1 },
+          },
+        },
+      };
+
+      const model = createBasicModel();
+
+      const result = await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.providerMetadata?.phota).toMatchObject({
+        knownSubjects: {
+          counts: { 'profile-abc': 1 },
+        },
+      });
+    });
+
+    it('includes timestamp, headers, and modelId in response metadata', async () => {
+      const testDate = new Date('2025-01-01T00:00:00Z');
+      const model = createBasicModel({ currentDate: () => testDate });
+
+      const result = await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.response).toStrictEqual({
+        timestamp: testDate,
+        modelId: 'generate',
+        headers: expect.any(Object),
+      });
+    });
+
+    it('merges provider and request headers', async () => {
+      const model = createBasicModel({
+        headers: () => ({
+          'X-API-Key': 'test-key',
+          'Custom-Provider-Header': 'provider-value',
+        }),
+      });
+
+      await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+        headers: {
+          'Custom-Request-Header': 'request-value',
+        },
+      });
+
+      expect(server.calls[0].requestHeaders).toStrictEqual({
+        'content-type': 'application/json',
+        'x-api-key': 'test-key',
+        'custom-provider-header': 'provider-value',
+        'custom-request-header': 'request-value',
+      });
+    });
+  });
+
+  describe('edit', () => {
+    const server = createTestServer({
+      'https://api.example.com/v1/phota/edit': {
+        response: {
+          type: 'json-value',
+          body: {
+            images: ['ZWRpdGVkLWltYWdl'],
+            known_subjects: null,
+          },
+        },
+      },
+    });
+
+    it('passes images, prompt, and profile_ids', async () => {
+      const model = createBasicModel({ modelId: 'edit' });
+
+      await model.doGenerate({
+        prompt: 'Make the sky blue',
+        files: [{ type: 'url', url: 'https://example.com/photo.jpg' }],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {
+          phota: {
+            profileIds: ['profile-123'],
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        prompt: 'Make the sky blue',
+        images: ['https://example.com/photo.jpg'],
+        profile_ids: ['profile-123'],
+        num_output_images: 1,
+      });
+    });
+
+    it('passes aspect_ratio and resolution with pro_mode', async () => {
+      const model = createBasicModel({ modelId: 'edit' });
+
+      await model.doGenerate({
+        prompt: 'Edit this',
+        files: [{ type: 'url', url: 'https://example.com/photo.jpg' }],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: '4:3',
+        seed: undefined,
+        providerOptions: {
+          phota: {
+            proMode: true,
+            resolution: '4K',
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        prompt: 'Edit this',
+        images: ['https://example.com/photo.jpg'],
+        pro_mode: true,
+        num_output_images: 1,
+        aspect_ratio: '4:3',
+        resolution: '4K',
+      });
+    });
+  });
+
+  describe('enhance', () => {
+    const server = createTestServer({
+      'https://api.example.com/v1/phota/enhance': {
+        response: {
+          type: 'json-value',
+          body: {
+            images: ['ZW5oYW5jZWQ='],
+            known_subjects: null,
+          },
+        },
+      },
+    });
+
+    it('passes single image (not array) and omits prompt/aspect_ratio/resolution', async () => {
+      const model = createBasicModel({ modelId: 'enhance' });
+
+      await model.doGenerate({
+        prompt: undefined,
+        files: [{ type: 'url', url: 'https://example.com/photo.jpg' }],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {
+          phota: {
+            profileIds: ['profile-123'],
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        image: 'https://example.com/photo.jpg',
+        profile_ids: ['profile-123'],
+        num_output_images: 1,
+      });
+    });
+  });
+
+  describe('train', () => {
+    const server = createTestServer({
+      'https://api.example.com/v1/phota/profiles/add': {
+        response: {
+          type: 'json-value',
+          body: {
+            profile_id: 'trained-profile-abc',
+          },
+        },
+      },
+    });
+
+    it('posts image URLs to profiles/add and returns profileId in metadata', async () => {
+      const model = createBasicModel({ modelId: 'train' });
+
+      const result = await model.doGenerate({
+        prompt: undefined,
+        files: [
+          { type: 'url', url: 'https://example.com/photo1.jpg' },
+          { type: 'url', url: 'https://example.com/photo2.jpg' },
+          { type: 'url', url: 'https://example.com/photo3.jpg' },
+        ],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(server.calls[0].requestUrl).toBe(
+        'https://api.example.com/v1/phota/profiles/add',
+      );
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        image_urls: [
+          'https://example.com/photo1.jpg',
+          'https://example.com/photo2.jpg',
+          'https://example.com/photo3.jpg',
+        ],
+      });
+
+      expect(result.providerMetadata?.phota).toMatchObject({
+        profileId: 'trained-profile-abc',
+      });
+      // Placeholder image returned so generateImage does not throw
+      expect(result.images).toHaveLength(1);
+    });
+
+    it('throws when files contain non-URL data', async () => {
+      const model = createBasicModel({ modelId: 'train' });
+
+      await expect(
+        model.doGenerate({
+          prompt: undefined,
+          files: [
+            {
+              type: 'file',
+              data: 'base64data',
+              mediaType: 'image/jpeg',
+            },
+          ],
+          mask: undefined,
+          n: 1,
+          size: undefined,
+          aspectRatio: undefined,
+          seed: undefined,
+          providerOptions: {},
+        }),
+      ).rejects.toThrow(
+        'Phota profile training requires publicly accessible image URLs.',
+      );
+    });
+  });
+
+  describe('status', () => {
+    const server = createTestServer({
+      'https://api.example.com/v1/phota/profiles/my-profile-id/status': {
+        response: {
+          type: 'json-value',
+          body: {
+            profile_id: 'my-profile-id',
+            status: 'READY',
+            message: 'Training complete',
+          },
+        },
+      },
+    });
+
+    it('polls profile status and returns it in metadata', async () => {
+      const model = createBasicModel({ modelId: 'status' });
+
+      const result = await model.doGenerate({
+        prompt: undefined,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {
+          phota: {
+            profileId: 'my-profile-id',
+          },
+        },
+      });
+
+      expect(server.calls[0].requestMethod).toBe('GET');
+      expect(server.calls[0].requestUrl).toBe(
+        'https://api.example.com/v1/phota/profiles/my-profile-id/status',
+      );
+
+      expect(result.providerMetadata?.phota).toMatchObject({
+        profileId: 'my-profile-id',
+        status: 'READY',
+        message: 'Training complete',
+      });
+      expect(result.images).toHaveLength(1);
+    });
+
+    it('throws when profileId is not provided', async () => {
+      const model = createBasicModel({ modelId: 'status' });
+
+      await expect(
+        model.doGenerate({
+          prompt: undefined,
+          files: undefined,
+          mask: undefined,
+          n: 1,
+          size: undefined,
+          aspectRatio: undefined,
+          seed: undefined,
+          providerOptions: {},
+        }),
+      ).rejects.toThrow(
+        'Phota status requires a profileId in providerOptions.phota.',
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    const server = createTestServer({
+      'https://api.example.com/v1/phota/generate': {
+        response: {
+          type: 'error',
+          status: 400,
+          body: JSON.stringify({
+            message: 'Content moderation violation',
+            detail: 'CONTENT_MODERATION',
+          }),
+        },
+      },
+    });
+
+    it('handles API errors with message and detail', async () => {
+      const model = createBasicModel();
+
+      await expect(
+        model.doGenerate({
+          prompt,
+          files: undefined,
+          mask: undefined,
+          n: 1,
+          size: undefined,
+          aspectRatio: undefined,
+          seed: undefined,
+          providerOptions: {},
+        }),
+      ).rejects.toMatchObject({
+        message: 'CONTENT_MODERATION',
+        statusCode: 400,
+        url: 'https://api.example.com/v1/phota/generate',
+      });
+    });
+  });
+
+  describe('constructor', () => {
+    it('exposes correct provider and model information', () => {
+      const model = createBasicModel();
+
+      expect(model.provider).toBe('phota.image');
+      expect(model.modelId).toBe('generate');
+      expect(model.specificationVersion).toBe('v4');
+      expect(model.maxImagesPerCall).toBe(4);
+    });
+
+    it('sets maxImagesPerCall to 1 for train model', () => {
+      const model = createBasicModel({ modelId: 'train' });
+      expect(model.maxImagesPerCall).toBe(1);
+    });
+
+    it('sets maxImagesPerCall to 1 for status model', () => {
+      const model = createBasicModel({ modelId: 'status' });
+      expect(model.maxImagesPerCall).toBe(1);
+    });
+  });
+});

--- a/packages/phota/src/phota-image-model.ts
+++ b/packages/phota/src/phota-image-model.ts
@@ -97,8 +97,7 @@ export class PhotaImageModel implements ImageModelV4 {
       warnings: [],
       providerMetadata: {
         phota: {
-          images: [],
-          profileId: value.profile_id,
+          images: [{ profileId: value.profile_id }],
         },
       },
       response: {
@@ -151,10 +150,13 @@ export class PhotaImageModel implements ImageModelV4 {
       warnings: [],
       providerMetadata: {
         phota: {
-          images: [],
-          profileId: value.profile_id,
-          status: value.status,
-          ...(value.message != null && { message: value.message }),
+          images: [
+            {
+              profileId: value.profile_id,
+              status: value.status,
+              ...(value.message != null && { message: value.message }),
+            },
+          ],
         },
       },
       response: {
@@ -257,10 +259,11 @@ export class PhotaImageModel implements ImageModelV4 {
       warnings,
       providerMetadata: {
         phota: {
-          images: value.images.map(() => ({})),
-          ...(value.known_subjects != null && {
-            knownSubjects: value.known_subjects,
-          }),
+          images: value.images.map(() => ({
+            ...(value.known_subjects != null && {
+              knownSubjects: value.known_subjects,
+            }),
+          })),
         },
       },
       response: {

--- a/packages/phota/src/phota-image-model.ts
+++ b/packages/phota/src/phota-image-model.ts
@@ -32,7 +32,7 @@ const PLACEHOLDER_IMAGE =
 
 export class PhotaImageModel implements ImageModelV4 {
   readonly specificationVersion = 'v4';
-  readonly maxImagesPerCall: number;
+  readonly maxImagesPerCall: number = 1;
 
   get provider(): string {
     return this.config.provider;
@@ -42,7 +42,7 @@ export class PhotaImageModel implements ImageModelV4 {
     readonly modelId: PhotaImageModelId,
     private readonly config: PhotaImageModelConfig,
   ) {
-    this.maxImagesPerCall = modelId === 'train' || modelId === 'status' ? 1 : 4;
+    
   }
 
   async doGenerate(

--- a/packages/phota/src/phota-image-model.ts
+++ b/packages/phota/src/phota-image-model.ts
@@ -1,0 +1,362 @@
+import type { ImageModelV4, SharedV4Warning } from '@ai-sdk/provider';
+import type { InferSchema, Resolvable } from '@ai-sdk/provider-utils';
+import {
+  FetchFunction,
+  combineHeaders,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  getFromApi,
+  lazySchema,
+  parseProviderOptions,
+  postJsonToApi,
+  resolve,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { PhotaImageModelId } from './phota-image-settings';
+
+interface PhotaImageModelConfig {
+  provider: string;
+  baseURL: string;
+  headers?: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+// Minimal 1x1 transparent PNG in base64, used as a placeholder for
+// non-image operations (train, status) so generateImage does not throw.
+const PLACEHOLDER_IMAGE =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQABNjN9GQAAAABJRUEFTkSuQmCC';
+
+export class PhotaImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly maxImagesPerCall: number;
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: PhotaImageModelId,
+    private readonly config: PhotaImageModelConfig,
+  ) {
+    this.maxImagesPerCall = modelId === 'train' || modelId === 'status' ? 1 : 4;
+  }
+
+  async doGenerate(
+    options: Parameters<ImageModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<ImageModelV4['doGenerate']>>> {
+    if (this.modelId === 'train') {
+      return this.doTrain(options);
+    }
+    if (this.modelId === 'status') {
+      return this.doStatus(options);
+    }
+    return this.doImageOperation(options);
+  }
+
+  private async doTrain({
+    files,
+    headers,
+    abortSignal,
+  }: Parameters<ImageModelV4['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV4['doGenerate']>>
+  > {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const combinedHeaders = combineHeaders(
+      await resolve(this.config.headers),
+      headers,
+    );
+
+    const imageUrls =
+      files?.map(file => {
+        if (file.type === 'url') {
+          return file.url;
+        }
+        throw new Error(
+          'Phota profile training requires publicly accessible image URLs.',
+        );
+      }) ?? [];
+
+    const { value, responseHeaders } = await postJsonToApi({
+      url: `${this.config.baseURL}/profiles/add`,
+      headers: combinedHeaders,
+      body: { image_urls: imageUrls },
+      failedResponseHandler: photaFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        photaTrainResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      images: [PLACEHOLDER_IMAGE],
+      warnings: [],
+      providerMetadata: {
+        phota: {
+          images: [],
+          profileId: value.profile_id,
+        },
+      },
+      response: {
+        modelId: this.modelId,
+        timestamp: currentDate,
+        headers: responseHeaders,
+      },
+    };
+  }
+
+  private async doStatus({
+    providerOptions,
+    headers,
+    abortSignal,
+  }: Parameters<ImageModelV4['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV4['doGenerate']>>
+  > {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const combinedHeaders = combineHeaders(
+      await resolve(this.config.headers),
+      headers,
+    );
+
+    const photaOptions = await parseProviderOptions({
+      provider: 'phota',
+      providerOptions,
+      schema: photaImageModelOptionsSchema,
+    });
+
+    const profileId = photaOptions?.profileId;
+    if (!profileId) {
+      throw new Error(
+        'Phota status requires a profileId in providerOptions.phota.',
+      );
+    }
+
+    const { value, responseHeaders } = await getFromApi({
+      url: `${this.config.baseURL}/profiles/${profileId}/status`,
+      headers: combinedHeaders,
+      failedResponseHandler: photaFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        photaStatusResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      images: [PLACEHOLDER_IMAGE],
+      warnings: [],
+      providerMetadata: {
+        phota: {
+          images: [],
+          profileId: value.profile_id,
+          status: value.status,
+          ...(value.message != null && { message: value.message }),
+        },
+      },
+      response: {
+        modelId: this.modelId,
+        timestamp: currentDate,
+        headers: responseHeaders,
+      },
+    };
+  }
+
+  private async doImageOperation({
+    prompt,
+    files,
+    n,
+    aspectRatio,
+    size,
+    providerOptions,
+    headers,
+    abortSignal,
+  }: Parameters<ImageModelV4['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV4['doGenerate']>>
+  > {
+    const warnings: Array<SharedV4Warning> = [];
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const combinedHeaders = combineHeaders(
+      await resolve(this.config.headers),
+      headers,
+    );
+
+    const photaOptions = await parseProviderOptions({
+      provider: 'phota',
+      providerOptions,
+      schema: photaImageModelOptionsSchema,
+    });
+
+    if (size) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'size',
+        details: 'Phota does not support size. Use aspectRatio instead.',
+      });
+    }
+
+    const body: Record<string, unknown> = {};
+
+    if (this.modelId === 'generate') {
+      body.prompt = prompt;
+      if (photaOptions?.proMode != null) body.pro_mode = photaOptions.proMode;
+      if (n != null) body.num_output_images = n;
+      if (aspectRatio != null) body.aspect_ratio = aspectRatio;
+      if (photaOptions?.resolution != null)
+        body.resolution = photaOptions.resolution;
+    } else if (this.modelId === 'edit') {
+      body.prompt = prompt;
+      body.images = this.filesToStrings(files);
+      if (photaOptions?.profileIds != null)
+        body.profile_ids = photaOptions.profileIds;
+      if (photaOptions?.proMode != null) body.pro_mode = photaOptions.proMode;
+      if (n != null) body.num_output_images = n;
+      if (aspectRatio != null) body.aspect_ratio = aspectRatio;
+      if (photaOptions?.resolution != null)
+        body.resolution = photaOptions.resolution;
+    } else if (this.modelId === 'enhance') {
+      const inputImages = this.filesToStrings(files);
+      if (inputImages.length > 0) {
+        body.image = inputImages[0];
+      }
+      if (photaOptions?.profileIds != null)
+        body.profile_ids = photaOptions.profileIds;
+      if (photaOptions?.proMode != null) body.pro_mode = photaOptions.proMode;
+      if (n != null) body.num_output_images = n;
+    } else {
+      // Custom/unknown model ID — pass through all params
+      body.prompt = prompt;
+      const inputImages = this.filesToStrings(files);
+      if (inputImages.length > 0) body.images = inputImages;
+      if (photaOptions?.profileIds != null)
+        body.profile_ids = photaOptions.profileIds;
+      if (photaOptions?.proMode != null) body.pro_mode = photaOptions.proMode;
+      if (n != null) body.num_output_images = n;
+      if (aspectRatio != null) body.aspect_ratio = aspectRatio;
+      if (photaOptions?.resolution != null)
+        body.resolution = photaOptions.resolution;
+    }
+
+    const { value, responseHeaders } = await postJsonToApi({
+      url: `${this.config.baseURL}/${this.modelId}`,
+      headers: combinedHeaders,
+      body,
+      failedResponseHandler: photaFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        photaImageResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      images: value.images,
+      warnings,
+      providerMetadata: {
+        phota: {
+          images: value.images.map(() => ({})),
+          ...(value.known_subjects != null && {
+            knownSubjects: value.known_subjects,
+          }),
+        },
+      },
+      response: {
+        modelId: this.modelId,
+        timestamp: currentDate,
+        headers: responseHeaders,
+      },
+    };
+  }
+
+  private filesToStrings(
+    files: Parameters<ImageModelV4['doGenerate']>[0]['files'],
+  ): string[] {
+    return (
+      files?.map(file => {
+        if (file.type === 'url') {
+          return file.url;
+        }
+        if (typeof file.data === 'string') {
+          return file.data;
+        }
+        return Buffer.from(file.data).toString('base64');
+      }) ?? []
+    );
+  }
+}
+
+// Provider options schema
+export const photaImageModelOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      /**
+       * Profile ID for polling training status (used with the `status` model).
+       */
+      profileId: z.string().optional(),
+
+      /**
+       * Profile IDs for identity preservation in edit/enhance operations.
+       */
+      profileIds: z.array(z.string()).optional(),
+
+      /**
+       * Enable pro mode for better instruction following at higher latency/cost.
+       * Required to use non-default aspect ratios or 4K resolution.
+       */
+      proMode: z.boolean().optional(),
+
+      /**
+       * Output resolution. Must be '1K' when pro_mode is disabled.
+       */
+      resolution: z.enum(['1K', '4K']).optional(),
+    }),
+  ),
+);
+
+export type PhotaImageModelOptions = InferSchema<
+  typeof photaImageModelOptionsSchema
+>;
+
+// Response schemas
+const photaImageResponseSchema = z.object({
+  images: z.array(z.string()),
+  known_subjects: z
+    .object({
+      counts: z.record(z.string(), z.number()),
+    })
+    .nullish(),
+});
+
+const photaTrainResponseSchema = z.object({
+  profile_id: z.string(),
+});
+
+const photaStatusResponseSchema = z.object({
+  profile_id: z.string(),
+  status: z.string(),
+  message: z.string().nullish(),
+});
+
+// Error handling
+const photaErrorSchema = z.object({
+  message: z.string().optional(),
+  detail: z.any().optional(),
+});
+
+const photaFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: photaErrorSchema,
+  errorToMessage: error => {
+    if (typeof error.detail === 'string') return error.detail;
+    if (error.detail != null) {
+      try {
+        return JSON.stringify(error.detail);
+      } catch {
+        // ignore
+      }
+    }
+    return error.message ?? 'Unknown Phota error';
+  },
+});

--- a/packages/phota/src/phota-image-model.ts
+++ b/packages/phota/src/phota-image-model.ts
@@ -133,7 +133,7 @@ export class PhotaImageModel implements ImageModelV4 {
     }
 
     const { value, responseHeaders } = await getFromApi({
-      url: `${this.config.baseURL}/profiles/${profileId}/status`,
+      url: `${this.config.baseURL}/profiles/${encodeURIComponent(profileId)}/status`,
       headers: combinedHeaders,
       failedResponseHandler: photaFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(

--- a/packages/phota/src/phota-image-model.ts
+++ b/packages/phota/src/phota-image-model.ts
@@ -41,9 +41,7 @@ export class PhotaImageModel implements ImageModelV4 {
   constructor(
     readonly modelId: PhotaImageModelId,
     private readonly config: PhotaImageModelConfig,
-  ) {
-    
-  }
+  ) {}
 
   async doGenerate(
     options: Parameters<ImageModelV4['doGenerate']>[0],

--- a/packages/phota/src/phota-image-settings.ts
+++ b/packages/phota/src/phota-image-settings.ts
@@ -1,0 +1,7 @@
+export type PhotaImageModelId =
+  | 'generate'
+  | 'edit'
+  | 'enhance'
+  | 'train'
+  | 'status'
+  | (string & {});

--- a/packages/phota/src/phota-metadata.ts
+++ b/packages/phota/src/phota-metadata.ts
@@ -14,14 +14,23 @@ export interface PhotaImageMetadata {
   };
 }
 
-function extractPhotaMeta(
+function extractFirstImageMeta(
   providerMetadata: Record<string, unknown> | undefined,
 ): Record<string, unknown> {
-  const meta = (providerMetadata as Record<string, unknown> | undefined)?.phota;
-  if (meta == null || typeof meta !== 'object') {
+  const phota = (providerMetadata as Record<string, unknown> | undefined)
+    ?.phota;
+  if (phota == null || typeof phota !== 'object') {
     throw new Error('Missing Phota provider metadata.');
   }
-  return meta as Record<string, unknown>;
+  const images = (phota as Record<string, unknown>).images;
+  if (!Array.isArray(images) || images.length === 0) {
+    throw new Error('Missing Phota provider metadata images.');
+  }
+  const first = images[0];
+  if (first == null || typeof first !== 'object') {
+    throw new Error('Missing Phota provider metadata in images[0].');
+  }
+  return first as Record<string, unknown>;
 }
 
 /**
@@ -35,7 +44,7 @@ function extractPhotaMeta(
 export function getPhotaTrainResult(
   providerMetadata: Record<string, unknown> | undefined,
 ): PhotaTrainMetadata {
-  const meta = extractPhotaMeta(providerMetadata);
+  const meta = extractFirstImageMeta(providerMetadata);
   const profileId = meta.profileId;
   if (typeof profileId !== 'string') {
     throw new Error('Missing profileId in Phota train metadata.');
@@ -54,7 +63,7 @@ export function getPhotaTrainResult(
 export function getPhotaStatusResult(
   providerMetadata: Record<string, unknown> | undefined,
 ): PhotaStatusMetadata {
-  const meta = extractPhotaMeta(providerMetadata);
+  const meta = extractFirstImageMeta(providerMetadata);
   const profileId = meta.profileId;
   const status = meta.status;
   if (typeof profileId !== 'string' || typeof status !== 'string') {
@@ -78,7 +87,7 @@ export function getPhotaStatusResult(
 export function getPhotaImageMetadata(
   providerMetadata: Record<string, unknown> | undefined,
 ): PhotaImageMetadata {
-  const meta = extractPhotaMeta(providerMetadata);
+  const meta = extractFirstImageMeta(providerMetadata);
   const knownSubjects = meta.knownSubjects as
     | { counts: Record<string, number> }
     | undefined;

--- a/packages/phota/src/phota-metadata.ts
+++ b/packages/phota/src/phota-metadata.ts
@@ -1,0 +1,88 @@
+export interface PhotaTrainMetadata {
+  profileId: string;
+}
+
+export interface PhotaStatusMetadata {
+  profileId: string;
+  status: string;
+  message?: string;
+}
+
+export interface PhotaImageMetadata {
+  knownSubjects?: {
+    counts: Record<string, number>;
+  };
+}
+
+function extractPhotaMeta(
+  providerMetadata: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const meta = (providerMetadata as Record<string, unknown> | undefined)?.phota;
+  if (meta == null || typeof meta !== 'object') {
+    throw new Error('Missing Phota provider metadata.');
+  }
+  return meta as Record<string, unknown>;
+}
+
+/**
+ * Extract the profile ID returned by the `train` model.
+ *
+ * ```ts
+ * const result = await generateImage({ model: phota.image('train'), ... });
+ * const { profileId } = getPhotaTrainResult(result.providerMetadata);
+ * ```
+ */
+export function getPhotaTrainResult(
+  providerMetadata: Record<string, unknown> | undefined,
+): PhotaTrainMetadata {
+  const meta = extractPhotaMeta(providerMetadata);
+  const profileId = meta.profileId;
+  if (typeof profileId !== 'string') {
+    throw new Error('Missing profileId in Phota train metadata.');
+  }
+  return { profileId };
+}
+
+/**
+ * Extract the training status returned by the `status` model.
+ *
+ * ```ts
+ * const result = await generateImage({ model: phota.image('status'), ... });
+ * const { status, profileId } = getPhotaStatusResult(result.providerMetadata);
+ * ```
+ */
+export function getPhotaStatusResult(
+  providerMetadata: Record<string, unknown> | undefined,
+): PhotaStatusMetadata {
+  const meta = extractPhotaMeta(providerMetadata);
+  const profileId = meta.profileId;
+  const status = meta.status;
+  if (typeof profileId !== 'string' || typeof status !== 'string') {
+    throw new Error('Missing profileId or status in Phota status metadata.');
+  }
+  return {
+    profileId,
+    status,
+    ...(typeof meta.message === 'string' && { message: meta.message }),
+  };
+}
+
+/**
+ * Extract image-specific metadata (known subjects) from generate/edit/enhance results.
+ *
+ * ```ts
+ * const result = await generateImage({ model: phota.image('generate'), ... });
+ * const meta = getPhotaImageMetadata(result.providerMetadata);
+ * ```
+ */
+export function getPhotaImageMetadata(
+  providerMetadata: Record<string, unknown> | undefined,
+): PhotaImageMetadata {
+  const meta = extractPhotaMeta(providerMetadata);
+  const knownSubjects = meta.knownSubjects as
+    | { counts: Record<string, number> }
+    | undefined;
+  return {
+    ...(knownSubjects != null && { knownSubjects }),
+  };
+}

--- a/packages/phota/src/phota-provider.test.ts
+++ b/packages/phota/src/phota-provider.test.ts
@@ -63,12 +63,12 @@ describe('Phota provider', () => {
     expect(server.calls[0].requestUserAgent).toContain('ai-sdk/phota/');
   });
 
-  it('sets maxImagesPerCall based on model ID', () => {
+  it('sets maxImagesPerCall to 1 for all models', () => {
     const provider = createPhota();
 
-    expect(provider.image('generate').maxImagesPerCall).toBe(4);
-    expect(provider.image('edit').maxImagesPerCall).toBe(4);
-    expect(provider.image('enhance').maxImagesPerCall).toBe(4);
+    expect(provider.image('generate').maxImagesPerCall).toBe(1);
+    expect(provider.image('edit').maxImagesPerCall).toBe(1);
+    expect(provider.image('enhance').maxImagesPerCall).toBe(1);
     expect(provider.image('train').maxImagesPerCall).toBe(1);
     expect(provider.image('status').maxImagesPerCall).toBe(1);
   });

--- a/packages/phota/src/phota-provider.test.ts
+++ b/packages/phota/src/phota-provider.test.ts
@@ -1,0 +1,86 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import { createPhota } from './phota-provider';
+
+const server = createTestServer({
+  'https://api.example.com/v1/phota/generate': {
+    response: {
+      type: 'json-value',
+      body: {
+        images: ['dGVzdC1pbWFnZQ=='],
+        known_subjects: null,
+      },
+    },
+  },
+});
+
+describe('Phota provider', () => {
+  it('creates image models via .image and .imageModel', () => {
+    const provider = createPhota();
+
+    const imageModel = provider.image('generate');
+    const imageModel2 = provider.imageModel('edit');
+
+    expect(imageModel.provider).toBe('phota.image');
+    expect(imageModel.modelId).toBe('generate');
+    expect(imageModel2.modelId).toBe('edit');
+    expect(imageModel.specificationVersion).toBe('v4');
+  });
+
+  it('configures baseURL and headers correctly', async () => {
+    const provider = createPhota({
+      apiKey: 'test-api-key',
+      baseURL: 'https://api.example.com/v1/phota',
+      headers: {
+        'x-extra-header': 'extra',
+      },
+    });
+
+    const model = provider.image('generate');
+
+    await model.doGenerate({
+      prompt: 'A serene mountain landscape',
+      files: undefined,
+      mask: undefined,
+      n: 1,
+      size: undefined,
+      seed: undefined,
+      aspectRatio: undefined,
+      providerOptions: {},
+    });
+
+    expect(server.calls[0].requestUrl).toBe(
+      'https://api.example.com/v1/phota/generate',
+    );
+    expect(server.calls[0].requestMethod).toBe('POST');
+    expect(server.calls[0].requestHeaders['x-api-key']).toBe('test-api-key');
+    expect(server.calls[0].requestHeaders['x-extra-header']).toBe('extra');
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      prompt: 'A serene mountain landscape',
+      num_output_images: 1,
+    });
+
+    expect(server.calls[0].requestUserAgent).toContain('ai-sdk/phota/');
+  });
+
+  it('sets maxImagesPerCall based on model ID', () => {
+    const provider = createPhota();
+
+    expect(provider.image('generate').maxImagesPerCall).toBe(4);
+    expect(provider.image('edit').maxImagesPerCall).toBe(4);
+    expect(provider.image('enhance').maxImagesPerCall).toBe(4);
+    expect(provider.image('train').maxImagesPerCall).toBe(1);
+    expect(provider.image('status').maxImagesPerCall).toBe(1);
+  });
+
+  it('throws NoSuchModelError for unsupported model types', () => {
+    const provider = createPhota();
+
+    expect(() => provider.languageModel('some-id')).toThrowError(
+      'No such languageModel',
+    );
+    expect(() => provider.embeddingModel('some-id')).toThrowError(
+      'No such embeddingModel',
+    );
+  });
+});

--- a/packages/phota/src/phota-provider.ts
+++ b/packages/phota/src/phota-provider.ts
@@ -1,0 +1,108 @@
+import { ImageModelV4, NoSuchModelError, ProviderV4 } from '@ai-sdk/provider';
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+import {
+  loadApiKey,
+  withoutTrailingSlash,
+  withUserAgentSuffix,
+} from '@ai-sdk/provider-utils';
+import { PhotaImageModel } from './phota-image-model';
+import { PhotaImageModelId } from './phota-image-settings';
+import { VERSION } from './version';
+
+export interface PhotaProviderSettings {
+  /**
+   * Phota API key. Default value is taken from the `PHOTA_API_KEY` environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * Base URL for the API calls. Defaults to `https://api.photalabs.com/v1/phota`.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept
+   * requests, or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+}
+
+export interface PhotaProvider extends ProviderV4 {
+  /**
+   * Creates a model for image operations.
+   *
+   * Model IDs:
+   * - `generate` — text-to-image generation
+   * - `edit` — edit existing images with a prompt
+   * - `enhance` — automatic image enhancement
+   * - `train` — create a profile from reference images (returns profileId in providerMetadata)
+   * - `status` — poll profile training status (pass profileId in providerOptions)
+   */
+  image(modelId: PhotaImageModelId): ImageModelV4;
+
+  /**
+   * Creates a model for image operations.
+   */
+  imageModel(modelId: PhotaImageModelId): ImageModelV4;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
+}
+
+const defaultBaseURL = 'https://api.photalabs.com/v1/phota';
+
+export function createPhota(
+  options: PhotaProviderSettings = {},
+): PhotaProvider {
+  const baseURL = withoutTrailingSlash(options.baseURL ?? defaultBaseURL);
+  const getHeaders = () =>
+    withUserAgentSuffix(
+      {
+        'X-API-Key': loadApiKey({
+          apiKey: options.apiKey,
+          environmentVariableName: 'PHOTA_API_KEY',
+          description: 'Phota',
+        }),
+        ...options.headers,
+      },
+      `ai-sdk/phota/${VERSION}`,
+    );
+
+  const createImageModel = (modelId: PhotaImageModelId) =>
+    new PhotaImageModel(modelId, {
+      provider: 'phota.image',
+      baseURL: baseURL ?? defaultBaseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
+  const embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'embeddingModel',
+    });
+  };
+
+  return {
+    specificationVersion: 'v4',
+    imageModel: createImageModel,
+    image: createImageModel,
+    languageModel: (modelId: string) => {
+      throw new NoSuchModelError({
+        modelId,
+        modelType: 'languageModel',
+      });
+    },
+    embeddingModel,
+    textEmbeddingModel: embeddingModel,
+  };
+}
+
+export const phota = createPhota();

--- a/packages/phota/src/version.ts
+++ b/packages/phota/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/phota/tsconfig.build.json
+++ b/packages/phota/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Disable project configuration for tsup builds
+    "composite": false
+  }
+}

--- a/packages/phota/tsconfig.json
+++ b/packages/phota/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": ["dist", "build", "node_modules", "tsup.config.ts"],
+  "references": [
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    },
+    {
+      "path": "../test-server"
+    }
+  ]
+}

--- a/packages/phota/tsup.config.ts
+++ b/packages/phota/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/phota/turbo.json
+++ b/packages/phota/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["**/dist/**"]
+    }
+  }
+}

--- a/packages/phota/vitest.edge.config.js
+++ b/packages/phota/vitest.edge.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/packages/phota/vitest.node.config.js
+++ b/packages/phota/vitest.node.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       '@ai-sdk/perplexity':
         specifier: workspace:*
         version: link:../../packages/perplexity
+      '@ai-sdk/phota':
+        specifier: workspace:*
+        version: link:../../packages/phota
       '@ai-sdk/prodia':
         specifier: workspace:*
         version: link:../../packages/prodia
@@ -1230,13 +1233,13 @@ importers:
     devDependencies:
       '@nuxt/devtools':
         specifier: 1.6.3
-        version: 1.6.3(rollup@4.34.9)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(vue@3.5.13(typescript@5.9.3))
+        version: 1.6.3(rollup@4.59.0)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(vue@3.5.13(typescript@5.9.3))
       '@nuxt/ui-templates':
         specifier: 1.3.4
         version: 1.3.4
       '@nuxtjs/tailwindcss':
         specifier: 6.12.2
-        version: 6.12.2(magicast@0.3.5)(rollup@4.34.9)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.9.3))
+        version: 6.12.2(magicast@0.3.5)(rollup@4.59.0)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.9.3))
       '@types/node':
         specifier: 20.17.24
         version: 20.17.24
@@ -1254,7 +1257,7 @@ importers:
         version: 3.5.12
       nuxt:
         specifier: 3.14.159
-        version: 3.14.159(@parcel/watcher@2.4.1)(@types/node@20.17.24)(@upstash/redis@1.34.3)(encoding@0.1.13)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.4.1)(less@4.4.0)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.9)(sass@1.90.0)(terser@5.43.1)(typescript@5.9.3)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(webpack-sources@3.3.4)
+        version: 3.14.159(@parcel/watcher@2.4.1)(@types/node@20.17.24)(@upstash/redis@1.34.3)(encoding@0.1.13)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.4.1)(less@4.4.0)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass@1.90.0)(terser@5.43.1)(typescript@5.9.3)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(webpack-sources@3.3.4)
       tailwindcss:
         specifier: 3.4.15
         version: 3.4.15(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.9.3))
@@ -2552,6 +2555,34 @@ importers:
         version: 3.25.76
 
   packages/perplexity:
+    dependencies:
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+    devDependencies:
+      '@ai-sdk/test-server':
+        specifier: workspace:*
+        version: link:../test-server
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.7.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
+  packages/phota:
     dependencies:
       '@ai-sdk/provider':
         specifier: workspace:*
@@ -6886,9 +6917,6 @@ packages:
 
   '@jimp/utils@0.16.13':
     resolution: {integrity: sha512-VyCpkZzFTHXtKgVO35iKN0sYR10psGpV6SkcSeV4oF7eSYlR8Bl6aQLCzVeFjvESF7mxTmIiI3/XrMobVrtxDA==}
-
-  '@jridgewell/gen-mapping@0.3.12':
-    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -19950,7 +19978,7 @@ snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.29
 
   '@angular-devkit/architect@0.2003.18(chokidar@4.0.3)':
@@ -19964,7 +19992,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19978,13 +20006,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
-      css-loader: 7.1.2(webpack@5.105.0)
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
+      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19992,22 +20020,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
-      license-webpack-plugin: 4.0.2(webpack@5.105.0)
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
+      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0)
+      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -20017,7 +20045,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -20047,7 +20075,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -20641,7 +20669,7 @@ snapshots:
   '@babel/code-frame@7.25.7':
     dependencies:
       '@babel/highlight': 7.25.7
-      picocolors: 1.1.0
+      picocolors: 1.1.1
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -20777,7 +20805,7 @@ snapshots:
     dependencies:
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
-      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.29
       jsesc: 3.0.2
 
@@ -21178,7 +21206,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.27.1
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.1.0
+      picocolors: 1.1.1
 
   '@babel/parser@7.26.2':
     dependencies:
@@ -24736,14 +24764,9 @@ snapshots:
       '@babel/runtime': 7.28.3
       regenerator-runtime: 0.13.11
 
-  '@jridgewell/gen-mapping@0.3.12':
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.29
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
@@ -24757,7 +24780,7 @@ snapshots:
 
   '@jridgewell/source-map@0.3.6':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.29
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
@@ -25421,7 +25444,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -25501,10 +25524,10 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.6.3(magicast@0.3.5)(rollup@4.34.9)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))':
+  '@nuxt/devtools-kit@1.6.3(magicast@0.3.5)(rollup@4.59.0)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))':
     dependencies:
-      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.34.9)
-      '@nuxt/schema': 3.14.1592(magicast@0.3.5)(rollup@4.34.9)
+      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.59.0)
+      '@nuxt/schema': 3.14.1592(magicast@0.3.5)(rollup@4.59.0)
       execa: 7.2.0
       vite: 5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)
     transitivePeerDependencies:
@@ -25514,7 +25537,7 @@ snapshots:
 
   '@nuxt/devtools-wizard@1.6.3':
     dependencies:
-      consola: 3.2.3
+      consola: 3.4.2
       diff: 7.0.0
       execa: 7.2.0
       global-directory: 4.0.1
@@ -25525,12 +25548,12 @@ snapshots:
       rc9: 2.1.2
       semver: 7.6.3
 
-  '@nuxt/devtools@1.6.3(rollup@4.34.9)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(vue@3.5.13(typescript@5.9.3))':
+  '@nuxt/devtools@1.6.3(rollup@4.59.0)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(vue@3.5.13(typescript@5.9.3))':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.6.3(magicast@0.3.5)(rollup@4.34.9)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))
+      '@nuxt/devtools-kit': 1.6.3(magicast@0.3.5)(rollup@4.59.0)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))
       '@nuxt/devtools-wizard': 1.6.3
-      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.34.9)
+      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.59.0)
       '@vue/devtools-core': 7.6.4(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(vue@3.5.13(typescript@5.9.3))
       '@vue/devtools-kit': 7.6.4
       birpc: 0.2.19
@@ -25559,9 +25582,9 @@ snapshots:
       simple-git: 3.27.0
       sirv: 3.0.0
       tinyglobby: 0.2.10
-      unimport: 3.14.4(rollup@4.34.9)
+      unimport: 3.14.4(rollup@4.59.0)
       vite: 5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)
-      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.34.9))(rollup@4.34.9)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))
+      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.59.0))(rollup@4.59.0)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))
       vite-plugin-vue-inspector: 5.1.3(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))
       which: 3.0.1
       ws: 8.18.0
@@ -25572,11 +25595,11 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/kit@3.14.159(magicast@0.3.5)(rollup@4.34.9)':
+  '@nuxt/kit@3.14.159(magicast@0.3.5)(rollup@4.59.0)':
     dependencies:
-      '@nuxt/schema': 3.14.159(magicast@0.3.5)(rollup@4.34.9)
+      '@nuxt/schema': 3.14.159(magicast@0.3.5)(rollup@4.59.0)
       c12: 2.0.1(magicast@0.3.5)
-      consola: 3.2.3
+      consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.3
       globby: 14.0.2
@@ -25592,18 +25615,18 @@ snapshots:
       semver: 7.7.4
       ufo: 1.5.4
       unctx: 2.3.1
-      unimport: 3.14.4(rollup@4.34.9)
+      unimport: 3.14.4(rollup@4.59.0)
       untyped: 1.5.1
     transitivePeerDependencies:
       - magicast
       - rollup
       - supports-color
 
-  '@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.34.9)':
+  '@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.59.0)':
     dependencies:
-      '@nuxt/schema': 3.14.1592(magicast@0.3.5)(rollup@4.34.9)
+      '@nuxt/schema': 3.14.1592(magicast@0.3.5)(rollup@4.59.0)
       c12: 2.0.1(magicast@0.3.5)
-      consola: 3.2.3
+      consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.3
       globby: 14.0.2
@@ -25619,18 +25642,18 @@ snapshots:
       semver: 7.6.3
       ufo: 1.5.4
       unctx: 2.3.1
-      unimport: 3.14.4(rollup@4.34.9)
+      unimport: 3.14.4(rollup@4.59.0)
       untyped: 1.5.1
     transitivePeerDependencies:
       - magicast
       - rollup
       - supports-color
 
-  '@nuxt/schema@3.14.159(magicast@0.3.5)(rollup@4.34.9)':
+  '@nuxt/schema@3.14.159(magicast@0.3.5)(rollup@4.59.0)':
     dependencies:
       c12: 2.0.1(magicast@0.3.5)
       compatx: 0.1.8
-      consola: 3.2.3
+      consola: 3.4.2
       defu: 6.1.4
       hookable: 5.5.3
       pathe: 1.1.2
@@ -25639,18 +25662,18 @@ snapshots:
       std-env: 3.8.0
       ufo: 1.5.4
       uncrypto: 0.1.3
-      unimport: 3.14.4(rollup@4.34.9)
+      unimport: 3.14.4(rollup@4.59.0)
       untyped: 1.5.1
     transitivePeerDependencies:
       - magicast
       - rollup
       - supports-color
 
-  '@nuxt/schema@3.14.1592(magicast@0.3.5)(rollup@4.34.9)':
+  '@nuxt/schema@3.14.1592(magicast@0.3.5)(rollup@4.59.0)':
     dependencies:
       c12: 2.0.1(magicast@0.3.5)
       compatx: 0.1.8
-      consola: 3.2.3
+      consola: 3.4.2
       defu: 6.1.4
       hookable: 5.5.3
       pathe: 1.1.2
@@ -25659,18 +25682,18 @@ snapshots:
       std-env: 3.10.0
       ufo: 1.5.4
       uncrypto: 0.1.3
-      unimport: 3.14.4(rollup@4.34.9)
+      unimport: 3.14.4(rollup@4.59.0)
       untyped: 1.5.1
     transitivePeerDependencies:
       - magicast
       - rollup
       - supports-color
 
-  '@nuxt/telemetry@2.6.0(magicast@0.3.5)(rollup@4.34.9)':
+  '@nuxt/telemetry@2.6.0(magicast@0.3.5)(rollup@4.59.0)':
     dependencies:
-      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.34.9)
+      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.59.0)
       ci-info: 4.0.0
-      consola: 3.2.3
+      consola: 3.4.2
       create-require: 1.1.1
       defu: 6.1.4
       destr: 2.0.3
@@ -25693,15 +25716,15 @@ snapshots:
 
   '@nuxt/ui-templates@1.3.4': {}
 
-  '@nuxt/vite-builder@3.14.159(@types/node@20.17.24)(eslint@9.39.3(jiti@2.6.1))(less@4.4.0)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.9)(sass@1.90.0)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.13(typescript@5.9.3))(webpack-sources@3.3.4)':
+  '@nuxt/vite-builder@3.14.159(@types/node@20.17.24)(eslint@9.39.3(jiti@2.6.1))(less@4.4.0)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass@1.90.0)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.13(typescript@5.9.3))(webpack-sources@3.3.4)':
     dependencies:
-      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.34.9)
-      '@rollup/plugin-replace': 6.0.1(rollup@4.34.9)
+      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.59.0)
+      '@rollup/plugin-replace': 6.0.1(rollup@4.59.0)
       '@vitejs/plugin-vue': 5.2.0(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(vue@3.5.13(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 4.1.0(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(vue@3.5.13(typescript@5.9.3))
       autoprefixer: 10.4.27(postcss@8.5.6)
       clear: 0.1.0
-      consola: 3.2.3
+      consola: 3.4.2
       cssnano: 7.0.6(postcss@8.5.6)
       defu: 6.1.4
       esbuild: 0.24.2
@@ -25719,7 +25742,7 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 1.2.1
       postcss: 8.5.6
-      rollup-plugin-visualizer: 5.12.0(rollup@4.34.9)
+      rollup-plugin-visualizer: 5.12.0(rollup@4.59.0)
       std-env: 3.8.0
       strip-literal: 2.1.0
       ufo: 1.5.4
@@ -25761,9 +25784,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nuxtjs/tailwindcss@6.12.2(magicast@0.3.5)(rollup@4.34.9)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.9.3))':
+  '@nuxtjs/tailwindcss@6.12.2(magicast@0.3.5)(rollup@4.59.0)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.9.3))':
     dependencies:
-      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.34.9)
+      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.59.0)
       autoprefixer: 10.4.27(postcss@8.5.6)
       consola: 3.2.3
       defu: 6.1.4
@@ -27569,21 +27592,9 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
-  '@rollup/plugin-alias@5.1.1(rollup@4.34.9)':
+  '@rollup/plugin-alias@5.1.1(rollup@4.59.0)':
     optionalDependencies:
-      rollup: 4.34.9
-
-  '@rollup/plugin-commonjs@28.0.1(rollup@4.34.9)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.34.9)
-      commondir: 1.0.1
-      estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      is-reference: 1.2.1
-      magic-string: 0.30.17
-      picomatch: 4.0.3
-    optionalDependencies:
-      rollup: 4.34.9
+      rollup: 4.59.0
 
   '@rollup/plugin-commonjs@28.0.1(rollup@4.52.3)':
     dependencies:
@@ -27597,65 +27608,69 @@ snapshots:
     optionalDependencies:
       rollup: 4.52.3
 
-  '@rollup/plugin-inject@5.0.5(rollup@4.34.9)':
+  '@rollup/plugin-commonjs@28.0.1(rollup@4.59.0)':
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.34.9)
+      '@rollup/pluginutils': 5.1.3(rollup@4.59.0)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      is-reference: 1.2.1
+      magic-string: 0.30.17
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.59.0
+
+  '@rollup/plugin-inject@5.0.5(rollup@4.59.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.3(rollup@4.59.0)
       estree-walker: 2.0.2
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: 4.34.9
+      rollup: 4.59.0
 
-  '@rollup/plugin-json@6.1.0(rollup@4.34.9)':
+  '@rollup/plugin-json@6.1.0(rollup@4.59.0)':
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.34.9)
+      '@rollup/pluginutils': 5.1.3(rollup@4.59.0)
     optionalDependencies:
-      rollup: 4.34.9
+      rollup: 4.59.0
 
-  '@rollup/plugin-node-resolve@15.3.0(rollup@4.34.9)':
+  '@rollup/plugin-node-resolve@15.3.0(rollup@4.59.0)':
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.34.9)
+      '@rollup/pluginutils': 5.1.3(rollup@4.59.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
     optionalDependencies:
-      rollup: 4.34.9
+      rollup: 4.59.0
 
-  '@rollup/plugin-replace@6.0.1(rollup@4.34.9)':
+  '@rollup/plugin-replace@6.0.1(rollup@4.59.0)':
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.34.9)
+      '@rollup/pluginutils': 5.1.3(rollup@4.59.0)
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: 4.34.9
+      rollup: 4.59.0
 
-  '@rollup/plugin-terser@0.4.4(rollup@4.34.9)':
+  '@rollup/plugin-terser@0.4.4(rollup@4.59.0)':
     dependencies:
       serialize-javascript: 6.0.2
       smob: 1.4.1
       terser: 5.43.1
     optionalDependencies:
-      rollup: 4.34.9
+      rollup: 4.59.0
 
   '@rollup/pluginutils@4.2.1':
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.1
 
-  '@rollup/pluginutils@5.1.0(rollup@4.34.9)':
+  '@rollup/pluginutils@5.1.0(rollup@4.59.0)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: 4.34.9
-
-  '@rollup/pluginutils@5.1.3(rollup@4.34.9)':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.3
-    optionalDependencies:
-      rollup: 4.34.9
+      rollup: 4.59.0
 
   '@rollup/pluginutils@5.1.3(rollup@4.52.3)':
     dependencies:
@@ -27664,6 +27679,14 @@ snapshots:
       picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.52.3
+
+  '@rollup/pluginutils@5.1.3(rollup@4.59.0)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.59.0
 
   '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
     dependencies:
@@ -29012,7 +29035,7 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.6': {}
 
@@ -29606,10 +29629,10 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@vue-macros/common@1.15.0(rollup@4.34.9)(vue@3.5.13(typescript@5.9.3))':
+  '@vue-macros/common@1.15.0(rollup@4.59.0)(vue@3.5.13(typescript@5.9.3))':
     dependencies:
       '@babel/types': 7.28.0
-      '@rollup/pluginutils': 5.1.3(rollup@4.34.9)
+      '@rollup/pluginutils': 5.1.3(rollup@4.59.0)
       '@vue/compiler-sfc': 3.5.13
       ast-kit: 1.3.1
       local-pkg: 0.5.1
@@ -30237,7 +30260,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30741,7 +30764,7 @@ snapshots:
 
   citty@0.1.6:
     dependencies:
-      consola: 3.2.3
+      consola: 3.4.2
 
   citty@0.2.1: {}
 
@@ -31030,7 +31053,7 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -31137,7 +31160,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0):
+  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -32414,7 +32437,7 @@ snapshots:
   externality@1.0.2:
     dependencies:
       enhanced-resolve: 5.20.0
-      mlly: 1.7.3
+      mlly: 1.8.0
       pathe: 1.1.2
       ufo: 1.5.4
 
@@ -32664,7 +32687,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.0
-      rollup: 4.52.3
+      rollup: 4.59.0
 
   flat-cache@4.0.1:
     dependencies:
@@ -32927,7 +32950,7 @@ snapshots:
   giget@1.2.3:
     dependencies:
       citty: 0.1.6
-      consola: 3.2.3
+      consola: 3.4.2
       defu: 6.1.4
       node-fetch-native: 1.6.4
       nypm: 0.3.12
@@ -33546,9 +33569,9 @@ snapshots:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
 
-  impound@0.2.0(rollup@4.34.9)(webpack-sources@3.3.4):
+  impound@0.2.0(rollup@4.59.0)(webpack-sources@3.3.4):
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.34.9)
+      '@rollup/pluginutils': 5.1.3(rollup@4.59.0)
       mlly: 1.7.2
       pathe: 1.1.2
       unenv: 1.10.0
@@ -34618,7 +34641,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -34646,7 +34669,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0):
+  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34734,14 +34757,14 @@ snapshots:
       '@parcel/watcher-wasm': 2.4.1
       citty: 0.1.6
       clipboardy: 4.0.0
-      consola: 3.2.3
+      consola: 3.4.2
       crossws: 0.3.1
       defu: 6.1.4
       get-port-please: 3.1.2
       h3: 1.13.0
       http-shutdown: 1.2.2
       jiti: 2.4.0
-      mlly: 1.7.3
+      mlly: 1.8.0
       node-forge: 1.3.1
       pathe: 1.1.2
       std-env: 3.10.0
@@ -35735,7 +35758,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36128,14 +36151,14 @@ snapshots:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
       '@netlify/functions': 2.8.2
-      '@rollup/plugin-alias': 5.1.1(rollup@4.34.9)
-      '@rollup/plugin-commonjs': 28.0.1(rollup@4.34.9)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.34.9)
-      '@rollup/plugin-json': 6.1.0(rollup@4.34.9)
-      '@rollup/plugin-node-resolve': 15.3.0(rollup@4.34.9)
-      '@rollup/plugin-replace': 6.0.1(rollup@4.34.9)
-      '@rollup/plugin-terser': 0.4.4(rollup@4.34.9)
-      '@rollup/pluginutils': 5.1.3(rollup@4.34.9)
+      '@rollup/plugin-alias': 5.1.1(rollup@4.59.0)
+      '@rollup/plugin-commonjs': 28.0.1(rollup@4.59.0)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.59.0)
+      '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
+      '@rollup/plugin-node-resolve': 15.3.0(rollup@4.59.0)
+      '@rollup/plugin-replace': 6.0.1(rollup@4.59.0)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.59.0)
+      '@rollup/pluginutils': 5.1.3(rollup@4.59.0)
       '@types/http-proxy': 1.17.15
       '@vercel/nft': 0.27.6(encoding@0.1.13)
       archiver: 7.0.1
@@ -36144,7 +36167,7 @@ snapshots:
       citty: 0.1.6
       compatx: 0.1.8
       confbox: 0.1.8
-      consola: 3.2.3
+      consola: 3.4.2
       cookie-es: 1.2.2
       croner: 9.0.0
       crossws: 0.3.1
@@ -36179,8 +36202,8 @@ snapshots:
       pkg-types: 1.2.1
       pretty-bytes: 6.1.1
       radix3: 1.1.2
-      rollup: 4.34.9
-      rollup-plugin-visualizer: 5.12.0(rollup@4.34.9)
+      rollup: 4.59.0
+      rollup-plugin-visualizer: 5.12.0(rollup@4.59.0)
       scule: 1.3.0
       semver: 7.6.3
       serve-placeholder: 2.0.2
@@ -36190,7 +36213,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.10.0
-      unimport: 3.14.4(rollup@4.34.9)
+      unimport: 3.14.4(rollup@4.59.0)
       unstorage: 1.13.1(@upstash/redis@1.34.3)(ioredis@5.4.1)
       untyped: 1.5.1
       unwasm: 0.3.9
@@ -36401,14 +36424,14 @@ snapshots:
 
   nuxi@3.15.0: {}
 
-  nuxt@3.14.159(@parcel/watcher@2.4.1)(@types/node@20.17.24)(@upstash/redis@1.34.3)(encoding@0.1.13)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.4.1)(less@4.4.0)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.9)(sass@1.90.0)(terser@5.43.1)(typescript@5.9.3)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(webpack-sources@3.3.4):
+  nuxt@3.14.159(@parcel/watcher@2.4.1)(@types/node@20.17.24)(@upstash/redis@1.34.3)(encoding@0.1.13)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.4.1)(less@4.4.0)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass@1.90.0)(terser@5.43.1)(typescript@5.9.3)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(webpack-sources@3.3.4):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.6.3(rollup@4.34.9)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(vue@3.5.13(typescript@5.9.3))
-      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.34.9)
-      '@nuxt/schema': 3.14.159(magicast@0.3.5)(rollup@4.34.9)
-      '@nuxt/telemetry': 2.6.0(magicast@0.3.5)(rollup@4.34.9)
-      '@nuxt/vite-builder': 3.14.159(@types/node@20.17.24)(eslint@9.39.3(jiti@2.6.1))(less@4.4.0)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.9)(sass@1.90.0)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.13(typescript@5.9.3))(webpack-sources@3.3.4)
+      '@nuxt/devtools': 1.6.3(rollup@4.59.0)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))(vue@3.5.13(typescript@5.9.3))
+      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.59.0)
+      '@nuxt/schema': 3.14.159(magicast@0.3.5)(rollup@4.59.0)
+      '@nuxt/telemetry': 2.6.0(magicast@0.3.5)(rollup@4.59.0)
+      '@nuxt/vite-builder': 3.14.159(@types/node@20.17.24)(eslint@9.39.3(jiti@2.6.1))(less@4.4.0)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.59.0)(sass@1.90.0)(terser@5.43.1)(typescript@5.9.3)(vue@3.5.13(typescript@5.9.3))(webpack-sources@3.3.4)
       '@unhead/dom': 1.11.11
       '@unhead/shared': 1.11.11
       '@unhead/ssr': 1.11.11
@@ -36431,7 +36454,7 @@ snapshots:
       h3: 1.13.0
       hookable: 5.5.3
       ignore: 6.0.2
-      impound: 0.2.0(rollup@4.34.9)(webpack-sources@3.3.4)
+      impound: 0.2.0(rollup@4.59.0)(webpack-sources@3.3.4)
       jiti: 2.4.0
       klona: 2.0.6
       knitwork: 1.1.0
@@ -36458,9 +36481,9 @@ snapshots:
       unctx: 2.3.1
       unenv: 1.10.0
       unhead: 1.11.11
-      unimport: 3.13.1(rollup@4.34.9)(webpack-sources@3.3.4)
+      unimport: 3.13.1(rollup@4.59.0)(webpack-sources@3.3.4)
       unplugin: 1.15.0(webpack-sources@3.3.4)
-      unplugin-vue-router: 0.10.8(rollup@4.34.9)(vue-router@4.5.0(vue@3.5.13(typescript@5.9.3)))(vue@3.5.13(typescript@5.9.3))(webpack-sources@3.3.4)
+      unplugin-vue-router: 0.10.8(rollup@4.59.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.9.3)))(vue@3.5.13(typescript@5.9.3))(webpack-sources@3.3.4)
       unstorage: 1.13.1(@upstash/redis@1.34.3)(ioredis@5.4.1)
       untyped: 1.5.1
       vue: 3.5.13(typescript@5.9.3)
@@ -36522,7 +36545,7 @@ snapshots:
   nypm@0.3.12:
     dependencies:
       citty: 0.1.6
-      consola: 3.2.3
+      consola: 3.4.2
       execa: 8.0.1
       pathe: 1.1.2
       pkg-types: 1.2.1
@@ -36531,7 +36554,7 @@ snapshots:
   nypm@0.4.1:
     dependencies:
       citty: 0.1.6
-      consola: 3.2.3
+      consola: 3.4.2
       pathe: 1.1.2
       pkg-types: 1.2.1
       tinyexec: 1.0.2
@@ -37236,7 +37259,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -38095,14 +38118,14 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
-  rollup-plugin-visualizer@5.12.0(rollup@4.34.9):
+  rollup-plugin-visualizer@5.12.0(rollup@4.59.0):
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
       source-map: 0.7.6
       yargs: 17.7.2
     optionalDependencies:
-      rollup: 4.34.9
+      rollup: 4.59.0
 
   rollup@3.29.5:
     optionalDependencies:
@@ -38266,7 +38289,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -38710,7 +38733,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0):
+  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -39005,7 +39028,7 @@ snapshots:
 
   sucrase@3.35.0:
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/gen-mapping': 0.3.13
       commander: 4.1.1
       glob: 10.5.0
       lines-and-columns: 1.2.4
@@ -39720,14 +39743,14 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.1
+      debug: 4.4.3(supports-color@9.4.0)
       esbuild: 0.27.3
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.19.2)(yaml@2.7.0)
       resolve-from: 5.0.0
-      rollup: 4.52.3
+      rollup: 4.59.0
       source-map: 0.7.6
       sucrase: 3.35.0
       tinyexec: 1.0.2
@@ -39748,14 +39771,14 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.1
+      debug: 4.4.3(supports-color@9.4.0)
       esbuild: 0.27.3
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.7.0)
       resolve-from: 5.0.0
-      rollup: 4.52.3
+      rollup: 4.59.0
       source-map: 0.7.6
       sucrase: 3.35.0
       tinyexec: 1.0.2
@@ -39776,14 +39799,14 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.1
+      debug: 4.4.3(supports-color@9.4.0)
       esbuild: 0.27.3
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.7.0)
       resolve-from: 5.0.0
-      rollup: 4.52.3
+      rollup: 4.59.0
       source-map: 0.7.6
       sucrase: 3.35.0
       tinyexec: 1.0.2
@@ -39951,7 +39974,7 @@ snapshots:
 
   unenv@1.10.0:
     dependencies:
-      consola: 3.2.3
+      consola: 3.4.2
       defu: 6.1.4
       mime: 3.0.0
       node-fetch-native: 1.6.4
@@ -39989,9 +40012,9 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unimport@3.13.1(rollup@4.34.9)(webpack-sources@3.3.4):
+  unimport@3.13.1(rollup@4.59.0)(webpack-sources@3.3.4):
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.34.9)
+      '@rollup/pluginutils': 5.1.3(rollup@4.59.0)
       acorn: 8.14.1
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
@@ -40008,9 +40031,9 @@ snapshots:
       - rollup
       - webpack-sources
 
-  unimport@3.14.4(rollup@4.34.9):
+  unimport@3.14.4(rollup@4.59.0):
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.34.9)
+      '@rollup/pluginutils': 5.1.3(rollup@4.59.0)
       acorn: 8.14.1
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
@@ -40022,7 +40045,7 @@ snapshots:
       pkg-types: 1.2.1
       scule: 1.3.0
       strip-literal: 2.1.1
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       unplugin: 1.16.0
     transitivePeerDependencies:
       - rollup
@@ -40091,11 +40114,11 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-vue-router@0.10.8(rollup@4.34.9)(vue-router@4.5.0(vue@3.5.13(typescript@5.9.3)))(vue@3.5.13(typescript@5.9.3))(webpack-sources@3.3.4):
+  unplugin-vue-router@0.10.8(rollup@4.59.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.9.3)))(vue@3.5.13(typescript@5.9.3))(webpack-sources@3.3.4):
     dependencies:
       '@babel/types': 7.26.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.34.9)
-      '@vue-macros/common': 1.15.0(rollup@4.34.9)(vue@3.5.13(typescript@5.9.3))
+      '@rollup/pluginutils': 5.1.0(rollup@4.59.0)
+      '@vue-macros/common': 1.15.0(rollup@4.59.0)(vue@3.5.13(typescript@5.9.3))
       ast-walker-scope: 0.6.2
       chokidar: 3.6.0
       fast-glob: 3.3.3
@@ -40155,7 +40178,7 @@ snapshots:
   untun@0.1.3:
     dependencies:
       citty: 0.1.6
-      consola: 3.2.3
+      consola: 3.4.2
       pathe: 1.1.2
 
   untyped@1.5.1:
@@ -40174,7 +40197,7 @@ snapshots:
     dependencies:
       knitwork: 1.1.0
       magic-string: 0.30.21
-      mlly: 1.7.3
+      mlly: 1.8.0
       pathe: 1.1.2
       pkg-types: 1.2.1
       unplugin: 1.16.0
@@ -40255,7 +40278,7 @@ snapshots:
 
   v8-to-istanbul@9.3.0:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.31
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
@@ -40366,10 +40389,10 @@ snapshots:
       optionator: 0.9.4
       typescript: 5.9.3
 
-  vite-plugin-inspect@0.8.9(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.34.9))(rollup@4.34.9)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)):
+  vite-plugin-inspect@0.8.9(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.59.0))(rollup@4.59.0)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.3(rollup@4.34.9)
+      '@rollup/pluginutils': 5.1.3(rollup@4.59.0)
       debug: 4.4.3(supports-color@9.4.0)
       error-stack-parser-es: 0.1.5
       fs-extra: 11.2.0
@@ -40379,7 +40402,7 @@ snapshots:
       sirv: 3.0.0
       vite: 5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)
     optionalDependencies:
-      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.34.9)
+      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.59.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -40937,7 +40960,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)


### PR DESCRIPTION
## Summary

- Adds `@ai-sdk/phota` provider package for the [Phota Labs](https://photalabs.mintlify.app/) image API
- Phota's multi-endpoint API (generate, edit, enhance, profile training) is mapped to AI SDK model strings so everything flows through the standard `generateImage()` interface
- Profile management (`train`, `status`) uses model strings with data returned via `providerMetadata.phota` (placeholder image returned so `generateImage` doesn't throw `NoImageGeneratedError`)
- Includes examples in `examples/ai-functions/src/generate-image/phota/`

### Model strings

| Model string | API endpoint | Purpose |
|---|---|---|
| `generate` | `POST /v1/phota/generate` | Text-to-image, supports `[[profileId]]` prompt syntax |
| `edit` | `POST /v1/phota/edit` | Edit images with prompt + optional profile identity preservation |
| `enhance` | `POST /v1/phota/enhance` | Automatic image enhancement (single image, no prompt) |
| `train` | `POST /v1/phota/profiles/add` | Kick off profile training from 30-100 image URLs, returns immediately |
| `status` | `GET /v1/phota/profiles/{id}/status` | Poll training status |

### Provider options

- `profileId` — for `status` polling
- `profileIds` — identity preservation in `edit`/`enhance`
- `proMode` — better quality at higher latency/cost
- `resolution` — `'1K'` or `'4K'` (requires `proMode`)

## Test plan

- [x] 22 unit tests passing in both Node and Edge runtimes
- [x] Formatter/linter clean (`pnpm fix` passes)
- [ ] Verify examples run against live Phota API with `PHOTA_API_KEY`