### PR TITLE
chore(provider/gateway): rename GatewayLanguageModelOptions back to GatewayProviderOptions

### DIFF
--- a/.changeset/unlucky-seas-prove.md
+++ b/.changeset/unlucky-seas-prove.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+chore(provider/gateway): rename GatewayLanguageModelOptions back to GatewayProviderOptions

--- a/content/docs/02-foundations/06-provider-options.mdx
+++ b/content/docs/02-foundations/06-provider-options.mdx
@@ -309,7 +309,7 @@ You can also combine gateway-specific options (like routing and fallbacks) with 
 
 ```ts
 import type { AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';
-import type { GatewayLanguageModelOptions } from '@ai-sdk/gateway';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 
 const result = await generateText({
@@ -319,7 +319,7 @@ const result = await generateText({
     // Gateway-specific: control routing
     gateway: {
       order: ['vertex', 'anthropic'],
-    } satisfies GatewayLanguageModelOptions,
+    } satisfies GatewayProviderOptions,
     // Provider-specific: enable reasoning
     anthropic: {
       thinking: { type: 'enabled', budgetTokens: 12000 },

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -540,7 +540,7 @@ Track usage per end-user and categorize requests with tags, then query the data 
 #### Usage Tracking with User and Tags
 
 ```ts
-import type { GatewayLanguageModelOptions } from '@ai-sdk/gateway';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
@@ -550,7 +550,7 @@ const { text } = await generateText({
     gateway: {
       user: 'user-abc-123', // Track usage for this specific end-user
       tags: ['document-summary', 'premium-feature'], // Categorize for reporting
-    } satisfies GatewayLanguageModelOptions,
+    } satisfies GatewayProviderOptions,
   },
 });
 ```
@@ -576,7 +576,7 @@ The AI Gateway provider accepts provider options that control routing behavior a
 You can use the `gateway` key in `providerOptions` to control how AI Gateway routes requests:
 
 ```ts
-import type { GatewayLanguageModelOptions } from '@ai-sdk/gateway';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
@@ -586,7 +586,7 @@ const { text } = await generateText({
     gateway: {
       order: ['vertex', 'anthropic'], // Try Vertex AI first, then Anthropic
       only: ['vertex', 'anthropic'], // Only use these providers
-    } satisfies GatewayLanguageModelOptions,
+    } satisfies GatewayProviderOptions,
   },
 });
 ```
@@ -650,7 +650,7 @@ The following gateway provider options are available:
 You can combine these options to have fine-grained control over routing and tracking:
 
 ```ts
-import type { GatewayLanguageModelOptions } from '@ai-sdk/gateway';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
@@ -660,7 +660,7 @@ const { text } = await generateText({
     gateway: {
       order: ['vertex'], // Prefer Vertex AI
       only: ['anthropic', 'vertex'], // Only allow these providers
-    } satisfies GatewayLanguageModelOptions,
+    } satisfies GatewayProviderOptions,
   },
 });
 ```
@@ -670,7 +670,7 @@ const { text } = await generateText({
 The `models` option enables automatic fallback to alternative models when the primary model fails:
 
 ```ts
-import type { GatewayLanguageModelOptions } from '@ai-sdk/gateway';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
@@ -679,7 +679,7 @@ const { text } = await generateText({
   providerOptions: {
     gateway: {
       models: ['openai/gpt-5-nano', 'gemini-2.0-flash'], // Fallback models
-    } satisfies GatewayLanguageModelOptions,
+    } satisfies GatewayProviderOptions,
   },
 });
 
@@ -697,7 +697,7 @@ that have zero data retention policies. When `zeroDataRetention` is `false` or n
 specified, there is no enforcement of restricting routing.
 
 ```ts
-import type { GatewayLanguageModelOptions } from '@ai-sdk/gateway';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
@@ -706,7 +706,7 @@ const { text } = await generateText({
   providerOptions: {
     gateway: {
       zeroDataRetention: true,
-    } satisfies GatewayLanguageModelOptions,
+    } satisfies GatewayProviderOptions,
   },
 });
 ```
