### PR TITLE
feat : add warning when default stopWhen ends tool loop

### DIFF
--- a/.changeset/warn-default-stop-when.md
+++ b/.changeset/warn-default-stop-when.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Log a console warning when a multi-step tool loop ends because the default `stopWhen` matched, so users can adjust `stopWhen` in `streamText` and `ToolLoopAgent`.

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -133,6 +133,10 @@ export class ToolLoopAgent<
       ...(await this.prepareCall(options)),
       abortSignal,
       timeout,
+      _internal: {
+        usedDefaultStopWhen: this.settings.stopWhen === undefined,
+        defaultStopStepCount: 20,
+      },
       experimental_onStart: this.mergeCallbacks(
         this.settings.experimental_onStart,
         experimental_onStart,
@@ -179,6 +183,10 @@ export class ToolLoopAgent<
       abortSignal,
       timeout,
       experimental_transform,
+      _internal: {
+        usedDefaultStopWhen: this.settings.stopWhen === undefined,
+        defaultStopStepCount: 20,
+      },
       experimental_onStart: this.mergeCallbacks(
         this.settings.experimental_onStart,
         experimental_onStart,

--- a/packages/ai/src/generate-text/default-stop-when-warning.ts
+++ b/packages/ai/src/generate-text/default-stop-when-warning.ts
@@ -1,0 +1,66 @@
+import { logWarnings } from '../logger/log-warnings';
+import {
+  getStopConditionStepCount,
+  isStopConditionMet,
+  StopCondition,
+} from './stop-condition';
+import { StepResult } from './step-result';
+import { ToolSet } from './tool-set';
+
+export async function logDefaultStopWhenWarningIfNeeded<
+  TOOLS extends ToolSet,
+>(options: {
+  provider: string;
+  model: string;
+  usedDefaultStopWhen: boolean;
+  defaultStopStepCount: number;
+  stopConditions: Array<StopCondition<TOOLS>>;
+  steps: Array<StepResult<TOOLS>>;
+  toolLoopCouldContinue: boolean;
+}): Promise<void> {
+  const {
+    provider,
+    model,
+    usedDefaultStopWhen,
+    defaultStopStepCount,
+    stopConditions,
+    steps,
+    toolLoopCouldContinue,
+  } = options;
+
+  if (!usedDefaultStopWhen || !toolLoopCouldContinue) {
+    return;
+  }
+
+  if (
+    !(await isStopConditionMet({
+      stopConditions,
+      steps,
+    }))
+  ) {
+    return;
+  }
+
+  if (stopConditions.length !== 1) {
+    return;
+  }
+
+  if (getStopConditionStepCount(stopConditions[0]) !== defaultStopStepCount) {
+    return;
+  }
+
+  if (steps.length !== defaultStopStepCount) {
+    return;
+  }
+
+  logWarnings({
+    provider,
+    model,
+    warnings: [
+      {
+        type: 'other',
+        message: `The tool loop stopped before the next model step because the default stopWhen condition matched (isStepCount(${defaultStopStepCount})). To run more tool rounds, pass a different stopWhen (for example isStepCount with a higher limit) or a custom stop condition.`,
+      },
+    ],
+  });
+}

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -72,6 +72,7 @@ import { PrepareStepFunction } from './prepare-step';
 import { convertToReasoningOutputs } from './reasoning-output';
 import { ResponseMessage } from './response-message';
 import { DefaultStepResult, StepResult } from './step-result';
+import { logDefaultStopWhenWarningIfNeeded } from './default-stop-when-warning';
 import {
   isStopConditionMet,
   isStepCount,
@@ -257,7 +258,7 @@ export async function generateText<
   abortSignal,
   timeout,
   headers,
-  stopWhen = isStepCount(1),
+  stopWhen: stopWhenFromUser,
   experimental_output,
   output = experimental_output,
   experimental_telemetry: telemetry,
@@ -273,6 +274,8 @@ export async function generateText<
   _internal: {
     generateId = originalGenerateId,
     generateCallId = originalGenerateCallId,
+    usedDefaultStopWhen: usedDefaultStopWhenFromInternal,
+    defaultStopStepCount: defaultStopStepCountFromInternal,
   } = {},
   experimental_onStart: onStart,
   experimental_onStepStart: onStepStart,
@@ -449,8 +452,18 @@ export async function generateText<
     _internal?: {
       generateId?: IdGenerator;
       generateCallId?: IdGenerator;
+      usedDefaultStopWhen?: boolean;
+      defaultStopStepCount?: number;
     };
   }): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
+  const usedDefaultStopWhen =
+    usedDefaultStopWhenFromInternal !== undefined
+      ? usedDefaultStopWhenFromInternal
+      : stopWhenFromUser === undefined;
+
+  const defaultStopStepCount = defaultStopStepCountFromInternal ?? 1;
+  const stopWhen = stopWhenFromUser ?? isStepCount(defaultStopStepCount);
+
   const model = resolveLanguageModel(modelArg);
   const createGlobalTelemetry = getGlobalTelemetryIntegration<TOOLS, OUTPUT>();
   const stopConditions = asArray(stopWhen);
@@ -1030,6 +1043,23 @@ export async function generateText<
     );
 
     const lastStep = steps[steps.length - 1];
