### PR TITLE
fix(amazon-bedrock): preserve reasoning text when signature is present

### DIFF
--- a/.changeset/fast-dots-draw.md
+++ b/.changeset/fast-dots-draw.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(amazon-bedrock): preserve reasoning text when signature is present

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -691,31 +691,37 @@ describe('assistant messages', () => {
       },
     ]);
 
-    expect(result).toEqual({
-      messages: [
-        {
-          role: 'user',
-          content: [{ text: 'Explain your reasoning' }],
-        },
-        {
-          role: 'assistant',
-          content: [
-            {
-              reasoningContent: {
-                reasoningText: {
-                  text: 'This is my reasoning with trailing space    ',
-                  signature: 'test-signature',
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "Explain your reasoning",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "reasoningContent": {
+                  "reasoningText": {
+                    "signature": "test-signature",
+                    "text": "This is my reasoning with trailing space    ",
+                  },
                 },
               },
-            },
-          ],
-        },
-      ],
-      system: [],
-    });
+            ],
+            "role": "assistant",
+          },
+        ],
+        "system": [],
+      }
+    `);
   });
 
-  it('should trim trailing whitespace from reasoning content without signature', async () => {
+  it('should trim trailing whitespace from reasoning content without signature when it is the last part', async () => {
     const result = await convertToBedrockChatMessages([
       {
         role: 'user',
@@ -732,27 +738,90 @@ describe('assistant messages', () => {
       },
     ]);
 
-    expect(result).toEqual({
-      messages: [
-        {
-          role: 'user',
-          content: [{ text: 'Explain your reasoning' }],
-        },
-        {
-          role: 'assistant',
-          content: [
-            {
-              reasoningContent: {
-                reasoningText: {
-                  text: 'This is my reasoning with trailing space',
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "Explain your reasoning",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "reasoningContent": {
+                  "reasoningText": {
+                    "text": "This is my reasoning with trailing space",
+                  },
                 },
               },
-            },
-          ],
-        },
-      ],
-      system: [],
-    });
+            ],
+            "role": "assistant",
+          },
+        ],
+        "system": [],
+      }
+    `);
+  });
+
+  it('should only trim last reasoning part when multiple reasoning parts have trailing spaces', async () => {
+    const result = await convertToBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Explain your reasoning' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'First reasoning with trailing space    ',
+          },
+          {
+            type: 'reasoning',
+            text: 'Second reasoning with trailing space    ',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "Explain your reasoning",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "reasoningContent": {
+                  "reasoningText": {
+                    "text": "First reasoning with trailing space    ",
+                  },
+                },
+              },
+              {
+                "reasoningContent": {
+                  "reasoningText": {
+                    "text": "Second reasoning with trailing space",
+                  },
+                },
+              },
+            ],
+            "role": "assistant",
+          },
+        ],
+        "system": [],
+      }
+    `);
   });
 
   it('should preserve reasoning text with signature in multi-turn tool use', async () => {
@@ -809,16 +878,76 @@ describe('assistant messages', () => {
       },
     ]);
 
-    const lastAssistant = result.messages[result.messages.length - 1];
-    const reasoningBlock = lastAssistant.content[0] as {
-      reasoningContent: { reasoningText: { text: string; signature: string } };
-    };
-    expect(reasoningBlock.reasoningContent.reasoningText.text).toBe(
-      'The weather is sunny and warm.\n',
-    );
-    expect(reasoningBlock.reasoningContent.reasoningText.signature).toBe(
-      'sig-def456',
-    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "What is the weather?",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "reasoningContent": {
+                  "reasoningText": {
+                    "signature": "sig-abc123",
+                    "text": "Let me check the weather API.
+      ",
+                  },
+                },
+              },
+              {
+                "toolUse": {
+                  "input": {
+                    "city": "SF",
+                  },
+                  "name": "getWeather",
+                  "toolUseId": "call-1",
+                },
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "toolResult": {
+                  "content": [
+                    {
+                      "text": "Sunny, 72F",
+                    },
+                  ],
+                  "toolUseId": "call-1",
+                },
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "reasoningContent": {
+                  "reasoningText": {
+                    "signature": "sig-def456",
+                    "text": "The weather is sunny and warm.
+      ",
+                  },
+                },
+              },
+              {
+                "text": "It is sunny and 72F in SF.",
+              },
+            ],
+            "role": "assistant",
+          },
+        ],
+        "system": [],
+      }
+    `);
   });
 
   it('should handle a mix of text and reasoning content types', async () => {

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -669,7 +669,7 @@ describe('assistant messages', () => {
     });
   });
 
