### PR TITLE
feat(provider/google): add Lyria 3 model IDs

### DIFF
--- a/.changeset/add-google-lyria-model-ids.md
+++ b/.changeset/add-google-lyria-model-ids.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(provider/google): add Lyria 3 model IDs

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -33,6 +33,8 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-flash-lite-latest'
   | 'deep-research-pro-preview-12-2025'
   | 'nano-banana-pro-preview'
+  | 'lyria-3-clip-preview'
+  | 'lyria-3-pro-preview'
   | 'aqa'
   // Experimental models
   // https://ai.google.dev/gemini-api/docs/models/experimental-models


### PR DESCRIPTION
## Background

`#13826` reports that `@ai-sdk/google` is missing the newly listed `lyria-3-clip-preview` and `lyria-3-pro-preview` model IDs. Adding them to `GoogleGenerativeAIModelId` keeps the provider type definitions aligned with the latest model list.

## Summary

- add `lyria-3-clip-preview` to `GoogleGenerativeAIModelId`
- add `lyria-3-pro-preview` to `GoogleGenerativeAIModelId`
- add a patch changeset for `@ai-sdk/google`

## Manual Verification

- ran `corepack pnpm --filter @ai-sdk/google type-check`

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Fixes #13826