### PR TITLE
feat: Realtime API support for browser<->provider websocket connection

### DIFF
--- a/.changeset/shy-shrimps-type.md
+++ b/.changeset/shy-shrimps-type.md
@@ -1,0 +1,20 @@
+---
+"@ai-sdk/provider": patch
+"@ai-sdk/google": patch
+"@ai-sdk/openai": patch
+"@ai-sdk/react": patch
+"@ai-sdk/xai": patch
+"ai": patch
+---
+
+feat(provider): add experimental Realtime API support for voice conversations
+
+Adds first-class support for realtime (speech-to-speech) APIs:
+
+- `Experimental_RealtimeModelV4` spec in `@ai-sdk/provider` with normalized event types and factory
+- OpenAI, Google, and xAI realtime provider implementations
+- `openai.experimental_realtime()` / `google.experimental_realtime()` / `xai.experimental_realtime()` work in both server and browser
+- `.getToken()` static method on each provider for server-side ephemeral token creation
+- `experimental_getRealtimeToolDefinitions` helper for provider session tool definitions
+- `experimental_useRealtime` hook in `@ai-sdk/react` returning `UIMessage[]` (aligned with `useChat`), with `onToolCall` and `addToolOutput` for client-driven tool execution
+- `inputAudioTranscription` session config for showing transcribed user audio messages when supported by the provider

--- a/content/docs/03-ai-sdk-core/36-realtime.mdx
+++ b/content/docs/03-ai-sdk-core/36-realtime.mdx
@@ -1,0 +1,203 @@
+---
+title: Realtime
+description: Learn how to build realtime voice conversations with the AI SDK.
+---
+
+# Realtime
+
+<Note type="warning">Realtime is an experimental feature.</Note>
+
+The AI SDK provides realtime models for bidirectional audio and text
+conversations over WebSockets. Realtime sessions run in the browser and connect
+directly to the provider using a short-lived token that you create on your
+server.
+
+The typical flow is:
+
+1. The browser calls your setup endpoint.
+1. Your server creates a short-lived provider token with `experimental_realtime.getToken()`.
+1. The browser opens a WebSocket connection to the provider.
+1. The model streams audio, text, and tool calls back to the browser.
+1. Tool calls are handled by your application with `onToolCall`.
+
+## Setup Endpoint
+
+Create a setup endpoint that returns a short-lived token for the realtime
+provider. This endpoint can also attach tool definitions to the session.
+
+```ts filename='app/api/realtime/setup/route.ts'
+import { openai } from '@ai-sdk/openai';
+import { experimental_getRealtimeToolDefinitions, tool } from 'ai';
+import { z } from 'zod';
+
+const tools = {
+  getWeather: tool({
+    description: 'Get the current weather for a city',
+    inputSchema: z.object({
+      city: z.string().describe('The city to get weather for'),
+    }),
+  }),
+};
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}));
+  const toolDefinitions = await experimental_getRealtimeToolDefinitions({
+    tools,
+  });
+
+  const token = await openai.experimental_realtime.getToken({
+    model: 'gpt-realtime',
+    sessionConfig: {
+      ...body.sessionConfig,
+      tools: toolDefinitions,
+    },
+  });
+
+  return Response.json({
+    ...token,
+    tools: toolDefinitions,
+  });
+}
+```
+
+<Note>
+  In production, authenticate and rate-limit your setup endpoint. It creates
+  provider sessions using your server-side API key.
+</Note>
+
+## Client Session
+
+Use the `experimental_useRealtime` hook to connect to the provider, capture microphone audio,
+play model audio, send text messages, and render messages.
+
+```tsx filename='app/realtime/page.tsx'
+'use client';
+
+import { openai } from '@ai-sdk/openai';
+import { experimental_useRealtime } from '@ai-sdk/react';
+
+export default function RealtimePage() {
+  const realtime = experimental_useRealtime({
+    model: openai.experimental_realtime('gpt-realtime'),
+    api: {
+      token: '/api/realtime/setup',
+    },
+    sessionConfig: {
+      instructions: 'You are a helpful assistant. Be concise.',
+      inputAudioTranscription: {},
+      voice: 'alloy',
+      turnDetection: { type: 'server-vad' },
+    },
+  });
+
+  return (
+    <div>
+      <button onClick={realtime.connect}>Connect</button>
+      <button onClick={realtime.disconnect}>Disconnect</button>
+
+      {realtime.messages.map(message => (
+        <div key={message.id}>
+          <strong>{message.role}</strong>
+          {message.parts.map((part, index) =>
+            part.type === 'text' ? <span key={index}>{part.text}</span> : null,
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+## Tool Calling
+
+Realtime tool execution is client-driven. The provider sends tool calls over the
+WebSocket, and your application handles them with `onToolCall`. If the result is
+available immediately, return it from `onToolCall`. The SDK sends it back to the
+provider as tool output.
+
+For server-backed tools, call an app-specific API endpoint from `onToolCall`.
+Avoid generic "execute tool by name" routes. App-specific endpoints are easier
+to secure because they can use your normal authentication, authorization,
+validation, and rate limiting rules.
+
+### Server-Backed Tool Endpoint
+
+```ts filename='app/api/weather/route.ts'
+import { z } from 'zod';
+
+const inputSchema = z.object({
+  city: z.string(),
+});
+
+export async function POST(request: Request) {
+  const input = inputSchema.safeParse(await request.json());
+
+  if (!input.success) {
+    return Response.json({ error: 'Invalid input' }, { status: 400 });
+  }
+
+  return Response.json({
+    city: input.data.city,
+    temperature: 72,
+    condition: 'sunny',
+  });
+}
+```
+
+### Client Tool Handler
+
+```tsx filename='app/realtime/page.tsx' highlight="10-24"
+import { openai } from '@ai-sdk/openai';
+import { experimental_useRealtime } from '@ai-sdk/react';
+
+export default function RealtimePage() {
+  const realtime = experimental_useRealtime({
+    model: openai.experimental_realtime('gpt-realtime'),
+    api: {
+      token: '/api/realtime/setup',
+    },
+    onToolCall: async ({ toolCall }) => {
+      if (toolCall.toolName === 'getWeather') {
+        const response = await fetch('/api/weather', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(toolCall.args),
+        });
+
+        if (!response.ok) {
+          throw new Error('Weather lookup failed');
+        }
+
+        return response.json();
+      }
+    },
+  });
+
+  // ...
+}
+```
+
+You can also submit tool output manually with `addToolOutput` when the tool
+requires user interaction or another asynchronous process:
+
+```tsx
+realtime.addToolOutput(toolCallId, {
+  approved: true,
+});
+```
+
+## Supported Providers
+
+Realtime models are available on providers that expose realtime WebSocket APIs:
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { google } from '@ai-sdk/google';
+import { xai } from '@ai-sdk/xai';
+
+const openaiModel = openai.experimental_realtime('gpt-realtime');
+const googleModel = google.experimental_realtime(
+  'gemini-3.1-flash-live-preview',
+);
+const xaiModel = xai.experimental_realtime('grok-voice-latest');
+```

