### PR TITLE
test(durable-agent): add e2e test for experimental_repairToolCall

### DIFF
--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -1,5 +1,9 @@
 import { DurableAgent, type ModelCallStreamPart } from '@ai-sdk/durable-agent';
-import { convertToModelMessages, type UIMessage } from 'ai';
+import {
+  convertToModelMessages,
+  ToolCallRepairFunction,
+  type UIMessage,
+} from 'ai';
 import { getWritable } from 'workflow';
 import z from 'zod';
 
@@ -49,6 +53,36 @@ async function calculate(input: {
 // Chat workflow — orchestrates the DurableAgent
 // ============================================================================
 
+const tools = {
+  getWeather: {
+    description:
+      'Get the current weather for a city. Returns temperature in Fahrenheit and conditions.',
+    inputSchema: z.object({
+      city: z.string().describe('The city name to get weather for'),
+    }),
+    execute: getWeather,
+  },
+  calculate: {
+    description:
+      'Evaluate a simple math expression. Supports +, -, *, /, and parentheses.',
+    inputSchema: z.object({
+      expression: z
+        .string()
+        .describe('The math expression to evaluate, e.g. "2 + 3 * 4"'),
+    }),
+    execute: calculate,
+  },
+};
+const repairToolCall: ToolCallRepairFunction<typeof tools> = async ({
+  toolCall,
+}) => {
+  'use step';
+
+  console.log('Repairing tool call', { toolCall });
+
+  return toolCall;
+};
+
 export async function chat(messages: UIMessage[]) {
   'use workflow';
 
@@ -58,26 +92,7 @@ export async function chat(messages: UIMessage[]) {
     model: 'anthropic/claude-sonnet-4-20250514',
     instructions:
       'You are a helpful assistant with access to weather and calculator tools. Use them when the user asks about weather in a city or needs math calculations. Keep responses concise.',
-    tools: {
-      getWeather: {
-        description:
-          'Get the current weather for a city. Returns temperature in Fahrenheit and conditions.',
-        inputSchema: z.object({
-          city: z.string().describe('The city name to get weather for'),
-        }),
-        execute: getWeather,
-      },
-      calculate: {
-        description:
-          'Evaluate a simple math expression. Supports +, -, *, /, and parentheses.',
-        inputSchema: z.object({
-          expression: z
-            .string()
-            .describe('The math expression to evaluate, e.g. "2 + 3 * 4"'),
-        }),
-        execute: calculate,
-      },
-    },
+    tools,
     onStepFinish: async stepResult => {
       console.log('[agent-chat] step finished:', {
         finishReason: stepResult.finishReason,
@@ -98,6 +113,7 @@ export async function chat(messages: UIMessage[]) {
   const result = await agent.stream({
     messages: modelMessages,
     writable: getWritable<ModelCallStreamPart>(),
+    experimental_repairToolCall: repairToolCall as any,
   });
 
   return { messages: result.messages };

--- a/packages/durable-agent/src/durable-agent-e2e.integration.test.ts
+++ b/packages/durable-agent/src/durable-agent-e2e.integration.test.ts
@@ -21,6 +21,7 @@ import {
   agentOnToolCallFinishE2e,
   agentOnToolCallStartE2e,
   agentPrepareCallE2e,
+  agentRepairToolCallE2e,
   agentTimeoutE2e,
   agentToolApprovalE2e,
   agentToolCallE2e,
@@ -77,6 +78,19 @@ describe('DurableAgent integration', { timeout: 120_000 }, () => {
       const run = await start(agentToolInputSchemaE2e, [3, 7]);
       const rv = await run.returnValue;
       expect(rv).toMatchObject({ stepCount: 2 });
+      expect(rv.lastStepText).toBe('The sum is 10');
+    });
+  });
+
+  // ==========================================================================
+  // experimental_repairToolCall serialization
+  // ==========================================================================
+
+  describe('experimental_repairToolCall', () => {
+    it('callback survives serialization and repairs malformed tool input', async () => {
+      const run = await start(agentRepairToolCallE2e, []);
+      const rv = await run.returnValue;
+      expect(rv).toMatchObject({ stepCount: 2, repaired: true });
       expect(rv.lastStepText).toBe('The sum is 10');
     });
   });

--- a/packages/durable-agent/src/test/agent-e2e-workflows.ts
+++ b/packages/durable-agent/src/test/agent-e2e-workflows.ts
@@ -142,6 +142,52 @@ export async function agentErrorToolE2e() {
 }
 
 // ============================================================================
+// experimental_repairToolCall serialization
+// ============================================================================
+
+async function repairToolCall({
+  toolCall,
+}: {
+  toolCall: { toolCallId: string; toolName: string; input: string };
+}) {
+  'use step';
+  // Fix the malformed JSON
+  return { ...toolCall, input: '{"a": 3, "b": 7}' };
+}
+
+export async function agentRepairToolCallE2e() {
+  'use workflow';
+  const agent = new DurableAgent({
+    model: mockSequenceModel([
+      {
+        type: 'tool-call',
+        toolName: 'addNumbers',
+        // Malformed input: missing closing brace
+        input: '{"a": 3, "b": 7',
+      },
+      { type: 'text', text: 'The sum is 10' },
+    ]),
+    tools: {
+      addNumbers: {
+        description: 'Add two numbers',
+        inputSchema: z.object({ a: z.number(), b: z.number() }),
+        execute: addNumbers,
+      },
+    },
+  });
+  const result = await agent.stream({
+    messages: [{ role: 'user', content: 'add 3 and 7' }],
+    writable: getWritable(),
+    experimental_repairToolCall: repairToolCall as any,
+  });
+  return {
+    stepCount: result.steps.length,
+    lastStepText: result.steps[result.steps.length - 1]?.text,
+    repaired: result.steps.length === 2, // If repair worked, we get 2 steps (tool call + text)
+  };
+}
+
+// ============================================================================
 // Callback tests — onStepFinish
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Adds an integration test verifying `experimental_repairToolCall` callbacks survive workflow serialization across the step boundary
- The repair callback uses `'use step'` so the workflow runtime can serialize it as a step reference when passed as an argument to `doStreamStep`
- Test sends a tool call with malformed JSON input (`'{"a": 3, "b": 7'` — missing closing brace), uses a repair step function to fix it, and verifies the tool executes successfully with 2 steps (tool call + text)
- Updates the `examples/next-workflow` chat example to wire up `experimental_repairToolCall` with a `'use step'` repair function

## Test plan

- [x] `pnpm --filter @ai-sdk/durable-agent test:integration` passes (17/17)
- [x] `pnpm --filter @ai-sdk/durable-agent test:node` passes