### PR TITLE
fix(docs): correct language model middleware source links

### DIFF
--- a/content/docs/03-ai-sdk-core/40-middleware.mdx
+++ b/content/docs/03-ai-sdk-core/40-middleware.mdx
@@ -271,15 +271,15 @@ Find more examples at this [link](https://github.com/minpeter/ai-sdk-tool-call-m
 <Note>
   Implementing language model middleware is advanced functionality and requires
   a solid understanding of the [language model
-  specification](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+  specification](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v4/language-model-v4.ts).
 </Note>
 
 You can implement any of the following three function to modify the behavior of the language model:
 
 1. `transformParams`: Transforms the parameters before they are passed to the language model, for both `doGenerate` and `doStream`.
-2. `wrapGenerate`: Wraps the `doGenerate` method of the [language model](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+2. `wrapGenerate`: Wraps the `doGenerate` method of the [language model](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v4/language-model-v4.ts).
    You can modify the parameters, call the language model, and modify the result.
-3. `wrapStream`: Wraps the `doStream` method of the [language model](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+3. `wrapStream`: Wraps the `doStream` method of the [language model](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v4/language-model-v4.ts).
    You can modify the parameters, call the language model, and modify the result.
 
 Here are some examples of how to implement language model middleware:

--- a/content/docs/07-reference/01-ai-sdk-core/65-language-model-v2-middleware.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/65-language-model-v2-middleware.mdx
@@ -28,8 +28,8 @@ See [Language Model Middleware](/docs/ai-sdk-core/middleware) for more informati
   content={[
     {
       name: 'specificationVersion',
-      type: "'v3'",
-      description: 'The specification version of the middleware. Must be "v3".',
+      type: "'v4'",
+      description: 'The specification version of the middleware. Must be "v4".',
     },
     {
       name: 'transformParams',


### PR DESCRIPTION
## Summary
- update the language model middleware guide so it links to the current `main` branch `LanguageModelV4` source instead of the stale `v5` / `v2` path
- align the `LanguageModelV4Middleware` reference page with the current provider source by correcting `specificationVersion` from `v3` to `v4`

Fixes #12617.

## Validation
- confirmed the stale `blob/v5/.../language-model-v2.ts` links are removed from the middleware guide
- checked the middleware reference page against `packages/provider/src/language-model-middleware/v4/language-model-v4-middleware.ts`
- ran `git diff --check`