--- a/content/docs/03-ai-sdk-core/index.mdx
+++ b/content/docs/03-ai-sdk-core/index.mdx
@@ -29,6 +29,11 @@ description: Learn about AI SDK Core.
       href: '/docs/ai-sdk-core/tools-and-tool-calling',
     },
     {
+      title: 'Realtime',
+      description: 'Learn how to build realtime voice conversations.',
+      href: '/docs/ai-sdk-core/realtime',
+    },
+    {
       title: 'MCP Apps',
       description:
         'Learn how to render interactive MCP tool UIs with the AI SDK.',

--- a/content/docs/07-reference/01-ai-sdk-core/23-get-realtime-tool-definitions.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-get-realtime-tool-definitions.mdx
@@ -1,0 +1,117 @@
+---
+title: experimental_getRealtimeToolDefinitions
+description: API reference for experimental_getRealtimeToolDefinitions.
+---
+
+# `experimental_getRealtimeToolDefinitions()`
+
+<Note type="warning">
+  `experimental_getRealtimeToolDefinitions` is part of the experimental realtime
+  API.
+</Note>
+
+Converts an AI SDK `ToolSet` into provider-neutral realtime tool definitions
+that can be passed to a realtime session setup request.
+
+Use it in the server-side setup endpoint that creates a short-lived realtime
+provider token.
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { experimental_getRealtimeToolDefinitions, tool } from 'ai';
+import { z } from 'zod';
+
+const tools = {
+  getWeather: tool({
+    description: 'Get the current weather for a city',
+    inputSchema: z.object({
+      city: z.string(),
+    }),
+  }),
+};
+
+const toolDefinitions = await experimental_getRealtimeToolDefinitions({
+  tools,
+});
+
+const token = await openai.experimental_realtime.getToken({
+  model: 'gpt-realtime',
+  sessionConfig: {
+    tools: toolDefinitions,
+  },
+});
+```
+
+## Import
+
+<Snippet
+  text={`import { experimental_getRealtimeToolDefinitions } from "ai"`}
+  prompt={false}
+/>
+
+## API Signature
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'options',
+      type: 'Object',
+      description: 'The options for converting tools.',
+      properties: [
+        {
+          type: 'Object',
+          parameters: [
+            {
+              name: 'tools',
+              type: 'ToolSet',
+              description:
+                'The AI SDK tools to expose to the realtime model. Function and dynamic tools are converted to realtime function definitions. Provider tools are skipped.',
+            },
+          ],
+        },
+      ],
+    },
+  ]}
+/>
+
+### Returns
+
+A `Promise<Experimental_RealtimeToolDefinition[]>`.
+
+Each returned definition contains:
+
+<PropertiesTable
+  content={[
+    {
+      name: 'type',
+      type: "'function'",
+      description: 'The realtime tool definition type.',
+    },
+    {
+      name: 'name',
+      type: 'string',
+      description: 'The tool name from the input ToolSet.',
+    },
+    {
+      name: 'description',
+      type: 'string | undefined',
+      description: 'The tool description sent to the realtime model.',
+    },
+    {
+      name: 'parameters',
+      type: 'JSONSchema7',
+      description:
+        'The JSON schema converted from the tool inputSchema. The realtime model uses this schema to generate tool call arguments.',
+    },
+  ]}
+/>
+
+## Notes
+
+- Tool execution is not handled by `experimental_getRealtimeToolDefinitions`. Use
+  [`experimental_useRealtime`](/docs/reference/ai-sdk-ui/use-realtime)
+  `onToolCall` and `addToolOutput` to execute tools and return results.
+- Provider tools are skipped because realtime providers expect regular function
+  definitions in the session config.

--- a/content/docs/07-reference/01-ai-sdk-core/index.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/index.mdx
@@ -86,6 +86,11 @@ It also contains the following helper functions:
       href: '/docs/reference/ai-sdk-core/tool',
     },
     {
+      title: 'experimental_getRealtimeToolDefinitions()',
+      description: 'Convert AI SDK tools into realtime tool definitions.',
+      href: '/docs/reference/ai-sdk-core/get-realtime-tool-definitions',
+    },
+    {
       title: 'Experimental_SandboxSession',
       description:
         'Experimental execution environment interface passed to tool execution.',

--- a/content/docs/07-reference/02-ai-sdk-ui/05-use-realtime.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/05-use-realtime.mdx
@@ -1,0 +1,243 @@
+---
+title: experimental_useRealtime
+description: API reference for the experimental_useRealtime hook.
+---
+
+# `experimental_useRealtime()`
+
+<Note type="warning">
+  `experimental_useRealtime` is an experimental feature.
+</Note>
+
+Creates a browser-side realtime session for bidirectional audio and text
+conversations with a realtime provider model.
+
+The hook connects to a provider WebSocket using a short-lived token from your
+setup endpoint, returns messages as `UIMessage[]`, and provides controls for
+audio capture, playback, text input, and tool output.
+
+```tsx
+import { openai } from '@ai-sdk/openai';
+import { experimental_useRealtime } from '@ai-sdk/react';
+
+const realtime = experimental_useRealtime({
+  model: openai.experimental_realtime('gpt-realtime'),
+  api: {
+    token: '/api/realtime/setup',
+  },
+});
+```
+
+## Import
+
+<Snippet
+  text={`import { experimental_useRealtime } from "@ai-sdk/react"`}
+  prompt={false}
+/>
+
+## API Signature
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'model',
+      type: 'Experimental_RealtimeModel',
+      description: 'The realtime model to connect to.',
+    },
+    {
+      name: 'api',
+      type: '{ token: string }',
+      description:
+        'API endpoints used by the realtime session. The token endpoint is called with POST to create the provider setup response.',
+      properties: [
+        {
+          type: 'Object',
+          parameters: [
+            {
+              name: 'token',
+              type: 'string',
+              description:
+                'The setup endpoint that returns an Experimental_RealtimeSetupResponse.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'sessionConfig',
+      type: 'Partial<Experimental_RealtimeSessionConfig>',
+      isOptional: true,
+      description:
+        'Provider-neutral session configuration, such as instructions, voice, audio formats, input audio transcription, turn detection, tools, and providerOptions.',
+    },
+    {
+      name: 'sampleRate',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Default audio sample rate used when inputAudioFormat.rate or outputAudioFormat.rate is not specified. Defaults to 24000.',
+    },
+    {
+      name: 'maxEvents',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Maximum number of provider events to keep in the events array. Defaults to 500.',
+    },
+    {
+      name: 'onToolCall',
+      type: '(options: { toolCall: { toolCallId: string; toolName: string; args: unknown } }) => unknown | Promise<unknown> | undefined',
+      isOptional: true,
+      description:
+        'Called when the provider requests a tool call. Return a value to automatically submit it as tool output, or return undefined and call addToolOutput manually later.',
+    },
+    {
+      name: 'onEvent',
+      type: '(event: Experimental_RealtimeServerEvent) => void',
+      isOptional: true,
+      description: 'Called for every normalized realtime server event.',
+    },
+    {
+      name: 'onError',
+      type: '(error: Error) => void',
+      isOptional: true,
+      description: 'Called when the realtime session encounters an error.',
+    },
+  ]}
+/>
+
+### Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: 'status',
+      type: "'disconnected' | 'connecting' | 'connected' | 'error'",
+      description: 'The current connection status.',
+    },
+    {
+      name: 'messages',
+      type: 'UIMessage[]',
+      description:
+        'Messages assembled from realtime text, transcript, and tool events.',
+    },
+    {
+      name: 'events',
+      type: 'Experimental_RealtimeServerEvent[]',
+      description:
+        'Recent normalized provider events for inspection or debug UI.',
+    },
+    {
+      name: 'isCapturing',
+      type: 'boolean',
+      description: 'Whether microphone audio capture is active.',
+    },
+    {
+      name: 'isPlaying',
+      type: 'boolean',
+      description: 'Whether model audio playback is active.',
+    },
+    {
+      name: 'connect',
+      type: '() => Promise<void>',
+      description:
+        'Fetches the setup token and opens the provider WebSocket connection.',
+    },
+    {
+      name: 'disconnect',
+      type: '() => void',
+      description: 'Closes the provider WebSocket connection.',
+    },
+    {
+      name: 'addToolOutput',
+      type: '(callId: string, result: unknown) => void',
+      description:
+        'Submits the result for a tool call back to the realtime provider.',
+    },
+    {
+      name: 'sendEvent',
+      type: '(event: Experimental_RealtimeClientEvent) => void',
+      description: 'Sends a normalized realtime client event.',
+    },
+    {
+      name: 'sendTextMessage',
+      type: '(text: string) => void',
+      description: 'Sends a user text message and requests a response.',
+    },
+    {
+      name: 'sendAudio',
+      type: '(base64Audio: string) => void',
+      description:
+        'Sends a base64-encoded audio chunk to the provider input audio buffer.',
+    },
+    {
+      name: 'commitAudio',
+      type: '() => void',
+      description: 'Commits the provider input audio buffer.',
+    },
+    {
+      name: 'clearAudioBuffer',
+      type: '() => void',
+      description: 'Clears the provider input audio buffer.',
+    },
+    {
+      name: 'requestResponse',
+      type: '(options?: { modalities?: string[] }) => void',
+      description: 'Requests a new model response.',
+    },
+    {
+      name: 'cancelResponse',
+      type: '() => void',
+      description: 'Cancels the active model response.',
+    },
+    {
+      name: 'startAudioCapture',
+      type: '(stream: MediaStream) => void',
+      description:
+        'Starts capturing microphone audio from the provided MediaStream.',
+    },
+    {
+      name: 'stopAudioCapture',
+      type: '() => void',
+      description: 'Stops microphone audio capture.',
+    },
+    {
+      name: 'stopPlayback',
+      type: '() => void',
+      description: 'Stops queued model audio playback.',
+    },
+  ]}
+/>
+
+## Tool Calling
+
+Realtime tool execution is client-driven. Use `onToolCall` to handle tool calls
+and return the tool output:
+
+```tsx
+const realtime = experimental_useRealtime({
+  model: openai.experimental_realtime('gpt-realtime'),
+  api: {
+    token: '/api/realtime/setup',
+  },
+  onToolCall: async ({ toolCall }) => {
+    if (toolCall.toolName === 'getWeather') {
+      const response = await fetch('/api/weather', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(toolCall.args),
+      });
+
+      return response.json();
+    }
+  },
+});
+```
+
+For tools that require user interaction, return `undefined` from `onToolCall`
+and call `addToolOutput` later.
+
+See [Realtime](/docs/ai-sdk-core/realtime#tool-calling) for a complete example
+with server-backed app-specific tool endpoints.

--- a/content/docs/07-reference/02-ai-sdk-ui/index.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/index.mdx
@@ -31,6 +31,11 @@ AI SDK UI contains the following hooks:
       href: '/docs/reference/ai-sdk-ui/use-object',
     },
     {
+      title: 'experimental_useRealtime',
+      description: 'Use a hook to build realtime voice conversations.',
+      href: '/docs/reference/ai-sdk-ui/use-realtime',
+    },
+    {
       title: 'convertToModelMessages',
       description:
         'Convert useChat messages to ModelMessages for AI functions.',

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -138,6 +138,31 @@ Supported values:
   your selected model. `'none'` requires `grok-4.3` or newer.
 </Note>
 
+## Realtime Models
+
+<Note type="warning">Realtime is an experimental feature.</Note>
+
+You can create models that call the [xAI Realtime API](https://docs.x.ai/docs/guides/realtime)
+using the `.experimental_realtime()` factory method.
+
+```ts
+import { xai } from '@ai-sdk/xai';
+
+const model = xai.experimental_realtime('grok-voice-latest');
+```
+
+Realtime sessions run in the browser and require a short-lived token created on
+your server with `xai.experimental_realtime.getToken()`:
+
+```ts
+const token = await xai.experimental_realtime.getToken({
+  model: 'grok-voice-latest',
+});
+```
+
+See [Realtime](/docs/ai-sdk-core/realtime) for the complete setup and tool
+calling pattern.
+
 ## Responses API (Agentic Tools)
 
 The xAI Responses API is the default when using `xai(modelId)`. You can also use `xai.responses(modelId)` explicitly. This enables the model to autonomously orchestrate tool calls and research on xAI's servers.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -2336,6 +2336,31 @@ The following optional provider options are available for OpenAI completion mode
   provider model ID as a string if needed.
 </Note>
 
+## Realtime Models
+
+<Note type="warning">Realtime is an experimental feature.</Note>
+
+You can create models that call the [OpenAI Realtime API](https://platform.openai.com/docs/guides/realtime)
+using the `.experimental_realtime()` factory method.
+
+```ts
+import { openai } from '@ai-sdk/openai';
+
+const model = openai.experimental_realtime('gpt-realtime');
+```
+
+Realtime sessions run in the browser and require a short-lived token created on
+your server with `openai.experimental_realtime.getToken()`:
+
+```ts
+const token = await openai.experimental_realtime.getToken({
+  model: 'gpt-realtime',
+});
+```
+
+See [Realtime](/docs/ai-sdk-core/realtime) for the complete setup and tool
+calling pattern.
+
 ## Embedding Models
 
 You can create models that call the [OpenAI embeddings API](https://platform.openai.com/docs/api-reference/embeddings)

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1065,6 +1065,32 @@ The following Zod features are known to not work with Google:
   available provider model ID as a string if needed.
 </Note>
 
+## Realtime Models
+
+<Note type="warning">Realtime is an experimental feature.</Note>
+
+You can create models that call the [Gemini Live API](https://ai.google.dev/gemini-api/docs/live)
+using the `.experimental_realtime()` factory method.
+
+```ts
+import { google } from '@ai-sdk/google';
+
+const model = google.experimental_realtime('gemini-3.1-flash-live-preview');
+```
+
+Realtime sessions run in the browser and require a short-lived token created on
+your server with `google.experimental_realtime.getToken()`:
+
+```ts
+const token = await google.experimental_realtime.getToken({
+  model: 'gemini-3.1-flash-live-preview',
+});
+```
+
+Google realtime models may require provider-specific audio formats, depending
+on the model and modality. See [Realtime](/docs/ai-sdk-core/realtime) for the
+complete setup and tool calling pattern.
+
 ## Interactions API
 
 The [Gemini Interactions API](https://ai.google.dev/gemini-api/docs/interactions)

--- a/examples/ai-e2e-next/app/api/realtime/[...path]/route.ts
+++ b/examples/ai-e2e-next/app/api/realtime/[...path]/route.ts
@@ -1,0 +1,95 @@
+import { openai } from '@ai-sdk/openai';
+import { google } from '@ai-sdk/google';
+import { xai } from '@ai-sdk/xai';
+import {
+  experimental_getRealtimeToolDefinitions as getRealtimeToolDefinitions,
+  type Experimental_RealtimeFactory as RealtimeFactory,
+  type Experimental_RealtimeSessionConfig as RealtimeSessionConfig,
+  tool,
+} from 'ai';
+import { z } from 'zod';
+
+const getWeatherInputSchema = z.object({
+  city: z.string().describe('The city to get weather for'),
+});
+
+const getWeather = ({ city }: z.infer<typeof getWeatherInputSchema>) => {
+  const conditions = ['sunny', 'cloudy', 'rainy', 'snowy', 'windy'];
+  return {
+    city,
+    temperature: Math.floor(Math.random() * 35) + 5,
+    condition: conditions[Math.floor(Math.random() * conditions.length)],
+  };
+};
+
+const rollDice = () => ({
+  result: Math.floor(Math.random() * 6) + 1,
+});
+
+const tools = {
+  getWeather: tool({
+    description: 'Get the current weather for a city',
+    inputSchema: getWeatherInputSchema,
+  }),
+  rollDice: tool({
+    description: 'Roll a six-sided die and return the result',
+    inputSchema: z.object({}),
+  }),
+};
+
+const providers: Record<string, { factory: RealtimeFactory; model: string }> = {
+  openai: {
+    factory: openai.experimental_realtime,
+    model: 'gpt-realtime',
+  },
+  google: {
+    factory: google.experimental_realtime,
+    model: 'gemini-3.1-flash-live-preview',
+  },
+  xai: {
+    factory: xai.experimental_realtime,
+    model: 'grok-voice-latest',
+  },
+};
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ path?: string[] }> },
+) {
+  const { path = [] } = await params;
+  const route = path.join('/');
+
+  if (route === 'setup') {
+    const { searchParams } = new URL(request.url);
+    const provider = searchParams.get('provider') ?? 'openai';
+
+    const body = await request.json().catch(() => ({}));
+    const sessionConfig: RealtimeSessionConfig | undefined =
+      body.sessionConfig ?? undefined;
+
+    const toolDefs = await getRealtimeToolDefinitions({ tools });
+
+    const { factory, model } = providers[provider] ?? providers.openai;
+    const tokenResult = await factory.getToken({
+      model,
+      sessionConfig: { ...sessionConfig, tools: toolDefs },
+    });
+
+    return Response.json({ ...tokenResult, tools: toolDefs });
+  }
+
+  if (route === 'weather') {
+    const input = getWeatherInputSchema.safeParse(await request.json());
+    if (!input.success) {
+      return Response.json({ error: 'Invalid weather input' }, { status: 400 });
+    }
+
+    return Response.json(getWeather(input.data));
+  }
+
+  if (route === 'roll-dice') {
+    return Response.json(rollDice());
+  }
+
+  return new Response('Not found', { status: 404 });
+}

--- a/examples/ai-e2e-next/app/realtime/page.tsx
+++ b/examples/ai-e2e-next/app/realtime/page.tsx
@@ -1,0 +1,626 @@
+'use client';
+
+import { experimental_useRealtime } from '@ai-sdk/react';
+import { openai } from '@ai-sdk/openai';
+import { google } from '@ai-sdk/google';
+import { xai } from '@ai-sdk/xai';
+import { useState, useRef, useEffect, useMemo } from 'react';
+
+type Provider = 'openai' | 'google' | 'xai';
+
+type VoiceOption = { id: string; label: string };
+
+function toVoiceOptions(names: string[]): VoiceOption[] {
+  return names.map(n => ({ id: n, label: n }));
+}
+
+const PROVIDER_CONFIG: Record<
+  Provider,
+  {
+    label: string;
+    defaultModel: string;
+    staticVoices: VoiceOption[];
+    createModel: (
+      modelId: string,
+    ) => ReturnType<typeof openai.experimental_realtime>;
+    sessionConfigOverrides?: Record<string, unknown>;
+  }
+> = {
+  openai: {
+    label: 'OpenAI',
+    defaultModel: 'gpt-realtime',
+    staticVoices: toVoiceOptions([
+      'alloy',
+      'ash',
+      'ballad',
+      'coral',
+      'echo',
+      'fable',
+      'marin',
+      'sage',
+      'shimmer',
+      'verse',
+    ]),
+    createModel: modelId => openai.experimental_realtime(modelId),
+  },
+  google: {
+    label: 'Google',
+    defaultModel: 'gemini-3.1-flash-live-preview',
+    staticVoices: toVoiceOptions(['Puck', 'Charon', 'Kore', 'Fenrir', 'Aoede']),
+    createModel: modelId => google.experimental_realtime(modelId),
+    sessionConfigOverrides: {
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      outputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+    },
+  },
+  xai: {
+    label: 'xAI',
+    defaultModel: 'grok-voice-latest',
+    staticVoices: toVoiceOptions(['ara', 'eve', 'leo', 'rex', 'sal']),
+    createModel: modelId => xai.experimental_realtime(modelId),
+  },
+};
+
+export default function RealtimePage() {
+  const [provider, setProvider] = useState<Provider>('openai');
+  const [voice, setVoice] = useState(
+    PROVIDER_CONFIG.openai.staticVoices[0]?.id ?? '',
+  );
+
+  const currentVoices = PROVIDER_CONFIG[provider].staticVoices;
+
+  const handleProviderChange = (next: Provider) => {
+    setProvider(next);
+    setVoice(PROVIDER_CONFIG[next].staticVoices[0]?.id ?? '');
+  };
+
+  const selectStyle = {
+    marginLeft: 8,
+    padding: '6px 10px',
+    borderRadius: 8,
+    border: '1px solid #e2e8f0',
+    fontSize: 13,
+    background: 'white',
+  } as const;
+
+  return (
+    <div
+      style={{
+        maxWidth: 720,
+        margin: '2rem auto',
+        padding: '0 1rem',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+      }}
+    >
+      <h1 style={{ fontSize: 24, fontWeight: 600, marginBottom: 4 }}>
+        Realtime Voice Chat
+      </h1>
+      <p style={{ color: '#64748b', fontSize: 14, marginBottom: 24 }}>
+        AI SDK Realtime API with tool calling
+      </p>
+
+      {/* Provider & voice selectors */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 12,
+          marginBottom: 16,
+          alignItems: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
+        <label style={{ fontSize: 13, fontWeight: 500, color: '#475569' }}>
+          Provider
+          <select
+            value={provider}
+            onChange={e => handleProviderChange(e.target.value as Provider)}
+            style={selectStyle}
+          >
+            {Object.entries(PROVIDER_CONFIG).map(([key, cfg]) => (
+              <option key={key} value={key}>
+                {cfg.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label style={{ fontSize: 13, fontWeight: 500, color: '#475569' }}>
+          Voice
+          <select
+            value={voice}
+            onChange={e => setVoice(e.target.value)}
+            style={selectStyle}
+          >
+            {currentVoices.length === 0 ? (
+              <option>No voices available</option>
+            ) : (
+              currentVoices.map(v => (
+                <option key={v.id} value={v.id}>
+                  {v.label}
+                </option>
+              ))
+            )}
+          </select>
+        </label>
+
+        <span
+          style={{
+            fontSize: 12,
+            color: '#94a3b8',
+            marginLeft: 'auto',
+            fontFamily: 'monospace',
+          }}
+        >
+          {PROVIDER_CONFIG[provider].defaultModel}
+        </span>
+      </div>
+
+      <RealtimeChat
+        key={`${provider}-${voice}`}
+        provider={provider}
+        voice={voice}
+      />
+    </div>
+  );
+}
+
+function RealtimeChat({
+  provider,
+  voice,
+}: {
+  provider: Provider;
+  voice: string;
+}) {
+  const [textInput, setTextInput] = useState('');
+  const [showEvents, setShowEvents] = useState(false);
+  const [expandedEvent, setExpandedEvent] = useState<number | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const eventsEndRef = useRef<HTMLDivElement>(null);
+
+  const config = PROVIDER_CONFIG[provider];
+  const model = useMemo(
+    () => config.createModel(config.defaultModel),
+    [config],
+  );
+
+  const {
+    status,
+    messages,
+    events,
+    isCapturing,
+    isPlaying,
+    connect,
+    disconnect,
+    sendTextMessage,
+    startAudioCapture,
+    stopAudioCapture,
+    stopPlayback,
+  } = experimental_useRealtime({
+    model,
+    api: {
+      token: `/api/realtime/setup?provider=${provider}`,
+    },
+    sessionConfig: {
+      instructions:
+        'You are a helpful assistant. Be concise. ' +
+        'You have access to tools for weather and dice rolling.',
+      inputAudioTranscription: {},
+      voice,
+      turnDetection: { type: 'server-vad' },
+      ...config.sessionConfigOverrides,
+    },
+    onEvent: event => {
+      if (event.type !== 'audio-delta') {
+        console.log(`[realtime:${provider}] ${event.type}`, event);
+      }
+    },
+    onToolCall: async ({ toolCall }) => {
+      switch (toolCall.toolName) {
+        case 'getWeather': {
+          const response = await fetch('/api/realtime/weather', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(toolCall.args),
+          });
+          if (!response.ok) {
+            throw new Error('Weather lookup failed');
+          }
+          return response.json();
+        }
+        case 'rollDice': {
+          const response = await fetch('/api/realtime/roll-dice', {
+            method: 'POST',
+          });
+          if (!response.ok) {
+            throw new Error('Dice roll failed');
+          }
+          return response.json();
+        }
+      }
+    },
+    onError: error => {
+      console.error(`[realtime:${provider}] error:`, error.message);
+    },
+  });
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  useEffect(() => {
+    eventsEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [events]);
+
+  const toggleMic = async () => {
+    if (isCapturing) {
+      stopAudioCapture();
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      startAudioCapture(stream);
+    } catch (err) {
+      console.error('[realtime] mic access denied:', err);
+    }
+  };
+
+  const handleSendText = (e: React.FormEvent) => {
+    e.preventDefault();
+    const text = textInput.trim();
+    if (!text) return;
+    sendTextMessage(text);
+    setTextInput('');
+  };
+
+  const statusColor: Record<string, string> = {
+    disconnected: '#94a3b8',
+    connecting: '#f59e0b',
+    connected: '#22c55e',
+    error: '#ef4444',
+  };
+
+  return (
+    <>
+      {/* Connection bar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '12px 16px',
+          background: '#f8fafc',
+          borderRadius: 12,
+          border: '1px solid #e2e8f0',
+          marginBottom: 16,
+        }}
+      >
+        <div
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            background: statusColor[status] ?? '#94a3b8',
+            boxShadow: status === 'connected' ? '0 0 6px #22c55e' : 'none',
+          }}
+        />
+        <span style={{ fontSize: 13, color: '#475569', fontWeight: 500 }}>
+          {status.toUpperCase()}
+        </span>
+        <div style={{ flex: 1 }} />
+        <button
+          onClick={status === 'connected' ? disconnect : connect}
+          disabled={status === 'connecting'}
+          style={{
+            padding: '6px 16px',
+            borderRadius: 8,
+            border: 'none',
+            cursor: 'pointer',
+            fontWeight: 500,
+            fontSize: 13,
+            background: status === 'connected' ? '#fee2e2' : '#dbeafe',
+            color: status === 'connected' ? '#dc2626' : '#2563eb',
+          }}
+        >
+          {status === 'connected'
+            ? 'Disconnect'
+            : status === 'connecting'
+              ? 'Connecting…'
+              : 'Connect'}
+        </button>
+      </div>
+
+      {/* Audio controls */}
+      {status === 'connected' && (
+        <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+          <button
+            onClick={toggleMic}
+            style={{
+              padding: '8px 20px',
+              borderRadius: 8,
+              border: 'none',
+              cursor: 'pointer',
+              fontWeight: 500,
+              fontSize: 13,
+              background: isCapturing ? '#fecaca' : '#d1fae5',
+              color: isCapturing ? '#b91c1c' : '#065f46',
+              animation: isCapturing ? 'pulse 1.5s infinite' : 'none',
+            }}
+          >
+            {isCapturing ? '⏹ Stop Mic' : '🎙 Start Mic'}
+          </button>
+          {isPlaying && (
+            <button
+              onClick={stopPlayback}
+              style={{
+                padding: '8px 20px',
+                borderRadius: 8,
+                border: 'none',
+                cursor: 'pointer',
+                fontWeight: 500,
+                fontSize: 13,
+                background: '#fef3c7',
+                color: '#92400e',
+              }}
+            >
+              ⏸ Stop Playback
+            </button>
+          )}
+          <div style={{ flex: 1 }} />
+          <button
+            onClick={() => setShowEvents(v => !v)}
+            style={{
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid #e2e8f0',
+              cursor: 'pointer',
+              fontWeight: 500,
+              fontSize: 12,
+              background: showEvents ? '#f1f5f9' : 'white',
+              color: '#475569',
+            }}
+          >
+            {showEvents ? 'Hide' : 'Show'} Events ({events.length})
+          </button>
+        </div>
+      )}
+
+      {/* Text input */}
+      {status === 'connected' && (
+        <form
+          onSubmit={handleSendText}
+          style={{ display: 'flex', gap: 8, marginBottom: 20 }}
+        >
+          <input
+            value={textInput}
+            onChange={e => setTextInput(e.target.value)}
+            placeholder="Type a message…"
+            style={{
+              flex: 1,
+              padding: '10px 14px',
+              borderRadius: 8,
+              border: '1px solid #e2e8f0',
+              fontSize: 14,
+              outline: 'none',
+            }}
+          />
+          <button
+            type="submit"
+            style={{
+              padding: '10px 20px',
+              borderRadius: 8,
+              border: 'none',
+              cursor: 'pointer',
+              fontWeight: 500,
+              fontSize: 14,
+              background: '#2563eb',
+              color: 'white',
+            }}
+          >
+            Send
+          </button>
+        </form>
+      )}
+
+      {/* Messages */}
+      <div
+        style={{
+          minHeight: 200,
+          maxHeight: 400,
+          overflowY: 'auto',
+          border: '1px solid #e2e8f0',
+          borderRadius: 12,
+          padding: 16,
+          background: 'white',
+          marginBottom: 16,
+        }}
+      >
+        {messages.length === 0 && (
+          <p style={{ color: '#94a3b8', textAlign: 'center', fontSize: 14 }}>
+            {status === 'connected'
+              ? 'Start talking or type a message…'
+              : 'Connect to start a conversation'}
+          </p>
+        )}
+        {messages.map(message => (
+          <div
+            key={message.id}
+            style={{
+              display: 'flex',
+              justifyContent:
+                message.role === 'user' ? 'flex-end' : 'flex-start',
+              marginBottom: 8,
+            }}
+          >
+            <div
+              style={{
+                maxWidth: '80%',
+                padding: '10px 14px',
+                borderRadius: 12,
+                fontSize: 14,
+                lineHeight: 1.5,
+                background: message.role === 'user' ? '#2563eb' : '#f1f5f9',
+                color: message.role === 'user' ? 'white' : '#1e293b',
+              }}
+            >
+              {message.parts.map((part, index) => {
+                switch (part.type) {
+                  case 'text':
+                    return (
+                      <span key={index}>
+                        {part.text}
+                        {part.state === 'streaming' && (
+                          <span
+                            style={{
+                              display: 'inline-block',
+                              width: 6,
+                              height: 14,
+                              marginLeft: 2,
+                              background:
+                                message.role === 'user' ? '#bfdbfe' : '#94a3b8',
+                              animation: 'blink 1s infinite',
+                            }}
+                          />
+                        )}
+                      </span>
+                    );
+
+                  case 'dynamic-tool':
+                    return (
+                      <div
+                        key={index}
+                        style={{
+                          marginTop: 6,
+                          padding: '6px 10px',
+                          borderRadius: 8,
+                          background:
+                            message.role === 'user' ? '#1d4ed8' : '#e2e8f0',
+                          fontSize: 12,
+                          fontFamily: 'monospace',
+                        }}
+                      >
+                        {part.state === 'input-streaming' && (
+                          <span style={{ color: '#a78bfa' }}>
+                            ⚙ Calling {part.toolName || 'tool'}
+                            {'…'}
+                          </span>
+                        )}
+                        {part.state === 'input-available' && (
+                          <span style={{ color: '#f59e0b' }}>
+                            ▶ {part.toolName}({JSON.stringify(part.input)})
+                          </span>
+                        )}
+                        {part.state === 'output-available' && (
+                          <span style={{ color: '#22c55e' }}>
+                            ✓ {part.toolName}: {JSON.stringify(part.output)}
+                          </span>
+                        )}
+                      </div>
+                    );
+
+                  default:
+                    return null;
+                }
+              })}
+            </div>
+          </div>
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Event log */}
+      {showEvents && (
+        <div
+          style={{
+            maxHeight: 350,
+            overflowY: 'auto',
+            border: '1px solid #e2e8f0',
+            borderRadius: 12,
+            background: '#1e293b',
+            padding: 12,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              color: '#94a3b8',
+              marginBottom: 8,
+              fontFamily: 'monospace',
+            }}
+          >
+            EVENT LOG ({events.length})
+          </div>
+          {events
+            .filter(e => e.type !== 'audio-delta')
+            .map((event, i) => (
+              <div key={i} style={{ marginBottom: 2 }}>
+                <div
+                  onClick={() =>
+                    setExpandedEvent(expandedEvent === i ? null : i)
+                  }
+                  style={{
+                    padding: '4px 8px',
+                    borderRadius: 4,
+                    cursor: 'pointer',
+                    fontFamily: 'monospace',
+                    fontSize: 12,
+                    color:
+                      event.type === 'error'
+                        ? '#fca5a5'
+                        : event.type === 'custom'
+                          ? '#fbbf24'
+                          : event.type.includes('function')
+                            ? '#a78bfa'
+                            : event.type.includes('text')
+                              ? '#86efac'
+                              : event.type.includes('audio')
+                                ? '#93c5fd'
+                                : '#cbd5e1',
+                    background: expandedEvent === i ? '#334155' : 'transparent',
+                  }}
+                >
+                  <span style={{ color: '#64748b' }}>
+                    {new Date().toLocaleTimeString('en', { hour12: false })}
+                  </span>{' '}
+                  {event.type === 'custom'
+                    ? `custom (${event.rawType})`
+                    : event.type}
+                </div>
+                {expandedEvent === i && (
+                  <pre
+                    style={{
+                      padding: '8px 12px',
+                      margin: '2px 0 6px',
+                      borderRadius: 4,
+                      background: '#0f172a',
+                      color: '#e2e8f0',
+                      fontSize: 11,
+                      overflow: 'auto',
+                      maxHeight: 200,
+                      fontFamily: 'monospace',
+                      whiteSpace: 'pre-wrap',
+                    }}
+                  >
+                    {JSON.stringify(event, null, 2)}
+                  </pre>
+                )}
+              </div>
+            ))}
+          <div ref={eventsEndRef} />
+        </div>
+      )}
+
+      {/* Animations */}
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.6; }
+        }
+        @keyframes blink {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0; }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/packages/ai/scripts/check-bundle-size.ts
+++ b/packages/ai/scripts/check-bundle-size.ts
@@ -3,7 +3,7 @@ import { writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 // Bundle size limits in bytes
-const LIMIT = 600 * 1024;
+const LIMIT = 610 * 1024;
 
 interface BundleResult {
   size: number;

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -40,6 +40,7 @@ export * from './generate-video';
 export * from './logger';
 export * from './middleware';
 export * from './prompt';
+export * from './realtime';
 export * from './registry';
 export * from './rerank';
 export * from './telemetry';

--- a/packages/ai/src/realtime/audio-utils.ts
+++ b/packages/ai/src/realtime/audio-utils.ts
@@ -1,0 +1,82 @@
+/**
+ * Converts Float32 audio samples to a base64-encoded PCM16 string
+ * for sending to a realtime model via input_audio_buffer.append.
+ *
+ * Samples are expected to be in the range [-1.0, 1.0].
+ * Output is 16-bit signed integer, little-endian, base64-encoded.
+ */
+export function encodeRealtimeAudio(float32Array: Float32Array): string {
+  const buffer = new ArrayBuffer(float32Array.length * 2);
+  const view = new DataView(buffer);
+
+  for (let i = 0; i < float32Array.length; i++) {
+    const s = Math.max(-1, Math.min(1, float32Array[i]));
+    view.setInt16(i * 2, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+  }
+
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Converts a base64-encoded PCM16 string (from a realtime model's
+ * audio-delta event) back to Float32 audio samples.
+ *
+ * Input is expected to be 16-bit signed integer, little-endian, base64-encoded.
+ * Output samples are in the range [-1.0, 1.0].
+ */
+export function decodeRealtimeAudio(base64Audio: string): Float32Array {
+  const binaryString = atob(base64Audio);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+
+  const pcm16 = new Int16Array(bytes.buffer);
+  const float32 = new Float32Array(pcm16.length);
+  for (let i = 0; i < pcm16.length; i++) {
+    float32[i] = pcm16[i] / 32768.0;
+  }
+  return float32;
+}
+
+/**
+ * Resamples audio from one sample rate to another using linear
+ * interpolation. Suitable for voice audio.
+ *
+ * @param input - Float32 audio samples at the input sample rate.
+ * @param inputRate - The sample rate of the input audio (e.g. 48000).
+ * @param outputRate - The desired output sample rate (e.g. 24000).
+ * @returns Float32 audio samples at the output sample rate.
+ */
+export function resampleAudio(
+  input: Float32Array,
+  inputRate: number,
+  outputRate: number,
+): Float32Array {
+  if (inputRate === outputRate) {
+    return input;
+  }
+
+  const ratio = inputRate / outputRate;
+  const outputLength = Math.round(input.length / ratio);
+  const output = new Float32Array(outputLength);
+
+  for (let i = 0; i < outputLength; i++) {
+    const srcIndex = i * ratio;
+    const srcIndexFloor = Math.floor(srcIndex);
+    const srcIndexCeil = Math.min(srcIndexFloor + 1, input.length - 1);
+    const fraction = srcIndex - srcIndexFloor;
+
+    output[i] =
+      input[srcIndexFloor] * (1 - fraction) + input[srcIndexCeil] * fraction;
+  }
+
+  return output;
+}

--- a/packages/ai/src/realtime/browser-realtime-audio.ts
+++ b/packages/ai/src/realtime/browser-realtime-audio.ts
@@ -1,0 +1,168 @@
+import {
+  decodeRealtimeAudio,
+  encodeRealtimeAudio,
+  resampleAudio,
+} from './audio-utils';
+
+export type BrowserRealtimeAudioOptions = {
+  captureSampleRate: number;
+  playbackSampleRate: number;
+  onAudio: (base64Audio: string) => void;
+  onPlayingChange: (isPlaying: boolean) => void;
+  onCapturingChange: (isCapturing: boolean) => void;
+};
+
+export class BrowserRealtimeAudio {
+  private readonly captureSampleRate: number;
+  private readonly playbackSampleRate: number;
+  private readonly onAudio: BrowserRealtimeAudioOptions['onAudio'];
+  private readonly onPlayingChange: BrowserRealtimeAudioOptions['onPlayingChange'];
+  private readonly onCapturingChange: BrowserRealtimeAudioOptions['onCapturingChange'];
+
+  private captureContext: AudioContext | null = null;
+  private captureProcessor: ScriptProcessorNode | null = null;
+  private captureSource: MediaStreamAudioSourceNode | null = null;
+  private captureStream: MediaStream | null = null;
+
+  private playbackContext: AudioContext | null = null;
+  private playbackQueue: Float32Array[] = [];
+  private playbackTime = 0;
+  private playbackStartTime = 0;
+  private activeSources = new Set<AudioBufferSourceNode>();
+  private isPlaying = false;
+
+  constructor(options: BrowserRealtimeAudioOptions) {
+    this.captureSampleRate = options.captureSampleRate;
+    this.playbackSampleRate = options.playbackSampleRate;
+    this.onAudio = options.onAudio;
+    this.onPlayingChange = options.onPlayingChange;
+    this.onCapturingChange = options.onCapturingChange;
+  }
+
+  ensurePlaybackContext(): void {
+    if (this.playbackContext == null) {
+      this.playbackContext = new AudioContext({
+        sampleRate: this.playbackSampleRate,
+      });
+    }
+  }
+
+  startCapture(stream: MediaStream): void {
+    const ctx = new AudioContext({ sampleRate: this.captureSampleRate });
+    this.captureContext = ctx;
+    this.captureStream = stream;
+
+    const source = ctx.createMediaStreamSource(stream);
+    this.captureSource = source;
+
+    const processor = ctx.createScriptProcessor(4096, 1, 1);
+    this.captureProcessor = processor;
+
+    processor.onaudioprocess = event => {
+      const inputData = event.inputBuffer.getChannelData(0);
+      const samples = resampleAudio(
+        new Float32Array(inputData),
+        ctx.sampleRate,
+        this.captureSampleRate,
+      );
+      this.onAudio(encodeRealtimeAudio(samples));
+    };
+
+    source.connect(processor);
+    processor.connect(ctx.destination);
+    this.onCapturingChange(true);
+  }
+
+  stopCapture(): void {
+    this.captureProcessor?.disconnect();
+    this.captureSource?.disconnect();
+    void this.captureContext?.close();
+    this.captureStream?.getTracks().forEach(track => track.stop());
+
+    this.captureProcessor = null;
+    this.captureSource = null;
+    this.captureContext = null;
+    this.captureStream = null;
+    this.onCapturingChange(false);
+  }
+
+  playAudio(base64Audio: string): void {
+    this.ensurePlaybackContext();
+    this.playbackQueue.push(decodeRealtimeAudio(base64Audio));
+    this.schedulePlayback();
+  }
+
+  stopPlayback(): void {
+    this.playbackQueue = [];
+
+    for (const source of this.activeSources) {
+      try {
+        source.stop();
+      } catch {
+        // Source may already be stopped by the browser.
+      }
+    }
+    this.activeSources.clear();
+
+    if (this.playbackContext != null) {
+      this.playbackTime = this.playbackContext.currentTime;
+    }
+    this.setPlaying(false);
+  }
+
+  getPlaybackOffsetMs(): number {
+    const ctx = this.playbackContext;
+    if (ctx == null) return 0;
+    return (ctx.currentTime - this.playbackStartTime) * 1000;
+  }
+
+  dispose(): void {
+    this.stopCapture();
+    this.stopPlayback();
+    void this.playbackContext?.close();
+    this.playbackContext = null;
+  }
+
+  private setPlaying(isPlaying: boolean): void {
+    if (isPlaying && !this.isPlaying) {
+      this.playbackStartTime = this.playbackContext?.currentTime ?? 0;
+    }
+    if (this.isPlaying !== isPlaying) {
+      this.isPlaying = isPlaying;
+      this.onPlayingChange(isPlaying);
+    }
+  }
+
+  private schedulePlayback(): void {
+    const ctx = this.playbackContext;
+    if (ctx == null || this.playbackQueue.length === 0) return;
+
+    while (this.playbackQueue.length > 0) {
+      const samples = this.playbackQueue.shift()!;
+      const buffer = ctx.createBuffer(
+        1,
+        samples.length,
+        this.playbackSampleRate,
+      );
+      buffer.getChannelData(0).set(samples);
+
+      const source = ctx.createBufferSource();
+      source.buffer = buffer;
+      source.connect(ctx.destination);
+
+      const startTime = Math.max(this.playbackTime, ctx.currentTime);
+      source.start(startTime);
+      this.playbackTime = startTime + buffer.duration;
+
+      this.activeSources.add(source);
+      this.setPlaying(true);
+
+      source.onended = () => {
+        this.activeSources.delete(source);
+        if (this.playbackQueue.length === 0 && this.activeSources.size === 0) {
+          this.setPlaying(false);
+        }
+      };
+    }
+  }
+}

--- a/packages/ai/src/realtime/browser-realtime-transport.test.ts
+++ b/packages/ai/src/realtime/browser-realtime-transport.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BrowserRealtimeTransport } from './browser-realtime-transport';
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  close = vi.fn(() => {
+    this.readyState = 3;
+  });
+  send = vi.fn();
+  onopen: (() => void) | null = null;
+  onmessage: ((event: unknown) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(
+    public url: string,
+    public protocols?: string | string[],
+  ) {
+    MockWebSocket.instances.push(this);
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+}
+
+const model = {
+  getWebSocketConfig: ({ url }: { url: string }) => ({ url }),
+  serializeClientEvent: (event: unknown) => event,
+  parseServerEvent: (raw: unknown) => raw,
+} as never;
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('BrowserRealtimeTransport', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('closes a socket that is still connecting on disconnect', () => {
+    const transport = new BrowserRealtimeTransport({
+      model,
+      onServerEvent: vi.fn(),
+      onError: vi.fn(),
+      onClose: vi.fn(),
+    });
+
+    const onOpen = vi.fn();
+    transport.connect({ token: 'token', url: 'wss://example.com', onOpen });
+
+    const ws = MockWebSocket.instances[0];
+    expect(ws.readyState).toBe(MockWebSocket.CONNECTING);
+
+    // Disconnect before the socket finishes connecting.
+    transport.disconnect();
+    expect(ws.close).toHaveBeenCalledOnce();
+
+    // A late open for the now-disconnected socket must not fire onOpen
+    // (which would send session-update against a disconnected session).
+    ws.open();
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('fires onOpen when the socket opens normally', () => {
+    const transport = new BrowserRealtimeTransport({
+      model,
+      onServerEvent: vi.fn(),
+      onError: vi.fn(),
+      onClose: vi.fn(),
+    });
+
+    const onOpen = vi.fn();
+    transport.connect({ token: 'token', url: 'wss://example.com', onOpen });
+
+    MockWebSocket.instances[0].open();
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('closes an existing socket before reconnecting', () => {
+    const onClose = vi.fn();
+    const transport = new BrowserRealtimeTransport({
+      model,
+      onServerEvent: vi.fn(),
+      onError: vi.fn(),
+      onClose,
+    });
+
+    transport.connect({
+      token: 'token-1',
+      url: 'wss://example.com/one',
+      onOpen: vi.fn(),
+    });
+    const firstSocket = MockWebSocket.instances[0];
+
+    transport.connect({
+      token: 'token-2',
+      url: 'wss://example.com/two',
+      onOpen: vi.fn(),
+    });
+    const secondSocket = MockWebSocket.instances[1];
+
+    expect(firstSocket.close).toHaveBeenCalledOnce();
+
+    firstSocket.onclose?.();
+    expect(onClose).not.toHaveBeenCalled();
+
+    secondSocket.onclose?.();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('preserves send order when serialization is async', async () => {
+    let resolveFirst: (() => void) | undefined;
+    const asyncModel = {
+      getWebSocketConfig: ({ url }: { url: string }) => ({ url }),
+      serializeClientEvent: (event: { type: string }) => {
+        if (event.type === 'first') {
+          return new Promise(resolve => {
+            resolveFirst = () => resolve({ type: 'first' });
+          });
+        }
+        return event;
+      },
+      parseServerEvent: (raw: unknown) => raw,
+    } as never;
+
+    const transport = new BrowserRealtimeTransport({
+      model: asyncModel,
+      onServerEvent: vi.fn(),
+      onError: vi.fn(),
+      onClose: vi.fn(),
+    });
+
+    transport.connect({
+      token: 'token',
+      url: 'wss://example.com',
+      onOpen: vi.fn(),
+    });
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+
+    transport.sendEvent({ type: 'first' } as never);
+    transport.sendEvent({ type: 'second' } as never);
+
+    await flush();
+    expect(ws.send).not.toHaveBeenCalled();
+
+    resolveFirst?.();
+    await flush();
+
+    expect(ws.send).toHaveBeenNthCalledWith(
+      1,
+      JSON.stringify({ type: 'first' }),
+    );
+    expect(ws.send).toHaveBeenNthCalledWith(
+      2,
+      JSON.stringify({ type: 'second' }),
+    );
+  });
+});

--- a/packages/ai/src/realtime/browser-realtime-transport.ts
+++ b/packages/ai/src/realtime/browser-realtime-transport.ts
@@ -1,0 +1,134 @@
+import { safeParseJSON } from '@ai-sdk/provider-utils';
+import type {
+  RealtimeClientEvent,
+  RealtimeModel,
+  RealtimeServerEvent,
+} from '../types/realtime-model';
+
+export type BrowserRealtimeTransportOptions = {
+  model: RealtimeModel;
+  onServerEvent: (event: RealtimeServerEvent) => void | Promise<void>;
+  onError: (error: Error) => void;
+  onClose: () => void;
+};
+
+export class BrowserRealtimeTransport {
+  private readonly model: RealtimeModel;
+  private readonly onServerEvent: BrowserRealtimeTransportOptions['onServerEvent'];
+  private readonly onError: BrowserRealtimeTransportOptions['onError'];
+  private readonly onClose: BrowserRealtimeTransportOptions['onClose'];
+  private ws: WebSocket | null = null;
+  private sendQueue: Promise<void> = Promise.resolve();
+
+  constructor(options: BrowserRealtimeTransportOptions) {
+    this.model = options.model;
+    this.onServerEvent = options.onServerEvent;
+    this.onError = options.onError;
+    this.onClose = options.onClose;
+  }
+
+  connect({
+    token,
+    url,
+    onOpen,
+  }: {
+    token: string;
+    url: string;
+    onOpen: () => void;
+  }): void {
+    this.ws?.close();
+    this.ws = null;
+
+    const wsConfig = this.model.getWebSocketConfig({ token, url });
+    const ws = new WebSocket(wsConfig.url, wsConfig.protocols);
+
+    // Track the socket immediately (not just in `onopen`) so that calling
+    // `disconnect()` while it is still connecting actually closes it. Otherwise
+    // `close()` would be a no-op and the socket could open afterwards and fire
+    // the `onOpen` (session-update) callback against a disconnected session.
+    this.ws = ws;
+
+    ws.onopen = () => {
+      // Ignore a late open for a socket that has since been replaced/closed.
+      if (this.ws !== ws) return;
+      onOpen();
+    };
+
+    ws.onmessage = messageEvent => {
+      void this.handleMessage(messageEvent);
+    };
+
+    ws.onerror = () => {
+      this.onError(new Error('WebSocket connection error'));
+    };
+
+    ws.onclose = () => {
+      if (this.ws === ws) {
+        this.ws = null;
+        this.onClose();
+      }
+    };
+  }
+
+  disconnect(): void {
+    this.ws?.close();
+    this.ws = null;
+  }
+
+  sendEvent(event: RealtimeClientEvent): void {
+    this.sendQueue = this.sendQueue
+      .then(async () => {
+        const serialized = await this.model.serializeClientEvent(event);
+        if (serialized != null) {
+          this.sendRaw(serialized);
+        }
+      })
+      .catch(error => {
+        this.onError(
+          error instanceof Error
+            ? error
+            : new Error(`Failed to send realtime event: ${String(error)}`),
+        );
+      });
+  }
+
+  sendRaw(data: unknown): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(data));
+    }
+  }
+
+  dispose(): void {
+    this.disconnect();
+  }
+
+  private async handleMessage(messageEvent: MessageEvent): Promise<void> {
+    let text: string;
+    if (typeof messageEvent.data === 'string') {
+      text = messageEvent.data;
+    } else if (messageEvent.data instanceof Blob) {
+      text = await messageEvent.data.text();
+    } else {
+      text = new TextDecoder().decode(messageEvent.data);
+    }
+
+    const parseResult = await safeParseJSON({ text });
+    if (!parseResult.success) return;
+
+    const rawEvent = parseResult.value;
+
+    if (this.model.getHealthCheckResponse != null) {
+      const autoResponse = this.model.getHealthCheckResponse(rawEvent);
+      if (autoResponse != null) {
+        this.sendRaw(autoResponse);
+      }
+    }
+
+    const result = this.model.parseServerEvent(rawEvent);
+    const events = Array.isArray(result) ? result : [result];
+
+    for (const event of events) {
+      await this.onServerEvent(event);
+    }
+  }
+}

--- a/packages/ai/src/realtime/get-realtime-tool-definitions.ts
+++ b/packages/ai/src/realtime/get-realtime-tool-definitions.ts
@@ -1,0 +1,66 @@
+import {
+  asSchema,
+  type InferToolSetContext,
+  type Tool,
+  type ToolSet,
+} from '@ai-sdk/provider-utils';
+import type { RealtimeToolDefinition } from '../types/realtime-model';
+
+export async function getRealtimeToolDefinitions<TOOLS extends ToolSet>({
+  tools,
+  toolsContext = {} as InferToolSetContext<TOOLS>,
+}: {
+  tools: TOOLS;
+  toolsContext?: InferToolSetContext<TOOLS>;
+}): Promise<RealtimeToolDefinition[]> {
+  const definitions: RealtimeToolDefinition[] = [];
+
+  for (const [name, tool] of Object.entries(tools)) {
+    const toolType = tool.type;
+
+    switch (toolType) {
+      case undefined:
+      case 'function':
+      case 'dynamic': {
+        const description = resolveRealtimeToolDescription({
+          tool,
+          toolName: name,
+          toolsContext,
+        });
+        definitions.push({
+          type: 'function',
+          name,
+          description,
+          parameters: await asSchema(tool.inputSchema).jsonSchema,
+        });
+        break;
+      }
+      case 'provider':
+        break;
+      default: {
+        const exhaustiveCheck: never = toolType as never;
+        throw new Error(`Unsupported tool type: ${exhaustiveCheck}`);
+      }
+    }
+  }
+
+  return definitions;
+}
+
+function resolveRealtimeToolDescription<TOOLS extends ToolSet>({
+  tool,
+  toolName,
+  toolsContext,
+}: {
+  tool: Tool;
+  toolName: string;
+  toolsContext: InferToolSetContext<TOOLS>;
+}): string | undefined {
+  return tool.description === undefined
+    ? undefined
+    : typeof tool.description === 'string'
+      ? tool.description
+      : tool.description({
+          context: toolsContext[toolName as keyof InferToolSetContext<TOOLS>],
+        });
+}

--- a/packages/ai/src/realtime/index.ts
+++ b/packages/ai/src/realtime/index.ts
@@ -1,0 +1,23 @@
+export {
+  encodeRealtimeAudio as experimental_encodeRealtimeAudio,
+  decodeRealtimeAudio as experimental_decodeRealtimeAudio,
+  resampleAudio as experimental_resampleAudio,
+} from './audio-utils';
+export { getRealtimeToolDefinitions as experimental_getRealtimeToolDefinitions } from './get-realtime-tool-definitions';
+export { AbstractRealtimeSession as Experimental_AbstractRealtimeSession } from './realtime-session';
+export type {
+  RealtimeSessionOptions as Experimental_RealtimeSessionOptions,
+  RealtimeState as Experimental_RealtimeState,
+  RealtimeStatus as Experimental_RealtimeStatus,
+} from './realtime-session';
+export type { RealtimeSetupResponse as Experimental_RealtimeSetupResponse } from './realtime-types';
+export type {
+  RealtimeClientEvent as Experimental_RealtimeClientEvent,
+  RealtimeFactory as Experimental_RealtimeFactory,
+  RealtimeFactoryGetTokenOptions as Experimental_RealtimeFactoryGetTokenOptions,
+  RealtimeFactoryGetTokenResult as Experimental_RealtimeFactoryGetTokenResult,
+  RealtimeModel as Experimental_RealtimeModel,
+  RealtimeServerEvent as Experimental_RealtimeServerEvent,
+  RealtimeSessionConfig as Experimental_RealtimeSessionConfig,
+  RealtimeToolDefinition as Experimental_RealtimeToolDefinition,
+} from '../types/realtime-model';

--- a/packages/ai/src/realtime/realtime-event-reducer.test.ts
+++ b/packages/ai/src/realtime/realtime-event-reducer.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createInitialRealtimeState,
+  RealtimeEventReducer,
+} from './realtime-event-reducer';
+
+describe('RealtimeEventReducer', () => {
+  it('assembles streamed text into UI messages', async () => {
+    const reducer = new RealtimeEventReducer();
+    let state = createInitialRealtimeState();
+
+    ({ state } = await reducer.reduceServerEvent(state, {
+      type: 'text-delta',
+      responseId: 'response-1',
+      itemId: 'item-1',
+      delta: 'Hel',
+      raw: {},
+    }));
+    ({ state } = await reducer.reduceServerEvent(state, {
+      type: 'text-delta',
+      responseId: 'response-1',
+      itemId: 'item-1',
+      delta: 'lo',
+      raw: {},
+    }));
+    ({ state } = await reducer.reduceServerEvent(state, {
+      type: 'text-done',
+      responseId: 'response-1',
+      itemId: 'item-1',
+      text: 'Hello',
+      raw: {},
+    }));
+
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].role).toBe('assistant');
+    expect(state.messages[0].parts).toEqual([
+      { type: 'text', text: 'Hello', state: 'done' },
+    ]);
+  });
+
+  it('keeps tool names available when adding tool output', async () => {
+    const reducer = new RealtimeEventReducer();
+    let state = createInitialRealtimeState();
+
+    ({ state } = await reducer.reduceServerEvent(state, {
+      type: 'function-call-arguments-delta',
+      responseId: 'response-1',
+      itemId: 'item-1',
+      callId: 'call-1',
+      delta: '{"city":"Paris"}',
+      raw: {},
+    }));
+
+    const result = await reducer.reduceServerEvent(state, {
+      type: 'function-call-arguments-done',
+      responseId: 'response-1',
+      itemId: 'item-1',
+      callId: 'call-1',
+      name: 'getWeather',
+      arguments: '{"city":"Paris"}',
+      raw: {},
+    });
+
+    expect(result.effects).toContainEqual({
+      type: 'tool-call',
+      callId: 'call-1',
+      name: 'getWeather',
+      args: { city: 'Paris' },
+      rawArguments: '{"city":"Paris"}',
+    });
+
+    const output = reducer.addToolOutput(result.state, 'call-1', {
+      temperature: 22,
+    });
+
+    expect(output.output).toEqual({
+      callId: 'call-1',
+      name: 'getWeather',
+      output: '{"temperature":22}',
+    });
+    expect(output.state.messages[0].parts).toMatchObject([
+      {
+        type: 'dynamic-tool',
+        toolName: 'getWeather',
+        toolCallId: 'call-1',
+        state: 'output-available',
+        input: { city: 'Paris' },
+        output: { temperature: 22 },
+      },
+    ]);
+  });
+
+  it('inserts delayed input transcriptions before the assistant response', async () => {
+    const reducer = new RealtimeEventReducer();
+    let state = createInitialRealtimeState();
+
+    ({ state } = await reducer.reduceServerEvent(state, {
+      type: 'audio-committed',
+      itemId: 'user-item-1',
+      raw: {},
+    }));
+    ({ state } = await reducer.reduceServerEvent(state, {
+      type: 'text-delta',
+      responseId: 'response-1',
+      itemId: 'assistant-item-1',
+      delta: 'Yes, I can hear you.',
+      raw: {},
+    }));
+    ({ state } = await reducer.reduceServerEvent(state, {
+      type: 'text-done',
+      responseId: 'response-1',
+      itemId: 'assistant-item-1',
+      text: 'Yes, I can hear you.',
+      raw: {},
+    }));
+    ({ state } = await reducer.reduceServerEvent(state, {
+      type: 'input-transcription-completed',
+      itemId: 'user-item-1',
+      transcript: 'Can you hear me?',
+      raw: {},
+    }));
+
+    expect(state.messages).toHaveLength(2);
+    expect(state.messages[0]).toMatchObject({
+      id: 'user-user-item-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Can you hear me?', state: 'done' }],
+    });
+    expect(state.messages[1]).toMatchObject({
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Yes, I can hear you.', state: 'done' }],
+    });
+  });
+});

--- a/packages/ai/src/realtime/realtime-event-reducer.ts
+++ b/packages/ai/src/realtime/realtime-event-reducer.ts
@@ -1,0 +1,523 @@
+import { safeParseJSON } from '@ai-sdk/provider-utils';
+import type { RealtimeServerEvent } from '../types/realtime-model';
+import type {
+  DynamicToolUIPart,
+  TextUIPart,
+  UIMessage,
+} from '../ui/ui-messages';
+
+export type RealtimeStatus =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'error';
+
+export interface RealtimeState {
+  status: RealtimeStatus;
+  messages: UIMessage[];
+  events: RealtimeServerEvent[];
+  isCapturing: boolean;
+  isPlaying: boolean;
+}
+
+export type RealtimeReducerEffect =
+  | {
+      type: 'play-audio';
+      itemId: string;
+      delta: string;
+    }
+  | {
+      type: 'speech-started';
+    }
+  | {
+      type: 'tool-call';
+      callId: string;
+      name: string;
+      args: Record<string, unknown>;
+      rawArguments: string;
+    }
+  | {
+      type: 'error';
+      error: Error;
+    };
+
+export type RealtimeToolOutput = {
+  callId: string;
+  name?: string;
+  output: string;
+};
+
+export function createInitialRealtimeState(): RealtimeState {
+  return {
+    status: 'disconnected',
+    messages: [],
+    events: [],
+    isCapturing: false,
+    isPlaying: false,
+  };
+}
+
+export class RealtimeEventReducer {
+  private currentAssistantMessageId: string | null = null;
+  private textAccumulators = new Map<string, string>();
+  private toolArgAccumulators = new Map<string, string>();
+  private toolCallIdToMessageId = new Map<string, string>();
+  private toolCallIdToName = new Map<string, string>();
+  private inputAudioMessageInsertIndex = new Map<string, number>();
+  private itemIdToPartLocation = new Map<
+    string,
+    { messageId: string; partIndex: number }
+  >();
+
+  constructor(private readonly maxEvents = 500) {}
+
+  setStatus(state: RealtimeState, status: RealtimeStatus): RealtimeState {
+    return { ...state, status };
+  }
+
+  setCapturing(state: RealtimeState, isCapturing: boolean): RealtimeState {
+    return { ...state, isCapturing };
+  }
+
+  setPlaying(state: RealtimeState, isPlaying: boolean): RealtimeState {
+    return { ...state, isPlaying };
+  }
+
+  addUserTextMessage(state: RealtimeState, text: string): RealtimeState {
+    return {
+      ...state,
+      messages: [
+        ...state.messages,
+        {
+          id: `user-${Date.now()}`,
+          role: 'user',
+          parts: [{ type: 'text', text, state: 'done' } as TextUIPart],
+        },
+      ],
+    };
+  }
+
+  addToolOutput(
+    state: RealtimeState,
+    callId: string,
+    result: unknown,
+  ): { state: RealtimeState; output: RealtimeToolOutput } {
+    return {
+      state: this.updateToolPartState(state, callId, result),
+      output: {
+        callId,
+        name: this.toolCallIdToName.get(callId),
+        output: JSON.stringify(result),
+      },
+    };
+  }
+
+  async reduceServerEvent(
+    state: RealtimeState,
+    event: RealtimeServerEvent,
+  ): Promise<{ state: RealtimeState; effects: RealtimeReducerEffect[] }> {
+    let nextState = this.pushEvent(state, event);
+    const effects: RealtimeReducerEffect[] = [];
+
+    switch (event.type) {
+      case 'session-created':
+      case 'session-updated': {
+        if (nextState.status === 'connecting') {
+          nextState = this.setStatus(nextState, 'connected');
+        }
+        break;
+      }
+
+      case 'audio-delta': {
+        effects.push({
+          type: 'play-audio',
+          itemId: event.itemId,
+          delta: event.delta,
+        });
+        break;
+      }
+
+      case 'audio-committed': {
+        if (event.itemId != null) {
+          this.inputAudioMessageInsertIndex.set(
+            event.itemId,
+            nextState.messages.length,
+          );
+        }
+        break;
+      }
+
+      case 'audio-transcript-delta':
+      case 'text-delta': {
+        nextState = this.appendTextDelta(nextState, event.itemId, event.delta);
+        break;
+      }
+
+      case 'audio-transcript-done': {
+        nextState = this.finalizeText(
+          nextState,
+          event.itemId,
+          event.transcript,
+        );
+        break;
+      }
+
+      case 'text-done': {
+        nextState = this.finalizeText(nextState, event.itemId, event.text);
+        break;
+      }
+
+      case 'input-transcription-completed': {
+        nextState = this.addInputTranscriptionMessage(
+          nextState,
+          event.itemId,
+          event.transcript,
+        );
+        break;
+      }
+
+      case 'response-created':
+      case 'response-done': {
+        this.currentAssistantMessageId = null;
+        break;
+      }
+
+      case 'speech-started': {
+        this.currentAssistantMessageId = null;
+        effects.push({ type: 'speech-started' });
+        break;
+      }
+
+      case 'function-call-arguments-delta': {
+        const { state: updatedState, messageId } =
+          this.getOrCreateAssistantMessage(nextState);
+        nextState = updatedState;
+        this.toolCallIdToMessageId.set(event.callId, messageId);
+
+        const acc = this.toolArgAccumulators.get(event.callId) ?? '';
+        this.toolArgAccumulators.set(event.callId, acc + event.delta);
+
+        nextState = this.ensureToolPart(nextState, messageId, event.callId);
+        break;
+      }
+
+      case 'function-call-arguments-done': {
+        this.toolArgAccumulators.delete(event.callId);
+        this.toolCallIdToName.set(event.callId, event.name);
+
+        const parseResult = await safeParseJSON({ text: event.arguments });
+        const parsedInput = parseResult.success
+          ? (parseResult.value as Record<string, unknown>)
+          : {};
+
+        const messageId = this.toolCallIdToMessageId.get(event.callId);
+        if (messageId != null) {
+          nextState = this.markToolInputAvailable(
+            nextState,
+            messageId,
+            event.callId,
+            event.name,
+            parsedInput,
+          );
+        }
+
+        if (!parseResult.success) {
+          effects.push({
+            type: 'error',
+            error: new Error(
+              `Failed to parse tool arguments: ${event.arguments}`,
+            ),
+          });
+        } else {
+          effects.push({
+            type: 'tool-call',
+            callId: event.callId,
+            name: event.name,
+            args: parsedInput,
+            rawArguments: event.arguments,
+          });
+        }
+        break;
+      }
+
+      case 'error': {
+        effects.push({ type: 'error', error: new Error(event.message) });
+        break;
+      }
+    }
+
+    return { state: nextState, effects };
+  }
+
+  private pushEvent(
+    state: RealtimeState,
+    event: RealtimeServerEvent,
+  ): RealtimeState {
+    const events = [...state.events, event];
+    return {
+      ...state,
+      events:
+        events.length > this.maxEvents ? events.slice(-this.maxEvents) : events,
+    };
+  }
+
+  private getOrCreateAssistantMessage(state: RealtimeState): {
+    state: RealtimeState;
+    messageId: string;
+  } {
+    if (this.currentAssistantMessageId != null) {
+      return { state, messageId: this.currentAssistantMessageId };
+    }
+
+    const messageId = `assistant-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 6)}`;
+    this.currentAssistantMessageId = messageId;
+
+    return {
+      state: {
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            id: messageId,
+            role: 'assistant',
+            parts: [],
+          },
+        ],
+      },
+      messageId,
+    };
+  }
+
+  private addInputTranscriptionMessage(
+    state: RealtimeState,
+    itemId: string,
+    transcript: string,
+  ): RealtimeState {
+    const messageId = `user-${itemId}`;
+    const existingMessage = state.messages.find(
+      message => message.id === messageId,
+    );
+
+    if (existingMessage != null) {
+      return {
+        ...state,
+        messages: state.messages.map(message =>
+          message.id === messageId
+            ? {
+                ...message,
+                parts: [
+                  {
+                    type: 'text',
+                    text: transcript,
+                    state: 'done',
+                  } as TextUIPart,
+                ],
+              }
+            : message,
+        ),
+      };
+    }
+
+    const insertIndex = Math.min(
+      this.inputAudioMessageInsertIndex.get(itemId) ?? state.messages.length,
+      state.messages.length,
+    );
+
+    const messages = [...state.messages];
+    messages.splice(insertIndex, 0, {
+      id: messageId,
+      role: 'user',
+      parts: [
+        {
+          type: 'text',
+          text: transcript,
+          state: 'done',
+        } as TextUIPart,
+      ],
+    });
+
+    return {
+      ...state,
+      messages,
+    };
+  }
+
+  private appendTextDelta(
+    state: RealtimeState,
+    itemId: string,
+    delta: string,
+  ): RealtimeState {
+    const { state: stateWithMessage, messageId } =
+      this.getOrCreateAssistantMessage(state);
+
+    const acc = this.textAccumulators.get(itemId) ?? '';
+    const text = acc + delta;
+    this.textAccumulators.set(itemId, text);
+
+    const location = this.itemIdToPartLocation.get(itemId);
+    if (location != null) {
+      return this.updateMessagePart(
+        stateWithMessage,
+        location.messageId,
+        location.partIndex,
+        { type: 'text', text, state: 'streaming' } as TextUIPart,
+      );
+    }
+
+    return {
+      ...stateWithMessage,
+      messages: stateWithMessage.messages.map(message => {
+        if (message.id !== messageId) return message;
+
+        const partIndex = message.parts.length;
+        this.itemIdToPartLocation.set(itemId, { messageId, partIndex });
+
+        return {
+          ...message,
+          parts: [
+            ...message.parts,
+            { type: 'text', text, state: 'streaming' } as TextUIPart,
+          ],
+        };
+      }),
+    };
+  }
+
+  private finalizeText(
+    state: RealtimeState,
+    itemId: string,
+    finalText?: string,
+  ): RealtimeState {
+    const text = finalText ?? this.textAccumulators.get(itemId) ?? '';
+    this.textAccumulators.delete(itemId);
+
+    const location = this.itemIdToPartLocation.get(itemId);
+    if (location == null) return state;
+
+    this.itemIdToPartLocation.delete(itemId);
+
+    return this.updateMessagePart(
+      state,
+      location.messageId,
+      location.partIndex,
+      { type: 'text', text, state: 'done' } as TextUIPart,
+    );
+  }
+
+  private ensureToolPart(
+    state: RealtimeState,
+    messageId: string,
+    callId: string,
+  ): RealtimeState {
+    return {
+      ...state,
+      messages: state.messages.map(message => {
+        if (message.id !== messageId) return message;
+
+        const existingPart = message.parts.find(
+          part =>
+            part.type === 'dynamic-tool' &&
+            (part as DynamicToolUIPart).toolCallId === callId,
+        );
+        if (existingPart != null) return message;
+
+        return {
+          ...message,
+          parts: [
+            ...message.parts,
+            {
+              type: 'dynamic-tool',
+              toolName: '',
+              toolCallId: callId,
+              state: 'input-streaming',
+              input: undefined,
+            } as DynamicToolUIPart,
+          ],
+        };
+      }),
+    };
+  }
+
+  private markToolInputAvailable(
+    state: RealtimeState,
+    messageId: string,
+    callId: string,
+    name: string,
+    input: Record<string, unknown>,
+  ): RealtimeState {
+    return {
+      ...state,
+      messages: state.messages.map(message => {
+        if (message.id !== messageId) return message;
+
+        return {
+          ...message,
+          parts: message.parts.map(part => {
+            if (part.type !== 'dynamic-tool') return part;
+            const toolPart = part as DynamicToolUIPart;
+            if (toolPart.toolCallId !== callId) return part;
+
+            return {
+              ...toolPart,
+              toolName: name,
+              state: 'input-available',
+              input,
+            } as DynamicToolUIPart;
+          }),
+        };
+      }),
+    };
+  }
+
+  private updateToolPartState(
+    state: RealtimeState,
+    callId: string,
+    result: unknown,
+  ): RealtimeState {
+    const messageId = this.toolCallIdToMessageId.get(callId);
+    if (messageId == null) return state;
+
+    return {
+      ...state,
+      messages: state.messages.map(message => {
+        if (message.id !== messageId) return message;
+
+        return {
+          ...message,
+          parts: message.parts.map(part => {
+            if (part.type !== 'dynamic-tool') return part;
+            const toolPart = part as DynamicToolUIPart;
+            if (toolPart.toolCallId !== callId) return part;
+
+            return {
+              ...toolPart,
+              state: 'output-available',
+              output: result,
+            } as DynamicToolUIPart;
+          }),
+        };
+      }),
+    };
+  }
+
+  private updateMessagePart(
+    state: RealtimeState,
+    messageId: string,
+    partIndex: number,
+    part: TextUIPart,
+  ): RealtimeState {
+    return {
+      ...state,
+      messages: state.messages.map(message => {
+        if (message.id !== messageId) return message;
+
+        const parts = [...message.parts];
+        parts[partIndex] = part;
+
+        return { ...message, parts };
+      }),
+    };
+  }
+}

--- a/packages/ai/src/realtime/realtime-session.test.ts
+++ b/packages/ai/src/realtime/realtime-session.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture transport instances and outgoing events. The transport is created
+// inside the session constructor, so we replace it with a controllable fake
+// that lets the test feed server events and observe sent client events.
+const sentEvents: Array<{ type: string; [key: string]: unknown }> = [];
+const transportInstances: Array<{
+  emitServerEvent: (event: unknown) => Promise<void> | void;
+}> = [];
+
+vi.mock('./browser-realtime-transport', () => ({
+  BrowserRealtimeTransport: class {
+    private readonly options: {
+      onServerEvent: (event: unknown) => Promise<void> | void;
+    };
+    constructor(options: {
+      onServerEvent: (event: unknown) => Promise<void> | void;
+    }) {
+      this.options = options;
+      transportInstances.push(this);
+    }
+    connect = vi.fn();
+    disconnect = vi.fn();
+    dispose = vi.fn();
+    sendRaw = vi.fn();
+    sendEvent = (event: { type: string }) => {
+      sentEvents.push(event);
+    };
+    emitServerEvent(event: unknown) {
+      return this.options.onServerEvent(event);
+    }
+  },
+}));
+
+vi.mock('./browser-realtime-audio', () => ({
+  BrowserRealtimeAudio: class {
+    constructor(_options: unknown) {}
+    ensurePlaybackContext = vi.fn();
+    startCapture = vi.fn();
+    stopCapture = vi.fn();
+    stopPlayback = vi.fn();
+    playAudio = vi.fn();
+    getPlaybackOffsetMs = vi.fn(() => 0);
+    dispose = vi.fn();
+  },
+}));
+
+const { AbstractRealtimeSession } = await import('./realtime-session');
+
+class TestSession extends AbstractRealtimeSession {
+  protected setState(): void {
+    // no-op for tests
+  }
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+const functionCallDone = (callId: string, name: string) => ({
+  type: 'function-call-arguments-done',
+  responseId: 'resp-1',
+  itemId: `item-${callId}`,
+  callId,
+  name,
+  arguments: '{}',
+  raw: {},
+});
+
+const responseDone = () => ({
+  type: 'response-done',
+  responseId: 'resp-1',
+  status: 'completed',
+  raw: {},
+});
+
+describe('AbstractRealtimeSession', () => {
+  beforeEach(() => {
+    sentEvents.length = 0;
+    transportInstances.length = 0;
+  });
+
+  it('does not error when onToolCall returns undefined (manual flow)', async () => {
+    const onError = vi.fn();
+    new TestSession({
+      model: {} as never,
+      api: { token: 'token' },
+      onToolCall: async () => undefined,
+      onError,
+    });
+
+    const transport = transportInstances.at(-1)!;
+    await transport.emitServerEvent(functionCallDone('call-1', 'getWeather'));
+    await flush();
+
+    // Returning undefined is the documented "submit later" pattern and must not
+    // be treated as a missing handler.
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('errors when no onToolCall handler is provided', async () => {
+    const onError = vi.fn();
+    new TestSession({ model: {} as never, api: { token: 'token' }, onError });
+
+    const transport = transportInstances.at(-1)!;
+    await transport.emitServerEvent(functionCallDone('call-1', 'getWeather'));
+    await flush();
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0].message).toContain(
+      'No handler provided for tool',
+    );
+  });
+
+  it('requests a single response after all tool outputs are submitted', async () => {
+    new TestSession({
+      model: {} as never,
+      api: { token: 'token' },
+      onToolCall: async () => ({ ok: true }),
+    });
+
+    const transport = transportInstances.at(-1)!;
+    await transport.emitServerEvent(functionCallDone('call-1', 'a'));
+    await transport.emitServerEvent(functionCallDone('call-2', 'b'));
+    await transport.emitServerEvent(responseDone());
+    await flush();
+
+    const responseCreates = sentEvents.filter(
+      e => e.type === 'response-create',
+    );
+    expect(responseCreates).toHaveLength(1);
+
+    const outputs = sentEvents.filter(
+      e =>
+        e.type === 'conversation-item-create' &&
+        (e.item as { type?: string })?.type === 'function-call-output',
+    );
+    expect(outputs).toHaveLength(2);
+  });
+
+  it('does not request a response before the tool-bearing response is done', async () => {
+    new TestSession({
+      model: {} as never,
+      api: { token: 'token' },
+      onToolCall: async () => ({ ok: true }),
+    });
+
+    const transport = transportInstances.at(-1)!;
+    // Output submitted before response-done arrives.
+    await transport.emitServerEvent(functionCallDone('call-1', 'a'));
+    await flush();
+    expect(sentEvents.filter(e => e.type === 'response-create')).toHaveLength(
+      0,
+    );
+
+    await transport.emitServerEvent(responseDone());
+    await flush();
+    expect(sentEvents.filter(e => e.type === 'response-create')).toHaveLength(
+      1,
+    );
+  });
+});

--- a/packages/ai/src/realtime/realtime-session.ts
+++ b/packages/ai/src/realtime/realtime-session.ts
@@ -1,0 +1,382 @@
+import type {
+  RealtimeClientEvent,
+  RealtimeModel,
+  RealtimeServerEvent,
+  RealtimeSessionConfig,
+} from '../types/realtime-model';
+import { BrowserRealtimeAudio } from './browser-realtime-audio';
+import { BrowserRealtimeTransport } from './browser-realtime-transport';
+import {
+  createInitialRealtimeState,
+  RealtimeEventReducer,
+  type RealtimeReducerEffect,
+  type RealtimeState,
+  type RealtimeStatus,
+} from './realtime-event-reducer';
+
+export type { RealtimeState, RealtimeStatus };
+
+export type RealtimeSessionOptions = {
+  model: RealtimeModel;
+  api: {
+    token: string;
+  };
+  sessionConfig?: Partial<RealtimeSessionConfig>;
+  sampleRate?: number;
+  maxEvents?: number;
+  onToolCall?: (args: {
+    toolCall: { toolCallId: string; toolName: string; args: unknown };
+  }) => Promise<unknown> | unknown | undefined;
+  onEvent?: (event: RealtimeServerEvent) => void;
+  onError?: (error: Error) => void;
+};
+
+export abstract class AbstractRealtimeSession {
+  protected state: RealtimeState = createInitialRealtimeState();
+  protected maxEvents: number;
+
+  onToolCall: RealtimeSessionOptions['onToolCall'];
+  onEvent: ((event: RealtimeServerEvent) => void) | undefined;
+  onError: ((error: Error) => void) | undefined;
+
+  private readonly model: RealtimeModel;
+  private readonly api: RealtimeSessionOptions['api'];
+  private readonly sessionConfig: Partial<RealtimeSessionConfig> | undefined;
+  private readonly reducer: RealtimeEventReducer;
+  private readonly transport: BrowserRealtimeTransport;
+  private readonly audio: BrowserRealtimeAudio;
+  private currentResponseItemId: string | null = null;
+
+  // Tool calls requested by the current (tool-bearing) response, the outputs
+  // that have been submitted for them, and whether that response has finished
+  // delivering its tool calls. Used to request a single response only once
+  // every tool output for the turn has been submitted.
+  private readonly toolCallsInResponse = new Set<string>();
+  private readonly submittedToolOutputs = new Set<string>();
+  private responseToolCallsClosed = false;
+
+  protected abstract setState<K extends keyof RealtimeState>(
+    key: K,
+    value: RealtimeState[K],
+  ): void;
+
+  constructor(options: RealtimeSessionOptions) {
+    this.model = options.model;
+    this.api = options.api;
+    this.sessionConfig = options.sessionConfig;
+    this.maxEvents = options.maxEvents ?? 500;
+    this.reducer = new RealtimeEventReducer(this.maxEvents);
+    this.onToolCall = options.onToolCall;
+    this.onEvent = options.onEvent;
+    this.onError = options.onError;
+
+    const sampleRate = options.sampleRate ?? 24000;
+    const captureSampleRate =
+      options.sessionConfig?.inputAudioFormat?.rate ?? sampleRate;
+    const playbackSampleRate =
+      options.sessionConfig?.outputAudioFormat?.rate ?? sampleRate;
+
+    this.transport = new BrowserRealtimeTransport({
+      model: this.model,
+      onServerEvent: event => this.handleServerEvent(event),
+      onError: error => {
+        this.applyState(this.reducer.setStatus(this.state, 'error'));
+        this.onError?.(error);
+      },
+      onClose: () => {
+        this.applyState(this.reducer.setStatus(this.state, 'disconnected'));
+      },
+    });
+
+    this.audio = new BrowserRealtimeAudio({
+      captureSampleRate,
+      playbackSampleRate,
+      onAudio: audio => this.sendAudio(audio),
+      onCapturingChange: isCapturing => {
+        this.applyState(this.reducer.setCapturing(this.state, isCapturing));
+      },
+      onPlayingChange: isPlaying => {
+        this.applyState(this.reducer.setPlaying(this.state, isPlaying));
+      },
+    });
+  }
+
+  // ── Connection ─────────────────────────────────────────────────────
+
+  async connect(): Promise<void> {
+    this.applyState(this.reducer.setStatus(this.state, 'connecting'));
+
+    try {
+      const response = await fetch(this.api.token, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionConfig: this.sessionConfig }),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch realtime setup: ${response.status}`);
+      }
+
+      const setupData = await response.json();
+      const { token, url, tools: toolDefinitions } = setupData;
+
+      const config: RealtimeSessionConfig = {
+        ...this.sessionConfig,
+        tools: toolDefinitions as RealtimeSessionConfig['tools'],
+      };
+
+      this.audio.ensurePlaybackContext();
+      this.transport.connect({
+        token,
+        url,
+        onOpen: () => {
+          this.sendEvent({
+            type: 'session-update',
+            config,
+          });
+        },
+      });
+    } catch (error) {
+      this.applyState(this.reducer.setStatus(this.state, 'error'));
+      this.onError?.(
+        error instanceof Error
+          ? error
+          : new Error(`Connection failed: ${String(error)}`),
+      );
+    }
+  }
+
+  disconnect(): void {
+    this.transport.disconnect();
+    this.applyState(this.reducer.setStatus(this.state, 'disconnected'));
+  }
+
+  // ── Sending events ─────────────────────────────────────────────────
+
+  sendEvent(event: RealtimeClientEvent): void {
+    this.transport.sendEvent(event);
+  }
+
+  sendTextMessage(text: string): void {
+    this.sendEvent({
+      type: 'conversation-item-create',
+      item: { type: 'text-message', role: 'user', text },
+    });
+    this.sendEvent({ type: 'response-create' });
+    this.applyState(this.reducer.addUserTextMessage(this.state, text));
+  }
+
+  sendAudio(base64Audio: string): void {
+    this.sendEvent({ type: 'input-audio-append', audio: base64Audio });
+  }
+
+  commitAudio(): void {
+    this.sendEvent({ type: 'input-audio-commit' });
+  }
+
+  clearAudioBuffer(): void {
+    this.sendEvent({ type: 'input-audio-clear' });
+  }
+
+  requestResponse(options?: { modalities?: string[] }): void {
+    this.sendEvent({
+      type: 'response-create',
+      ...(options != null ? { options } : {}),
+    });
+  }
+
+  cancelResponse(): void {
+    this.sendEvent({ type: 'response-cancel' });
+  }
+
+  // ── Tool output ───────────────────────────────────────────────────
+
+  addToolOutput(callId: string, result: unknown): void {
+    const { state, output } = this.reducer.addToolOutput(
+      this.state,
+      callId,
+      result,
+    );
+    this.applyState(state);
+
+    this.sendEvent({
+      type: 'conversation-item-create',
+      item: {
+        type: 'function-call-output',
+        callId: output.callId,
+        name: output.name,
+        output: output.output,
+      },
+    });
+
+    this.submittedToolOutputs.add(callId);
+    this.maybeRequestToolResponse();
+  }
+
+  /**
+   * Requests a single response once the tool-bearing response has finished
+   * delivering its tool calls and every one of them has an output. Requesting a
+   * response after each individual output can cause the model to continue
+   * without the full tool context on multi-tool turns.
+   */
+  private maybeRequestToolResponse(): void {
+    if (!this.responseToolCallsClosed) return;
+    if (this.toolCallsInResponse.size === 0) return;
+
+    for (const callId of this.toolCallsInResponse) {
+      if (!this.submittedToolOutputs.has(callId)) return;
+    }
+
+    this.sendEvent({ type: 'response-create' });
+    this.toolCallsInResponse.clear();
+    this.submittedToolOutputs.clear();
+    this.responseToolCallsClosed = false;
+  }
+
+  // ── Audio capture ──────────────────────────────────────────────────
+
+  startAudioCapture(stream: MediaStream): void {
+    this.audio.startCapture(stream);
+  }
+
+  stopAudioCapture(): void {
+    this.audio.stopCapture();
+  }
+
+  // ── Playback ───────────────────────────────────────────────────────
+
+  stopPlayback(): void {
+    this.audio.stopPlayback();
+  }
+
+  // ── Cleanup ────────────────────────────────────────────────────────
+
+  dispose(): void {
+    this.transport.dispose();
+    this.audio.dispose();
+    this.applyState(
+      this.reducer.setStatus(
+        this.reducer.setPlaying(
+          this.reducer.setCapturing(this.state, false),
+          false,
+        ),
+        'disconnected',
+      ),
+    );
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────
+
+  private applyState(nextState: RealtimeState): void {
+    const previousState = this.state;
+    this.state = nextState;
+
+    if (previousState.status !== nextState.status) {
+      this.setState('status', nextState.status);
+    }
+    if (previousState.messages !== nextState.messages) {
+      this.setState('messages', nextState.messages);
+    }
+    if (previousState.events !== nextState.events) {
+      this.setState('events', nextState.events);
+    }
+    if (previousState.isCapturing !== nextState.isCapturing) {
+      this.setState('isCapturing', nextState.isCapturing);
+    }
+    if (previousState.isPlaying !== nextState.isPlaying) {
+      this.setState('isPlaying', nextState.isPlaying);
+    }
+  }
+
+  private async executeToolCall({
+    name,
+    args,
+    callId,
+  }: {
+    name: string;
+    args: Record<string, unknown>;
+    callId: string;
+  }): Promise<void> {
+    if (this.onToolCall == null) {
+      this.onError?.(new Error(`No handler provided for tool "${name}"`));
+      return;
+    }
+
+    try {
+      const result = await this.onToolCall({
+        toolCall: { toolCallId: callId, toolName: name, args },
+      });
+
+      // Returning `undefined` is the documented human-in-the-loop pattern:
+      // the application submits the output later via `addToolOutput`. Only an
+      // explicitly returned value is submitted automatically here.
+      if (result !== undefined) {
+        this.addToolOutput(callId, result);
+      }
+    } catch (error) {
+      this.onError?.(
+        error instanceof Error
+          ? error
+          : new Error(`Client tool execution failed: ${String(error)}`),
+      );
+    }
+  }
+
+  private async handleServerEvent(event: RealtimeServerEvent): Promise<void> {
+    const result = await this.reducer.reduceServerEvent(this.state, event);
+    this.applyState(result.state);
+    this.onEvent?.(event);
+
+    for (const effect of result.effects) {
+      this.handleReducerEffect(effect);
+    }
+
+    // `response-done` for a response that requested tool calls marks the point
+    // where no further tool calls will arrive for that turn, so we can request
+    // the follow-up response once every output is in.
+    if (event.type === 'response-done' && this.toolCallsInResponse.size > 0) {
+      this.responseToolCallsClosed = true;
+      this.maybeRequestToolResponse();
+    }
+  }
+
+  private handleReducerEffect(effect: RealtimeReducerEffect): void {
+    switch (effect.type) {
+      case 'play-audio': {
+        this.currentResponseItemId = effect.itemId;
+        this.audio.playAudio(effect.delta);
+        break;
+      }
+      case 'speech-started': {
+        if (this.state.isPlaying) {
+          const playedMs = this.audio.getPlaybackOffsetMs();
+          this.audio.stopPlayback();
+
+          if (this.currentResponseItemId != null) {
+            this.sendEvent({
+              type: 'conversation-item-truncate',
+              itemId: this.currentResponseItemId,
+              contentIndex: 0,
+              audioEndMs: Math.round(playedMs),
+            });
+          }
+        }
+        break;
+      }
+      case 'tool-call': {
+        // Track every tool call in the response so a multi-tool turn only
+        // triggers a single `response-create` once all outputs are submitted.
+        this.toolCallsInResponse.add(effect.callId);
+        void this.executeToolCall({
+          name: effect.name,
+          args: effect.args,
+          callId: effect.callId,
+        });
+        break;
+      }
+      case 'error': {
+        this.onError?.(effect.error);
+        break;
+      }
+    }
+  }
+}

