### PR TITLE
fix(mcp): strip trailing slash from OAuth resource parameter

### DIFF
--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -451,7 +451,7 @@ export async function startAuthorization(
   }
 
   if (resource) {
-    authorizationUrl.searchParams.set('resource', resource.href);
+    authorizationUrl.searchParams.set('resource', resource.href.replace(/\/$/, ''));
   }
 
   return { authorizationUrl, codeVerifier };
@@ -675,7 +675,7 @@ export async function exchangeAuthorization(
   }
 
   if (resource) {
-    params.set('resource', resource.href);
+    params.set('resource', resource.href.replace(/\/$/, ''));
   }
 
   const response = await (fetchFn ?? fetch)(tokenUrl, {
@@ -762,7 +762,7 @@ export async function refreshAuthorization(
   }
 
   if (resource) {
-    params.set('resource', resource.href);
+    params.set('resource', resource.href.replace(/\/$/, ''));
   }
 
   const response = await (fetchFn ?? fetch)(tokenUrl, {

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -21,6 +21,24 @@ import {
   InvalidGrantError,
   UnauthorizedClientError,
 } from '../error/oauth-error';
+
+/**
+ * Return the canonical resource URI for OAuth parameters.
+ *
+ * `new URL("https://host").href` appends a trailing slash (`https://host/`)
+ * per the WHATWG URL spec, but the MCP spec recommends the form without the
+ * trailing slash for origin-only URIs. Auth servers that do exact matching
+ * reject the slashed form.
+ *
+ * Only strips the slash when the pathname is exactly `/` (origin-only URL).
+ * Path-based resource URIs like `https://host/api/` are left unchanged.
+ */
+function canonicalResourceUri(resource: URL): string {
+  if (resource.pathname === '/') {
+    return resource.href.replace(/\/$/, '');
+  }
+  return resource.href;
+}
 import {
   resourceUrlFromServerUrl,
   checkResourceAllowed,
@@ -451,7 +469,7 @@ export async function startAuthorization(
   }
 
   if (resource) {
-    authorizationUrl.searchParams.set('resource', resource.href.replace(/\/$/, ''));
+    authorizationUrl.searchParams.set('resource', canonicalResourceUri(resource));
   }
 
   return { authorizationUrl, codeVerifier };
@@ -675,7 +693,7 @@ export async function exchangeAuthorization(
   }
 
   if (resource) {
-    params.set('resource', resource.href.replace(/\/$/, ''));
+    params.set('resource', canonicalResourceUri(resource));
   }
 
   const response = await (fetchFn ?? fetch)(tokenUrl, {
@@ -762,7 +780,7 @@ export async function refreshAuthorization(
   }
 
   if (resource) {
-    params.set('resource', resource.href.replace(/\/$/, ''));
+    params.set('resource', canonicalResourceUri(resource));
   }
 
   const response = await (fetchFn ?? fetch)(tokenUrl, {


### PR DESCRIPTION
## Summary

Fixes #13988

`new URL("https://mcp.example.com").href` returns `"https://mcp.example.com/"` per the URL spec. Auth servers that do exact matching on the `resource` parameter reject the request because the trailing slash makes it a different URI than what was registered.

## Fix

Strip trailing slash from `resource.href` in all three locations where it's used as an OAuth parameter:

- `startAuthorization` (line 454)
- `exchangeAuthorization` (line 678)
- `refreshAuthorization` (line 765)

```diff
- params.set('resource', resource.href);
+ params.set('resource', resource.href.replace(/\/$/, ''));
```

## Why this is correct

The MCP spec explicitly recommends the form without trailing slash for better interoperability:

> implementations SHOULD consistently use the form without the trailing slash

Source: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#canonical-server-uri

## Test plan

- MCP servers with pathless resource URLs (e.g. `https://mcp.example.com`) should no longer get rejected by auth servers doing exact match
- MCP servers with path-based resource URLs (e.g. `https://mcp.example.com/api`) are unaffected (no trailing slash to strip)