### PR TITLE
fix(ai): remove orphaned reasoning-only assistant messages in pruneMessages

### DIFF
--- a/packages/ai/src/generate-text/prune-messages.test.ts
+++ b/packages/ai/src/generate-text/prune-messages.test.ts
@@ -407,15 +407,6 @@ describe('pruneMessages', () => {
             {
               "content": [
                 {
-                  "text": "I need to get the weather in Tokyo and Busan.",
-                  "type": "reasoning",
-                },
-              ],
-              "role": "assistant",
-            },
-            {
-              "content": [
-                {
                   "text": "I have got the weather in Tokyo and Busan.",
                   "type": "reasoning",
                 },
@@ -715,6 +706,143 @@ describe('pruneMessages', () => {
           ]
         `);
       });
+    });
+  });
+
+  describe('orphaned reasoning', () => {
+    it('should remove assistant messages containing only reasoning parts after tool call pruning', () => {
+      const messages: ModelMessage[] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Check for errors' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              text: 'Let me check for errors...',
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'checkErrors',
+              input: '{}',
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'checkErrors',
+              output: { type: 'text', value: 'no errors' },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              text: 'Errors checked successfully.',
+            },
+            {
+              type: 'text',
+              text: 'No errors found.',
+            },
+          ],
+        },
+      ];
+
+      // Prune all tool calls — the first assistant message becomes reasoning-only
+      const result = pruneMessages({
+        messages,
+        toolCalls: 'all',
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Check for errors",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "text": "Errors checked successfully.",
+                "type": "reasoning",
+              },
+              {
+                "text": "No errors found.",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
+    it('should keep assistant messages that have reasoning plus non-reasoning parts', () => {
+      const messages: ModelMessage[] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              text: 'The user said hello.',
+            },
+            {
+              type: 'text',
+              text: 'Hi there!',
+            },
+          ],
+        },
+      ];
+
+      const result = pruneMessages({
+        messages,
+        toolCalls: 'all',
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Hello",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "text": "The user said hello.",
+                "type": "reasoning",
+              },
+              {
+                "text": "Hi there!",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
     });
   });
 });

--- a/packages/ai/src/generate-text/prune-messages.ts
+++ b/packages/ai/src/generate-text/prune-messages.ts
@@ -159,6 +159,24 @@ export function pruneMessages({
     });
   }
 
+  // Remove assistant messages that contain only reasoning parts.
+  // After pruning tool calls, reasoning parts that preceded the removed
+  // tool calls become orphaned. Providers like Anthropic reject assistant
+  // messages containing only reasoning blocks — they require at least one
+  // non-reasoning content block. This is a structural validity concern that
+  // applies regardless of the emptyMessages setting.
+  messages = messages.filter(message => {
+    if (
+      message.role === 'assistant' &&
+      typeof message.content !== 'string' &&
+      message.content.length > 0 &&
+      message.content.every(part => part.type === 'reasoning')
+    ) {
+      return false;
+    }
+    return true;
+  });
+
   if (emptyMessages === 'remove') {
     messages = messages.filter(message => message.content.length > 0);
   }


### PR DESCRIPTION
Fixes #13430

When `pruneMessages` removes tool-call parts from assistant messages, associated reasoning (thinking) parts become orphaned. If an assistant message ends up containing **only reasoning parts** after pruning, providers like Anthropic reject it with a 400 error because a valid assistant message must contain at least one non-reasoning content block.

This is a structural validity concern independent of the `emptyMessages` setting — reasoning-only assistant messages are always removed because they will cause API errors when sent to any thinking-model provider (Anthropic extended thinking, etc.).

**Changes:**
- Added post-pruning filter that removes assistant messages containing only reasoning parts
- Placed before the `emptyMessages` check so it applies regardless of that setting
- Updated existing `toolCalls: all` test snapshot
- Added new test cases for orphaned reasoning scenarios

**Compared to PR #13435:**
- This handles the concern as a structural validity issue (always removes, not tied to `emptyMessages`)
- Added explicit test coverage for the reasoning-only edge case
- Cleaner separation of concerns (reasoning validity vs empty message handling)