--- a/packages/ai/src/realtime/realtime-types.ts
+++ b/packages/ai/src/realtime/realtime-types.ts
@@ -1,0 +1,13 @@
+import type { RealtimeToolDefinition } from '../types/realtime-model';
+
+/**
+ * Response shape for the realtime setup/token endpoint.
+ * The client uses this to establish a WebSocket connection and
+ * configure the session with tool definitions.
+ */
+export type RealtimeSetupResponse = {
+  token: string;
+  url: string;
+  expiresAt?: number;
+  tools: RealtimeToolDefinition[];
+};

--- a/packages/ai/src/types/realtime-model.ts
+++ b/packages/ai/src/types/realtime-model.ts
@@ -1,0 +1,26 @@
+import type {
+  Experimental_RealtimeFactoryV4 as RealtimeFactoryV4,
+  Experimental_RealtimeFactoryV4GetTokenOptions as RealtimeFactoryV4GetTokenOptions,
+  Experimental_RealtimeFactoryV4GetTokenResult as RealtimeFactoryV4GetTokenResult,
+  Experimental_RealtimeModelV4 as RealtimeModelV4,
+  Experimental_RealtimeModelV4ClientEvent as RealtimeModelV4ClientEvent,
+  Experimental_RealtimeModelV4ServerEvent as RealtimeModelV4ServerEvent,
+  Experimental_RealtimeModelV4SessionConfig as RealtimeModelV4SessionConfig,
+  Experimental_RealtimeModelV4ToolDefinition as RealtimeModelV4ToolDefinition,
+} from '@ai-sdk/provider';
+
+export type RealtimeFactory = RealtimeFactoryV4;
+
+export type RealtimeFactoryGetTokenOptions = RealtimeFactoryV4GetTokenOptions;
+
+export type RealtimeFactoryGetTokenResult = RealtimeFactoryV4GetTokenResult;
+
+export type RealtimeModel = RealtimeModelV4;
+
+export type RealtimeClientEvent = RealtimeModelV4ClientEvent;
+
+export type RealtimeServerEvent = RealtimeModelV4ServerEvent;
+
+export type RealtimeSessionConfig = RealtimeModelV4SessionConfig;
+
+export type RealtimeToolDefinition = RealtimeModelV4ToolDefinition;

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -5,6 +5,8 @@ import type {
   ImageModelV4,
   LanguageModelV4,
   ProviderV4,
+  Experimental_RealtimeFactoryV4 as RealtimeFactoryV4,
+  Experimental_RealtimeFactoryV4GetTokenOptions as RealtimeFactoryV4GetTokenOptions,
   SpeechModelV4,
 } from '@ai-sdk/provider';
 import {
@@ -37,6 +39,7 @@ import {
 } from './interactions/google-interactions-language-model';
 import type { GoogleInteractionsModelId } from './interactions/google-interactions-language-model-options';
 import type { GoogleInteractionsAgentName } from './interactions/google-interactions-agent';
+import { GoogleRealtimeModel } from './realtime/google-realtime-model';
 
 export interface GoogleProvider extends ProviderV4 {
   (modelId: GoogleModelId): LanguageModelV4;
@@ -114,6 +117,8 @@ export interface GoogleProvider extends ProviderV4 {
       | { agent: GoogleInteractionsAgentName }
       | { managedAgent: string },
   ): LanguageModelV4;
+
+  experimental_realtime: RealtimeFactoryV4;
 
   tools: typeof googleTools;
 }
@@ -236,6 +241,14 @@ export function createGoogle(
       generateId: options.generateId ?? generateId,
     });
 
