### PR TITLE
fix(amazon-bedrock): use template literal in tool warning message

### DIFF
--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.test.ts
@@ -174,6 +174,25 @@ describe('prepareTools', () => {
       ]);
     });
 
+    it('should warn with actual tool id for unrecognized provider-defined tools on anthropic models', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'anthropic.unknown_tool',
+            name: 'unknown_tool',
+            args: {},
+          },
+        ],
+        modelId: ANTHROPIC_MODEL,
+      });
+
+      expect(result.toolWarnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'tool anthropic.unknown_tool',
+      });
+    });
+
     it('should return empty toolConfig when all tools are filtered out', async () => {
       const result = await prepareTools({
         tools: [

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -115,7 +115,7 @@ export async function prepareTools({
           },
         });
       } else {
-        toolWarnings.push({ type: 'unsupported', feature: 'tool ${tool.id}' });
+        toolWarnings.push({ type: 'unsupported', feature: `tool ${tool.id}` });
       }
     }
   } else {


### PR DESCRIPTION
In `bedrock-prepare-tools.ts` line 118, a regular string `'tool ${tool.id}'` is used instead of a template literal, so the warning message outputs the literal text `tool ${tool.id}` rather than the actual tool ID.

Line 124 in the same file already uses the correct template literal `` `tool ${tool.id}` `` for the same pattern.

One character fix: `'` → `` ` ``.