### PR TITLE
feat(amazon-bedrock): return request body from doGenerate and doStream

### DIFF
--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -566,6 +566,7 @@ export class BedrockChatLanguageModel implements LanguageModelV4 {
         raw: response.stopReason ?? undefined,
       },
       usage: convertBedrockUsage(response.usage),
+      request: { body: args },
       response: {
         id: responseHeaders?.['x-amzn-requestid'] ?? undefined,
         timestamp:
@@ -970,7 +971,7 @@ export class BedrockChatLanguageModel implements LanguageModelV4 {
           },
         }),
       ),
-      // TODO request?
+      request: { body: args },
       response: { headers: responseHeaders },
     };
   }


### PR DESCRIPTION
## Summary

`BedrockChatLanguageModel.doGenerate()` and `doStream()` do not return a `request` field, so consumers that rely on the request body (observability frameworks, `onFinish` callbacks, etc.) receive `undefined`. There was an existing `// TODO request?` comment at the `doStream` return site.

This PR adds `request: { body: args }` to both methods, matching the pattern used by `@ai-sdk/anthropic`:

```diff
 // doGenerate return
 return {
   content,
   finishReason: { ... },
   usage: convertBedrockUsage(response.usage),
+  request: { body: args },
   response: { ... },
   warnings,
 };

 // doStream return
 return {
   stream: response.pipeThrough(...),
-  // TODO request?
+  request: { body: args },
   response: { headers: responseHeaders },
 };
```

`args` is the Bedrock Converse API command object (the same value passed as `body` to `postJsonToApi`), so it captures the full request payload including model config, messages, tools, and inference parameters.

## Motivation

Observability frameworks like [Mastra](https://github.com/mastra-ai/mastra) use the `request` field from provider `doStream()`/`doGenerate()` to populate tracing span inputs (e.g., `model_step.input`). With the Bedrock provider, this is always `undefined`, resulting in empty span attributes — making it impossible to see what was sent to the LLM.

The `@ai-sdk/anthropic` provider already returns `request: { body: args }` from both methods ([ref](https://github.com/vercel/ai/blob/main/packages/anthropic/src/anthropic-messages-language-model.ts#L1212)).

Fixes #13927
Related: #5129