### PR TITLE
feat (provider/openai): add namespace tool for grouping related tools

### DIFF
--- a/.changeset/feat-openai-namespace.md
+++ b/.changeset/feat-openai-namespace.md
@@ -1,0 +1,28 @@
+---
+'@ai-sdk/openai': minor
+---
+
+feat (provider/openai): add namespace tool for grouping related tools
+
+Added `openai.tools.namespace()` provider tool that lets you group related tools
+under a logical container. Tools within a namespace can have `defer_loading: true`
+to be lazily loaded via tool_search. This is useful for organizing tools from
+different MCP servers or tool providers.
+
+Usage:
+```ts
+const result = await streamText({
+  model: openai('gpt-5.4'),
+  tools: {
+    myTools: openai.tools.namespace({
+      name: 'mcp_github',
+      description: 'Tools from GitHub MCP server',
+      tools: [
+        { type: 'function', name: 'create_issue', description: '...', defer_loading: true, parameters: { ... } },
+        { type: 'function', name: 'list_repos', description: '...', defer_loading: true, parameters: { ... } },
+      ],
+    }),
+    toolSearch: openai.tools.toolSearch(),
+  },
+});
+```

--- a/examples/ai-e2e-next/agent/openai/namespace-agent.ts
+++ b/examples/ai-e2e-next/agent/openai/namespace-agent.ts
@@ -1,0 +1,137 @@
+import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
+import { InferAgentUIMessage, tool, ToolLoopAgent } from 'ai';
+import { z } from 'zod';
+
+const weatherTool = tool({
+  description: 'Get the current weather at a specific location',
+  inputSchema: z.object({
+    location: z.string().describe('The city and state, e.g. San Francisco, CA'),
+    unit: z
+      .enum(['celsius', 'fahrenheit'])
+      .optional()
+      .describe('Temperature unit'),
+  }),
+  execute: async ({ location, unit = 'fahrenheit' }) => ({
+    location,
+    temperature: unit === 'celsius' ? 18 : 64,
+    condition: 'Partly cloudy',
+    humidity: 65,
+  }),
+});
+
+const searchFilesTool = tool({
+  description: 'Search through files in the workspace',
+  inputSchema: z.object({
+    query: z.string().describe('The search query'),
+    file_types: z.array(z.string()).optional().describe('Filter by file types'),
+  }),
+  execute: async ({ query }) => ({
+    results: [
+      `document1.pdf - Contains "${query}" on page 3`,
+      `notes.txt - Found "${query}" in title`,
+      `report.docx - "${query}" mentioned in summary`,
+    ],
+  }),
+});
+
+const sendEmailTool = tool({
+  description: 'Send an email to a recipient',
+  inputSchema: z.object({
+    to: z.string().describe('Recipient email address'),
+    subject: z.string().describe('Email subject'),
+    body: z.string().describe('Email body content'),
+  }),
+  execute: async ({ to, subject }) => ({
+    success: true,
+    message: `Email sent to ${to} with subject: ${subject}`,
+    timestamp: new Date().toISOString(),
+  }),
+});
+
+export const openaiNamespaceAgent = new ToolLoopAgent({
+  model: openai.responses('gpt-5.4'),
+  instructions:
+    'You are a helpful assistant with access to weather, file search, and email tools organized in namespaces.',
+  tools: {
+    toolSearch: openai.tools.toolSearch(),
+
+    // Group tools by domain using namespaces
+    weatherNamespace: openai.tools.namespace({
+      name: 'weather_tools',
+      description: 'Tools for getting weather information',
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: 'Get the current weather at a specific location',
+          defer_loading: true,
+          parameters: {
+            type: 'object',
+            properties: {
+              location: { type: 'string', description: 'The city and state' },
+              unit: { type: 'string', enum: ['celsius', 'fahrenheit'] },
+            },
+            required: ['location'],
+          },
+        },
+      ],
+    }),
+
+    productivityNamespace: openai.tools.namespace({
+      name: 'productivity_tools',
+      description: 'Tools for file search and email',
+      tools: [
+        {
+          type: 'function',
+          name: 'search_files',
+          description: 'Search through files in the workspace',
+          defer_loading: true,
+          parameters: {
+            type: 'object',
+            properties: {
+              query: { type: 'string', description: 'The search query' },
+              file_types: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'Filter by file types',
+              },
+            },
+            required: ['query'],
+          },
+        },
+        {
+          type: 'function',
+          name: 'send_email',
+          description: 'Send an email to a recipient',
+          defer_loading: true,
+          parameters: {
+            type: 'object',
+            properties: {
+              to: { type: 'string', description: 'Recipient email' },
+              subject: { type: 'string', description: 'Email subject' },
+              body: { type: 'string', description: 'Email body' },
+            },
+            required: ['to', 'subject', 'body'],
+          },
+        },
+      ],
+    }),
+
+    // Tool execution handlers
+    get_weather: weatherTool,
+    search_files: searchFilesTool,
+    send_email: sendEmailTool,
+  },
+  onStepFinish: ({ request }) => {
+    console.dir(request.body, { depth: Infinity });
+  },
+  providerOptions: {
+    openai: {
+      store: false,
+    } satisfies OpenAILanguageModelResponsesOptions,
+  },
+});
+
+export type OpenAINamespaceMessage = InferAgentUIMessage<
+  typeof openaiNamespaceAgent
+>;

