### PR TITLE
feat(provider/google): add `gemini-3.1-flash-live-preview`

### DIFF
--- a/.changeset/add-google-flash-live-preview-model.md
+++ b/.changeset/add-google-flash-live-preview-model.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(provider/google): add `gemini-3.1-flash-live-preview`

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -25,6 +25,7 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-3.1-pro-preview'
   | 'gemini-3.1-pro-preview-customtools'
   | 'gemini-3.1-flash-image-preview'
+  | 'gemini-3.1-flash-live-preview'
   | 'gemini-3.1-flash-lite-preview'
   // latest version
   // https://ai.google.dev/gemini-api/docs/models#latest


### PR DESCRIPTION
## Background

`#13848` reports that Google has added `gemini-3.1-flash-live-preview`, but `@ai-sdk/google` does not currently include it in `GoogleGenerativeAIModelId`. That means users miss autocomplete and type support for the new model ID.

## Summary

- add `gemini-3.1-flash-live-preview` to `GoogleGenerativeAIModelId` in `@ai-sdk/google`
- add a patch changeset for `@ai-sdk/google`

## Manual Verification

- installed workspace dependencies locally
- generated local declaration output for `@ai-sdk/test-server` so the `with-vitest` workspace export resolves in this checkout
- ran `corepack pnpm --filter @ai-sdk/google type-check`

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Fixes #13848