### PR TITLE
fix(amazon-bedrock): support tool examples for Anthropic

### DIFF
--- a/.changeset/hot-kiwis-destroy.md
+++ b/.changeset/hot-kiwis-destroy.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(provider/amazon-bedrock): support tool examples for Anthropic

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-call-input-examples.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-call-input-examples.ts
@@ -1,0 +1,52 @@
+import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { generateText, stepCountIs, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+const conditions = [
+  { name: 'sunny', minTemperature: -5, maxTemperature: 35 },
+  { name: 'snowy', minTemperature: -10, maxTemperature: 0 },
+  { name: 'rainy', minTemperature: 0, maxTemperature: 15 },
+  { name: 'cloudy', minTemperature: 5, maxTemperature: 25 },
+];
+
+run(async () => {
+  const result = await generateText({
+    model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    stopWhen: stepCountIs(5),
+    onStepFinish: step => {
+      console.log(`\n=== Step Response ===`);
+      console.dir(step.response.body, { depth: Infinity });
+    },
+    tools: {
+      weather: tool({
+        description: 'Get the weather in a location',
+        inputSchema: z.object({
+          location: z.string().describe('The location to get the weather for'),
+        }),
+        inputExamples: [
+          { input: { location: 'San Francisco' } },
+          { input: { location: 'London' } },
+        ],
+        execute: async ({ location }) => {
+          const condition =
+            conditions[Math.floor(Math.random() * conditions.length)];
+          return {
+            location,
+            condition: condition.name,
+            temperature:
+              Math.floor(
+                Math.random() *
+                  (condition.maxTemperature - condition.minTemperature + 1),
+              ) + condition.minTemperature,
+          };
+        },
+      }),
+    },
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  console.log('\n=== Final Result ===');
+  console.log('Text:', result.text);
+});

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-call-input-examples.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-call-input-examples.ts
@@ -1,0 +1,50 @@
+import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { stepCountIs, streamText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+import { printFullStream } from '../../lib/print-full-stream';
+import { run } from '../../lib/run';
+
+const conditions = [
+  { name: 'sunny', minTemperature: -5, maxTemperature: 35 },
+  { name: 'snowy', minTemperature: -10, maxTemperature: 0 },
+  { name: 'rainy', minTemperature: 0, maxTemperature: 15 },
+  { name: 'cloudy', minTemperature: 5, maxTemperature: 25 },
+];
+
+run(async () => {
+  const result = streamText({
+    model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    stopWhen: stepCountIs(5),
+    tools: {
+      weather: tool({
+        description: 'Get the weather in a location',
+        inputSchema: z.object({
+          location: z.string().describe('The location to get the weather for'),
+        }),
+        inputExamples: [
+          { input: { location: 'San Francisco' } },
+          { input: { location: 'London' } },
+        ],
+        execute: async ({ location }) => {
+          const condition =
+            conditions[Math.floor(Math.random() * conditions.length)];
+          return {
+            location,
+            condition: condition.name,
+            temperature:
+              Math.floor(
+                Math.random() *
+                  (condition.maxTemperature - condition.minTemperature + 1),
+              ) + condition.minTemperature,
+          };
+        },
+      }),
+    },
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  await printFullStream({ result });
+
+  console.log(JSON.stringify((await result.request).body, null, 2));
+});

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -512,6 +512,42 @@ describe('bedrock-anthropic-provider', () => {
     );
   });
 
+  it('should remap advanced-tool-use beta to tool-examples beta for Bedrock', () => {
+    const provider = createBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model-id');
+
+    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
+      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const config = constructorCall[1];
+
+    const transformedBody = config.transformRequestBody?.(
+      {
+        model: 'test-model-id',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 1024,
+        tools: [
+          {
+            name: 'weather',
+            input_schema: { type: 'object', properties: {} },
+            input_examples: [{ location: 'San Francisco' }],
+          },
+        ],
+      },
+      new Set(['advanced-tool-use-2025-11-20']),
+    );
+
+    expect(transformedBody?.anthropic_beta).toContain(
+      'tool-examples-2025-10-29',
+    );
+    expect(transformedBody?.anthropic_beta).not.toContain(
+      'advanced-tool-use-2025-11-20',
+    );
+  });
+
   it('should handle models with us. prefix for inference profiles', () => {
     const provider = createBedrockAnthropic({
       region: 'us-east-1',

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -37,6 +37,11 @@ const BEDROCK_TOOL_NAME_MAP: Record<string, string> = {
   text_editor_20250728: 'str_replace_based_edit_tool',
 };
 
+// Map Anthropic beta values to their Bedrock equivalents
+const BEDROCK_BETA_REMAP: Record<string, string> = {
+  'advanced-tool-use-2025-11-20': 'tool-examples-2025-10-29',
+};
+
 // Map tool types to required anthropic_beta values for Bedrock
 const BEDROCK_TOOL_BETA_MAP: Record<string, string> = {
   bash_20250124: 'computer-use-2025-01-24',
@@ -271,7 +276,11 @@ export function createBedrockAnthropic(
               }
             : undefined;
 
-        const requiredBetas = new Set<string>(betas);
+        // Remap Anthropic betas to their Bedrock equivalents
+        const requiredBetas = new Set<string>();
+        for (const beta of betas) {
+          requiredBetas.add(BEDROCK_BETA_REMAP[beta] ?? beta);
+        }
         const transformedTools = tools?.map((tool: Record<string, unknown>) => {
           const toolType = tool.type as string | undefined;
 


### PR DESCRIPTION
## Background
                                                                                                                                 
Bedrock's Anthropic integration needs `tool-examples-2025-10-29` set for tool examples

## Summary                                                                                                                      
                      
Added `tool-examples-2025-10-29` instead of `advanced-tool-use-2025-11-20` for Bedrock Anthropic.


## Manual Verification   

Added new examples and ran them to validate the new behavior.
                                                                                                      Before:

```
APICallError [AI_APICallError]: Bad Request

requestBodyValues: {
  "anthropic_beta": [
    "fine-grained-tool-streaming-2025-05-14",
    "structured-outputs-2025-11-13",
    "advanced-tool-use-2025-11-20"
  ],
  "anthropic_version": "bedrock-2023-05-31"
}

statusCode: 400
responseBody: {"message":"tools.0.custom.input_examples: Extra inputs are not permitted"}
```

After:

```
TOOL CALL: weather
{ "location": "San Francisco" }

TOOL RESULT: weather
{ "location": "San Francisco", "condition": "snowy", "temperature": -6 }

TEXT:
The weather in San Francisco is currently snowy with a temperature of -6°C (21°F).
This is quite unusual weather for San Francisco!
```

## Checklist                                                                                                                    
                        
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A patch changeset for relevant packages has been added (for bug fixes / features - run pnpm changeset in the project root)
- [x] I have reviewed this pull request (self-review)                                                                              
  
## Related Issues  

n/a