### PR TITLE
fix: prevent O(n) string copies in streamText partial output

### DIFF
--- a/packages/ai/src/generate-text/output.ts
+++ b/packages/ai/src/generate-text/output.ts
@@ -71,7 +71,7 @@ export const text = (): Output<string, string, never> => ({
   },
 
   async parsePartialOutput({ text }: { text: string }) {
-    return { partial: text };
+    return undefined;
   },
 
   createElementStreamTransform() {


### PR DESCRIPTION
## Summary
- Return `undefined` from `parsePartialOutput` in the default `text()` output instead of `{ partial: text2 }`
- This prevents `JSON.stringify` from being called on every streaming chunk, eliminating quadratic memory growth
- Partial output parsing is only meaningful for `Output.object()` calls, not plain text streaming

## Problem
The current implementation causes ~350MB heap growth per stream and OOM crashes at 3 concurrent streams on 4GB containers. See #13839 for detailed heap snapshots and production metrics.

## Test plan
- [ ] Verify streaming text output still works correctly
- [ ] Verify structured object output still receives partial updates  
- [ ] Memory profiling shows constant heap during text streaming

Fixes #13839