--- a/examples/ai-e2e-next/app/api/chat/openai-namespace/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/openai-namespace/route.ts
@@ -1,0 +1,11 @@
+import { openaiNamespaceAgent } from '@/agent/openai/namespace-agent';
+import { createAgentUIStreamResponse } from 'ai';
+
+export async function POST(req: Request) {
+  const body = await req.json();
+
+  return createAgentUIStreamResponse({
+    agent: openaiNamespaceAgent,
+    uiMessages: body.messages,
+  });
+}

--- a/examples/ai-e2e-next/app/chat/openai-namespace/page.tsx
+++ b/examples/ai-e2e-next/app/chat/openai-namespace/page.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { OpenAINamespaceMessage } from '@/agent/openai/namespace-agent';
+import { Response } from '@/components/ai-elements/response';
+import ChatInput from '@/components/chat-input';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+
+export default function TestOpenAINamespace() {
+  const { error, status, sendMessage, messages, regenerate } =
+    useChat<OpenAINamespaceMessage>({
+      transport: new DefaultChatTransport({
+        api: '/api/chat/openai-namespace',
+      }),
+    });
+
+  return (
+    <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
+      <h1 className="mb-4 text-xl font-bold">
+        OpenAI Namespace Tools (Multi-turn)
+      </h1>
+      <p className="mb-4 text-sm text-gray-600">
+        This example demonstrates OpenAI&apos;s namespace feature for grouping
+        related tools. Tools are organized into weather and productivity
+        namespaces with deferred loading.
+      </p>
+
+      {messages.map(message => (
+        <div key={message.id} className="whitespace-pre-wrap">
+          {message.role === 'user' ? 'User: ' : 'AI: '}
+          {message.parts.map((part, index) => {
+            switch (part.type) {
+              case 'text': {
+                return <Response key={index}>{part.text}</Response>;
+              }
+              case 'tool-get_weather':
+              case 'tool-search_files':
+              case 'tool-send_email': {
+                return (
+                  <div
+                    key={index}
+                    className="mb-2 bg-gray-600 rounded-xl border border-gray-900 shadow-lg"
+                  >
+                    <pre className="overflow-x-auto p-4 text-sm text-gray-100 whitespace-pre-wrap">
+                      <div className="pb-2 font-semibold">
+                        Tool call &quot;{part.type.replace('tool-', '')}&quot;
+                      </div>
+                      {JSON.stringify(part.input, null, 2)}
+                      {part.state === 'output-available' && (
+                        <>
+                          <div className="pt-2 pb-2 font-semibold">Output:</div>
+                          {JSON.stringify(part.output, null, 2)}
+                        </>
+                      )}
+                    </pre>
+                  </div>
+                );
+              }
+            }
+          })}
+        </div>
+      ))}
+
+      {error && (
+        <div className="mt-4">
+          <div className="text-red-500">An error occurred: {error.message}</div>
+          <button
+            type="button"
+            className="px-4 py-2 mt-4 text-blue-500 rounded-md border border-blue-500"
+            onClick={() => regenerate()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <ChatInput status={status} onSubmit={text => sendMessage({ text })} />
+    </div>
+  );
+}

--- a/examples/ai-functions/src/generate-text/openai/responses-namespace.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-namespace.ts
@@ -1,0 +1,116 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: openai.responses('gpt-5.4'),
+    prompt: 'What is the weather in San Francisco?',
+    stopWhen: stepCountIs(10),
+    onStepFinish: step => {
+      console.log(`\n=== Step Content ===`);
+      console.dir(step.content, { depth: Infinity });
+      console.log(`\n=== Step Response ===`);
+      console.dir(step.response.body, { depth: Infinity });
+    },
+    tools: {
+      toolSearch: openai.tools.toolSearch(),
+
+      // Group weather tools into a namespace with deferred loading
+      weatherNamespace: openai.tools.namespace({
+        name: 'weather_tools',
+        description: 'Tools for getting weather information and forecasts',
+        tools: [
+          {
+            type: 'function',
+            name: 'get_weather',
+            description: 'Get the current weather at a specific location',
+            defer_loading: true,
+            parameters: {
+              type: 'object',
+              properties: {
+                location: {
+                  type: 'string',
+                  description: 'The city and state, e.g. San Francisco, CA',
+                },
+                unit: {
+                  type: 'string',
+                  enum: ['celsius', 'fahrenheit'],
+                  description: 'Temperature unit',
+                },
+              },
+              required: ['location'],
+            },
+          },
+          {
+            type: 'function',
+            name: 'get_forecast',
+            description: 'Get the 5-day weather forecast for a location',
+            defer_loading: true,
+            parameters: {
+              type: 'object',
+              properties: {
+                location: {
+                  type: 'string',
+                  description: 'The city and state',
+                },
+              },
+              required: ['location'],
+            },
+          },
+        ],
+      }),
+
+      // Non-namespaced tool with deferred loading
+      send_email: tool({
+        description: 'Send an email to a recipient',
+        inputSchema: z.object({
+          to: z.string().describe('Recipient email address'),
+          subject: z.string().describe('Email subject'),
+          body: z.string().describe('Email body content'),
+        }),
+        execute: async ({ to, subject }) => ({
+          success: true,
+          message: `Email sent to ${to} with subject: ${subject}`,
+        }),
+        providerOptions: {
+          openai: { deferLoading: true },
+        },
+      }),
+
+      // Handlers for namespace tools (executed when the model calls them)
+      get_weather: tool({
+        description: 'Get the current weather at a specific location',
+        inputSchema: z.object({
+          location: z.string(),
+          unit: z.enum(['celsius', 'fahrenheit']).optional(),
+        }),
+        execute: async ({ location, unit = 'fahrenheit' }) => ({
+          location,
+          temperature: unit === 'celsius' ? 18 : 64,
+          condition: 'Partly cloudy',
+          humidity: 65,
+        }),
+      }),
+
+      get_forecast: tool({
+        description: 'Get the 5-day weather forecast for a location',
+        inputSchema: z.object({
+          location: z.string(),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          forecast: [
+            { day: 'Monday', high: 68, low: 55 },
+            { day: 'Tuesday', high: 72, low: 58 },
+            { day: 'Wednesday', high: 65, low: 52 },
+          ],
+        }),
+      }),
+    },
+  });
+
+  console.log('\n=== Final Result ===');
+  console.log('Text:', result.text);
+});

