### PR TITLE
fix(ai): remove otel Tracer api from telemetry settings

### DIFF
--- a/.changeset/gorgeous-onions-admire.md
+++ b/.changeset/gorgeous-onions-admire.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): remove otel Tracer api from telemetry settings

--- a/packages/ai/src/telemetry/telemetry-settings.ts
+++ b/packages/ai/src/telemetry/telemetry-settings.ts
@@ -1,5 +1,4 @@
 import type { JSONValue } from '@ai-sdk/provider';
-import type { Tracer } from '@opentelemetry/api';
 import type { TelemetryIntegration } from './telemetry-integration';
 
 /**
@@ -38,12 +37,6 @@ export type TelemetrySettings = {
    * Additional information to include in the telemetry data.
    */
   metadata?: Record<string, JSONValue>;
-
-  /**
-   * A custom tracer to use for the telemetry data.
-   */
-  // TODO remove tracer (all ai functions need to be updated)
-  tracer?: Tracer;
 
   /**
    * Per-call telemetry integrations that receive lifecycle events during generation.


### PR DESCRIPTION
## Background

in the ongoing effort to decouple otel from core functions and core package, we had to remove the `Tracer` api imported in `TelemetrySettings` since we now pass the tracer through `integrations()` in the `TelemetrySettings`

## Summary

remove the import of Tracer 

## Manual Verification

na

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)