+  const createRealtimeModel = (modelId: string) =>
+    new GoogleRealtimeModel(modelId, {
+      provider: `${providerName}.realtime`,
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
   const createSpeechModel = (modelId: GoogleSpeechModelId) =>
     new GoogleSpeechModel(modelId, {
       provider: `${providerName}.speech`,
@@ -243,6 +256,25 @@ export function createGoogle(
       headers: getHeaders,
       fetch: options.fetch,
     });
+
+  const experimentalRealtimeFactory = Object.assign(
+    (modelId: string) => createRealtimeModel(modelId),
+    {
+      getToken: async (tokenOptions: RealtimeFactoryV4GetTokenOptions) => {
+        const model = createRealtimeModel(tokenOptions.model);
+        const secret = await model.doCreateClientSecret({
+          sessionConfig: tokenOptions.sessionConfig,
+          expiresAfterSeconds: tokenOptions.expiresAfterSeconds,
+        });
+
+        return {
+          token: secret.token,
+          url: secret.url,
+          expiresAt: secret.expiresAt,
+        };
+      },
+    },
+  ) as RealtimeFactoryV4;
 
   const createInteractionsModel = (
     modelIdOrAgent:
@@ -283,6 +315,7 @@ export function createGoogle(
   provider.imageModel = createImageModel;
   provider.video = createVideoModel;
   provider.videoModel = createVideoModel;
+  provider.experimental_realtime = experimentalRealtimeFactory;
   provider.files = createFiles;
   provider.speech = createSpeechModel;
   provider.speechModel = createSpeechModel;

--- a/packages/google/src/index.ts
+++ b/packages/google/src/index.ts
@@ -54,5 +54,7 @@ export type {
   /** @deprecated Use `GoogleProviderSettings` instead. */
   GoogleProviderSettings as GoogleGenerativeAIProviderSettings,
 } from './google-provider';
+export { GoogleRealtimeModel as Experimental_GoogleRealtimeModel } from './realtime/google-realtime-model';
+export type { GoogleRealtimeModelConfig as Experimental_GoogleRealtimeModelConfig } from './realtime/google-realtime-model';
 
 export { VERSION } from './version';

--- a/packages/google/src/realtime/google-realtime-event-mapper.test.ts
+++ b/packages/google/src/realtime/google-realtime-event-mapper.test.ts
@@ -1,0 +1,704 @@
+import { beforeEach, describe, it, expect } from 'vitest';
+import {
+  GoogleRealtimeEventMapper,
+  buildGoogleSessionConfig,
+} from './google-realtime-event-mapper';
+
+describe('GoogleRealtimeEventMapper', () => {
+  describe('parseServerEvent', () => {
+    it('maps setupComplete to session-created', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = { setupComplete: true };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual({
+        type: 'session-created',
+        raw,
+      });
+    });
+
+    it('maps serverContent with audio to audio-delta', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = {
+        serverContent: {
+          modelTurn: {
+            parts: [{ inlineData: { data: 'base64audio' } }],
+          },
+        },
+      };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual({
+        type: 'audio-delta',
+        responseId: 'google-resp-0',
+        itemId: 'google-item-0',
+        delta: 'base64audio',
+        raw,
+      });
+    });
+
+    it('maps serverContent with text to text-delta', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = {
+        serverContent: {
+          modelTurn: {
+            parts: [{ text: 'hello world' }],
+          },
+        },
+      };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual({
+        type: 'text-delta',
+        responseId: 'google-resp-0',
+        itemId: 'google-item-0',
+        delta: 'hello world',
+        raw,
+      });
+    });
+
+    it('maps serverContent with outputTranscription to audio-transcript-delta', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = {
+        serverContent: {
+          outputTranscription: { text: 'transcribed text' },
+        },
+      };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual({
+        type: 'audio-transcript-delta',
+        responseId: 'google-resp-0',
+        itemId: 'google-item-0',
+        delta: 'transcribed text',
+        raw,
+      });
+    });
+
+    it('maps serverContent with inputTranscription to input-transcription-completed', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = {
+        serverContent: {
+          inputTranscription: { text: 'Can you hear me?' },
+        },
+      };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual({
+        type: 'input-transcription-completed',
+        itemId: 'google-input-0',
+        transcript: 'Can you hear me?',
+        raw,
+      });
+    });
+
+    it('maps top-level inputTranscription to input-transcription-completed', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = {
+        inputTranscription: { text: 'Can you hear me?' },
+      };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual({
+        type: 'input-transcription-completed',
+        itemId: 'google-input-0',
+        transcript: 'Can you hear me?',
+        raw,
+      });
+    });
+
+    it('maps serverContent with interrupted to speech-started', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = {
+        serverContent: { interrupted: true },
+      };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual({
+        type: 'speech-started',
+        raw,
+      });
+    });
+
+    it('maps serverContent with turnComplete after audio to done events + response-done', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+
+      mapper.parseServerEvent({
+        serverContent: {
+          modelTurn: {
+            parts: [{ inlineData: { data: 'audio' } }],
+          },
+        },
+      });
+
+      const raw = { serverContent: { turnComplete: true } };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual([
+        {
+          type: 'audio-done',
+          responseId: 'google-resp-0',
+          itemId: 'google-item-0',
+          raw,
+        },
+        {
+          type: 'response-done',
+          responseId: 'google-resp-0',
+          status: 'completed',
+          raw,
+        },
+      ]);
+    });
+
+    it('maps serverContent with turnComplete after text to done events + response-done', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+
+      mapper.parseServerEvent({
+        serverContent: {
+          modelTurn: {
+            parts: [{ text: 'hello' }],
+          },
+        },
+      });
+
+      const raw = { serverContent: { turnComplete: true } };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual([
+        {
+          type: 'text-done',
+          responseId: 'google-resp-0',
+          itemId: 'google-item-0',
+          raw,
+        },
+        {
+          type: 'response-done',
+          responseId: 'google-resp-0',
+          status: 'completed',
+          raw,
+        },
+      ]);
+    });
+
+    it('increments IDs after turnComplete', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+
+      mapper.parseServerEvent({
+        serverContent: {
+          modelTurn: {
+            parts: [{ inlineData: { data: 'audio1' } }],
+          },
+        },
+      });
+
+      mapper.parseServerEvent({
+        serverContent: { turnComplete: true },
+      });
+
+      const raw = {
+        serverContent: {
+          modelTurn: {
+            parts: [{ inlineData: { data: 'audio2' } }],
+          },
+        },
+      };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual({
+        type: 'audio-delta',
+        responseId: 'google-resp-1',
+        itemId: 'google-item-1',
+        delta: 'audio2',
+        raw,
+      });
+    });
+
+    it('keeps a late transcript attached to the just-completed turn', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+
+      mapper.parseServerEvent({
+        serverContent: {
+          modelTurn: { parts: [{ inlineData: { data: 'audio1' } }] },
+        },
+      });
+
+      mapper.parseServerEvent({ serverContent: { turnComplete: true } });
+
+      // A transcript that arrives after turnComplete (Google delivers
+      // transcription independently) must still reference the turn it belongs
+      // to, not the next one. The counter only advances when new model content
+      // actually arrives.
+      const raw = {
+        serverContent: { outputTranscription: { text: 'late transcript' } },
+      };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual({
+        type: 'audio-transcript-delta',
+        responseId: 'google-resp-0',
+        itemId: 'google-item-0',
+        delta: 'late transcript',
+        raw,
+      });
+
+      // The next model response then opens turn 1.
+      const next = mapper.parseServerEvent({
+        serverContent: {
+          modelTurn: { parts: [{ inlineData: { data: 'audio2' } }] },
+        },
+      });
+      expect(next).toMatchObject({ responseId: 'google-resp-1' });
+    });
+
+    it('maps multi-part serverContent to multiple events', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = {
+        serverContent: {
+          modelTurn: {
+            parts: [{ inlineData: { data: 'audio' } }, { text: 'text' }],
+          },
+        },
+      };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toEqual([
+        {
+          type: 'audio-delta',
+          responseId: 'google-resp-0',
+          itemId: 'google-item-0',
+          delta: 'audio',
+          raw,
+        },
+        {
+          type: 'text-delta',
+          responseId: 'google-resp-0',
+          itemId: 'google-item-0',
+          delta: 'text',
+          raw,
+        },
+      ]);
+    });
+
+    it('maps toolCall to function-call-arguments-delta and done events', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = {
+        toolCall: {
+          functionCalls: [
+            { id: 'call_1', name: 'getWeather', args: { city: 'NYC' } },
+            { id: 'call_2', name: 'rollDice', args: {} },
+          ],
+        },
+      };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toEqual([
+        {
+          type: 'function-call-arguments-delta',
+          responseId: 'google-resp-0',
+          itemId: 'google-item-0',
+          callId: 'call_1',
+          delta: '{"city":"NYC"}',
+          raw,
+        },
+        {
+          type: 'function-call-arguments-done',
+          responseId: 'google-resp-0',
+          itemId: 'google-item-0',
+          callId: 'call_1',
+          name: 'getWeather',
+          arguments: '{"city":"NYC"}',
+          raw,
+        },
+        {
+          type: 'function-call-arguments-delta',
+          responseId: 'google-resp-0',
+          itemId: 'google-item-0',
+          callId: 'call_2',
+          delta: '{}',
+          raw,
+        },
+        {
+          type: 'function-call-arguments-done',
+          responseId: 'google-resp-0',
+          itemId: 'google-item-0',
+          callId: 'call_2',
+          name: 'rollDice',
+          arguments: '{}',
+          raw,
+        },
+      ]);
+    });
+
+    it('maps toolCallCancellation to custom event', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = { toolCallCancellation: { ids: ['call_1'] } };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual({
+        type: 'custom',
+        rawType: 'toolCallCancellation',
+        raw,
+      });
+    });
+
+    it('maps unrecognized top-level key to custom event', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = { somethingNew: { data: 123 } };
+      const result = mapper.parseServerEvent(raw);
+
+      expect(result).toEqual({
+        type: 'custom',
+        rawType: 'somethingNew',
+        raw,
+      });
+    });
+  });
+
+  describe('serializeClientEvent', () => {
+    let mapper: GoogleRealtimeEventMapper;
+
+    beforeEach(() => {
+      mapper = new GoogleRealtimeEventMapper();
+    });
+
+    it('serializes session-update as setup message', () => {
+      const result = mapper.serializeClientEvent(
+        { type: 'session-update', config: {} },
+        'gemini-2.0-flash-live-001',
+      );
+
+      expect(result).toEqual({
+        setup: {
+          model: 'models/gemini-2.0-flash-live-001',
+          generationConfig: {
+            responseModalities: ['AUDIO'],
+          },
+        },
+      });
+    });
+
+    it('serializes session-update with normalized session config', () => {
+      const result = mapper.serializeClientEvent(
+        {
+          type: 'session-update',
+          config: {
+            instructions: 'Be helpful',
+            voice: 'Puck',
+            outputModalities: ['audio', 'text'],
+            inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+            tools: [
+              {
+                type: 'function',
+                name: 'getWeather',
+                description: 'Get weather',
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    city: { type: 'string' },
+                  },
+                },
+              },
+            ],
+          },
+        },
+        'gemini-2.0-flash-live-001',
+      );
+
+      expect(result).toEqual({
+        setup: {
+          model: 'models/gemini-2.0-flash-live-001',
+          systemInstruction: {
+            parts: [{ text: 'Be helpful' }],
+          },
+          generationConfig: {
+            responseModalities: ['AUDIO', 'TEXT'],
+            speechConfig: {
+              voiceConfig: {
+                prebuiltVoiceConfig: {
+                  voiceName: 'Puck',
+                },
+              },
+            },
+          },
+          tools: [
+            {
+              functionDeclarations: [
+                {
+                  name: 'getWeather',
+                  description: 'Get weather',
+                  parameters: {
+                    type: 'object',
+                    properties: {
+                      city: { type: 'string' },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      });
+    });
+
+    it('serializes input-audio-append as realtimeInput', () => {
+      const result = mapper.serializeClientEvent(
+        { type: 'input-audio-append', audio: 'base64data' },
+        'model',
+      );
+
+      expect(result).toEqual({
+        realtimeInput: {
+          audio: {
+            data: 'base64data',
+            mimeType: 'audio/pcm;rate=16000',
+          },
+        },
+      });
+    });
+
+    it('returns null for input-audio-commit', () => {
+      expect(
+        mapper.serializeClientEvent({ type: 'input-audio-commit' }, 'model'),
+      ).toBeNull();
+    });
+
+    it('returns null for input-audio-clear', () => {
+      expect(
+        mapper.serializeClientEvent({ type: 'input-audio-clear' }, 'model'),
+      ).toBeNull();
+    });
+
+    it('returns null for response-create', () => {
+      expect(
+        mapper.serializeClientEvent({ type: 'response-create' }, 'model'),
+      ).toBeNull();
+    });
+
+    it('returns null for response-cancel', () => {
+      expect(
+        mapper.serializeClientEvent({ type: 'response-cancel' }, 'model'),
+      ).toBeNull();
+    });
+
+    it('serializes text message as realtimeInput', () => {
+      const result = mapper.serializeClientEvent(
+        {
+          type: 'conversation-item-create',
+          item: { type: 'text-message', role: 'user', text: 'hello' },
+        },
+        'model',
+      );
+
+      expect(result).toEqual({
+        realtimeInput: {
+          text: 'hello',
+        },
+      });
+    });
+
+    it('serializes function-call-output as toolResponse', async () => {
+      const result = await mapper.serializeClientEvent(
+        {
+          type: 'conversation-item-create',
+          item: {
+            type: 'function-call-output',
+            callId: 'call_1',
+            name: 'getWeather',
+            output: '{"temp":72}',
+          },
+        },
+        'model',
+      );
+
+      expect(result).toEqual({
+        toolResponse: {
+          functionResponses: [
+            {
+              id: 'call_1',
+              name: 'getWeather',
+              response: { temp: 72 },
+            },
+          ],
+        },
+      });
+    });
+
+    it('falls back to empty object for malformed function-call-output', async () => {
+      const result = await mapper.serializeClientEvent(
+        {
+          type: 'conversation-item-create',
+          item: {
+            type: 'function-call-output',
+            callId: 'call_1',
+            name: 'getWeather',
+            output: '{',
+          },
+        },
+        'model',
+      );
+
+      expect(result).toEqual({
+        toolResponse: {
+          functionResponses: [
+            {
+              id: 'call_1',
+              name: 'getWeather',
+              response: {},
+            },
+          ],
+        },
+      });
+    });
+
+    it('returns null for conversation-item-truncate', () => {
+      expect(
+        mapper.serializeClientEvent(
+          {
+            type: 'conversation-item-truncate',
+            itemId: 'item_1',
+            contentIndex: 0,
+            audioEndMs: 1000,
+          },
+          'model',
+        ),
+      ).toBeNull();
+    });
+  });
+});
+
+describe('buildGoogleSessionConfig', () => {
+  it('builds config with model path', () => {
+    const result = buildGoogleSessionConfig(undefined, 'gemini-2.0-flash');
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "generationConfig": {
+          "responseModalities": [
+            "AUDIO",
+          ],
+        },
+        "model": "models/gemini-2.0-flash",
+      }
+    `);
+  });
+
+  it('builds config with instructions and voice', () => {
+    const result = buildGoogleSessionConfig(
+      {
+        instructions: 'Be helpful',
+        voice: 'Puck',
+      },
+      'gemini-2.0-flash',
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "generationConfig": {
+          "responseModalities": [
+            "AUDIO",
+          ],
+          "speechConfig": {
+            "voiceConfig": {
+              "prebuiltVoiceConfig": {
+                "voiceName": "Puck",
+              },
+            },
+          },
+        },
+        "model": "models/gemini-2.0-flash",
+        "systemInstruction": {
+          "parts": [
+            {
+              "text": "Be helpful",
+            },
+          ],
+        },
+      }
+    `);
+  });
+
+  it('builds config with tools', () => {
+    const result = buildGoogleSessionConfig(
+      {
+        tools: [
+          {
+            type: 'function',
+            name: 'getWeather',
+            description: 'Get weather',
+            parameters: {
+              type: 'object',
+              properties: {
+                city: { type: 'string' },
+              },
+              required: ['city'],
+            },
+          },
+        ],
+      },
+      'gemini-2.0-flash',
+    );
+
+    expect(result.tools).toMatchInlineSnapshot(`
+      [
+        {
+          "functionDeclarations": [
+            {
+              "description": "Get weather",
+              "name": "getWeather",
+              "parameters": {
+                "properties": {
+                  "city": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "city",
+                ],
+                "type": "object",
+              },
+            },
+          ],
+        },
+      ]
+    `);
+  });
+
+  it('maps output modalities to uppercase', () => {
+    const result = buildGoogleSessionConfig(
+      { outputModalities: ['audio', 'text'] },
+      'model',
+    );
+
+    expect(
+      (result.generationConfig as Record<string, unknown>).responseModalities,
+    ).toEqual(['AUDIO', 'TEXT']);
+  });
+
+  it('enables input audio transcription', () => {
+    const result = buildGoogleSessionConfig(
+      { inputAudioTranscription: {} },
+      'model',
+    );
+
+    expect(result.inputAudioTranscription).toEqual({});
+  });
+
+  it('enables output audio transcription', () => {
+    const result = buildGoogleSessionConfig(
+      { outputAudioTranscription: {} },
+      'model',
+    );
+
+    expect(result.outputAudioTranscription).toEqual({});
+  });
+
+  it('preserves model path that already includes slash', () => {
+    const result = buildGoogleSessionConfig(
+      undefined,
+      'models/gemini-2.0-flash',
+    );
+    expect(result.model).toBe('models/gemini-2.0-flash');
+  });
+});

--- a/packages/google/src/realtime/google-realtime-event-mapper.ts
+++ b/packages/google/src/realtime/google-realtime-event-mapper.ts
@@ -1,0 +1,383 @@
+import type {
+  Experimental_RealtimeModelV4 as RealtimeModelV4,
+  Experimental_RealtimeModelV4ClientEvent as RealtimeModelV4ClientEvent,
+  Experimental_RealtimeModelV4FunctionCallOutput as RealtimeModelV4FunctionCallOutput,
+  Experimental_RealtimeModelV4ServerEvent as RealtimeModelV4ServerEvent,
+  Experimental_RealtimeModelV4SessionConfig as RealtimeModelV4SessionConfig,
+} from '@ai-sdk/provider';
+import { safeParseJSON } from '@ai-sdk/provider-utils';
+import { convertJSONSchemaToOpenAPISchema } from '../convert-json-schema-to-openapi-schema';
+import { getModelPath } from '../get-model-path';
+
+type GoogleRealtimeFunctionCall = {
+  id: string;
+  name: string;
+  args?: Record<string, unknown>;
+};
+
+type GoogleRealtimeServerContent = {
+  interrupted?: boolean;
+  modelTurn?: {
+    parts?: Array<{
+      inlineData?: { data?: string };
+      text?: string;
+    }>;
+  };
+  outputTranscription?: { text?: string };
+  inputTranscription?: { text?: string };
+  turnComplete?: boolean;
+};
+
+type GoogleRealtimeWireEvent = {
+  setupComplete?: unknown;
+  toolCall?: {
+    functionCalls?: GoogleRealtimeFunctionCall[];
+  };
+  toolCallCancellation?: unknown;
+  serverContent?: GoogleRealtimeServerContent;
+  inputTranscription?: { text?: string };
+};
+
+/**
+ * Stateful event mapper for Google's Gemini Live API.
+ *
+ * Unlike OpenAI/xAI, Google's events don't have response/item IDs and
+ * a single message can contain multiple pieces of data. This class
+ * tracks turn state to generate consistent synthetic IDs.
+ */
+export class GoogleRealtimeEventMapper {
+  private turnCounter = 0;
+  private hasAudio = false;
+  private hasText = false;
+  private hasTranscript = false;
+  private turnClosed = false;
+  private inputAudioRate = 16000;
+
+  private get responseId(): string {
+    return `google-resp-${this.turnCounter}`;
+  }
+
+  private get itemId(): string {
+    return `google-item-${this.turnCounter}`;
+  }
+
+  /**
+   * Rolls over to the next turn lazily, only once new model content actually
+   * arrives. `turnComplete` merely marks the current turn closed; the counter
+   * is not advanced until the next response begins. This keeps a transcript
+   * that arrives shortly after `turnComplete` attached to the turn it belongs
+   * to, since Google delivers transcription independently with no guaranteed
+   * ordering relative to `turnComplete`.
+   */
+  private beginTurnIfClosed(): void {
+    if (!this.turnClosed) return;
+    this.turnCounter++;
+    this.hasAudio = false;
+    this.hasText = false;
+    this.hasTranscript = false;
+    this.turnClosed = false;
+  }
+
+  parseServerEvent(
+    raw: unknown,
+  ): RealtimeModelV4ServerEvent | RealtimeModelV4ServerEvent[] {
+    const data = raw as GoogleRealtimeWireEvent;
+
+    if (data.setupComplete != null) {
+      return { type: 'session-created', raw };
+    }
+
+    if (data.toolCall != null) {
+      this.beginTurnIfClosed();
+      const functionCalls = data.toolCall.functionCalls ?? [];
+      return functionCalls.flatMap(functionCall => {
+        const args = JSON.stringify(functionCall.args ?? {});
+        return [
+          {
+            type: 'function-call-arguments-delta' as const,
+            responseId: this.responseId,
+            itemId: this.itemId,
+            callId: functionCall.id,
+            delta: args,
+            raw,
+          },
+          {
+            type: 'function-call-arguments-done' as const,
+            responseId: this.responseId,
+            itemId: this.itemId,
+            callId: functionCall.id,
+            name: functionCall.name,
+            arguments: args,
+            raw,
+          },
+        ];
+      });
+    }
+
+    if (data.toolCallCancellation != null) {
+      return {
+        type: 'custom',
+        rawType: 'toolCallCancellation',
+        raw,
+      };
+    }
+
+    if (data.serverContent != null) {
+      return this.parseServerContent(data.serverContent, raw);
+    }
+
+    if (data.inputTranscription?.text != null) {
+      return {
+        type: 'input-transcription-completed',
+        itemId: `google-input-${this.turnCounter}`,
+        transcript: data.inputTranscription.text,
+        raw,
+      };
+    }
+
+    return { type: 'custom', rawType: String(Object.keys(data)[0]), raw };
+  }
+
+  private parseServerContent(
+    serverContent: GoogleRealtimeServerContent,
+    raw: unknown,
+  ): RealtimeModelV4ServerEvent | RealtimeModelV4ServerEvent[] {
+    const events: RealtimeModelV4ServerEvent[] = [];
+
+    if (serverContent.interrupted) {
+      events.push({
+        type: 'speech-started',
+        raw,
+      });
+    }
+
+    if (serverContent.modelTurn?.parts) {
+      // New model response content marks the start of the next turn.
+      this.beginTurnIfClosed();
+      for (const part of serverContent.modelTurn.parts) {
+        if (part.inlineData?.data) {
+          this.hasAudio = true;
+          events.push({
+            type: 'audio-delta',
+            responseId: this.responseId,
+            itemId: this.itemId,
+            delta: part.inlineData.data,
+            raw,
+          });
+        }
+        if (part.text) {
+          this.hasText = true;
+          events.push({
+            type: 'text-delta',
+            responseId: this.responseId,
+            itemId: this.itemId,
+            delta: part.text,
+            raw,
+          });
+        }
+      }
+    }
+
+    if (serverContent.outputTranscription?.text) {
+      this.hasTranscript = true;
+      events.push({
+        type: 'audio-transcript-delta',
+        responseId: this.responseId,
+        itemId: this.itemId,
+        delta: serverContent.outputTranscription.text,
+        raw,
+      });
+    }
+
+    if (serverContent.inputTranscription?.text) {
+      events.push({
+        type: 'input-transcription-completed',
+        itemId: `google-input-${this.turnCounter}`,
+        transcript: serverContent.inputTranscription.text,
+        raw,
+      });
+    }
+
+    if (serverContent.turnComplete) {
+      if (this.hasAudio) {
+        events.push({
+          type: 'audio-done',
+          responseId: this.responseId,
+          itemId: this.itemId,
+          raw,
+        });
+      }
+      if (this.hasText) {
+        events.push({
+          type: 'text-done',
+          responseId: this.responseId,
+          itemId: this.itemId,
+          raw,
+        });
+      }
+      if (this.hasTranscript) {
+        events.push({
+          type: 'audio-transcript-done',
+          responseId: this.responseId,
+          itemId: this.itemId,
+          raw,
+        });
+      }
+      events.push({
+        type: 'response-done',
+        responseId: this.responseId,
+        status: 'completed',
+        raw,
+      });
+      // Mark the turn closed but defer advancing the counter until the next
+      // response actually begins (see `beginTurnIfClosed`).
+      this.turnClosed = true;
+    }
+
+    if (events.length === 0) {
+      return { type: 'custom', rawType: 'serverContent', raw };
+    }
+
+    return events.length === 1 ? events[0] : events;
+  }
+
+  serializeClientEvent(
+    event: RealtimeModelV4ClientEvent,
+    modelId: string,
+  ): ReturnType<RealtimeModelV4['serializeClientEvent']> {
+    switch (event.type) {
+      case 'session-update':
+        // Capture the configured capture rate so input audio blobs advertise
+        // the real rate. Google accepts any rate as long as the blob's mimeType
+        // matches; a mismatched label corrupts custom-rate audio.
+        if (event.config.inputAudioFormat?.rate != null) {
+          this.inputAudioRate = event.config.inputAudioFormat.rate;
+        }
+        return {
+          setup: buildGoogleSessionConfig(event.config, modelId),
+        };
+
+      case 'input-audio-append':
+        return {
+          realtimeInput: {
+            audio: {
+              data: event.audio,
+              mimeType: `audio/pcm;rate=${this.inputAudioRate}`,
+            },
+          },
+        };
+
+      case 'input-audio-commit':
+      case 'input-audio-clear':
+      case 'response-create':
+      case 'response-cancel':
+      case 'conversation-item-truncate':
+        return null;
+
+      case 'conversation-item-create': {
+        const item = event.item;
+        switch (item.type) {
+          case 'text-message':
+            return {
+              realtimeInput: {
+                text: item.text,
+              },
+            };
+          case 'function-call-output':
+            return serializeFunctionCallOutput(item);
+          case 'audio-message':
+            return null;
+        }
+        break;
+      }
+    }
+
+    return null;
+  }
+}
+
+async function serializeFunctionCallOutput(
+  item: RealtimeModelV4FunctionCallOutput,
+): Promise<unknown> {
+  const parseResult = await safeParseJSON({ text: item.output });
+  const response = parseResult.success ? parseResult.value : {};
+
+  return {
+    toolResponse: {
+      functionResponses: [
+        {
+          id: item.callId,
+          name: item.name,
+          response,
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Builds a Google-specific session configuration from a normalized config.
+ * Used to construct the `bidiGenerateContentSetup` payload for auth token creation.
+ */
+export function buildGoogleSessionConfig(
+  config: RealtimeModelV4SessionConfig | undefined,
+  modelId: string,
+): Record<string, unknown> {
+  const setup: Record<string, unknown> = {
+    model: getModelPath(modelId),
+  };
+
+  const generationConfig: Record<string, unknown> = {};
+
+  if (config?.outputModalities != null) {
+    generationConfig.responseModalities = config.outputModalities.map(m =>
+      m.toUpperCase(),
+    );
+  } else {
+    generationConfig.responseModalities = ['AUDIO'];
+  }
+
+  if (config?.voice != null) {
+    generationConfig.speechConfig = {
+      voiceConfig: {
+        prebuiltVoiceConfig: {
+          voiceName: config.voice,
+        },
+      },
+    };
+  }
+
+  setup.generationConfig = generationConfig;
+
+  if (config?.instructions != null) {
+    setup.systemInstruction = {
+      parts: [{ text: config.instructions }],
+    };
+  }
+
+  if (config?.tools != null && config.tools.length > 0) {
+    setup.tools = [
+      {
+        functionDeclarations: config.tools.map(tool => ({
+          name: tool.name,
+          description: tool.description,
+          parameters: convertJSONSchemaToOpenAPISchema(tool.parameters),
+        })),
+      },
+    ];
+  }
+
+  if (config?.inputAudioTranscription != null) {
+    setup.inputAudioTranscription = {};
+  }
+
+  if (config?.outputAudioTranscription != null) {
+    setup.outputAudioTranscription = {};
+  }
+
+  if (config?.providerOptions != null) {
+    Object.assign(setup, config.providerOptions);
+  }
+
+  return setup;
+}

--- a/packages/google/src/realtime/google-realtime-model-options.ts
+++ b/packages/google/src/realtime/google-realtime-model-options.ts
@@ -1,0 +1,3 @@
+export type GoogleRealtimeModelId = string;
+
+export type GoogleRealtimeModelOptions = Record<string, never>;

--- a/packages/google/src/realtime/google-realtime-model.test.ts
+++ b/packages/google/src/realtime/google-realtime-model.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GoogleRealtimeModel } from './google-realtime-model';
+
+describe('GoogleRealtimeModel', () => {
+  describe('doCreateClientSecret', () => {
+    it('calls auth_tokens endpoint with correct payload', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          name: 'projects/123/locations/us/accessTokens/abc',
+          expireTime: '2026-01-01T00:05:00.000Z',
+        }),
+      });
+
+      const model = new GoogleRealtimeModel('gemini-2.0-flash-live-001', {
+        provider: 'google.realtime',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        headers: () => ({ 'x-goog-api-key': 'test-key' }),
+        fetch: mockFetch,
+      });
+
+      const result = await model.doCreateClientSecret({
+        sessionConfig: {
+          instructions: 'Be helpful',
+          voice: 'Puck',
+        },
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe(
+        'https://generativelanguage.googleapis.com/v1alpha/auth_tokens?key=test-key',
+      );
+      expect(options.method).toBe('POST');
+
+      const body = JSON.parse(options.body);
+      expect(body.uses).toBe(0);
+      expect(body.expireTime).toBeDefined();
+      expect(body.bidiGenerateContentSetup.model).toBe(
+        'models/gemini-2.0-flash-live-001',
+      );
+      expect(body.bidiGenerateContentSetup.systemInstruction).toEqual({
+        parts: [{ text: 'Be helpful' }],
+      });
+      expect(
+        body.bidiGenerateContentSetup.generationConfig.speechConfig.voiceConfig
+          .prebuiltVoiceConfig.voiceName,
+      ).toBe('Puck');
+
+      expect(result.token).toBe('projects/123/locations/us/accessTokens/abc');
+      expect(result.url).toContain('generativelanguage.googleapis.com');
+    });
+
+    it('sets newSessionExpireTime from expiresAfterSeconds', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ name: 'token', expireTime: undefined }),
+      });
+
+      const model = new GoogleRealtimeModel('gemini-2.0-flash-live-001', {
+        provider: 'google.realtime',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        headers: () => ({ 'x-goog-api-key': 'test-key' }),
+        fetch: mockFetch,
+      });
+
+      const before = Date.now();
+      await model.doCreateClientSecret({ expiresAfterSeconds: 120 });
+      const after = Date.now();
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+
+      // newSessionExpireTime controls the window to open a session.
+      const newSessionExpireMs = new Date(body.newSessionExpireTime).getTime();
+      expect(newSessionExpireMs).toBeGreaterThanOrEqual(before + 120_000);
+      expect(newSessionExpireMs).toBeLessThanOrEqual(after + 120_000);
+
+      // expireTime is the overall token lifetime and must outlast the open
+      // window so the opened session has room to run.
+      expect(new Date(body.expireTime).getTime()).toBeGreaterThan(
+        newSessionExpireMs,
+      );
+    });
+
+    it('uses the configured base URL for realtime endpoints', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ name: 'token' }),
+      });
+
+      const model = new GoogleRealtimeModel('gemini-2.0-flash-live-001', {
+        provider: 'google.realtime',
+        baseURL: 'https://proxy.example.com/google/v1beta',
+        headers: () => ({ 'x-goog-api-key': 'test-key' }),
+        fetch: mockFetch,
+      });
+
+      const result = await model.doCreateClientSecret({});
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://proxy.example.com/google/v1alpha/auth_tokens?key=test-key',
+        expect.any(Object),
+      );
+      expect(result.url).toBe(
+        'wss://proxy.example.com/google/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained',
+      );
+    });
+
+    it('uses ws protocol for http base URLs', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ name: 'token' }),
+      });
+
+      const model = new GoogleRealtimeModel('gemini-2.0-flash-live-001', {
+        provider: 'google.realtime',
+        baseURL: 'http://localhost:8787/v1beta',
+        headers: () => ({ 'x-goog-api-key': 'test-key' }),
+        fetch: mockFetch,
+      });
+
+      const result = await model.doCreateClientSecret({});
+
+      expect(result.url).toBe(
+        'ws://localhost:8787/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained',
+      );
+    });
+
+    it('enables output audio transcription when configured', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ name: 'token' }),
+      });
+
+      const model = new GoogleRealtimeModel('gemini-2.0-flash-live-001', {
+        provider: 'google.realtime',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        headers: () => ({ 'x-goog-api-key': 'test-key' }),
+        fetch: mockFetch,
+      });
+
+      await model.doCreateClientSecret({
+        sessionConfig: { outputAudioTranscription: {} },
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.bidiGenerateContentSetup.outputAudioTranscription).toEqual(
+        {},
+      );
+    });
+
+    it('throws on missing API key', async () => {
+      const model = new GoogleRealtimeModel('gemini-2.0-flash-live-001', {
+        provider: 'google.realtime',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        headers: () => ({}),
+      });
+
+      await expect(model.doCreateClientSecret({})).rejects.toThrow(
+        'API key is required',
+      );
+    });
+
+    it('throws on failed request', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: async () => 'Forbidden',
+      });
+
+      const model = new GoogleRealtimeModel('gemini-2.0-flash-live-001', {
+        provider: 'google.realtime',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        headers: () => ({ 'x-goog-api-key': 'test-key' }),
+        fetch: mockFetch,
+      });
+
+      await expect(model.doCreateClientSecret({})).rejects.toThrow(
+        '403 Forbidden',
+      );
+    });
+  });
+
+  describe('getWebSocketConfig', () => {
+    it('returns URL with access_token query param', () => {
+      const model = new GoogleRealtimeModel('gemini-2.0-flash-live-001', {
+        provider: 'google.realtime',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        headers: () => ({ 'x-goog-api-key': 'test-key' }),
+      });
+
+      const config = model.getWebSocketConfig({
+        token: 'my-token',
+        url: 'wss://example.com/ws',
+      });
+
+      expect(config.url).toBe('wss://example.com/ws?access_token=my-token');
+      expect(config.protocols).toBeUndefined();
+    });
+  });
+
+  describe('parseServerEvent', () => {
+    it('delegates to mapper', () => {
+      const model = new GoogleRealtimeModel('gemini-2.0-flash-live-001', {
+        provider: 'google.realtime',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        headers: () => ({ 'x-goog-api-key': 'test-key' }),
+      });
+
+      const result = model.parseServerEvent({ setupComplete: true });
+      expect(result).toEqual({
+        type: 'session-created',
+        raw: { setupComplete: true },
+      });
+    });
+  });
+
+  describe('serializeClientEvent', () => {
+    it('delegates to mapper', () => {
+      const model = new GoogleRealtimeModel('gemini-2.0-flash-live-001', {
+        provider: 'google.realtime',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        headers: () => ({ 'x-goog-api-key': 'test-key' }),
+      });
+
+      const result = model.serializeClientEvent({
+        type: 'input-audio-append',
+        audio: 'base64',
+      });
+      expect(result).toEqual({
+        realtimeInput: {
+          audio: { data: 'base64', mimeType: 'audio/pcm;rate=16000' },
+        },
+      });
+    });
+
+    it('labels input audio with the configured capture rate', () => {
+      const model = new GoogleRealtimeModel('gemini-2.0-flash-live-001', {
+        provider: 'google.realtime',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        headers: () => ({ 'x-goog-api-key': 'test-key' }),
+      });
+
+      // The session-update carries the configured capture rate; later input
+      // audio blobs must advertise that real rate, not a hardcoded 16000.
+      model.serializeClientEvent({
+        type: 'session-update',
+        config: { inputAudioFormat: { type: 'audio/pcm', rate: 24000 } },
+      });
+
+      const result = model.serializeClientEvent({
+        type: 'input-audio-append',
+        audio: 'base64',
+      });
+      expect(result).toEqual({
+        realtimeInput: {
+          audio: { data: 'base64', mimeType: 'audio/pcm;rate=24000' },
+        },
+      });
+    });
+  });
+});

