### PR TITLE
fix(amazon-bedrock): add tool search beta for Anthropic

### DIFF
--- a/.changeset/friendly-paws-think.md
+++ b/.changeset/friendly-paws-think.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+add tool search beta and strip unsupported beta

--- a/.changeset/friendly-paws-think.md
+++ b/.changeset/friendly-paws-think.md
@@ -2,4 +2,4 @@
 "@ai-sdk/amazon-bedrock": patch
 ---
 
-add tool search beta and strip unsupported beta
+add tool search beta for Anthropic

--- a/.changeset/friendly-paws-think.md
+++ b/.changeset/friendly-paws-think.md
@@ -2,4 +2,4 @@
 "@ai-sdk/amazon-bedrock": patch
 ---
 
-add tool search beta for Anthropic
+fix(provider/amazon-bedrock): add tool search beta for Anthropic

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-bm25.ts
@@ -1,5 +1,6 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
 import { generateText, tool, stepCountIs } from 'ai';
+import 'dotenv/config';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -10,7 +11,7 @@ run(async () => {
     stopWhen: stepCountIs(10),
     onStepFinish: step => {
       console.log(`\n=== Step Response ===`);
-      console.dir(step.response.messages, { depth: Infinity });
+      console.dir(step.response.body, { depth: Infinity });
     },
     tools: {
       toolSearch: bedrockAnthropic.tools.toolSearchBm25_20251119(),

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-bm25.ts
@@ -1,11 +1,11 @@
-import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
 import { generateText, tool, stepCountIs } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
     prompt: 'What is the weather in San Francisco?',
     stopWhen: stepCountIs(10),
     onStepFinish: step => {
@@ -13,7 +13,7 @@ run(async () => {
       console.dir(step.response.messages, { depth: Infinity });
     },
     tools: {
-      toolSearch: bedrock.tools.toolSearchBm25_20251119(),
+      toolSearch: bedrockAnthropic.tools.toolSearchBm25_20251119(),
 
       get_weather: tool({
         description: 'Get the current weather at a specific location',

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-bm25.ts
@@ -1,0 +1,77 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    prompt: 'What is the weather in San Francisco?',
+    stopWhen: stepCountIs(10),
+    onStepFinish: step => {
+      console.log(`\n=== Step Response ===`);
+      console.dir(step.response.messages, { depth: Infinity });
+    },
+    tools: {
+      toolSearch: bedrock.tools.toolSearchBm25_20251119(),
+
+      get_weather: tool({
+        description: 'Get the current weather at a specific location',
+        inputSchema: z.object({
+          location: z
+            .string()
+            .describe('The city and state, e.g. San Francisco, CA'),
+          unit: z
+            .enum(['celsius', 'fahrenheit'])
+            .optional()
+            .describe('Temperature unit'),
+        }),
+        execute: async ({ location, unit = 'fahrenheit' }) => ({
+          location,
+          temperature: unit === 'celsius' ? 18 : 64,
+          condition: 'Partly cloudy',
+          humidity: 65,
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+
+      search_files: tool({
+        description: 'Search through files in the workspace',
+        inputSchema: z.object({
+          query: z.string().describe('The search query'),
+          file_types: z
+            .array(z.string())
+            .optional()
+            .describe('Filter by file types'),
+        }),
+        execute: async ({ query }) => ({
+          results: [`Found 3 files matching "${query}"`],
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+
+      send_email: tool({
+        description: 'Send an email to a recipient',
+        inputSchema: z.object({
+          to: z.string().describe('Recipient email address'),
+          subject: z.string().describe('Email subject'),
+          body: z.string().describe('Email body content'),
+        }),
+        execute: async ({ to, subject }) => ({
+          success: true,
+          message: `Email sent to ${to} with subject: ${subject}`,
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+    },
+  });
+
+  console.log('\n=== Final Result ===');
+  console.log('Text:', result.text);
+});

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-regex.ts
@@ -1,5 +1,6 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
 import { generateText, tool, stepCountIs } from 'ai';
+import 'dotenv/config';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -10,7 +11,7 @@ run(async () => {
     stopWhen: stepCountIs(10),
     onStepFinish: step => {
       console.log(`\n=== Step Response ===`);
-      console.dir(step.response.messages, { depth: Infinity });
+      console.dir(step.response.body, { depth: Infinity });
     },
     tools: {
       toolSearch: bedrockAnthropic.tools.toolSearchRegex_20251119(),

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-regex.ts
@@ -1,11 +1,11 @@
-import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
 import { generateText, tool, stepCountIs } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
     prompt: 'Find out weather data in SF',
     stopWhen: stepCountIs(10),
     onStepFinish: step => {
@@ -13,7 +13,7 @@ run(async () => {
       console.dir(step.response.messages, { depth: Infinity });
     },
     tools: {
-      toolSearch: bedrock.tools.toolSearchRegex_20251119(),
+      toolSearch: bedrockAnthropic.tools.toolSearchRegex_20251119(),
 
       get_temp_data: tool({
         description: 'For a location',

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-regex.ts
@@ -1,0 +1,77 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    prompt: 'Find out weather data in SF',
+    stopWhen: stepCountIs(10),
+    onStepFinish: step => {
+      console.log(`\n=== Step Response ===`);
+      console.dir(step.response.messages, { depth: Infinity });
+    },
+    tools: {
+      toolSearch: bedrock.tools.toolSearchRegex_20251119(),
+
+      get_temp_data: tool({
+        description: 'For a location',
+        inputSchema: z.object({
+          location: z
+            .string()
+            .describe('The city and state, e.g. San Francisco, CA'),
+          unit: z
+            .enum(['celsius', 'fahrenheit'])
+            .optional()
+            .describe('Temperature unit'),
+        }),
+        execute: async ({ location, unit = 'fahrenheit' }) => ({
+          location,
+          temperature: unit === 'celsius' ? 18 : 64,
+          condition: 'Partly cloudy',
+          humidity: 65,
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+
+      search_files: tool({
+        description: 'Search through files in the workspace',
+        inputSchema: z.object({
+          query: z.string().describe('The search query'),
+          file_types: z
+            .array(z.string())
+            .optional()
+            .describe('Filter by file types'),
+        }),
+        execute: async ({ query }) => ({
+          results: [`Found 3 files matching "${query}"`],
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+
+      send_email: tool({
+        description: 'Send an email to a recipient',
+        inputSchema: z.object({
+          to: z.string().describe('Recipient email address'),
+          subject: z.string().describe('Email subject'),
+          body: z.string().describe('Email body content'),
+        }),
+        execute: async ({ to, subject }) => ({
+          success: true,
+          message: `Email sent to ${to} with subject: ${subject}`,
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+    },
+  });
+
+  console.log('\n=== Final Result ===');
+  console.log('Text:', result.text);
+});

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-bm25.ts
@@ -1,0 +1,101 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { streamText, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    prompt: 'What is the weather in San Francisco?',
+    stopWhen: stepCountIs(10),
+    tools: {
+      toolSearch: bedrock.tools.toolSearchBm25_20251119(),
+
+      get_weather: tool({
+        description: 'Get the current weather at a specific location',
+        inputSchema: z.object({
+          location: z
+            .string()
+            .describe('The city and state, e.g. San Francisco, CA'),
+          unit: z
+            .enum(['celsius', 'fahrenheit'])
+            .optional()
+            .describe('Temperature unit'),
+        }),
+        execute: async ({ location, unit = 'fahrenheit' }) => ({
+          location,
+          temperature: unit === 'celsius' ? 18 : 64,
+          condition: 'Partly cloudy',
+          humidity: 65,
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+
+      search_files: tool({
+        description: 'Search through files in the workspace',
+        inputSchema: z.object({
+          query: z.string().describe('The search query'),
+          file_types: z
+            .array(z.string())
+            .optional()
+            .describe('Filter by file types'),
+        }),
+        execute: async ({ query }) => ({
+          results: [`Found 3 files matching "${query}"`],
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+
+      send_email: tool({
+        description: 'Send an email to a recipient',
+        inputSchema: z.object({
+          to: z.string().describe('Recipient email address'),
+          subject: z.string().describe('Email subject'),
+          body: z.string().describe('Email body content'),
+        }),
+        execute: async ({ to, subject }) => ({
+          success: true,
+          message: `Email sent to ${to} with subject: ${subject}`,
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+    },
+  });
+
+  for await (const chunk of result.fullStream) {
+    switch (chunk.type) {
+      case 'text-delta': {
+        process.stdout.write(chunk.text);
+        break;
+      }
+
+      case 'tool-call': {
+        console.log(
+          `\n\x1b[32m\x1b[1mTool call:\x1b[22m ${chunk.toolName}\x1b[0m`,
+        );
+        console.log(JSON.stringify(chunk.input, null, 2));
+        break;
+      }
+
+      case 'tool-result': {
+        console.log(
+          `\x1b[32m\x1b[1mTool result:\x1b[22m ${chunk.toolName}\x1b[0m`,
+        );
+        console.log(JSON.stringify(chunk.output, null, 2));
+        break;
+      }
+
+      case 'error':
+        console.error('Error:', chunk.error);
+        break;
+    }
+  }
+
+  console.log('\n');
+});

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-bm25.ts
@@ -1,5 +1,6 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
 import { streamText, tool, stepCountIs } from 'ai';
+import 'dotenv/config';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-bm25.ts
@@ -1,15 +1,15 @@
-import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
 import { streamText, tool, stepCountIs } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
     prompt: 'What is the weather in San Francisco?',
     stopWhen: stepCountIs(10),
     tools: {
-      toolSearch: bedrock.tools.toolSearchBm25_20251119(),
+      toolSearch: bedrockAnthropic.tools.toolSearchBm25_20251119(),
 
       get_weather: tool({
         description: 'Get the current weather at a specific location',

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-regex.ts
@@ -1,0 +1,101 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { streamText, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    prompt: 'Find out weather data in SF',
+    stopWhen: stepCountIs(10),
+    tools: {
+      toolSearch: bedrock.tools.toolSearchRegex_20251119(),
+
+      get_temp_data: tool({
+        description: 'Get the current weather at a specific location',
+        inputSchema: z.object({
+          location: z
+            .string()
+            .describe('The city and state, e.g. San Francisco, CA'),
+          unit: z
+            .enum(['celsius', 'fahrenheit'])
+            .optional()
+            .describe('Temperature unit'),
+        }),
+        execute: async ({ location, unit = 'fahrenheit' }) => ({
+          location,
+          temperature: unit === 'celsius' ? 18 : 64,
+          condition: 'Partly cloudy',
+          humidity: 65,
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+
+      search_files: tool({
+        description: 'Search through files in the workspace',
+        inputSchema: z.object({
+          query: z.string().describe('The search query'),
+          file_types: z
+            .array(z.string())
+            .optional()
+            .describe('Filter by file types'),
+        }),
+        execute: async ({ query }) => ({
+          results: [`Found 3 files matching "${query}"`],
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+
+      send_email: tool({
+        description: 'Send an email to a recipient',
+        inputSchema: z.object({
+          to: z.string().describe('Recipient email address'),
+          subject: z.string().describe('Email subject'),
+          body: z.string().describe('Email body content'),
+        }),
+        execute: async ({ to, subject }) => ({
+          success: true,
+          message: `Email sent to ${to} with subject: ${subject}`,
+        }),
+        providerOptions: {
+          anthropic: { deferLoading: true },
+        },
+      }),
+    },
+  });
+
+  for await (const chunk of result.fullStream) {
+    switch (chunk.type) {
+      case 'text-delta': {
+        process.stdout.write(chunk.text);
+        break;
+      }
+
+      case 'tool-call': {
+        console.log(
+          `\n\x1b[32m\x1b[1mTool call:\x1b[22m ${chunk.toolName}\x1b[0m`,
+        );
+        console.log(JSON.stringify(chunk.input, null, 2));
+        break;
+      }
+
+      case 'tool-result': {
+        console.log(
+          `\x1b[32m\x1b[1mTool result:\x1b[22m ${chunk.toolName}\x1b[0m`,
+        );
+        console.log(JSON.stringify(chunk.output, null, 2));
+        break;
+      }
+
+      case 'error':
+        console.error('Error:', chunk.error);
+        break;
+    }
+  }
+
+  console.log('\n');
+});

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-regex.ts
@@ -1,15 +1,15 @@
-import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
 import { streamText, tool, stepCountIs } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: bedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
     prompt: 'Find out weather data in SF',
     stopWhen: stepCountIs(10),
     tools: {
-      toolSearch: bedrock.tools.toolSearchRegex_20251119(),
+      toolSearch: bedrockAnthropic.tools.toolSearchRegex_20251119(),
 
       get_temp_data: tool({
         description: 'Get the current weather at a specific location',

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-regex.ts
@@ -1,5 +1,6 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
 import { streamText, tool, stepCountIs } from 'ai';
+import 'dotenv/config';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -512,33 +512,6 @@ describe('bedrock-anthropic-provider', () => {
     );
   });
 
-  it('should strip unsupported betas and preserve supported ones', () => {
-    const provider = createBedrockAnthropic({
-      region: 'us-east-1',
-      accessKeyId: 'test-key',
-      secretAccessKey: 'test-secret',
-    });
-    provider('test-model-id');
-
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
-    const config = constructorCall[1];
-
-    const transformedBody = config.transformRequestBody?.(
-      {
-        model: 'test-model-id',
-        messages: [{ role: 'user', content: 'Hello' }],
-        max_tokens: 1024,
-      },
-      new Set(['advanced-tool-use-2025-11-20', 'some-other-beta']),
-    );
-
-    expect(transformedBody?.anthropic_beta).toContain('some-other-beta');
-    expect(transformedBody?.anthropic_beta).not.toContain(
-      'advanced-tool-use-2025-11-20',
-    );
-  });
-
   it('should handle models with us. prefix for inference profiles', () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -482,6 +482,63 @@ describe('bedrock-anthropic-provider', () => {
     expect(typeof provider.languageModel).toBe('function');
   });
 
+  it('should add tool-search-tool beta when tool search tools are present', () => {
+    const provider = createBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model-id');
+
+    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
+      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const config = constructorCall[1];
+
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tools: [
+          { type: 'tool_search_tool_regex_20251119', name: 'tool_search' },
+          { type: 'tool_search_tool_bm25_20251119', name: 'tool_search_bm25' },
+        ],
+      },
+      new Set(),
+    );
+
+    expect(transformedBody?.anthropic_beta).toContain(
+      'tool-search-tool-2025-10-19',
+    );
+  });
+
+  it('should strip unsupported betas and preserve supported ones', () => {
+    const provider = createBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model-id');
+
+    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
+      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const config = constructorCall[1];
+
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+      },
+      new Set(['advanced-tool-use-2025-11-20', 'some-other-beta']),
+    );
+
+    expect(transformedBody?.anthropic_beta).toContain('some-other-beta');
+    expect(transformedBody?.anthropic_beta).not.toContain(
+      'advanced-tool-use-2025-11-20',
+    );
+  });
+
   it('should handle models with us. prefix for inference profiles', () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -1,8 +1,4 @@
 import {
-  anthropicTools,
-  AnthropicMessagesLanguageModel,
-} from '@ai-sdk/anthropic/internal';
-import {
   LanguageModelV4,
   NoSuchModelError,
   ProviderV4,
@@ -17,13 +13,17 @@ import {
   withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
 import {
+  anthropicTools,
+  AnthropicMessagesLanguageModel,
+} from '@ai-sdk/anthropic/internal';
+import {
   BedrockCredentials,
   createApiKeyFetchFunction,
   createSigV4FetchFunction,
 } from '../bedrock-sigv4-fetch';
-import { VERSION } from '../version';
 import { createBedrockAnthropicFetch } from './bedrock-anthropic-fetch';
 import { BedrockAnthropicModelId } from './bedrock-anthropic-options';
+import { VERSION } from '../version';
 
 // Bedrock requires newer tool versions than the default Anthropic SDK versions
 const BEDROCK_TOOL_VERSION_MAP = {
@@ -165,7 +165,10 @@ export function createBedrockAnthropic(
         // If a credential provider is provided, use it to get the credentials.
         if (options.credentialProvider) {
           try {
-            return { ...(await options.credentialProvider()), region };
+            return {
+              ...(await options.credentialProvider()),
+              region,
+            };
           } catch (error) {
             const errorMessage =
               error instanceof Error ? error.message : String(error);
@@ -288,7 +291,11 @@ export function createBedrockAnthropic(
               newType in BEDROCK_TOOL_NAME_MAP
                 ? BEDROCK_TOOL_NAME_MAP[newType]
                 : tool.name;
-            return { ...tool, type: newType, name: newName };
+            return {
+              ...tool,
+              type: newType,
+              name: newName,
+            };
           }
 
           if (toolType && toolType in BEDROCK_TOOL_BETA_MAP) {
@@ -296,7 +303,10 @@ export function createBedrockAnthropic(
           }
 
           if (toolType && toolType in BEDROCK_TOOL_NAME_MAP) {
-            return { ...tool, name: BEDROCK_TOOL_NAME_MAP[toolType] };
+            return {
+              ...tool,
+              name: BEDROCK_TOOL_NAME_MAP[toolType],
+            };
           }
 
           return tool;

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -51,6 +51,8 @@ const BEDROCK_TOOL_BETA_MAP: Record<string, string> = {
   computer_20250124: 'computer-use-2025-01-24',
   computer_20241022: 'computer-use-2024-10-22',
   tool_search_tool_regex_20251119: 'tool-search-tool-2025-10-19',
+  // BM25 is not currently supported on Bedrock, but including the beta flag
+  // so that Bedrock returns a more useful error message if it's used.
   tool_search_tool_bm25_20251119: 'tool-search-tool-2025-10-19',
 };
 

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -1,4 +1,8 @@
 import {
+  anthropicTools,
+  AnthropicMessagesLanguageModel,
+} from '@ai-sdk/anthropic/internal';
+import {
   LanguageModelV4,
   NoSuchModelError,
   ProviderV4,
@@ -13,17 +17,13 @@ import {
   withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
 import {
-  anthropicTools,
-  AnthropicMessagesLanguageModel,
-} from '@ai-sdk/anthropic/internal';
-import {
   BedrockCredentials,
   createApiKeyFetchFunction,
   createSigV4FetchFunction,
 } from '../bedrock-sigv4-fetch';
+import { VERSION } from '../version';
 import { createBedrockAnthropicFetch } from './bedrock-anthropic-fetch';
 import { BedrockAnthropicModelId } from './bedrock-anthropic-options';
-import { VERSION } from '../version';
 
 // Bedrock requires newer tool versions than the default Anthropic SDK versions
 const BEDROCK_TOOL_VERSION_MAP = {
@@ -37,6 +37,9 @@ const BEDROCK_TOOL_NAME_MAP: Record<string, string> = {
   text_editor_20250728: 'str_replace_based_edit_tool',
 };
 
+// Betas unsupported by Bedrock that must be stripped from upstream Anthropic SDK
+const BEDROCK_UNSUPPORTED_BETAS = ['advanced-tool-use-2025-11-20'] as const;
+
 // Map tool types to required anthropic_beta values for Bedrock
 const BEDROCK_TOOL_BETA_MAP: Record<string, string> = {
   bash_20250124: 'computer-use-2025-01-24',
@@ -47,6 +50,8 @@ const BEDROCK_TOOL_BETA_MAP: Record<string, string> = {
   text_editor_20250728: 'computer-use-2025-01-24',
   computer_20250124: 'computer-use-2025-01-24',
   computer_20241022: 'computer-use-2024-10-22',
+  tool_search_tool_regex_20251119: 'tool-search-tool-2025-10-19',
+  tool_search_tool_bm25_20251119: 'tool-search-tool-2025-10-19',
 };
 
 export interface BedrockAnthropicProvider extends ProviderV4 {
@@ -160,10 +165,7 @@ export function createBedrockAnthropic(
         // If a credential provider is provided, use it to get the credentials.
         if (options.credentialProvider) {
           try {
-            return {
-              ...(await options.credentialProvider()),
-              region,
-            };
+            return { ...(await options.credentialProvider()), region };
           } catch (error) {
             const errorMessage =
               error instanceof Error ? error.message : String(error);
@@ -268,6 +270,9 @@ export function createBedrockAnthropic(
             : undefined;
 
         const requiredBetas = new Set<string>(betas);
+        for (const beta of BEDROCK_UNSUPPORTED_BETAS) {
+          requiredBetas.delete(beta);
+        }
         const transformedTools = tools?.map((tool: Record<string, unknown>) => {
           const toolType = tool.type as string | undefined;
 
@@ -283,11 +288,7 @@ export function createBedrockAnthropic(
               newType in BEDROCK_TOOL_NAME_MAP
                 ? BEDROCK_TOOL_NAME_MAP[newType]
                 : tool.name;
-            return {
-              ...tool,
-              type: newType,
-              name: newName,
-            };
+            return { ...tool, type: newType, name: newName };
           }
 
           if (toolType && toolType in BEDROCK_TOOL_BETA_MAP) {
@@ -295,10 +296,7 @@ export function createBedrockAnthropic(
           }
 
           if (toolType && toolType in BEDROCK_TOOL_NAME_MAP) {
-            return {
-              ...tool,
-              name: BEDROCK_TOOL_NAME_MAP[toolType],
-            };
+            return { ...tool, name: BEDROCK_TOOL_NAME_MAP[toolType] };
           }
 
           return tool;

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -37,9 +37,6 @@ const BEDROCK_TOOL_NAME_MAP: Record<string, string> = {
   text_editor_20250728: 'str_replace_based_edit_tool',
 };
 
-// Betas unsupported by Bedrock that must be stripped from upstream Anthropic SDK
-const BEDROCK_UNSUPPORTED_BETAS = ['advanced-tool-use-2025-11-20'] as const;
-
 // Map tool types to required anthropic_beta values for Bedrock
 const BEDROCK_TOOL_BETA_MAP: Record<string, string> = {
   bash_20250124: 'computer-use-2025-01-24',
@@ -275,9 +272,6 @@ export function createBedrockAnthropic(
             : undefined;
 
         const requiredBetas = new Set<string>(betas);
-        for (const beta of BEDROCK_UNSUPPORTED_BETAS) {
-          requiredBetas.delete(beta);
-        }
         const transformedTools = tools?.map((tool: Record<string, unknown>) => {
           const toolType = tool.type as string | undefined;
 


### PR DESCRIPTION
## Background
                                                                                                                                 
Bedrock's Anthropic integration needs specific beta flags for tool search tools (`tool_search_tool_regex_20251119` and `tool_search_tool_bm25_20251119`), but the upstream `@ai-sdk/anthropic` package doesn't set them since they aren't needed for direct Anthropic API calls.

## Summary                                                                                                                      
                      
- Added `tool_search_tool_regex_20251119` and `tool_search_tool_bm25_20251119` to `BEDROCK_TOOL_BETA_MAP` with the `tool-search-tool-2025-10-19` beta value.

## Manual Verification                                                                                                            
                                                                                                                               
Tested tool search with deferred tool loading on Bedrock — requests now include the correct `tool-search-tool-2025-10-19` beta.

## Checklist                                                                                                                    
                        
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A patch changeset for relevant packages has been added (for bug fixes / features - run pnpm changeset in the project root)
- [x] I have reviewed this pull request (self-review)                                                                              
  
## Related Issues  

n/a