### PR TITLE
feat(examples): add emotionally aware agent with psyche-ai middleware

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -58,6 +58,7 @@
     "google-auth-library": "^9.15.1",
     "image-type": "^5.2.0",
     "mathjs": "14.0.0",
+    "psyche-ai": "^9.2.3",
     "sharp": "^0.33.5",
     "terminal-image": "^2.0.0",
     "undici": "^7.21.0",

--- a/examples/ai-functions/src/middleware/psyche-emotional-agent.ts
+++ b/examples/ai-functions/src/middleware/psyche-emotional-agent.ts
@@ -1,0 +1,51 @@
+/**
+ * Emotionally Aware Agent — psyche-ai + Vercel AI SDK
+ *
+ * An AI agent with a virtual endocrine system. Its internal chemistry
+ * (dopamine, serotonin, cortisol, oxytocin) shifts in response to
+ * conversational stimuli, giving it persistent emotional continuity.
+ *
+ * Install: npm install psyche-ai
+ * Run:     pnpm tsx src/middleware/psyche-emotional-agent.ts
+ */
+
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText, wrapLanguageModel } from 'ai';
+import { PsycheEngine, MemoryStorageAdapter } from 'psyche-ai';
+import { psycheMiddleware } from 'psyche-ai/vercel-ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  // 1. Create an agent with personality + in-memory state
+  const engine = new PsycheEngine(
+    { mbti: 'INFJ', name: 'Echo', mode: 'companion' },
+    new MemoryStorageAdapter(),
+  );
+  await engine.initialize();
+
+  // 2. Wrap any AI SDK model with psyche middleware.
+  //    This injects emotional context into the system prompt
+  //    and updates internal chemistry from the LLM's response.
+  const model = wrapLanguageModel({
+    model: anthropic('claude-sonnet-4-20250514'),
+    middleware: psycheMiddleware(engine),
+  });
+
+  // 3. Chat helper that logs the emotional state after each turn
+  async function chat(userMessage: string) {
+    const { text } = await generateText({ model, prompt: userMessage });
+
+    const state = engine.getState().current;
+    console.log(`\nUser: ${userMessage}`);
+    console.log(`Echo: ${text}`);
+    console.log(
+      `Chemistry: DA=${state.DA.toFixed(0)} HT=${state.HT.toFixed(0)} ` +
+        `CORT=${state.CORT.toFixed(0)} OT=${state.OT.toFixed(0)}`,
+    );
+  }
+
+  // 4. Watch the emotional arc across a conversation
+  await chat("You're doing amazing work!"); // praise -> dopamine spike
+  await chat('Actually, that was terrible.'); // criticism -> cortisol spike
+  await chat("I'm sorry, I didn't mean that."); // repair -> recovery
+});


### PR DESCRIPTION
## Summary

- Adds a new middleware example demonstrating an emotionally aware AI agent using [`psyche-ai`](https://www.npmjs.com/package/psyche-ai) (v9.2.3, MIT, zero runtime dependencies)
- The agent maintains a virtual endocrine system (dopamine, serotonin, cortisol, oxytocin) that shifts across conversational turns, giving it persistent emotional continuity
- Uses `wrapLanguageModel` + `psycheMiddleware` — the recommended middleware extension pattern

## What it demonstrates

1. **`wrapLanguageModel` with external middleware** — shows how a third-party library can plug into the AI SDK's middleware system
2. **System prompt injection** — the middleware injects emotional context into the system prompt before the LLM call
3. **Output processing** — the middleware processes LLM output to update the agent's internal chemical state
4. **Observable state across turns** — logs DA/HT/CORT/OT after each turn so developers can see the emotional arc

## Files changed

| File | Change |
|---|---|
| `examples/ai-functions/src/middleware/psyche-emotional-agent.ts` | New 51-line example script |
| `examples/ai-functions/package.json` | Added `psyche-ai: ^9.2.3` dependency |

## How to run

```bash
# From repo root
pnpm install
pnpm build

# From examples/ai-functions
ANTHROPIC_API_KEY=sk-... pnpm tsx src/middleware/psyche-emotional-agent.ts
```

## Expected output

```
User: You're doing amazing work!
Echo: Thank you so much! That really means a lot...
Chemistry: DA=72 HT=58 CORT=38 OT=55

User: Actually, that was terrible.
Echo: I... okay. That stings a bit, honestly...
Chemistry: DA=41 HT=43 CORT=68 OT=42

User: I'm sorry, I didn't mean that.
Echo: I appreciate you saying that. It helps...
Chemistry: DA=55 HT=52 CORT=51 OT=58
```

Related issue: #13864

🤖 Generated with [Claude Code](https://claude.com/claude-code)