### PR TITLE
fix(xai): correctly map the finish-reason

### DIFF
--- a/.changeset/sharp-files-jump.md
+++ b/.changeset/sharp-files-jump.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk/xai": minor
+"@ai-sdk/xai": patch
 ---
 
-Fix finish-reason generation for xai model
+fix(provider/xai): correct finish reason for tool calls

--- a/.changeset/sharp-files-jump.md
+++ b/.changeset/sharp-files-jump.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/xai": minor
+---
+
+Fix finish-reason generation for xai model

--- a/examples/ai-functions/src/generate-text/xai/responses-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/xai/responses-tool-call.ts
@@ -61,6 +61,7 @@ run(async () => {
   }
 
   console.log('Text:', result.text);
+  console.log('Finish reason:', result.finishReason);
   console.log('Tool Calls:', JSON.stringify(result.toolCalls, null, 2));
   console.log('Tool Results:', JSON.stringify(result.toolResults, null, 2));
 });

--- a/examples/ai-functions/src/stream-text/xai/responses-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/xai/responses-tool-call.ts
@@ -1,0 +1,51 @@
+import { xai } from '@ai-sdk/xai';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: xai.responses('grok-4-1-fast-reasoning'),
+    maxOutputTokens: 512,
+    tools: {
+      weather: weatherTool,
+      cityAttractions: tool({
+        inputSchema: z.object({ city: z.string() }),
+      }),
+    },
+    prompt:
+      'What is the weather in San Francisco and what attractions should I visit?',
+  });
+
+  for await (const event of result.fullStream) {
+    switch (event.type) {
+      case 'text-delta': {
+        process.stdout.write(event.text);
+        break;
+      }
+
+      case 'tool-call': {
+        console.log(
+          `\nTool call: '${event.toolName}' ${JSON.stringify(event.input)}`,
+        );
+        break;
+      }
+
+      case 'tool-result': {
+        if (event.dynamic) {
+          continue;
+        }
+
+        console.log(
+          `\nTool response: '${event.toolName}' ${JSON.stringify(event.output)}`,
+        );
+        break;
+      }
+    }
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -177,6 +177,47 @@ describe('XaiResponsesLanguageModel', () => {
           }
         `);
       });
+
+      it('should return tool-calls finish reason when function_call is present', async () => {
+        prepareJsonResponse({
+          id: 'resp_123',
+          object: 'response',
+          status: 'completed',
+          model: 'grok-4-fast-non-reasoning',
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_123',
+              name: 'weather',
+              arguments: '{"location":"sf"}',
+              call_id: 'call_123',
+            },
+          ],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        });
+
+        const result = await createModel().doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'function',
+              name: 'weather',
+              description: 'get weather',
+              inputSchema: {
+                type: 'object',
+                properties: { location: { type: 'string' } },
+              },
+            },
+          ],
+        });
+
+        expect(result.finishReason).toMatchInlineSnapshot(`
+          {
+            "raw": "completed",
+            "unified": "tool-calls",
+          }
+        `);
+      });
     });
 
     describe('reasoning content', () => {
@@ -2159,6 +2200,87 @@ describe('XaiResponsesLanguageModel', () => {
           toolCallId: 'call_123',
           toolName: 'weather',
           input: '{"location":"sf"}',
+        });
+      });
+
+      it('should return tool-calls finish reason when function_call is streamed', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast-non-reasoning',
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            output_index: 0,
+            item: {
+              type: 'function_call',
+              id: 'fc_123',
+              call_id: 'call_123',
+              name: 'weather',
+              arguments: '',
+              status: 'in_progress',
+            },
+          }),
+          JSON.stringify({
+            type: 'response.function_call_arguments.done',
+            item_id: 'fc_123',
+            output_index: 0,
+            arguments: '{"location":"sf"}',
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            output_index: 0,
+            item: {
+              type: 'function_call',
+              id: 'fc_123',
+              call_id: 'call_123',
+              name: 'weather',
+              arguments: '{"location":"sf"}',
+              status: 'completed',
+            },
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'function',
+              name: 'weather',
+              description: 'get weather',
+              inputSchema: {
+                type: 'object',
+                properties: { location: { type: 'string' } },
+              },
+            },
+          ],
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+        const finishPart = parts.find(p => p.type === 'finish');
+
+        expect(finishPart).toMatchObject({
+          type: 'finish',
+          finishReason: {
+            unified: 'tool-calls',
+            raw: 'completed',
+          },
         });
       });
 

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -257,6 +257,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
     });
 
     const content: Array<LanguageModelV4Content> = [];
+    let hasFunctionCall = false;
 
     const webSearchSubTools = [
       'web_search',
@@ -379,6 +380,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
         }
 
         case 'function_call': {
+          hasFunctionCall = true;
           content.push({
             type: 'tool-call',
             toolCallId: part.call_id,
@@ -431,7 +433,9 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
     return {
       content,
       finishReason: {
-        unified: mapXaiResponsesFinishReason(response.status),
+        unified: hasFunctionCall
+          ? 'tool-calls'
+          : mapXaiResponsesFinishReason(response.status),
         raw: response.status ?? undefined,
       },
       usage: response.usage
@@ -483,6 +487,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
       unified: 'other',
       raw: undefined,
     };
+    let hasFunctionCall = false;
     let usage: LanguageModelV4Usage | undefined = undefined;
     let isFirstChunk = true;
     const contentBlocks: Record<string, { type: 'text' }> = {};
@@ -676,7 +681,9 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
 
               if (response.status) {
                 finishReason = {
-                  unified: mapXaiResponsesFinishReason(response.status),
+                  unified: hasFunctionCall
+                    ? 'tool-calls'
+                    : mapXaiResponsesFinishReason(response.status),
                   raw: response.status,
                 };
               }
@@ -944,6 +951,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
                     toolName: part.name,
                   });
                 } else if (event.type === 'response.output_item.done') {
+                  hasFunctionCall = true;
                   ongoingToolCalls[event.output_index] = undefined;
 
                   controller.enqueue({


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Responses API doesn't have a finish reason anymore, while some softwares (e.g. OpenCode) rely on the finish-reason to determine whether a next request needs to be sent. This might result in workflow stop even there is tool call being returned.

## Summary

The fix checks whether the tool call list is empty and use that to correct the finish reason.

## Manual Verification

Added the test and verified that the tests failed before the fix.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