@@ -717,7 +717,7 @@ When using provider-specific options through AI Gateway, use the actual provider
 
 ```ts
 import type { AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';
-import type { GatewayLanguageModelOptions } from '@ai-sdk/gateway';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
@@ -726,7 +726,7 @@ const { text } = await generateText({
   providerOptions: {
     gateway: {
       order: ['vertex', 'anthropic'],
-    } satisfies GatewayLanguageModelOptions,
+    } satisfies GatewayProviderOptions,
     anthropic: {
       thinking: { type: 'enabled', budgetTokens: 12000 },
     } satisfies AnthropicLanguageModelOptions,

--- a/contributing/providers.md
+++ b/contributing/providers.md
@@ -19,6 +19,7 @@ to prevent unnecessary breakages.
 
 Types and Zod schemas for the provider specific model options follow the pattern `{Provider}{ModelType}Options`, e.g. `AnthropicLanguageModelOptions`.
 If a provider has multiple implementations for the same model type, add a qualifier: `{Provider}{ModelType}{Qualifier}Options`, e.g. `OpenAILanguageModelChatOptions` and `OpenAILanguageModelResponsesOptions`.
+If options apply provider-wide rather than to a specific model type, use `{Provider}ProviderOptions` instead, e.g. `GatewayProviderOptions`.
 
 - types are PascalCase, Zod schemas are camelCase (e.g. `openaiLanguageModelChatOptions`)
 - types must be exported from the provider package, Zod schemas must not

--- a/examples/ai-functions/src/deprecated-options-types.test-d.ts
+++ b/examples/ai-functions/src/deprecated-options-types.test-d.ts
@@ -206,8 +206,8 @@ describe('deprecated provider options type aliases', () => {
   });
 
   describe('@ai-sdk/gateway', () => {
-    it('GatewayProviderOptions equals GatewayLanguageModelOptions', () => {
-      expectTypeOf<GatewayProviderOptions>().toEqualTypeOf<GatewayLanguageModelOptions>();
+    it('GatewayLanguageModelOptions equals GatewayProviderOptions', () => {
+      expectTypeOf<GatewayLanguageModelOptions>().toEqualTypeOf<GatewayProviderOptions>();
     });
   });
 

--- a/examples/ai-functions/src/generate-text/gateway/request-byok.ts
+++ b/examples/ai-functions/src/generate-text/gateway/request-byok.ts
@@ -1,4 +1,4 @@
-import { type GatewayLanguageModelOptions } from '@ai-sdk/gateway';
+import { type GatewayProviderOptions } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 import { run } from '../../lib/run';
 
@@ -11,7 +11,7 @@ run(async () => {
         byok: {
           anthropic: [{ apiKey: process.env.ANTHROPIC_API_KEY }],
         },
-      } satisfies GatewayLanguageModelOptions,
+      } satisfies GatewayProviderOptions,
     },
   });
 

--- a/examples/ai-functions/src/stream-text/gateway/provider-options-models.ts
+++ b/examples/ai-functions/src/stream-text/gateway/provider-options-models.ts
@@ -1,4 +1,4 @@
-import type { GatewayLanguageModelOptions } from '@ai-sdk/gateway';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
@@ -12,7 +12,7 @@ run(async () => {
     providerOptions: {
       gateway: {
         models: ['openai/gpt-5-nano', 'zai/glm-4.6'],
-      } satisfies GatewayLanguageModelOptions,
+      } satisfies GatewayProviderOptions,
     },
   });
 

--- a/examples/ai-functions/src/stream-text/gateway/provider-options-order.ts
+++ b/examples/ai-functions/src/stream-text/gateway/provider-options-order.ts
@@ -1,4 +1,4 @@
-import { type GatewayLanguageModelOptions } from '@ai-sdk/gateway';
+import { type GatewayProviderOptions } from '@ai-sdk/gateway';
 import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
@@ -9,7 +9,7 @@ run(async () => {
     providerOptions: {
       gateway: {
         order: ['bedrock', 'anthropic'],
-      } satisfies GatewayLanguageModelOptions,
+      } satisfies GatewayProviderOptions,
     },
   });
 

--- a/examples/ai-functions/src/stream-text/gateway/provider-options-tags.ts
+++ b/examples/ai-functions/src/stream-text/gateway/provider-options-tags.ts
@@ -1,4 +1,4 @@
-import type { GatewayLanguageModelOptions } from '@ai-sdk/gateway';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
@@ -10,7 +10,7 @@ run(async () => {
       gateway: {
         user: 'user-123',
         tags: ['chat', 'v2'],
-      } satisfies GatewayLanguageModelOptions,
+      } satisfies GatewayProviderOptions,
     },
   });
 

--- a/examples/ai-functions/src/stream-text/gateway/provider-options-zero-data-retention.ts
+++ b/examples/ai-functions/src/stream-text/gateway/provider-options-zero-data-retention.ts
@@ -1,4 +1,4 @@
-import type { GatewayLanguageModelOptions } from '@ai-sdk/gateway';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { streamText } from 'ai';
 import { run } from '../../lib/run';
 
@@ -9,7 +9,7 @@ run(async () => {
     providerOptions: {
       gateway: {
         zeroDataRetention: true,
-      } satisfies GatewayLanguageModelOptions,
+      } satisfies GatewayProviderOptions,
     },
   });
 

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -2,7 +2,7 @@ import { InferSchema, lazySchema, zodSchema } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
 // https://vercel.com/docs/ai-gateway/provider-options
-const gatewayLanguageModelOptions = lazySchema(() =>
+const gatewayProviderOptions = lazySchema(() =>
   zodSchema(
     z.object({
       /**
@@ -75,6 +75,4 @@ const gatewayLanguageModelOptions = lazySchema(() =>
   ),
 );
 
-export type GatewayLanguageModelOptions = InferSchema<
-  typeof gatewayLanguageModelOptions
->;
+export type GatewayProviderOptions = InferSchema<typeof gatewayProviderOptions>;

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -16,9 +16,9 @@ export type {
   GatewayProviderSettings,
 } from './gateway-provider';
 export type {
-  GatewayLanguageModelOptions,
-  /** @deprecated Use `GatewayLanguageModelOptions` instead. */
-  GatewayLanguageModelOptions as GatewayProviderOptions,
+  GatewayProviderOptions,
+  /** @deprecated Use `GatewayProviderOptions` instead. */
+  GatewayProviderOptions as GatewayLanguageModelOptions,
 } from './gateway-provider-options';
 export {
   GatewayError,


### PR DESCRIPTION
## Background

When provider options types were recently renamed from `{Provider}ProviderOptions` to `{Provider}{ModelType}Options` across all providers (see #12443), the AI Gateway's type was renamed from `GatewayProviderOptions` to `GatewayLanguageModelOptions`. However, unlike other providers, the gateway's options are truly provider-wide (routing, fallbacks, tags, BYOK, etc.) — not specific to any model type. The original name was more accurate.

## Summary

- Renamed `GatewayLanguageModelOptions` back to `GatewayProviderOptions` as the primary export, with `GatewayLanguageModelOptions` kept as a deprecated alias
- Updated all examples, docs, and type tests to use `GatewayProviderOptions`
- Added a note to `contributing/providers.md` documenting when `{Provider}ProviderOptions` should be used instead of `{Provider}{ModelType}Options`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
