### PR TITLE
fix(ai): deduplicate concurrent resumeStream calls on shared Chat instances

### DIFF
--- a/.changeset/cool-resume-dedup.md
+++ b/.changeset/cool-resume-dedup.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): deduplicate concurrent resumeStream calls on shared Chat instances

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -2952,4 +2952,111 @@ describe('Chat', () => {
       `);
     });
   });
+
+  describe('resumeStream deduplication', () => {
+    function createResumeStream(): ReadableStream<UIMessageChunk> {
+      return new ReadableStream<UIMessageChunk>({
+        start(controller) {
+          controller.enqueue({ type: 'start' });
+          controller.enqueue({ type: 'finish' });
+          controller.close();
+        },
+      });
+    }
+
+    it('should make a single resume request for concurrent resumeStream calls on a shared chat instance', async () => {
+      let reconnectCount = 0;
+      // Hold the resume request in flight so all three concurrent calls are
+      // provably overlapping before any of them settles.
+      const release = createResolvablePromise<void>();
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport: {
+          sendMessages: async () => {
+            throw new Error('sendMessages should not be called during resume');
+          },
+          reconnectToStream: async () => {
+            reconnectCount++;
+            await release.promise;
+            return createResumeStream();
+          },
+        },
+      });
+
+      // Simulate many useChat hooks sharing one Chat instance, each firing
+      // resumeStream() on mount (e.g. via `resume: true`).
+      const resumed = Promise.all([
+        chat.resumeStream(),
+        chat.resumeStream(),
+        chat.resumeStream(),
+      ]);
+
+      // While the first resume is still in flight, only one request has been
+      // made even though resumeStream() was called three times.
+      expect(reconnectCount).toBe(1);
+
+      release.resolve();
+      await resumed;
+
+      // Still a single request after everything settles.
+      expect(reconnectCount).toBe(1);
+      expect(chat.status).toBe('ready');
+    });
+
+    // Pairs with the test above: dedup must apply only while a resume is in
+    // flight, not permanently. Once the first resume settles, a later call
+    // must issue a fresh request (guards against a missing `.finally()` reset).
+    it('should make a new resume request once the previous resume has settled', async () => {
+      let reconnectCount = 0;
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport: {
+          sendMessages: async () => {
+            throw new Error('sendMessages should not be called during resume');
+          },
+          reconnectToStream: async () => {
+            reconnectCount++;
+            return createResumeStream();
+          },
+        },
+      });
+
+      await chat.resumeStream();
+      await chat.resumeStream();
+
+      expect(reconnectCount).toBe(2);
+      expect(chat.status).toBe('ready');
+    });
+
+    // The in-flight guard must also reset when there is no active stream to
+    // resume (reconnectToStream resolves to null), otherwise a later resume
+    // would be permanently suppressed.
+    it('should reset the in-flight guard when there is no active stream to resume', async () => {
+      let reconnectCount = 0;
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport: {
+          sendMessages: async () => {
+            throw new Error('sendMessages should not be called during resume');
+          },
+          reconnectToStream: async () => {
+            reconnectCount++;
+            return null;
+          },
+        },
+      });
+
+      await chat.resumeStream();
+      await chat.resumeStream();
+
+      expect(reconnectCount).toBe(2);
+      expect(chat.status).toBe('ready');
+    });
+  });
 });

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -254,6 +254,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
   private sendAutomaticallyWhen?: ChatInit<UI_MESSAGE>['sendAutomaticallyWhen'];
 
   private activeResponse: ActiveResponse<UI_MESSAGE> | undefined = undefined;
+  private resumePromise: Promise<void> | undefined = undefined;
   private jobExecutor = new SerialJobExecutor();
 
   constructor({
@@ -459,9 +460,35 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
   /**
    * Attempt to resume an ongoing streaming response.
+   *
+   * Concurrent calls are deduplicated: while a resume request is in flight,
+   * additional calls reuse the same promise instead of issuing another
+   * request. This prevents a burst of duplicate resume requests when multiple
+   * `useChat` hooks share a single Chat instance (e.g. via a shared chat
+   * context) and each triggers a resume on mount. Once the in-flight resume
+   * settles, a later call starts a fresh request.
+   *
+   * Note this is first-call-wins: the in-flight request is reused as-is, so
+   * options passed by later concurrent callers are not applied while a resume
+   * is already running. That is an acceptable tradeoff for collapsing the
+   * duplicate-request storm, since in the shared-context scenario every caller
+   * issues the same parameterless resume.
    */
   resumeStream = async (options: ChatRequestOptions = {}): Promise<void> => {
-    await this.makeRequest({ trigger: 'resume-stream', ...options });
+    if (this.resumePromise) {
+      return this.resumePromise;
+    }
+
+    this.resumePromise = this.makeRequest({
+      trigger: 'resume-stream',
+      ...options,
+    })
+      .then(() => undefined)
+      .finally(() => {
+        this.resumePromise = undefined;
+      });
+
+    return this.resumePromise;
   };
 
   /**


### PR DESCRIPTION
## Problem

When multiple `useChat` hooks share the same `Chat` instance via React context ([shared chat pattern](https://ai-sdk.dev/cookbook/next/use-shared-chat-context)), every hook independently calls `resumeStream()` on mount. With `resume: true` and 20+ components, this fires 20+ resume-stream requests to the server instead of 1.

```tsx
// 20+ components all do this:
const { chat } = useSharedChatContext();
const { messages } = useChat({ chat, resume: true });
// Each mounts its own useEffect -> each calls resumeStream() -> 20+ requests
```

Expected: 1 resume-stream request. Actual: N requests (one per `useChat` hook instance).

## Root Cause

In `packages/ai/src/ui/chat.ts`, `resumeStream()` was a bare passthrough to `makeRequest()` with no deduplication. Each `useChat` hook in `packages/react/src/use-chat.ts` registers its own `useEffect` that calls `chatRef.current.resumeStream()`, and since they all share the same `Chat` object, N hooks means N concurrent `reconnectToStream()` requests.

## Solution

Coalesce concurrent calls behind an in-flight promise. While a resume is running, additional calls reuse the same promise instead of starting another request. The promise is cleared in `finally` on every settle path (success, no-active-stream, and error), so a later resume starts fresh.

```typescript
resumeStream = async (options: ChatRequestOptions = {}): Promise<void> => {
  if (this.resumePromise) {
    return this.resumePromise;
  }

  this.resumePromise = this.makeRequest({
    trigger: 'resume-stream',
    ...options,
  })
    .then(() => undefined)
    .finally(() => {
      this.resumePromise = undefined;
    });

  return this.resumePromise;
};
```

`.then(() => undefined)` keeps the field typed as `Promise<void>` (`makeRequest` resolves to `void | null` on the abort path). This is the same coalescing pattern SWR, React Query, and Apollo use for request dedup.

Note this is first-call-wins on options: while a resume is in flight, later callers' options are not applied. That is intentional and safe for the shared-context scenario, where every caller issues the same parameterless resume.

## Changes

- `packages/ai/src/ui/chat.ts` — `resumePromise` field + dedup guard in `resumeStream()`
- `packages/ai/src/ui/chat.test.ts` — regression tests (below)
- `.changeset/cool-resume-dedup.md` — patch changeset for `ai`

## Tests

New `resumeStream deduplication` suite in `chat.test.ts`:

- 3 concurrent `resumeStream()` calls on a shared instance -> exactly 1 `reconnectToStream` request. Fails on current `main` with 3, passes with the fix.
- Two sequential (awaited) resumes -> 2 requests. Proves the dedup is in-flight only, not permanent.
- No-active-stream path (`reconnectToStream` resolves to `null`) -> the guard still resets, so a later resume fires.

Verified locally: `pnpm --filter ai test:node` (chat suite 29/29), `pnpm type-check` clean, `pnpm check` (ultracite) clean.

## Notes

Rebased onto current `main`. As a side effect the dedup also avoids the pre-fix situation where N overlapping resumes each overwrite `this.activeResponse`. It is complementary to the open abort-on-resume PRs (#14350 / #12924), which touch `makeRequest`'s reconnect call rather than the `resumeStream` wrapper, so there is no overlap.

Closes #13863
