### PR TITLE
fix(xai): preserve response message suffixes from repeated output items

### DIFF
--- a/.changeset/fix-xai-output-item-text.md
+++ b/.changeset/fix-xai-output-item-text.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(provider/xai): preserve unseen response text from repeated message output items

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -1990,6 +1990,76 @@ describe('XaiResponsesLanguageModel', () => {
         const fullTextDelta = textDeltas.find(d => d.delta === 'Hello world');
         expect(fullTextDelta).toBeUndefined();
       });
+
+      it('should emit the unseen text suffix from repeated message output_item events', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast-non-reasoning',
+              created_at: 1700000000,
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'message',
+              id: 'msg_123',
+              status: 'in_progress',
+              role: 'assistant',
+              content: [
+                {
+                  type: 'output_text',
+                  text: 'Hello',
+                  annotations: [],
+                },
+              ],
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'message',
+              id: 'msg_123',
+              status: 'completed',
+              role: 'assistant',
+              content: [
+                {
+                  type: 'output_text',
+                  text: 'Hello world',
+                  annotations: [],
+                },
+              ],
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+        const textDeltas = parts.filter(part => part.type === 'text-delta');
+
+        expect(textDeltas).toHaveLength(2);
+        expect(textDeltas.map(part => part.delta)).toEqual(['Hello', ' world']);
+      });
     });
 
     describe('tool call streaming', () => {

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -485,7 +485,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
     };
     let usage: LanguageModelV4Usage | undefined = undefined;
     let isFirstChunk = true;
-    const contentBlocks: Record<string, { type: 'text' }> = {};
+    const contentBlocks: Record<string, { type: 'text'; text: string }> = {};
     const seenToolCalls = new Set<string>();
 
     // Track ongoing function calls by output_index so we can stream
@@ -501,6 +501,40 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
     > = {};
 
     const self = this;
+
+    const emitTextDelta = (
+      controller: TransformStreamDefaultController<LanguageModelV4StreamPart>,
+      blockId: string,
+      text: string,
+    ) => {
+      if (text.length === 0) {
+        return;
+      }
+
+      if (contentBlocks[blockId] == null) {
+        contentBlocks[blockId] = { type: 'text', text: '' };
+        controller.enqueue({
+          type: 'text-start',
+          id: blockId,
+        });
+      }
+
+      const block = contentBlocks[blockId];
+      const delta = text.startsWith(block.text)
+        ? text.slice(block.text.length)
+        : text;
+
+      if (delta.length === 0) {
+        return;
+      }
+
+      block.text += delta;
+      controller.enqueue({
+        type: 'text-delta',
+        id: blockId,
+        delta,
+      });
+    };
 
     return {
       stream: response.pipeThrough(
@@ -610,20 +644,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
 
             if (event.type === 'response.output_text.delta') {
               const blockId = `text-${event.item_id}`;
-
-              if (contentBlocks[blockId] == null) {
-                contentBlocks[blockId] = { type: 'text' };
-                controller.enqueue({
-                  type: 'text-start',
-                  id: blockId,
-                });
-              }
-
-              controller.enqueue({
-                type: 'text-delta',
-                id: blockId,
-                delta: event.delta,
-              });
+              emitTextDelta(controller, blockId, event.delta);
 
               return;
             }
@@ -895,21 +916,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
                 for (const contentPart of part.content) {
                   if (contentPart.text && contentPart.text.length > 0) {
                     const blockId = `text-${part.id}`;
-
-                    // Only emit text if we haven't already streamed it via output_text.delta events
-                    if (contentBlocks[blockId] == null) {
-                      contentBlocks[blockId] = { type: 'text' };
-                      controller.enqueue({
-                        type: 'text-start',
-                        id: blockId,
-                      });
-
-                      controller.enqueue({
-                        type: 'text-delta',
-                        id: blockId,
-                        delta: contentPart.text,
-                      });
-                    }
+                    emitTextDelta(controller, blockId, contentPart.text);
                   }
 
                   if (contentPart.annotations) {


### PR DESCRIPTION
## Summary
- preserve unseen message text when xAI Responses sends repeated esponse.output_item.* events for the same assistant message
- track emitted text per message block so esponse.output_item.done only appends the unseen suffix instead of dropping it or re-emitting the full accumulated text
- add a focused regression for repeated message output items and include a patch changeset for @ai-sdk/xai

## Test Plan
- corepack pnpm --dir packages/xai exec vitest --config vitest.node.config.js --run src/responses/xai-responses-language-model.test.ts
- corepack pnpm --dir packages/xai exec vitest --config vitest.edge.config.js --run src/responses/xai-responses-language-model.test.ts
- corepack pnpm exec ultracite check packages/xai/src/responses/xai-responses-language-model.ts packages/xai/src/responses/xai-responses-language-model.test.ts .changeset/fix-xai-output-item-text.md

Closes #13836