+
+    if (lastStep != null) {
+      const toolLoopCouldContinue =
+        ((clientToolCalls.length > 0 &&
+          clientToolOutputs.length === clientToolCalls.length) ||
+          pendingDeferredToolCalls.size > 0);
+
+      await logDefaultStopWhenWarningIfNeeded({
+        provider: lastStep.model.provider,
+        model: lastStep.model.modelId,
+        usedDefaultStopWhen,
+        defaultStopStepCount,
+        stopConditions,
+        steps,
+        toolLoopCouldContinue,
+      });
+    }
 
     const totalUsage = steps.reduce(
       (totalUsage, step) => {

--- a/packages/ai/src/generate-text/stop-condition.ts
+++ b/packages/ai/src/generate-text/stop-condition.ts
@@ -5,8 +5,26 @@ export type StopCondition<TOOLS extends ToolSet> = (options: {
   steps: Array<StepResult<TOOLS>>;
 }) => PromiseLike<boolean> | boolean;
 
+const stepCountSymbol = Symbol.for('ai.stopCondition.stepCount');
+
+export function getStopConditionStepCount(
+  condition: StopCondition<any>,
+): number | undefined {
+  const value = (condition as unknown as Record<symbol, unknown>)[
+    stepCountSymbol
+  ];
+  return typeof value === 'number' ? value : undefined;
+}
+
 export function isStepCount(stepCount: number): StopCondition<any> {
-  return ({ steps }) => steps.length === stepCount;
+  function condition({ steps }: { steps: Array<StepResult<any>> }) {
+    return steps.length === stepCount;
+  }
+  Object.defineProperty(condition, stepCountSymbol, {
+    value: stepCount,
+    enumerable: false,
+  });
+  return condition;
 }
 
 export function isLoopFinished(): StopCondition<any> {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -16,6 +16,7 @@ import {
 import { ServerResponse } from 'node:http';
 import { NoOutputGeneratedError } from '../error';
 import { logWarnings } from '../logger/log-warnings';
+import { logDefaultStopWhenWarningIfNeeded } from './default-stop-when-warning';
 import { resolveLanguageModel } from '../model/resolve-model';
 import {
   CallSettings,
@@ -302,7 +303,7 @@ export function streamText<
   abortSignal,
   timeout,
   headers,
-  stopWhen = isStepCount(1),
+  stopWhen: stopWhenFromUser,
   experimental_output,
   output = experimental_output,
   experimental_telemetry: telemetry,
@@ -331,6 +332,8 @@ export function streamText<
     now = originalNow,
     generateId = originalGenerateId,
     generateCallId = originalGenerateCallId,
+    usedDefaultStopWhen: usedDefaultStopWhenFromInternal,
+    defaultStopStepCount: defaultStopStepCountFromInternal,
   } = {},
   ...settings
 }: CallSettings &
@@ -534,8 +537,18 @@ export function streamText<
       now?: () => number;
       generateId?: IdGenerator;
       generateCallId?: IdGenerator;
+      usedDefaultStopWhen?: boolean;
+      defaultStopStepCount?: number;
     };
   }): StreamTextResult<TOOLS, OUTPUT> {
+  const usedDefaultStopWhen =
+    usedDefaultStopWhenFromInternal !== undefined
+      ? usedDefaultStopWhenFromInternal
+      : stopWhenFromUser === undefined;
+
+  const defaultStopStepCount = defaultStopStepCountFromInternal ?? 1;
+  const stopWhen = stopWhenFromUser ?? isStepCount(defaultStopStepCount);
+
   const totalTimeoutMs = getTotalTimeoutMs(timeout);
   const stepTimeoutMs = getStepTimeoutMs(timeout);
   const chunkTimeoutMs = getChunkTimeoutMs(timeout);
@@ -590,6 +603,8 @@ export function streamText<
     experimental_context,
     download,
     include,
+    usedDefaultStopWhen,
+    defaultStopStepCount,
   });
 }
 
