### PR TITLE
fix(@ai-sdk/google-vertex): translate top-level cache_control to message-level for Vertex Anthropic

### DIFF
--- a/.changeset/vertex-anthropic-cache-control.md
+++ b/.changeset/vertex-anthropic-cache-control.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google-vertex": patch
+---
+
+fix(@ai-sdk/google-vertex): translate top-level cache_control to message-level for Vertex Anthropic

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -56,6 +56,179 @@ describe('google-vertex-anthropic-provider', () => {
     );
   });
 
+  describe('transformRequestBody', () => {
+    function getTransformRequestBody() {
+      const provider = createVertexAnthropic({
+        project: 'test-project',
+        location: 'test-location',
+      });
+      provider('test-model-id');
+      const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
+        .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+      return constructorCall[1].transformRequestBody!;
+    }
+
+    it('should remove model and add anthropic_version', () => {
+      const transform = getTransformRequestBody();
+      const result = transform({
+        model: 'claude-3-5-sonnet-v2@20241022',
+        max_tokens: 4096,
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+        ],
+      });
+
+      expect(result).toEqual({
+        max_tokens: 4096,
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+        ],
+        anthropic_version: 'vertex-2023-10-16',
+      });
+      expect(result).not.toHaveProperty('model');
+    });
+
+    it('should move top-level cache_control to message before last user message', () => {
+      const transform = getTransformRequestBody();
+      const result = transform({
+        model: 'claude-3-5-sonnet-v2@20241022',
+        max_tokens: 4096,
+        cache_control: { type: 'ephemeral' },
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'System context' }],
+          },
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Got it' }],
+          },
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Latest question' }],
+          },
+        ],
+      });
+
+      expect(result).not.toHaveProperty('cache_control');
+      // cache_control should be on the assistant message (before last user)
+      expect(result.messages[1].content[0].cache_control).toEqual({
+        type: 'ephemeral',
+      });
+      // Other messages should not have cache_control
+      expect(result.messages[0].content[0].cache_control).toBeUndefined();
+      expect(result.messages[2].content[0].cache_control).toBeUndefined();
+    });
+
+    it('should preserve cache_control ttl when moving to message level', () => {
+      const transform = getTransformRequestBody();
+      const result = transform({
+        model: 'claude-3-5-sonnet-v2@20241022',
+        max_tokens: 4096,
+        cache_control: { type: 'ephemeral', ttl: '1h' },
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'Context' }] },
+          { role: 'assistant', content: [{ type: 'text', text: 'Ok' }] },
+          { role: 'user', content: [{ type: 'text', text: 'Question' }] },
+        ],
+      });
+
+      expect(result.messages[1].content[0].cache_control).toEqual({
+        type: 'ephemeral',
+        ttl: '1h',
+      });
+    });
+
+    it('should fall back to system message when only one user message', () => {
+      const transform = getTransformRequestBody();
+      const result = transform({
+        model: 'claude-3-5-sonnet-v2@20241022',
+        max_tokens: 4096,
+        cache_control: { type: 'ephemeral' },
+        system: [{ type: 'text', text: 'You are a helpful assistant' }],
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+        ],
+      });
+
+      expect(result).not.toHaveProperty('cache_control');
+      expect(result.system[0].cache_control).toEqual({ type: 'ephemeral' });
+    });
+
+    it('should not overwrite existing message-level cache_control', () => {
+      const transform = getTransformRequestBody();
+      const result = transform({
+        model: 'claude-3-5-sonnet-v2@20241022',
+        max_tokens: 4096,
+        cache_control: { type: 'ephemeral' },
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Context' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'Ok',
+                cache_control: { type: 'ephemeral', ttl: '5m' },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Question' }],
+          },
+        ],
+      });
+
+      // Should NOT overwrite the existing cache_control
+      expect(result.messages[1].content[0].cache_control).toEqual({
+        type: 'ephemeral',
+        ttl: '5m',
+      });
+    });
+
+    it('should not overwrite existing system-level cache_control', () => {
+      const transform = getTransformRequestBody();
+      const result = transform({
+        model: 'claude-3-5-sonnet-v2@20241022',
+        max_tokens: 4096,
+        cache_control: { type: 'ephemeral' },
+        system: [
+          {
+            type: 'text',
+            text: 'You are helpful',
+            cache_control: { type: 'ephemeral', ttl: '5m' },
+          },
+        ],
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+        ],
+      });
+
+      expect(result.system[0].cache_control).toEqual({
+        type: 'ephemeral',
+        ttl: '5m',
+      });
+    });
+
+    it('should pass through request without cache_control unchanged', () => {
+      const transform = getTransformRequestBody();
+      const result = transform({
+        model: 'claude-3-5-sonnet-v2@20241022',
+        max_tokens: 4096,
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+        ],
+      });
+
+      expect(result).not.toHaveProperty('cache_control');
+      expect(result.messages[0].content[0]).not.toHaveProperty('cache_control');
+    });
+  });
+
   it('should throw an error when using new keyword', () => {
     const provider = createVertexAnthropic({ project: 'test-project' });
 

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -158,6 +158,72 @@ export interface GoogleVertexAnthropicProviderSettings {
 }
 
 /**
+ * Distributes a top-level `cache_control` value to the last cacheable content
+ * block in the messages array. Targets the message immediately before the last
+ * user message (the stable conversation prefix), falling back to the last
+ * system message block if there is no prior message.
+ *
+ * This replicates Anthropic's automatic caching semantics in a way that
+ * Vertex's strict input validation accepts.
+ */
+function distributeCacheControlToMessages(
+  body: Record<string, unknown>,
+  cacheControl: unknown,
+): void {
+  const messages = body.messages as
+    | Array<{ role: string; content: unknown }>
+    | undefined;
+
+  // Find the last user message index
+  let lastUserIndex = -1;
+  if (messages) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'user') {
+        lastUserIndex = i;
+        break;
+      }
+    }
+  }
+
+  // Target the message before the last user message
+  const targetIndex = lastUserIndex > 0 ? lastUserIndex - 1 : -1;
+
+  if (targetIndex >= 0 && messages) {
+    const targetMessage = messages[targetIndex];
+    applyCacheControlToMessage(targetMessage, cacheControl);
+    return;
+  }
+
+  // Fall back to the last system message block
+  const system = body.system as
+    | Array<{ type: string; cache_control?: unknown }>
+    | undefined;
+  if (system && system.length > 0) {
+    const lastSystemBlock = system[system.length - 1];
+    if (lastSystemBlock.cache_control == null) {
+      lastSystemBlock.cache_control = cacheControl;
+    }
+  }
+}
+
+/**
+ * Applies cache_control to the last content block of a message,
+ * only if that block doesn't already have cache_control set.
+ */
+function applyCacheControlToMessage(
+  message: { role: string; content: unknown },
+  cacheControl: unknown,
+): void {
+  const content = message.content;
+  if (Array.isArray(content) && content.length > 0) {
+    const lastBlock = content[content.length - 1];
+    if (lastBlock.cache_control == null) {
+      lastBlock.cache_control = cacheControl;
+    }
+  }
+}
+
+/**
  * Create a Google Vertex Anthropic provider instance.
  */
 export function createVertexAnthropic(
@@ -192,11 +258,22 @@ export function createVertexAnthropic(
         }`,
       transformRequestBody: args => {
         // Remove model from args and add anthropic version
-        const { model, ...rest } = args;
-        return {
+        const { model, cache_control, ...rest } = args;
+
+        const body: Record<string, unknown> = {
           ...rest,
           anthropic_version: 'vertex-2023-10-16',
         };
+
+        // Vertex Anthropic rejects top-level cache_control. Translate it to
+        // message-level cache_control on the last cacheable content block
+        // before the final user turn, matching Anthropic's automatic caching
+        // semantics.
+        if (cache_control != null) {
+          distributeCacheControlToMessages(body, cache_control);
+        }
+
+        return body;
       },
       // Google Vertex Anthropic doesn't support URL sources, force download and base64 conversion
       supportedUrls: () => ({}),


### PR DESCRIPTION
## Background

Anthropic's native API accepts `cacheControl` at the top level of `providerOptions.anthropic`, placing `cache_control` at the request body root for "automatic caching." However, Vertex Anthropic's strict input validation rejects `cache_control` at the request root with a `400 cache_control: Extra inputs are not permitted` error.

This is currently worked around in AI Gateway (https://github.com/vercel/ai-gateway/pull/1567), https://github.com/vercel/ai-gateway/pull/1574), but the translation belongs in the provider itself so that **all** Vertex Anthropic users benefit, not just gateway users.

## Summary

Enhances the Vertex Anthropic provider's `transformRequestBody` to intercept top-level `cache_control` and distribute it to the appropriate message-level content block:

1. Removes `cache_control` from the request body root
2. Finds the last user message, then targets the message **before** it (the stable conversation prefix)
3. Applies `cache_control` to the last content block of that target message
4. Falls back to the last system message block if there's only one user message
5. Respects existing message-level `cache_control` (never overwrites)
6. Preserves TTL values (`5m`, `1h`) through the translation

This replicates Anthropic's automatic caching semantics in a way Vertex accepts.

## Manual Verification

Unit tests cover all scenarios. End-to-end verification against Vertex Anthropic API pending.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

### Alternative approach: push the logic into `AnthropicMessagesLanguageModel`

Instead of handling this in each provider's `transformRequestBody`, the shared `AnthropicMessagesLanguageModel` could accept a configuration flag (e.g., `distributeCacheControl: true`) that tells it to auto-distribute top-level `cacheControl` to messages instead of placing it at the request root. This would:

- Keep all Anthropic cache control logic in one place (`@ai-sdk/anthropic`)
- Let Vertex (and potentially Bedrock) simply pass a flag rather than reimplementing the translation
- Make it easier to evolve the automatic caching heuristic (e.g., targeting different messages) in a single location

The tradeoff is that it couples `AnthropicMessagesLanguageModel` to provider-specific API constraints, whereas the current `transformRequestBody` approach keeps the concern isolated to the provider that needs it.

### Bedrock Anthropic

The Bedrock Anthropic provider uses a fundamentally different cache format (`cachePoint` vs `cache_control`) and doesn't use `AnthropicMessagesLanguageModel` internals, so the gateway translation in [#1574](https://github.com/vercel/ai-gateway/pull/1574) would still be needed for Bedrock unless the Bedrock provider is also updated to accept `providerOptions.anthropic.cacheControl`.

## Related Issues

- https://github.com/vercel/ai-gateway/pull/1567
- https://github.com/vercel/ai-gateway/pull/1574