### PR TITLE
fix: prevent O(n) string copies in streamText text() output

### DIFF
--- a/.changeset/fix-stream-text-memory.md
+++ b/.changeset/fix-stream-text-memory.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix: prevent quadratic memory growth in streamText with default text() output by returning undefined from parsePartialOutput, skipping unnecessary JSON.stringify on every chunk

--- a/packages/ai/src/generate-text/output.test.ts
+++ b/packages/ai/src/generate-text/output.test.ts
@@ -69,14 +69,14 @@ describe('Output.text', () => {
   });
 
   describe('parsePartialOutput', () => {
-    it('should return the string as partial', async () => {
+    it('should return undefined (no structured partial output for plain text)', async () => {
       const result = await text1.parsePartialOutput({ text: 'partial text' });
-      expect(result).toEqual({ partial: 'partial text' });
+      expect(result).toBeUndefined();
     });
 
-    it('should handle empty string partial', async () => {
+    it('should return undefined for empty string', async () => {
       const result = await text1.parsePartialOutput({ text: '' });
-      expect(result).toEqual({ partial: '' });
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/packages/ai/src/generate-text/output.ts
+++ b/packages/ai/src/generate-text/output.ts
@@ -70,8 +70,8 @@ export const text = (): Output<string, string, never> => ({
     return text;
   },
 
-  async parsePartialOutput({ text }: { text: string }) {
-    return { partial: text };
+  async parsePartialOutput() {
+    return undefined; // plain text has no structured partial output to parse
   },
 
   createElementStreamTransform() {

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -38,6 +38,7 @@ export {
   getToolOrDynamicToolName,
   isCustomContentUIPart,
   isDataUIPart,
+  isDynamicToolUIPart,
   isFileUIPart,
   isReasoningFileUIPart,
   isReasoningUIPart,


### PR DESCRIPTION
## Summary

- Fix quadratic memory growth in `streamText` when using the default `text()` output mode
- The `text()` output's `parsePartialOutput` was returning `{ partial: text }`, which triggered `JSON.stringify(result.partial)` on every streaming chunk in `createOutputTransformStream`
- For a 110KB response arriving in ~13,000 chunks, this created ~350MB of string copies per stream, landing in V8's `large_object_space` and only reclaimable via full stop-the-world GC
- The fix returns `undefined` instead, skipping the `JSON.stringify` branch entirely — plain text streaming has no structured partial output to parse incrementally (unlike `Output.object()` or `Output.array()`)

## Performance impact

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Heap at task end (3 concurrent streams) | 3,374 MB | 133 MB | **25x reduction** |
| `large_object_space` | 1,864 MB | ~0 MB | Eliminated |
| Container memory usage | 95% (OOM risk on 4GB) | 10% | **10x reduction** |

## Test plan

- [x] Updated `Output.text` `parsePartialOutput` tests to expect `undefined`
- [x] All 60 existing output tests pass
- [x] Changeset added

Fixes #13839