--- a/packages/google/src/realtime/google-realtime-model.ts
+++ b/packages/google/src/realtime/google-realtime-model.ts
@@ -1,0 +1,160 @@
+import type {
+  Experimental_RealtimeModelV4 as RealtimeModelV4,
+  Experimental_RealtimeModelV4ClientEvent as RealtimeModelV4ClientEvent,
+  Experimental_RealtimeModelV4ClientSecretOptions as RealtimeModelV4ClientSecretOptions,
+  Experimental_RealtimeModelV4ClientSecretResult as RealtimeModelV4ClientSecretResult,
+  Experimental_RealtimeModelV4ServerEvent as RealtimeModelV4ServerEvent,
+  Experimental_RealtimeModelV4SessionConfig as RealtimeModelV4SessionConfig,
+} from '@ai-sdk/provider';
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+import {
+  GoogleRealtimeEventMapper,
+  buildGoogleSessionConfig,
+} from './google-realtime-event-mapper';
+
+const realtimeWebSocketPath =
+  'google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained';
+
+function getRealtimeBaseURL(baseURL: string): URL {
+  const url = new URL(baseURL);
+  const pathSegments = url.pathname.split('/');
+  const version = pathSegments.at(-1);
+
+  if (version === 'v1beta' || version === 'v1alpha') {
+    pathSegments.pop();
+    url.pathname = pathSegments.join('/') || '/';
+  }
+
+  return url;
+}
+
+function getAuthTokensURL(baseURL: string): string {
+  const url = getRealtimeBaseURL(baseURL);
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/v1alpha/auth_tokens`;
+  return url.toString();
+}
+
+function getWebSocketURL(baseURL: string): string {
+  const url = getRealtimeBaseURL(baseURL);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/ws/${realtimeWebSocketPath}`;
+  return url.toString();
+}
+
+export type GoogleRealtimeModelConfig = {
+  provider: string;
+  baseURL: string;
+  headers: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+};
+
+export class GoogleRealtimeModel implements RealtimeModelV4 {
+  readonly specificationVersion = 'v4' as const;
+  readonly provider: string;
+  readonly modelId: string;
+
+  private readonly config: GoogleRealtimeModelConfig;
+  private readonly mapper = new GoogleRealtimeEventMapper();
+
+  constructor(modelId: string, config: GoogleRealtimeModelConfig) {
+    this.modelId = modelId;
+    this.provider = config.provider;
+    this.config = config;
+  }
+
+  async doCreateClientSecret(
+    options: RealtimeModelV4ClientSecretOptions,
+  ): Promise<RealtimeModelV4ClientSecretResult> {
+    const fetchFn = this.config.fetch ?? fetch;
+    const headers = this.config.headers();
+    const apiKey = headers['x-goog-api-key'];
+
+    if (!apiKey) {
+      throw new Error(
+        'Google Generative AI API key is required for realtime token creation.',
+      );
+    }
+
+    // `newSessionExpireTime` controls how long the token can be used to *open*
+    // a session — the window callers actually care about — so map
+    // `expiresAfterSeconds` to it (Google otherwise defaults it to ~60s).
+    // `expireTime` is the overall token lifetime and must be >=
+    // `newSessionExpireTime`, so extend it to leave room for the opened session
+    // to run.
+    const now = Date.now();
+    const openWindowMs = (options.expiresAfterSeconds ?? 60) * 1000;
+    const newSessionExpireTime = new Date(now + openWindowMs).toISOString();
+    const expireTime = new Date(
+      now + openWindowMs + 30 * 60 * 1000,
+    ).toISOString();
+
+    const setupPayload = buildGoogleSessionConfig(
+      options.sessionConfig,
+      this.modelId,
+    );
+
+    const response = await fetchFn(
+      `${getAuthTokensURL(this.config.baseURL)}?key=${encodeURIComponent(apiKey)}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          // `uses: 0` means no limit is applied to how many times the token can
+          // start a session (per the AuthToken spec). An unset value would
+          // default to 1, which breaks WebSocket reconnects within the session.
+          uses: 0,
+          expireTime,
+          newSessionExpireTime,
+          bidiGenerateContentSetup: setupPayload,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Google realtime auth token request failed: ${response.status} ${text}`,
+      );
+    }
+
+    const data = (await response.json()) as {
+      name: string;
+      expireTime?: string;
+    };
+
+    return {
+      token: data.name,
+      url: getWebSocketURL(this.config.baseURL),
+      expiresAt: data.expireTime
+        ? Math.floor(new Date(data.expireTime).getTime() / 1000)
+        : undefined,
+    };
+  }
+
+  getWebSocketConfig(options: { token: string; url: string }): {
+    url: string;
+    protocols?: string[];
+  } {
+    return {
+      url: `${options.url}?access_token=${encodeURIComponent(options.token)}`,
+    };
+  }
+
+  parseServerEvent(
+    raw: unknown,
+  ): RealtimeModelV4ServerEvent | RealtimeModelV4ServerEvent[] {
+    return this.mapper.parseServerEvent(raw);
+  }
+
+  serializeClientEvent(
+    event: RealtimeModelV4ClientEvent,
+  ): ReturnType<RealtimeModelV4['serializeClientEvent']> {
+    return this.mapper.serializeClientEvent(event, this.modelId);
+  }
+
+  buildSessionConfig(
+    config: RealtimeModelV4SessionConfig,
+  ): Record<string, unknown> {
+    return buildGoogleSessionConfig(config, this.modelId);
+  }
+}

