### PR TITLE
fix(ai): export isDynamicToolUIPart function

### DIFF
--- a/.changeset/fix-isdynamictooluipart-export.md
+++ b/.changeset/fix-isdynamictooluipart-export.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+fix(ai): export isDynamicToolUIPart function
+
+The `isDynamicToolUIPart` function was defined in `ui-messages.ts` but not exported from the package's `index.ts` file. This fix adds the missing export so the function can be used by consumers of the package as documented.

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -38,6 +38,7 @@ export {
   getToolOrDynamicToolName,
   isCustomContentUIPart,
   isDataUIPart,
+  isDynamicToolUIPart,
   isFileUIPart,
   isReasoningFileUIPart,
   isReasoningUIPart,


### PR DESCRIPTION
## Description

Fixes #13867

The `isDynamicToolUIPart` function was defined in `ui-messages.ts` but was not exported from the package's `index.ts` file. This PR adds the missing export so the function can be used by consumers of the package as documented.

## Changes

- Added `isDynamicToolUIPart` to the exports from `packages/ai/src/ui/index.ts`

## Verification

The function is now properly exported alongside other UI message type guards like `isStaticToolUIPart` and `isToolUIPart`.