### PR TITLE
feat(google): support Gemini built-in tool and function combinations

### DIFF
--- a/packages/google/src/convert-to-google-generative-ai-messages.test.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.test.ts
@@ -71,6 +71,7 @@ describe('thought signatures', () => {
                   "args": {
                     "value": "test",
                   },
+                  "id": "call1",
                   "name": "test",
                 },
                 "thoughtSignature": "sig3",
@@ -134,6 +135,7 @@ describe('thought signatures with vertex providerOptionsName', () => {
                   "args": {
                     "location": "London",
                   },
+                  "id": "call1",
                   "name": "getWeather",
                 },
                 "thoughtSignature": "sig3",
@@ -173,6 +175,7 @@ describe('thought signatures with vertex providerOptionsName', () => {
       functionCall: {
         name: 'getWeather',
         args: { location: 'London' },
+        id: 'call1',
       },
       thoughtSignature: 'vertex_sig',
     });
@@ -203,6 +206,7 @@ describe('thought signatures with vertex providerOptionsName', () => {
       functionCall: {
         name: 'getWeather',
         args: { location: 'London' },
+        id: 'call1',
       },
       thoughtSignature: 'vertex_sig',
     });
@@ -258,6 +262,7 @@ describe('thought signatures with google providerOptionsName (gateway failover)'
                   "args": {
                     "location": "London",
                   },
+                  "id": "call1",
                   "name": "getWeather",
                 },
                 "thoughtSignature": "sig3",
@@ -297,6 +302,7 @@ describe('thought signatures with google providerOptionsName (gateway failover)'
       functionCall: {
         name: 'getWeather',
         args: { location: 'London' },
+        id: 'call1',
       },
       thoughtSignature: 'google_sig',
     });
@@ -324,6 +330,7 @@ describe('thought signatures with google providerOptionsName (gateway failover)'
       functionCall: {
         name: 'getWeather',
         args: { location: 'London' },
+        id: 'call1',
       },
       thoughtSignature: 'vertex_sig',
     });