@@ -728,6 +743,10 @@ class DefaultStreamTextResult<
 
   private tools: TOOLS | undefined;
 
+  private readonly usedDefaultStopWhen: boolean;
+
+  private readonly defaultStopStepCount: number;
+
   constructor({
     model,
     telemetry,
@@ -770,6 +789,8 @@ class DefaultStreamTextResult<
     experimental_context,
     download,
     include,
+    usedDefaultStopWhen,
+    defaultStopStepCount,
   }: {
     model: LanguageModelV4;
     telemetry: TelemetrySettings | undefined;
@@ -817,7 +838,11 @@ class DefaultStreamTextResult<
     onStepStart: undefined | StreamTextOnStepStartCallback<TOOLS, OUTPUT>;
     onToolCallStart: undefined | StreamTextOnToolCallStartCallback<TOOLS>;
     onToolCallFinish: undefined | StreamTextOnToolCallFinishCallback<TOOLS>;
+    usedDefaultStopWhen: boolean;
+    defaultStopStepCount: number;
   }) {
+    this.usedDefaultStopWhen = usedDefaultStopWhen;
+    this.defaultStopStepCount = defaultStopStepCount;
     this.outputSpecification = output;
     this.includeRawChunks = includeRawChunks;
     this.tools = tools;
@@ -1951,6 +1976,21 @@ class DefaultStreamTextResult<
                       self.closeStream();
                     }
                   } else {
+                    const toolLoopCouldContinue =
+                      ((clientToolCalls.length > 0 &&
+                        clientToolOutputs.length === clientToolCalls.length) ||
+                        pendingDeferredToolCalls.size > 0);
+
+                    await logDefaultStopWhenWarningIfNeeded({
+                      provider: model.provider,
+                      model: model.modelId,
+                      usedDefaultStopWhen: self.usedDefaultStopWhen,
+                      defaultStopStepCount: self.defaultStopStepCount,
+                      stopConditions,
+                      steps: recordedSteps,
+                      toolLoopCouldContinue,
+                    });
+
                     controller.enqueue({
                       type: 'finish',
                       finishReason: stepFinishReason,


### PR DESCRIPTION
### Summary

- Add a warning when a loop stops due to default stopWhen, with guidance to set a custom stopWhen.
- Applied in streamText, generateText, and ToolLoopAgent, with a patch changeset.

### Manual Verification

- Ran focused tests for these paths and verified warning behavior for default-vs-explicit stopWhen.

### Related Issues

Fixes #13938