### PR TITLE
fix(ai): wrap invalid JSON tool inputs for persisted messages

### DIFF
--- a/.changeset/fix-invalid-json-tool-input.md
+++ b/.changeset/fix-invalid-json-tool-input.md
@@ -1,0 +1,7 @@
+---
+"ai": patch
+---
+
+fix(ai): wrap non-JSON tool inputs so persisted messages stay API-valid
+
+When tool arguments could not be parsed as JSON, the SDK kept the raw string as `input`, which broke follow-up requests that reuse `response.messages`. Those cases now use `{ __invalidObject: "<raw>" }` as the stored input.

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -282,7 +282,7 @@ describe('parseToolCall', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "dynamic": true,
-        "error": [AI_InvalidToolInputError: Invalid input for tool testTool: Type validation failed: Value: {"param1":"test"}.
+        "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_TypeValidationError: Type validation failed: Value: {"param1":"test"}.
       Error message: [
         {
           "expected": "number",
@@ -393,9 +393,11 @@ describe('parseToolCall', () => {
       expect(result).toMatchInlineSnapshot(`
         {
           "dynamic": true,
-          "error": [AI_InvalidToolInputError: Invalid input for tool testTool: JSON parsing failed: Text: invalid json.
-        Error message: Unexpected token 'i', "invalid json" is not valid JSON],
-          "input": "invalid json",
+          "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_JSONParseError: JSON parsing failed: Text: invalid json.
+        Error message: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON],
+          "input": {
+            "__invalidObject": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,
@@ -433,8 +435,10 @@ describe('parseToolCall', () => {
       expect(result).toMatchInlineSnapshot(`
         {
           "dynamic": true,
-          "error": [AI_ToolCallRepairError: Error repairing tool call: test error],
-          "input": "invalid json",
+          "error": [AI_ToolCallRepairError: Error repairing tool call: Error: test error],
+          "input": {
+            "__invalidObject": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -78,9 +78,10 @@ export async function parseToolCall<TOOLS extends ToolSet>({
       return await doParseToolCall({ toolCall: repairedToolCall, tools });
     }
   } catch (error) {
-    // use parsed input when possible
     const parsedInput = await safeParseJSON({ text: toolCall.input });
-    const input = parsedInput.success ? parsedInput.value : toolCall.input;
+    const input = parsedInput.success
+      ? parsedInput.value
+      : { __invalidObject: toolCall.input };
 
     // TODO AI SDK 6: special invalid tool call parts
     return {


### PR DESCRIPTION
### summary

- Wrap unparsable tool input as { __invalidObject: "<raw>" }.
- Update invalid-JSON test snapshots.
- Add patch changeset for ai.

### Manual Verification

- Ran pnpm exec vitest run src/generate-text/parse-tool-call.test.ts.
- Confirmed invalid JSON now persists as object input.

### Checklist

[x] Tests have been added / updated (for bug fixes / features)
[x] A patch changeset for relevant packages has been added (for bug fixes / features - run pnpm changeset in the project root)
[x] I have reviewed this pull request (self-review)

Fixes #13892


