### PR TITLE
fix: export isDynamicToolUIPart from ui/index.ts

### DIFF
--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -38,6 +38,7 @@ export {
   getToolOrDynamicToolName,
   isCustomContentUIPart,
   isDataUIPart,
+  isDynamicToolUIPart,
   isFileUIPart,
   isReasoningFileUIPart,
   isReasoningUIPart,


### PR DESCRIPTION
## Summary

`isDynamicToolUIPart` is defined in `packages/ai/src/ui/ui-messages.ts` and referenced in the docs, but was not re-exported from `packages/ai/src/ui/index.ts`, making it unavailable to consumers of the `ai` package.

This PR adds the missing export alongside the other type-guard functions (`isStaticToolUIPart`, `isToolUIPart`, etc.).

Fixes #13867

## Test plan

- Verified that all other similar type-guard functions (`isStaticToolUIPart`, `isToolUIPart`, `isToolOrDynamicToolUIPart`) are exported from the same location
- The change is a single-line addition to the existing export block — no behavior change, just exposing an already-public function