### PR TITLE
fix(google-vertex): strip cache_control for Vertex Anthropic

### DIFF
--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -139,6 +139,12 @@ type AnthropicMessagesConfig = {
    * Defaults to true.
    */
   supportsStrictTools?: boolean;
+
+  /**
+   * When false, `cache_control` on message content blocks and tool definitions
+   * will be stripped and a warning emitted. Defaults to true.
+   */
+  supportsCacheControl?: boolean;
 };
 
 export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
@@ -306,8 +312,9 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
 
     const contextManagement = anthropicOptions?.contextManagement;
 
-    // Create a shared cache control validator to track breakpoints across tools and messages
-    const cacheControlValidator = new CacheControlValidator();
+    const cacheControlValidator = new CacheControlValidator({
+      supportsCacheControl: this.config.supportsCacheControl ?? true,
+    });
 
     const toolNameMapping = createToolNameMapping({
       tools,

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -1409,6 +1409,51 @@ describe('prepareTools', () => {
       ]
     `);
   });
+
+  it('should strip cache_control from tools when supportsCacheControl is false', async () => {
+    const cacheControlValidator = new CacheControlValidator({
+      supportsCacheControl: false,
+    });
+    const result = await prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'tool1',
+          description: 'Test 1',
+          inputSchema: {},
+          providerOptions: {
+            anthropic: { cacheControl: { type: 'ephemeral' } },
+          },
+        },
+        {
+          type: 'function',
+          name: 'tool2',
+          description: 'Test 2',
+          inputSchema: {},
+          providerOptions: {
+            anthropic: { cacheControl: { type: 'ephemeral' } },
+          },
+        },
+      ],
+      toolChoice: undefined,
+      supportsStructuredOutput: true,
+      supportsStrictTools: true,
+      cacheControlValidator,
+    });
+
+    expect(result.tools?.[0]).toHaveProperty('cache_control', undefined);
+    expect(result.tools?.[1]).toHaveProperty('cache_control', undefined);
+
+    expect(cacheControlValidator.getWarnings()).toMatchInlineSnapshot(`
+      [
+        {
+          "details": "cache_control on message content blocks is not supported by this provider. All cache_control markers will be stripped.",
+          "feature": "cacheControl",
+          "type": "unsupported",
+        },
+      ]
+    `);
+  });
 });
 
 describe('webFetch_20250910OutputSchema', () => {

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -2642,6 +2642,72 @@ describe('cache control', () => {
         ]
       `);
     });