-  it('should trim trailing whitespace from reasoning content when it is the last part', async () => {
+  it('should not trim reasoning text when a signature is present', async () => {
     const result = await convertToBedrockChatMessages([
       {
         role: 'user',
@@ -703,7 +703,7 @@ describe('assistant messages', () => {
             {
               reasoningContent: {
                 reasoningText: {
-                  text: 'This is my reasoning with trailing space',
+                  text: 'This is my reasoning with trailing space    ',
                   signature: 'test-signature',
                 },
               },
@@ -713,6 +713,112 @@ describe('assistant messages', () => {
       ],
       system: [],
     });
+  });
+
+  it('should trim trailing whitespace from reasoning content without signature', async () => {
+    const result = await convertToBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Explain your reasoning' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'This is my reasoning with trailing space    ',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Explain your reasoning' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              reasoningContent: {
+                reasoningText: {
+                  text: 'This is my reasoning with trailing space',
+                },
+              },
+            },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
+
+  it('should preserve reasoning text with signature in multi-turn tool use', async () => {
+    const result = await convertToBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'What is the weather?' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'Let me check the weather API.\n',
+            providerOptions: {
+              bedrock: {
+                signature: 'sig-abc123',
+              } satisfies BedrockReasoningMetadata,
+            },
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'getWeather',
+            input: { city: 'SF' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'getWeather',
+            output: { type: 'text', value: 'Sunny, 72F' },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'The weather is sunny and warm.\n',
+            providerOptions: {
+              bedrock: {
+                signature: 'sig-def456',
+              } satisfies BedrockReasoningMetadata,
+            },
+          },
+          { type: 'text', text: 'It is sunny and 72F in SF.' },
+        ],
+      },
+    ]);
+
+    const lastAssistant = result.messages[result.messages.length - 1];
+    const reasoningBlock = lastAssistant.content[0] as {
+      reasoningContent: { reasoningText: { text: string; signature: string } };
+    };
+    expect(reasoningBlock.reasoningContent.reasoningText.text).toBe(
+      'The weather is sunny and warm.\n',
+    );
+    expect(reasoningBlock.reasoningContent.reasoningText.signature).toBe(
+      'sig-def456',
+    );
   });
 
   it('should handle a mix of text and reasoning content types', async () => {

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -287,33 +287,36 @@ export async function convertToBedrockChatMessages(
                   schema: bedrockReasoningMetadataSchema,
                 });
 
-                if (reasoningMetadata != null) {
-                  if (reasoningMetadata.signature != null) {
-                    bedrockContent.push({
-                      reasoningContent: {
-                        reasoningText: {
-                          // trim the last text part if it's the last message in the block
-                          // because Bedrock does not allow trailing whitespace
-                          // in pre-filled assistant responses
-                          text: trimIfLast(
-                            isLastBlock,
-                            isLastMessage,
-                            isLastContentPart,
-                            part.text,
-                          ),
-                          signature: reasoningMetadata.signature,
-                        },
+                if (reasoningMetadata?.signature != null) {
+                  bedrockContent.push({
+                    reasoningContent: {
+                      reasoningText: {
+                        text: part.text,
+                        signature: reasoningMetadata.signature,
                       },
-                    });
-                  } else if (reasoningMetadata.redactedData != null) {
-                    bedrockContent.push({
-                      reasoningContent: {
-                        redactedReasoning: {
-                          data: reasoningMetadata.redactedData,
-                        },
+                    },
+                  });
+                } else if (reasoningMetadata?.redactedData != null) {
+                  bedrockContent.push({
+                    reasoningContent: {
+                      redactedReasoning: {
+                        data: reasoningMetadata.redactedData,
                       },
-                    });
-                  }
+                    },
+                  });
+                } else {
+                  bedrockContent.push({
+                    reasoningContent: {
+                      reasoningText: {
+                        text: trimIfLast(
+                          isLastBlock,
+                          isLastMessage,
+                          isLastContentPart,
+                          part.text,
+                        ),
+                      },
+                    },
+                  });
                 }
 
                 break;

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -288,6 +288,8 @@ export async function convertToBedrockChatMessages(
                 });
 
                 if (reasoningMetadata?.signature != null) {
+                  // do not trim reasoning text when a signature is present:
+                  // the signature validates the exact original bytes
                   bedrockContent.push({
                     reasoningContent: {
                       reasoningText: {
@@ -305,6 +307,9 @@ export async function convertToBedrockChatMessages(
                     },
                   });
                 } else {
+                  // trim the last text part if it's the last message in the block
+                  // because Bedrock does not allow trailing whitespace
+                  // in pre-filled assistant responses
                   bedrockContent.push({
                     reasoningContent: {
                       reasoningText: {


### PR DESCRIPTION
## background

`trimIfLast()` trims trailing whitespace from reasoning block text even when a cryptographic `signature` is present. the signature is computed over the exact original bytes - trimming even a single trailing newline invalidates the text/signature pair, causing Bedrock to reject with `ValidationException: thinking blocks cannot be modified`

## summary

- skip `trimIfLast` for reasoning blocks that have a signature
- reasoning blocks without a signature still get trimmed as before
- add test for multi-turn tool use with signed reasoning blocks

## checklist

- [x] tests have been added / updated (for bug fixes / features)
- [ ] documentation has been added / updated (for bug fixes / features)
- [x] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)

## related issues

fixes #13583