### PR TITLE
fix(ai): export isDynamicToolUIPart from ui barrel

### DIFF
--- a/.changeset/contributor-02-ai-13867-export.md
+++ b/.changeset/contributor-02-ai-13867-export.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Export `isDynamicToolUIPart` from the public UI barrel.

--- a/packages/ai/src/ui/index.test.ts
+++ b/packages/ai/src/ui/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { isDynamicToolUIPart } from './index';
+
+describe('ui public exports', () => {
+  it('exports isDynamicToolUIPart', () => {
+    expect(
+      isDynamicToolUIPart({
+        type: 'dynamic-tool',
+        toolName: 'search',
+        toolCallId: 'tool-call-1',
+        state: 'input-available',
+        input: { query: 'weather' },
+      }),
+    ).toBe(true);
+
+    expect(
+      isDynamicToolUIPart({
+        type: 'text',
+        text: 'hello',
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -38,6 +38,7 @@ export {
   getToolOrDynamicToolName,
   isCustomContentUIPart,
   isDataUIPart,
+  isDynamicToolUIPart,
   isFileUIPart,
   isReasoningFileUIPart,
   isReasoningUIPart,


### PR DESCRIPTION
## Summary
- export isDynamicToolUIPart from the public i/ui barrel
- add a focused runtime test covering the barrel export
- add a patch changeset for the i package

## Testing
- pnpm exec vitest --config vitest.node.config.js --run src/ui/index.test.ts`n- pnpm exec ultracite check packages/ai/src/ui/index.ts packages/ai/src/ui/index.test.ts`n- git diff --check`n
Closes #13867.