### PR TITLE
fix(ai): avoid stringify copies for string partial outputs

### DIFF
--- a/.changeset/forty-badgers-jump.md
+++ b/.changeset/forty-badgers-jump.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Avoid extra string copies when streaming string partial outputs.

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -15858,6 +15858,37 @@ describe('streamText', () => {
         `);
       });
 
+      it('should not stringify string partial outputs', async () => {
+        const stringifySpy = vi.spyOn(JSON, 'stringify');
+
+        const result = streamText({
+          model: createTestModel({
+            stream: convertArrayToReadableStream([
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'Hello, ' },
+              { type: 'text-delta', id: '1', delta: 'world!' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          }),
+          prompt: 'prompt',
+        });
+
+        expect(await convertAsyncIterableToArray(result.partialOutputStream))
+          .toMatchInlineSnapshot(`
+          [
+            "Hello, ",
+            "Hello, world!",
+          ]
+        `);
+        expect(stringifySpy).not.toHaveBeenCalled();
+        stringifySpy.mockRestore();
+      });
+
       it('should resolve output promise with the correct content', async () => {
         const result = streamText({
           model: createTestModel({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -610,6 +610,7 @@ function createOutputTransformStream<
   let textChunk = '';
   let textProviderMetadata: ProviderMetadata | undefined = undefined;
   let lastPublishedJson = '';
+  let lastPublishedString: string | undefined = undefined;
 
   function publishTextChunk({
     controller,
@@ -682,6 +683,14 @@ function createOutputTransformStream<
 
       // null should be allowed (valid JSON value) but undefined should not:
       if (result !== undefined) {
+        if (typeof result.partial === 'string') {
+          if (result.partial !== lastPublishedString) {
+            publishTextChunk({ controller, partialOutput: result.partial });
+            lastPublishedString = result.partial;
+          }
+          return;
+        }
+
         // only send new json if it has changed:
         const currentJson = JSON.stringify(result.partial);
         if (currentJson !== lastPublishedJson) {


### PR DESCRIPTION
## Background

`createOutputTransformStream` currently stringifies every parsed partial output so it can suppress duplicate publishes. For `Output.text()` this means each streaming chunk stringifies the full accumulated text even though every new text chunk necessarily changes the partial output. On long streams that creates avoidable extra string copies and memory pressure.

## Summary

- skip the `JSON.stringify` duplicate-check path for string partial outputs and compare the streamed string directly instead
- keep the existing text `partialOutputStream` behavior unchanged
- add a regression test that verifies default text output no longer calls `JSON.stringify` while still emitting the same partial output sequence
- add a patch changeset for `ai`

## Manual Verification

- `corepack pnpm exec vitest --config packages/ai/vitest.node.config.js --run packages/ai/src/generate-text/stream-text.test.ts -t "text output"`
- `corepack pnpm exec ultracite check packages/ai/src/generate-text/stream-text.ts packages/ai/src/generate-text/stream-text.test.ts`
- manually confirmed the new branch only changes the string partial-output fast path and leaves object/json duplicate detection untouched

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

- Fixes #13839