### PR TITLE
fix(ai): prevent duplicate tool parts in tool-input-available handler

### DIFF
--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -6706,6 +6706,104 @@ describe('processUIMessageStream', () => {
     });
   });
 
+  describe('tool input available with dynamic flag mismatch', () => {
+    // Regression: when tool-input-start creates a static part (dynamic is
+    // undefined because the tool isn't in the tools object) and tool-input-available
+    // arrives with dynamic: true (from parseToolCall's catch for NoSuchToolError),
+    // the available handler should update the existing static part instead of
+    // creating a second dynamic-tool part.
+    beforeEach(async () => {
+      const stream = createUIMessageStream([
+        {
+          type: 'start',
+        },
+        {
+          type: 'start-step',
+        },
+        {
+          toolCallId: 'call-1',
+          toolName: 'nonExistentTool',
+          type: 'tool-input-start',
+          // dynamic is NOT set (undefined) — this is what happens when the
+          // tool isn't in the tools object and the provider doesn't set it
+        },
+        {
+          inputTextDelta: '{ "foo": "bar" }',
+          toolCallId: 'call-1',
+          type: 'tool-input-delta',
+        },
+        {
+          input: { foo: 'bar' },
+          toolCallId: 'call-1',
+          toolName: 'nonExistentTool',
+          type: 'tool-input-available',
+          // dynamic IS set to true — this is what parseToolCall returns for
+          // invalid tool calls (NoSuchToolError catch)
+          dynamic: true,
+        },
+        {
+          type: 'finish-step',
+        },
+        {
+          type: 'finish',
+        },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+    });
+
+    it('should produce exactly one tool part (no duplicate)', async () => {
+      const toolParts = state!.message.parts.filter(
+        (p: any) => p.toolCallId === 'call-1',
+      );
+      expect(toolParts).toHaveLength(1);
+    });
+
+    it('should keep the static tool type from tool-input-start', async () => {
+      const toolPart = state!.message.parts.find(
+        (p: any) => p.toolCallId === 'call-1',
+      ) as any;
+      expect(toolPart.type).toBe('tool-nonExistentTool');
+    });
+
+    it('should have the correct final message state', async () => {
+      expect(state!.message.parts).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "step-start",
+          },
+          {
+            "errorText": undefined,
+            "input": {
+              "foo": "bar",
+            },
+            "output": undefined,
+            "preliminary": undefined,
+            "providerExecuted": undefined,
+            "rawInput": undefined,
+            "state": "input-available",
+            "title": undefined,
+            "toolCallId": "call-1",
+            "type": "tool-nonExistentTool",
+          },
+        ]
+      `);
+    });
+  });
+
   describe('preliminary tool results', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -585,7 +585,18 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'tool-input-available': {
-              if (chunk.dynamic) {
+              // When a part already exists for this toolCallId (e.g. from
+              // tool-input-start), honour its type so we update in place
+              // instead of creating a duplicate with a mismatched type.
+              const existingInputAvailablePart = state.message.parts
+                .filter(isToolUIPart)
+                .find(p => p.toolCallId === chunk.toolCallId);
+              const isInputAvailableDynamic =
+                existingInputAvailablePart != null
+                  ? existingInputAvailablePart.type === 'dynamic-tool'
+                  : !!chunk.dynamic;
+
+              if (isInputAvailableDynamic) {
                 updateDynamicToolPart({
                   toolCallId: chunk.toolCallId,
                   toolName: chunk.toolName,


### PR DESCRIPTION
## Summary

Follow-up to #12774 which fixed the same duplicate-part bug in the `tool-input-error` handler.

The `tool-input-available` handler has the same bug: it uses `chunk.dynamic` directly to decide whether to call `updateDynamicToolPart` or `updateToolPart`, without first checking if there's already an existing part for the same `toolCallId`. This causes a duplicate when:

1. `tool-input-start` creates a static `tool-{name}` part (dynamic is `undefined`/`false`)
2. `tool-input-available` arrives with `dynamic: true` (from `parseToolCall`'s `NoSuchToolError` catch)
3. `updateDynamicToolPart` doesn't find an existing `dynamic-tool` part, so it creates a **new** one — resulting in two parts for the same `toolCallId`

**Real-world impact**: sessions become permanently broken when the model calls a non-existent tool, because the duplicate `tool_use` IDs cause API rejection on every subsequent request.

The fix applies the same pattern already used in the `tool-input-error` case: look up the existing part by `toolCallId` and use its type to decide the update path, falling back to `chunk.dynamic` only when no existing part is found.

Closes #12772

## Test plan

- [x] Added regression test `tool input available with dynamic flag mismatch` (mirrors the existing `tool input error with dynamic flag mismatch` test from #12774)
- [x] Test asserts exactly one part exists for the `toolCallId` (no duplicate)
- [x] Test asserts the static tool type from `tool-input-start` is preserved
- [x] All 97 existing tests in `process-ui-message-stream.test.ts` continue to pass