### PR TITLE
fix(xai): stream drops final text fragments when output_text.delta is incomplete

### DIFF
--- a/.changeset/fix-xai-stream-text-drop.md
+++ b/.changeset/fix-xai-stream-text-drop.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Fix text truncation in xAI Responses streaming when output_text.delta events don't deliver all text fragments

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -485,7 +485,10 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
     };
     let usage: LanguageModelV4Usage | undefined = undefined;
     let isFirstChunk = true;
-    const contentBlocks: Record<string, { type: 'text' }> = {};
+    const contentBlocks: Record<
+      string,
+      { type: 'text'; streamedLength: number }
+    > = {};
     const seenToolCalls = new Set<string>();
 
     // Track ongoing function calls by output_index so we can stream
@@ -612,12 +615,14 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
               const blockId = `text-${event.item_id}`;
 
               if (contentBlocks[blockId] == null) {
-                contentBlocks[blockId] = { type: 'text' };
+                contentBlocks[blockId] = { type: 'text', streamedLength: 0 };
                 controller.enqueue({
                   type: 'text-start',
                   id: blockId,
                 });
               }
+
+              contentBlocks[blockId].streamedLength += event.delta.length;
 
               controller.enqueue({
                 type: 'text-delta',
@@ -896,18 +901,27 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
                   if (contentPart.text && contentPart.text.length > 0) {
                     const blockId = `text-${part.id}`;
 
-                    // Only emit text if we haven't already streamed it via output_text.delta events
                     if (contentBlocks[blockId] == null) {
-                      contentBlocks[blockId] = { type: 'text' };
+                      contentBlocks[blockId] = {
+                        type: 'text',
+                        streamedLength: 0,
+                      };
                       controller.enqueue({
                         type: 'text-start',
                         id: blockId,
                       });
+                    }
 
+                    // Only emit text that wasn't already delivered via
+                    // output_text.delta events to avoid duplicates.
+                    const remaining = contentPart.text.slice(
+                      contentBlocks[blockId].streamedLength,
+                    );
+                    if (remaining.length > 0) {
                       controller.enqueue({
                         type: 'text-delta',
                         id: blockId,
-                        delta: contentPart.text,
+                        delta: remaining,
                       });
                     }
                   }


### PR DESCRIPTION
Closes #13836

In the xAI Responses stream handler, `response.output_item.done` carries the full accumulated text for a content block. Previously, if the block already existed (created by earlier `output_text.delta` events), the text from `output_item.done` was completely skipped. This works fine when all text is delivered via delta events, but if the stream ends before all deltas arrive, the remaining text gets silently dropped.

The fix tracks how many characters were already streamed via `output_text.delta` events (`streamedLength`), and when `output_item.done` fires, only emits the slice that wasn't already delivered. So:
- Normal case (all deltas arrived): `remaining` is empty, nothing extra emitted
- Truncated case (some deltas missing): only the missing tail gets emitted