### PR TITLE
fix(ai): skip null/undefined tool entries in prepareToolsAndToolChoice (fixes #13906)

### DIFF
--- a/.changeset/fix-null-tool-entries-crash.md
+++ b/.changeset/fix-null-tool-entries-crash.md
@@ -1,0 +1,14 @@
+---
+'ai': patch
+---
+
+Fix crash when tools object contains null/undefined entries
+
+`prepareToolsAndToolChoice` now skips null/undefined tool values instead of
+throwing `TypeError: Cannot read properties of undefined (reading 'type')`.
+
+This crash occurred when a provider tool factory result was accidentally spread
+into the `tools` parameter (e.g., `tools: { ...anthropic.tools.webSearch_20260209({}) }`).
+The factory returns a `Tool` object whose properties include `execute: undefined`,
+`needsApproval: undefined`, etc. Spreading these into `tools` populated the record
+with `undefined` values, causing the crash during stream processing.

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
@@ -407,6 +407,32 @@ describe('prepareToolsAndToolChoice', () => {
     `);
   });
 
+  it('should skip null/undefined tool entries without crashing', async () => {
+    // Simulates accidentally spreading a Tool object into the tools record:
+    //   tools: { ...anthropic.tools.webSearch_20260209({ maxUses: 3 }) }
+    // The factory creates a Tool with execute: undefined, needsApproval: undefined, etc.
+    // These undefined values become spurious tool entries when spread.
+    const result = await prepareToolsAndToolChoice({
+      tools: {
+        validTool: tool({
+          description: 'A valid tool',
+          inputSchema: z.object({}),
+        }),
+        execute: undefined as any,
+        needsApproval: undefined as any,
+        toModelOutput: undefined as any,
+      },
+      toolChoice: undefined,
+      activeTools: undefined,
+    });
+
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools?.[0]).toMatchObject({
+      name: 'validTool',
+      type: 'function',
+    });
+  });
+
   it('should pass through input examples', async () => {
     const result = await prepareToolsAndToolChoice({
       tools: {

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
@@ -41,6 +41,10 @@ export async function prepareToolsAndToolChoice<TOOLS extends ToolSet>({
     LanguageModelV4FunctionTool | LanguageModelV4ProviderTool
   > = [];
   for (const [name, tool] of filteredTools) {
+    if (tool == null) {
+      continue;
+    }
+
     const toolType = tool.type;
 
     switch (toolType) {


### PR DESCRIPTION
## Summary

Fixes #13906.

`prepareToolsAndToolChoice` now skips null/undefined tool values instead of crashing with `TypeError: Cannot read properties of undefined (reading 'type')`.

---

## Root Cause

In `prepare-tools-and-tool-choice.ts:44`, the loop iterates `Object.entries(tools)` and accesses `tool.type` unconditionally:

```typescript
for (const [name, tool] of filteredTools) {
  const toolType = tool.type;  // crashes when tool is undefined
```

This crashes when a user accidentally **spreads** a provider tool factory result into the `tools` record instead of assigning it under a key:

```typescript
// ❌ Incorrect (issue reproducer)
tools: {
  ...anthropic.tools.webSearch_20260209({ maxUses: 3 }),
}

// ✅ Correct
tools: {
  web_search: anthropic.tools.webSearch_20260209({ maxUses: 3 }),
}
```

The factory always produces a `Tool` object with `execute: undefined`, `needsApproval: undefined`, `toModelOutput: undefined`, etc. Spreading this object into `tools` creates entries like `['execute', undefined]`. When `prepareToolsAndToolChoice` iterates these entries, it hits `undefined.type` and throws.

Because `prepareToolsAndToolChoice` is called lazily during stream processing, the HTTP response is already 200 when the crash occurs — the client receives no usable body.

## Solution

Guard against null/undefined tool values with an early `continue` in the loop:

```typescript
for (const [name, tool] of filteredTools) {
  if (tool == null) {
    continue;
  }
  const toolType = tool.type;
```

## Testing

- Added `should skip null/undefined tool entries without crashing` in `prepare-tools-and-tool-choice.test.ts` that directly reproduces the crash scenario.
- All 2176 existing tests continue to pass.
- Run with: `cd packages/ai && pnpm test:node`