+
+    it('should strip all cache_control when supportsCacheControl is false', async () => {
+      const warnings: SharedV4Warning[] = [];
+      const cacheControlValidator = new CacheControlValidator({
+        supportsCacheControl: false,
+      });
+      const result = await convertToAnthropicMessagesPrompt({
+        prompt: [
+          {
+            role: 'system',
+            content: 'system prompt',
+            providerOptions: {
+              anthropic: { cacheControl: { type: 'ephemeral' } },
+            },
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'user message',
+                providerOptions: {
+                  anthropic: { cacheControl: { type: 'ephemeral' } },
+                },
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'assistant reply',
+                providerOptions: {
+                  anthropic: { cacheControl: { type: 'ephemeral' } },
+                },
+              },
+            ],
+          },
+        ],
+        sendReasoning: true,
+        warnings,
+        cacheControlValidator,
+        toolNameMapping: defaultToolNameMapping,
+      });
+
+      expect(result.prompt.system).toEqual([
+        { type: 'text', text: 'system prompt', cache_control: undefined },
+      ]);
+      expect(result.prompt.messages[0].content).toEqual([
+        { type: 'text', text: 'user message', cache_control: undefined },
+      ]);
+      expect(result.prompt.messages[1].content).toEqual([
+        { type: 'text', text: 'assistant reply', cache_control: undefined },
+      ]);
+
+      expect(cacheControlValidator.getWarnings()).toMatchInlineSnapshot(`
+        [
+          {
+            "details": "cache_control on message content blocks is not supported by this provider. All cache_control markers will be stripped.",
+            "feature": "cacheControl",
+            "type": "unsupported",
+          },
+        ]
+      `);
+    });
   });
 
   it('should limit cache breakpoints to 4', async () => {

--- a/packages/anthropic/src/get-cache-control.ts
+++ b/packages/anthropic/src/get-cache-control.ts
@@ -22,6 +22,14 @@ function getCacheControl(
 export class CacheControlValidator {
   private breakpointCount = 0;
   private warnings: SharedV4Warning[] = [];
+  private readonly supportsCacheControl: boolean;
+  private hasEmittedUnsupportedWarning = false;
+
+  constructor({
+    supportsCacheControl = true,
+  }: { supportsCacheControl?: boolean } = {}) {
+    this.supportsCacheControl = supportsCacheControl;
+  }
 
   getCacheControl(
     providerMetadata: SharedV4ProviderMetadata | undefined,
@@ -33,7 +41,19 @@ export class CacheControlValidator {
       return undefined;
     }
 
-    // Validate that cache_control is allowed in this context
+    if (!this.supportsCacheControl) {
+      if (!this.hasEmittedUnsupportedWarning) {
+        this.hasEmittedUnsupportedWarning = true;
+        this.warnings.push({
+          type: 'unsupported',
+          feature: 'cacheControl',
+          details:
+            'cache_control on message content blocks is not supported by this provider. All cache_control markers will be stripped.',
+        });
+      }
+      return undefined;
+    }
+
     if (!context.canCache) {
       this.warnings.push({
         type: 'unsupported',
@@ -43,7 +63,6 @@ export class CacheControlValidator {
       return undefined;
     }
 
-    // Validate cache breakpoint limit
     this.breakpointCount++;
     if (this.breakpointCount > MAX_CACHE_BREAKPOINTS) {
       this.warnings.push({

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -52,6 +52,7 @@ describe('google-vertex-anthropic-provider', () => {
         transformRequestBody: expect.any(Function),
         supportsNativeStructuredOutput: false,
         supportsStrictTools: false,
+        supportsCacheControl: false,
       }),
     );
   });

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -204,6 +204,8 @@ export function createVertexAnthropic(
       supportsNativeStructuredOutput: false,
       // Vertex Anthropic doesn't support strict mode on tool definitions.
       supportsStrictTools: false,
+      // Vertex Anthropic doesn't support cache_control on message content blocks or tools.
+      supportsCacheControl: false,
     });
 
   const provider = function (modelId: GoogleVertexAnthropicMessagesModelId) {


### PR DESCRIPTION
## Summary

Vertex Anthropic's `rawPredict` / `streamRawPredict` endpoint does not support `cache_control` on message content blocks. When users set `providerOptions.anthropic.cacheControl` on messages, the shared `@ai-sdk/anthropic` code injects `cache_control` into the Anthropic wire format. This works for direct Anthropic, but Vertex rejects it:

```
400: "cache_control: Extra inputs are not permitted"
```

This wastes a fallback slot on every Vertex provider attempt in gateway scenarios.

## Root Cause

```
User sets providerOptions.anthropic.cacheControl on messages
         |
         v
@ai-sdk/anthropic injects cache_control into wire-format content blocks
         |
         v
+---------+-------------------+
|                             |
v                             v
Direct Anthropic          Vertex Anthropic (rawPredict)
cache_control: OK         cache_control: REJECTED (400)
```

The `cache_control` field is baked into the request body at the SDK level, before any per-backend transformation happens. Vertex's `transformRequestBody` only strips `model` and adds `anthropic_version` — it doesn't touch message content.

## Fix

Mirrors the existing `supportsStrictTools` pattern from PR #13353 (which fixed the identical problem for `strict` on tool definitions):

1. **`CacheControlValidator`** — new `supportsCacheControl` constructor param. When `false`, `getCacheControl()` returns `undefined` and emits a single warning
2. **`AnthropicMessagesConfig`** — new `supportsCacheControl?: boolean` field (defaults to `true`)
3. **Vertex provider** — sets `supportsCacheControl: false`

```
AnthropicMessagesConfig
  supportsCacheControl: false   <-- Vertex sets this
         |
         v
CacheControlValidator({ supportsCacheControl: false })
         |
         v
getCacheControl() called for each content block
  -> returns undefined (instead of { type: "ephemeral" })
  -> emits warning once: "cache_control ... not supported by this provider"
```

## Files Changed

| File | Change |
|------|--------|
| `packages/anthropic/src/get-cache-control.ts` | `CacheControlValidator` accepts `supportsCacheControl` flag |
| `packages/anthropic/src/anthropic-messages-language-model.ts` | New config field, threaded to validator |
| `packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts` | `supportsCacheControl: false` |
| `packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts` | Verify flag is passed |
| `packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts` | Prompt strips cache_control |
| `packages/anthropic/src/anthropic-prepare-tools.test.ts` | Tools strip cache_control |

## Evidence This Works

### Test coverage (all pass)

- **Prompt conversion**: system, user, and assistant messages with `cacheControl` all get `cache_control: undefined` when `supportsCacheControl: false`
- **Tool preparation**: tool definitions with `cacheControl` get `cache_control: undefined` when `supportsCacheControl: false`
- **Warning dedup**: only one warning is emitted regardless of how many `cache_control` markers exist
- **No regression**: existing cache control behavior unchanged when `supportsCacheControl` defaults to `true` (115 existing tests pass)

### How to verify

```bash
# Run the directly affected tests:
pnpm vitest run packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
pnpm vitest run packages/anthropic/src/anthropic-prepare-tools.test.ts
pnpm vitest run packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts

# Look for the new test names:
#   "should strip all cache_control when supportsCacheControl is false"
#   "should strip cache_control from tools when supportsCacheControl is false"
```

### Precedent

This is the same pattern as PR #13353 (merged Mar 16 2026) which added `supportsStrictTools: false` for Vertex to strip `strict` from tool definitions. The approach is proven and already in production.

## Test Plan

- [x] `CacheControlValidator` with `supportsCacheControl: false` returns `undefined` for all cache_control values
- [x] Single warning emitted per request (not per marker)
- [x] Prompt conversion strips `cache_control` from system, user, and assistant content blocks
- [x] Tool preparation strips `cache_control` from tool definitions
- [x] Vertex provider test verifies `supportsCacheControl: false` is passed to config
- [x] Existing cache control tests pass unchanged (default `true` behavior)
- [x] `pnpm fix` passes with zero lint/format issues

Made with [Cursor](https://cursor.com)