### PR TITLE
feat(google): support external HTTPS URLs natively for Gemini 2.5+ models

### DIFF
--- a/.changeset/google-gemini-external-https-urls.md
+++ b/.changeset/google-gemini-external-https-urls.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+feat(google): pass external HTTPS URLs directly to Gemini 2.5+ models via fileUri instead of downloading and re-encoding as base64

--- a/packages/google/src/google-provider.test.ts
+++ b/packages/google/src/google-provider.test.ts
@@ -271,6 +271,95 @@ describe('google-provider', () => {
       }
     `);
   });
+
+  it('should include external HTTPS URLs in supportedUrls for Gemini 2.5+ models', () => {
+    const provider = createGoogleGenerativeAI({ apiKey: 'test-api-key' });
+    provider('gemini-2.5-pro');
+
+    const call = vi.mocked(GoogleGenerativeAILanguageModel).mock.calls[0];
+    const supportedUrlsFunction = call[1].supportedUrls;
+    const supportedUrls = supportedUrlsFunction!() as Record<string, RegExp[]>;
+    const patterns = supportedUrls['*'];
+
+    const externalUrls = [
+      'https://example.com/image.jpg',
+      'https://cdn.example.com/audio.mp3',
+      'https://s3.amazonaws.com/bucket/file.pdf?X-Amz-Signature=abc',
+    ];
+
+    for (const url of externalUrls) {
+      expect(patterns.some((p: RegExp) => p.test(url))).toBe(true);
+    }
+  });
+
+  it('should include external HTTPS URLs in supportedUrls for gemini-flash-latest', () => {
+    const provider = createGoogleGenerativeAI({ apiKey: 'test-api-key' });
+    provider('gemini-flash-latest');
+
+    const call = vi.mocked(GoogleGenerativeAILanguageModel).mock.calls[0];
+    const supportedUrlsFunction = call[1].supportedUrls;
+    const supportedUrls = supportedUrlsFunction!() as Record<string, RegExp[]>;
+    const patterns = supportedUrls['*'];
+
+    expect(
+      patterns.some((p: RegExp) => p.test('https://example.com/file.jpg')),
+    ).toBe(true);
+  });
+
+  it('should NOT include external HTTPS URLs in supportedUrls for Gemini 2.0 models', () => {
+    const provider = createGoogleGenerativeAI({ apiKey: 'test-api-key' });
+    provider('gemini-2.0-flash');
+
+    const call = vi.mocked(GoogleGenerativeAILanguageModel).mock.calls[0];
+    const supportedUrlsFunction = call[1].supportedUrls;
+    const supportedUrls = supportedUrlsFunction!() as Record<string, RegExp[]>;
+    const patterns = supportedUrls['*'];
+
+    // YouTube and Files API URLs should still be supported
+    expect(
+      patterns.some((p: RegExp) =>
+        p.test(
+          'https://generativelanguage.googleapis.com/v1beta/files/test123',
+        ),
+      ),
+    ).toBe(true);
+
+    // But arbitrary external HTTPS should NOT be supported
+    expect(
+      patterns.some((p: RegExp) => p.test('https://example.com/image.jpg')),
+    ).toBe(false);
+    expect(
+      patterns.some((p: RegExp) => p.test('https://vimeo.com/123456789')),
+    ).toBe(false);
+  });
+
+  it('should NOT include external HTTPS URLs in supportedUrls for non-versioned gemini-pro', () => {
+    const provider = createGoogleGenerativeAI({ apiKey: 'test-api-key' });
+    provider('gemini-pro');
+
+    const call = vi.mocked(GoogleGenerativeAILanguageModel).mock.calls[0];
+    const supportedUrlsFunction = call[1].supportedUrls;
+    const supportedUrls = supportedUrlsFunction!() as Record<string, RegExp[]>;
+    const patterns = supportedUrls['*'];
+
+    expect(
+      patterns.some((p: RegExp) => p.test('https://example.com/image.jpg')),
+    ).toBe(false);
+  });
+
+  it('should NOT include external HTTPS URLs for tuned model path IDs', () => {
+    const provider = createGoogleGenerativeAI({ apiKey: 'test-api-key' });
+    provider('tunedModels/gemini-2.5-tuned' as any);
+
+    const call = vi.mocked(GoogleGenerativeAILanguageModel).mock.calls[0];
+    const supportedUrlsFunction = call[1].supportedUrls;
+    const supportedUrls = supportedUrlsFunction!() as Record<string, RegExp[]>;
+    const patterns = supportedUrls['*'];
+
+    expect(
+      patterns.some((p: RegExp) => p.test('https://example.com/image.jpg')),
+    ).toBe(false);
+  });
 });
 
 describe('google provider - custom provider name', () => {

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -121,6 +121,28 @@ export interface GoogleGenerativeAIProviderSettings {
 }
 
 /**
+ * Returns true if the given model ID supports passing external HTTPS URLs
+ * natively via fileUri (instead of downloading and re-encoding as base64).
+ *
+ * Supported: Gemini 2.5+, Gemini 3+, and current "latest" aliases.
+ * Not supported: Gemini 2.0 and older, gemma-*, tuned model paths (contain '/').
+ */
+function supportsExternalHttpsUrls(modelId: string): boolean {
+  // Tuned models (e.g. "tunedModels/my-model") — be conservative
+  if (modelId.includes('/')) return false;
+
+  const id = modelId.toLowerCase();
+  return (
+    id.includes('gemini-2.5') ||
+    id.includes('gemini-3') ||
+    // "latest" aliases currently resolve to 2.5+ stable
+    id === 'gemini-flash-latest' ||
+    id === 'gemini-pro-latest' ||
+    id === 'gemini-flash-lite-latest'
+  );
+}
+
+/**
  * Create a Google Generative AI provider instance.
  */
 export function createGoogleGenerativeAI(
@@ -161,6 +183,9 @@ export function createGoogleGenerativeAI(
             `^https://(?:www\\.)?youtube\\.com/watch\\?v=[\\w-]+(?:&[\\w=&.-]*)?$`,
           ),
           new RegExp(`^https://youtu\\.be/[\\w-]+(?:\\?[\\w=&.-]*)?$`),
