### PR TITLE
fix(gateway): preserve incremental tool input streaming (#13429)

### DIFF
--- a/.changeset/fix-gateway-tool-input-streaming.md
+++ b/.changeset/fix-gateway-tool-input-streaming.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(gateway): preserve incremental tool input streaming for streaming language model calls
+
+Gateway streaming language model requests now send `Accept: text/event-stream`
+so upstream SSE tool input deltas are forwarded incrementally instead of being
+buffered until long JSON string values complete.

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -638,6 +638,7 @@ describe('GatewayLanguageModel', () => {
         'ai-language-model-specification-version': '4',
         'ai-language-model-id': 'test-model',
         'ai-language-model-streaming': 'true',
+        accept: 'text/event-stream',
       });
     });
 

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -108,6 +108,7 @@ export class GatewayLanguageModel implements LanguageModelV4 {
           options.headers,
           this.getModelConfigHeaders(this.modelId, true),
           await resolve(this.config.o11yHeaders),
+          { accept: 'text/event-stream' },
         ),
         body: args,
         successfulResponseHandler: createEventSourceResponseHandler(z.any()),


### PR DESCRIPTION
This preserves incremental tool input streaming for Gateway language model calls by sending `Accept: text/event-stream`.

Validation:
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @ai-sdk/gateway type-check`
- `corepack pnpm exec oxlint packages/gateway/src/gateway-language-model.ts packages/gateway/src/gateway-language-model.test.ts`
- `corepack pnpm exec tsup --tsconfig tsconfig.build.json` in `packages/provider`
- `packages/test-server`
- `packages/provider-utils`
- `packages/gateway`
- `corepack pnpm exec vitest --config vitest.node.config.js --run src/gateway-language-model.test.ts` in `packages/gateway`