--- a/packages/google/src/realtime/index.ts
+++ b/packages/google/src/realtime/index.ts
@@ -1,0 +1,2 @@
+export { GoogleRealtimeModel as Experimental_GoogleRealtimeModel } from './google-realtime-model';
+export type { GoogleRealtimeModelConfig as Experimental_GoogleRealtimeModelConfig } from './google-realtime-model';

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -1,5 +1,7 @@
 export { createOpenAI, openai } from './openai-provider';
 export type { OpenAIProvider, OpenAIProviderSettings } from './openai-provider';
+export { OpenAIRealtimeModel as Experimental_OpenAIRealtimeModel } from './realtime/openai-realtime-model';
+export type { OpenAIRealtimeModelConfig as Experimental_OpenAIRealtimeModelConfig } from './realtime/openai-realtime-model';
 export type {
   OpenAILanguageModelResponsesOptions,
   /** @deprecated Use `OpenAILanguageModelResponsesOptions` instead. */

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -4,6 +4,8 @@ import type {
   ImageModelV4,
   LanguageModelV4,
   ProviderV4,
+  Experimental_RealtimeFactoryV4 as RealtimeFactoryV4,
+  Experimental_RealtimeFactoryV4GetTokenOptions as RealtimeFactoryV4GetTokenOptions,
   SpeechModelV4,
   SkillsV4,
   TranscriptionModelV4,
@@ -25,6 +27,7 @@ import type { OpenAIEmbeddingModelId } from './embedding/openai-embedding-model-
 import { OpenAIImageModel } from './image/openai-image-model';
 import type { OpenAIImageModelId } from './image/openai-image-model-options';
 import { openaiTools } from './openai-tools';
+import { OpenAIRealtimeModel } from './realtime/openai-realtime-model';
 import { OpenAIResponsesLanguageModel } from './responses/openai-responses-language-model';
 import type { OpenAIResponsesModelId } from './responses/openai-responses-language-model-options';
 import { OpenAISpeechModel } from './speech/openai-speech-model';
@@ -96,6 +99,12 @@ export interface OpenAIProvider extends ProviderV4 {
    * Creates a model for speech generation.
    */
   speech(modelId: OpenAISpeechModelId): SpeechModelV4;
+
+  /**
+   * Creates an experimental realtime model for bidirectional audio/text
+   * communication over WebSocket.
+   */
+  experimental_realtime: RealtimeFactoryV4;
 
   /**
    * Returns a FilesV4 interface for uploading files to OpenAI.
@@ -267,6 +276,33 @@ export function createOpenAI(
     });
   };
 
+  const createRealtimeModel = (modelId: string) =>
+    new OpenAIRealtimeModel(modelId, {
+      provider: `${providerName}.realtime`,
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
+  const experimentalRealtimeFactory = Object.assign(
+    (modelId: string) => createRealtimeModel(modelId),
+    {
+      getToken: async (tokenOptions: RealtimeFactoryV4GetTokenOptions) => {
+        const model = createRealtimeModel(tokenOptions.model);
+        const secret = await model.doCreateClientSecret({
+          sessionConfig: tokenOptions.sessionConfig,
+          expiresAfterSeconds: tokenOptions.expiresAfterSeconds,
+        });
+
+        return {
+          token: secret.token,
+          url: secret.url,
+          expiresAt: secret.expiresAt,
+        };
+      },
+    },
+  ) as RealtimeFactoryV4;
+
   const provider = function (modelId: OpenAIResponsesModelId) {
     return createLanguageModel(modelId);
   };
@@ -291,6 +327,8 @@ export function createOpenAI(
   provider.speechModel = createSpeechModel;
   provider.files = createFiles;
   provider.skills = createSkills;
+
+  provider.experimental_realtime = experimentalRealtimeFactory;
 
   provider.tools = openaiTools;
 

--- a/packages/openai/src/realtime/index.ts
+++ b/packages/openai/src/realtime/index.ts
@@ -1,0 +1,2 @@
+export { OpenAIRealtimeModel as Experimental_OpenAIRealtimeModel } from './openai-realtime-model';
+export type { OpenAIRealtimeModelConfig as Experimental_OpenAIRealtimeModelConfig } from './openai-realtime-model';

--- a/packages/openai/src/realtime/openai-realtime-event-mapper.test.ts
+++ b/packages/openai/src/realtime/openai-realtime-event-mapper.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { buildOpenAISessionConfig } from './openai-realtime-event-mapper';
+
+describe('buildOpenAISessionConfig', () => {
+  it('enables input audio transcription with a default model', () => {
+    const result = buildOpenAISessionConfig(
+      { inputAudioTranscription: {} },
+      'gpt-realtime',
+    );
+
+    expect(result.audio).toEqual({
+      input: {
+        transcription: {
+          model: 'gpt-realtime-whisper',
+        },
+      },
+    });
+  });
+
+  it('maps input audio transcription options', () => {
+    const result = buildOpenAISessionConfig(
+      {
+        inputAudioTranscription: {
+          model: 'gpt-4o-mini-transcribe',
+          language: 'en',
+          prompt: 'Transcribe short voice chat messages.',
+        },
+      },
+      'gpt-realtime',
+    );
+
+    expect(result.audio).toEqual({
+      input: {
+        transcription: {
+          model: 'gpt-4o-mini-transcribe',
+          language: 'en',
+          prompt: 'Transcribe short voice chat messages.',
+        },
+      },
+    });
+  });
+});

--- a/packages/openai/src/realtime/openai-realtime-event-mapper.ts
+++ b/packages/openai/src/realtime/openai-realtime-event-mapper.ts
@@ -1,0 +1,436 @@
+import type {
+  Experimental_RealtimeModelV4ClientEvent as RealtimeModelV4ClientEvent,
+  Experimental_RealtimeModelV4ServerEvent as RealtimeModelV4ServerEvent,
+  Experimental_RealtimeModelV4SessionConfig as RealtimeModelV4SessionConfig,
+} from '@ai-sdk/provider';
+
+type OpenAIRealtimeWireEvent = {
+  type: string;
+  session?: { id?: string };
+  item?: { id?: string } & Record<string, unknown>;
+  response?: { id?: string; status?: string };
+  error?: { message?: string; code?: string };
+  item_id: string;
+  previous_item_id?: string;
+  response_id: string;
+  transcript?: string;
+  delta: string;
+  text?: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+  message?: string;
+  code?: string;
+};
+
+/**
+ * Parses a raw OpenAI Realtime API server event into a normalized event.
+ */
+export function parseOpenAIRealtimeServerEvent(
+  raw: unknown,
+): RealtimeModelV4ServerEvent {
+  const event = raw as OpenAIRealtimeWireEvent;
+  const type = event.type;
+
+  switch (type) {
+    // ── Session lifecycle ──────────────────────────────────────────
+    case 'session.created':
+      return {
+        type: 'session-created',
+        sessionId: event.session?.id,
+        raw,
+      };
+
+    case 'session.updated':
+      return { type: 'session-updated', raw };
+
+    // ── Input audio buffer ─────────────────────────────────────────
+    case 'input_audio_buffer.speech_started':
+      return {
+        type: 'speech-started',
+        itemId: event.item_id,
+        raw,
+      };
+
+    case 'input_audio_buffer.speech_stopped':
+      return {
+        type: 'speech-stopped',
+        itemId: event.item_id,
+        raw,
+      };
+
+    case 'input_audio_buffer.committed':
+      return {
+        type: 'audio-committed',
+        itemId: event.item_id,
+        previousItemId: event.previous_item_id,
+        raw,
+      };
+
+    // ── Conversation items ─────────────────────────────────────────
+    case 'conversation.item.added':
+      return {
+        type: 'conversation-item-added',
+        itemId: event.item?.id ?? event.item_id,
+        item: event.item,
+        raw,
+      };
+
+    case 'conversation.item.input_audio_transcription.completed':
+      return {
+        type: 'input-transcription-completed',
+        itemId: event.item_id,
+        transcript: event.transcript ?? '',
+        raw,
+      };
+
+    // ── Response lifecycle ──────────────────────────────────────────
+    case 'response.created':
+      return {
+        type: 'response-created',
+        responseId: event.response?.id ?? event.response_id,
+        raw,
+      };
+
+    case 'response.done':
+      return {
+        type: 'response-done',
+        responseId: event.response?.id ?? event.response_id,
+        status: event.response?.status ?? 'completed',
+        raw,
+      };
+
+    // ── Output item lifecycle ───────────────────────────────────────
+    case 'response.output_item.added':
+      return {
+        type: 'output-item-added',
+        responseId: event.response_id,
+        itemId: event.item?.id ?? event.item_id,
+        raw,
+      };
+
+    case 'response.output_item.done':
+      return {
+        type: 'output-item-done',
+        responseId: event.response_id,
+        itemId: event.item?.id ?? event.item_id,
+        raw,
+      };
+
+    case 'response.content_part.added':
+      return {
+        type: 'content-part-added',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        raw,
+      };
+
+    case 'response.content_part.done':
+      return {
+        type: 'content-part-done',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        raw,
+      };
+
+    // ── Audio output ────────────────────────────────────────────────
+    case 'response.output_audio.delta':
+      return {
+        type: 'audio-delta',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        delta: event.delta,
+        raw,
+      };
+
+    case 'response.output_audio.done':
+      return {
+        type: 'audio-done',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        raw,
+      };
+
+    // ── Audio transcript output ─────────────────────────────────────
+    case 'response.output_audio_transcript.delta':
+      return {
+        type: 'audio-transcript-delta',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        delta: event.delta,
+        raw,
+      };
+
+    case 'response.output_audio_transcript.done':
+      return {
+        type: 'audio-transcript-done',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        transcript: event.transcript,
+        raw,
+      };
+
+    // ── Text output ─────────────────────────────────────────────────
+    case 'response.output_text.delta':
+      return {
+        type: 'text-delta',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        delta: event.delta,
+        raw,
+      };
+
+    case 'response.output_text.done':
+      return {
+        type: 'text-done',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        text: event.text,
+        raw,
+      };
+
+    // ── Function calling ────────────────────────────────────────────
+    case 'response.function_call_arguments.delta':
+      return {
+        type: 'function-call-arguments-delta',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        callId: event.call_id,
+        delta: event.delta,
+        raw,
+      };
+
+    case 'response.function_call_arguments.done':
+      return {
+        type: 'function-call-arguments-done',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        callId: event.call_id,
+        name: event.name,
+        arguments: event.arguments,
+        raw,
+      };
+
+    // ── Error ───────────────────────────────────────────────────────
+    case 'error':
+      return {
+        type: 'error',
+        message: event.error?.message ?? event.message ?? 'Unknown error',
+        code: event.error?.code ?? event.code,
+        raw,
+      };
+
+    // ── Pass-through ────────────────────────────────────────────────
+    default:
+      return { type: 'custom', rawType: type, raw };
+  }
+}
+
+/**
+ * Serializes a normalized client event into OpenAI's Realtime API format.
+ */
+export function serializeOpenAIRealtimeClientEvent(
+  event: RealtimeModelV4ClientEvent,
+  modelId: string,
+): unknown {
+  switch (event.type) {
+    case 'session-update':
+      return {
+        type: 'session.update',
+        session: buildOpenAISessionConfig(event.config, modelId),
+      };
+
+    case 'input-audio-append':
+      return {
+        type: 'input_audio_buffer.append',
+        audio: event.audio,
+      };
+
+    case 'input-audio-commit':
+      return { type: 'input_audio_buffer.commit' };
+
+    case 'input-audio-clear':
+      return { type: 'input_audio_buffer.clear' };
+
+    case 'conversation-item-create': {
+      const item = event.item;
+      switch (item.type) {
+        case 'text-message':
+          return {
+            type: 'conversation.item.create',
+            item: {
+              type: 'message',
+              role: item.role,
+              content: [{ type: 'input_text', text: item.text }],
+            },
+          };
+        case 'audio-message':
+          return {
+            type: 'conversation.item.create',
+            item: {
+              type: 'message',
+              role: item.role,
+              content: [{ type: 'input_audio', audio: item.audio }],
+            },
+          };
+        case 'function-call-output':
+          return {
+            type: 'conversation.item.create',
+            item: {
+              type: 'function_call_output',
+              call_id: item.callId,
+              output: item.output,
+            },
+          };
+      }
+      break;
+    }
+
+    case 'conversation-item-truncate':
+      return {
+        type: 'conversation.item.truncate',
+        item_id: event.itemId,
+        content_index: event.contentIndex,
+        audio_end_ms: event.audioEndMs,
+      };
+
+    case 'response-create':
+      return {
+        type: 'response.create',
+        ...(event.options != null
+          ? {
+              response: {
+                ...(event.options.modalities != null
+                  ? { output_modalities: event.options.modalities }
+                  : {}),
+                ...(event.options.instructions != null
+                  ? { instructions: event.options.instructions }
+                  : {}),
+                ...(event.options.metadata != null
+                  ? { metadata: event.options.metadata }
+                  : {}),
+              },
+            }
+          : {}),
+      };
+
+    case 'response-cancel':
+      return { type: 'response.cancel' };
+  }
+}
+
+/**
+ * Builds an OpenAI-specific session configuration from a normalized config.
+ */
+export function buildOpenAISessionConfig(
+  config: RealtimeModelV4SessionConfig,
+  modelId: string,
+): Record<string, unknown> {
+  const session: Record<string, unknown> = {
+    type: 'realtime',
+    model: modelId,
+  };
+
+  if (config.instructions != null) {
+    session.instructions = config.instructions;
+  }
+
+  if (config.outputModalities != null) {
+    session.output_modalities = config.outputModalities;
+  }
+
+  const audio: Record<string, unknown> = {};
+
+  if (
+    config.inputAudioFormat != null ||
+    config.inputAudioTranscription != null ||
+    config.turnDetection != null
+  ) {
+    const input: Record<string, unknown> = {};
+
+    if (config.inputAudioFormat != null) {
+      input.format = {
+        type: config.inputAudioFormat.type,
+        ...(config.inputAudioFormat.rate != null
+          ? { rate: config.inputAudioFormat.rate }
+          : {}),
+      };
+    }
+
+    if (config.turnDetection != null) {
+      if (config.turnDetection.type === 'disabled') {
+        input.turn_detection = null;
+      } else {
+        const td: Record<string, unknown> = {
+          type:
+            config.turnDetection.type === 'server-vad'
+              ? 'server_vad'
+              : 'semantic_vad',
+        };
+        if (config.turnDetection.threshold != null) {
+          td.threshold = config.turnDetection.threshold;
+        }
+        if (config.turnDetection.silenceDurationMs != null) {
+          td.silence_duration_ms = config.turnDetection.silenceDurationMs;
+        }
+        if (config.turnDetection.prefixPaddingMs != null) {
+          td.prefix_padding_ms = config.turnDetection.prefixPaddingMs;
+        }
+        input.turn_detection = td;
+      }
+    }
+
+    if (config.inputAudioTranscription != null) {
+      input.transcription = {
+        model: config.inputAudioTranscription.model ?? 'gpt-realtime-whisper',
+        ...(config.inputAudioTranscription.language != null
+          ? { language: config.inputAudioTranscription.language }
+          : {}),
+        ...(config.inputAudioTranscription.prompt != null
+          ? { prompt: config.inputAudioTranscription.prompt }
+          : {}),
+      };
+    }
+
+    audio.input = input;
+  }
+
+  if (config.outputAudioFormat != null || config.voice != null) {
+    const output: Record<string, unknown> = {};
+
+    if (config.outputAudioFormat != null) {
+      output.format = {
+        type: config.outputAudioFormat.type,
+        ...(config.outputAudioFormat.rate != null
+          ? { rate: config.outputAudioFormat.rate }
+          : {}),
+      };
+    }
+
+    if (config.voice != null) {
+      output.voice = config.voice;
+    }
+
+    audio.output = output;
+  }
+
+  if (Object.keys(audio).length > 0) {
+    session.audio = audio;
+  }
+
+  if (config.tools != null && config.tools.length > 0) {
+    session.tools = config.tools.map(tool => ({
+      type: tool.type,
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    }));
+    session.tool_choice = 'auto';
+  }
+
+  if (config.providerOptions != null) {
+    Object.assign(session, config.providerOptions);
+  }
+
+  return session;
+}

--- a/packages/openai/src/realtime/openai-realtime-model-options.ts
+++ b/packages/openai/src/realtime/openai-realtime-model-options.ts
@@ -1,0 +1,3 @@
+export type OpenAIRealtimeModelId = string;
+
+export type OpenAIRealtimeModelOptions = Record<string, never>;

--- a/packages/openai/src/realtime/openai-realtime-model.test.ts
+++ b/packages/openai/src/realtime/openai-realtime-model.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { OpenAIRealtimeModel } from './openai-realtime-model';
+
+describe('OpenAIRealtimeModel', () => {
+  describe('doCreateClientSecret', () => {
+    const createModel = (fetch: typeof globalThis.fetch) =>
+      new OpenAIRealtimeModel('gpt-realtime', {
+        provider: 'openai.realtime',
+        baseURL: 'https://api.openai.com/v1',
+        headers: () => ({ authorization: 'Bearer test-key' }),
+        fetch,
+      });
+
+    it('omits expires_after when no ttl is requested', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ value: 'secret', expires_at: 123 }),
+      });
+
+      await createModel(
+        mockFetch as unknown as typeof fetch,
+      ).doCreateClientSecret({});
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.expires_after).toBeUndefined();
+    });
+
+    it('includes the required anchor with expires_after', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ value: 'secret', expires_at: 123 }),
+      });
+
+      await createModel(
+        mockFetch as unknown as typeof fetch,
+      ).doCreateClientSecret({ expiresAfterSeconds: 60 });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      // The client secrets endpoint 400s without `anchor`.
+      expect(body.expires_after).toEqual({
+        anchor: 'created_at',
+        seconds: 60,
+      });
+    });
+  });
+});