+          // External HTTPS URLs — Gemini 2.5+ supports passing them directly
+          // via fileUri instead of downloading and re-encoding as base64.
+          ...(supportsExternalHttpsUrls(modelId) ? [/^https:\/\/.+/] : []),
         ],
       }),
       fetch: options.fetch,


### PR DESCRIPTION
## Summary

Closes #13007

This PR adds model-aware external HTTPS URL passthrough for Gemini 2.5+ models in `@ai-sdk/google`.

## Problem

Previously, all external URLs (e.g. S3, CDN, presigned URLs) passed to a Google Gemini model were fetched and re-encoded as base64 `inlineData` by the `ai` core package before being sent to the Gemini API. This is inefficient for large files and unnecessary for Gemini 2.5+ models, which now support passing external HTTPS URLs directly via `file_data.file_uri`.

## Solution

Added a `supportsExternalHttpsUrls(modelId)` helper that returns `true` for:
- `gemini-2.5-*` models (e.g. gemini-2.5-pro, gemini-2.5-flash)
- `gemini-3-*` models
- Current `latest` aliases (`gemini-flash-latest`, `gemini-pro-latest`, `gemini-flash-lite-latest`)

When the model supports external URLs, a `/^https:\/\/.+/` regex is added to `supportedUrls['*']`. This causes the `ai` core to pass matching URLs through as-is (as `URL` objects), which the existing `convert-to-google-generative-ai-messages.ts` logic already converts to `fileData.fileUri` correctly.

## Changes

- **`packages/google/src/google-provider.ts`** — Add `supportsExternalHttpsUrls()` helper; conditionally include HTTPS regex in `supportedUrls`
- **`packages/google/src/google-provider.test.ts`** — Add tests for Gemini 2.5 (supported) and Gemini 2.0 (not supported) cases
- **`.changeset/google-gemini-external-https-urls.md`** — Patch changeset

## Not changed

- `google-vertex`: already supports all HTTPS URLs without model-gating (`/^https?:\/\/.*/`)
- `convert-to-google-generative-ai-messages.ts`: already handles `URL` objects correctly

## Test

