### PR TITLE
feat(ai): rename `stepCountIs` to `isStepCount`

### DIFF
--- a/.changeset/poor-kids-joke.md
+++ b/.changeset/poor-kids-joke.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): rename `stepCountIs` to `isStepCount`

--- a/content/cookbook/00-guides/01-rag-chatbot.mdx
+++ b/content/cookbook/00-guides/01-rag-chatbot.mdx
@@ -679,7 +679,7 @@ import {
   streamText,
   tool,
   UIMessage,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 import { z } from 'zod';
 
@@ -695,7 +695,7 @@ export async function POST(req: Request) {
     Only respond to questions using information from tool calls.
     if no relevant information is found in the tool calls, respond, "Sorry, I don't know."`,
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       addResource: tool({
         description: `add a resource to your knowledge base.
@@ -789,7 +789,7 @@ import {
   streamText,
   tool,
   UIMessage,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 import { z } from 'zod';
 import { findRelevantContent } from '@/lib/ai/embedding';
@@ -803,7 +803,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: 'openai/gpt-4o',
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     system: `You are a helpful assistant. Check your knowledge base before answering any questions.
     Only respond to questions using information from tool calls.
     if no relevant information is found in the tool calls, respond, "Sorry, I don't know."`,

--- a/content/cookbook/00-guides/03-slackbot.mdx
+++ b/content/cookbook/00-guides/03-slackbot.mdx
@@ -349,7 +349,7 @@ This basic implementation:
 The real power of the AI SDK comes from tools that enable your bot to perform actions. Let's add two useful tools:
 
 ```typescript filename="lib/generate-response.ts"
-import { generateText, tool, ModelMessage, stepCountIs } from 'ai';
+import { generateText, tool, ModelMessage, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
 import { exa } from './utils';
@@ -365,7 +365,7 @@ export const generateResponse = async (
     - Current date is: ${new Date().toISOString().split('T')[0]}
     - Always include sources in your final response if you use web search.`,
     messages,
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     tools: {
       getWeather: tool({
         description: 'Get the current weather at a location',
@@ -433,7 +433,7 @@ In this updated implementation:
    - `getWeather`: Fetches weather data for a specified location
    - `searchWeb`: Searches the web for information using the Exa API
 
-2. You set `stopWhen: stepCountIs(10)` to enable multi-step conversations. This defines the stopping conditions of your agent, when the model generates a tool call. This will automatically send any tool results back to the LLM to trigger additional tool calls or responses as the LLM deems necessary. This turns your LLM call from a one-off operation into a multi-step agentic flow.
+2. You set `stopWhen: isStepCount(10)` to enable multi-step conversations. This defines the stopping conditions of your agent, when the model generates a tool call. This will automatically send any tool results back to the LLM to trigger additional tool calls or responses as the LLM deems necessary. This turns your LLM call from a one-off operation into a multi-step agentic flow.
 
 ## How It Works
 

--- a/content/cookbook/00-guides/05-computer-use.mdx
+++ b/content/cookbook/00-guides/05-computer-use.mdx
@@ -167,13 +167,13 @@ for await (const chunk of result.textStream) {
 To allow the model to perform multiple steps without user intervention, use the `stopWhen` parameter. This will automatically send any tool results back to the model to trigger a subsequent generation:
 
 ```ts highlight="1,7"
-import { stepCountIs } from 'ai';
+import { isStepCount } from 'ai';
 
 const stream = streamText({
   model: 'anthropic/claude-sonnet-4-20250514',
   prompt: 'Open the browser and navigate to vercel.com',
   tools: { computer: computerTool },
-  stopWhen: stepCountIs(10), // experiment with this value based on your use case
+  stopWhen: isStepCount(10), // experiment with this value based on your use case
 });
 ```
 

--- a/content/cookbook/00-guides/17-gemini.mdx
+++ b/content/cookbook/00-guides/17-gemini.mdx
@@ -76,7 +76,7 @@ Gemini 3 excels at tool calling with improved reliability and consistency for mu
 
 ```ts
 import { z } from 'zod';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { google } from '@ai-sdk/google';
 
 const result = await generateText({
@@ -94,7 +94,7 @@ const result = await generateText({
       }),
     }),
   },
-  stopWhen: stepCountIs(5), // enables multi-step calling
+  stopWhen: isStepCount(5), // enables multi-step calling
 });
 
 console.log(result.text);

--- a/content/cookbook/00-guides/19-openai-responses.mdx
+++ b/content/cookbook/00-guides/19-openai-responses.mdx
@@ -84,11 +84,11 @@ const { text } = await generateText({
       }),
     }),
   },
-  stopWhen: stepCountIs(5), // enable multi-step 'agentic' LLM calls
+  stopWhen: isStepCount(5), // enable multi-step 'agentic' LLM calls
 });
 ```
 
-This example demonstrates how `stopWhen` transforms a single LLM call into an agent. The `stopWhen: stepCountIs(5)` parameter allows the model to autonomously call tools, analyze results, and make additional tool calls as needed - turning what would be a simple one-shot completion into an intelligent agent that can chain multiple actions together to complete complex tasks.
+This example demonstrates how `stopWhen` transforms a single LLM call into an agent. The `stopWhen: isStepCount(5)` parameter allows the model to autonomously call tools, analyze results, and make additional tool calls as needed - turning what would be a simple one-shot completion into an intelligent agent that can chain multiple actions together to complete complex tasks.
 
 ### Web Search Tool
 

--- a/content/cookbook/00-guides/26-deepseek-v3-2.mdx
+++ b/content/cookbook/00-guides/26-deepseek-v3-2.mdx
@@ -158,7 +158,7 @@ Let's add a weather tool to your agent. Update your route handler at `app/api/ch
 import { deepseek } from '@ai-sdk/deepseek';
 import {
   convertToModelMessages,
-  stepCountIs,
+  isStepCount,
   streamText,
   tool,
   UIMessage,
@@ -184,14 +184,14 @@ export async function POST(req: Request) {
         }),
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   return result.toUIMessageStreamResponse({ sendReasoning: true });
 }
 ```
 
-This adds a weather tool that the model can call when needed. The `stopWhen: stepCountIs(5)` parameter allows the agent to continue executing for multiple steps (up to 5), enabling it to use tools and reason iteratively before stopping. Learn more about [loop control](/docs/agents/loop-control) to customize when and how your agent stops execution.
+This adds a weather tool that the model can call when needed. The `stopWhen: isStepCount(5)` parameter allows the agent to continue executing for multiple steps (up to 5), enabling it to use tools and reason iteratively before stopping. Learn more about [loop control](/docs/agents/loop-control) to customize when and how your agent stops execution.
 
 ## Get Started
 

--- a/content/cookbook/01-next/12-generate-image-with-chat-prompt.mdx
+++ b/content/cookbook/01-next/12-generate-image-with-chat-prompt.mdx
@@ -36,7 +36,7 @@ export const generateImageTool = tool({
 import {
   convertToModelMessages,
   type InferUITools,
-  stepCountIs,
+  isStepCount,
   streamText,
   type UIMessage,
 } from 'ai';
@@ -55,7 +55,7 @@ export async function POST(request: Request) {
   const result = streamText({
     model: 'openai/gpt-4o',
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools,
   });
 

--- a/content/cookbook/01-next/70-call-tools.mdx
+++ b/content/cookbook/01-next/70-call-tools.mdx
@@ -101,7 +101,7 @@ import {
   type UIDataTypes,
   type UIMessage,
   convertToModelMessages,
-  stepCountIs,
+  isStepCount,
   streamText,
   tool,
 } from 'ai';
@@ -138,7 +138,7 @@ export async function POST(req: Request) {
     model: 'openai/gpt-4o',
     system: 'You are a helpful assistant.',
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools,
   });
 

--- a/content/cookbook/01-next/72-call-tools-multiple-steps.mdx
+++ b/content/cookbook/01-next/72-call-tools-multiple-steps.mdx
@@ -77,7 +77,7 @@ You will use the [`tools`](/docs/reference/ai-sdk-core/generate-text#tools) para
 
 You will add the two functions mentioned earlier and use zod to specify the schema for its parameters.
 
-To call tools in multiple steps, you can use the `stopWhen` option to specify the stopping conditions for when the model generates a tool call. In this example, you will set it to `stepCountIs(5)` to allow for multiple consecutive tool calls (steps).
+To call tools in multiple steps, you can use the `stopWhen` option to specify the stopping conditions for when the model generates a tool call. In this example, you will set it to `isStepCount(5)` to allow for multiple consecutive tool calls (steps).
 
 ```ts filename='app/api/chat/route.ts'
 import {
@@ -86,7 +86,7 @@ import {
   type UIDataTypes,
   type UIMessage,
   convertToModelMessages,
-  stepCountIs,
+  isStepCount,
   streamText,
   tool,
 } from 'ai';
@@ -131,7 +131,7 @@ export async function POST(req: Request) {
     model: 'openai/gpt-4o',
     system: 'You are a helpful assistant.',
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools,
   });
 

--- a/content/cookbook/01-next/85-custom-stream-format.mdx
+++ b/content/cookbook/01-next/85-custom-stream-format.mdx
@@ -27,7 +27,7 @@ Create a route handler that calls a model and then streams the responses in a cu
 
 ```tsx filename="app/api/stream/route.ts"
 import { tools } from '@/ai/tools'; // your tools
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 __PROVIDER_IMPORT__;
 
 export type StreamEvent =
@@ -48,7 +48,7 @@ export async function POST(request: Request) {
     prompt,
     model: __MODEL__,
     tools,
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   const transformStream = new TransformStream({

--- a/content/cookbook/01-next/90-render-visual-interface-in-chat.mdx
+++ b/content/cookbook/01-next/90-render-visual-interface-in-chat.mdx
@@ -211,7 +211,7 @@ import {
   type UIDataTypes,
   type UIMessage,
   convertToModelMessages,
-  stepCountIs,
+  isStepCount,
   streamText,
   tool,
 } from 'ai';
@@ -264,7 +264,7 @@ export async function POST(request: Request) {
     model: 'openai/gpt-4.1',
     messages: await convertToModelMessages(messages),
     tools,
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   return result.toUIMessageStreamResponse();

--- a/content/cookbook/05-node/101-knowledge-base-agent.mdx
+++ b/content/cookbook/05-node/101-knowledge-base-agent.mdx
@@ -113,7 +113,7 @@ Navigate to the Upstash Console and check the data browser of your Search databa
 Now let's create an agent that can interact with this knowledge base. Create a new file called `agent.ts`:
 
 ```ts filename="agent.ts"
-import { tool, stepCountIs, generateText, generateId } from 'ai';
+import { tool, isStepCount, generateText, generateId } from 'ai';
 import { z } from 'zod';
 import { Search } from '@upstash/search';
 
@@ -136,7 +136,7 @@ async function main(prompt: string) {
   const { text } = await generateText({
     model: 'openai/gpt-4o',
     prompt,
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       addResource: tool({
         description:

--- a/content/cookbook/05-node/53-call-tools-multiple-steps.mdx
+++ b/content/cookbook/05-node/53-call-tools-multiple-steps.mdx
@@ -13,12 +13,12 @@ You can enable multi-step tool calls in `generateText` by defining stopping cond
 This allows you to define the conditions for which your agent should stop when the model generates a tool call.
 
 ```ts highlight={"7"}
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 
 const { text, steps } = await generateText({
   model: 'openai/gpt-4.1',
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
   tools: {
     weather: tool({
       description: 'Get the weather in a location',

--- a/content/cookbook/05-node/54-mcp-tools.mdx
+++ b/content/cookbook/05-node/54-mcp-tools.mdx
@@ -14,7 +14,7 @@ If you prefer to use the official transports (optional), install the official Mo
 
 ```ts
 import { createMCPClient } from '@ai-sdk/mcp';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 import { openai } from '@ai-sdk/openai';
 // Optional: Official transports if you prefer them
@@ -83,7 +83,7 @@ try {
   const response = await generateText({
     model: 'openai/gpt-4o',
     tools,
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     messages: [
       {
         role: 'user',

--- a/content/cookbook/05-node/56-web-search-agent.mdx
+++ b/content/cookbook/05-node/56-web-search-agent.mdx
@@ -118,7 +118,7 @@ const safetyRatings = metadata?.safetyRatings;
 
 When using tools for web search, you have two options: use ready-made tools that integrate directly with the AI SDK, or build custom tools tailored to your specific needs.
 
-Unlike the native web search examples where searching is built into the model, using web search tools requires multiple steps. The language model will make two generations - the first to call the relevant web search tool (extracting search queries from the context), and the second to process the results and generate a response. This multi-step process is handled automatically when you set `stopWhen: stepCountIs(n)` to a value greater than 1.
+Unlike the native web search examples where searching is built into the model, using web search tools requires multiple steps. The language model will make two generations - the first to call the relevant web search tool (extracting search queries from the context), and the second to process the results and generate a response. This multi-step process is handled automatically when you set `stopWhen: isStepCount(n)` to a value greater than 1.
 
 <Note>
   By using `stopWhen`, you can automatically send tool results back to the
@@ -147,7 +147,7 @@ pnpm install @exalabs/ai-sdk
 Then, you can import and pass it into `generateText`, `streamText`, or your agent:
 
 ```ts
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import { webSearch } from '@exalabs/ai-sdk';
 
@@ -157,7 +157,7 @@ const { text } = await generateText({
   tools: {
     webSearch: webSearch(),
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 console.log(text);
@@ -178,7 +178,7 @@ pnpm install @parallel-web/ai-sdk-tools
 Then, you can import and pass the tools into `generateText`, `streamText`, or your agent. Parallel Web provides two tools: `searchTool` for web search and `extractTool` for extracting web page content:
 
 ```ts
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import { searchTool, extractTool } from '@parallel-web/ai-sdk-tools';
 
@@ -189,7 +189,7 @@ const { text } = await generateText({
     webSearch: searchTool,
     webExtract: extractTool,
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 console.log(text);
@@ -211,7 +211,7 @@ pnpm install @perplexity-ai/ai-sdk
 Then, you can import and pass it into `generateText`, `streamText`, or your agent. Perplexity Search provides real-time web search with advanced filtering options including domain, language, date range, and recency filters:
 
 ```ts
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import { perplexitySearch } from '@perplexity-ai/ai-sdk';
 
@@ -222,7 +222,7 @@ const { text } = await generateText({
   tools: {
     search: perplexitySearch(),
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 console.log(text);
@@ -245,7 +245,7 @@ pnpm install @tavily/ai-sdk
 Then, you can import and pass it into `generateText`, `streamText`, or your agent:
 
 ```ts
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import { tavilySearch, tavilyExtract } from '@tavily/ai-sdk';
 
@@ -256,7 +256,7 @@ const { text } = await generateText({
     webSearch: tavilySearch(),
     webExtract: tavilyExtract(),
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 console.log(text);
@@ -277,7 +277,7 @@ pnpm install exa-js
 ```
 
 ```ts
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
 import Exa from 'exa-js';
@@ -309,7 +309,7 @@ const { text } = await generateText({
   tools: {
     webSearch,
   },
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
 });
 ```
 
@@ -322,7 +322,7 @@ pnpm install @mendable/firecrawl-js
 ```
 
 ```ts
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
 import FirecrawlApp from '@mendable/firecrawl-js';
@@ -361,7 +361,7 @@ const main = async () => {
     tools: {
       webSearch,
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
   console.log(text);
 };

--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -161,7 +161,7 @@ pnpm add some-tool-package
 Then pass them directly to `generateText`, `streamText`, or your agent definition:
 
 ```ts highlight="2, 8"
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { searchTool } from 'some-tool-package';
 
 const { text } = await generateText({
@@ -170,7 +170,7 @@ const { text } = await generateText({
   tools: {
     webSearch: searchTool,
   },
-  stopWhen: stepCountIs(10),
+  stopWhen: isStepCount(10),
 });
 ```
 

--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -370,7 +370,7 @@ Now, when you ask about the weather, you'll see the tool call and its result dis
 
 You may have noticed that while the tool is now visible in the chat interface, the model isn't using this information to answer your original query. This is because once the model generates a tool call, it has technically completed its generation.
 
-To solve this, you can enable multi-step tool calls using `stopWhen`. By default, `stopWhen` is set to `stepCountIs(1)`, which means generation stops after the first step when there are tool results. By changing this condition, you can allow the model to automatically send tool results back to itself to trigger additional generations until your specified stopping condition is met. In this case, you want the model to continue generating so it can use the weather tool results to answer your original question.
+To solve this, you can enable multi-step tool calls using `stopWhen`. By default, `stopWhen` is set to `isStepCount(1)`, which means generation stops after the first step when there are tool results. By changing this condition, you can allow the model to automatically send tool results back to itself to trigger additional generations until your specified stopping condition is met. In this case, you want the model to continue generating so it can use the weather tool results to answer your original question.
 
 ### Update Your Route Handler
 
@@ -382,7 +382,7 @@ import {
   UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
@@ -393,7 +393,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: __MODEL__,
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       weather: tool({
         description: 'Get the weather in a location (fahrenheit)',
@@ -420,12 +420,12 @@ export async function POST(req: Request) {
 
 In this updated code:
 
-1. You set `stopWhen` to be when `stepCountIs` 5, allowing the model to use up to 5 "steps" for any given generation.
+1. You set `stopWhen` to be when `isStepCount` 5, allowing the model to use up to 5 "steps" for any given generation.
 2. You add an `onStepFinish` callback to log any `toolResults` from each step of the interaction, helping you understand the model's tool usage.
 
 Head back to the browser and ask about the weather in a location. You should now see the model using the weather tool results to answer your question.
 
-By setting `stopWhen: stepCountIs(5)`, you're allowing the model to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the model to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Celsius to Fahrenheit.
+By setting `stopWhen: isStepCount(5)`, you're allowing the model to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the model to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Celsius to Fahrenheit.
 
 ### Add another tool
 
@@ -437,7 +437,7 @@ import {
   UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
@@ -448,7 +448,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: __MODEL__,
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       weather: tool({
         description: 'Get the weather in a location (fahrenheit)',

--- a/content/docs/02-getting-started/03-nextjs-pages-router.mdx
+++ b/content/docs/02-getting-started/03-nextjs-pages-router.mdx
@@ -363,7 +363,7 @@ Now, when you ask about the weather, you'll see the tool call and its result dis
 
 You may have noticed that while the tool is now visible in the chat interface, the model isn't using this information to answer your original query. This is because once the model generates a tool call, it has technically completed its generation.
 
-To solve this, you can enable multi-step tool calls using `stopWhen`. By default, `stopWhen` is set to `stepCountIs(1)`, which means generation stops after the first step when there are tool results. By changing this condition, you can allow the model to automatically send tool results back to itself to trigger additional generations until your specified stopping condition is met. In this case, you want the model to continue generating so it can use the weather tool results to answer your original question.
+To solve this, you can enable multi-step tool calls using `stopWhen`. By default, `stopWhen` is set to `isStepCount(1)`, which means generation stops after the first step when there are tool results. By changing this condition, you can allow the model to automatically send tool results back to itself to trigger additional generations until your specified stopping condition is met. In this case, you want the model to continue generating so it can use the weather tool results to answer your original question.
 
 ### Update Your Route Handler
 
@@ -375,7 +375,7 @@ import {
   UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
@@ -386,7 +386,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: __MODEL__,
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       weather: tool({
         description: 'Get the weather in a location (fahrenheit)',
@@ -410,7 +410,7 @@ export async function POST(req: Request) {
 
 Head back to the browser and ask about the weather in a location. You should now see the model using the weather tool results to answer your question.
 
-By setting `stopWhen: stepCountIs(5)`, you're allowing the model to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the model to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Celsius to Fahrenheit.
+By setting `stopWhen: isStepCount(5)`, you're allowing the model to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the model to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Celsius to Fahrenheit.
 
 ### Add another tool
 
@@ -422,7 +422,7 @@ import {
   UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
@@ -433,7 +433,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: __MODEL__,
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       weather: tool({
         description: 'Get the weather in a location (fahrenheit)',

--- a/content/docs/02-getting-started/04-svelte.mdx
+++ b/content/docs/02-getting-started/04-svelte.mdx
@@ -259,7 +259,7 @@ import {
   type UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 import { z } from 'zod';
 
@@ -367,7 +367,7 @@ Now, when you ask about the weather, you'll see the tool call and its result dis
 
 You may have noticed that while the tool is now visible in the chat interface, the model isn't using this information to answer your original query. This is because once the model generates a tool call, it has technically completed its generation.
 
-To solve this, you can enable multi-step tool calls using `stopWhen`. By default, `stopWhen` is set to `stepCountIs(1)`, which means generation stops after the first step when there are tool results. By changing this condition, you can allow the model to automatically send tool results back to itself to trigger additional generations until your specified stopping condition is met. In this case, you want the model to continue generating so it can use the weather tool results to answer your original question.
+To solve this, you can enable multi-step tool calls using `stopWhen`. By default, `stopWhen` is set to `isStepCount(1)`, which means generation stops after the first step when there are tool results. By changing this condition, you can allow the model to automatically send tool results back to itself to trigger additional generations until your specified stopping condition is met. In this case, you want the model to continue generating so it can use the weather tool results to answer your original question.
 
 ### Update Your API Route
 
@@ -380,7 +380,7 @@ import {
   type UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 import { z } from 'zod';
 
@@ -396,7 +396,7 @@ export async function POST({ request }) {
   const result = streamText({
     model: gateway('anthropic/claude-sonnet-4.5'),
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       weather: tool({
         description: 'Get the weather in a location (fahrenheit)',
@@ -420,7 +420,7 @@ export async function POST({ request }) {
 
 Head back to the browser and ask about the weather in a location. You should now see the model using the weather tool results to answer your question.
 
-By setting `stopWhen: stepCountIs(5)`, you're allowing the model to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the model to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Fahrenheit to Celsius.
+By setting `stopWhen: isStepCount(5)`, you're allowing the model to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the model to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Fahrenheit to Celsius.
 
 ### Add another tool
 
@@ -433,7 +433,7 @@ import {
   type UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 import { z } from 'zod';
 
@@ -449,7 +449,7 @@ export async function POST({ request }) {
   const result = streamText({
     model: gateway('anthropic/claude-sonnet-4.5'),
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       weather: tool({
         description: 'Get the weather in a location (fahrenheit)',

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -373,7 +373,7 @@ Now, when you ask about the weather, you'll see the tool call and its result dis
 
 You may have noticed that while the tool is now visible in the chat interface, the model isn't using this information to answer your original query. This is because once the model generates a tool call, it has technically completed its generation.
 
-To solve this, you can enable multi-step tool calls using `stopWhen`. By default, `stopWhen` is set to `stepCountIs(1)`, which means generation stops after the first step when there are tool results. By changing this condition, you can allow the model to automatically send tool results back to itself to trigger additional generations until your specified stopping condition is met. In this case, you want the model to continue generating so it can use the weather tool results to answer your original question.
+To solve this, you can enable multi-step tool calls using `stopWhen`. By default, `stopWhen` is set to `isStepCount(1)`, which means generation stops after the first step when there are tool results. By changing this condition, you can allow the model to automatically send tool results back to itself to trigger additional generations until your specified stopping condition is met. In this case, you want the model to continue generating so it can use the weather tool results to answer your original question.
 
 ### Update Your API Route
 
@@ -386,7 +386,7 @@ import {
   UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 import { z } from 'zod';
 
@@ -403,7 +403,7 @@ export default defineLazyEventHandler(async () => {
     const result = streamText({
       model: gateway('anthropic/claude-sonnet-4.5'),
       messages: await convertToModelMessages(messages),
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       tools: {
         weather: tool({
           description: 'Get the weather in a location (fahrenheit)',
@@ -430,7 +430,7 @@ export default defineLazyEventHandler(async () => {
 
 Head back to the browser and ask about the weather in a location. You should now see the model using the weather tool results to answer your question.
 
-By setting `stopWhen: stepCountIs(5)`, you're allowing the model to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the model to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Fahrenheit to Celsius.
+By setting `stopWhen: isStepCount(5)`, you're allowing the model to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the model to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Fahrenheit to Celsius.
 
 ### Add another tool
 
@@ -443,7 +443,7 @@ import {
   UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 import { z } from 'zod';
 
@@ -460,7 +460,7 @@ export default defineLazyEventHandler(async () => {
     const result = streamText({
       model: gateway('anthropic/claude-sonnet-4.5'),
       messages: await convertToModelMessages(messages),
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       tools: {
         weather: tool({
           description: 'Get the weather in a location (fahrenheit)',

--- a/content/docs/02-getting-started/06-nodejs.mdx
+++ b/content/docs/02-getting-started/06-nodejs.mdx
@@ -340,7 +340,7 @@ To solve this, you can enable multi-step tool calls using `stopWhen`. This featu
 Modify your `index.ts` file to configure stopping conditions with `stopWhen`:
 
 ```ts filename="index.ts" highlight="38-41"
-import { ModelMessage, streamText, tool, stepCountIs } from 'ai';
+import { ModelMessage, streamText, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import 'dotenv/config';
 import { z } from 'zod';
@@ -379,7 +379,7 @@ async function main() {
           },
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       onStepFinish: async ({ toolResults }) => {
         if (toolResults.length) {
           console.log(JSON.stringify(toolResults, null, 2));
@@ -404,19 +404,19 @@ main().catch(console.error);
 
 In this updated code:
 
-1. You set `stopWhen` to be when `stepCountIs` 5, allowing the agent to use up to 5 "steps" for any given generation.
+1. You set `stopWhen` to be when `isStepCount` 5, allowing the agent to use up to 5 "steps" for any given generation.
 2. You add an `onStepFinish` callback to log any `toolResults` from each step of the interaction, helping you understand the agent's tool usage. This means we can also delete the `toolCall` and `toolResult` `console.log` statements from the previous example.
 
 Now, when you ask about the weather in a location, you should see the agent using the weather tool results to answer your question.
 
-By setting `stopWhen: stepCountIs(5)`, you're allowing the agent to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the agent to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Celsius to Fahrenheit.
+By setting `stopWhen: isStepCount(5)`, you're allowing the agent to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the agent to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Celsius to Fahrenheit.
 
 ### Adding a second tool
 
 Update your `index.ts` file to add a new tool to convert the temperature from Celsius to Fahrenheit:
 
 ```ts filename="index.ts" highlight="37-48"
-import { ModelMessage, streamText, tool, stepCountIs } from 'ai';
+import { ModelMessage, streamText, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import 'dotenv/config';
 import { z } from 'zod';
@@ -469,7 +469,7 @@ async function main() {
           },
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       onStepFinish: async ({ toolResults }) => {
         if (toolResults.length) {
           console.log(JSON.stringify(toolResults, null, 2));

--- a/content/docs/02-getting-started/07-expo.mdx
+++ b/content/docs/02-getting-started/07-expo.mdx
@@ -467,7 +467,7 @@ Now, when you ask about the weather, you'll see the tool call and its result dis
 
 You may have noticed that while the tool results are visible in the chat interface, the model isn't using this information to answer your original query. This is because once the model generates a tool call, it has technically completed its generation.
 
-To solve this, you can enable multi-step tool calls using `stopWhen`. By default, `stopWhen` is set to `stepCountIs(1)`, which means generation stops after the first step when there are tool results. By changing this condition, you can allow the model to automatically send tool results back to itself to trigger additional generations until your specified stopping condition is met. In this case, you want the model to continue generating so it can use the weather tool results to answer your original question.
+To solve this, you can enable multi-step tool calls using `stopWhen`. By default, `stopWhen` is set to `isStepCount(1)`, which means generation stops after the first step when there are tool results. By changing this condition, you can allow the model to automatically send tool results back to itself to trigger additional generations until your specified stopping condition is met. In this case, you want the model to continue generating so it can use the weather tool results to answer your original question.
 
 ### Update Your API Route
 
@@ -479,7 +479,7 @@ import {
   UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
@@ -490,7 +490,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: __MODEL__,
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       weather: tool({
         description: 'Get the weather in a location (fahrenheit)',
@@ -524,7 +524,7 @@ export async function POST(req: Request) {
 
 Head back to the Expo app and ask about the weather in a location. You should now see the model using the weather tool results to answer your question.
 
-By setting `stopWhen: stepCountIs(5)`, you're allowing the model to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the model to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Fahrenheit to Celsius.
+By setting `stopWhen: isStepCount(5)`, you're allowing the model to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the model to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Fahrenheit to Celsius.
 
 ### Add More Tools
 
@@ -536,7 +536,7 @@ import {
   UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
@@ -547,7 +547,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: __MODEL__,
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       weather: tool({
         description: 'Get the weather in a location (fahrenheit)',

--- a/content/docs/02-getting-started/08-tanstack-start.mdx
+++ b/content/docs/02-getting-started/08-tanstack-start.mdx
@@ -379,7 +379,7 @@ Now, when you ask about the weather, you'll see the tool call and its result dis
 
 You may have noticed that while the tool is now visible in the chat interface, the model isn't using this information to answer your original query. This is because once the model generates a tool call, it has technically completed its generation.
 
-To solve this, you can enable multi-step tool calls using `stopWhen`. By default, `stopWhen` is set to `stepCountIs(1)`, which means generation stops after the first step when there are tool results. By changing this condition, you can allow the model to automatically send tool results back to itself to trigger additional generations until your specified stopping condition is met. In this case, you want the model to continue generating so it can use the weather tool results to answer your original question.
+To solve this, you can enable multi-step tool calls using `stopWhen`. By default, `stopWhen` is set to `isStepCount(1)`, which means generation stops after the first step when there are tool results. By changing this condition, you can allow the model to automatically send tool results back to itself to trigger additional generations until your specified stopping condition is met. In this case, you want the model to continue generating so it can use the weather tool results to answer your original question.
 
 ### Update Your Route Handler
 
@@ -391,7 +391,7 @@ import {
   UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 __PROVIDER_IMPORT__;
 import { createFileRoute } from '@tanstack/react-router';
@@ -406,7 +406,7 @@ export const Route = createFileRoute('/api/chat')({
         const result = streamText({
           model: __MODEL__,
           messages: await convertToModelMessages(messages),
-          stopWhen: stepCountIs(5),
+          stopWhen: isStepCount(5),
           tools: {
             weather: tool({
               description: 'Get the weather in a location (fahrenheit)',
@@ -433,11 +433,11 @@ export const Route = createFileRoute('/api/chat')({
 });
 ```
 
-In this updated code, you set `stopWhen` to be when `stepCountIs(5)`, allowing the model to use up to 5 "steps" for any given generation.
+In this updated code, you set `stopWhen` to be when `isStepCount(5)`, allowing the model to use up to 5 "steps" for any given generation.
 
 Head back to the browser and ask about the weather in a location. You should now see the model using the weather tool results to answer your question.
 
-By setting `stopWhen: stepCountIs(5)`, you're allowing the model to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the model to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Celsius to Fahrenheit.
+By setting `stopWhen: isStepCount(5)`, you're allowing the model to use up to 5 "steps" for any given generation. This enables more complex interactions and allows the model to gather and process information over several steps if needed. You can see this in action by adding another tool to convert the temperature from Celsius to Fahrenheit.
 
 ### Add another tool
 
@@ -449,7 +449,7 @@ import {
   UIMessage,
   convertToModelMessages,
   tool,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 __PROVIDER_IMPORT__;
 import { createFileRoute } from '@tanstack/react-router';
@@ -464,7 +464,7 @@ export const Route = createFileRoute('/api/chat')({
         const result = streamText({
           model: __MODEL__,
           messages: await convertToModelMessages(messages),
-          stopWhen: stepCountIs(5),
+          stopWhen: isStepCount(5),
           tools: {
             weather: tool({
               description: 'Get the weather in a location (fahrenheit)',

--- a/content/docs/02-getting-started/09-coding-agents.mdx
+++ b/content/docs/02-getting-started/09-coding-agents.mdx
@@ -136,7 +136,7 @@ For multi-step agent interactions, DevTools groups everything into **runs** (a c
 You can also log tool results directly in code during development:
 
 ```ts
-import { streamText, tool, stepCountIs } from 'ai';
+import { streamText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 
 const result = streamText({
@@ -154,7 +154,7 @@ const result = streamText({
       }),
     }),
   },
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
   onStepFinish: async ({ toolResults }) => {
     if (toolResults.length) {
       console.log(JSON.stringify(toolResults, null, 2));

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -79,17 +79,17 @@ const codeAgent = new ToolLoopAgent({
 
 ### Loop Control
 
-By default, agents run for 20 steps (`stopWhen: stepCountIs(20)`). In each step, the model either generates text or calls a tool. If it generates text, the agent completes. If it calls a tool, the AI SDK executes that tool.
+By default, agents run for 20 steps (`stopWhen: isStepCount(20)`). In each step, the model either generates text or calls a tool. If it generates text, the agent completes. If it calls a tool, the AI SDK executes that tool.
 
 You can configure `stopWhen` differently to allow more steps. After each tool execution, the agent triggers a new generation where the model can call another tool or generate text:
 
 ```ts
-import { ToolLoopAgent, stepCountIs } from 'ai';
+import { ToolLoopAgent, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 
 const agent = new ToolLoopAgent({
   model: __MODEL__,
-  stopWhen: stepCountIs(50), // Increase default from 20 to 50.
+  stopWhen: isStepCount(50), // Increase default from 20 to 50.
 });
 ```
 
@@ -103,13 +103,13 @@ Each step represents one generation (which results in either text or a tool call
 You can combine multiple conditions:
 
 ```ts
-import { ToolLoopAgent, stepCountIs } from 'ai';
+import { ToolLoopAgent, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 
 const agent = new ToolLoopAgent({
   model: __MODEL__,
   stopWhen: [
-    stepCountIs(20), // Maximum 20 steps
+    isStepCount(20), // Maximum 20 steps
     yourCustomCondition(), // Custom logic for when to stop
   ],
 });

--- a/content/docs/03-agents/04-loop-control.mdx
+++ b/content/docs/03-agents/04-loop-control.mdx
@@ -16,7 +16,7 @@ The AI SDK provides built-in loop control through two parameters: `stopWhen` for
 
 ## Stop Conditions
 
-The `stopWhen` parameter controls when to stop execution when there are tool results in the last step. By default, agents stop after 20 steps using `stepCountIs(20)`. This default is a safety measure to prevent runaway loops that could result in excessive API calls and costs.
+The `stopWhen` parameter controls when to stop execution when there are tool results in the last step. By default, agents stop after 20 steps using `isStepCount(20)`. This default is a safety measure to prevent runaway loops that could result in excessive API calls and costs.
 
 When you provide `stopWhen`, the agent continues executing after tool calls until a stopping condition is met. When the condition is an array, execution stops when any of the conditions are met.
 
@@ -24,14 +24,14 @@ When you provide `stopWhen`, the agent continues executing after tool calls unti
 
 The AI SDK provides several built-in stopping conditions:
 
-- `stepCountIs(count)` — stops after a specified number of steps
+- `isStepCount(count)` — stops after a specified number of steps
 - `hasToolCall(toolName)` — stops when a specific tool is called
 - `isLoopFinished()` — never triggers, letting the loop run until the agent is naturally finished
 
 ### Run Up to a Maximum Number of Steps
 
 ```ts
-import { ToolLoopAgent, stepCountIs } from 'ai';
+import { ToolLoopAgent, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 
 const agent = new ToolLoopAgent({
@@ -39,7 +39,7 @@ const agent = new ToolLoopAgent({
   tools: {
     // your tools
   },
-  stopWhen: stepCountIs(50), // Increasing the default of 20 to 50.
+  stopWhen: isStepCount(50), // Increasing the default of 20 to 50.
 });
 
 const result = await agent.generate({
@@ -79,7 +79,7 @@ const result = await agent.generate({
 Combine multiple stopping conditions. The loop stops when it meets any condition:
 
 ```ts
-import { ToolLoopAgent, stepCountIs, hasToolCall } from 'ai';
+import { ToolLoopAgent, isStepCount, hasToolCall } from 'ai';
 __PROVIDER_IMPORT__;
 
 const agent = new ToolLoopAgent({
@@ -88,7 +88,7 @@ const agent = new ToolLoopAgent({
     // your tools
   },
   stopWhen: [
-    stepCountIs(20), // Maximum 20 steps
+    isStepCount(20), // Maximum 20 steps
     hasToolCall('someTool'), // Stop after calling 'someTool'
   ],
 });

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -281,7 +281,7 @@ For more advanced validation or different structures, see [the Output API refere
 One of the key advantages of using structured output with `generateText` and `streamText` is the ability to combine it with tool calling.
 
 ```ts
-import { generateText, Output, tool, stepCountIs } from 'ai';
+import { generateText, Output, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
 
@@ -303,7 +303,7 @@ const { output } = await generateText({
       recommendation: z.string(),
     }),
   }),
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
   prompt: 'What should I wear in San Francisco today?',
 });
 ```

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -22,7 +22,7 @@ The `tools` parameter of `generateText` and `streamText` is an object that has t
 
 ```ts highlight="6-17"
 import { z } from 'zod';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 
 const result = await generateText({
@@ -39,7 +39,7 @@ const result = await generateText({
       }),
     }),
   },
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
   prompt: 'What is the weather in San Francisco?',
 });
 ```
@@ -228,7 +228,7 @@ With the `stopWhen` setting, you can enable multi-step calls in `generateText` a
 
 The AI SDK provides several built-in stopping conditions:
 
-- `stepCountIs(count)` — stops after a specified number of steps (default: `stepCountIs(20)`)
+- `isStepCount(count)` — stops after a specified number of steps (default: `isStepCount(20)`)
 - `hasToolCall(toolName)` — stops when a specific tool is called
 - `isLoopFinished()` — never triggers, letting the loop run until naturally finished
 
@@ -259,7 +259,7 @@ In the following example, there are two steps:
 
 ```ts highlight="18-19"
 import { z } from 'zod';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 
 const { text, steps } = await generateText({
@@ -276,7 +276,7 @@ const { text, steps } = await generateText({
       }),
     }),
   },
-  stopWhen: stepCountIs(5), // stop after a maximum of 5 steps if tools were called
+  stopWhen: isStepCount(5), // stop after a maximum of 5 steps if tools were called
   prompt: 'What is the weather in San Francisco?',
 });
 ```
@@ -297,7 +297,7 @@ __PROVIDER_IMPORT__;
 
 const { steps } = await generateText({
   model: __MODEL__,
-  stopWhen: stepCountIs(10),
+  stopWhen: isStepCount(10),
   // ...
 });
 

--- a/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
@@ -604,7 +604,7 @@ You can also use multi-step calls on the server-side with `streamText`.
 This works when all invoked tools have an `execute` function on the server side.
 
 ```tsx filename='app/api/chat/route.ts' highlight="15-21,24"
-import { convertToModelMessages, streamText, UIMessage, stepCountIs } from 'ai';
+import { convertToModelMessages, streamText, UIMessage, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import { z } from 'zod';
 
@@ -627,7 +627,7 @@ export async function POST(req: Request) {
         },
       },
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   return result.toUIMessageStreamResponse();

--- a/content/docs/04-ai-sdk-ui/04-generative-user-interfaces.mdx
+++ b/content/docs/04-ai-sdk-ui/04-generative-user-interfaces.mdx
@@ -76,7 +76,7 @@ export default function Page() {
 To handle the chat requests and model responses, set up an API route:
 
 ```ts filename="app/api/chat/route.ts"
-import { streamText, convertToModelMessages, UIMessage, stepCountIs } from 'ai';
+import { streamText, convertToModelMessages, UIMessage, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 
 export async function POST(request: Request) {
@@ -86,7 +86,7 @@ export async function POST(request: Request) {
     model: __MODEL__,
     system: 'You are a friendly assistant!',
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   return result.toUIMessageStreamResponse();
@@ -128,7 +128,7 @@ In this file, you've created a tool called `weatherTool`. This tool simulates fe
 Update the API route to include the tool you've defined:
 
 ```ts filename="app/api/chat/route.ts" highlight="3,8,14"
-import { streamText, convertToModelMessages, UIMessage, stepCountIs } from 'ai';
+import { streamText, convertToModelMessages, UIMessage, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 import { tools } from '@/ai/tools';
 
@@ -139,7 +139,7 @@ export async function POST(request: Request) {
     model: __MODEL__,
     system: 'You are a friendly assistant!',
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools,
   });
 

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -544,7 +544,7 @@ To see `generateText` in action, check out [these examples](#examples).
       type: 'StopCondition<TOOLS> | Array<StopCondition<TOOLS>>',
       isOptional: true,
       description:
-        'Condition for stopping the generation when there are tool results in the last step. When the condition is an array, any of the conditions can be met to stop the generation. Default: stepCountIs(1).',
+        'Condition for stopping the generation when there are tool results in the last step. When the condition is an array, any of the conditions can be met to stop the generation. Default: isStepCount(1).',
     },
     {
       name: 'prepareStep',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -588,7 +588,7 @@ To see `streamText` in action, check out [these examples](#examples).
       type: 'StopCondition<TOOLS> | Array<StopCondition<TOOLS>>',
       isOptional: true,
       description:
-        'Condition for stopping the generation when there are tool results in the last step. When the condition is an array, any of the conditions can be met to stop the generation. Default: stepCountIs(1).',
+        'Condition for stopping the generation when there are tool results in the last step. When the condition is an array, any of the conditions can be met to stop the generation. Default: isStepCount(1).',
     },
     {
       name: 'prepareStep',

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -74,7 +74,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
       type: 'StopCondition | StopCondition[]',
       isOptional: true,
       description:
-        'Condition(s) for ending the agent loop. Default: stepCountIs(20).',
+        'Condition(s) for ending the agent loop. Default: isStepCount(20).',
     },
     {
       name: 'activeTools',
@@ -887,7 +887,7 @@ type MetadataAgentUIMessage = InferAgentUIMessage<
 ### Basic Agent with Tools
 
 ```ts
-import { ToolLoopAgent, stepCountIs } from 'ai';
+import { ToolLoopAgent, isStepCount } from 'ai';
 import { weatherTool, calculatorTool } from './tools';
 
 const assistant = new ToolLoopAgent({
@@ -897,7 +897,7 @@ const assistant = new ToolLoopAgent({
     weather: weatherTool,
     calculator: calculatorTool,
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 const result = await assistant.generate({

--- a/content/docs/07-reference/01-ai-sdk-core/70-is-step-count.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/70-is-step-count.mdx
@@ -1,16 +1,16 @@
 ---
-title: stepCountIs
-description: API Reference for stepCountIs.
+title: isStepCount
+description: API Reference for isStepCount.
 ---
 
-# `stepCountIs()`
+# `isStepCount()`
 
 Creates a stop condition that stops when the number of steps reaches a specified count.
 
 This function is used with `stopWhen` in `generateText` and `streamText` to control when a tool-calling loop should stop based on the number of steps executed.
 
 ```ts
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 
 const result = await generateText({
@@ -19,13 +19,13 @@ const result = await generateText({
     // your tools
   },
   // Stop after 5 steps
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
 });
 ```
 
 ## Import
 
-<Snippet text={`import { stepCountIs } from "ai"`} prompt={false} />
+<Snippet text={`import { isStepCount } from "ai"`} prompt={false} />
 
 ## API Signature
 
@@ -53,12 +53,12 @@ A `StopCondition` function that returns `true` when the step count reaches the s
 Stop after 3 steps:
 
 ```ts
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 
 const result = await generateText({
   model: yourModel,
   tools: yourTools,
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 ```
 
@@ -67,13 +67,13 @@ const result = await generateText({
 You can combine multiple stop conditions in an array:
 
 ```ts
-import { generateText, stepCountIs, hasToolCall } from 'ai';
+import { generateText, isStepCount, hasToolCall } from 'ai';
 
 const result = await generateText({
   model: yourModel,
   tools: yourTools,
   // Stop after 10 steps OR when finalAnswer tool is called
-  stopWhen: [stepCountIs(10), hasToolCall('finalAnswer')],
+  stopWhen: [isStepCount(10), hasToolCall('finalAnswer')],
 });
 ```
 

--- a/content/docs/07-reference/01-ai-sdk-core/71-has-tool-call.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/71-has-tool-call.mdx
@@ -71,7 +71,7 @@ const result = await generateText({
 You can combine multiple stop conditions in an array:
 
 ```ts
-import { generateText, hasToolCall, stepCountIs } from 'ai';
+import { generateText, hasToolCall, isStepCount } from 'ai';
 
 const result = await generateText({
   model: yourModel,
@@ -84,7 +84,7 @@ const result = await generateText({
   stopWhen: [
     hasToolCall('weather'),
     hasToolCall('finalAnswer'),
-    stepCountIs(5),
+    isStepCount(5),
   ],
 });
 ```
@@ -115,6 +115,6 @@ const result = await generateText({
 
 ## See also
 
-- [`stepCountIs()`](/docs/reference/ai-sdk-core/step-count-is)
+- [`isStepCount()`](/docs/reference/ai-sdk-core/is-step-count)
 - [`generateText()`](/docs/reference/ai-sdk-core/generate-text)
 - [`streamText()`](/docs/reference/ai-sdk-core/stream-text)

--- a/content/docs/07-reference/01-ai-sdk-core/72-loop-finished.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/72-loop-finished.mdx
@@ -7,7 +7,7 @@ description: API Reference for isLoopFinished.
 
 Creates a stop condition that never triggers, letting the agent loop run until it naturally finishes (i.e., the model stops making tool calls).
 
-By default, `ToolLoopAgent` uses `stepCountIs(20)` as a safety measure to prevent runaway loops that could result in excessive API calls and costs. If you are confident that your agent will terminate naturally or you are less concerned about costs, `isLoopFinished()` removes that limit and lets the agent run until the model is truly done.
+By default, `ToolLoopAgent` uses `isStepCount(20)` as a safety measure to prevent runaway loops that could result in excessive API calls and costs. If you are confident that your agent will terminate naturally or you are less concerned about costs, `isLoopFinished()` removes that limit and lets the agent run until the model is truly done.
 
 ```ts
 import { ToolLoopAgent, isLoopFinished } from 'ai';
@@ -78,6 +78,6 @@ In practice, this does not make much sense in this context, since you could just
 
 ## See also
 
-- [`stepCountIs()`](/docs/reference/ai-sdk-core/step-count-is)
+- [`isStepCount()`](/docs/reference/ai-sdk-core/is-step-count)
 - [`hasToolCall()`](/docs/reference/ai-sdk-core/has-tool-call)
 - [`ToolLoopAgent`](/docs/reference/ai-sdk-core/tool-loop-agent)

--- a/content/docs/07-reference/01-ai-sdk-core/index.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/index.mdx
@@ -136,10 +136,10 @@ It also contains the following helper functions:
       href: '/docs/reference/ai-sdk-core/extract-json-middleware',
     },
     {
-      title: 'stepCountIs()',
+      title: 'isStepCount()',
       description:
         'Creates a stop condition that triggers after a specified number of steps.',
-      href: '/docs/reference/ai-sdk-core/step-count-is',
+      href: '/docs/reference/ai-sdk-core/is-step-count',
     },
     {
       title: 'hasToolCall()',

--- a/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
+++ b/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
@@ -87,10 +87,10 @@ npx @ai-sdk/codemod v6/rename-text-embedding-to-embedding src/
 The `Experimental_Agent` class has been replaced with the `ToolLoopAgent` class. Two key changes:
 
 1. The `system` parameter has been renamed to `instructions`
-2. The default `stopWhen` has changed from `stepCountIs(1)` to `stepCountIs(20)`
+2. The default `stopWhen` has changed from `isStepCount(1)` to `isStepCount(20)`
 
 ```tsx filename="AI SDK 5"
-import { Experimental_Agent as Agent, stepCountIs } from 'ai';
+import { Experimental_Agent as Agent, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 
 const agent = new Agent({
@@ -99,7 +99,7 @@ const agent = new Agent({
   tools: {
     // your tools here
   },
-  stopWhen: stepCountIs(20), // Required for multi-step agent loops
+  stopWhen: isStepCount(20), // Required for multi-step agent loops
 });
 
 const result = await agent.generate({
@@ -117,7 +117,7 @@ const agent = new ToolLoopAgent({
   tools: {
     // your tools here
   },
-  // stopWhen defaults to stepCountIs(20)
+  // stopWhen defaults to isStepCount(20)
 });
 
 const result = await agent.generate({

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -1164,14 +1164,14 @@ const { messages } = useChat({
 ```
 
 ```tsx filename="AI SDK 5.0"
-import { stepCountIs, hasToolCall } from 'ai';
+import { isStepCount, hasToolCall } from 'ai';
 
 // V5: Server-side - flexible stopping conditions with stopWhen
 const result = await generateText({
   model: __MODEL__,
   messages,
   // Only triggers when last step has tool results
-  stopWhen: stepCountIs(5), // Stop at step 5 if tools were called
+  stopWhen: isStepCount(5), // Stop at step 5 if tools were called
 });
 
 // Server-side - stop when specific tool is called
@@ -1187,14 +1187,14 @@ const result = await generateText({
 ```tsx filename="AI SDK 5.0"
 // Stop after N steps (equivalent to old maxSteps)
 // Note: Only applies when the last step has tool results
-stopWhen: stepCountIs(5);
+stopWhen: isStepCount(5);
 
 // Stop when specific tool is called
 stopWhen: hasToolCall('finalizeTask');
 
 // Multiple conditions (stops if ANY condition is met)
 stopWhen: [
-  stepCountIs(10), // Maximum 10 steps
+  isStepCount(10), // Maximum 10 steps
   hasToolCall('submitOrder'), // Or when order is submitted
 ];
 
@@ -1274,13 +1274,13 @@ const { messages, sendMessage } = useChat({
 
 ```tsx filename="AI SDK 5.0"
 // Server-side: Use stopWhen for multi-step control
-import { streamText, convertToModelMessages, stepCountIs } from 'ai';
+import { streamText, convertToModelMessages, isStepCount } from 'ai';
 __PROVIDER_IMPORT__;
 
 const result = await streamText({
   model: __MODEL__,
   messages: convertToModelMessages(messages),
-  stopWhen: stepCountIs(5), // Stop after 5 steps with tool calls
+  stopWhen: isStepCount(5), // Stop after 5 steps with tool calls
 });
 
 // Client-side: Configure automatic submission

--- a/content/docs/09-troubleshooting/14-tool-calling-with-structured-outputs.mdx
+++ b/content/docs/09-troubleshooting/14-tool-calling-with-structured-outputs.mdx
@@ -40,7 +40,7 @@ const result = await generateText({
     },
   },
   // Add at least 1 to your intended step count to account for structured output
-  stopWhen: stepCountIs(3), // Now accounts for: tool call + tool result + structured output
+  stopWhen: isStepCount(3), // Now accounts for: tool call + tool result + structured output
   prompt: 'Analyze the data and provide a summary',
 });
 ```

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -377,13 +377,13 @@ const { text } = await generateText({
 Some providers offer tools that are executed by the provider itself, such as [OpenAI's web search tool](/providers/ai-sdk-providers/openai#web-search-tool). To use these tools through AI Gateway, import the provider to access the tool definitions:
 
 ```ts
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const result = await generateText({
   model: 'openai/gpt-5-mini',
   prompt: 'What is the Vercel AI Gateway?',
-  stopWhen: stepCountIs(10),
+  stopWhen: isStepCount(10),
   tools: {
     web_search: openai.tools.webSearch({}),
   },

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -769,7 +769,7 @@ const result = await generateText({
     }),
   },
   prompt: 'List the files in my home directory.',
-  stopWhen: stepCountIs(2),
+  stopWhen: isStepCount(2),
 });
 ```
 
@@ -927,7 +927,7 @@ const result = await generateText({
     }),
   },
   prompt: 'Use the skill to solve this problem.',
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
 });
 ```
 
@@ -942,7 +942,7 @@ enabling iterative, multi-step code editing workflows.
 
 ```ts
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 
 const result = await generateText({
   model: openai('gpt-5.1'),
@@ -954,7 +954,7 @@ const result = await generateText({
     }),
   },
   prompt: 'Create a python file that calculates the factorial of a number',
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
 });
 ```
 
@@ -982,13 +982,13 @@ Add `openai.tools.toolSearch()` with no arguments and mark your tools with `defe
 
 ```ts
 import { openai } from '@ai-sdk/openai';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 
 const result = await generateText({
   model: openai.responses('gpt-5.4'),
   prompt: 'What is the weather in San Francisco?',
-  stopWhen: stepCountIs(10),
+  stopWhen: isStepCount(10),
   tools: {
     toolSearch: openai.tools.toolSearch(),
 
@@ -1033,13 +1033,13 @@ a `description`, `parameters` schema, and an `execute` callback:
 
 ```ts
 import { openai } from '@ai-sdk/openai';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 
 const result = await generateText({
   model: openai.responses('gpt-5.4'),
   prompt: 'What is the weather in San Francisco?',
-  stopWhen: stepCountIs(10),
+  stopWhen: isStepCount(10),
   tools: {
     toolSearch: openai.tools.toolSearch({
       execution: 'client',
@@ -1113,7 +1113,7 @@ SQL queries, code snippets, or any output that must match a specific pattern.
 
 ```ts
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 
 const result = await generateText({
   model: openai.responses('gpt-5.2-codex'),
@@ -1134,7 +1134,7 @@ const result = await generateText({
   },
   toolChoice: 'required',
   prompt: 'Write a SQL query to get all users older than 25.',
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 ```
 

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -1161,12 +1161,12 @@ import {
   anthropic,
   forwardAnthropicContainerIdFromLastStep,
 } from '@ai-sdk/anthropic';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 
 const result = await generateText({
   model: anthropic('claude-sonnet-4-5'),
-  stopWhen: stepCountIs(10),
+  stopWhen: isStepCount(10),
   prompt:
     'Get the weather for Tokyo, Sydney, and London, then calculate the average temperature.',
   tools: {

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -1443,7 +1443,7 @@ They are available via the `tools` property of the provider instance.
 
 ```ts
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 
 const result = await generateText({
   model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
@@ -1456,7 +1456,7 @@ const result = await generateText({
     }),
   },
   prompt: 'List the files in my directory.',
-  stopWhen: stepCountIs(2),
+  stopWhen: isStepCount(2),
 });
 ```
 
@@ -1464,7 +1464,7 @@ const result = await generateText({
 
 ```ts
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 
 const result = await generateText({
   model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
@@ -1477,7 +1477,7 @@ const result = await generateText({
     }),
   },
   prompt: 'Update my README file.',
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
 });
 ```
 
@@ -1485,7 +1485,7 @@ const result = await generateText({
 
 ```ts
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import fs from 'fs';
 
 const result = await generateText({
@@ -1520,7 +1520,7 @@ const result = await generateText({
     }),
   },
   prompt: 'Take a screenshot.',
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 ```
 

--- a/content/providers/03-community-providers/50-hindsight.mdx
+++ b/content/providers/03-community-providers/50-hindsight.mdx
@@ -87,7 +87,7 @@ const tools = createHindsightTools({
 ```ts
 import { HindsightClient } from '@vectorize-io/hindsight-client';
 import { createHindsightTools } from '@vectorize-io/hindsight-ai-sdk';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const client = new HindsightClient({ baseUrl: process.env.HINDSIGHT_API_URL });
@@ -96,7 +96,7 @@ const tools = createHindsightTools({ client, bankId: 'user-123' });
 const { text } = await generateText({
   model: openai('gpt-4o'),
   tools,
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
   system: 'You are a helpful assistant with long-term memory.',
   prompt: 'Remember that I prefer dark mode and large fonts.',
 });
@@ -129,7 +129,7 @@ In multi-user applications, create tools inside your request handler so each req
 
 ```ts
 // app/api/chat/route.ts
-import { streamText, stepCountIs, convertToModelMessages } from 'ai';
+import { streamText, isStepCount, convertToModelMessages } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { HindsightClient } from '@vectorize-io/hindsight-client';
 import { createHindsightTools } from '@vectorize-io/hindsight-ai-sdk';
@@ -149,7 +149,7 @@ export async function POST(req: Request) {
   return streamText({
     model: openai('gpt-4o'),
     tools,
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     system: 'You are a helpful assistant with long-term memory.',
     messages: await convertToModelMessages(messages),
   }).toUIMessageStreamResponse();

--- a/content/providers/05-observability/confident-ai.mdx
+++ b/content/providers/05-observability/confident-ai.mdx
@@ -88,7 +88,7 @@ for await (const textPart of result.textStream) {
 ### Generate text with tool calls
 
 ```typescript highlight="3,6,26"
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { configureAiSdkTracing } from 'deepeval-ts';
 import { z } from 'zod';
@@ -109,7 +109,7 @@ const result = await generateText({
       }),
     }),
   },
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
   prompt: 'What is the weather in San Francisco?',
   experimental_telemetry: {
     isEnabled: true,

--- a/content/providers/05-observability/langsmith.mdx
+++ b/content/providers/05-observability/langsmith.mdx
@@ -72,7 +72,7 @@ You can also trace runs with tool calls:
 
 ```ts
 import * as ai from 'ai';
-import { tool, stepCountIs } from 'ai';
+import { tool, isStepCount } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { z } from 'zod';
 
@@ -102,7 +102,7 @@ await generateText({
         `Here is the tracking information for ${orderId}`,
     }),
   },
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
 });
 ```
 
@@ -117,7 +117,7 @@ want to group runs together in LangSmith:
 
 ```ts
 import * as ai from 'ai';
-import { tool, stepCountIs } from 'ai';
+import { tool, isStepCount } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { z } from 'zod';
 
@@ -150,7 +150,7 @@ const wrapper = traceable(
             `Here is the tracking information for ${orderId}`,
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
     });
     return text;
   },

--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -36,7 +36,7 @@ export const tools: Tool[] = [
       yarn: 'yarn add ai-sdk-tool-code-execution',
       bun: 'bun add ai-sdk-tool-code-execution',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { executeCode } from 'ai-sdk-tool-code-execution';
 
 const { text } = await generateText({
@@ -45,7 +45,7 @@ const { text } = await generateText({
   tools: {
     executeCode: executeCode(),
   },
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
 });
 
 console.log(text);`,
@@ -68,7 +68,7 @@ console.log(text);`,
       yarn: 'yarn add @exalabs/ai-sdk',
       bun: 'bun add @exalabs/ai-sdk',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { webSearch } from '@exalabs/ai-sdk';
 
 const { text } = await generateText({
@@ -77,7 +77,7 @@ const { text } = await generateText({
   tools: {
     webSearch: webSearch(),
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 console.log(text);`,
@@ -100,7 +100,7 @@ console.log(text);`,
       yarn: 'yarn add @parallel-web/ai-sdk-tools',
       bun: 'bun add @parallel-web/ai-sdk-tools',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { searchTool, extractTool } from '@parallel-web/ai-sdk-tools';
 
 const { text } = await generateText({
@@ -110,7 +110,7 @@ const { text } = await generateText({
     webSearch: searchTool,
     webExtract: extractTool,
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 console.log(text);`,
@@ -132,7 +132,7 @@ console.log(text);`,
       yarn: 'yarn add ctx-zip',
       bun: 'bun add ctx-zip',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { createVercelSandboxCodeMode, SANDBOX_SYSTEM_PROMPT } from 'ctx-zip';
 
 const { tools } = await createVercelSandboxCodeMode({
@@ -154,7 +154,7 @@ const { tools } = await createVercelSandboxCodeMode({
 const { text } = await generateText({
   model: 'openai/gpt-5.2',
   tools,
-  stopWhen: stepCountIs(20),
+  stopWhen: isStepCount(20),
   system: SANDBOX_SYSTEM_PROMPT,
   messages: [
     {
@@ -185,7 +185,7 @@ console.log(text);
       yarn: 'yarn add @perplexity-ai/ai-sdk',
       bun: 'bun add @perplexity-ai/ai-sdk',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { perplexitySearch } from '@perplexity-ai/ai-sdk';
 
 const { text } = await generateText({
@@ -194,7 +194,7 @@ const { text } = await generateText({
   tools: {
     search: perplexitySearch(),
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 console.log(text);`,
@@ -217,7 +217,7 @@ console.log(text);`,
       yarn: 'yarn add @tavily/ai-sdk',
       bun: 'bun add @tavily/ai-sdk',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { tavilySearch } from '@tavily/ai-sdk';
 
 const { text } = await generateText({
@@ -226,7 +226,7 @@ const { text } = await generateText({
   tools: {
     webSearch: tavilySearch,
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 console.log(text);`,
@@ -249,7 +249,7 @@ console.log(text);`,
       yarn: 'yarn add firecrawl-aisdk',
       bun: 'bun add firecrawl-aisdk',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { scrapeTool } from 'firecrawl-aisdk';
 
 const { text } = await generateText({
@@ -258,7 +258,7 @@ const { text } = await generateText({
   tools: {
     scrape: scrapeTool,
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 console.log(text);`,
@@ -281,7 +281,7 @@ console.log(text);`,
       yarn: 'yarn add bedrock-agentcore',
       bun: 'bun add bedrock-agentcore',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { bedrock } from '@ai-sdk/amazon-bedrock';
 import { awsCredentialsProvider } from '@vercel/oidc-aws-credentials-provider';
 import { CodeInterpreterTools } from 'bedrock-agentcore/code-interpreter/vercel-ai';
@@ -302,7 +302,7 @@ try {
       ...codeInterpreter.tools,
       ...browser.tools,
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log(text);
@@ -330,7 +330,7 @@ try {
       yarn: 'yarn add @superagent-ai/ai-sdk',
       bun: 'bun add @superagent-ai/ai-sdk',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { guard, redact, verify } from '@superagent-ai/ai-sdk';
 import { openai } from '@ai-sdk/openai';
 
@@ -342,7 +342,7 @@ const { text } = await generateText({
     redact: redact(),
     verify: verify(),
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 console.log(text);`,
@@ -364,7 +364,7 @@ console.log(text);`,
       bun: 'bun add @takoviz/ai-sdk',
     },
     codeExample: `import { takoSearch } from '@takoviz/ai-sdk';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 
 const { text } = await generateText({
   model: 'openai/gpt-5.2',
@@ -372,7 +372,7 @@ const { text } = await generateText({
   tools: {
     takoSearch: takoSearch(),
   },
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
 });
 
 console.log(text);`,
@@ -397,7 +397,7 @@ console.log(text);`,
       yarn: 'yarn add @valyu/ai-sdk',
       bun: 'bun add @valyu/ai-sdk',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { webSearch } from '@valyu/ai-sdk';
 // Available specialised search tools: financeSearch, paperSearch,
 // bioSearch, patentSearch, secSearch, economicsSearch, companyResearch
@@ -408,7 +408,7 @@ const { text } = await generateText({
   tools: {
     webSearch: webSearch(),
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 console.log(text);`,
@@ -431,7 +431,7 @@ console.log(text);`,
       yarn: 'yarn add @airweave/vercel-ai-sdk',
       bun: 'bun add @airweave/vercel-ai-sdk',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { airweaveSearch } from '@airweave/vercel-ai-sdk';
 
 const { text } = await generateText({
@@ -442,7 +442,7 @@ const { text } = await generateText({
       defaultCollection: 'my-knowledge-base',
     }),
   },
-  stopWhen: stepCountIs(3),
+  stopWhen: isStepCount(3),
 });
 
 console.log(text);`,
@@ -464,7 +464,7 @@ console.log(text);`,
       yarn: 'yarn add bash-tool',
       bun: 'bun add bash-tool',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { createBashTool } from 'bash-tool';
 
 const { tools } = await createBashTool({
@@ -475,7 +475,7 @@ const { text } = await generateText({
   model: 'anthropic/claude-sonnet-4',
   prompt: 'List the files in src/ and show me the contents of index.ts',
   tools,
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
 });
 
 console.log(text);`,
@@ -497,7 +497,7 @@ console.log(text);`,
       yarn: 'yarn add @browserbasehq/ai-sdk',
       bun: 'bun add @browserbasehq/ai-sdk',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { createBrowserbaseTools } from '@browserbasehq/ai-sdk';
 
 const browserbase = createBrowserbaseTools();
@@ -505,7 +505,7 @@ const browserbase = createBrowserbaseTools();
 const { text } = await generateText({
   model: 'google/gemini-3-pro-preview',
   tools: browserbase.tools,
-  stopWhen: stepCountIs(10),
+  stopWhen: isStepCount(10),
   prompt: 'Open https://news.ycombinator.com and summarize the top 3 stories.',
 });
 

--- a/contributing/add-new-tool-to-registry.md
+++ b/contributing/add-new-tool-to-registry.md
@@ -39,7 +39,7 @@ Before submitting your tool, ensure you have:
        yarn: 'yarn add your-package-name',
        bun: 'bun add your-package-name',
      },
-     codeExample: `import { generateText, gateway, stepCountIs } from 'ai';
+     codeExample: `import { generateText, gateway, isStepCount } from 'ai';
    import { yourTool } from 'your-package-name';
 
    const { text } = await generateText({
@@ -48,7 +48,7 @@ Before submitting your tool, ensure you have:
      tools: {
        yourTool: yourTool(),
      },
-     stopWhen: stepCountIs(3),
+     stopWhen: isStepCount(3),
    });
 
    console.log(text);`,

--- a/examples/ai-e2e-next/app/api/chat/data-ui-parts/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/data-ui-parts/route.ts
@@ -4,7 +4,7 @@ import {
   convertToModelMessages,
   createUIMessageStream,
   createUIMessageStreamResponse,
-  stepCountIs,
+  isStepCount,
   streamText,
 } from 'ai';
 import { z } from 'zod';
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
     execute: ({ writer }) => {
       const result = streamText({
         model: openai('gpt-4o'),
-        stopWhen: stepCountIs(2),
+        stopWhen: isStepCount(2),
         tools: {
           weather: {
             description: 'Get the weather in a city',

--- a/examples/ai-e2e-next/app/api/chat/dynamic-tools/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/dynamic-tools/route.ts
@@ -3,7 +3,7 @@ import {
   convertToModelMessages,
   dynamicTool,
   InferUITools,
-  stepCountIs,
+  isStepCount,
   streamText,
   tool,
   ToolSet,
@@ -68,7 +68,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: openai('gpt-4o'),
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5), // multi-steps for server-side tools
+    stopWhen: isStepCount(5), // multi-steps for server-side tools
     tools: {
       ...staticTools,
       ...dynamicTools(),

--- a/examples/ai-e2e-next/app/api/chat/human-in-the-loop/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/human-in-the-loop/route.ts
@@ -4,7 +4,7 @@ import {
   streamText,
   createUIMessageStream,
   convertToModelMessages,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 import { processToolCalls } from './utils';
 import { tools } from './tools';
@@ -43,7 +43,7 @@ export async function POST(req: Request) {
         model: openai('gpt-4o'),
         messages: await convertToModelMessages(processedMessages),
         tools,
-        stopWhen: stepCountIs(20),
+        stopWhen: isStepCount(20),
       });
 
       writer.merge(

--- a/examples/ai-e2e-next/app/api/chat/mcp-elicitation/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/mcp-elicitation/route.ts
@@ -4,7 +4,7 @@ import {
   streamText,
   createUIMessageStream,
   convertToModelMessages,
-  stepCountIs,
+  isStepCount,
 } from 'ai';
 import { createMCPClient, ElicitationRequestSchema } from '@ai-sdk/mcp';
 import { MCPElicitationUIMessage } from './types';
@@ -83,7 +83,7 @@ async function processMessages(
     const result = streamText({
       model: openai('gpt-4o-mini'),
       tools,
-      stopWhen: stepCountIs(10),
+      stopWhen: isStepCount(10),
       onStepFinish: async ({ toolResults }) => {
         if (toolResults.length > 0) {
           console.log('TOOL RESULTS:', JSON.stringify(toolResults, null, 2));

--- a/examples/ai-e2e-next/app/api/chat/mcp-with-auth/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/mcp-with-auth/route.ts
@@ -1,7 +1,7 @@
 import { openai } from '@ai-sdk/openai';
 import {
   convertToModelMessages,
-  stepCountIs,
+  isStepCount,
   streamText,
   createUIMessageStream,
   createUIMessageStreamResponse,
@@ -240,7 +240,7 @@ export async function POST(req: Request) {
           const result = streamText({
             model: openai('gpt-4o-mini'),
             tools,
-            stopWhen: stepCountIs(10),
+            stopWhen: isStepCount(10),
             system:
               'You are a helpful assistant with access to protected tools.',
             messages: await convertToModelMessages(messages),

--- a/examples/ai-e2e-next/app/api/chat/mcp-zapier/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/mcp-zapier/route.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { convertToModelMessages, stepCountIs, streamText } from 'ai';
+import { convertToModelMessages, isStepCount, streamText } from 'ai';
 import { createMCPClient } from '@ai-sdk/mcp';
 
 export const maxDuration = 30;
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
       onFinish: async () => {
         await mcpClient.close();
       },
-      stopWhen: stepCountIs(10),
+      stopWhen: isStepCount(10),
     });
 
     return result.toUIMessageStreamResponse();

--- a/examples/ai-e2e-next/app/api/chat/openai-previous-response-id/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/openai-previous-response-id/route.ts
@@ -8,7 +8,7 @@ import {
   createUIMessageStream,
   createUIMessageStreamResponse,
   InferUITools,
-  stepCountIs,
+  isStepCount,
   streamText,
   UIMessage,
 } from 'ai';
@@ -49,7 +49,7 @@ export async function POST(req: Request) {
         // Send only the latest user message; OpenAI will fetch prior turns via previousResponseId.
         messages: await convertToModelMessages([message]),
         tools,
-        stopWhen: stepCountIs(20),
+        stopWhen: isStepCount(20),
         reasoning: 'low',
         providerOptions: {
           openai: {

--- a/examples/ai-e2e-next/app/api/chat/test-invalid-tool-call/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/test-invalid-tool-call/route.ts
@@ -2,7 +2,7 @@ import { openai } from '@ai-sdk/openai';
 import {
   convertToModelMessages,
   InferUITools,
-  stepCountIs,
+  isStepCount,
   streamText,
   tool,
   UIDataTypes,
@@ -45,7 +45,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: openai('gpt-4o'),
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5), // multi-steps for server-side tools
+    stopWhen: isStepCount(5), // multi-steps for server-side tools
     tools,
     prepareStep: async ({ stepNumber }) => {
       // inject invalid tool call in first step:

--- a/examples/ai-e2e-next/app/api/chat/tool-timeout/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/tool-timeout/route.ts
@@ -2,7 +2,7 @@ import { openai } from '@ai-sdk/openai';
 import {
   convertToModelMessages,
   InferUITools,
-  stepCountIs,
+  isStepCount,
   streamText,
   tool,
   UIDataTypes,
@@ -55,7 +55,7 @@ export async function POST(req: Request) {
     timeout: {
       toolMs: 1000,
     },
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
   });
 
   return result.toUIMessageStreamResponse();

--- a/examples/ai-e2e-next/app/api/chat/tools/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/tools/route.ts
@@ -2,7 +2,7 @@ import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
 import {
   convertToModelMessages,
   InferUITools,
-  stepCountIs,
+  isStepCount,
   streamText,
   tool,
   UIDataTypes,
@@ -95,7 +95,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: openai('gpt-5-mini'),
     messages: await convertToModelMessages(messages),
-    stopWhen: stepCountIs(5), // multi-steps for server-side tools
+    stopWhen: isStepCount(5), // multi-steps for server-side tools
     tools,
     providerOptions: {
       openai: {

--- a/examples/ai-e2e-next/app/api/use-completion-server-side-multi-step/route.ts
+++ b/examples/ai-e2e-next/app/api/use-completion-server-side-multi-step/route.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 
 // Allow streaming responses up to 60 seconds
@@ -23,7 +23,7 @@ export async function POST(req: Request) {
         }),
       }),
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
     prompt,
   });
 

--- a/examples/ai-e2e-next/app/chat/mcp/chat/route.ts
+++ b/examples/ai-e2e-next/app/chat/mcp/chat/route.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { convertToModelMessages, stepCountIs, streamText } from 'ai';
+import { convertToModelMessages, isStepCount, streamText } from 'ai';
 import { createMCPClient } from '@ai-sdk/mcp';
 
 export async function POST(req: Request) {
@@ -21,7 +21,7 @@ export async function POST(req: Request) {
     const result = streamText({
       model: openai('gpt-4o-mini'),
       tools,
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       onStepFinish: async ({ toolResults }) => {
         console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
       },

--- a/examples/ai-functions/src/agent/openai/agent-nested-context.ts
+++ b/examples/ai-functions/src/agent/openai/agent-nested-context.ts
@@ -2,7 +2,7 @@ import { openai } from '@ai-sdk/openai';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node';
-import { ToolLoopAgent, tool, stepCountIs } from 'ai';
+import { ToolLoopAgent, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -29,7 +29,7 @@ run(async () => {
         },
       }),
     },
-    stopWhen: stepCountIs(3),
+    stopWhen: isStepCount(3),
     experimental_telemetry: {
       isEnabled: true,
       functionId: 'child-agent',
@@ -59,7 +59,7 @@ run(async () => {
         },
       }),
     },
-    stopWhen: stepCountIs(3),
+    stopWhen: isStepCount(3),
     experimental_telemetry: {
       isEnabled: true,
       functionId: 'parent-agent',

--- a/examples/ai-functions/src/complex/math-agent/agent-required-tool-choice.ts
+++ b/examples/ai-functions/src/complex/math-agent/agent-required-tool-choice.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import * as mathjs from 'mathjs';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -31,7 +31,7 @@ run(async () => {
       }),
     },
     toolChoice: 'required',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     onStepFinish: async ({ toolResults }) => {
       console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
     },

--- a/examples/ai-functions/src/complex/math-agent/agent.ts
+++ b/examples/ai-functions/src/complex/math-agent/agent.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import * as mathjs from 'mathjs';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -16,7 +16,7 @@ run(async () => {
         execute: async ({ expression }) => mathjs.evaluate(expression),
       }),
     },
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     onStepFinish: async ({ toolResults }) => {
       console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
     },

--- a/examples/ai-functions/src/e2e/amazon-bedrock-anthropic.test.ts
+++ b/examples/ai-functions/src/e2e/amazon-bedrock-anthropic.test.ts
@@ -3,7 +3,7 @@ import {
   createBedrockAnthropic,
 } from '@ai-sdk/amazon-bedrock/anthropic';
 import { LanguageModelV3, LanguageModelV4 } from '@ai-sdk/provider';
-import { APICallError, generateText, stepCountIs } from 'ai';
+import { APICallError, generateText, isStepCount } from 'ai';
 import 'dotenv/config';
 import fs from 'fs';
 import { describe, expect, it } from 'vitest';
@@ -160,7 +160,7 @@ const toolTests = (model: LanguageModelV4) => {
         },
         prompt:
           'How can I switch to dark mode? Take a look at the screen and tell me.',
-        stopWhen: stepCountIs(5),
+        stopWhen: isStepCount(5),
       });
 
       console.log(result.text);
@@ -195,7 +195,7 @@ README.md     build         data          node_modules  package.json  src       
           }),
         },
         prompt: 'List the files in my directory.',
-        stopWhen: stepCountIs(2),
+        stopWhen: isStepCount(2),
       });
 
       expect(result.text).toBeTruthy();
@@ -240,7 +240,7 @@ README.md     build         data          node_modules  package.json  src       
           }),
         },
         prompt: 'Update my README file to talk about AI.',
-        stopWhen: stepCountIs(5),
+        stopWhen: isStepCount(5),
       });
 
       expect(result.text).toBeTruthy();

--- a/examples/ai-functions/src/e2e/feature-test-suite.ts
+++ b/examples/ai-functions/src/e2e/feature-test-suite.ts
@@ -14,7 +14,7 @@ import {
   generateImage,
   generateText,
   Output,
-  stepCountIs,
+  isStepCount,
   streamText,
 } from 'ai';
 import fs from 'fs';
@@ -749,7 +749,7 @@ export function createFeatureTestSuite({
                       },
                     },
                   },
-                  stopWhen: stepCountIs(10),
+                  stopWhen: isStepCount(10),
                 });
 
                 expect(weatherCalls).toBe(1);

--- a/examples/ai-functions/src/e2e/google-vertex-anthropic.test.ts
+++ b/examples/ai-functions/src/e2e/google-vertex-anthropic.test.ts
@@ -8,7 +8,7 @@ import {
   vertexAnthropic as vertexAnthropicEdge,
 } from '@ai-sdk/google-vertex/anthropic/edge';
 import { LanguageModelV3, LanguageModelV4 } from '@ai-sdk/provider';
-import { APICallError, generateText, stepCountIs } from 'ai';
+import { APICallError, generateText, isStepCount } from 'ai';
 import 'dotenv/config';
 import fs from 'fs';
 import { describe, expect, it } from 'vitest';
@@ -156,7 +156,7 @@ const toolTests = (model: LanguageModelV4) => {
         },
         prompt:
           'How can I switch to dark mode? Take a look at the screen and tell me.',
-        stopWhen: stepCountIs(5),
+        stopWhen: isStepCount(5),
       });
 
       console.log(result.text);
@@ -188,7 +188,7 @@ README.md     build         data          node_modules  package.json  src       
           }),
         },
         prompt: 'List the files in my directory.',
-        stopWhen: stepCountIs(2),
+        stopWhen: isStepCount(2),
       });
 
       expect(result.text).toBeTruthy();
@@ -233,7 +233,7 @@ README.md     build         data          node_modules  package.json  src       
           }),
         },
         prompt: 'Update my README file to talk about AI.',
-        stopWhen: stepCountIs(5),
+        stopWhen: isStepCount(5),
       });
 
       expect(result.text).toBeTruthy();

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-computer-use-bash.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-computer-use-bash.ts
@@ -1,5 +1,5 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import 'dotenv/config';
 import { run } from '../../lib/run';
 
@@ -23,7 +23,7 @@ README.md     build         data          node_modules  package.json  src       
       }),
     },
     prompt: 'List the files in my directory.',
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
   });
 
   console.log('Response:', result.text);

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-computer-use-computer.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-computer-use-computer.ts
@@ -1,5 +1,5 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import 'dotenv/config';
 import fs from 'fs';
 import { run } from '../../lib/run';
@@ -45,7 +45,7 @@ run(async () => {
     },
     prompt:
       'How can I switch to dark mode? Take a look at the screen and tell me.',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('Response:', result.text);

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-computer-use-editor.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-computer-use-editor.ts
@@ -1,5 +1,5 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import 'dotenv/config';
 import { run } from '../../lib/run';
 
@@ -35,7 +35,7 @@ run(async () => {
       }),
     },
     prompt: 'Update my README file to talk about AI.',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('Response:', result.text);

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-output-array-tools.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-output-array-tools.ts
@@ -1,12 +1,12 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { generateText, Output, stepCountIs, tool } from 'ai';
+import { generateText, Output, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
     model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     output: Output.array({
       element: z.object({
         location: z.string(),

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-bm25.ts
@@ -1,5 +1,5 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -8,7 +8,7 @@ run(async () => {
   const result = await generateText({
     model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     onStepFinish: step => {
       console.log(`\n=== Step Response ===`);
       console.dir(step.response.body, { depth: Infinity });

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-anthropic-tool-search-regex.ts
@@ -1,5 +1,5 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -8,7 +8,7 @@ run(async () => {
   const result = await generateText({
     model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
     prompt: 'Find out weather data in SF',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     onStepFinish: step => {
       console.log(`\n=== Step Response ===`);
       console.dir(step.response.body, { depth: Infinity });

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-reasoning-adaptive.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-reasoning-adaptive.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
@@ -8,7 +8,7 @@ run(async () => {
     prompt: 'How many "r"s are in the word "strawberry"?',
     reasoning: 'xhigh',
     maxRetries: 0,
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('Reasoning:');

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-reasoning-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-reasoning-chatbot.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { ModelMessage, generateText, stepCountIs } from 'ai';
+import { ModelMessage, generateText, isStepCount } from 'ai';
 import * as readline from 'node:readline/promises';
 import { weatherTool } from '../../tools/weather-tool';
 import { run } from '../../lib/run';
@@ -21,7 +21,7 @@ run(async () => {
       tools: { weatherTool },
       system: `You are a helpful, respectful and honest assistant.`,
       messages,
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       reasoning: 'medium',
     });
 

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-reasoning.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-reasoning.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
@@ -9,7 +9,7 @@ run(async () => {
     temperature: 0.5, // should get ignored (warning)
     reasoning: 'medium',
     maxRetries: 0,
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('Reasoning:');

--- a/examples/ai-functions/src/generate-text/amazon/bedrock-tool-call-image-result.ts
+++ b/examples/ai-functions/src/generate-text/amazon/bedrock-tool-call-image-result.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -43,7 +43,7 @@ run(async () => {
         },
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log(result.text);

--- a/examples/ai-functions/src/generate-text/anthropic/bash-tool.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/bash-tool.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
@@ -22,7 +22,7 @@ run(async () => {
       }),
     },
     prompt: 'List the files in my home directory.',
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
   });
 
   console.log(result.text);

--- a/examples/ai-functions/src/generate-text/anthropic/chatbot-websearch.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/chatbot-websearch.ts
@@ -1,5 +1,5 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
-import { ModelMessage, generateText, stepCountIs } from 'ai';
+import { ModelMessage, generateText, isStepCount } from 'ai';
 import * as readline from 'node:readline/promises';
 import { run } from '../../lib/run';
 
@@ -36,7 +36,7 @@ run(async () => {
       },
       system: `You are a helpful, respectful and honest assistant.`,
       messages,
-      stopWhen: stepCountIs(3),
+      stopWhen: isStepCount(3),
     });
 
     console.log('Assistant:');

--- a/examples/ai-functions/src/generate-text/anthropic/computer-use-computer.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/computer-use-computer.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import fs from 'node:fs';
 import { run } from '../../lib/run';
 
@@ -51,7 +51,7 @@ run(async () => {
     },
     prompt:
       'How can I switch to dark mode? Take a look at the screen and tell me.',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log(result.text);

--- a/examples/ai-functions/src/generate-text/anthropic/computer-use-zoom.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/computer-use-zoom.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import fs from 'node:fs';
 import { run } from '../../lib/run';
 
@@ -60,7 +60,7 @@ run(async () => {
     },
     prompt:
       'Look at the screen and zoom in on any text that looks small or hard to read.',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log(result.text);

--- a/examples/ai-functions/src/generate-text/anthropic/deferred-results.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/deferred-results.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -17,7 +17,7 @@ run(async () => {
         execute: async ({ a, b }) => a * b,
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     onStepFinish: step => {
       stepNumber++;
       console.log(`\n${'='.repeat(60)}`);

--- a/examples/ai-functions/src/generate-text/anthropic/image-tool-result-url.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/image-tool-result-url.ts
@@ -1,4 +1,4 @@
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { run } from '../../lib/run';
 import { z } from 'zod';
 import { anthropic } from '@ai-sdk/anthropic';
@@ -43,7 +43,7 @@ run(async () => {
     tools: {
       readImage,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   console.log(`Assistant response : ${JSON.stringify(result.text, null, 2)}`);

--- a/examples/ai-functions/src/generate-text/anthropic/memory-20250818.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/memory-20250818.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { stepCountIs, generateText } from 'ai';
+import { isStepCount, generateText } from 'ai';
 import { run } from '../../lib/run';
 import { anthropicLocalFsMemoryTool } from '../../lib/anthropic-local-fs-memory-tool';
 
@@ -13,7 +13,7 @@ Acknowledge by saying "stored".
     tools: {
       memory: anthropicLocalFsMemoryTool({ basePath: './memory' }),
     },
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
   });
 
   console.dir(result.content, { depth: Infinity });

--- a/examples/ai-functions/src/generate-text/anthropic/output-array-tools.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/output-array-tools.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, Output, stepCountIs } from 'ai';
+import { generateText, Output, isStepCount } from 'ai';
 import { z } from 'zod';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
@@ -8,7 +8,7 @@ import { weatherTool } from '../../tools/weather-tool';
 run(async () => {
   const result = await generateText({
     model: anthropic('claude-haiku-4-5'),
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     output: Output.array({
       element: z.object({
         location: z.string(),

--- a/examples/ai-functions/src/generate-text/anthropic/pdf-tool-results-base64.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/pdf-tool-results-base64.ts
@@ -1,4 +1,4 @@
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { run } from '../../lib/run';
 import { z } from 'zod';
 import path from 'path';
@@ -53,7 +53,7 @@ run(async () => {
     tools: {
       readPDFDocument,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   console.log(`Assisstant response : ${JSON.stringify(result.text, null, 2)}`);

--- a/examples/ai-functions/src/generate-text/anthropic/pdf-tool-results-url.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/pdf-tool-results-url.ts
@@ -1,4 +1,4 @@
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { run } from '../../lib/run';
 import { z } from 'zod';
 import { anthropic } from '@ai-sdk/anthropic';
@@ -43,7 +43,7 @@ run(async () => {
     tools: {
       readPDFDocument,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   console.log(`Assisstant response : ${JSON.stringify(result.text, null, 2)}`);

--- a/examples/ai-functions/src/generate-text/anthropic/programmatic-tool-calling.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/programmatic-tool-calling.ts
@@ -3,7 +3,7 @@ import {
   forwardAnthropicContainerIdFromLastStep,
   type AnthropicLanguageModelOptions,
 } from '@ai-sdk/anthropic';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -12,7 +12,7 @@ run(async () => {
 
   const result = await generateText({
     model: anthropic('claude-sonnet-4-5'),
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     prompt:
       'Two players are playing a game. ' +
       'Each round both players roll a die. ' +

--- a/examples/ai-functions/src/generate-text/anthropic/reasoning-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/reasoning-chatbot.ts
@@ -1,5 +1,5 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
-import { ModelMessage, generateText, stepCountIs } from 'ai';
+import { ModelMessage, generateText, isStepCount } from 'ai';
 import * as readline from 'node:readline/promises';
 import { weatherTool } from '../../tools/weather-tool';
 import { run } from '../../lib/run';
@@ -33,7 +33,7 @@ run(async () => {
       tools: { weatherTool },
       system: `You are a helpful, respectful and honest assistant.`,
       messages,
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       reasoning: 'medium',
     });
 

--- a/examples/ai-functions/src/generate-text/anthropic/text-editor-tool.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/text-editor-tool.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
@@ -39,7 +39,7 @@ This is a test file.
     },
     prompt:
       'Call insert to add "INTEGRATION TEST SUCCESS" after line 1 of editorContent',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('TEXT', result.text);

--- a/examples/ai-functions/src/generate-text/anthropic/tool-search-bm25.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/tool-search-bm25.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = await generateText({
     model: anthropic('claude-sonnet-4-5'),
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     onStepFinish: step => {
       console.log(`\n=== Step Response ===`);
       console.dir(step.response.body, { depth: Infinity });

--- a/examples/ai-functions/src/generate-text/anthropic/tool-search-deferred-bm25.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/tool-search-deferred-bm25.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -14,7 +14,7 @@ run(async () => {
 
             The noteId is "d10aa585-982b-4bd9-984e-420f9b3717f7".
             Remember, you may need to search for the right tools to perform editor operations.`,
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     onStepFinish: step => {
       stepNumber++;
       console.log(`\n========== STEP ${stepNumber} ==========`);

--- a/examples/ai-functions/src/generate-text/anthropic/tool-search-regex.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/tool-search-regex.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = await generateText({
     model: anthropic('claude-sonnet-4-5'),
     prompt: 'Find out weather data in SF',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     onStepFinish: step => {
       console.log(`\n=== Step Response ===`);
       console.dir(step.response.body, { depth: Infinity });

--- a/examples/ai-functions/src/generate-text/anthropic/with-langfuse-telemetry.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/with-langfuse-telemetry.ts
@@ -1,5 +1,5 @@
 import { anthropic, createAnthropic } from '@ai-sdk/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { LangfuseSpanProcessor } from '@langfuse/otel';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { run } from '../../lib/run';
@@ -34,7 +34,7 @@ run(async () => {
       },
     },
     reasoning: 'medium',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     experimental_telemetry: {
       isEnabled: true,
       functionId: 'anthropic-custom-provider-demo',

--- a/examples/ai-functions/src/generate-text/azure/provider-options-name-openai-compatible.ts
+++ b/examples/ai-functions/src/generate-text/azure/provider-options-name-openai-compatible.ts
@@ -1,4 +1,4 @@
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 import { azure } from '@ai-sdk/azure';
@@ -38,7 +38,7 @@ run(async () => {
         },
       }),
     },
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     providerOptions: {
       openai: {
         reasoningEffort: 'high',

--- a/examples/ai-functions/src/generate-text/deepseek/output-json.ts
+++ b/examples/ai-functions/src/generate-text/deepseek/output-json.ts
@@ -1,5 +1,5 @@
 import { deepseek } from '@ai-sdk/deepseek';
-import { generateText, Output, stepCountIs } from 'ai';
+import { generateText, Output, isStepCount } from 'ai';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -8,7 +8,7 @@ run(async () => {
   const result = await generateText({
     model: deepseek('deepseek-reasoner'),
     tools: { weather: weatherTool },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     output: Output.json(),
     prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });

--- a/examples/ai-functions/src/generate-text/deepseek/output-object.ts
+++ b/examples/ai-functions/src/generate-text/deepseek/output-object.ts
@@ -1,5 +1,5 @@
 import { deepseek } from '@ai-sdk/deepseek';
-import { generateText, Output, stepCountIs } from 'ai';
+import { generateText, Output, isStepCount } from 'ai';
 import { z } from 'zod';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
@@ -11,7 +11,7 @@ run(async () => {
     tools: {
       weather: weatherTool,
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     output: Output.object({
       schema: z.object({
         elements: z.array(

--- a/examples/ai-functions/src/generate-text/deepseek/tool-call.ts
+++ b/examples/ai-functions/src/generate-text/deepseek/tool-call.ts
@@ -1,5 +1,5 @@
 import { deepseek } from '@ai-sdk/deepseek';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -8,7 +8,7 @@ run(async () => {
   const result = await generateText({
     model: deepseek('deepseek-reasoner'),
     tools: { weather: weatherTool },
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-functions/src/generate-text/google/gemini-2-5-flash-lite-multi-step.ts
+++ b/examples/ai-functions/src/generate-text/google/gemini-2-5-flash-lite-multi-step.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -18,7 +18,7 @@ run(async () => {
         },
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   for (const [i, step] of result.steps.entries()) {

--- a/examples/ai-functions/src/generate-text/google/image-tool-result-base64.ts
+++ b/examples/ai-functions/src/generate-text/google/image-tool-result-base64.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { run } from '../../lib/run';
@@ -48,7 +48,7 @@ run(async () => {
     tools: {
       readImage,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   console.log(`Assistant response : ${JSON.stringify(result.text, null, 2)}`);

--- a/examples/ai-functions/src/generate-text/google/image-tool-result-data-url.ts
+++ b/examples/ai-functions/src/generate-text/google/image-tool-result-data-url.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { run } from '../../lib/run';
@@ -48,7 +48,7 @@ run(async () => {
     tools: {
       readImage,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   console.log(`Assistant response : ${JSON.stringify(result.text, null, 2)}`);

--- a/examples/ai-functions/src/generate-text/google/image-tool-result-old.ts
+++ b/examples/ai-functions/src/generate-text/google/image-tool-result-old.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -55,7 +55,7 @@ run(async () => {
     tools: {
       analyzeImage: imageAnalysisTool,
     },
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     prompt: `Whats in this image?`,
   });
 

--- a/examples/ai-functions/src/generate-text/google/image-tool-result-url.ts
+++ b/examples/ai-functions/src/generate-text/google/image-tool-result-url.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { run } from '../../lib/run';
 import { z } from 'zod';
 
@@ -41,7 +41,7 @@ run(async () => {
     tools: {
       readImage,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   console.log(`Assistant response : ${JSON.stringify(result.text, null, 2)}`);

--- a/examples/ai-functions/src/generate-text/google/multi-step.ts
+++ b/examples/ai-functions/src/generate-text/google/multi-step.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -28,7 +28,7 @@ run(async () => {
         }),
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     // prompt: 'What is the weather in my current location?',
     prompt: 'What is the weather in Paris?',
   });

--- a/examples/ai-functions/src/generate-text/google/pdf-tool-results-base64.ts
+++ b/examples/ai-functions/src/generate-text/google/pdf-tool-results-base64.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { run } from '../../lib/run';
@@ -49,7 +49,7 @@ run(async () => {
     tools: {
       readPDFDocument,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   console.log(`Assistant response : ${JSON.stringify(result.text, null, 2)}`);

--- a/examples/ai-functions/src/generate-text/google/pdf-tool-results-data-url.ts
+++ b/examples/ai-functions/src/generate-text/google/pdf-tool-results-data-url.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { run } from '../../lib/run';
@@ -48,7 +48,7 @@ run(async () => {
     tools: {
       readPDFDocument,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   console.log(`Assistant response : ${JSON.stringify(result.text, null, 2)}`);

--- a/examples/ai-functions/src/generate-text/google/pdf-tool-results-url.ts
+++ b/examples/ai-functions/src/generate-text/google/pdf-tool-results-url.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { run } from '../../lib/run';
 import { z } from 'zod';
 
@@ -41,7 +41,7 @@ run(async () => {
     tools: {
       readPDFDocument,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   console.log(`Assistant response : ${JSON.stringify(result.text, null, 2)}`);

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-computer-use-bash.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-computer-use-bash.ts
@@ -1,6 +1,6 @@
 import { run } from '../../lib/run';
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 
 run(async () => {
   const result = await generateText({
@@ -22,7 +22,7 @@ run(async () => {
       }),
     },
     prompt: 'List the files in my home directory.',
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
   });
 
   console.log(result.text);

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-computer-use-computer.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-computer-use-computer.ts
@@ -1,6 +1,6 @@
 import { run } from '../../lib/run';
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import fs from 'node:fs';
 
 run(async () => {
@@ -51,7 +51,7 @@ run(async () => {
     },
     prompt:
       'How can I switch to dark mode? Take a look at the screen and tell me.',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log(result.text);

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-computer-use-editor-cache-control.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-computer-use-editor-cache-control.ts
@@ -1,7 +1,7 @@
 import { type AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';
 import { run } from '../../lib/run';
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 
 run(async () => {
   let editorContent = `
@@ -46,7 +46,7 @@ This is a test file.
         },
       },
     ],
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('TEXT', result.text);

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-computer-use-editor.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-computer-use-editor.ts
@@ -1,6 +1,6 @@
 import { run } from '../../lib/run';
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 
 run(async () => {
   let editorContent = `
@@ -35,7 +35,7 @@ This is a test file.
       }),
     },
     prompt: 'Update my README file to talk about AI.',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('TEXT', result.text);

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-output-array-tools.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-output-array-tools.ts
@@ -1,5 +1,5 @@
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, Output, stepCountIs } from 'ai';
+import { generateText, Output, isStepCount } from 'ai';
 import { z } from 'zod';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
@@ -8,7 +8,7 @@ import { weatherTool } from '../../tools/weather-tool';
 run(async () => {
   const result = await generateText({
     model: vertexAnthropic('claude-3-5-sonnet-v2@20241022'),
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     output: Output.array({
       element: z.object({
         location: z.string(),

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-bm25.ts
@@ -1,5 +1,5 @@
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = await generateText({
     model: vertexAnthropic('claude-sonnet-4-5'),
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     onStepFinish: step => {
       console.log(`\n=== Step Response ===`);
       console.dir(step.response.body, { depth: Infinity });

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-deferred-bm25.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-deferred-bm25.ts
@@ -1,5 +1,5 @@
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -14,7 +14,7 @@ run(async () => {
 
             The noteId is "d10aa585-982b-4bd9-984e-420f9b3717f7".
             Remember, you may need to search for the right tools to perform editor operations.`,
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     onStepFinish: step => {
       stepNumber++;
       console.log(`\n========== STEP ${stepNumber} ==========`);

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-tool-search-regex.ts
@@ -1,5 +1,5 @@
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = await generateText({
     model: vertexAnthropic('claude-sonnet-4-5'),
     prompt: 'Find out weather data in SF',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     onStepFinish: step => {
       console.log(`\n=== Step Response ===`);
       console.dir(step.response.body, { depth: Infinity });

--- a/examples/ai-functions/src/generate-text/google/vertex-multi-step.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-multi-step.ts
@@ -1,5 +1,5 @@
 import { vertex } from '@ai-sdk/google-vertex';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -28,7 +28,7 @@ run(async () => {
         }),
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     // prompt: 'What is the weather in my current location?',
     prompt: 'What is the weather in Paris?',
   });

--- a/examples/ai-functions/src/generate-text/google/vertex-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-tool-call.ts
@@ -1,5 +1,5 @@
 import { vertex } from '@ai-sdk/google-vertex';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -22,7 +22,7 @@ run(async () => {
         },
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log(text);

--- a/examples/ai-functions/src/generate-text/huggingface/multi-step.ts
+++ b/examples/ai-functions/src/generate-text/huggingface/multi-step.ts
@@ -1,5 +1,5 @@
 import { huggingface } from '@ai-sdk/huggingface';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod/v4';
 import { run } from '../../lib/run';
 
@@ -53,7 +53,7 @@ run(async () => {
         },
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     prompt:
       'What activities would you recommend for today based on my current location and weather?',
 

--- a/examples/ai-functions/src/generate-text/huggingface/tools.ts
+++ b/examples/ai-functions/src/generate-text/huggingface/tools.ts
@@ -1,12 +1,12 @@
 import { huggingface } from '@ai-sdk/huggingface';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod/v4';
 import { run } from '../../lib/run';
 
 run(async () => {
   const { text, usage, toolCalls, toolResults } = await generateText({
     model: huggingface.responses('deepseek-ai/DeepSeek-V3-0324'),
-    stopWhen: stepCountIs(3),
+    stopWhen: isStepCount(3),
     tools: {
       getWeather: tool({
         description: 'Get the current weather for a specific location',

--- a/examples/ai-functions/src/generate-text/mock/invalid-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/mock/invalid-tool-call.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -55,7 +55,7 @@ run(async () => {
       }
     },
     prompt: 'What are the tourist attractions in San Francisco?',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('Content:');

--- a/examples/ai-functions/src/generate-text/moonshot/tool-call.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/tool-call.ts
@@ -1,5 +1,5 @@
 import { moonshotai } from '@ai-sdk/moonshotai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = await generateText({
     model: moonshotai('kimi-k2.5'),
     tools: { weather: weatherTool },
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-functions/src/generate-text/openai/active-tools.ts
+++ b/examples/ai-functions/src/generate-text/openai/active-tools.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { weatherTool } from '../../tools/weather-tool';
 import { run } from '../../lib/run';
@@ -14,7 +14,7 @@ run(async () => {
       }),
     },
     activeTools: [], // disable all tools
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     prompt:
       'What is the weather in San Francisco and what attractions should I visit?',
   });

--- a/examples/ai-functions/src/generate-text/openai/compatible-google-thought-signatures.ts
+++ b/examples/ai-functions/src/generate-text/openai/compatible-google-thought-signatures.ts
@@ -1,5 +1,5 @@
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-import { generateText, tool, ModelMessage, stepCountIs } from 'ai';
+import { generateText, tool, ModelMessage, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -47,7 +47,7 @@ run(async () => {
     tools,
     prompt:
       'Check flight status for AA100 and book a taxi 2 hours before if delayed.',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     onStepFinish: ({ toolCalls, toolResults }) => {
       if (toolCalls) {
         toolCalls.forEach(call => {
@@ -114,7 +114,7 @@ run(async () => {
       model,
       messages: messagesForTurn2,
       tools,
-      stopWhen: stepCountIs(1),
+      stopWhen: isStepCount(1),
     });
 
     console.log('Turn 2 response:');
@@ -141,7 +141,7 @@ run(async () => {
       }),
     },
     prompt: 'Check the weather in Paris and London.',
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     onStepFinish: ({ toolCalls }) => {
       if (toolCalls && toolCalls.length > 1) {
         console.log('Parallel tool calls:');

--- a/examples/ai-functions/src/generate-text/openai/dynamic-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/openai/dynamic-tool-call.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { dynamicTool, generateText, stepCountIs, ToolSet } from 'ai';
+import { dynamicTool, generateText, isStepCount, ToolSet } from 'ai';
 import { z } from 'zod';
 import { weatherTool } from '../../tools/weather-tool';
 import { run } from '../../lib/run';
@@ -22,7 +22,7 @@ function dynamicTools(): ToolSet {
 run(async () => {
   const result = await generateText({
     model: openai('gpt-4o'),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       ...dynamicTools(),
       weather: weatherTool,

--- a/examples/ai-functions/src/generate-text/openai/listen-to-events.ts
+++ b/examples/ai-functions/src/generate-text/openai/listen-to-events.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import * as z from 'zod';
 
 async function main() {
@@ -19,7 +19,7 @@ async function main() {
         },
       }),
     },
-    stopWhen: stepCountIs(3),
+    stopWhen: isStepCount(3),
     experimental_onStart: event => {
       console.log('\n--- onStart ---');
       console.log('Provider:', event.provider);

--- a/examples/ai-functions/src/generate-text/openai/local-shell-tool.ts
+++ b/examples/ai-functions/src/generate-text/openai/local-shell-tool.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
@@ -21,7 +21,7 @@ README.md     build         data          node_modules  package.json  src       
       }),
     },
     prompt: 'List the files in my home directory.',
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     onStepFinish: step => {
       console.dir(step.content, { depth: Infinity });
     },

--- a/examples/ai-functions/src/generate-text/openai/multi-step.ts
+++ b/examples/ai-functions/src/generate-text/openai/multi-step.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -28,7 +28,7 @@ run(async () => {
         }),
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     prompt: 'What is the weather in my current location?',
 
     onStepFinish: step => {

--- a/examples/ai-functions/src/generate-text/openai/output-array.ts
+++ b/examples/ai-functions/src/generate-text/openai/output-array.ts
@@ -1,5 +1,5 @@
 import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
-import { generateText, Output, stepCountIs } from 'ai';
+import { generateText, Output, isStepCount } from 'ai';
 import { z } from 'zod';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
@@ -16,7 +16,7 @@ run(async () => {
     tools: {
       weather: weatherTool,
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     output: Output.array({
       element: z.object({
         location: z.string(),

--- a/examples/ai-functions/src/generate-text/openai/output-choice.ts
+++ b/examples/ai-functions/src/generate-text/openai/output-choice.ts
@@ -1,5 +1,5 @@
 import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
-import { generateText, Output, stepCountIs } from 'ai';
+import { generateText, Output, isStepCount } from 'ai';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -15,7 +15,7 @@ run(async () => {
     tools: {
       weather: weatherTool,
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     output: Output.choice({
       options: [
         'winter jacket',

--- a/examples/ai-functions/src/generate-text/openai/output-default.ts
+++ b/examples/ai-functions/src/generate-text/openai/output-default.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -8,7 +8,7 @@ run(async () => {
   const result = await generateText({
     model: openai('gpt-4o-mini'),
     tools: { weather: weatherTool },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });
 

--- a/examples/ai-functions/src/generate-text/openai/output-json.ts
+++ b/examples/ai-functions/src/generate-text/openai/output-json.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, Output, stepCountIs } from 'ai';
+import { generateText, Output, isStepCount } from 'ai';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -8,7 +8,7 @@ run(async () => {
   const result = await generateText({
     model: openai('gpt-4o-mini'),
     tools: { weather: weatherTool },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     output: Output.json(),
     system: 'Return JSON only, no other text.',
     prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',

--- a/examples/ai-functions/src/generate-text/openai/output-object.ts
+++ b/examples/ai-functions/src/generate-text/openai/output-object.ts
@@ -1,5 +1,5 @@
 import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
-import { generateText, Output, stepCountIs } from 'ai';
+import { generateText, Output, isStepCount } from 'ai';
 import { z } from 'zod';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
@@ -16,7 +16,7 @@ run(async () => {
     tools: {
       weather: weatherTool,
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     output: Output.object({
       schema: z.object({
         elements: z.array(

--- a/examples/ai-functions/src/generate-text/openai/responses-apply-patch.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-apply-patch.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { createApplyPatchExecutor } from '../../lib/apply-patch-file-editor';
@@ -17,7 +17,7 @@ run(async () => {
       }),
     },
     prompt: `Create a markdown file with a shopping checklist of 5 entries.`,
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('\n=== Result ===');

--- a/examples/ai-functions/src/generate-text/openai/responses-client-tool-search.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-client-tool-search.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = await generateText({
     model: openai.responses('gpt-5.4'),
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     onStepFinish: step => {
       console.log(`\n=== Step Content ===`);
       console.dir(step.content, { depth: Infinity });

--- a/examples/ai-functions/src/generate-text/openai/responses-custom-tool-multi-turn.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-custom-tool-multi-turn.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { run } from '../../lib/run';
 import { print } from '../../lib/print';
 
@@ -21,7 +21,7 @@ run(async () => {
       }),
     },
     prompt: 'How many users are older than 25? Use SQL to find out.',
-    stopWhen: stepCountIs(3),
+    stopWhen: isStepCount(3),
   });
 
   const allToolCalls = result.steps.flatMap(step => step.toolCalls);

--- a/examples/ai-functions/src/generate-text/openai/responses-file-url-tool-result.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-file-url-tool-result.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -36,7 +36,7 @@ run(async () => {
     tools: {
       readPDFDocument,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   console.log(`Assistant response: ${JSON.stringify(result.text, null, 2)}`);

--- a/examples/ai-functions/src/generate-text/openai/responses-image-tool-result-url.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-image-tool-result-url.ts
@@ -1,4 +1,4 @@
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { run } from '../../lib/run';
 import { z } from 'zod';
 import { openai } from '@ai-sdk/openai';
@@ -45,7 +45,7 @@ run(async () => {
       readImage,
     },
 
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   console.log(`Assistant response : ${JSON.stringify(result.text, null, 2)}`);

--- a/examples/ai-functions/src/generate-text/openai/responses-mcp-tool-approval.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-mcp-tool-approval.ts
@@ -2,7 +2,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import {
   generateText,
   ModelMessage,
-  stepCountIs,
+  isStepCount,
   ToolApprovalResponse,
 } from 'ai';
 import * as readline from 'node:readline/promises';
@@ -56,7 +56,7 @@ run(async () => {
         }),
       },
       messages,
-      stopWhen: stepCountIs(10),
+      stopWhen: isStepCount(10),
     });
 
     // Log raw response for debugging

--- a/examples/ai-functions/src/generate-text/openai/responses-output-object.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-output-object.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, Output, tool } from 'ai';
+import { generateText, isStepCount, Output, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -25,7 +25,7 @@ run(async () => {
         temperature: z.number(),
       }),
     }),
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-functions/src/generate-text/openai/responses-shell-local-multiturn.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-shell-local-multiturn.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { executeShellCommand } from '../../lib/shell-executor';
 import { run } from '../../lib/run';
 
@@ -19,7 +19,7 @@ run(async () => {
       }),
     },
     prompt: 'Run uname -a',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('Turn 1:', result1.text);
@@ -43,7 +43,7 @@ run(async () => {
       ...result1.response.messages,
       { role: 'user', content: 'What architecture do you run in?' },
     ],
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('Turn 2:', result2.text);

--- a/examples/ai-functions/src/generate-text/openai/responses-shell-local-skills.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-shell-local-skills.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { resolve } from 'path';
 import { executeShellCommand } from '../../lib/shell-executor';
 import { run } from '../../lib/run';
@@ -32,7 +32,7 @@ run(async () => {
     },
     prompt:
       'You are trapped and lost on a lonely island in 1895. Find a way to get rescued!',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('Result:', result.text);

--- a/examples/ai-functions/src/generate-text/openai/responses-shell-tool-with-approval.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-shell-tool-with-approval.ts
@@ -2,7 +2,7 @@ import { openai } from '@ai-sdk/openai';
 import {
   generateText,
   ModelMessage,
-  stepCountIs,
+  isStepCount,
   ToolApprovalResponse,
 } from 'ai';
 import * as readline from 'node:readline/promises';
@@ -46,7 +46,7 @@ run(async () => {
         }),
       },
       messages,
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       system:
         'You have access to a shell tool that can execute commands on the local filesystem. ' +
         'Use the shell tool when you need to perform file operations or run commands. ' +

--- a/examples/ai-functions/src/generate-text/openai/responses-shell-tool.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-shell-tool.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { executeShellCommand } from '../../lib/shell-executor';
 import { run } from '../../lib/run';
 
@@ -21,7 +21,7 @@ run(async () => {
     },
     prompt:
       'Create a file in my ~/Desktop directory called dec1.txt with the text: THIS WORKS!',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('Result:', result.text);

--- a/examples/ai-functions/src/generate-text/openai/responses-tool-search.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-tool-search.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, tool, stepCountIs } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = await generateText({
     model: openai.responses('gpt-5.4'),
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     onStepFinish: step => {
       console.log(`\n=== Step Content ===`);
       console.dir(step.content, { depth: Infinity });

--- a/examples/ai-functions/src/generate-text/openai/timeout-step.ts
+++ b/examples/ai-functions/src/generate-text/openai/timeout-step.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -20,7 +20,7 @@ run(async () => {
         }),
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     timeout: { stepMs: 1000 }, // 1 second timeout per step
   });
 

--- a/examples/ai-functions/src/generate-text/openai/tool-approval-dynamic-tool.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-approval-dynamic-tool.ts
@@ -3,7 +3,7 @@ import {
   dynamicTool,
   generateText,
   ModelMessage,
-  stepCountIs,
+  isStepCount,
   ToolApprovalResponse,
   ToolSet,
 } from 'ai';
@@ -53,7 +53,7 @@ run(async () => {
         'Just say that the tool execution was not approved.',
       tools,
       messages,
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
     });
 
     process.stdout.write(`\nAssistant:\n`);

--- a/examples/ai-functions/src/generate-text/openai/tool-approval.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-approval.ts
@@ -2,7 +2,7 @@ import { openai } from '@ai-sdk/openai';
 import {
   generateText,
   ModelMessage,
-  stepCountIs,
+  isStepCount,
   tool,
   ToolApprovalResponse,
 } from 'ai';
@@ -49,7 +49,7 @@ run(async () => {
         'Just say that the tool execution was not approved.',
       tools: { weather: weatherTool },
       messages,
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
     });
 
     process.stdout.write(`\nAssistant:\n`);

--- a/examples/ai-functions/src/generate-text/openai/tool-timeout-error.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-timeout-error.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -25,7 +25,7 @@ run(async () => {
     timeout: {
       toolMs: 500,
     },
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     prompt: 'Search for "hello world"',
   });
 

--- a/examples/ai-functions/src/generate-text/openai/tool-timeout-per-tool-error.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-timeout-per-tool-error.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -43,7 +43,7 @@ run(async () => {
         slowApiMs: 1000,
       },
     },
-    stopWhen: stepCountIs(3),
+    stopWhen: isStepCount(3),
     prompt: 'Search for "hello" using both the fast API and slow API',
   });
 

--- a/examples/ai-functions/src/generate-text/openai/tool-timeout-per-tool.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-timeout-per-tool.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { weatherTool } from '../../tools/weather-tool';
 import { run } from '../../lib/run';
@@ -30,7 +30,7 @@ run(async () => {
         weatherMs: 3000,
       },
     },
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-functions/src/generate-text/openai/tool-timeout.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-timeout.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { weatherTool } from '../../tools/weather-tool';
 import { run } from '../../lib/run';
@@ -27,7 +27,7 @@ run(async () => {
     timeout: {
       toolMs: 2000,
     },
-    stopWhen: stepCountIs(3),
+    stopWhen: isStepCount(3),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-functions/src/stream-text/alibaba/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/alibaba/chatbot.ts
@@ -1,5 +1,5 @@
 import { alibaba } from '@ai-sdk/alibaba';
-import { ModelMessage, stepCountIs, streamText, tool } from 'ai';
+import { ModelMessage, isStepCount, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -21,7 +21,7 @@ run(async () => {
       model: alibaba('qwen-plus'),
       system: 'You are a helpful, respectful and honest assistant.',
       messages,
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       tools: {
         getWeather: tool({
           description: 'Get the weather in a location',

--- a/examples/ai-functions/src/stream-text/alibaba/disable-parallel-tools.ts
+++ b/examples/ai-functions/src/stream-text/alibaba/disable-parallel-tools.ts
@@ -1,5 +1,5 @@
 import { alibaba, type AlibabaLanguageModelOptions } from '@ai-sdk/alibaba';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = streamText({
     model: alibaba('qwen-plus'),
     prompt: 'What is the weather in Paris, Tokyo, and London?',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     providerOptions: {
       alibaba: {
         parallelToolCalls: false,

--- a/examples/ai-functions/src/stream-text/alibaba/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/alibaba/tool-call.ts
@@ -1,5 +1,5 @@
 import { alibaba } from '@ai-sdk/alibaba';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = streamText({
     model: alibaba('qwen-plus'),
     prompt: 'What is the weather in Paris and Tokyo?',
-    stopWhen: stepCountIs(5), // Allow multi-turn: call tools → get results → generate answer
+    stopWhen: isStepCount(5), // Allow multi-turn: call tools → get results → generate answer
     tools: {
       getWeather: tool({
         description: 'Get the weather for a location',

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-activetools.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-activetools.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { streamText, tool, stepCountIs } from 'ai';
+import { streamText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -15,7 +15,7 @@ run(async () => {
         }),
       }),
     },
-    stopWhen: [stepCountIs(5)],
+    stopWhen: [isStepCount(5)],
     prepareStep: ({ stepNumber }) => {
       if (stepNumber > 0) {
         console.log(`Setting activeTools: [] for step ${stepNumber}`);

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-bash.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-bash.ts
@@ -1,5 +1,5 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { stepCountIs, streamText, ToolCallPart, ToolResultPart } from 'ai';
+import { isStepCount, streamText, ToolCallPart, ToolResultPart } from 'ai';
 import 'dotenv/config';
 import { run } from '../../lib/run';
 
@@ -23,7 +23,7 @@ run(async () => {
       }),
     },
     prompt: 'List the files in my home directory.',
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
   });
 
   let fullResponse = '';

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-computer-use-bash.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-computer-use-bash.ts
@@ -1,5 +1,5 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 import 'dotenv/config';
 import { run } from '../../lib/run';
 
@@ -23,7 +23,7 @@ README.md     build         data          node_modules  package.json  src       
       }),
     },
     prompt: 'List the files in my directory.',
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-computer-use-computer.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-computer-use-computer.ts
@@ -1,5 +1,5 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 import fs from 'fs';
 import 'dotenv/config';
 import { run } from '../../lib/run';
@@ -42,7 +42,7 @@ run(async () => {
       }),
     },
     prompt: 'Take a screenshot of my screen and describe what you see.',
-    stopWhen: stepCountIs(3),
+    stopWhen: isStepCount(3),
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-computer-use-editor.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-computer-use-editor.ts
@@ -1,5 +1,5 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 import 'dotenv/config';
 import { run } from '../../lib/run';
 
@@ -31,7 +31,7 @@ This is a sample README file for testing the text editor tool.
       }),
     },
     prompt: 'Update my README file to mention that this project uses AI SDK.',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-output-array-tools.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-output-array-tools.ts
@@ -1,12 +1,12 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { Output, stepCountIs, streamText, tool } from 'ai';
+import { Output, isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
     model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     output: Output.array({
       element: z.object({
         location: z.string(),

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-bm25.ts
@@ -1,5 +1,5 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { streamText, tool, stepCountIs } from 'ai';
+import { streamText, tool, isStepCount } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -8,7 +8,7 @@ run(async () => {
   const result = streamText({
     model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     tools: {
       toolSearch: bedrockAnthropic.tools.toolSearchBm25_20251119(),
 

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-tool-search-regex.ts
@@ -1,5 +1,5 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { streamText, tool, stepCountIs } from 'ai';
+import { streamText, tool, isStepCount } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -8,7 +8,7 @@ run(async () => {
   const result = streamText({
     model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
     prompt: 'Find out weather data in SF',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     tools: {
       toolSearch: bedrockAnthropic.tools.toolSearchRegex_20251119(),
 

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-websearch.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-anthropic-websearch.ts
@@ -1,5 +1,5 @@
 import { bedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
-import { stepCountIs, streamText, ToolCallPart, ToolResultPart } from 'ai';
+import { isStepCount, streamText, ToolCallPart, ToolResultPart } from 'ai';
 import 'dotenv/config';
 import { run } from '../../lib/run';
 
@@ -22,7 +22,7 @@ run(async () => {
         },
       }),
     },
-    stopWhen: stepCountIs(3),
+    stopWhen: isStepCount(3),
   });
 
   let fullResponse = '';

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-chatbot.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
+import { isStepCount, ModelMessage, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -33,7 +33,7 @@ run(async () => {
           }),
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       messages,
     });
 

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-fullstream.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-fullstream.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { stepCountIs, streamText, ToolCallPart, ToolResultPart } from 'ai';
+import { isStepCount, streamText, ToolCallPart, ToolResultPart } from 'ai';
 import { z } from 'zod';
 import { weatherTool } from '../../tools/weather-tool';
 import { run } from '../../lib/run';
@@ -14,7 +14,7 @@ run(async () => {
       },
     },
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   let enteredReasoning = false;

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-reasoning-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-reasoning-chatbot.ts
@@ -1,5 +1,5 @@
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
-import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
+import { isStepCount, ModelMessage, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -46,7 +46,7 @@ run(async () => {
           }),
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       maxRetries: 0,
       reasoning: 'low',
       onError: error => {

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-reasoning-fullstream.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-reasoning-fullstream.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { stepCountIs, streamText, ToolCallPart, ToolResultPart } from 'ai';
+import { isStepCount, streamText, ToolCallPart, ToolResultPart } from 'ai';
 import { weatherTool } from '../../tools/weather-tool';
 import { run } from '../../lib/run';
 
@@ -11,7 +11,7 @@ run(async () => {
     },
     prompt: 'What is the weather in San Francisco?',
     reasoning: 'low',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     maxRetries: 5,
   });
 

--- a/examples/ai-functions/src/stream-text/amazon/bedrock-reasoning.ts
+++ b/examples/ai-functions/src/stream-text/amazon/bedrock-reasoning.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
@@ -12,7 +12,7 @@ run(async () => {
     },
     reasoning: 'low',
     maxRetries: 0,
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/anthropic/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/chatbot.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
+import { isStepCount, ModelMessage, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -33,7 +33,7 @@ run(async () => {
           }),
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       messages,
     });
 

--- a/examples/ai-functions/src/stream-text/anthropic/computer-use-zoom.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/computer-use-zoom.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { streamText, stepCountIs } from 'ai';
+import { streamText, isStepCount } from 'ai';
 import fs from 'node:fs';
 import { run } from '../../lib/run';
 
@@ -60,7 +60,7 @@ run(async () => {
     },
     prompt:
       'Look at the screen and zoom in on any text that looks small or hard to read.',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/anthropic/memory-20250818.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/memory-20250818.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { streamText, stepCountIs } from 'ai';
+import { streamText, isStepCount } from 'ai';
 import { run } from '../../lib/run';
 import { anthropicLocalFsMemoryTool } from '../../lib/anthropic-local-fs-memory-tool';
 
@@ -13,7 +13,7 @@ Acknowledge by saying "stored".
     tools: {
       memory: anthropicLocalFsMemoryTool({ basePath: './memory' }),
     },
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/anthropic/output-array.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/output-array.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { Output, stepCountIs, streamText } from 'ai';
+import { Output, isStepCount, streamText } from 'ai';
 import z from 'zod';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -7,7 +7,7 @@ import { weatherTool } from '../../tools/weather-tool';
 run(async () => {
   const { partialOutputStream } = streamText({
     model: anthropic('claude-haiku-4-5'),
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     output: Output.array({
       element: z.object({
         location: z.string(),

--- a/examples/ai-functions/src/stream-text/anthropic/output-object.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/output-object.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { Output, stepCountIs, streamText } from 'ai';
+import { Output, isStepCount, streamText } from 'ai';
 import z from 'zod';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -7,7 +7,7 @@ import { weatherTool } from '../../tools/weather-tool';
 run(async () => {
   const result = streamText({
     model: anthropic('claude-sonnet-4-5'),
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     output: Output.object({
       schema: z.object({
         elements: z.array(

--- a/examples/ai-functions/src/stream-text/anthropic/programmatic-tool-calling.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/programmatic-tool-calling.ts
@@ -3,7 +3,7 @@ import {
   forwardAnthropicContainerIdFromLastStep,
   type AnthropicLanguageModelOptions,
 } from '@ai-sdk/anthropic';
-import { streamText, stepCountIs, tool } from 'ai';
+import { streamText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -12,7 +12,7 @@ run(async () => {
 
   const result = streamText({
     model: anthropic('claude-sonnet-4-5'),
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     prompt:
       'Two players are playing a game. ' +
       'Each round both players roll a die. ' +

--- a/examples/ai-functions/src/stream-text/anthropic/reasoning-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/reasoning-chatbot.ts
@@ -1,5 +1,5 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
-import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
+import { isStepCount, ModelMessage, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -46,7 +46,7 @@ run(async () => {
           }),
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       maxRetries: 0,
       reasoning: 'medium',
       onError: error => {

--- a/examples/ai-functions/src/stream-text/anthropic/reasoning-fullstream.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/reasoning-fullstream.ts
@@ -4,7 +4,7 @@ import {
 } from '@ai-sdk/anthropic';
 import {
   extractReasoningMiddleware,
-  stepCountIs,
+  isStepCount,
   streamText,
   ToolCallPart,
   ToolResultPart,
@@ -32,7 +32,7 @@ run(async () => {
       weather: weatherTool,
     },
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   let enteredReasoning = false;

--- a/examples/ai-functions/src/stream-text/anthropic/tool-call-input-examples.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/tool-call-input-examples.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
@@ -14,7 +14,7 @@ const conditions = [
 run(async () => {
   const result = streamText({
     model: anthropic('claude-sonnet-4-5'),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       weather: tool({
         description: 'Get the weather in a location',

--- a/examples/ai-functions/src/stream-text/anthropic/tool-call-strict.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/tool-call-strict.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
@@ -14,7 +14,7 @@ const conditions = [
 run(async () => {
   const result = streamText({
     model: anthropic('claude-sonnet-4-5'),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       weather: tool({
         description: 'Get the weather in a location',

--- a/examples/ai-functions/src/stream-text/anthropic/tool-search-bm25.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/tool-search-bm25.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { streamText, tool, stepCountIs } from 'ai';
+import { streamText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = streamText({
     model: anthropic('claude-sonnet-4-5'),
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     tools: {
       toolSearch: anthropic.tools.toolSearchBm25_20251119(),
 

--- a/examples/ai-functions/src/stream-text/anthropic/tool-search-regex.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/tool-search-regex.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { streamText, tool, stepCountIs } from 'ai';
+import { streamText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = streamText({
     model: anthropic('claude-sonnet-4-5'),
     prompt: 'Find out weather data in SF',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     tools: {
       toolSearch: anthropic.tools.toolSearchRegex_20251119(),
 

--- a/examples/ai-functions/src/stream-text/azure/provider-options-name-openai-compatible.ts
+++ b/examples/ai-functions/src/stream-text/azure/provider-options-name-openai-compatible.ts
@@ -1,4 +1,4 @@
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 import { azure } from '@ai-sdk/azure';
@@ -38,7 +38,7 @@ run(async () => {
         },
       }),
     },
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     providerOptions: {
       openai: {
         reasoningEffort: 'high',

--- a/examples/ai-functions/src/stream-text/bedrock/output-array-tools.ts
+++ b/examples/ai-functions/src/stream-text/bedrock/output-array-tools.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { Output, stepCountIs, streamText } from 'ai';
+import { Output, isStepCount, streamText } from 'ai';
 import z from 'zod';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -7,7 +7,7 @@ import { weatherTool } from '../../tools/weather-tool';
 run(async () => {
   const { partialOutputStream } = streamText({
     model: bedrock('us.anthropic.claude-3-5-sonnet-20241022-v2:0'),
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     output: Output.array({
       element: z.object({
         location: z.string(),

--- a/examples/ai-functions/src/stream-text/cohere/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/cohere/chatbot.ts
@@ -1,5 +1,5 @@
 import { cohere } from '@ai-sdk/cohere';
-import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
+import { isStepCount, ModelMessage, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -31,7 +31,7 @@ run(async () => {
           }),
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       messages,
     });
 

--- a/examples/ai-functions/src/stream-text/deepseek/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/deepseek/tool-call.ts
@@ -1,5 +1,5 @@
 import { deepseek } from '@ai-sdk/deepseek';
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -8,7 +8,7 @@ run(async () => {
   const result = streamText({
     model: deepseek('deepseek-reasoner'),
     tools: { weather: weatherTool },
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-functions/src/stream-text/fireworks/kimi-k2-5-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/fireworks/kimi-k2-5-tool-call.ts
@@ -2,7 +2,7 @@ import {
   fireworks,
   type FireworksLanguageModelOptions,
 } from '@ai-sdk/fireworks';
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -17,7 +17,7 @@ run(async () => {
       } satisfies FireworksLanguageModelOptions,
     },
     tools: { weather: weatherTool },
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/gateway/google-gemini-tool-call.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 import { google } from '@ai-sdk/google';
 import { createVertex } from '@ai-sdk/google-vertex';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 
 /**
@@ -45,7 +45,7 @@ async function main() {
     model: google('gemini-3.1-pro-preview'),
     tools: { weather: weatherTool },
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
   });
 
   for await (const chunk of turn1.fullStream) {
@@ -94,7 +94,7 @@ async function main() {
         ...response1.messages,
         { role: 'user', content: 'What about New York?' },
       ],
-      stopWhen: stepCountIs(2),
+      stopWhen: isStepCount(2),
     });
 
     for await (const chunk of scenarioA.fullStream) {
@@ -151,7 +151,7 @@ async function main() {
         ...(vertexKeyMessages as any),
         { role: 'user', content: 'What about New York?' },
       ],
-      stopWhen: stepCountIs(2),
+      stopWhen: isStepCount(2),
     });
 
     for await (const chunk of scenarioB.fullStream) {
@@ -193,7 +193,7 @@ async function main() {
           ...response1.messages,
           { role: 'user', content: 'What about New York?' },
         ],
-        stopWhen: stepCountIs(2),
+        stopWhen: isStepCount(2),
       });
 
       for await (const chunk of scenarioC.fullStream) {

--- a/examples/ai-functions/src/stream-text/gateway/kimi-k2-5-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/gateway/kimi-k2-5-tool-call.ts
@@ -1,6 +1,6 @@
 import { type FireworksLanguageModelOptions } from '@ai-sdk/fireworks';
 import { gateway } from '@ai-sdk/gateway';
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -15,7 +15,7 @@ run(async () => {
       } satisfies FireworksLanguageModelOptions,
     },
     tools: { weather: weatherTool },
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-functions/src/stream-text/google/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/google/chatbot.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
+import { isStepCount, ModelMessage, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -54,7 +54,7 @@ run(async () => {
           },
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       messages,
     });
 

--- a/examples/ai-functions/src/stream-text/google/gemini-2-5-flash-lite-multi-step.ts
+++ b/examples/ai-functions/src/stream-text/google/gemini-2-5-flash-lite-multi-step.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -18,7 +18,7 @@ run(async () => {
         },
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/google/image-tool-result-base64.ts
+++ b/examples/ai-functions/src/stream-text/google/image-tool-result-base64.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { run } from '../../lib/run';
@@ -48,7 +48,7 @@ run(async () => {
     tools: {
       readImage,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/google/image-tool-result-data-url.ts
+++ b/examples/ai-functions/src/stream-text/google/image-tool-result-data-url.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { run } from '../../lib/run';
@@ -48,7 +48,7 @@ run(async () => {
     tools: {
       readImage,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/google/image-tool-result-old.ts
+++ b/examples/ai-functions/src/stream-text/google/image-tool-result-old.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -55,7 +55,7 @@ run(async () => {
     tools: {
       analyzeImage: imageAnalysisTool,
     },
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     prompt: `Whats in this image?`,
   });
 

--- a/examples/ai-functions/src/stream-text/google/image-tool-result-url.ts
+++ b/examples/ai-functions/src/stream-text/google/image-tool-result-url.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { run } from '../../lib/run';
 import { z } from 'zod';
 
@@ -41,7 +41,7 @@ run(async () => {
     tools: {
       readImage,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/google/pdf-tool-results-url.ts
+++ b/examples/ai-functions/src/stream-text/google/pdf-tool-results-url.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { run } from '../../lib/run';
 import { z } from 'zod';
 
@@ -41,7 +41,7 @@ run(async () => {
     tools: {
       readPDFDocument,
     },
-    stopWhen: stepCountIs(4),
+    stopWhen: isStepCount(4),
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/google/reasoning.ts
+++ b/examples/ai-functions/src/stream-text/google/reasoning.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 import { weatherTool } from '../../tools/weather-tool';
 import { run } from '../../lib/run';
 
@@ -8,7 +8,7 @@ run(async () => {
     model: google('gemini-2.5-flash'),
     tools: { weather: weatherTool },
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     reasoning: 'low',
     onError: console.error,
   });

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-chatbot.ts
@@ -1,5 +1,5 @@
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
+import { isStepCount, ModelMessage, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -33,7 +33,7 @@ run(async () => {
           }),
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       messages,
     });
 

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-output-array-tools.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-output-array-tools.ts
@@ -1,5 +1,5 @@
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { Output, stepCountIs, streamText } from 'ai';
+import { Output, isStepCount, streamText } from 'ai';
 import z from 'zod';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -7,7 +7,7 @@ import { weatherTool } from '../../tools/weather-tool';
 run(async () => {
   const { partialOutputStream } = streamText({
     model: vertexAnthropic('claude-3-5-sonnet-v2@20241022'),
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     output: Output.array({
       element: z.object({
         location: z.string(),

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-search-bm25.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-search-bm25.ts
@@ -1,5 +1,5 @@
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { streamText, tool, stepCountIs } from 'ai';
+import { streamText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = streamText({
     model: vertexAnthropic('claude-sonnet-4-5'),
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     tools: {
       toolSearch: vertexAnthropic.tools.toolSearchBm25_20251119(),
 

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-search-regex.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-tool-search-regex.ts
@@ -1,5 +1,5 @@
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { streamText, tool, stepCountIs } from 'ai';
+import { streamText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = streamText({
     model: vertexAnthropic('claude-sonnet-4-5'),
     prompt: 'Find out weather data in SF',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     tools: {
       toolSearch: vertexAnthropic.tools.toolSearchRegex_20251119(),
 

--- a/examples/ai-functions/src/stream-text/groq/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/groq/chatbot.ts
@@ -1,5 +1,5 @@
 import { groq } from '@ai-sdk/groq';
-import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
+import { isStepCount, ModelMessage, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -37,7 +37,7 @@ run(async () => {
           }),
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       messages,
       onStepFinish(step) {
         console.log(

--- a/examples/ai-functions/src/stream-text/huggingface/tools.ts
+++ b/examples/ai-functions/src/stream-text/huggingface/tools.ts
@@ -1,12 +1,12 @@
 import { huggingface } from '@ai-sdk/huggingface';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod/v4';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
     model: huggingface.responses('deepseek-ai/DeepSeek-V3-0324'),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     toolChoice: 'required',
     tools: {
       currentLocation: tool({

--- a/examples/ai-functions/src/stream-text/mistral/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/mistral/chatbot.ts
@@ -1,5 +1,5 @@
 import { mistral } from '@ai-sdk/mistral';
-import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
+import { isStepCount, ModelMessage, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -37,7 +37,7 @@ run(async () => {
           }),
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       messages,
     });
 

--- a/examples/ai-functions/src/stream-text/moonshot/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/moonshot/tool-call.ts
@@ -1,13 +1,13 @@
 import { moonshotai } from '@ai-sdk/moonshotai';
 import { weatherTool } from '../../tools/weather-tool';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
     model: moonshotai('kimi-k2.5'),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       currentLocation: tool({
         description: 'Get the current location.',

--- a/examples/ai-functions/src/stream-text/open-responses/lmstudio-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/open-responses/lmstudio-chatbot.ts
@@ -1,5 +1,5 @@
 import { createOpenResponses } from '@ai-sdk/open-responses';
-import { stepCountIs, ModelMessage, streamText, APICallError } from 'ai';
+import { isStepCount, ModelMessage, streamText, APICallError } from 'ai';
 import * as readline from 'node:readline/promises';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -26,7 +26,7 @@ run(async () => {
       model: lmstudio('zai-org/glm-4.7-flash'),
       tools: { weather: weatherTool },
       system: `You are a helpful, respectful and honest assistant.`,
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       messages,
       onError: ({ error }) => {
         console.log('onError');

--- a/examples/ai-functions/src/stream-text/openai/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/openai/chatbot.ts
@@ -1,5 +1,5 @@
 import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
-import { stepCountIs, ModelMessage, streamText, tool, APICallError } from 'ai';
+import { isStepCount, ModelMessage, streamText, tool, APICallError } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -35,7 +35,7 @@ run(async () => {
           }),
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       messages,
       onError: ({ error }) => {
         console.log('onError');

--- a/examples/ai-functions/src/stream-text/openai/dynamic-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/openai/dynamic-tool-call.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { weatherTool } from '../../tools/weather-tool';
-import { stepCountIs, streamText, dynamicTool, ToolSet } from 'ai';
+import { isStepCount, streamText, dynamicTool, ToolSet } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -22,7 +22,7 @@ function dynamicTools(): ToolSet {
 run(async () => {
   const result = streamText({
     model: openai('gpt-4o'),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       ...dynamicTools(),
       weather: weatherTool,

--- a/examples/ai-functions/src/stream-text/openai/local-shell-tool.ts
+++ b/examples/ai-functions/src/stream-text/openai/local-shell-tool.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
@@ -21,7 +21,7 @@ README.md     build         data          node_modules  package.json  src       
       }),
     },
     prompt: 'List the files in my home directory.',
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
   });
 
   for await (const chunk of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/openai/multi-step.ts
+++ b/examples/ai-functions/src/stream-text/openai/multi-step.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -28,7 +28,7 @@ run(async () => {
         }),
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     prompt: 'What is the weather in my current location?',
 
     onStepFinish: step => {

--- a/examples/ai-functions/src/stream-text/openai/on-finish-response-messages.ts
+++ b/examples/ai-functions/src/stream-text/openai/on-finish-response-messages.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -15,7 +15,7 @@ run(async () => {
         }),
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     onFinish({ response }) {
       console.log(JSON.stringify(response.messages, null, 2));
     },

--- a/examples/ai-functions/src/stream-text/openai/on-finish-steps.ts
+++ b/examples/ai-functions/src/stream-text/openai/on-finish-steps.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -15,7 +15,7 @@ run(async () => {
         }),
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     onFinish({ steps }) {
       console.log(JSON.stringify(steps, null, 2));
     },

--- a/examples/ai-functions/src/stream-text/openai/on-step-finish.ts
+++ b/examples/ai-functions/src/stream-text/openai/on-step-finish.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -15,7 +15,7 @@ run(async () => {
         }),
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     onStepFinish(step) {
       console.log(JSON.stringify(step, null, 2));
     },

--- a/examples/ai-functions/src/stream-text/openai/output-array-element-stream.ts
+++ b/examples/ai-functions/src/stream-text/openai/output-array-element-stream.ts
@@ -1,5 +1,5 @@
 import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
-import { Output, stepCountIs, streamText } from 'ai';
+import { Output, isStepCount, streamText } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -15,7 +15,7 @@ run(async () => {
     tools: {
       weather: weatherTool,
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     output: Output.array({
       element: z.object({
         location: z.string(),

--- a/examples/ai-functions/src/stream-text/openai/output-array.ts
+++ b/examples/ai-functions/src/stream-text/openai/output-array.ts
@@ -1,5 +1,5 @@
 import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
-import { Output, stepCountIs, streamText } from 'ai';
+import { Output, isStepCount, streamText } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -15,7 +15,7 @@ run(async () => {
     tools: {
       weather: weatherTool,
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     output: Output.array({
       element: z.object({
         location: z.string(),

--- a/examples/ai-functions/src/stream-text/openai/output-choice.ts
+++ b/examples/ai-functions/src/stream-text/openai/output-choice.ts
@@ -1,5 +1,5 @@
 import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
-import { Output, stepCountIs, streamText } from 'ai';
+import { Output, isStepCount, streamText } from 'ai';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
 
@@ -14,7 +14,7 @@ run(async () => {
     tools: {
       weather: weatherTool,
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     output: Output.choice({
       options: [
         'winter jacket',

--- a/examples/ai-functions/src/stream-text/openai/output-default.ts
+++ b/examples/ai-functions/src/stream-text/openai/output-default.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
@@ -8,7 +8,7 @@ run(async () => {
   const result = streamText({
     model: openai('gpt-4o-mini'),
     tools: { weather: weatherTool },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });
 

--- a/examples/ai-functions/src/stream-text/openai/output-json.ts
+++ b/examples/ai-functions/src/stream-text/openai/output-json.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { Output, stepCountIs, streamText } from 'ai';
+import { Output, isStepCount, streamText } from 'ai';
 import { run } from '../../lib/run';
 import { weatherTool } from '../../tools/weather-tool';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = streamText({
     model: openai('gpt-4o-mini'),
     tools: { weather: weatherTool },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     output: Output.json(),
     system: 'Return JSON only, no other text.',
     prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',

--- a/examples/ai-functions/src/stream-text/openai/output-object.ts
+++ b/examples/ai-functions/src/stream-text/openai/output-object.ts
@@ -1,5 +1,5 @@
 import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
-import { Output, stepCountIs, streamText } from 'ai';
+import { Output, isStepCount, streamText } from 'ai';
 import { z } from 'zod';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
@@ -16,7 +16,7 @@ run(async () => {
     tools: {
       weather: weatherTool,
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     output: Output.object({
       schema: z.object({
         elements: z.array(

--- a/examples/ai-functions/src/stream-text/openai/prepare-step.ts
+++ b/examples/ai-functions/src/stream-text/openai/prepare-step.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -31,7 +31,7 @@ run(async () => {
       }
     },
     activeTools: [],
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   await result.consumeStream();

--- a/examples/ai-functions/src/stream-text/openai/read-ui-message-stream.ts
+++ b/examples/ai-functions/src/stream-text/openai/read-ui-message-stream.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { readUIMessageStream, stepCountIs, streamText, Tool, tool } from 'ai';
+import { readUIMessageStream, isStepCount, streamText, Tool, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -29,7 +29,7 @@ run(async () => {
         },
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     prompt: 'What is the weather in Tokyo?',
   });
 

--- a/examples/ai-functions/src/stream-text/openai/responses-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-chatbot.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
+import { isStepCount, ModelMessage, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -33,7 +33,7 @@ run(async () => {
           }),
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       messages,
     });
 

--- a/examples/ai-functions/src/stream-text/openai/responses-client-tool-search.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-client-tool-search.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { streamText, tool, stepCountIs } from 'ai';
+import { streamText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = streamText({
     model: openai.responses('gpt-5.4'),
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     tools: {
       toolSearch: openai.tools.toolSearch({
         execution: 'client',

--- a/examples/ai-functions/src/stream-text/openai/responses-custom-tool-multi-turn.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-custom-tool-multi-turn.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { streamText, stepCountIs } from 'ai';
+import { streamText, isStepCount } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
@@ -20,7 +20,7 @@ run(async () => {
       }),
     },
     prompt: 'How many users are older than 25? Use SQL to find out.',
-    stopWhen: stepCountIs(3),
+    stopWhen: isStepCount(3),
   });
 
   for await (const chunk of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/openai/responses-mcp-tool-approval.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-mcp-tool-approval.ts
@@ -1,7 +1,7 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import {
   ModelMessage,
-  stepCountIs,
+  isStepCount,
   streamText,
   ToolApprovalResponse,
 } from 'ai';
@@ -56,7 +56,7 @@ run(async () => {
         }),
       },
       messages,
-      stopWhen: stepCountIs(10),
+      stopWhen: isStepCount(10),
     });
 
     // Stream text output

--- a/examples/ai-functions/src/stream-text/openai/responses-reasoning-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-reasoning-tool-call.ts
@@ -1,12 +1,12 @@
 import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
     model: openai.responses('o3-mini'),
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     tools: {
       generateRandomText: tool({
         description: 'Generate a random text of a given length',

--- a/examples/ai-functions/src/stream-text/openai/responses-shell-local-multiturn.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-shell-local-multiturn.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, streamText } from 'ai';
+import { generateText, isStepCount, streamText } from 'ai';
 import { executeShellCommand } from '../../lib/shell-executor';
 import { run } from '../../lib/run';
 
@@ -19,7 +19,7 @@ run(async () => {
       }),
     },
     prompt: 'Run uname -a',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   console.log('Turn 1:', result1.text);
@@ -43,7 +43,7 @@ run(async () => {
       ...result1.response.messages,
       { role: 'user', content: 'What architecture do you run in?' },
     ],
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   for await (const chunk of result2.fullStream) {

--- a/examples/ai-functions/src/stream-text/openai/responses-shell-local-skills.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-shell-local-skills.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 import { resolve } from 'path';
 import { executeShellCommand } from '../../lib/shell-executor';
 import { run } from '../../lib/run';
@@ -32,7 +32,7 @@ run(async () => {
     },
     prompt:
       'You are trapped and lost on a lonely island in 1895. Find a way to get rescued!',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   for await (const chunk of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/openai/responses-shell-tool.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-shell-tool.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText } from 'ai';
+import { isStepCount, streamText } from 'ai';
 import { executeShellCommand } from '../../lib/shell-executor';
 import { run } from '../../lib/run';
 
@@ -20,7 +20,7 @@ run(async () => {
       }),
     },
     prompt: 'List the files in my ~/Desktop directory',
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
   });
 
   for await (const chunk of result.fullStream) {

--- a/examples/ai-functions/src/stream-text/openai/responses-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-tool-call.ts
@@ -1,13 +1,13 @@
 import { openai, OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
 import { weatherTool } from '../../tools/weather-tool';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
     model: openai.responses('gpt-4o-mini'),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       currentLocation: tool({
         description: 'Get the current location.',

--- a/examples/ai-functions/src/stream-text/openai/responses-tool-search.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-tool-search.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { streamText, tool, stepCountIs } from 'ai';
+import { streamText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -7,7 +7,7 @@ run(async () => {
   const result = streamText({
     model: openai.responses('gpt-5.4'),
     prompt: 'What is the weather in San Francisco?',
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     tools: {
       toolSearch: openai.tools.toolSearch(),
 

--- a/examples/ai-functions/src/stream-text/openai/swarm.ts
+++ b/examples/ai-functions/src/stream-text/openai/swarm.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -28,7 +28,7 @@ run(async () => {
         },
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     prepareStep: () => activeAgent,
     prompt: 'I want to talk to agent B.',
   });

--- a/examples/ai-functions/src/stream-text/openai/timeout-step.ts
+++ b/examples/ai-functions/src/stream-text/openai/timeout-step.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
@@ -22,7 +22,7 @@ run(async () => {
         }),
       }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     timeout: { stepMs: 1000 }, // 1 second timeout per step
   });
 

--- a/examples/ai-functions/src/stream-text/openai/tool-abort.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-abort.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -8,7 +8,7 @@ run(async () => {
 
   const result = streamText({
     model: openai('gpt-4o'),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       currentLocation: tool({
         description: 'Get the weather in a location',

--- a/examples/ai-functions/src/stream-text/openai/tool-approval-dynamic-tool.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-approval-dynamic-tool.ts
@@ -1,7 +1,7 @@
 import { openai } from '@ai-sdk/openai';
 import {
   ModelMessage,
-  stepCountIs,
+  isStepCount,
   streamText,
   dynamicTool,
   ToolApprovalResponse,
@@ -53,7 +53,7 @@ run(async () => {
         'Just say that the tool execution was not approved.',
       tools,
       messages,
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
     });
 
     process.stdout.write('\nAssistant: ');

--- a/examples/ai-functions/src/stream-text/openai/tool-approval.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-approval.ts
@@ -1,7 +1,7 @@
 import { openai } from '@ai-sdk/openai';
 import {
   ModelMessage,
-  stepCountIs,
+  isStepCount,
   streamText,
   tool,
   ToolApprovalResponse,
@@ -49,7 +49,7 @@ run(async () => {
         'Just say that the tool execution was not approved.',
       tools: { weather: weatherTool },
       messages,
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
     });
 
     process.stdout.write('\nAssistant: ');

--- a/examples/ai-functions/src/stream-text/openai/tool-call-strict.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-call-strict.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 import { printFullStream } from '../../lib/print-full-stream';
@@ -14,7 +14,7 @@ const conditions = [
 run(async () => {
   const result = streamText({
     model: openai('gpt-5-nano'),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     reasoning: 'medium',
     tools: {
       weather: tool({

--- a/examples/ai-functions/src/stream-text/openai/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-call.ts
@@ -1,13 +1,13 @@
 import { openai } from '@ai-sdk/openai';
 import { weatherTool } from '../../tools/weather-tool';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
     model: openai('gpt-5-mini'),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       currentLocation: tool({
         description: 'Get the current location.',

--- a/examples/ai-functions/src/stream-text/openai/tool-output-stream.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-output-stream.ts
@@ -1,12 +1,12 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText, tool } from 'ai';
+import { isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
     model: openai('gpt-4o'),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     tools: {
       weather: tool({
         description: 'Get the current weather.',

--- a/examples/ai-functions/src/stream-text/openai/tool-timeout-error.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-timeout-error.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { streamText, stepCountIs, tool } from 'ai';
+import { streamText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
 
@@ -25,7 +25,7 @@ run(async () => {
     timeout: {
       toolMs: 500,
     },
-    stopWhen: stepCountIs(2),
+    stopWhen: isStepCount(2),
     prompt: 'Search for "hello world"',
   });
 

--- a/examples/ai-functions/src/stream-text/openai/tool-timeout.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-timeout.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { streamText, stepCountIs, tool } from 'ai';
+import { streamText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 import { weatherTool } from '../../tools/weather-tool';
 import { run } from '../../lib/run';
@@ -27,7 +27,7 @@ run(async () => {
     timeout: {
       toolMs: 2000,
     },
-    stopWhen: stepCountIs(3),
+    stopWhen: isStepCount(3),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-functions/src/stream-text/xai/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/xai/chatbot.ts
@@ -1,5 +1,5 @@
 import { xai } from '@ai-sdk/xai';
-import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
+import { isStepCount, ModelMessage, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -33,7 +33,7 @@ run(async () => {
           }),
         }),
       },
-      stopWhen: stepCountIs(5),
+      stopWhen: isStepCount(5),
       messages,
     });
 

--- a/examples/angular/src/server.ts
+++ b/examples/angular/src/server.ts
@@ -1,5 +1,5 @@
 import { type OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
-import { convertToModelMessages, Output, stepCountIs, streamText } from 'ai';
+import { convertToModelMessages, Output, isStepCount, streamText } from 'ai';
 import 'dotenv/config';
 import express, { Request, Response } from 'express';
 import { z } from 'zod';
@@ -18,7 +18,7 @@ app.post('/api/chat', async (req: Request, res: Response) => {
   const result = streamText({
     model: modelId,
     messages: await convertToModelMessages(messages ?? []),
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     providerOptions: {
       openai: {
         reasoningEffort: 'low',

--- a/examples/mcp/src/elicitation-multi-step/client.ts
+++ b/examples/mcp/src/elicitation-multi-step/client.ts
@@ -1,6 +1,6 @@
 import { createMCPClient, ElicitationRequestSchema } from '@ai-sdk/mcp';
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { createInterface } from 'node:readline/promises';
 import { stdin, stdout } from 'node:process';
 import 'dotenv/config';
@@ -151,7 +151,7 @@ async function main() {
     const { text: response } = await generateText({
       model: openai('gpt-4o-mini'),
       tools,
-      stopWhen: stepCountIs(12),
+      stopWhen: isStepCount(12),
       onStepFinish: async ({ toolResults }) => {
         if (toolResults.length > 0) {
           console.log('TOOL RESULTS:', JSON.stringify(toolResults, null, 2));

--- a/examples/mcp/src/elicitation/client.ts
+++ b/examples/mcp/src/elicitation/client.ts
@@ -1,6 +1,6 @@
 import { createMCPClient, ElicitationRequestSchema } from '@ai-sdk/mcp';
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { createInterface } from 'node:readline/promises';
 import { stdin, stdout } from 'node:process';
 import 'dotenv/config';
@@ -151,7 +151,7 @@ async function main() {
     const { text: response } = await generateText({
       model: openai('gpt-4o-mini'),
       tools,
-      stopWhen: stepCountIs(10),
+      stopWhen: isStepCount(10),
       onStepFinish: async ({ toolResults }) => {
         if (toolResults.length > 0) {
           console.log('TOOL RESULTS:', JSON.stringify(toolResults, null, 2));

--- a/examples/mcp/src/http/client.ts
+++ b/examples/mcp/src/http/client.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import 'dotenv/config';
 import { createMCPClient, MCPClient } from '@ai-sdk/mcp';
 
@@ -19,7 +19,7 @@ async function main() {
     const { text: answer } = await generateText({
       model: openai('gpt-4o-mini'),
       tools,
-      stopWhen: stepCountIs(10),
+      stopWhen: isStepCount(10),
       onStepFinish: async ({ toolResults }) => {
         console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
       },

--- a/examples/mcp/src/mcp-resources/client.ts
+++ b/examples/mcp/src/mcp-resources/client.ts
@@ -1,6 +1,6 @@
 import { createMCPClient } from '@ai-sdk/mcp';
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 
 async function main() {
   const mcpClient = await createMCPClient({

--- a/examples/mcp/src/mcp-with-auth/client.ts
+++ b/examples/mcp/src/mcp-with-auth/client.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 
 /**
  * @deprecated Use the `@ai-sdk/mcp` package instead.
@@ -199,7 +199,7 @@ async function main() {
   const { text: answer } = await generateText({
     model: openai('gpt-4o-mini'),
     tools,
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     onStepFinish: async ({ toolResults }) => {
       if (toolResults.length > 0) {
         console.log('Tool execution results:');

--- a/examples/mcp/src/sse/client.ts
+++ b/examples/mcp/src/sse/client.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { createMCPClient } from '@ai-sdk/mcp';
 
 import 'dotenv/config';
@@ -20,7 +20,7 @@ async function main() {
   const { text: answer } = await generateText({
     model: openai('gpt-4o-mini'),
     tools,
-    stopWhen: stepCountIs(10),
+    stopWhen: isStepCount(10),
     onStepFinish: async ({ toolResults }) => {
       console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
     },

--- a/examples/mcp/src/stdio/client.ts
+++ b/examples/mcp/src/stdio/client.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { createMCPClient } from '@ai-sdk/mcp';
 import 'dotenv/config';
 import { z } from 'zod';
@@ -32,7 +32,7 @@ async function main() {
           },
         },
       }),
-      stopWhen: stepCountIs(10),
+      stopWhen: isStepCount(10),
       onStepFinish: async ({ toolResults }) => {
         console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
       },

--- a/examples/mcp/src/tool-definitions/client.ts
+++ b/examples/mcp/src/tool-definitions/client.ts
@@ -1,6 +1,6 @@
 import { createMCPClient } from '@ai-sdk/mcp';
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -20,7 +20,7 @@ async function main() {
   const { text: answer, steps } = await generateText({
     model: openai('gpt-4o-mini'),
     tools,
-    stopWhen: stepCountIs(20),
+    stopWhen: isStepCount(20),
     onStepFinish: async ({ toolResults }) => {
       if (toolResults.length > 0) {
         console.log('Tool results:', JSON.stringify(toolResults, null, 2));

--- a/examples/nuxt-openai/server/api/use-chat-tools.ts
+++ b/examples/nuxt-openai/server/api/use-chat-tools.ts
@@ -1,5 +1,5 @@
 import { createOpenAI } from '@ai-sdk/openai';
-import { convertToModelMessages, stepCountIs, streamText } from 'ai';
+import { convertToModelMessages, isStepCount, streamText } from 'ai';
 import { z } from 'zod';
 
 export default defineLazyEventHandler(async () => {
@@ -13,7 +13,7 @@ export default defineLazyEventHandler(async () => {
     const result = streamText({
       model: openai('gpt-4o'),
       messages: await convertToModelMessages(messages),
-      stopWhen: stepCountIs(5), // multi-steps for server-side tools
+      stopWhen: isStepCount(5), // multi-steps for server-side tools
       tools: {
         // server-side tool with execute function:
         getWeatherInformation: {

--- a/examples/sveltekit-openai/src/routes/api/chat/+server.ts
+++ b/examples/sveltekit-openai/src/routes/api/chat/+server.ts
@@ -1,6 +1,6 @@
 import { env } from '$env/dynamic/private';
 import { createOpenAI } from '@ai-sdk/openai';
-import { convertToModelMessages, streamText, stepCountIs } from 'ai';
+import { convertToModelMessages, streamText, isStepCount } from 'ai';
 import { z } from 'zod';
 
 const openai = createOpenAI({
@@ -13,7 +13,7 @@ export const POST = async ({ request }: { request: Request }) => {
   const result = streamText({
     model: openai('gpt-4o'),
     messages: convertToModelMessages(messages),
-    stopWhen: stepCountIs(5), // multi-steps for server-side tools
+    stopWhen: isStepCount(5), // multi-steps for server-side tools
     tools: {
       // server-side tool with execute function:
       getWeatherInformation: {

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1328,7 +1328,7 @@
 - 81d4308: feat: provider-executed dynamic tools
 - e0d1ea9: fix(ai): align logic of text-end with reasoning-end
 - 2406576: chore(agent): rename messages property on agent ui stream functions to uiMessages
-- b1aeea7: feat(ai): set default stopWhen on Agent to stepCountIs(20)
+- b1aeea7: feat(ai): set default stopWhen on Agent to isStepCount(20)
 - dce4e7b: chore(agent): rename system to instructions
 - 4ece5f9: feat(agent): add experimental_download to ToolLoopAgent
 - a417a34: feat(agent): introduce version property
@@ -2504,7 +2504,7 @@
 
 - aa0515c: feat(ai): move Agent to stable
 - e7d9b00: feat(agent): add optional name property to agent
-- b1aeea7: feat(ai): set default stopWhen on Agent to stepCountIs(20)
+- b1aeea7: feat(ai): set default stopWhen on Agent to isStepCount(20)
 
 ## 5.1.0-beta.18
 
@@ -3074,7 +3074,7 @@
 - c7710a9: chore (ai): rename DataStreamToSSETransformStream to JsonToSseTransformStream
 - bfbfc4c: feat (ai): streamText/generateText: totalUsage contains usage for all steps. usage is for a single step.
 - 9ae327d: chore (ui): replace chat store concept with chat instances
-- 9315076: chore (ai): rename continueUntil to stopWhen. Rename maxSteps stop condition to stepCountIs.
+- 9315076: chore (ai): rename continueUntil to stopWhen. Rename maxSteps stop condition to isStepCount.
 - 247ee0c: chore (ai): remove steps from tool invocation ui parts
 - 109c0ac: chore (ai): rename id to chatId (in post request, resume request, and useChat)
 - 954aa73: feat (ui): extended regenerate support
@@ -3817,7 +3817,7 @@
 ### Major Changes
 
 - 72d7d72: chore (ai): stable activeTools
-- 9315076: chore (ai): rename continueUntil to stopWhen. Rename maxSteps stop condition to stepCountIs.
+- 9315076: chore (ai): rename continueUntil to stopWhen. Rename maxSteps stop condition to isStepCount.
 
 ### Patch Changes
 

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -97,7 +97,7 @@ export type ToolLoopAgentSettings<
    * Condition for stopping the generation when there are tool results in the last step.
    * When the condition is an array, any of the conditions can be met to stop the generation.
    *
-   * @default stepCountIs(20)
+   * @default isStepCount(20)
    */
   stopWhen?:
     | StopCondition<NoInfer<TOOLS>>

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -1,7 +1,7 @@
 import { generateText } from '../generate-text/generate-text';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
 import { Output } from '../generate-text/output';
-import { stepCountIs } from '../generate-text/stop-condition';
+import { isStepCount } from '../generate-text/stop-condition';
 import { streamText } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolSet } from '../generate-text/tool-set';
@@ -18,7 +18,7 @@ import { ToolLoopAgentSettings } from './tool-loop-agent-settings';
  * - A finish reasoning other than tool-calls is returned, or
  * - A tool that is invoked does not have an execute function, or
  * - A tool call needs approval, or
- * - A stop condition is met (default stop condition is stepCountIs(20))
+ * - A stop condition is met (default stop condition is isStepCount(20))
  */
 export class ToolLoopAgent<
   CALL_OPTIONS = never,
@@ -77,7 +77,7 @@ export class ToolLoopAgent<
 
     const baseCallArgs = {
       ...settingsWithoutCallbacks,
-      stopWhen: this.settings.stopWhen ?? stepCountIs(20),
+      stopWhen: this.settings.stopWhen ?? isStepCount(20),
       ...options,
     };
 

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -41,7 +41,7 @@ import {
 } from './generate-text';
 import { GenerateTextResult } from './generate-text-result';
 import { StepResult } from './step-result';
-import { isLoopFinished, stepCountIs } from './stop-condition';
+import { isLoopFinished, isStepCount } from './stop-condition';
 import { OpenTelemetryIntegration } from '../telemetry/open-telemetry-integration';
 
 vi.mock('../version', () => {
@@ -1006,7 +1006,7 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        stopWhen: stepCountIs(3),
+        stopWhen: isStepCount(3),
         experimental_onStepStart: async event => {
           stepStartEvents.push(event);
         },
@@ -1097,7 +1097,7 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        stopWhen: stepCountIs(3),
+        stopWhen: isStepCount(3),
         prepareStep: async ({ stepNumber }) => {
           if (stepNumber === 1) {
             return { model: alternateModel };
@@ -1191,7 +1191,7 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        stopWhen: stepCountIs(4),
+        stopWhen: isStepCount(4),
         experimental_onStepStart: async event => {
           stepStartEvents.push(event);
         },
@@ -1262,7 +1262,7 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        stopWhen: stepCountIs(3),
+        stopWhen: isStepCount(3),
         experimental_onStepStart: async event => {
           stepStartEvents.push(event);
         },
@@ -1340,7 +1340,7 @@ describe('generateText', () => {
         },
         prompt: 'test-input',
         experimental_context: { counter: 0 },
-        stopWhen: stepCountIs(3),
+        stopWhen: isStepCount(3),
         prepareStep: async ({ experimental_context, stepNumber }) => {
           return {
             experimental_context: {
@@ -1439,7 +1439,7 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        stopWhen: stepCountIs(4),
+        stopWhen: isStepCount(4),
         onStepFinish: async event => {
           stepNumbers.push(event.stepNumber);
         },
@@ -1487,7 +1487,7 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        stopWhen: stepCountIs(3),
+        stopWhen: isStepCount(3),
         experimental_onStepStart: async event => {
           startStepNumbers.push(event.stepNumber);
         },
@@ -2157,7 +2157,7 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        stopWhen: stepCountIs(4),
+        stopWhen: isStepCount(4),
         experimental_onToolCallStart: async event => {
           toolCallStartEvents.push(event);
         },
@@ -2635,7 +2635,7 @@ describe('generateText', () => {
           onStepFinish: async event => {
             onStepFinishResults.push(event);
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
         });
       });
 
@@ -2808,7 +2808,7 @@ describe('generateText', () => {
             generateId: () => 'test-call-id',
             generateCallId: () => 'test-telemetry-call-id',
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           onStepFinish: async event => {
             onStepFinishResults.push(event);
           },
@@ -4175,7 +4175,7 @@ describe('generateText', () => {
         },
         prompt: 'test-input',
         timeout: { stepMs: 5000 },
-        stopWhen: stepCountIs(2),
+        stopWhen: isStepCount(2),
       });
 
       expect(receivedAbortSignals.length).toBe(2);
@@ -4668,7 +4668,7 @@ describe('generateText', () => {
             execute: async () => 'result1',
           },
         },
-        stopWhen: stepCountIs(2),
+        stopWhen: isStepCount(2),
         prompt: 'test-input',
         experimental_telemetry: {
           isEnabled: true,
@@ -5013,7 +5013,7 @@ describe('generateText', () => {
             },
           },
           prompt: 'test-input',
-          stopWhen: stepCountIs(4),
+          stopWhen: isStepCount(4),
         });
       });
 
@@ -6037,7 +6037,7 @@ describe('generateText', () => {
             }),
           },
           prompt: 'Play a dice game between two players.',
-          stopWhen: stepCountIs(10),
+          stopWhen: isStepCount(10),
           onFinish: async event => {
             onFinishResult = event as unknown as typeof onFinishResult;
           },
@@ -7501,7 +7501,7 @@ describe('generateText', () => {
             execute: async () => 'result',
           },
         },
-        stopWhen: stepCountIs(3),
+        stopWhen: isStepCount(3),
       });
 
       expect(logWarningsSpy).toHaveBeenCalledTimes(2);
@@ -7566,7 +7566,7 @@ describe('generateText', () => {
               needsApproval: true,
             }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           prompt: 'test-input',
           _internal: {
             generateId: mockId({ prefix: 'id' }),
@@ -7683,7 +7683,7 @@ describe('generateText', () => {
               },
             }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           prompt: 'test-input',
           _internal: {
             generateId: mockId({ prefix: 'id' }),
@@ -7874,7 +7874,7 @@ describe('generateText', () => {
               needsApproval: true,
             }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           _internal: {
             generateId: mockId({ prefix: 'id' }),
             generateCallId: () => 'test-telemetry-call-id',
@@ -8040,7 +8040,7 @@ describe('generateText', () => {
               needsApproval: true,
             }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           _internal: {
             generateId: mockId({ prefix: 'id' }),
           },
@@ -8154,7 +8154,7 @@ describe('generateText', () => {
               needsApproval: true,
             }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           _internal: {
             generateId: mockId({ prefix: 'id' }),
             generateCallId: () => 'test-telemetry-call-id',
@@ -8313,7 +8313,7 @@ describe('generateText', () => {
               needsApproval: true,
             }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           _internal: {
             generateId: mockId({ prefix: 'id' }),
             generateCallId: () => 'test-telemetry-call-id',
@@ -8520,7 +8520,7 @@ describe('generateText', () => {
                 args: {},
               },
             },
-            stopWhen: stepCountIs(3),
+            stopWhen: isStepCount(3),
             prompt: 'test-input',
             _internal: {
               generateId: mockId({ prefix: 'id' }),
@@ -8654,7 +8654,7 @@ describe('generateText', () => {
                 args: {},
               },
             },
-            stopWhen: stepCountIs(3),
+            stopWhen: isStepCount(3),
             _internal: {
               generateId: mockId({ prefix: 'id' }),
               generateCallId: () => 'test-telemetry-call-id',
@@ -8814,7 +8814,7 @@ describe('generateText', () => {
                 args: {},
               },
             },
-            stopWhen: stepCountIs(3),
+            stopWhen: isStepCount(3),
             _internal: {
               generateId: mockId({ prefix: 'id' }),
               generateCallId: () => 'test-telemetry-call-id',

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -73,7 +73,7 @@ import { ResponseMessage } from './response-message';
 import { DefaultStepResult, StepResult } from './step-result';
 import {
   isStopConditionMet,
-  stepCountIs,
+  isStepCount,
   StopCondition,
 } from './stop-condition';
 import { toResponseMessages } from './to-response-messages';
@@ -256,7 +256,7 @@ export async function generateText<
   abortSignal,
   timeout,
   headers,
-  stopWhen = stepCountIs(1),
+  stopWhen = isStepCount(1),
   experimental_output,
   output = experimental_output,
   experimental_telemetry: telemetry,
@@ -309,7 +309,7 @@ export async function generateText<
      * Condition for stopping the generation when there are tool results in the last step.
      * When the condition is an array, any of the conditions can be met to stop the generation.
      *
-     * @default stepCountIs(1)
+     * @default isStepCount(1)
      */
     stopWhen?:
       | StopCondition<NoInfer<TOOLS>>

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -36,7 +36,12 @@ export type { StepResult } from './step-result';
 export {
   hasToolCall,
   isLoopFinished,
-  stepCountIs,
+  isStepCount,
+
+  /**
+   * @deprecated Use `isStepCount` instead.
+   */
+  isStepCount as stepCountIs,
   type StopCondition,
 } from './stop-condition';
 export {

--- a/packages/ai/src/generate-text/stop-condition.ts
+++ b/packages/ai/src/generate-text/stop-condition.ts
@@ -5,7 +5,7 @@ export type StopCondition<TOOLS extends ToolSet> = (options: {
   steps: Array<StepResult<TOOLS>>;
 }) => PromiseLike<boolean> | boolean;
 
-export function stepCountIs(stepCount: number): StopCondition<any> {
+export function isStepCount(stepCount: number): StopCondition<any> {
   return ({ steps }) => steps.length === stepCount;
 }
 

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -49,7 +49,7 @@ import {
   createNullLanguageModelUsage,
 } from '../types/usage';
 import { StepResult } from './step-result';
-import { isLoopFinished, stepCountIs } from './stop-condition';
+import { isLoopFinished, isStepCount } from './stop-condition';
 import {
   streamText,
   StreamTextOnFinishCallback,
@@ -2180,7 +2180,7 @@ describe('streamText', () => {
             execute: async () => 'result1',
           },
         },
-        stopWhen: stepCountIs(3),
+        stopWhen: isStepCount(3),
         onError,
       });
 
@@ -5655,7 +5655,7 @@ describe('streamText', () => {
         model: createTestModel(),
         prompt: 'test-input',
         timeout: { totalMs: 5000, stepMs: 1000 },
-        stopWhen: stepCountIs(3),
+        stopWhen: isStepCount(3),
         experimental_onStart: async event => {
           startEvent = event;
         },
@@ -5789,7 +5789,7 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        stopWhen: stepCountIs(3),
+        stopWhen: isStepCount(3),
         experimental_onStepStart: async event => {
           stepStartEvents.push(event);
         },
@@ -5926,7 +5926,7 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        stopWhen: stepCountIs(3),
+        stopWhen: isStepCount(3),
         prepareStep: async ({ stepNumber }) => {
           if (stepNumber === 1) {
             return { model: alternateModel };
@@ -6796,7 +6796,7 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        stopWhen: stepCountIs(4),
+        stopWhen: isStepCount(4),
         experimental_onToolCallStart: async event => {
           toolCallStartEvents.push(event);
         },
@@ -8120,7 +8120,7 @@ describe('streamText', () => {
             isEnabled: true,
             integrations: new OpenTelemetryIntegration({ tracer }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           _internal: {
             now: mockValues(0, 100, 500, 600, 1000),
             generateId: mockId({ prefix: 'id' }),
@@ -9417,7 +9417,7 @@ describe('streamText', () => {
           },
           experimental_context: { context: 'state1' },
           prompt: 'test-input',
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           _internal: {
             generateId: () => 'test-call-id',
             generateCallId: () => 'test-telemetry-call-id',
@@ -10144,7 +10144,7 @@ describe('streamText', () => {
             isEnabled: true,
             integrations: new OpenTelemetryIntegration({ tracer }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           _internal: {
             now: mockValues(0, 100, 500, 600, 1000),
             generateId: mockId({ prefix: 'id' }),
@@ -11891,7 +11891,7 @@ describe('streamText', () => {
             },
           },
           ...defaultSettings(),
-          stopWhen: stepCountIs(4),
+          stopWhen: isStepCount(4),
         });
       });
 
@@ -12209,7 +12209,7 @@ describe('streamText', () => {
             },
           },
           ...defaultSettings(),
-          stopWhen: stepCountIs(4),
+          stopWhen: isStepCount(4),
         });
 
         const chunks = await convertReadableStreamToArray(
@@ -12362,7 +12362,7 @@ describe('streamText', () => {
             }),
           },
           prompt: 'test-input',
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
         });
 
         await result.consumeStream();
@@ -13136,7 +13136,7 @@ describe('streamText', () => {
         },
         prompt: 'test-input',
         timeout: { stepMs: 5000 },
-        stopWhen: stepCountIs(2),
+        stopWhen: isStepCount(2),
         onError: () => {},
       });
 
@@ -17779,7 +17779,7 @@ describe('streamText', () => {
               execute: async () => 'result1',
             },
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           ...defaultSettings(),
           onError: error => {
             onErrorCalls.push({ error });
@@ -18110,7 +18110,7 @@ describe('streamText', () => {
               },
             },
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
         });
       });
 
@@ -19569,7 +19569,7 @@ describe('streamText', () => {
             }),
           },
           prompt: 'Play a dice game between two players.',
-          stopWhen: stepCountIs(10),
+          stopWhen: isStepCount(10),
           onFinish: async event => {
             onFinishResult = event as unknown as typeof onFinishResult;
           },
@@ -20856,7 +20856,7 @@ describe('streamText', () => {
             },
           },
           ...defaultSettings(),
-          stopWhen: stepCountIs(2),
+          stopWhen: isStepCount(2),
         });
 
         // Consume the stream
@@ -20987,7 +20987,7 @@ describe('streamText', () => {
             },
           },
           ...defaultSettings(),
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
         });
 
         // Consume the stream
@@ -21130,7 +21130,7 @@ describe('streamText', () => {
             execute: async () => 'result',
           },
         },
-        stopWhen: stepCountIs(3),
+        stopWhen: isStepCount(3),
         ...defaultSettings(),
       });
 
@@ -21436,7 +21436,7 @@ describe('streamText', () => {
               },
             }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           prompt: 'test-input',
           _internal: {
             generateId: mockId({ prefix: 'id' }),
@@ -21761,7 +21761,7 @@ describe('streamText', () => {
               needsApproval: true,
             }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           _internal: {
             generateId: mockId({ prefix: 'id' }),
             generateCallId: () => 'test-telemetry-call-id',
@@ -22065,7 +22065,7 @@ describe('streamText', () => {
               needsApproval: true,
             }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           _internal: {
             generateId: mockId({ prefix: 'id' }),
           },
@@ -22189,7 +22189,7 @@ describe('streamText', () => {
               needsApproval: true,
             }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           _internal: {
             generateId: mockId({ prefix: 'id' }),
             generateCallId: () => 'test-telemetry-call-id',
@@ -22518,7 +22518,7 @@ describe('streamText', () => {
               needsApproval: true,
             }),
           },
-          stopWhen: stepCountIs(3),
+          stopWhen: isStepCount(3),
           _internal: {
             generateId: mockId({ prefix: 'id' }),
             generateCallId: () => 'test-telemetry-call-id',

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -96,7 +96,7 @@ import { ResponseMessage } from './response-message';
 import { DefaultStepResult, StepResult } from './step-result';
 import {
   isStopConditionMet,
-  stepCountIs,
+  isStepCount,
   StopCondition,
 } from './stop-condition';
 import { ModelCallStreamPart, streamModelCall } from './stream-model-call';
@@ -301,7 +301,7 @@ export function streamText<
   abortSignal,
   timeout,
   headers,
-  stopWhen = stepCountIs(1),
+  stopWhen = isStepCount(1),
   experimental_output,
   output = experimental_output,
   experimental_telemetry: telemetry,
@@ -361,7 +361,7 @@ export function streamText<
      * Condition for stopping the generation when there are tool results in the last step.
      * When the condition is an array, any of the conditions can be met to stop the generation.
      *
-     * @default stepCountIs(1)
+     * @default isStepCount(1)
      */
     stopWhen?:
       | StopCondition<NoInfer<TOOLS>>

--- a/packages/codemod/src/codemods/v5/move-maxsteps-to-stopwhen.ts
+++ b/packages/codemod/src/codemods/v5/move-maxsteps-to-stopwhen.ts
@@ -60,7 +60,7 @@ export default createTransformer((fileInfo, api, options, context) => {
     const stopWhenProp = j.property(
       'init',
       j.identifier('stopWhen'),
-      j.callExpression(j.identifier('isStepCount'), [property.value]),
+      j.callExpression(j.identifier('stepCountIs'), [property.value]),
     );
     objExpr.properties.splice(index, 1, stopWhenProp);
     shouldAddStepCountIsImport = true;
@@ -92,7 +92,7 @@ export default createTransformer((fileInfo, api, options, context) => {
           trackedFunctions.generateText = localName;
         } else if (importedName === 'streamText') {
           trackedFunctions.streamText = localName;
-        } else if (importedName === 'isStepCount') {
+        } else if (importedName === 'stepCountIs') {
           hasStepCountIsImport = true;
         }
       } else if (source === '@ai-sdk/react' && importedName === 'useChat') {
@@ -154,7 +154,7 @@ export default createTransformer((fileInfo, api, options, context) => {
     }
   });
 
-  // Add isStepCount to existing `ai` or create new import if needed
+  // Add stepCountIs to existing `ai` or create new import if needed
   if (shouldAddStepCountIsImport && !hasStepCountIsImport) {
     const aiImport = root
       .find(j.ImportDeclaration)
@@ -165,17 +165,17 @@ export default createTransformer((fileInfo, api, options, context) => {
       const specifiers = path.node.specifiers;
       const alreadyImported = specifiers?.some(
         (s: any) =>
-          s.type === 'ImportSpecifier' && s.imported.name === 'isStepCount',
+          s.type === 'ImportSpecifier' && s.imported.name === 'stepCountIs',
       );
       if (!alreadyImported) {
-        specifiers.push(j.importSpecifier(j.identifier('isStepCount')));
+        specifiers.push(j.importSpecifier(j.identifier('stepCountIs')));
         path.node.specifiers = specifiers;
       }
     } else {
       // In reality, this branch is unreachable cause `ai` import should always exist
       const firstImport = root.find(j.ImportDeclaration).at(0);
       const importDecl = j.importDeclaration(
-        [j.importSpecifier(j.identifier('isStepCount'))],
+        [j.importSpecifier(j.identifier('stepCountIs'))],
         j.literal('ai'),
       );
       if (firstImport.size()) {

--- a/packages/codemod/src/codemods/v5/move-maxsteps-to-stopwhen.ts
+++ b/packages/codemod/src/codemods/v5/move-maxsteps-to-stopwhen.ts
@@ -60,7 +60,7 @@ export default createTransformer((fileInfo, api, options, context) => {
     const stopWhenProp = j.property(
       'init',
       j.identifier('stopWhen'),
-      j.callExpression(j.identifier('stepCountIs'), [property.value]),
+      j.callExpression(j.identifier('isStepCount'), [property.value]),
     );
     objExpr.properties.splice(index, 1, stopWhenProp);
     shouldAddStepCountIsImport = true;
@@ -92,7 +92,7 @@ export default createTransformer((fileInfo, api, options, context) => {
           trackedFunctions.generateText = localName;
         } else if (importedName === 'streamText') {
           trackedFunctions.streamText = localName;
-        } else if (importedName === 'stepCountIs') {
+        } else if (importedName === 'isStepCount') {
           hasStepCountIsImport = true;
         }
       } else if (source === '@ai-sdk/react' && importedName === 'useChat') {
@@ -154,7 +154,7 @@ export default createTransformer((fileInfo, api, options, context) => {
     }
   });
 
-  // Add stepCountIs to existing `ai` or create new import if needed
+  // Add isStepCount to existing `ai` or create new import if needed
   if (shouldAddStepCountIsImport && !hasStepCountIsImport) {
     const aiImport = root
       .find(j.ImportDeclaration)
@@ -165,17 +165,17 @@ export default createTransformer((fileInfo, api, options, context) => {
       const specifiers = path.node.specifiers;
       const alreadyImported = specifiers?.some(
         (s: any) =>
-          s.type === 'ImportSpecifier' && s.imported.name === 'stepCountIs',
+          s.type === 'ImportSpecifier' && s.imported.name === 'isStepCount',
       );
       if (!alreadyImported) {
-        specifiers.push(j.importSpecifier(j.identifier('stepCountIs')));
+        specifiers.push(j.importSpecifier(j.identifier('isStepCount')));
         path.node.specifiers = specifiers;
       }
     } else {
       // In reality, this branch is unreachable cause `ai` import should always exist
       const firstImport = root.find(j.ImportDeclaration).at(0);
       const importDecl = j.importDeclaration(
-        [j.importSpecifier(j.identifier('stepCountIs'))],
+        [j.importSpecifier(j.identifier('isStepCount'))],
         j.literal('ai'),
       );
       if (firstImport.size()) {

--- a/packages/codemod/src/test/__testfixtures__/move-maxsteps-to-stopwhen-alias.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/move-maxsteps-to-stopwhen-alias.output.ts
@@ -1,12 +1,12 @@
 // @ts-nocheck
-import { generateText as GT, isStepCount } from 'ai';
+import { generateText as GT, stepCountIs } from 'ai';
 import { useChat as UC } from '@ai-sdk/react';
 
 async function foo() {
   const result = await GT({
     model: 'gpt-4',
     messages: [],
-    stopWhen: isStepCount(5)
+    stopWhen: stepCountIs(5)
   });
 
   const maxSteps = 5;
@@ -14,25 +14,25 @@ async function foo() {
   await GT({
     model: 'gpt-4',
     messages: [],
-    stopWhen: isStepCount(maxSteps)
+    stopWhen: stepCountIs(maxSteps)
   });
 
   await GT({
     model: 'gpt-4',
     messages: [],
-    stopWhen: isStepCount(5 + 5)
+    stopWhen: stepCountIs(5 + 5)
   });
 
   await GT({
     model: 'gpt-4',
     messages: [],
-    stopWhen: isStepCount(maxSteps + 5)
+    stopWhen: stepCountIs(maxSteps + 5)
   });
 
   const obj = {
     model: 'gpt-4',
     messages: [],
-    stopWhen: isStepCount(maxSteps + 5)
+    stopWhen: stepCountIs(maxSteps + 5)
   }
 
   await GT(obj);

--- a/packages/codemod/src/test/__testfixtures__/move-maxsteps-to-stopwhen-alias.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/move-maxsteps-to-stopwhen-alias.output.ts
@@ -1,12 +1,12 @@
 // @ts-nocheck
-import { generateText as GT, stepCountIs } from 'ai';
+import { generateText as GT, isStepCount } from 'ai';
 import { useChat as UC } from '@ai-sdk/react';
 
 async function foo() {
   const result = await GT({
     model: 'gpt-4',
     messages: [],
-    stopWhen: stepCountIs(5)
+    stopWhen: isStepCount(5)
   });
 
   const maxSteps = 5;
@@ -14,25 +14,25 @@ async function foo() {
   await GT({
     model: 'gpt-4',
     messages: [],
-    stopWhen: stepCountIs(maxSteps)
+    stopWhen: isStepCount(maxSteps)
   });
 
   await GT({
     model: 'gpt-4',
     messages: [],
-    stopWhen: stepCountIs(5 + 5)
+    stopWhen: isStepCount(5 + 5)
   });
 
   await GT({
     model: 'gpt-4',
     messages: [],
-    stopWhen: stepCountIs(maxSteps + 5)
+    stopWhen: isStepCount(maxSteps + 5)
   });
 
   const obj = {
     model: 'gpt-4',
     messages: [],
-    stopWhen: stepCountIs(maxSteps + 5)
+    stopWhen: isStepCount(maxSteps + 5)
   }
 
   await GT(obj);

--- a/packages/codemod/src/test/__testfixtures__/move-maxsteps-to-stopwhen.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/move-maxsteps-to-stopwhen.output.ts
@@ -1,12 +1,12 @@
 // @ts-nocheck
-import { generateText, isStepCount } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import { useChat } from '@ai-sdk/react';
 
 async function foo() {
   const result = await generateText({
     model: 'gpt-4',
     messages: [],
-    stopWhen: isStepCount(5)
+    stopWhen: stepCountIs(5)
   });
 
   const maxSteps = 5;
@@ -14,25 +14,25 @@ async function foo() {
   await generateText({
     model: 'gpt-4',
     messages: [],
-    stopWhen: isStepCount(maxSteps)
+    stopWhen: stepCountIs(maxSteps)
   });
 
   await generateText({
     model: 'gpt-4',
     messages: [],
-    stopWhen: isStepCount(5 + 5)
+    stopWhen: stepCountIs(5 + 5)
   });
 
   await generateText({
     model: 'gpt-4',
     messages: [],
-    stopWhen: isStepCount(maxSteps + 5)
+    stopWhen: stepCountIs(maxSteps + 5)
   });
 
   const obj = {
     model: 'gpt-4',
     messages: [],
-    stopWhen: isStepCount(maxSteps + 5)
+    stopWhen: stepCountIs(maxSteps + 5)
   }
 
   await generateText(obj);

--- a/packages/codemod/src/test/__testfixtures__/move-maxsteps-to-stopwhen.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/move-maxsteps-to-stopwhen.output.ts
@@ -1,12 +1,12 @@
 // @ts-nocheck
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { useChat } from '@ai-sdk/react';
 
 async function foo() {
   const result = await generateText({
     model: 'gpt-4',
     messages: [],
-    stopWhen: stepCountIs(5)
+    stopWhen: isStepCount(5)
   });
 
   const maxSteps = 5;
@@ -14,25 +14,25 @@ async function foo() {
   await generateText({
     model: 'gpt-4',
     messages: [],
-    stopWhen: stepCountIs(maxSteps)
+    stopWhen: isStepCount(maxSteps)
   });
 
   await generateText({
     model: 'gpt-4',
     messages: [],
-    stopWhen: stepCountIs(5 + 5)
+    stopWhen: isStepCount(5 + 5)
   });
 
   await generateText({
     model: 'gpt-4',
     messages: [],
-    stopWhen: stepCountIs(maxSteps + 5)
+    stopWhen: isStepCount(maxSteps + 5)
   });
 
   const obj = {
     model: 'gpt-4',
     messages: [],
-    stopWhen: stepCountIs(maxSteps + 5)
+    stopWhen: isStepCount(maxSteps + 5)
   }
 
   await generateText(obj);

--- a/packages/devtools/examples/basic/index.ts
+++ b/packages/devtools/examples/basic/index.ts
@@ -1,4 +1,4 @@
-import { gateway, stepCountIs, streamText, wrapLanguageModel } from 'ai';
+import { gateway, isStepCount, streamText, wrapLanguageModel } from 'ai';
 import { tools } from './tools';
 import { devToolsMiddleware } from '../../src';
 import { print } from './utils';
@@ -12,7 +12,7 @@ const result = streamText({
   system: 'Always call the weather before recommending plans.',
   prompt: 'Whats the weather in SF and London in C?',
   tools,
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
   providerOptions: {
     anthropic: {
       thinking: {

--- a/skills/use-ai-sdk/references/common-errors.md
+++ b/skills/use-ai-sdk/references/common-errors.md
@@ -23,24 +23,24 @@ const result = await generateText({
 });
 ```
 
-## `maxSteps` → `stopWhen: stepCountIs(n)`
+## `maxSteps` → `stopWhen: isStepCount(n)`
 
 ```typescript
 // ❌ Incorrect
 const result = await generateText({
   model: 'anthropic/claude-opus-4.5',
   tools: { weather },
-  maxSteps: 5, // deprecated: use `stopWhen: stepCountIs(n)` instead
+  maxSteps: 5, // deprecated: use `stopWhen: isStepCount(n)` instead
   prompt: 'What is the weather in NYC?',
 });
 
 // ✅ Correct
-import { generateText, stepCountIs } from 'ai';
+import { generateText, isStepCount } from 'ai';
 
 const result = await generateText({
   model: 'anthropic/claude-opus-4.5',
   tools: { weather },
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
   prompt: 'What is the weather in NYC?',
 });
 ```


### PR DESCRIPTION
## Background

Follow-up to #13937 which added the `isLoopFinished` stop condition helper. The `stepCountIs` naming was inconsistent with the other stop condition helpers (`hasToolCall`, `isLoopFinished`) which all use a verb-first naming convention (common best practice in TypeScript).

## Summary

- Rename `stepCountIs` to `isStepCount` for consistency with other stop condition helpers
- Keep `stepCountIs` as a deprecated alias for backward compatibility
- Update all docs, examples, and tests to use `isStepCount`

This change is v7 only, so while it's somewhat disruptive, that's okay. The alias means there will be no immediate breakage, and consumers will have at least until v8 to migrate to `isStepCount`.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
