### PR TITLE
fix(errors): preserve error type prefix via toString in getErrorMessage

### DIFF
--- a/.changeset/get-error-message-tostring.md
+++ b/.changeset/get-error-message-tostring.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/provider": patch
+"@ai-sdk/provider-utils": patch
+---
+
+Serialize thrown errors with `Error.prototype.toString()` in `getErrorMessage` so tool and stream error text includes the error name (for example `Error: ...`, `TypeError: ...`, `AbortError: ...`).

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -5150,7 +5150,7 @@ describe('generateText', () => {
               {
                 "output": {
                   "type": "error-text",
-                  "value": "test error",
+                  "value": "Error: test error",
                 },
                 "toolCallId": "call-1",
                 "toolName": "tool1",
@@ -6645,7 +6645,7 @@ describe('generateText', () => {
           [
             {
               "dynamic": true,
-              "error": [AI_InvalidToolInputError: Invalid input for tool cityAttractions: Type validation failed: Value: {"cities":"San Francisco"}.
+              "error": [AI_InvalidToolInputError: Invalid input for tool cityAttractions: AI_TypeValidationError: Type validation failed: Value: {"cities":"San Francisco"}.
           Error message: [
             {
               "expected": "string",
@@ -6669,7 +6669,7 @@ describe('generateText', () => {
             },
             {
               "dynamic": true,
-              "error": "Invalid input for tool cityAttractions: Type validation failed: Value: {"cities":"San Francisco"}.
+              "error": "AI_InvalidToolInputError: Invalid input for tool cityAttractions: AI_TypeValidationError: Type validation failed: Value: {"cities":"San Francisco"}.
           Error message: [
             {
               "expected": "string",
@@ -6714,7 +6714,7 @@ describe('generateText', () => {
                 {
                   "output": {
                     "type": "error-text",
-                    "value": "Invalid input for tool cityAttractions: Type validation failed: Value: {"cities":"San Francisco"}.
+                    "value": "AI_InvalidToolInputError: Invalid input for tool cityAttractions: AI_TypeValidationError: Type validation failed: Value: {"cities":"San Francisco"}.
           Error message: [
             {
               "expected": "string",
@@ -7633,7 +7633,7 @@ describe('generateText', () => {
                   toolName: 'tool1',
                   output: {
                     type: 'error-text',
-                    value: 'No valid token for plugin',
+                    value: 'Error: No valid token for plugin',
                   },
                   providerOptions: undefined,
                 },

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -282,7 +282,7 @@ describe('parseToolCall', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "dynamic": true,
-        "error": [AI_InvalidToolInputError: Invalid input for tool testTool: Type validation failed: Value: {"param1":"test"}.
+        "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_TypeValidationError: Type validation failed: Value: {"param1":"test"}.
       Error message: [
         {
           "expected": "number",
@@ -393,8 +393,8 @@ describe('parseToolCall', () => {
       expect(result).toMatchInlineSnapshot(`
         {
           "dynamic": true,
-          "error": [AI_InvalidToolInputError: Invalid input for tool testTool: JSON parsing failed: Text: invalid json.
-        Error message: Unexpected token 'i', "invalid json" is not valid JSON],
+          "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_JSONParseError: JSON parsing failed: Text: invalid json.
+        Error message: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON],
           "input": "invalid json",
           "invalid": true,
           "providerExecuted": undefined,
@@ -433,7 +433,7 @@ describe('parseToolCall', () => {
       expect(result).toMatchInlineSnapshot(`
         {
           "dynamic": true,
-          "error": [AI_ToolCallRepairError: Error repairing tool call: test error],
+          "error": [AI_ToolCallRepairError: Error repairing tool call: Error: test error],
           "input": "invalid json",
           "invalid": true,
           "providerExecuted": undefined,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -13900,7 +13900,7 @@ describe('streamText', () => {
                     {
                       "output": {
                         "type": "error-text",
-                        "value": "test error",
+                        "value": "Error: test error",
                       },
                       "toolCallId": "call-1",
                       "toolName": "tool1",
@@ -13960,7 +13960,7 @@ describe('streamText', () => {
               {
                 "output": {
                   "type": "error-text",
-                  "value": "test error",
+                  "value": "Error: test error",
                 },
                 "toolCallId": "call-1",
                 "toolName": "tool1",
@@ -13992,7 +13992,7 @@ describe('streamText', () => {
               "type": "tool-input-available",
             },
             {
-              "errorText": "test error",
+              "errorText": "Error: test error",
               "toolCallId": "call-1",
               "type": "tool-output-error",
             },
@@ -17210,7 +17210,7 @@ describe('streamText', () => {
                 "warnings": [],
               },
               {
-                "reason": "This operation was aborted",
+                "reason": "AbortError: This operation was aborted",
                 "type": "abort",
               },
             ]
@@ -17228,7 +17228,7 @@ describe('streamText', () => {
                 "type": "start-step",
               },
               {
-                "reason": "This operation was aborted",
+                "reason": "AbortError: This operation was aborted",
                 "type": "abort",
               },
             ]
@@ -17576,7 +17576,7 @@ describe('streamText', () => {
                 },
               },
               {
-                "reason": "This operation was aborted",
+                "reason": "AbortError: This operation was aborted",
                 "type": "abort",
               },
             ]
@@ -17610,7 +17610,7 @@ describe('streamText', () => {
                 "type": "finish-step",
               },
               {
-                "reason": "This operation was aborted",
+                "reason": "AbortError: This operation was aborted",
                 "type": "abort",
               },
             ]
@@ -17770,7 +17770,7 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
-                "reason": "This operation was aborted",
+                "reason": "AbortError: This operation was aborted",
                 "type": "abort",
               },
             ]
@@ -17960,7 +17960,7 @@ describe('streamText', () => {
           [
             {
               "dynamic": true,
-              "error": [AI_InvalidToolInputError: Invalid input for tool cityAttractions: Type validation failed: Value: {"cities":"San Francisco"}.
+              "error": [AI_InvalidToolInputError: Invalid input for tool cityAttractions: AI_TypeValidationError: Type validation failed: Value: {"cities":"San Francisco"}.
           Error message: [
             {
               "expected": "string",
@@ -17984,7 +17984,7 @@ describe('streamText', () => {
             },
             {
               "dynamic": true,
-              "error": "Invalid input for tool cityAttractions: Type validation failed: Value: {"cities":"San Francisco"}.
+              "error": "AI_InvalidToolInputError: Invalid input for tool cityAttractions: AI_TypeValidationError: Type validation failed: Value: {"cities":"San Francisco"}.
           Error message: [
             {
               "expected": "string",
@@ -18037,7 +18037,7 @@ describe('streamText', () => {
               },
               {
                 "dynamic": true,
-                "error": [AI_InvalidToolInputError: Invalid input for tool cityAttractions: Type validation failed: Value: {"cities":"San Francisco"}.
+                "error": [AI_InvalidToolInputError: Invalid input for tool cityAttractions: AI_TypeValidationError: Type validation failed: Value: {"cities":"San Francisco"}.
             Error message: [
               {
                 "expected": "string",
@@ -18061,7 +18061,7 @@ describe('streamText', () => {
               },
               {
                 "dynamic": true,
-                "error": "Invalid input for tool cityAttractions: Type validation failed: Value: {"cities":"San Francisco"}.
+                "error": "AI_InvalidToolInputError: Invalid input for tool cityAttractions: AI_TypeValidationError: Type validation failed: Value: {"cities":"San Francisco"}.
             Error message: [
               {
                 "expected": "string",
@@ -18155,7 +18155,7 @@ describe('streamText', () => {
                 "type": "tool-input-delta",
               },
               {
-                "errorText": "Invalid input for tool cityAttractions: Type validation failed: Value: {"cities":"San Francisco"}.
+                "errorText": "AI_InvalidToolInputError: Invalid input for tool cityAttractions: AI_TypeValidationError: Type validation failed: Value: {"cities":"San Francisco"}.
             Error message: [
               {
                 "expected": "string",
@@ -18174,7 +18174,7 @@ describe('streamText', () => {
                 "type": "tool-input-error",
               },
               {
-                "errorText": "Invalid input for tool cityAttractions: Type validation failed: Value: {"cities":"San Francisco"}.
+                "errorText": "AI_InvalidToolInputError: Invalid input for tool cityAttractions: AI_TypeValidationError: Type validation failed: Value: {"cities":"San Francisco"}.
             Error message: [
               {
                 "expected": "string",
@@ -21754,7 +21754,7 @@ describe('streamText', () => {
                   toolName: 'tool1',
                   output: {
                     type: 'error-text',
-                    value: 'No valid token for plugin',
+                    value: 'Error: No valid token for plugin',
                   },
                   providerOptions: undefined,
                 },

--- a/packages/provider-utils/src/get-error-message.ts
+++ b/packages/provider-utils/src/get-error-message.ts
@@ -8,7 +8,7 @@ export function getErrorMessage(error: unknown | undefined) {
   }
 
   if (error instanceof Error) {
-    return error.message;
+    return error.toString();
   }
 
   return JSON.stringify(error);

--- a/packages/provider/src/errors/get-error-message.ts
+++ b/packages/provider/src/errors/get-error-message.ts
@@ -8,7 +8,7 @@ export function getErrorMessage(error: unknown | undefined) {
   }
 
   if (error instanceof Error) {
-    return error.message;
+    return error.toString();
   }
 
   return JSON.stringify(error);


### PR DESCRIPTION
### summary

- Use error.toString() in getErrorMessage() (provider + provider-utils) so outputs keep prefixes like Error: / TypeError: / AbortError:.
- Updated affected tests and added a patch changeset.

### Manual Verification

- Ran tests and confirmed tool/abort error text now includes the error type prefix.

Fixes #14002