--- a/examples/ai-functions/src/stream-text/openai/responses-namespace.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-namespace.ts
@@ -1,0 +1,151 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: openai.responses('gpt-5.4'),
+    prompt: 'What is the weather in San Francisco?',
+    stopWhen: stepCountIs(10),
+    tools: {
+      toolSearch: openai.tools.toolSearch(),
+
+      // Group weather tools into a namespace with deferred loading
+      weatherNamespace: openai.tools.namespace({
+        name: 'weather_tools',
+        description: 'Tools for getting weather information and forecasts',
+        tools: [
+          {
+            type: 'function',
+            name: 'get_weather',
+            description: 'Get the current weather at a specific location',
+            defer_loading: true,
+            parameters: {
+              type: 'object',
+              properties: {
+                location: {
+                  type: 'string',
+                  description: 'The city and state, e.g. San Francisco, CA',
+                },
+                unit: {
+                  type: 'string',
+                  enum: ['celsius', 'fahrenheit'],
+                  description: 'Temperature unit',
+                },
+              },
+              required: ['location'],
+            },
+          },
+          {
+            type: 'function',
+            name: 'get_forecast',
+            description: 'Get the 5-day weather forecast for a location',
+            defer_loading: true,
+            parameters: {
+              type: 'object',
+              properties: {
+                location: {
+                  type: 'string',
+                  description: 'The city and state',
+                },
+              },
+              required: ['location'],
+            },
+          },
+        ],
+      }),
+
+      // Non-namespaced tool with deferred loading
+      send_email: tool({
+        description: 'Send an email to a recipient',
+        inputSchema: z.object({
+          to: z.string().describe('Recipient email address'),
+          subject: z.string().describe('Email subject'),
+          body: z.string().describe('Email body content'),
+        }),
+        execute: async ({ to, subject }) => ({
+          success: true,
+          message: `Email sent to ${to} with subject: ${subject}`,
+        }),
+        providerOptions: {
+          openai: { deferLoading: true },
+        },
+      }),
+
+      // Handlers for namespace tools
+      get_weather: tool({
+        description: 'Get the current weather at a specific location',
+        inputSchema: z.object({
+          location: z.string(),
+          unit: z.enum(['celsius', 'fahrenheit']).optional(),
+        }),
+        execute: async ({ location, unit = 'fahrenheit' }) => ({
+          location,
+          temperature: unit === 'celsius' ? 18 : 64,
+          condition: 'Partly cloudy',
+          humidity: 65,
+        }),
+      }),
+
+      get_forecast: tool({
+        description: 'Get the 5-day weather forecast for a location',
+        inputSchema: z.object({
+          location: z.string(),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          forecast: [
+            { day: 'Monday', high: 68, low: 55 },
+            { day: 'Tuesday', high: 72, low: 58 },
+            { day: 'Wednesday', high: 65, low: 52 },
+          ],
+        }),
+      }),
+    },
+  });
+
+  for await (const chunk of result.fullStream) {
+    switch (chunk.type) {
+      case 'text-delta': {
+        process.stdout.write(chunk.text);
+        break;
+      }
+
+      case 'tool-call': {
+        console.log(
+          `TOOL CALL ${chunk.toolName} ${JSON.stringify(chunk.input)}`,
+        );
+        break;
+      }
+
+      case 'tool-result': {
+        console.log(
+          `TOOL RESULT ${chunk.toolName} ${JSON.stringify(chunk.output)}`,
+        );
+        break;
+      }
+
+      case 'finish-step': {
+        console.log();
+        console.log();
+        console.log('STEP FINISH');
+        console.log('Finish reason:', chunk.finishReason);
+        console.log('Usage:', chunk.usage);
+        console.log();
+        break;
+      }
+
+      case 'finish': {
+        console.log('FINISH');
+        console.log('Finish reason:', chunk.finishReason);
+        console.log('Total Usage:', chunk.totalUsage);
+        break;
+      }
+
+      case 'error':
+        console.error('Error:', chunk.error);
+        break;
+    }
+  }
+});