--- a/packages/openai/src/realtime/openai-realtime-model.ts
+++ b/packages/openai/src/realtime/openai-realtime-model.ts
@@ -1,0 +1,111 @@
+import type {
+  Experimental_RealtimeModelV4 as RealtimeModelV4,
+  Experimental_RealtimeModelV4ClientEvent as RealtimeModelV4ClientEvent,
+  Experimental_RealtimeModelV4ClientSecretOptions as RealtimeModelV4ClientSecretOptions,
+  Experimental_RealtimeModelV4ClientSecretResult as RealtimeModelV4ClientSecretResult,
+  Experimental_RealtimeModelV4ServerEvent as RealtimeModelV4ServerEvent,
+  Experimental_RealtimeModelV4SessionConfig as RealtimeModelV4SessionConfig,
+} from '@ai-sdk/provider';
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+import {
+  buildOpenAISessionConfig,
+  parseOpenAIRealtimeServerEvent,
+  serializeOpenAIRealtimeClientEvent,
+} from './openai-realtime-event-mapper';
+
+export type OpenAIRealtimeModelConfig = {
+  provider: string;
+  baseURL: string;
+  headers: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+};
+
+export class OpenAIRealtimeModel implements RealtimeModelV4 {
+  readonly specificationVersion = 'v4' as const;
+  readonly provider: string;
+  readonly modelId: string;
+
+  private readonly config: OpenAIRealtimeModelConfig;
+
+  constructor(modelId: string, config: OpenAIRealtimeModelConfig) {
+    this.modelId = modelId;
+    this.provider = config.provider;
+    this.config = config;
+  }
+
+  async doCreateClientSecret(
+    options: RealtimeModelV4ClientSecretOptions,
+  ): Promise<RealtimeModelV4ClientSecretResult> {
+    const fetchFn = this.config.fetch ?? fetch;
+    const url = `${this.config.baseURL}/realtime/client_secrets`;
+
+    const session =
+      options.sessionConfig != null
+        ? buildOpenAISessionConfig(options.sessionConfig, this.modelId)
+        : { type: 'realtime', model: this.modelId };
+
+    const response = await fetchFn(url, {
+      method: 'POST',
+      headers: {
+        ...this.config.headers(),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        session,
+        ...(options.expiresAfterSeconds != null
+          ? {
+              // `anchor` is required by the client secrets endpoint; without it
+              // the request fails with "Missing required parameter:
+              // 'expires_after.anchor'".
+              expires_after: {
+                anchor: 'created_at',
+                seconds: options.expiresAfterSeconds,
+              },
+            }
+          : {}),
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `OpenAI realtime client secret request failed: ${response.status} ${text}`,
+      );
+    }
+
+    const data = (await response.json()) as {
+      value: string;
+      expires_at?: number;
+    };
+
+    return {
+      token: data.value,
+      url: `wss://${new URL(this.config.baseURL).host}/v1/realtime?model=${encodeURIComponent(this.modelId)}`,
+      expiresAt: data.expires_at,
+    };
+  }
+
+  getWebSocketConfig(options: { token: string; url: string }): {
+    url: string;
+    protocols?: string[];
+  } {
+    return {
+      url: options.url,
+      protocols: ['realtime', `openai-insecure-api-key.${options.token}`],
+    };
+  }
+
+  parseServerEvent(raw: unknown): RealtimeModelV4ServerEvent {
+    return parseOpenAIRealtimeServerEvent(raw);
+  }
+
+  serializeClientEvent(event: RealtimeModelV4ClientEvent): unknown {
+    return serializeOpenAIRealtimeClientEvent(event, this.modelId);
+  }
+
+  buildSessionConfig(
+    config: RealtimeModelV4SessionConfig,
+  ): Record<string, unknown> {
+    return buildOpenAISessionConfig(config, this.modelId);
+  }
+}

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -8,6 +8,7 @@ export * from './language-model-middleware/index';
 export * from './embedding-model-middleware/index';
 export * from './language-model/index';
 export * from './provider/index';
+export * from './realtime-model/v4/index';
 export * from './reranking-model/index';
 export * from './shared/index';
 export * from './skills/index';

--- a/packages/provider/src/realtime-model/index.ts
+++ b/packages/provider/src/realtime-model/index.ts
@@ -1,0 +1,1 @@
+export * from './v4/index';

--- a/packages/provider/src/realtime-model/v4/index.ts
+++ b/packages/provider/src/realtime-model/v4/index.ts
@@ -1,0 +1,20 @@
+export type {
+  RealtimeFactoryV4 as Experimental_RealtimeFactoryV4,
+  RealtimeFactoryV4GetTokenOptions as Experimental_RealtimeFactoryV4GetTokenOptions,
+  RealtimeFactoryV4GetTokenResult as Experimental_RealtimeFactoryV4GetTokenResult,
+} from './realtime-factory-v4';
+export type { RealtimeModelV4 as Experimental_RealtimeModelV4 } from './realtime-model-v4';
+export type { RealtimeModelV4ClientEvent as Experimental_RealtimeModelV4ClientEvent } from './realtime-model-v4-client-event';
+export type {
+  RealtimeModelV4ClientSecretOptions as Experimental_RealtimeModelV4ClientSecretOptions,
+  RealtimeModelV4ClientSecretResult as Experimental_RealtimeModelV4ClientSecretResult,
+} from './realtime-model-v4-client-secret';
+export type {
+  RealtimeModelV4ConversationItem as Experimental_RealtimeModelV4ConversationItem,
+  RealtimeModelV4TextMessage as Experimental_RealtimeModelV4TextMessage,
+  RealtimeModelV4AudioMessage as Experimental_RealtimeModelV4AudioMessage,
+  RealtimeModelV4FunctionCallOutput as Experimental_RealtimeModelV4FunctionCallOutput,
+} from './realtime-model-v4-conversation-item';
+export type { RealtimeModelV4ServerEvent as Experimental_RealtimeModelV4ServerEvent } from './realtime-model-v4-server-event';
+export type { RealtimeModelV4SessionConfig as Experimental_RealtimeModelV4SessionConfig } from './realtime-model-v4-session-config';
+export type { RealtimeModelV4ToolDefinition as Experimental_RealtimeModelV4ToolDefinition } from './realtime-model-v4-tool-definition';

--- a/packages/provider/src/realtime-model/v4/realtime-factory-v4.ts
+++ b/packages/provider/src/realtime-model/v4/realtime-factory-v4.ts
@@ -1,0 +1,20 @@
+import type { RealtimeModelV4 } from './realtime-model-v4';
+import type { RealtimeModelV4ClientSecretOptions } from './realtime-model-v4-client-secret';
+
+export type RealtimeFactoryV4GetTokenOptions = {
+  model: string;
+} & RealtimeModelV4ClientSecretOptions;
+
+export type RealtimeFactoryV4GetTokenResult = {
+  token: string;
+  url: string;
+  expiresAt?: number;
+};
+
+export interface RealtimeFactoryV4 {
+  (modelId: string): RealtimeModelV4;
+
+  getToken(
+    options: RealtimeFactoryV4GetTokenOptions,
+  ): Promise<RealtimeFactoryV4GetTokenResult>;
+}

--- a/packages/provider/src/realtime-model/v4/realtime-model-v4-client-event.ts
+++ b/packages/provider/src/realtime-model/v4/realtime-model-v4-client-event.ts
@@ -1,0 +1,68 @@
+import type { RealtimeModelV4ConversationItem } from './realtime-model-v4-conversation-item';
+import type { RealtimeModelV4SessionConfig } from './realtime-model-v4-session-config';
+
+/**
+ * Normalized events sent from the browser to the realtime model.
+ * Each provider maps this to its native event format before sending
+ * over the WebSocket.
+ */
+export type RealtimeModelV4ClientEvent =
+  // ── Session ────────────────────────────────────────────────────────
+
+  | {
+      type: 'session-update';
+      config: RealtimeModelV4SessionConfig;
+    }
+
+  // ── Input audio buffer ─────────────────────────────────────────────
+  | {
+      type: 'input-audio-append';
+
+      /**
+       * Base64-encoded audio chunk to append to the input buffer.
+       */
+      audio: string;
+    }
+  | {
+      type: 'input-audio-commit';
+    }
+  | {
+      type: 'input-audio-clear';
+    }
+
+  // ── Conversation items ─────────────────────────────────────────────
+  | {
+      type: 'conversation-item-create';
+      item: RealtimeModelV4ConversationItem;
+    }
+  | {
+      type: 'conversation-item-truncate';
+
+      /**
+       * The ID of the assistant message item to truncate.
+       */
+      itemId: string;
+
+      /**
+       * The index of the content part to truncate.
+       */
+      contentIndex: number;
+
+      /**
+       * Truncate audio after this many milliseconds.
+       */
+      audioEndMs: number;
+    }
+
+  // ── Response control ───────────────────────────────────────────────
+  | {
+      type: 'response-create';
+      options?: {
+        modalities?: string[];
+        instructions?: string;
+        metadata?: Record<string, unknown>;
+      };
+    }
+  | {
+      type: 'response-cancel';
+    };

--- a/packages/provider/src/realtime-model/v4/realtime-model-v4-client-secret.ts
+++ b/packages/provider/src/realtime-model/v4/realtime-model-v4-client-secret.ts
@@ -1,0 +1,40 @@
+import type { RealtimeModelV4SessionConfig } from './realtime-model-v4-session-config';
+
+/**
+ * Options for creating an ephemeral client secret for browser-side
+ * WebSocket connections to a realtime model.
+ */
+export type RealtimeModelV4ClientSecretOptions = {
+  /**
+   * Number of seconds until the client secret expires.
+   */
+  expiresAfterSeconds?: number;
+
+  /**
+   * Optional session configuration to embed in the token request.
+   * Some providers (e.g. Google) require the full session config at token creation time.
+   */
+  sessionConfig?: RealtimeModelV4SessionConfig;
+};
+
+/**
+ * Result of creating an ephemeral client secret.
+ */
+export type RealtimeModelV4ClientSecretResult = {
+  /**
+   * The ephemeral token value. Used as a Bearer token or in the
+   * WebSocket subprotocol header for authentication.
+   */
+  token: string;
+
+  /**
+   * The WebSocket URL to connect to. Includes any provider-specific
+   * query parameters (e.g. model ID).
+   */
+  url: string;
+
+  /**
+   * Unix timestamp (seconds) when this client secret expires.
+   */
+  expiresAt?: number;
+};

--- a/packages/provider/src/realtime-model/v4/realtime-model-v4-conversation-item.ts
+++ b/packages/provider/src/realtime-model/v4/realtime-model-v4-conversation-item.ts
@@ -1,0 +1,55 @@
+/**
+ * A conversation item that can be created by the client and sent to
+ * the model via the conversation.item.create event.
+ */
+export type RealtimeModelV4ConversationItem =
+  | RealtimeModelV4TextMessage
+  | RealtimeModelV4AudioMessage
+  | RealtimeModelV4FunctionCallOutput;
+
+/**
+ * A text message from the user.
+ */
+export type RealtimeModelV4TextMessage = {
+  type: 'text-message';
+  role: 'user';
+  text: string;
+};
+
+/**
+ * An audio message from the user (complete audio, not streamed).
+ */
+export type RealtimeModelV4AudioMessage = {
+  type: 'audio-message';
+  role: 'user';
+
+  /**
+   * Base64-encoded audio data.
+   */
+  audio: string;
+};
+
+/**
+ * The output of a function call, sent back to the model so it can
+ * continue generating a response using the tool result.
+ */
+export type RealtimeModelV4FunctionCallOutput = {
+  type: 'function-call-output';
+
+  /**
+   * The call ID from the function-call-arguments-done event.
+   * Must match so the model knows which function call this result is for.
+   */
+  callId: string;
+
+  /**
+   * The name of the function that was called.
+   * Required by some providers (e.g. Google) in the tool response routing.
+   */
+  name?: string;
+
+  /**
+   * JSON string containing the function call result.
+   */
+  output: string;
+};

--- a/packages/provider/src/realtime-model/v4/realtime-model-v4-server-event.ts
+++ b/packages/provider/src/realtime-model/v4/realtime-model-v4-server-event.ts
@@ -1,0 +1,199 @@
+/**
+ * Normalized events emitted by the realtime model (model → browser).
+ * Each provider maps its native event format to this discriminated union.
+ *
+ * Every event includes a `raw` field with the original provider-specific
+ * event data for debugging and provider-specific access.
+ */
+export type RealtimeModelV4ServerEvent =
+  // ── Session lifecycle ──────────────────────────────────────────────
+
+  | {
+      type: 'session-created';
+      sessionId?: string;
+      raw: unknown;
+    }
+  | {
+      type: 'session-updated';
+      raw: unknown;
+    }
+
+  // ── Input audio buffer ─────────────────────────────────────────────
+  | {
+      type: 'speech-started';
+      itemId?: string;
+      raw: unknown;
+    }
+  | {
+      type: 'speech-stopped';
+      itemId?: string;
+      raw: unknown;
+    }
+  | {
+      type: 'audio-committed';
+      itemId?: string;
+      previousItemId?: string;
+      raw: unknown;
+    }
+
+  // ── Conversation items ─────────────────────────────────────────────
+  | {
+      type: 'conversation-item-added';
+      itemId: string;
+      item: unknown;
+      raw: unknown;
+    }
+  | {
+      type: 'input-transcription-completed';
+      itemId: string;
+      transcript: string;
+      raw: unknown;
+    }
+
+  // ── Response lifecycle ─────────────────────────────────────────────
+  | {
+      type: 'response-created';
+      responseId: string;
+      raw: unknown;
+    }
+  | {
+      type: 'response-done';
+      responseId: string;
+      status: string;
+      raw: unknown;
+    }
+
+  // ── Output item lifecycle ──────────────────────────────────────────
+  | {
+      type: 'output-item-added';
+      responseId: string;
+      itemId: string;
+      raw: unknown;
+    }
+  | {
+      type: 'output-item-done';
+      responseId: string;
+      itemId: string;
+      raw: unknown;
+    }
+  | {
+      type: 'content-part-added';
+      responseId: string;
+      itemId: string;
+      raw: unknown;
+    }
+  | {
+      type: 'content-part-done';
+      responseId: string;
+      itemId: string;
+      raw: unknown;
+    }
+
+  // ── Audio output ───────────────────────────────────────────────────
+  | {
+      type: 'audio-delta';
+      responseId: string;
+      itemId: string;
+
+      /**
+       * Base64-encoded audio chunk.
+       */
+      delta: string;
+      raw: unknown;
+    }
+  | {
+      type: 'audio-done';
+      responseId: string;
+      itemId: string;
+      raw: unknown;
+    }
+
+  // ── Audio transcript output ────────────────────────────────────────
+  | {
+      type: 'audio-transcript-delta';
+      responseId: string;
+      itemId: string;
+
+      /**
+       * Text chunk of the audio transcript.
+       */
+      delta: string;
+      raw: unknown;
+    }
+  | {
+      type: 'audio-transcript-done';
+      responseId: string;
+      itemId: string;
+      transcript?: string;
+      raw: unknown;
+    }
+
+  // ── Text output ────────────────────────────────────────────────────
+  | {
+      type: 'text-delta';
+      responseId: string;
+      itemId: string;
+
+      /**
+       * Text chunk of the model's text response.
+       */
+      delta: string;
+      raw: unknown;
+    }
+  | {
+      type: 'text-done';
+      responseId: string;
+      itemId: string;
+      text?: string;
+      raw: unknown;
+    }
+
+  // ── Function calling ───────────────────────────────────────────────
+  | {
+      type: 'function-call-arguments-delta';
+      responseId: string;
+      itemId: string;
+      callId: string;
+
+      /**
+       * Partial JSON string of function call arguments.
+       */
+      delta: string;
+      raw: unknown;
+    }
+  | {
+      type: 'function-call-arguments-done';
+      responseId: string;
+      itemId: string;
+      callId: string;
+
+      /**
+       * The name of the function to call.
+       */
+      name: string;
+
+      /**
+       * Complete JSON string of function call arguments.
+       */
+      arguments: string;
+      raw: unknown;
+    }
+
+  // ── Error ──────────────────────────────────────────────────────────
+  | {
+      type: 'error';
+      message: string;
+      code?: string;
+      raw: unknown;
+    }
+
+  // ── Custom / provider-specific ────────────────────────────────────
+  | {
+      type: 'custom';
+
+      /**
+       * The original event type string from the provider.
+       */
+      rawType: string;
+      raw: unknown;
+    };

--- a/packages/provider/src/realtime-model/v4/realtime-model-v4-session-config.ts
+++ b/packages/provider/src/realtime-model/v4/realtime-model-v4-session-config.ts
@@ -1,0 +1,142 @@
+import type { RealtimeModelV4ToolDefinition } from './realtime-model-v4-tool-definition';
+
+/**
+ * Provider-neutral configuration for a realtime session.
+ * Each provider maps this to their specific session.update payload.
+ */
+export type RealtimeModelV4SessionConfig = {
+  /**
+   * System instructions for the model.
+   */
+  instructions?: string;
+
+  /**
+   * Voice to use for audio output.
+   */
+  voice?: string;
+
+  /**
+   * Which output modalities the model should produce.
+   */
+  outputModalities?: Array<'text' | 'audio'>;
+
+  /**
+   * Audio format configuration for input audio.
+   */
+  inputAudioFormat?: {
+    /**
+     * Audio format type (e.g. "audio/pcm", "audio/pcmu", "audio/pcma").
+     */
+    type: string;
+
+    /**
+     * Sample rate in Hz. Only applicable for PCM format.
+     */
+    rate?: number;
+  };
+
+  /**
+   * Input audio transcription configuration.
+   *
+   * When enabled, providers that support input transcription emit normalized
+   * `input-transcription-completed` events that can be rendered as user
+   * messages.
+   */
+  inputAudioTranscription?: {
+    /**
+     * Provider-specific transcription model.
+     */
+    model?: string;
+
+    /**
+     * Optional language hint for the input audio.
+     */
+    language?: string;
+
+    /**
+     * Optional prompt to guide transcription.
+     */
+    prompt?: string;
+  };
+
+  /**
+   * Output audio transcription configuration.
+   *
+   * When enabled, providers that support output transcription emit normalized
+   * `audio-transcript-delta` / `audio-transcript-done` events for the model's
+   * spoken response. Some providers transcribe output by default; setting this
+   * makes the behavior explicit rather than relying on that default.
+   */
+  outputAudioTranscription?: {
+    /**
+     * Provider-specific transcription model.
+     */
+    model?: string;
+
+    /**
+     * Optional language hint for the output audio.
+     */
+    language?: string;
+
+    /**
+     * Optional prompt to guide transcription.
+     */
+    prompt?: string;
+  };
+
+  /**
+   * Audio format configuration for output audio.
+   */
+  outputAudioFormat?: {
+    /**
+     * Audio format type (e.g. "audio/pcm", "audio/pcmu", "audio/pcma").
+     */
+    type: string;
+
+    /**
+     * Sample rate in Hz. Only applicable for PCM format.
+     */
+    rate?: number;
+  };
+
+  /**
+   * Voice activity detection configuration.
+   * Set to null or type 'disabled' to turn off VAD (push-to-talk mode).
+   */
+  turnDetection?: {
+    /**
+     * VAD mode. 'server-vad' for automatic detection,
+     * 'semantic-vad' for OpenAI's semantic detection,
+     * 'disabled' to turn off VAD.
+     */
+    type: 'server-vad' | 'semantic-vad' | 'disabled';
+
+    /**
+     * VAD activation threshold (0.0-1.0).
+     * Higher values require louder audio to trigger.
+     */
+    threshold?: number;
+
+    /**
+     * How long the user must be silent (in ms) before
+     * the server ends the turn.
+     */
+    silenceDurationMs?: number;
+
+    /**
+     * Amount of audio (in ms) to include before the
+     * detected start of speech.
+     */
+    prefixPaddingMs?: number;
+  } | null;
+
+  /**
+   * Tool definitions available to the model in this session.
+   */
+  tools?: RealtimeModelV4ToolDefinition[];
+
+  /**
+   * Provider-specific options that are passed through to the provider.
+   */
+  providerOptions?: Record<string, unknown>;
+};

--- a/packages/provider/src/realtime-model/v4/realtime-model-v4-tool-definition.ts
+++ b/packages/provider/src/realtime-model/v4/realtime-model-v4-tool-definition.ts
@@ -1,0 +1,28 @@
+import type { JSONSchema7 } from 'json-schema';
+
+/**
+ * A tool definition for realtime models. Sent as part of the session
+ * configuration so the model knows which functions it can call.
+ */
+export type RealtimeModelV4ToolDefinition = {
+  /**
+   * The type of the tool (always 'function').
+   */
+  type: 'function';
+
+  /**
+   * The name of the tool. Unique within the session.
+   */
+  name: string;
+
+  /**
+   * A description of what the tool does. The model uses this to decide
+   * whether to call the tool.
+   */
+  description?: string;
+
+  /**
+   * JSON Schema describing the parameters the tool expects.
+   */
+  parameters: JSONSchema7;
+};

--- a/packages/provider/src/realtime-model/v4/realtime-model-v4.ts
+++ b/packages/provider/src/realtime-model/v4/realtime-model-v4.ts
@@ -1,0 +1,89 @@
+import type {
+  RealtimeModelV4ClientSecretOptions,
+  RealtimeModelV4ClientSecretResult,
+} from './realtime-model-v4-client-secret';
+import type { RealtimeModelV4ClientEvent } from './realtime-model-v4-client-event';
+import type { RealtimeModelV4ServerEvent } from './realtime-model-v4-server-event';
+import type { RealtimeModelV4SessionConfig } from './realtime-model-v4-session-config';
+
+/**
+ * Specification for a realtime model that supports bidirectional
+ * audio/text communication over WebSocket.
+ *
+ * Providers implement this interface to enable realtime voice
+ * conversations through the AI SDK.
+ */
+export type RealtimeModelV4 = {
+  /**
+   * The realtime model must specify which interface version it implements.
+   */
+  readonly specificationVersion: 'v4';
+
+  /**
+   * Provider ID (e.g. 'openai', 'xai').
+   */
+  readonly provider: string;
+
+  /**
+   * Provider-specific model ID (e.g. 'gpt-4o-realtime', 'grok-3').
+   */
+  readonly modelId: string;
+
+  /**
+   * Server-side: Creates an ephemeral client secret for authenticating
+   * browser-side WebSocket connections. The secret is short-lived and
+   * safe to expose to client code.
+   *
+   * Naming: "do" prefix to prevent accidental direct usage by the user.
+   */
+  doCreateClientSecret(
+    options: RealtimeModelV4ClientSecretOptions,
+  ): PromiseLike<RealtimeModelV4ClientSecretResult>;
+
+  /**
+   * Browser-side: Returns the WebSocket URL and subprotocols to use
+   * when connecting. Each provider has its own authentication mechanism
+   * (e.g. OpenAI uses subprotocol headers, xAI may use query params).
+   */
+  getWebSocketConfig(options: { token: string; url: string }): {
+    url: string;
+    protocols?: string[];
+  };
+
+  /**
+   * Browser-side: Parses a raw JSON event received over the WebSocket
+   * and returns one or more normalized events. Providers map their native
+   * event format to the common RealtimeModelV4ServerEvent union.
+   *
+   * Returns an array when a single provider message maps to multiple
+   * normalized events (e.g. Google's serverContent can contain audio,
+   * text, and turn-complete data in one message).
+   */
+  parseServerEvent(
+    raw: unknown,
+  ): RealtimeModelV4ServerEvent | RealtimeModelV4ServerEvent[];
+
+  /**
+   * Browser-side: Serializes a normalized client event into the
+   * provider's native JSON format for sending over the WebSocket.
+   */
+  serializeClientEvent(
+    event: RealtimeModelV4ClientEvent,
+  ): unknown | PromiseLike<unknown>;
+
+  /**
+   * Browser-side: Builds the provider-specific session configuration
+   * payload from a normalized session config. Used to construct the
+   * session.update event sent after WebSocket connection.
+   */
+  buildSessionConfig(config: RealtimeModelV4SessionConfig): unknown;
+
+  /**
+   * Browser-side: Returns a message to auto-send back over the WebSocket
+   * in response to a raw incoming message, or null if no response is needed.
+   *
+   * Used for provider-specific keepalive protocols (e.g. ping/pong).
+   * Called by the session layer before parseServerEvent.
+   */
+  getHealthCheckResponse?(raw: unknown): unknown | null;
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,4 +2,5 @@ export * from './use-chat';
 export { Chat } from './chat.react';
 export * from './use-completion';
 export * from './use-object';
+export * from './use-realtime';
 export * from './mcp-apps';

--- a/packages/react/src/use-realtime.test.tsx
+++ b/packages/react/src/use-realtime.test.tsx
@@ -1,0 +1,117 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { realtimeInstances } = vi.hoisted(() => ({
+  realtimeInstances: [] as Array<{
+    options: {
+      api: { token: string };
+      onError?: (error: Error) => void;
+    };
+    dispose: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock('ai', () => ({
+  Experimental_AbstractRealtimeSession: class {
+    protected state = {
+      status: 'disconnected',
+      messages: [],
+      events: [],
+      isCapturing: false,
+      isPlaying: false,
+    };
+    protected maxEvents = 500;
+
+    readonly options: {
+      api: { token: string };
+      onError?: (error: Error) => void;
+    };
+    dispose = vi.fn();
+
+    constructor(options: {
+      api: { token: string };
+      maxEvents?: number;
+      onError?: (error: Error) => void;
+    }) {
+      this.options = options;
+      this.maxEvents = options.maxEvents ?? 500;
+      realtimeInstances.push(this);
+    }
+
+    connect = vi.fn(async () => {});
+    disconnect = vi.fn();
+    addToolOutput = vi.fn();
+    sendEvent = vi.fn();
+    sendTextMessage = vi.fn();
+    sendAudio = vi.fn();
+    commitAudio = vi.fn();
+    clearAudioBuffer = vi.fn();
+    requestResponse = vi.fn();
+    cancelResponse = vi.fn();
+    startAudioCapture = vi.fn();
+    stopAudioCapture = vi.fn();
+    stopPlayback = vi.fn();
+  },
+}));
+
+const { experimental_useRealtime } = await import('./use-realtime');
+
+const testModel = {} as never;
+
+function TestComponent({
+  token,
+  onError,
+}: {
+  token: string;
+  onError?: (error: Error) => void;
+}) {
+  experimental_useRealtime({
+    model: testModel,
+    api: { token },
+    onError,
+  });
+
+  return null;
+}
+
+describe('experimental_useRealtime', () => {
+  afterEach(() => {
+    cleanup();
+    realtimeInstances.length = 0;
+  });
+
+  it('keeps the session when only callbacks change', () => {
+    const firstOnError = vi.fn();
+    const secondOnError = vi.fn();
+
+    const { rerender } = render(
+      <TestComponent token="/api/realtime/setup" onError={firstOnError} />,
+    );
+
+    rerender(
+      <TestComponent token="/api/realtime/setup" onError={secondOnError} />,
+    );
+
+    expect(realtimeInstances).toHaveLength(1);
+
+    realtimeInstances[0].options.onError?.(new Error('test'));
+
+    expect(firstOnError).not.toHaveBeenCalled();
+    expect(secondOnError).toHaveBeenCalledOnce();
+  });
+
+  it('replaces the session when the token endpoint changes', () => {
+    const { rerender } = render(
+      <TestComponent token="/api/realtime/setup-a" />,
+    );
+    const firstInstance = realtimeInstances[0];
+
+    rerender(<TestComponent token="/api/realtime/setup-b" />);
+
+    expect(realtimeInstances).toHaveLength(2);
+    expect(realtimeInstances[1].options.api.token).toBe(
+      '/api/realtime/setup-b',
+    );
+    expect(firstInstance.dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react/src/use-realtime.ts
+++ b/packages/react/src/use-realtime.ts
@@ -1,0 +1,252 @@
+import {
+  Experimental_AbstractRealtimeSession as AbstractRealtimeSession,
+  type Experimental_RealtimeServerEvent as RealtimeServerEvent,
+  type Experimental_RealtimeSessionOptions as RealtimeSessionOptions,
+  type Experimental_RealtimeState as RealtimeState,
+  type Experimental_RealtimeStatus as RealtimeStatus,
+  type UIMessage,
+} from 'ai';
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
+
+type UseRealtimeOptions = RealtimeSessionOptions;
+
+type RealtimeStateKey = keyof RealtimeState;
+type RealtimeStoreKey = {
+  model: RealtimeSessionOptions['model'];
+  token: RealtimeSessionOptions['api']['token'];
+  sessionConfig: RealtimeSessionOptions['sessionConfig'];
+  sampleRate: RealtimeSessionOptions['sampleRate'];
+  maxEvents: RealtimeSessionOptions['maxEvents'];
+};
+
+function getRealtimeStoreKey(options: UseRealtimeOptions): RealtimeStoreKey {
+  return {
+    model: options.model,
+    token: options.api.token,
+    sessionConfig: options.sessionConfig,
+    sampleRate: options.sampleRate,
+    maxEvents: options.maxEvents,
+  };
+}
+
+function shouldCreateRealtimeStore(
+  currentKey: RealtimeStoreKey,
+  nextOptions: UseRealtimeOptions,
+): boolean {
+  return (
+    currentKey.model !== nextOptions.model ||
+    currentKey.token !== nextOptions.api.token ||
+    currentKey.sessionConfig !== nextOptions.sessionConfig ||
+    currentKey.sampleRate !== nextOptions.sampleRate ||
+    currentKey.maxEvents !== nextOptions.maxEvents
+  );
+}
+
+class RealtimeStore extends AbstractRealtimeSession {
+  protected state: RealtimeState = {
+    status: 'disconnected',
+    messages: [],
+    events: [],
+    isCapturing: false,
+    isPlaying: false,
+  };
+
+  private callbacks: { [K in RealtimeStateKey]: Set<() => void> } = {
+    status: new Set(),
+    messages: new Set(),
+    events: new Set(),
+    isCapturing: new Set(),
+    isPlaying: new Set(),
+  };
+
+  get status(): RealtimeStatus {
+    return this.state.status;
+  }
+
+  get messages(): UIMessage[] {
+    return this.state.messages;
+  }
+
+  get events(): RealtimeServerEvent[] {
+    return this.state.events;
+  }
+
+  get isCapturing(): boolean {
+    return this.state.isCapturing;
+  }
+
+  get isPlaying(): boolean {
+    return this.state.isPlaying;
+  }
+
+  subscribe(key: RealtimeStateKey, onChange: () => void): () => void {
+    this.callbacks[key].add(onChange);
+
+    return () => {
+      this.callbacks[key].delete(onChange);
+    };
+  }
+
+  protected setState<K extends RealtimeStateKey>(
+    key: K,
+    value: RealtimeState[K],
+  ): void {
+    this.state = { ...this.state, [key]: value };
+    this.callbacks[key].forEach(callback => callback());
+  }
+
+  protected pushMessage(message: UIMessage): void {
+    this.state = {
+      ...this.state,
+      messages: [...this.state.messages, message],
+    };
+    this.callbacks.messages.forEach(callback => callback());
+  }
+
+  protected updateMessages(
+    updater: (messages: UIMessage[]) => UIMessage[],
+  ): void {
+    this.state = {
+      ...this.state,
+      messages: updater(this.state.messages),
+    };
+    this.callbacks.messages.forEach(callback => callback());
+  }
+
+  protected pushEvent(event: RealtimeServerEvent): void {
+    const nextEvents = [...this.state.events, event];
+    this.state = {
+      ...this.state,
+      events:
+        nextEvents.length > this.maxEvents
+          ? nextEvents.slice(-this.maxEvents)
+          : nextEvents,
+    };
+    this.callbacks.events.forEach(callback => callback());
+  }
+}
+
+type UseRealtimeReturn = {
+  status: RealtimeStatus;
+  messages: UIMessage[];
+  events: RealtimeServerEvent[];
+  isCapturing: boolean;
+  isPlaying: boolean;
+
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  addToolOutput: (callId: string, result: unknown) => void;
+  sendEvent: RealtimeStore['sendEvent'];
+  sendTextMessage: (text: string) => void;
+  sendAudio: (base64Audio: string) => void;
+  commitAudio: () => void;
+  clearAudioBuffer: () => void;
+  requestResponse: (options?: { modalities?: string[] }) => void;
+  cancelResponse: () => void;
+  startAudioCapture: (stream: MediaStream) => void;
+  stopAudioCapture: () => void;
+  stopPlayback: () => void;
+};
+
+function useRealtime(options: UseRealtimeOptions): UseRealtimeReturn {
+  const callbacksRef = useRef({
+    onToolCall: options.onToolCall,
+    onEvent: options.onEvent,
+    onError: options.onError,
+  });
+  callbacksRef.current = {
+    onToolCall: options.onToolCall,
+    onEvent: options.onEvent,
+    onError: options.onError,
+  };
+
+  const realtimeRef = useRef<{
+    store: RealtimeStore;
+    key: RealtimeStoreKey;
+  } | null>(null);
+
+  let realtimeEntry = realtimeRef.current;
+
+  if (
+    realtimeEntry == null ||
+    shouldCreateRealtimeStore(realtimeEntry.key, options)
+  ) {
+    realtimeEntry = {
+      store: new RealtimeStore({
+        ...options,
+        onToolCall: (...args) => callbacksRef.current.onToolCall?.(...args),
+        onEvent: (...args) => callbacksRef.current.onEvent?.(...args),
+        onError: (...args) => callbacksRef.current.onError?.(...args),
+      }),
+      key: getRealtimeStoreKey(options),
+    };
+    realtimeRef.current = realtimeEntry;
+  } else {
+    realtimeEntry.key = getRealtimeStoreKey(options);
+  }
+
+  const rt = realtimeEntry.store;
+
+  const status = useSyncExternalStore(
+    useCallback(cb => rt.subscribe('status', cb), [rt]),
+    () => rt.status,
+    () => rt.status,
+  );
+
+  const messages = useSyncExternalStore(
+    useCallback(cb => rt.subscribe('messages', cb), [rt]),
+    () => rt.messages,
+    () => rt.messages,
+  );
+
+  const events = useSyncExternalStore(
+    useCallback(cb => rt.subscribe('events', cb), [rt]),
+    () => rt.events,
+    () => rt.events,
+  );
+
+  const isCapturing = useSyncExternalStore(
+    useCallback(cb => rt.subscribe('isCapturing', cb), [rt]),
+    () => rt.isCapturing,
+    () => rt.isCapturing,
+  );
+
+  const isPlaying = useSyncExternalStore(
+    useCallback(cb => rt.subscribe('isPlaying', cb), [rt]),
+    () => rt.isPlaying,
+    () => rt.isPlaying,
+  );
+
+  useEffect(() => {
+    return () => rt.dispose();
+  }, [rt]);
+
+  return {
+    status,
+    messages,
+    events,
+    isCapturing,
+    isPlaying,
+    connect: rt.connect.bind(rt),
+    disconnect: rt.disconnect.bind(rt),
+    addToolOutput: rt.addToolOutput.bind(rt),
+    sendEvent: rt.sendEvent.bind(rt),
+    sendTextMessage: rt.sendTextMessage.bind(rt),
+    sendAudio: rt.sendAudio.bind(rt),
+    commitAudio: rt.commitAudio.bind(rt),
+    clearAudioBuffer: rt.clearAudioBuffer.bind(rt),
+    requestResponse: rt.requestResponse.bind(rt),
+    cancelResponse: rt.cancelResponse.bind(rt),
+    startAudioCapture: rt.startAudioCapture.bind(rt),
+    stopAudioCapture: rt.stopAudioCapture.bind(rt),
+    stopPlayback: rt.stopPlayback.bind(rt),
+  };
+}
+
+export const experimental_useRealtime = useRealtime;
+
+export type {
+  RealtimeStatus as Experimental_RealtimeStatus,
+  UseRealtimeOptions as Experimental_UseRealtimeOptions,
+  UseRealtimeReturn as Experimental_UseRealtimeReturn,
+};

--- a/packages/xai/src/index.ts
+++ b/packages/xai/src/index.ts
@@ -23,6 +23,8 @@ export type {
 export type { XaiFilesOptions } from './files/xai-files-options';
 export { createXai, xai } from './xai-provider';
 export type { XaiProvider, XaiProviderSettings } from './xai-provider';
+export { XaiRealtimeModel as Experimental_XaiRealtimeModel } from './realtime/xai-realtime-model';
+export type { XaiRealtimeModelConfig as Experimental_XaiRealtimeModelConfig } from './realtime/xai-realtime-model';
 export {
   codeExecution,
   mcpServer,

--- a/packages/xai/src/realtime/index.ts
+++ b/packages/xai/src/realtime/index.ts
@@ -1,0 +1,2 @@
+export { XaiRealtimeModel as Experimental_XaiRealtimeModel } from './xai-realtime-model';
+export type { XaiRealtimeModelConfig as Experimental_XaiRealtimeModelConfig } from './xai-realtime-model';

--- a/packages/xai/src/realtime/xai-realtime-event-mapper.ts
+++ b/packages/xai/src/realtime/xai-realtime-event-mapper.ts
@@ -1,0 +1,399 @@
+import type {
+  Experimental_RealtimeModelV4ClientEvent as RealtimeModelV4ClientEvent,
+  Experimental_RealtimeModelV4ServerEvent as RealtimeModelV4ServerEvent,
+  Experimental_RealtimeModelV4SessionConfig as RealtimeModelV4SessionConfig,
+} from '@ai-sdk/provider';
+
+type XaiRealtimeWireEvent = {
+  type: string;
+  session?: { id?: string };
+  item?: { id?: string } & Record<string, unknown>;
+  response?: { id?: string; status?: string };
+  error?: { message?: string; code?: string };
+  item_id: string;
+  previous_item_id?: string;
+  response_id: string;
+  transcript?: string;
+  delta: string;
+  text?: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+  message?: string;
+  code?: string;
+};
+
+export function parseXaiRealtimeServerEvent(
+  raw: unknown,
+): RealtimeModelV4ServerEvent {
+  const event = raw as XaiRealtimeWireEvent;
+  const type = event.type;
+
+  switch (type) {
+    case 'session.created':
+      return {
+        type: 'session-created',
+        sessionId: event.session?.id,
+        raw,
+      };
+
+    case 'session.updated':
+      return { type: 'session-updated', raw };
+
+    case 'conversation.created':
+      return { type: 'custom', rawType: type, raw };
+
+    case 'input_audio_buffer.speech_started':
+      return {
+        type: 'speech-started',
+        itemId: event.item_id,
+        raw,
+      };
+
+    case 'input_audio_buffer.speech_stopped':
+      return {
+        type: 'speech-stopped',
+        itemId: event.item_id,
+        raw,
+      };
+
+    case 'input_audio_buffer.committed':
+      return {
+        type: 'audio-committed',
+        itemId: event.item_id,
+        previousItemId: event.previous_item_id,
+        raw,
+      };
+
+    case 'conversation.item.added':
+      return {
+        type: 'conversation-item-added',
+        itemId: event.item?.id ?? event.item_id,
+        item: event.item,
+        raw,
+      };
+
+    case 'conversation.item.input_audio_transcription.completed':
+      return {
+        type: 'input-transcription-completed',
+        itemId: event.item_id,
+        transcript: event.transcript ?? '',
+        raw,
+      };
+
+    case 'response.created':
+      return {
+        type: 'response-created',
+        responseId: event.response?.id ?? event.response_id,
+        raw,
+      };
+
+    case 'response.done':
+      return {
+        type: 'response-done',
+        responseId: event.response?.id ?? event.response_id,
+        status: event.response?.status ?? 'completed',
+        raw,
+      };
+
+    case 'response.output_item.added':
+      return {
+        type: 'output-item-added',
+        responseId: event.response_id,
+        itemId: event.item?.id ?? event.item_id,
+        raw,
+      };
+
+    case 'response.output_item.done':
+      return {
+        type: 'output-item-done',
+        responseId: event.response_id,
+        itemId: event.item?.id ?? event.item_id,
+        raw,
+      };
+
+    case 'response.content_part.added':
+      return {
+        type: 'content-part-added',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        raw,
+      };
+
+    case 'response.content_part.done':
+      return {
+        type: 'content-part-done',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        raw,
+      };
+
+    case 'response.output_audio.delta':
+      return {
+        type: 'audio-delta',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        delta: event.delta,
+        raw,
+      };
+
+    case 'response.output_audio.done':
+      return {
+        type: 'audio-done',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        raw,
+      };
+
+    case 'response.output_audio_transcript.delta':
+      return {
+        type: 'audio-transcript-delta',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        delta: event.delta,
+        raw,
+      };
+
+    case 'response.output_audio_transcript.done':
+      return {
+        type: 'audio-transcript-done',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        transcript: event.transcript,
+        raw,
+      };
+
+    case 'response.text.delta':
+      return {
+        type: 'text-delta',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        delta: event.delta,
+        raw,
+      };
+
+    case 'response.text.done':
+      return {
+        type: 'text-done',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        text: event.text,
+        raw,
+      };
+
+    case 'response.function_call_arguments.delta':
+      return {
+        type: 'function-call-arguments-delta',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        callId: event.call_id,
+        delta: event.delta,
+        raw,
+      };
+
+    case 'response.function_call_arguments.done':
+      return {
+        type: 'function-call-arguments-done',
+        responseId: event.response_id,
+        itemId: event.item_id,
+        callId: event.call_id,
+        name: event.name,
+        arguments: event.arguments,
+        raw,
+      };
+
+    case 'mcp_list_tools.in_progress':
+    case 'mcp_list_tools.completed':
+    case 'mcp_list_tools.failed':
+    case 'response.mcp_call_arguments.delta':
+    case 'response.mcp_call_arguments.done':
+    case 'response.mcp_call.in_progress':
+    case 'response.mcp_call.completed':
+    case 'response.mcp_call.failed':
+      return { type: 'custom', rawType: type, raw };
+
+    case 'error':
+      return {
+        type: 'error',
+        message: event.error?.message ?? event.message ?? 'Unknown error',
+        code: event.error?.code ?? event.code,
+        raw,
+      };
+
+    default:
+      return { type: 'custom', rawType: type, raw };
+  }
+}
+
+export function serializeXaiRealtimeClientEvent(
+  event: RealtimeModelV4ClientEvent,
+): unknown {
+  switch (event.type) {
+    case 'session-update':
+      return {
+        type: 'session.update',
+        session: buildXaiSessionConfig(event.config),
+      };
+
+    case 'input-audio-append':
+      return {
+        type: 'input_audio_buffer.append',
+        audio: event.audio,
+      };
+
+    case 'input-audio-commit':
+      return { type: 'input_audio_buffer.commit' };
+
+    case 'input-audio-clear':
+      return { type: 'input_audio_buffer.clear' };
+
+    case 'conversation-item-create': {
+      const item = event.item;
+      switch (item.type) {
+        case 'text-message':
+          return {
+            type: 'conversation.item.create',
+            item: {
+              type: 'message',
+              role: item.role,
+              content: [{ type: 'input_text', text: item.text }],
+            },
+          };
+        case 'audio-message':
+          return {
+            type: 'conversation.item.create',
+            item: {
+              type: 'message',
+              role: item.role,
+              content: [{ type: 'input_audio', audio: item.audio }],
+            },
+          };
+        case 'function-call-output':
+          return {
+            type: 'conversation.item.create',
+            item: {
+              type: 'function_call_output',
+              call_id: item.callId,
+              output: item.output,
+            },
+          };
+      }
+      break;
+    }
+
+    case 'conversation-item-truncate':
+      // xAI does not support `conversation.item.truncate` over WebSocket (it is
+      // silently ignored by the server). Barge-in still works because the SDK
+      // stops local playback when `speech_started` fires, so dropping the event
+      // here just avoids sending a no-op.
+      return undefined;
+
+    case 'response-create':
+      return {
+        type: 'response.create',
+        ...(event.options != null
+          ? {
+              response: {
+                ...(event.options.modalities != null
+                  ? { modalities: event.options.modalities }
+                  : {}),
+                ...(event.options.instructions != null
+                  ? { instructions: event.options.instructions }
+                  : {}),
+              },
+            }
+          : {}),
+      };
+
+    case 'response-cancel':
+      return { type: 'response.cancel' };
+  }
+}
+
+export function buildXaiSessionConfig(
+  config: RealtimeModelV4SessionConfig,
+): Record<string, unknown> {
+  const session: Record<string, unknown> = {};
+
+  if (config.instructions != null) {
+    session.instructions = config.instructions;
+  }
+
+  if (config.voice != null) {
+    session.voice = config.voice;
+  }
+
+  const audio: Record<string, unknown> = {};
+
+  if (config.inputAudioFormat != null) {
+    audio.input = {
+      format: {
+        type: config.inputAudioFormat.type,
+        ...(config.inputAudioFormat.rate != null
+          ? { rate: config.inputAudioFormat.rate }
+          : {}),
+      },
+    };
+  }
+
+  if (config.outputAudioFormat != null) {
+    audio.output = {
+      format: {
+        type: config.outputAudioFormat.type,
+        ...(config.outputAudioFormat.rate != null
+          ? { rate: config.outputAudioFormat.rate }
+          : {}),
+      },
+    };
+  }
+
+  if (Object.keys(audio).length > 0) {
+    session.audio = audio;
+  }
+
+  if (config.turnDetection != null) {
+    if (config.turnDetection.type === 'disabled') {
+      session.turn_detection = null;
+    } else {
+      const td: Record<string, unknown> = {
+        type: 'server_vad',
+      };
+      if (config.turnDetection.threshold != null) {
+        td.threshold = config.turnDetection.threshold;
+      }
+      if (config.turnDetection.silenceDurationMs != null) {
+        td.silence_duration_ms = config.turnDetection.silenceDurationMs;
+      }
+      if (config.turnDetection.prefixPaddingMs != null) {
+        td.prefix_padding_ms = config.turnDetection.prefixPaddingMs;
+      }
+      session.turn_detection = td;
+    }
+  }
+
+  if (config.tools != null && config.tools.length > 0) {
+    session.tools = config.tools.map(tool => ({
+      type: tool.type,
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    }));
+  }
+
+  if (config.providerOptions != null) {
+    const xaiOptions = config.providerOptions as Record<string, unknown>;
+
+    if (Array.isArray(xaiOptions.tools)) {
+      const existingTools = (session.tools as unknown[]) ?? [];
+      session.tools = [...existingTools, ...xaiOptions.tools];
+    }
+
+    for (const [key, value] of Object.entries(xaiOptions)) {
+      if (key !== 'tools') {
+        session[key] = value;
+      }
+    }
+  }
+
+  return session;
+}

--- a/packages/xai/src/realtime/xai-realtime-model-options.ts
+++ b/packages/xai/src/realtime/xai-realtime-model-options.ts
@@ -1,0 +1,3 @@
+export type XaiRealtimeModelId = string;
+
+export type XaiRealtimeModelOptions = Record<string, never>;

--- a/packages/xai/src/realtime/xai-realtime-model.test.ts
+++ b/packages/xai/src/realtime/xai-realtime-model.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { XaiRealtimeModel } from './xai-realtime-model';
+
+describe('XaiRealtimeModel', () => {
+  const createModel = (fetch?: typeof globalThis.fetch) =>
+    new XaiRealtimeModel('grok-voice-latest', {
+      provider: 'xai.realtime',
+      baseURL: 'https://api.x.ai/v1',
+      headers: () => ({ authorization: 'Bearer test-key' }),
+      fetch,
+    });
+
+  describe('doCreateClientSecret', () => {
+    it('includes the model as a query param on the WebSocket URL', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ value: 'secret', expires_at: 123 }),
+      });
+
+      const result = await createModel(
+        mockFetch as unknown as typeof fetch,
+      ).doCreateClientSecret({});
+
+      // xAI selects the voice model from the `model` query param; without it
+      // the model choice is silently ignored.
+      expect(result.url).toBe(
+        'wss://api.x.ai/v1/realtime?model=grok-voice-latest',
+      );
+    });
+  });
+
+  describe('serializeClientEvent', () => {
+    it('drops conversation-item-truncate (unsupported over WebSocket)', () => {
+      const result = createModel().serializeClientEvent({
+        type: 'conversation-item-truncate',
+        itemId: 'item-1',
+        contentIndex: 0,
+        audioEndMs: 100,
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/xai/src/realtime/xai-realtime-model.ts
+++ b/packages/xai/src/realtime/xai-realtime-model.ts
@@ -1,0 +1,101 @@
+import type {
+  Experimental_RealtimeModelV4 as RealtimeModelV4,
+  Experimental_RealtimeModelV4ClientEvent as RealtimeModelV4ClientEvent,
+  Experimental_RealtimeModelV4ClientSecretOptions as RealtimeModelV4ClientSecretOptions,
+  Experimental_RealtimeModelV4ClientSecretResult as RealtimeModelV4ClientSecretResult,
+  Experimental_RealtimeModelV4ServerEvent as RealtimeModelV4ServerEvent,
+  Experimental_RealtimeModelV4SessionConfig as RealtimeModelV4SessionConfig,
+} from '@ai-sdk/provider';
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+import {
+  buildXaiSessionConfig,
+  parseXaiRealtimeServerEvent,
+  serializeXaiRealtimeClientEvent,
+} from './xai-realtime-event-mapper';
+
+export type XaiRealtimeModelConfig = {
+  provider: string;
+  baseURL: string;
+  headers: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+};
+
+export class XaiRealtimeModel implements RealtimeModelV4 {
+  readonly specificationVersion = 'v4' as const;
+  readonly provider: string;
+  readonly modelId: string;
+
+  private readonly config: XaiRealtimeModelConfig;
+
+  constructor(modelId: string, config: XaiRealtimeModelConfig) {
+    this.modelId = modelId;
+    this.provider = config.provider;
+    this.config = config;
+  }
+
+  async doCreateClientSecret(
+    options: RealtimeModelV4ClientSecretOptions,
+  ): Promise<RealtimeModelV4ClientSecretResult> {
+    const fetchFn = this.config.fetch ?? fetch;
+    const url = `${this.config.baseURL}/realtime/client_secrets`;
+
+    const body: Record<string, unknown> = {};
+    if (options.expiresAfterSeconds != null) {
+      body.expires_after = { seconds: options.expiresAfterSeconds };
+    }
+
+    const response = await fetchFn(url, {
+      method: 'POST',
+      headers: {
+        ...this.config.headers(),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `xAI realtime client secret request failed: ${response.status} ${text}`,
+      );
+    }
+
+    const data = (await response.json()) as {
+      value: string;
+      expires_at?: number;
+    };
+
+    return {
+      token: data.value,
+      // xAI selects the voice model from the `model` query parameter on the
+      // WebSocket URL. Without it the model choice is silently ignored and the
+      // server falls back to its default voice model.
+      url: `wss://${new URL(this.config.baseURL).host}/v1/realtime?model=${encodeURIComponent(this.modelId)}`,
+      expiresAt: data.expires_at,
+    };
+  }
+
+  getWebSocketConfig(options: { token: string; url: string }): {
+    url: string;
+    protocols?: string[];
+  } {
+    return {
+      url: options.url,
+      protocols: [`xai-client-secret.${options.token}`],
+    };
+  }
+
+  parseServerEvent(raw: unknown): RealtimeModelV4ServerEvent {
+    return parseXaiRealtimeServerEvent(raw);
+  }
+
+  serializeClientEvent(event: RealtimeModelV4ClientEvent): unknown {
+    return serializeXaiRealtimeClientEvent(event);
+  }
+
+  buildSessionConfig(
+    config: RealtimeModelV4SessionConfig,
+  ): Record<string, unknown> {
+    return buildXaiSessionConfig(config);
+  }
+}

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -1,9 +1,11 @@
 import {
-  NoSuchModelError,
+  type Experimental_RealtimeFactoryV4 as RealtimeFactoryV4,
+  type Experimental_RealtimeFactoryV4GetTokenOptions as RealtimeFactoryV4GetTokenOptions,
   type Experimental_VideoModelV4,
   type FilesV4,
   type ImageModelV4,
   type LanguageModelV4,
+  NoSuchModelError,
   type ProviderV4,
 } from '@ai-sdk/provider';
 import {
@@ -19,6 +21,7 @@ import { XaiImageModel } from './xai-image-model';
 import type { XaiImageModelId } from './xai-image-settings';
 import { XaiResponsesLanguageModel } from './responses/xai-responses-language-model';
 import type { XaiResponsesModelId } from './responses/xai-responses-language-model-options';
+import { XaiRealtimeModel } from './realtime/xai-realtime-model';
 import { xaiTools } from './tool';
 import { VERSION } from './version';
 import { XaiFiles } from './files/xai-files';
@@ -62,6 +65,8 @@ export interface XaiProvider extends ProviderV4 {
    * Creates an Xai video model for video generation.
    */
   videoModel(modelId: XaiVideoModelId): Experimental_VideoModelV4;
+
+  experimental_realtime: RealtimeFactoryV4;
 
   /**
    * Returns the xAI files interface for uploading files.
@@ -157,6 +162,34 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
     });
   };
 
+  const createRealtimeModel = (modelId: string) => {
+    return new XaiRealtimeModel(modelId, {
+      provider: 'xai.realtime',
+      baseURL: baseURL ?? 'https://api.x.ai/v1',
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+  };
+
+  const experimentalRealtimeFactory = Object.assign(
+    (modelId: string) => createRealtimeModel(modelId),
+    {
+      getToken: async (tokenOptions: RealtimeFactoryV4GetTokenOptions) => {
+        const model = createRealtimeModel(tokenOptions.model);
+        const secret = await model.doCreateClientSecret({
+          sessionConfig: tokenOptions.sessionConfig,
+          expiresAfterSeconds: tokenOptions.expiresAfterSeconds,
+        });
+
+        return {
+          token: secret.token,
+          url: secret.url,
+          expiresAt: secret.expiresAt,
+        };
+      },
+    },
+  ) as RealtimeFactoryV4;
+
   const createFiles = () =>
     new XaiFiles({
       provider: 'xai.files',
@@ -180,6 +213,7 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
   provider.image = createImageModel;
   provider.videoModel = createVideoModel;
   provider.video = createVideoModel;
+  provider.experimental_realtime = experimentalRealtimeFactory;
   provider.files = createFiles;
   provider.tools = xaiTools;
 


### PR DESCRIPTION
## Background

Part of https://github.com/vercel/ai/issues/13897

Support for Realtime API has been requested for a long time. We want to support different architectures

1. Websocket connection from browser directly to provider
2. Websocket connection from browser through user's server to provider
3. Websocket connection from browser through gateway to provider
4. Websocket connection from browser through user's server and gateway to provider

This pull requests implements the first, see [Architecture](#architecture) below

## Summary

Alternative implementation of the Realtime API support proposed in #13889, with a reworked developer-facing API:

- **`openai.experimental_realtime('gpt-realtime')`** works in both server and browser (no separate `@ai-sdk/openai/realtime` import needed)
- **`openai.experimental_realtime.getToken()`** static method for server-side ephemeral token creation
- **`experimental_useRealtime`** hook returns `messages: UIMessage[]` (aligned with `useChat` format) instead of `transcript`
- **`inputAudioTranscription`** session config enables rendered user messages for transcribed microphone input
- **`addToolOutput(callId, result)`** for client-side tools that need manual result submission
- **`onToolCall`** callback for auto-executed client-side tools
- Framework-agnostic helper type: `Experimental_RealtimeSetupResponse`

Provider implementations included: **OpenAI**, **Google**, and **xAI**. ElevenLabs support is split into a stacked follow-up: **#15747**.

<a name="architecture"></a>

## Architecture

```mermaid
sequenceDiagram
  participant Browser
  participant Server
  participant Provider as AI Provider<br/>(OpenAI / xAI / Gemini / ...)

  Browser->>Server: POST /api/setup
  Server->>Provider: Request token (with tool definitions)
  Provider-->>Server: Short-lived auth token
  Server-->>Browser: { token }

  Browser->>Provider: Open WebSocket (using token)
  Provider-->>Browser: Audio/text chunks (streaming)
  Provider-->>Browser: Tool call request

  Browser->>Server: App-specific tool request (optional)
  Server-->>Browser: App-specific tool result

  Browser->>Provider: Send tool result via WebSocket
  Provider-->>Browser: Continue streaming
```

### Alternatives considered

#### Generic RPC route for server-side tools

One option was for the SDK to expose a generic server-side tool execution flow: the realtime session would receive a tool call, POST `{ name, inputs, callId }` to an `execute-tools` route, execute a matching server-side tool, and send the result back to the provider automatically.

We decided against that for the initial implementation. A generic RPC route is convenient, but it creates a security-sensitive application boundary: the app must authenticate the user, bind the request to a realtime session, allowlist tool names, validate call IDs, rate limit access, and authorize each tool invocation. If the SDK provides the generic route shape, it is easy to copy into production without those controls.

Instead, the SDK keeps tool execution client-driven through `onToolCall` and `addToolOutput`. Server-backed tools should call app-specific API endpoints from `onToolCall` (for example `/api/weather`), where the application can apply its normal auth, validation, authorization, and rate limiting rules. Documentation should cover secure server-backed tool calling patterns, but the SDK should not own the generic remote tool RPC abstraction yet.

## Manual verification

The realtime voice example added in this PR lives at `examples/ai-e2e-next/app/realtime/page.tsx` (UI) and `examples/ai-e2e-next/app/api/realtime/[...path]/route.ts` (server-side token endpoint).

1. Add the provider API key(s) for whichever provider(s) you want to test to `examples/ai-e2e-next/.env.local`:

   ```bash
   OPENAI_API_KEY=...                  # OpenAI realtime (gpt-realtime)
   GOOGLE_GENERATIVE_AI_API_KEY=...    # Google realtime (gemini-3.1-flash-live-preview)
   XAI_API_KEY=...                     # xAI realtime (grok-voice-latest)
   ```

2. Start the example:

   ```bash
   cd examples/ai-e2e-next
   pnpm dev
   ```

3. Open http://localhost:3000/realtime, pick a provider + voice, and click **Connect**. Use the microphone or type a message. Ask "what's the weather in Paris?" or "roll a dice" to exercise client-side tool calling (`onToolCall`).

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)
- [ ] Security Audit - esp. securing remote tool calling
- [ ] Update internal Architecture / how it works docs

### Future Work

1. **ElevenLabs** provider support — stacked follow-up in #15747
2. Websocket connection from browser through user's server to provider
3. Websocket connection from browser through gateway to provider
4. Websocket connection from browser through user's server and gateway to provider

## Related issues

- #3176
- #3907
- #4082
- #5007
- #9559
- #12381
- #13706
- #13889