@@ -527,6 +534,7 @@ describe('tool messages', () => {
           parts: [
             {
               functionResponse: {
+                id: 'testCallId',
                 name: 'testFunction',
                 response: {
                   name: 'testFunction',
@@ -576,6 +584,7 @@ describe('tool messages', () => {
           parts: [
             {
               functionResponse: {
+                id: 'testCallId',
                 name: 'imageGenerator',
                 response: {
                   name: 'imageGenerator',
@@ -624,6 +633,7 @@ describe('tool messages', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionResponse: {
+        id: 'testCallId',
         name: 'documentReader',
         response: {
           name: 'documentReader',
@@ -666,6 +676,7 @@ describe('tool messages', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionResponse: {
+        id: 'testCallId',
         name: 'imageGenerator',
         response: {
           name: 'imageGenerator',
@@ -708,6 +719,7 @@ describe('tool messages', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionResponse: {
+        id: 'testCallId',
         name: 'imageGenerator',
         response: {
           name: 'imageGenerator',
@@ -742,6 +754,7 @@ describe('tool messages', () => {
 
     expect(result.contents[0].parts[0]).toEqual({
       functionResponse: {
+        id: 'testCallId',
         name: 'documentReader',
         response: {
           name: 'documentReader',
@@ -791,6 +804,7 @@ describe('tool messages', () => {
     expect(result.contents[0].parts).toEqual([
       {
         functionResponse: {
+          id: 'testCallId',
           name: 'imageGenerator',
           response: {
             name: 'imageGenerator',
@@ -1122,6 +1136,7 @@ describe('parallel tool calls', () => {
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
         args: { city: 'paris' },
+        id: 'call1',
         name: 'checkweather',
       },
       thoughtSignature: 'sig_parallel',
@@ -1130,6 +1145,7 @@ describe('parallel tool calls', () => {
     expect(result.contents[0].parts[1]).toEqual({
       functionCall: {
         args: { city: 'london' },
+        id: 'call2',
         name: 'checkweather',
       },
       thoughtSignature: undefined,
@@ -1172,6 +1188,7 @@ describe('tool results with thought signatures', () => {
     expect(result.contents[0].parts[0]).toEqual({
       functionCall: {
         args: { userId: '123' },
+        id: 'call1',
         name: 'readdata',
       },
       thoughtSignature: 'sig_original',
@@ -1179,6 +1196,7 @@ describe('tool results with thought signatures', () => {
 
     expect(result.contents[1].parts[0]).toEqual({
       functionResponse: {
+        id: 'call1',
         name: 'readdata',
         response: {
           content: 'file not found',
@@ -1188,5 +1206,67 @@ describe('tool results with thought signatures', () => {
     });
 
     expect(result.contents[1].parts[0]).not.toHaveProperty('thoughtSignature');
+  });
+
+  it('should preserve provider-executed built-in tool context in assistant messages', async () => {
+    const result = convertToGoogleGenerativeAIMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'search-call',
+            toolName: 'GOOGLE_SEARCH_WEB',
+            input: '{"queries":["weather today"]}',
+            providerExecuted: true,
+            providerOptions: {
+              google: {
+                thoughtSignature: 'sig-tool-call',
+                serverSideToolCall: {
+                  id: 'search-call',
+                  toolType: 'GOOGLE_SEARCH_WEB',
+                  args: { queries: ['weather today'] },
+                },
+              },
+            },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'search-call',
+            toolName: 'GOOGLE_SEARCH_WEB',
+            result: { summary: 'cold' },
+            providerOptions: {
+              google: {
+                thoughtSignature: 'sig-tool-response',
+                serverSideToolResponse: {
+                  id: 'search-call',
+                  toolType: 'GOOGLE_SEARCH_WEB',
+                  response: { summary: 'cold' },
+                },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.contents[0].parts).toEqual([
+      {
+        toolCall: {
+          id: 'search-call',
+          toolType: 'GOOGLE_SEARCH_WEB',
+          args: { queries: ['weather today'] },
+        },
+        thoughtSignature: 'sig-tool-call',
+      },
+      {
+        toolResponse: {
+          id: 'search-call',
+          toolType: 'GOOGLE_SEARCH_WEB',
+          response: { summary: 'cold' },
+        },
+        thoughtSignature: 'sig-tool-response',
+      },
+    ]);
   });
 });

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -4,10 +4,14 @@ import {
 } from '@ai-sdk/provider';
 import { convertToBase64 } from '@ai-sdk/provider-utils';
 import {
+  GoogleGenerativeAICodeExecutionResultPart,
   GoogleGenerativeAIContent,
   GoogleGenerativeAIContentPart,
+  GoogleGenerativeAIExecutableCodePart,
   GoogleGenerativeAIFunctionResponsePart,
   GoogleGenerativeAIPrompt,
+  GoogleGenerativeAIServerSideToolCall,
+  GoogleGenerativeAIServerSideToolResponse,
 } from './google-generative-ai-prompt';
 
 const dataUrlRegex = /^data:([^;,]+);base64,(.+)$/s;
@@ -52,6 +56,7 @@ function convertUrlToolResultPart(
  */
 function appendToolResultParts(
   parts: GoogleGenerativeAIContentPart[],
+  toolCallId: string,
   toolName: string,
   outputValue: Array<{
     type: string;
@@ -99,6 +104,7 @@ function appendToolResultParts(
 
   parts.push({
     functionResponse: {
+      id: toolCallId,
       name: toolName,
       response: {
         name: toolName,
@@ -121,6 +127,7 @@ function appendToolResultParts(
  */
 function appendLegacyToolResultParts(
   parts: GoogleGenerativeAIContentPart[],
+  toolCallId: string,
   toolName: string,
   outputValue: Array<{
     type: string;
@@ -132,6 +139,7 @@ function appendLegacyToolResultParts(
       case 'text':
         parts.push({
           functionResponse: {
+            id: toolCallId,
             name: toolName,
             response: {
               name: toolName,
@@ -158,6 +166,65 @@ function appendLegacyToolResultParts(
         break;
     }
   }
+}
+
+function getProviderOptions(
+  providerOptions: Record<string, any> | undefined,
+  providerOptionsName: string,
+) {
+  return (
+    providerOptions?.[providerOptionsName] ??
+    (providerOptionsName !== 'google'
+      ? providerOptions?.google
+      : providerOptions?.vertex)
+  );
+}
+
+function getThoughtSignature(
+  providerOptions: Record<string, any> | undefined,
+  providerOptionsName: string,
+) {
+  const providerOpts = getProviderOptions(providerOptions, providerOptionsName);
+
+  return providerOpts?.thoughtSignature != null
+    ? String(providerOpts.thoughtSignature)
+    : undefined;
+}
+
+function getServerSideToolCall(
+  providerOptions: Record<string, any> | undefined,
+  providerOptionsName: string,
+): GoogleGenerativeAIServerSideToolCall | undefined {
+  return getProviderOptions(providerOptions, providerOptionsName)
+    ?.serverSideToolCall as GoogleGenerativeAIServerSideToolCall | undefined;
+}
+
+function getServerSideToolResponse(
+  providerOptions: Record<string, any> | undefined,
+  providerOptionsName: string,
+): GoogleGenerativeAIServerSideToolResponse | undefined {
+  return getProviderOptions(providerOptions, providerOptionsName)
+    ?.serverSideToolResponse as
+    | GoogleGenerativeAIServerSideToolResponse
+    | undefined;
+}
+
+function getExecutableCode(
+  providerOptions: Record<string, any> | undefined,
+  providerOptionsName: string,
+): GoogleGenerativeAIExecutableCodePart | undefined {
+  return getProviderOptions(providerOptions, providerOptionsName)
+    ?.executableCode as GoogleGenerativeAIExecutableCodePart | undefined;
+}
+
+function getCodeExecutionResult(
+  providerOptions: Record<string, any> | undefined,
+  providerOptionsName: string,
+): GoogleGenerativeAICodeExecutionResultPart | undefined {
+  return getProviderOptions(providerOptions, providerOptionsName)
+    ?.codeExecutionResult as
+    | GoogleGenerativeAICodeExecutionResultPart
+    | undefined;
 }
 
 export function convertToGoogleGenerativeAIMessages(
@@ -239,15 +306,14 @@ export function convertToGoogleGenerativeAIMessages(
           role: 'model',
           parts: content
             .map(part => {
-              const providerOpts =
-                part.providerOptions?.[providerOptionsName] ??
-                (providerOptionsName !== 'google'
-                  ? part.providerOptions?.google
-                  : part.providerOptions?.vertex);
-              const thoughtSignature =
-                providerOpts?.thoughtSignature != null
-                  ? String(providerOpts.thoughtSignature)
-                  : undefined;
+              const providerOpts = getProviderOptions(
+                part.providerOptions,
+                providerOptionsName,
+              );
+              const thoughtSignature = getThoughtSignature(
+                part.providerOptions,
+                providerOptionsName,
+              );
 
               switch (part.type) {
                 case 'text': {
@@ -308,13 +374,68 @@ export function convertToGoogleGenerativeAIMessages(
                 }
 
                 case 'tool-call': {
+                  if (part.providerExecuted === true) {
+                    const serverSideToolCall = getServerSideToolCall(
+                      part.providerOptions,
+                      providerOptionsName,
+                    );
+
+                    if (serverSideToolCall != null) {
+                      return {
+                        toolCall: serverSideToolCall,
+                        thoughtSignature,
+                      };
+                    }
+
+                    const executableCode = getExecutableCode(
+                      part.providerOptions,
+                      providerOptionsName,
+                    );
+
+                    if (executableCode != null) {
+                      return {
+                        executableCode,
+                        thoughtSignature,
+                      };
+                    }
+                  }
+
                   return {
                     functionCall: {
                       name: part.toolName,
                       args: part.input,
+                      id: part.toolCallId,
                     },
                     thoughtSignature,
                   };
+                }
+
+                case 'tool-result': {
+                  const serverSideToolResponse = getServerSideToolResponse(
+                    part.providerOptions,
+                    providerOptionsName,
+                  );
+
+                  if (serverSideToolResponse != null) {
+                    return {
+                      toolResponse: serverSideToolResponse,
+                      thoughtSignature,
+                    };
+                  }
+
+                  const codeExecutionResult = getCodeExecutionResult(
+                    part.providerOptions,
+                    providerOptionsName,
+                  );
+
+                  if (codeExecutionResult != null) {
+                    return {
+                      codeExecutionResult,
+                      thoughtSignature,
+                    };
+                  }
+
+                  return undefined;
                 }
               }
             })
@@ -336,13 +457,24 @@ export function convertToGoogleGenerativeAIMessages(
 
           if (output.type === 'content') {
             if (supportsFunctionResponseParts) {
-              appendToolResultParts(parts, part.toolName, output.value);
+              appendToolResultParts(
+                parts,
+                part.toolCallId,
+                part.toolName,
+                output.value,
+              );
             } else {
-              appendLegacyToolResultParts(parts, part.toolName, output.value);
+              appendLegacyToolResultParts(
+                parts,
+                part.toolCallId,
+                part.toolName,
+                output.value,
+              );
             }
           } else {
             parts.push({
               functionResponse: {
+                id: part.toolCallId,
                 name: part.toolName,
                 response: {
                   name: part.toolName,

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -395,7 +395,12 @@ describe('doGenerate', () => {
         | typeof TEST_URL_GEMINI_2_0_PRO
         | typeof TEST_URL_GEMINI_2_0_FLASH_EXP
         | typeof TEST_URL_GEMINI_1_0_PRO
-        | typeof TEST_URL_GEMINI_1_5_FLASH;
+        | typeof TEST_URL_GEMINI_1_5_FLASH
+        | typeof TEST_URL_GEMINI_3_PRO
+        | typeof TEST_URL_GEMINI_3_1_PRO
+        | typeof TEST_URL_GEMINI_2_5_PRO
+        | typeof TEST_URL_GEMINI_2_5_FLASH
+        | typeof TEST_URL_GEMINI_2_5_FLASH_LITE;
     } = {},
   ) {
     server.urls[url].response = {
@@ -431,7 +436,12 @@ describe('doGenerate', () => {
       | typeof TEST_URL_GEMINI_2_0_PRO
       | typeof TEST_URL_GEMINI_2_0_FLASH_EXP
       | typeof TEST_URL_GEMINI_1_0_PRO
-      | typeof TEST_URL_GEMINI_1_5_FLASH;
+      | typeof TEST_URL_GEMINI_1_5_FLASH
+      | typeof TEST_URL_GEMINI_3_PRO
+      | typeof TEST_URL_GEMINI_3_1_PRO
+      | typeof TEST_URL_GEMINI_2_5_PRO
+      | typeof TEST_URL_GEMINI_2_5_FLASH
+      | typeof TEST_URL_GEMINI_2_5_FLASH_LITE;
   }) => {
     server.urls[url].response = {
       type: 'json-value',
@@ -627,6 +637,338 @@ describe('doGenerate', () => {
       });
 
       expect(result).toMatchSnapshot();
+    });
+  });
+
+  it('should pass combined tools and include server-side tool invocations in combo mode', async () => {
+    prepareJsonResponse({
+      content: 'combined tools ready',
+      url: TEST_URL_GEMINI_3_1_PRO,
+    });
+
+    const comboModel = provider.chat('gemini-3.1-pro-preview');
+
+    await comboModel.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'getWeather',
+          description: 'Get weather for a city',
+          inputSchema: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+            required: ['city'],
+          },
+        },
+        {
+          type: 'provider',
+          id: 'google.google_search',
+          name: 'google_search',
+          args: {},
+        },
+      ],
+      toolChoice: { type: 'auto' },
+      providerOptions: {
+        google: {
+          retrievalConfig: {
+            latLng: {
+              latitude: 64.8378,
+              longitude: -147.7164,
+            },
+          },
+        },
+      },
+    });
+
+    expect(await server.calls.at(-1)?.requestBodyJson).toMatchObject({
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: 'getWeather',
+              description: 'Get weather for a city',
+            },
+          ],
+        },
+        { googleSearch: {} },
+      ],
+      toolConfig: {
+        includeServerSideToolInvocations: true,
+        functionCallingConfig: { mode: 'VALIDATED' },
+        retrievalConfig: {
+          latLng: {
+            latitude: 64.8378,
+            longitude: -147.7164,
+          },
+        },
+      },
+    });
+  });
+
+  it('should parse server-side tool parts alongside function calls', async () => {
+    server.urls[TEST_URL_GEMINI_3_1_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  thoughtSignature: 'sig-tool-call',
+                  toolCall: {
+                    id: 'search-call',
+                    toolType: 'GOOGLE_SEARCH_WEB',
+                    args: { queries: ['northernmost city in the US'] },
+                  },
+                },
+                {
+                  thoughtSignature: 'sig-tool-response',
+                  toolResponse: {
+                    id: 'search-call',
+                    toolType: 'GOOGLE_SEARCH_WEB',
+                    response: { city: 'Utqiagvik, Alaska' },
+                  },
+                },
+                {
+                  thoughtSignature: 'sig-function-call',
+                  functionCall: {
+                    id: 'weather-call',
+                    name: 'getWeather',
+                    args: { city: 'Utqiagvik, Alaska' },
+                  },
+                },
+              ],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+          totalTokenCount: 30,
+        },
+      },
+    };
+
+    const comboModel = provider.chat('gemini-3.1-pro-preview');
+    const result = await comboModel.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'getWeather',
+          inputSchema: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+          },
+        },
+        {
+          type: 'provider',
+          id: 'google.google_search',
+          name: 'google_search',
+          args: {},
+        },
+      ],
+    });
+
+    expect(result.content).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'search-call',
+        toolName: 'GOOGLE_SEARCH_WEB',
+        input: '{"queries":["northernmost city in the US"]}',
+        providerExecuted: true,
+        providerMetadata: {
+          google: {
+            thoughtSignature: 'sig-tool-call',
+            serverSideToolCall: {
+              id: 'search-call',
+              toolType: 'GOOGLE_SEARCH_WEB',
+              args: { queries: ['northernmost city in the US'] },
+            },
+          },
+        },
+      },
+      {
+        type: 'tool-result',
+        toolCallId: 'search-call',
+        toolName: 'GOOGLE_SEARCH_WEB',
+        result: { city: 'Utqiagvik, Alaska' },
+        providerMetadata: {
+          google: {
+            thoughtSignature: 'sig-tool-response',
+            serverSideToolResponse: {
+              id: 'search-call',
+              toolType: 'GOOGLE_SEARCH_WEB',
+              response: { city: 'Utqiagvik, Alaska' },
+            },
+          },
+        },
+      },
+      {
+        type: 'tool-call',
+        toolCallId: 'weather-call',
+        toolName: 'getWeather',
+        input: '{"city":"Utqiagvik, Alaska"}',
+        providerMetadata: {
+          google: {
+            thoughtSignature: 'sig-function-call',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('should circulate built-in tool context and function response on follow-up turns', async () => {
+    prepareJsonResponse({
+      content: 'follow up',
+      url: TEST_URL_GEMINI_3_1_PRO,
+    });
+
+    const comboModel = provider.chat('gemini-3.1-pro-preview');
+
+    await comboModel.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'What is the weather there?' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'search-call',
+              toolName: 'GOOGLE_SEARCH_WEB',
+              input: '{"queries":["northernmost city in the US"]}',
+              providerExecuted: true,
+              providerOptions: {
+                google: {
+                  thoughtSignature: 'sig-tool-call',
+                  serverSideToolCall: {
+                    id: 'search-call',
+                    toolType: 'GOOGLE_SEARCH_WEB',
+                    args: { queries: ['northernmost city in the US'] },
+                  },
+                },
+              },
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'search-call',
+              toolName: 'GOOGLE_SEARCH_WEB',
+              result: { city: 'Utqiagvik, Alaska' },
+              providerOptions: {
+                google: {
+                  thoughtSignature: 'sig-tool-response',
+                  serverSideToolResponse: {
+                    id: 'search-call',
+                    toolType: 'GOOGLE_SEARCH_WEB',
+                    response: { city: 'Utqiagvik, Alaska' },
+                  },
+                },
+              },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'weather-call',
+              toolName: 'getWeather',
+              input: { city: 'Utqiagvik, Alaska' },
+              providerOptions: {
+                google: { thoughtSignature: 'sig-function-call' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'weather-call',
+              toolName: 'getWeather',
+              output: {
+                type: 'json',
+                value: { response: 'Very cold. 22 degrees Fahrenheit.' },
+              },
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          type: 'function',
+          name: 'getWeather',
+          inputSchema: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+          },
+        },
+        {
+          type: 'provider',
+          id: 'google.google_search',
+          name: 'google_search',
+          args: {},
+        },
+      ],
+    });
+
+    expect(await server.calls.at(-1)?.requestBodyJson).toMatchObject({
+      contents: [
+        {
+          role: 'user',
+          parts: [{ text: 'What is the weather there?' }],
+        },
+        {
+          role: 'model',
+          parts: [
+            {
+              thoughtSignature: 'sig-tool-call',
+              toolCall: {
+                id: 'search-call',
+                toolType: 'GOOGLE_SEARCH_WEB',
+                args: { queries: ['northernmost city in the US'] },
+              },
+            },
+            {
+              thoughtSignature: 'sig-tool-response',
+              toolResponse: {
+                id: 'search-call',
+                toolType: 'GOOGLE_SEARCH_WEB',
+                response: { city: 'Utqiagvik, Alaska' },
+              },
+            },
+            {
+              thoughtSignature: 'sig-function-call',
+              functionCall: {
+                id: 'weather-call',
+                name: 'getWeather',
+                args: { city: 'Utqiagvik, Alaska' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'weather-call',
+                name: 'getWeather',
+                response: {
+                  name: 'getWeather',
+                  content: { response: 'Very cold. 22 degrees Fahrenheit.' },
+                },
+              },
+            },
+          ],
+        },
+      ],
+      toolConfig: {
+        includeServerSideToolInvocations: true,
+      },
     });
   });
 

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -1,4 +1,5 @@
 import {
+  JSONValue,
   LanguageModelV4,
   LanguageModelV4CallOptions,
   LanguageModelV4Content,
@@ -42,8 +43,12 @@ import {
   googleLanguageModelOptions,
 } from './google-generative-ai-options';
 import {
+  GoogleGenerativeAICodeExecutionResultPart,
   GoogleGenerativeAIContentPart,
+  GoogleGenerativeAIExecutableCodePart,
   GoogleGenerativeAIProviderMetadata,
+  GoogleGenerativeAIServerSideToolCall,
+  GoogleGenerativeAIServerSideToolResponse,
 } from './google-generative-ai-prompt';
 import { prepareTools } from './google-prepare-tools';
 import { mapGoogleGenerativeAIFinishReason } from './map-google-generative-ai-finish-reason';
@@ -124,7 +129,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
     // Add warning if Vertex rag tools are used with a non-Vertex Google provider
     if (
       tools?.some(
-        tool =>
+        (tool: NonNullable<LanguageModelV4CallOptions['tools']>[number]) =>
           tool.type === 'provider' && tool.id === 'google.vertex_rag_store',
       ) &&
       !this.config.provider.startsWith('google.vertex.')
@@ -159,6 +164,29 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
       toolChoice,
       modelId: this.modelId,
     });
+    const hasServerSideToolContext = prompt.some(
+      (message: LanguageModelV4CallOptions['prompt'][number]) =>
+        message.role === 'assistant' &&
+        message.content.some(
+          (
+            part: LanguageModelV4CallOptions['prompt'][number] extends {
+              role: 'assistant';
+              content: infer T;
+            }
+              ? T extends Array<infer U>
+                ? U
+                : never
+              : never,
+          ) =>
+            ((part.type === 'tool-call' && part.providerExecuted === true) ||
+              part.type === 'tool-result') &&
+            part.providerOptions != null &&
+            (part.providerOptions.google?.serverSideToolCall != null ||
+              part.providerOptions.vertex?.serverSideToolCall != null ||
+              part.providerOptions.google?.serverSideToolResponse != null ||
+              part.providerOptions.vertex?.serverSideToolResponse != null),
+        ),
+    );
 
     const resolvedThinking = resolveThinkingConfig({
       reasoning,
@@ -213,12 +241,18 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
         systemInstruction: isGemmaModel ? undefined : systemInstruction,
         safetySettings: googleOptions?.safetySettings,
         tools: googleTools,
-        toolConfig: googleOptions?.retrievalConfig
-          ? {
-              ...googleToolConfig,
-              retrievalConfig: googleOptions.retrievalConfig,
-            }
-          : googleToolConfig,
+        toolConfig:
+          googleOptions?.retrievalConfig != null || hasServerSideToolContext
+            ? {
+                ...googleToolConfig,
+                ...(googleOptions?.retrievalConfig != null
+                  ? { retrievalConfig: googleOptions.retrievalConfig }
+                  : {}),
+                ...(hasServerSideToolContext
+                  ? { includeServerSideToolInvocations: true }
+                  : {}),
+              }
+            : googleToolConfig,
         cachedContent: googleOptions?.cachedContent,
         labels: googleOptions?.labels,
       },
@@ -267,7 +301,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
     // Build content array from all parts
     for (const part of parts) {
       if ('executableCode' in part && part.executableCode?.code) {
-        const toolCallId = this.config.generateId();
+        const toolCallId = part.executableCode.id ?? this.config.generateId();
         lastCodeExecutionToolCallId = toolCallId;
 
         content.push({
@@ -276,28 +310,61 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
           toolName: 'code_execution',
           input: JSON.stringify(part.executableCode),
           providerExecuted: true,
+          providerMetadata: getExecutableCodeMetadata({
+            providerOptionsName,
+            executableCode: part.executableCode,
+            thoughtSignature: part.thoughtSignature,
+          }),
         });
       } else if ('codeExecutionResult' in part && part.codeExecutionResult) {
         content.push({
           type: 'tool-result',
           // Assumes a result directly follows its corresponding call part.
-          toolCallId: lastCodeExecutionToolCallId!,
+          toolCallId:
+            part.codeExecutionResult.id ?? lastCodeExecutionToolCallId!,
           toolName: 'code_execution',
           result: {
             outcome: part.codeExecutionResult.outcome,
             output: part.codeExecutionResult.output ?? '',
           },
+          providerMetadata: getCodeExecutionResultMetadata({
+            providerOptionsName,
+            codeExecutionResult: part.codeExecutionResult,
+            thoughtSignature: part.thoughtSignature,
+          }),
         });
         // Clear the ID after use to avoid accidental reuse.
         lastCodeExecutionToolCallId = undefined;
+      } else if ('toolCall' in part && part.toolCall) {
+        content.push({
+          type: 'tool-call',
+          toolCallId: part.toolCall.id,
+          toolName: part.toolCall.toolType,
+          input: JSON.stringify(part.toolCall.args ?? {}),
+          providerExecuted: true,
+          providerMetadata: getServerSideToolCallMetadata({
+            providerOptionsName,
+            toolCall: part.toolCall,
+            thoughtSignature: part.thoughtSignature,
+          }),
+        });
+      } else if ('toolResponse' in part && part.toolResponse) {
+        content.push({
+          type: 'tool-result',
+          toolCallId: part.toolResponse.id,
+          toolName: part.toolResponse.toolType,
+          result: (part.toolResponse.response ?? {}) as NonNullable<JSONValue>,
+          providerMetadata: getServerSideToolResponseMetadata({
+            providerOptionsName,
+            toolResponse: part.toolResponse,
+            thoughtSignature: part.thoughtSignature,
+          }),
+        });
       } else if ('text' in part && part.text != null) {
-        const thoughtSignatureMetadata = part.thoughtSignature
-          ? {
-              [providerOptionsName]: {
-                thoughtSignature: part.thoughtSignature,
-              },
-            }
-          : undefined;
+        const thoughtSignatureMetadata = getThoughtSignatureMetadata({
+          providerOptionsName,
+          thoughtSignature: part.thoughtSignature,
+        });
 
         if (part.text.length === 0) {
           if (thoughtSignatureMetadata != null && content.length > 0) {
@@ -314,16 +381,13 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
       } else if ('functionCall' in part) {
         content.push({
           type: 'tool-call' as const,
-          toolCallId: this.config.generateId(),
+          toolCallId: part.functionCall.id ?? this.config.generateId(),
           toolName: part.functionCall.name,
           input: JSON.stringify(part.functionCall.args),
-          providerMetadata: part.thoughtSignature
-            ? {
-                [providerOptionsName]: {
-                  thoughtSignature: part.thoughtSignature,
-                },
-              }
-            : undefined,
+          providerMetadata: getThoughtSignatureMetadata({
+            providerOptionsName,
+            thoughtSignature: part.thoughtSignature,
+          }),
         });
       } else if ('inlineData' in part) {
         const hasThought = part.thought === true;
@@ -495,22 +559,28 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
               const parts = content.parts ?? [];
               for (const part of parts) {
                 if ('executableCode' in part && part.executableCode?.code) {
-                  const toolCallId = generateId();
+                  const toolCallId = part.executableCode.id ?? generateId();
                   lastCodeExecutionToolCallId = toolCallId;
 
-                  controller.enqueue({
-                    type: 'tool-call',
+                  emitToolCallEvents({
+                    controller,
                     toolCallId,
                     toolName: 'code_execution',
                     input: JSON.stringify(part.executableCode),
                     providerExecuted: true,
+                    providerMetadata: getExecutableCodeMetadata({
+                      providerOptionsName,
+                      executableCode: part.executableCode,
+                      thoughtSignature: part.thoughtSignature,
+                    }),
                   });
                 } else if (
                   'codeExecutionResult' in part &&
                   part.codeExecutionResult
                 ) {
                   // Assumes a result directly follows its corresponding call part.
-                  const toolCallId = lastCodeExecutionToolCallId;
+                  const toolCallId =
+                    part.codeExecutionResult.id ?? lastCodeExecutionToolCallId;
 
                   if (toolCallId) {
                     controller.enqueue({
@@ -521,18 +591,46 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
                         outcome: part.codeExecutionResult.outcome,
                         output: part.codeExecutionResult.output ?? '',
                       },
+                      providerMetadata: getCodeExecutionResultMetadata({
+                        providerOptionsName,
+                        codeExecutionResult: part.codeExecutionResult,
+                        thoughtSignature: part.thoughtSignature,
+                      }),
                     });
                     // Clear the ID after use.
                     lastCodeExecutionToolCallId = undefined;
                   }
+                } else if ('toolCall' in part && part.toolCall) {
+                  emitToolCallEvents({
+                    controller,
+                    toolCallId: part.toolCall.id,
+                    toolName: part.toolCall.toolType,
+                    input: JSON.stringify(part.toolCall.args ?? {}),
+                    providerExecuted: true,
+                    providerMetadata: getServerSideToolCallMetadata({
+                      providerOptionsName,
+                      toolCall: part.toolCall,
+                      thoughtSignature: part.thoughtSignature,
+                    }),
+                  });
+                } else if ('toolResponse' in part && part.toolResponse) {
+                  controller.enqueue({
+                    type: 'tool-result',
+                    toolCallId: part.toolResponse.id,
+                    toolName: part.toolResponse.toolType,
+                    result: (part.toolResponse.response ??
+                      {}) as NonNullable<JSONValue>,
+                    providerMetadata: getServerSideToolResponseMetadata({
+                      providerOptionsName,
+                      toolResponse: part.toolResponse,
+                      thoughtSignature: part.thoughtSignature,
+                    }),
+                  });
                 } else if ('text' in part && part.text != null) {
-                  const thoughtSignatureMetadata = part.thoughtSignature
-                    ? {
-                        [providerOptionsName]: {
-                          thoughtSignature: part.thoughtSignature,
-                        },
-                      }
-                    : undefined;
+                  const thoughtSignatureMetadata = getThoughtSignatureMetadata({
+                    providerOptionsName,
+                    thoughtSignature: part.thoughtSignature,
+                  });
 
                   if (part.text.length === 0) {
                     if (
@@ -630,45 +728,17 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
                     data: part.inlineData.data,
                     providerMetadata: fileMeta,
                   });
-                }
-              }
-
-              const toolCallDeltas = getToolCallsFromParts({
-                parts: content.parts,
-                generateId,
-                providerOptionsName,
-              });
-
-              if (toolCallDeltas != null) {
-                for (const toolCall of toolCallDeltas) {
-                  controller.enqueue({
-                    type: 'tool-input-start',
-                    id: toolCall.toolCallId,
-                    toolName: toolCall.toolName,
-                    providerMetadata: toolCall.providerMetadata,
+                } else if ('functionCall' in part) {
+                  emitToolCallEvents({
+                    controller,
+                    toolCallId: part.functionCall.id ?? generateId(),
+                    toolName: part.functionCall.name,
+                    input: JSON.stringify(part.functionCall.args),
+                    providerMetadata: getThoughtSignatureMetadata({
+                      providerOptionsName,
+                      thoughtSignature: part.thoughtSignature,
+                    }),
                   });
-
-                  controller.enqueue({
-                    type: 'tool-input-delta',
-                    id: toolCall.toolCallId,
-                    delta: toolCall.args,
-                    providerMetadata: toolCall.providerMetadata,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.toolCallId,
-                    providerMetadata: toolCall.providerMetadata,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.toolCallId,
-                    toolName: toolCall.toolName,
-                    input: toolCall.args,
-                    providerMetadata: toolCall.providerMetadata,
-                  });
-
                   hasToolCalls = true;
                 }
               }
@@ -828,39 +898,134 @@ function resolveGemini25ThinkingConfig({
   return { thinkingBudget };
 }
 
-function getToolCallsFromParts({
-  parts,
-  generateId,
+function getThoughtSignatureMetadata({
   providerOptionsName,
+  thoughtSignature,
 }: {
-  parts: ContentSchema['parts'];
-  generateId: () => string;
   providerOptionsName: string;
+  thoughtSignature?: string | null;
 }) {
-  const functionCallParts = parts?.filter(
-    part => 'functionCall' in part,
-  ) as Array<
-    GoogleGenerativeAIContentPart & {
-      functionCall: { name: string; args: unknown };
-      thoughtSignature?: string | null;
-    }
-  >;
+  return thoughtSignature
+    ? {
+        [providerOptionsName]: {
+          thoughtSignature,
+        },
+      }
+    : undefined;
+}
 
-  return functionCallParts == null || functionCallParts.length === 0
-    ? undefined
-    : functionCallParts.map(part => ({
-        type: 'tool-call' as const,
-        toolCallId: generateId(),
-        toolName: part.functionCall.name,
-        args: JSON.stringify(part.functionCall.args),
-        providerMetadata: part.thoughtSignature
-          ? {
-              [providerOptionsName]: {
-                thoughtSignature: part.thoughtSignature,
-              },
-            }
-          : undefined,
-      }));
+function getServerSideToolCallMetadata({
+  providerOptionsName,
+  toolCall,
+  thoughtSignature,
+}: {
+  providerOptionsName: string;
+  toolCall: GoogleGenerativeAIServerSideToolCall;
+  thoughtSignature?: string | null;
+}) {
+  return {
+    [providerOptionsName]: {
+      ...(thoughtSignature != null ? { thoughtSignature } : {}),
+      serverSideToolCall: toolCall,
+    },
+  };
+}
+
+function getServerSideToolResponseMetadata({
+  providerOptionsName,
+  toolResponse,
+  thoughtSignature,
+}: {
+  providerOptionsName: string;
+  toolResponse: GoogleGenerativeAIServerSideToolResponse;
+  thoughtSignature?: string | null;
+}) {
+  return {
+    [providerOptionsName]: {
+      ...(thoughtSignature != null ? { thoughtSignature } : {}),
+      serverSideToolResponse: toolResponse,
+    },
+  };
+}
+
+function getExecutableCodeMetadata({
+  providerOptionsName,
+  executableCode,
+  thoughtSignature,
+}: {
+  providerOptionsName: string;
+  executableCode: GoogleGenerativeAIExecutableCodePart;
+  thoughtSignature?: string | null;
+}) {
+  return {
+    [providerOptionsName]: {
+      ...(thoughtSignature != null ? { thoughtSignature } : {}),
+      executableCode,
+    },
+  };
+}
+
+function getCodeExecutionResultMetadata({
+  providerOptionsName,
+  codeExecutionResult,
+  thoughtSignature,
+}: {
+  providerOptionsName: string;
+  codeExecutionResult: GoogleGenerativeAICodeExecutionResultPart;
+  thoughtSignature?: string | null;
+}) {
+  return {
+    [providerOptionsName]: {
+      ...(thoughtSignature != null ? { thoughtSignature } : {}),
+      codeExecutionResult,
+    },
+  };
+}
+
+function emitToolCallEvents({
+  controller,
+  toolCallId,
+  toolName,
+  input,
+  providerMetadata,
+  providerExecuted,
+}: {
+  controller: TransformStreamDefaultController<LanguageModelV4StreamPart>;
+  toolCallId: string;
+  toolName: string;
+  input: string;
+  providerMetadata?: SharedV4ProviderMetadata;
+  providerExecuted?: boolean;
+}) {
+  controller.enqueue({
+    type: 'tool-input-start',
+    id: toolCallId,
+    toolName,
+    providerMetadata,
+    providerExecuted,
+  });
+
+  controller.enqueue({
+    type: 'tool-input-delta',
+    id: toolCallId,
+    delta: input,
+    providerMetadata,
+  });
+
+  controller.enqueue({
+    type: 'tool-input-end',
+    id: toolCallId,
+    providerMetadata,
+  });
+
+  controller.enqueue({
+    type: 'tool-call',
+    toolCallId,
+    toolName,
+    input,
+    providerMetadata,
+    providerExecuted,
+  });
 }
 
 function extractSources({
@@ -1050,7 +1215,28 @@ const getContentSchema = () =>
             functionCall: z.object({
               name: z.string(),
               args: z.unknown(),
+              id: z.string().nullish(),
             }),
+            thoughtSignature: z.string().nullish(),
+          }),
+          z.object({
+            toolCall: z
+              .object({
+                id: z.string(),
+                toolType: z.string(),
+                args: z.unknown().nullish(),
+              })
+              .passthrough(),
+            thoughtSignature: z.string().nullish(),
+          }),
+          z.object({
+            toolResponse: z
+              .object({
+                id: z.string(),
+                toolType: z.string(),
+                response: z.unknown().nullish(),
+              })
+              .passthrough(),
             thoughtSignature: z.string().nullish(),
           }),
           z.object({
@@ -1066,12 +1252,14 @@ const getContentSchema = () =>
               .object({
                 language: z.string(),
                 code: z.string(),
+                id: z.string().nullish(),
               })
               .nullish(),
             codeExecutionResult: z
               .object({
                 outcome: z.string(),
                 output: z.string().nullish(),
+                id: z.string().nullish(),
               })
               .nullish(),
             text: z.string().nullish(),

--- a/packages/google/src/google-generative-ai-prompt.ts
+++ b/packages/google/src/google-generative-ai-prompt.ts
@@ -20,14 +20,58 @@ export type GoogleGenerativeAIContent = {
   parts: Array<GoogleGenerativeAIContentPart>;
 };
 
+export type GoogleGenerativeAIServerSideToolCall = {
+  id: string;
+  toolType: string;
+  args?: unknown;
+} & Record<string, unknown>;
+
+export type GoogleGenerativeAIServerSideToolResponse = {
+  id: string;
+  toolType: string;
+  response?: unknown;
+} & Record<string, unknown>;
+
+export type GoogleGenerativeAIExecutableCodePart = {
+  language: string;
+  code: string;
+  id?: string;
+} & Record<string, unknown>;
+
+export type GoogleGenerativeAICodeExecutionResultPart = {
+  outcome: string;
+  output?: string | null;
+  id?: string;
+} & Record<string, unknown>;
+
 export type GoogleGenerativeAIContentPart =
   | { text: string; thought?: boolean; thoughtSignature?: string }
   | { inlineData: { mimeType: string; data: string } }
-  | { functionCall: { name: string; args: unknown }; thoughtSignature?: string }
+  | {
+      functionCall: { name: string; args: unknown; id?: string };
+      thoughtSignature?: string;
+    }
+  | {
+      toolCall: GoogleGenerativeAIServerSideToolCall;
+      thoughtSignature?: string;
+    }
+  | {
+      toolResponse: GoogleGenerativeAIServerSideToolResponse;
+      thoughtSignature?: string;
+    }
+  | {
+      executableCode: GoogleGenerativeAIExecutableCodePart;
+      thoughtSignature?: string;
+    }
+  | {
+      codeExecutionResult: GoogleGenerativeAICodeExecutionResultPart;
+      thoughtSignature?: string;
+    }
   | {
       functionResponse: {
         name: string;
         response: unknown;
+        id?: string;
         parts?: Array<GoogleGenerativeAIFunctionResponsePart>;
       };
     }

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -2,23 +2,23 @@ import { LanguageModelV4ProviderTool } from '@ai-sdk/provider';
 import { expect, it } from 'vitest';
 import { prepareTools } from './google-prepare-tools';
 
-it('should return undefined tools and tool_choice when tools are null', () => {
+it('should return undefined tools and toolConfig when tools are null', () => {
   const result = prepareTools({
     tools: undefined,
     modelId: 'gemini-2.5-flash',
   });
   expect(result).toEqual({
     tools: undefined,
-    tool_choice: undefined,
+    toolConfig: undefined,
     toolWarnings: [],
   });
 });
 
-it('should return undefined tools and tool_choice when tools are empty', () => {
+it('should return undefined tools and toolConfig when tools are empty', () => {
   const result = prepareTools({ tools: [], modelId: 'gemini-2.5-flash' });
   expect(result).toEqual({
     tools: undefined,
-    tool_choice: undefined,
+    toolConfig: undefined,
     toolWarnings: [],
   });
 });
@@ -297,7 +297,7 @@ it('should handle tool choice "tool"', () => {
   });
 });
 
-it('should warn when mixing function and provider-defined tools', () => {
+it('should combine function and provider-defined tools on Gemini 3', () => {
   const result = prepareTools({
     tools: [
       {
@@ -313,24 +313,29 @@ it('should warn when mixing function and provider-defined tools', () => {
         args: {},
       },
     ],
-    modelId: 'gemini-2.5-flash',
+    modelId: 'gemini-3.1-pro-preview',
   });
 
-  expect(result.tools).toEqual([{ googleSearch: {} }]);
-
-  expect(result.toolWarnings).toMatchInlineSnapshot(`
-    [
-      {
-        "feature": "combination of function and provider-defined tools",
-        "type": "unsupported",
-      },
-    ]
-  `);
-
-  expect(result.toolConfig).toBeUndefined();
+  expect(result.tools).toEqual([
+    {
+      functionDeclarations: [
+        {
+          name: 'testFunction',
+          description: 'A test function',
+          parameters: undefined,
+        },
+      ],
+    },
+    { googleSearch: {} },
+  ]);
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'VALIDATED' },
+    includeServerSideToolInvocations: true,
+  });
+  expect(result.toolWarnings).toEqual([]);
 });
 
-it('should handle tool choice with mixed tools (provider-defined tools only)', () => {
+it('should use combo-aware tool choice for mixed tools', () => {
   const result = prepareTools({
     tools: [
       {
@@ -347,21 +352,50 @@ it('should handle tool choice with mixed tools (provider-defined tools only)', (
       },
     ],
     toolChoice: { type: 'auto' },
-    modelId: 'gemini-2.5-flash',
+    modelId: 'gemini-3.1-pro-preview',
   });
 
-  expect(result.tools).toEqual([{ googleSearch: {} }]);
+  expect(result.tools).toEqual([
+    {
+      functionDeclarations: [
+        {
+          name: 'testFunction',
+          description: 'A test function',
+          parameters: undefined,
+        },
+      ],
+    },
+    { googleSearch: {} },
+  ]);
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'VALIDATED' },
+    includeServerSideToolInvocations: true,
+  });
+  expect(result.toolWarnings).toEqual([]);
+});
 
-  expect(result.toolConfig).toEqual(undefined);
-
-  expect(result.toolWarnings).toMatchInlineSnapshot(`
-    [
-      {
-        "feature": "combination of function and provider-defined tools",
-        "type": "unsupported",
-      },
-    ]
-  `);
+it('should reject mixed tools on unsupported models', () => {
+  expect(() =>
+    prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'A test function',
+          inputSchema: { type: 'object', properties: {} },
+        },
+        {
+          type: 'provider',
+          id: 'google.google_search',
+          name: 'google_search',
+          args: {},
+        },
+      ],
+      modelId: 'gemini-2.5-flash',
+    }),
+  ).toThrow(
+    'Gemini built-in tool and function combinations require a Gemini 3 model',
+  );
 });
 
 it('should handle latest modelId for provider-defined tools correctly', () => {
@@ -573,6 +607,35 @@ it('should use VALIDATED mode when any function tool has strict: true', () => {
     functionCallingConfig: { mode: 'VALIDATED' },
   });
   expect(result.toolWarnings).toEqual([]);
+});
+
+it('should keep allowed function names in combo mode', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'testFunction',
+        description: 'A test function',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      {
+        type: 'provider',
+        id: 'google.google_search',
+        name: 'google_search',
+        args: {},
+      },
+    ],
+    toolChoice: { type: 'tool', toolName: 'testFunction' },
+    modelId: 'gemini-3.1-pro-preview',
+  });
+
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: {
+      mode: 'VALIDATED',
+      allowedFunctionNames: ['testFunction'],
+    },
+    includeServerSideToolInvocations: true,
+  });
 });
 
 it('should use VALIDATED mode with toolChoice auto when strict: true', () => {

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -30,10 +30,11 @@ export function prepareTools({
   toolConfig:
     | undefined
     | {
-        functionCallingConfig: {
+        functionCallingConfig?: {
           mode: 'AUTO' | 'NONE' | 'ANY' | 'VALIDATED';
           allowedFunctionNames?: string[];
         };
+        includeServerSideToolInvocations?: boolean;
       };
   toolWarnings: SharedV4Warning[];
 } {
@@ -56,134 +57,127 @@ export function prepareTools({
     isLatest;
   const supportsFileSearch =
     modelId.includes('gemini-2.5') || modelId.includes('gemini-3');
+  const supportsToolCombination = modelId.includes('gemini-3');
 
   if (tools == null) {
     return { tools: undefined, toolConfig: undefined, toolWarnings };
   }
 
-  // Check for mixed tool types and add warnings
   const hasFunctionTools = tools.some(tool => tool.type === 'function');
   const hasProviderTools = tools.some(tool => tool.type === 'provider');
+  const hasMixedTools = hasFunctionTools && hasProviderTools;
 
-  if (hasFunctionTools && hasProviderTools) {
-    toolWarnings.push({
-      type: 'unsupported',
-      feature: `combination of function and provider-defined tools`,
+  if (hasMixedTools && !supportsToolCombination) {
+    throw new UnsupportedFunctionalityError({
+      functionality:
+        'Gemini built-in tool and function combinations require a Gemini 3 model',
     });
   }
 
-  if (hasProviderTools) {
-    const googleTools: any[] = [];
+  const googleTools: any[] = [];
 
-    const ProviderTools = tools.filter(tool => tool.type === 'provider');
-    ProviderTools.forEach(tool => {
-      switch (tool.id) {
-        case 'google.google_search':
-          if (isGemini2orNewer) {
-            googleTools.push({ googleSearch: { ...tool.args } });
-          } else {
-            toolWarnings.push({
-              type: 'unsupported',
-              feature: `provider-defined tool ${tool.id}`,
-              details: 'Google Search requires Gemini 2.0 or newer.',
-            });
-          }
-          break;
-        case 'google.enterprise_web_search':
-          if (isGemini2orNewer) {
-            googleTools.push({ enterpriseWebSearch: {} });
-          } else {
-            toolWarnings.push({
-              type: 'unsupported',
-              feature: `provider-defined tool ${tool.id}`,
-              details: 'Enterprise Web Search requires Gemini 2.0 or newer.',
-            });
-          }
-          break;
-        case 'google.url_context':
-          if (isGemini2orNewer) {
-            googleTools.push({ urlContext: {} });
-          } else {
-            toolWarnings.push({
-              type: 'unsupported',
-              feature: `provider-defined tool ${tool.id}`,
-              details:
-                'The URL context tool is not supported with other Gemini models than Gemini 2.',
-            });
-          }
-          break;
-        case 'google.code_execution':
-          if (isGemini2orNewer) {
-            googleTools.push({ codeExecution: {} });
-          } else {
-            toolWarnings.push({
-              type: 'unsupported',
-              feature: `provider-defined tool ${tool.id}`,
-              details:
-                'The code execution tools is not supported with other Gemini models than Gemini 2.',
-            });
-          }
-          break;
-        case 'google.file_search':
-          if (supportsFileSearch) {
-            googleTools.push({ fileSearch: { ...tool.args } });
-          } else {
-            toolWarnings.push({
-              type: 'unsupported',
-              feature: `provider-defined tool ${tool.id}`,
-              details:
-                'The file search tool is only supported with Gemini 2.5 models and Gemini 3 models.',
-            });
-          }
-          break;
-        case 'google.vertex_rag_store':
-          if (isGemini2orNewer) {
-            googleTools.push({
-              retrieval: {
-                vertex_rag_store: {
-                  rag_resources: {
-                    rag_corpus: tool.args.ragCorpus,
-                  },
-                  similarity_top_k: tool.args.topK as number | undefined,
-                },
-              },
-            });
-          } else {
-            toolWarnings.push({
-              type: 'unsupported',
-              feature: `provider-defined tool ${tool.id}`,
-              details:
-                'The RAG store tool is not supported with other Gemini models than Gemini 2.',
-            });
-          }
-          break;
-        case 'google.google_maps':
-          if (isGemini2orNewer) {
-            googleTools.push({ googleMaps: {} });
-          } else {
-            toolWarnings.push({
-              type: 'unsupported',
-              feature: `provider-defined tool ${tool.id}`,
-              details:
-                'The Google Maps grounding tool is not supported with Gemini models other than Gemini 2 or newer.',
-            });
-          }
-          break;
-        default:
+  const providerTools = tools.filter(tool => tool.type === 'provider');
+  providerTools.forEach(tool => {
+    switch (tool.id) {
+      case 'google.google_search':
+        if (isGemini2orNewer) {
+          googleTools.push({ googleSearch: { ...tool.args } });
+        } else {
           toolWarnings.push({
             type: 'unsupported',
             feature: `provider-defined tool ${tool.id}`,
+            details: 'Google Search requires Gemini 2.0 or newer.',
           });
-          break;
-      }
-    });
-
-    return {
-      tools: googleTools.length > 0 ? googleTools : undefined,
-      toolConfig: undefined,
-      toolWarnings,
-    };
-  }
+        }
+        break;
+      case 'google.enterprise_web_search':
+        if (isGemini2orNewer) {
+          googleTools.push({ enterpriseWebSearch: {} });
+        } else {
+          toolWarnings.push({
+            type: 'unsupported',
+            feature: `provider-defined tool ${tool.id}`,
+            details: 'Enterprise Web Search requires Gemini 2.0 or newer.',
+          });
+        }
+        break;
+      case 'google.url_context':
+        if (isGemini2orNewer) {
+          googleTools.push({ urlContext: {} });
+        } else {
+          toolWarnings.push({
+            type: 'unsupported',
+            feature: `provider-defined tool ${tool.id}`,
+            details:
+              'The URL context tool is not supported with other Gemini models than Gemini 2.',
+          });
+        }
+        break;
+      case 'google.code_execution':
+        if (isGemini2orNewer) {
+          googleTools.push({ codeExecution: {} });
+        } else {
+          toolWarnings.push({
+            type: 'unsupported',
+            feature: `provider-defined tool ${tool.id}`,
+            details:
+              'The code execution tools is not supported with other Gemini models than Gemini 2.',
+          });
+        }
+        break;
+      case 'google.file_search':
+        if (supportsFileSearch) {
+          googleTools.push({ fileSearch: { ...tool.args } });
+        } else {
+          toolWarnings.push({
+            type: 'unsupported',
+            feature: `provider-defined tool ${tool.id}`,
+            details:
+              'The file search tool is only supported with Gemini 2.5 models and Gemini 3 models.',
+          });
+        }
+        break;
+      case 'google.vertex_rag_store':
+        if (isGemini2orNewer) {
+          googleTools.push({
+            retrieval: {
+              vertex_rag_store: {
+                rag_resources: {
+                  rag_corpus: tool.args.ragCorpus,
+                },
+                similarity_top_k: tool.args.topK as number | undefined,
+              },
+            },
+          });
+        } else {
+          toolWarnings.push({
+            type: 'unsupported',
+            feature: `provider-defined tool ${tool.id}`,
+            details:
+              'The RAG store tool is not supported with other Gemini models than Gemini 2.',
+          });
+        }
+        break;
+      case 'google.google_maps':
+        if (isGemini2orNewer) {
+          googleTools.push({ googleMaps: {} });
+        } else {
+          toolWarnings.push({
+            type: 'unsupported',
+            feature: `provider-defined tool ${tool.id}`,
+            details:
+              'The Google Maps grounding tool is not supported with Gemini models other than Gemini 2 or newer.',
+          });
+        }
+        break;
+      default:
+        toolWarnings.push({
+          type: 'unsupported',
+          feature: `provider-defined tool ${tool.id}`,
+        });
+        break;
+    }
+  });
 
   const functionDeclarations = [];
   let hasStrictTools = false;
@@ -199,6 +193,8 @@ export function prepareTools({
           hasStrictTools = true;
         }
         break;
+      case 'provider':
+        break;
       default:
         toolWarnings.push({
           type: 'unsupported',
@@ -208,58 +204,79 @@ export function prepareTools({
     }
   }
 
+  const combinedTools = [
+    ...(functionDeclarations.length > 0 ? [{ functionDeclarations }] : []),
+    ...googleTools,
+  ];
+  const comboMode = hasMixedTools && supportsToolCombination;
+
+  const functionCallingConfig =
+    functionDeclarations.length === 0
+      ? undefined
+      : resolveFunctionCallingConfig({
+          toolChoice,
+          hasStrictTools,
+          comboMode,
+        });
+
+  const toolConfig =
+    functionCallingConfig != null || comboMode
+      ? {
+          ...(functionCallingConfig != null ? { functionCallingConfig } : {}),
+          ...(comboMode ? { includeServerSideToolInvocations: true } : {}),
+        }
+      : undefined;
+
+  return {
+    tools: combinedTools.length > 0 ? combinedTools : undefined,
+    toolConfig,
+    toolWarnings,
+  };
+}
+
+function resolveFunctionCallingConfig({
+  toolChoice,
+  hasStrictTools,
+  comboMode,
+}: {
+  toolChoice?: LanguageModelV4CallOptions['toolChoice'];
+  hasStrictTools: boolean;
+  comboMode: boolean;
+}):
+  | {
+      mode: 'AUTO' | 'NONE' | 'ANY' | 'VALIDATED';
+      allowedFunctionNames?: string[];
+    }
+  | undefined {
   if (toolChoice == null) {
-    return {
-      tools: [{ functionDeclarations }],
-      toolConfig: hasStrictTools
-        ? { functionCallingConfig: { mode: 'VALIDATED' } }
-        : undefined,
-      toolWarnings,
-    };
+    return hasStrictTools || comboMode ? { mode: 'VALIDATED' } : undefined;
   }
 
-  const type = toolChoice.type;
+  const validatedMode = (allowedFunctionNames?: string[]) => ({
+    mode: 'VALIDATED' as const,
+    ...(allowedFunctionNames != null ? { allowedFunctionNames } : {}),
+  });
 
-  switch (type) {
+  switch (toolChoice.type) {
     case 'auto':
-      return {
-        tools: [{ functionDeclarations }],
-        toolConfig: {
-          functionCallingConfig: {
-            mode: hasStrictTools ? 'VALIDATED' : 'AUTO',
-          },
-        },
-        toolWarnings,
-      };
+      return comboMode
+        ? validatedMode()
+        : { mode: hasStrictTools ? 'VALIDATED' : 'AUTO' };
     case 'none':
-      return {
-        tools: [{ functionDeclarations }],
-        toolConfig: { functionCallingConfig: { mode: 'NONE' } },
-        toolWarnings,
-      };
+      return { mode: 'NONE' };
     case 'required':
-      return {
-        tools: [{ functionDeclarations }],
-        toolConfig: {
-          functionCallingConfig: {
-            mode: hasStrictTools ? 'VALIDATED' : 'ANY',
-          },
-        },
-        toolWarnings,
-      };
+      return comboMode
+        ? validatedMode()
+        : { mode: hasStrictTools ? 'VALIDATED' : 'ANY' };
     case 'tool':
-      return {
-        tools: [{ functionDeclarations }],
-        toolConfig: {
-          functionCallingConfig: {
+      return comboMode
+        ? validatedMode([toolChoice.toolName])
+        : {
             mode: hasStrictTools ? 'VALIDATED' : 'ANY',
             allowedFunctionNames: [toolChoice.toolName],
-          },
-        },
-        toolWarnings,
-      };
+          };
     default: {
-      const _exhaustiveCheck: never = type;
+      const _exhaustiveCheck: never = toolChoice.type;
       throw new UnsupportedFunctionalityError({
         functionality: `tool choice type: ${_exhaustiveCheck}`,
       });


### PR DESCRIPTION
## Background

`@ai-sdk/google` did not support Gemini built-in tools and custom function tools in the same request.
When Google provider tools were present, the provider dropped custom function declarations and omitted the tool config needed for combo mode.

This change implements Google’s documented tool-combination flow for supported Gemini 3 models and fixes the limitation reported in https://github.com/vercel/ai/issues/7173.

References:
- https://ai.google.dev/gemini-api/docs/tool-combination
- https://github.com/vercel/ai/issues/7173

## Summary

- update `google-prepare-tools` to emit combined Google built-in tools and custom `functionDeclarations` in the same request
- enable combo-aware `toolConfig`, including `includeServerSideToolInvocations: true` and `VALIDATED` function-calling mode in mixed-tool flows
- gate mixed built-in + function tool combinations to Gemini 3 models with a clear unsupported-model error
- extend Google wire types and response parsing to support server-side `toolCall` / `toolResponse` parts and preserve tool IDs
- round-trip built-in tool context, `thoughtSignature`, and `functionResponse.id` across follow-up turns via provider metadata and prompt conversion
- add regression coverage for mixed request building, combo parsing, follow-up circulation, unsupported-model behavior, and combo tool-choice handling

## Manual Verification

I did add/update targeted tests covering:
- function-only behavior
- built-in-tool-only behavior
- mixed built-in + function request generation
- parsing first-turn `toolCall` / `toolResponse` / `functionCall`
- second-turn circulation with preserved built-in tool context
- unsupported-model behavior
- combo-mode tool-choice behavior

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- run the Google package test suite and type-check once dependencies are installed in the workspace
- consider whether `includeServerSideToolInvocations` should also be exposed as an explicit Google provider option outside mixed-tool mode
- add docs/examples for Gemini combo usage if this behavior is intended to be user-facing in the provider docs

## Related Issues

Fixes #7173