--- a/packages/openai/src/openai-tools.ts
+++ b/packages/openai/src/openai-tools.ts
@@ -5,6 +5,7 @@ import { fileSearch } from './tool/file-search';
 import { imageGeneration } from './tool/image-generation';
 import { localShell } from './tool/local-shell';
 import { shell } from './tool/shell';
+import { namespace } from './tool/namespace';
 import { toolSearch } from './tool/tool-search';
 import { webSearch } from './tool/web-search';
 import { webSearchPreview } from './tool/web-search-preview';
@@ -134,4 +135,16 @@ export const openaiTools = {
    * when it determines they are needed.
    */
   toolSearch,
+
+  /**
+   * Namespaces group related tools together under a logical container.
+   * Tools within a namespace can have `defer_loading: true` to be lazily
+   * loaded via tool_search. This is useful for organizing tools from
+   * different MCP servers or tool providers.
+   *
+   * @param name - The namespace identifier (e.g., 'mcp_github').
+   * @param description - Description of the namespace and its tools.
+   * @param tools - Array of function tool definitions within this namespace.
+   */
+  namespace,
 };

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -205,6 +205,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
         'openai.mcp': 'mcp',
         'openai.apply_patch': 'apply_patch',
         'openai.tool_search': 'tool_search',
+        'openai.namespace': 'namespace',
       },
     });
 

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -1649,5 +1649,178 @@ describe('prepareResponsesTools', () => {
         }
       `);
     });
+
+    it('should prepare namespace tool', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'openai.namespace',
+            name: 'namespace',
+            args: {
+              name: 'mcp_github',
+              description: 'Tools from GitHub MCP server',
+              tools: [
+                {
+                  type: 'function',
+                  name: 'github__create_issue',
+                  description: 'Create a GitHub issue',
+                  defer_loading: true,
+                  parameters: {
+                    type: 'object',
+                    properties: { title: { type: 'string' } },
+                  },
+                },
+                {
+                  type: 'function',
+                  name: 'github__list_repos',
+                  description: 'List repositories',
+                  defer_loading: true,
+                  parameters: {
+                    type: 'object',
+                    properties: {},
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "description": "Tools from GitHub MCP server",
+              "name": "mcp_github",
+              "tools": [
+                {
+                  "defer_loading": true,
+                  "description": "Create a GitHub issue",
+                  "name": "github__create_issue",
+                  "parameters": {
+                    "properties": {
+                      "title": {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "function",
+                },
+                {
+                  "defer_loading": true,
+                  "description": "List repositories",
+                  "name": "github__list_repos",
+                  "parameters": {
+                    "properties": {},
+                    "type": "object",
+                  },
+                  "type": "function",
+                },
+              ],
+              "type": "namespace",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('should prepare namespace alongside tool_search and function tools', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'openai.tool_search',
+            name: 'toolSearch',
+            args: {},
+          },
+          {
+            type: 'provider',
+            id: 'openai.namespace',
+            name: 'namespace',
+            args: {
+              name: 'mcp_slack',
+              tools: [
+                {
+                  type: 'function',
+                  name: 'slack__send_message',
+                  description: 'Send a Slack message',
+                  defer_loading: true,
+                  parameters: {
+                    type: 'object',
+                    properties: { channel: { type: 'string' } },
+                  },
+                },
+              ],
+            },
+          },
+          {
+            type: 'function',
+            name: 'get_weather',
+            description: 'Get the current weather',
+            inputSchema: {
+              type: 'object',
+              properties: { location: { type: 'string' } },
+              required: ['location'],
+              additionalProperties: false,
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "type": "tool_search",
+            },
+            {
+              "name": "mcp_slack",
+              "tools": [
+                {
+                  "defer_loading": true,
+                  "description": "Send a Slack message",
+                  "name": "slack__send_message",
+                  "parameters": {
+                    "properties": {
+                      "channel": {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "function",
+                },
+              ],
+              "type": "namespace",
+            },
+            {
+              "description": "Get the current weather",
+              "name": "get_weather",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "location": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "location",
+                ],
+                "type": "object",
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
   });
 });

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -10,6 +10,7 @@ import { imageGenerationArgsSchema } from '../tool/image-generation';
 import { customArgsSchema } from '../tool/custom';
 import { mcpArgsSchema } from '../tool/mcp';
 import { shellArgsSchema } from '../tool/shell';
+import { namespaceArgsSchema } from '../tool/namespace';
 import { toolSearchArgsSchema } from '../tool/tool-search';
 import { webSearchArgsSchema } from '../tool/web-search';
 import { webSearchPreviewArgsSchema } from '../tool/web-search-preview';
@@ -270,6 +271,21 @@ export async function prepareResponsesTools({
               ...(args.parameters != null
                 ? { parameters: args.parameters }
                 : {}),
+            });
+            break;
+          }
+          case 'openai.namespace': {
+            const args = await validateTypes({
+              value: tool.args,
+              schema: namespaceArgsSchema,
+            });
+            openaiTools.push({
+              type: 'namespace',
+              name: args.name,
+              ...(args.description != null
+                ? { description: args.description }
+                : {}),
+              tools: args.tools,
             });
             break;
           }

--- a/packages/openai/src/tool/namespace.ts
+++ b/packages/openai/src/tool/namespace.ts
@@ -1,0 +1,59 @@
+import {
+  createProviderToolFactory,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const namespaceArgsSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      name: z.string(),
+      description: z.string().optional(),
+      tools: z.array(
+        z.object({
+          type: z.literal('function'),
+          name: z.string(),
+          description: z.string().optional(),
+          defer_loading: z.boolean().optional(),
+          parameters: z.record(z.string(), z.unknown()).optional(),
+          strict: z.boolean().optional(),
+        }),
+      ),
+    }),
+  ),
+);
+
+const namespaceToolFactory = createProviderToolFactory<{
+  /**
+   * The name of the namespace. Used to group related tools together.
+   * Convention: use lowercase with underscores (e.g., 'mcp_github').
+   */
+  name: string;
+
+  /**
+   * A description of the namespace and the tools it contains.
+   * Helps the model understand when to search within this namespace.
+   */
+  description?: string;
+
+  /**
+   * The tools within this namespace. Each tool is a function definition
+   * that can optionally have `defer_loading: true` to be lazily loaded
+   * via the tool_search mechanism.
+   */
+  tools: Array<{
+    type: 'function';
+    name: string;
+    description?: string;
+    defer_loading?: boolean;
+    parameters?: Record<string, unknown>;
+    strict?: boolean;
+  }>;
+}>({
+  id: 'openai.namespace',
+});
+
+export const namespace = (
+  args: Parameters<typeof namespaceToolFactory>[0],
+) => namespaceToolFactory(args);


### PR DESCRIPTION
## Summary

Adds `openai.tools.namespace()` provider tool that groups related tools under a logical container. Tools within a namespace can have `defer_loading: true` for lazy loading via `tool_search`.

This is useful for organizing tools from different MCP servers or tool providers, giving the model organizational context about which tools belong together.

### Usage

```ts
const result = await streamText({
  model: openai.responses('gpt-5.4'),
  tools: {
    toolSearch: openai.tools.toolSearch(),
    githubTools: openai.tools.namespace({
      name: 'mcp_github',
      description: 'Tools from GitHub MCP server',
      tools: [
        { type: 'function', name: 'create_issue', description: 'Create a GitHub issue', defer_loading: true, parameters: { ... } },
        { type: 'function', name: 'list_repos', description: 'List repositories', defer_loading: true, parameters: { ... } },
      ],
    }),
    // Tool execution handlers
    create_issue: tool({ ... }),
    list_repos: tool({ ... }),
  },
});
```

### Changes

- **New tool factory**: `packages/openai/src/tool/namespace.ts`
- **Serialization**: Added `openai.namespace` case in `openai-responses-prepare-tools.ts`
- **Tool name mapping**: Added `openai.namespace` in `openai-responses-language-model.ts`
- **Export**: Added `namespace` in `openai-tools.ts` with JSDoc
- **Unit tests**: Namespace serialization (standalone + alongside tool_search)
- **Examples**: `generateText`, `streamText`, and e2e Next.js agent with namespace
- **Changeset**: Minor version bump for `@ai-sdk/openai`

### Motivation

When using deferred tool loading with many MCP servers, the model sees a flat list of tools with no organizational context. Namespaces let you group tools by server/domain, so the model understands which tools belong together and can make better search decisions.

OpenAI's Responses API already supports namespaces in the `tools` array — this PR exposes that capability through the AI SDK.

## Test plan

- [x] Unit tests for namespace serialization pass
- [x] Namespace tool appears correctly in serialized request body
- [x] Namespace works alongside `tool_search` and regular function tools
- [x] Example apps run successfully with namespace + deferred loading (verified with gpt-5.4)