### PR TITLE
feat(provider/anthropic): add v5 support for code_execution_20260120

### DIFF
--- a/.changeset/brown-mirrors-flow.md
+++ b/.changeset/brown-mirrors-flow.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+feat(anthropic): support new code_execution tool

--- a/.changeset/brown-mirrors-flow.md
+++ b/.changeset/brown-mirrors-flow.md
@@ -2,4 +2,4 @@
 "@ai-sdk/anthropic": patch
 ---
 
-feat(anthropic): support new code_execution tool
+feat(provider/anthropic): support new code_execution tool

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -709,7 +709,7 @@ You can enable code execution using the provider-defined code execution tool:
 import { anthropic } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 
-const codeExecutionTool = anthropic.tools.codeExecution_20250825();
+const codeExecutionTool = anthropic.tools.codeExecution_20260120();
 
 const result = await generateText({
   model: anthropic('claude-opus-4-20250514'),
@@ -720,6 +720,13 @@ const result = await generateText({
   },
 });
 ```
+
+<Note>
+  Three versions are available: `codeExecution_20260120` (recommended, does not
+  require a beta header, supports Claude Opus 4.6, Sonnet 4.6, Sonnet 4.5, and
+  Opus 4.5), `codeExecution_20250825` (supports Python and Bash with enhanced
+  file operations), and `codeExecution_20250522` (supports Bash only).
+</Note>
 
 #### Error Handling
 
@@ -794,7 +801,7 @@ import { generateText } from 'ai';
 const result = await generateText({
   model: anthropic('claude-sonnet-4-5'),
   tools: {
-    code_execution: anthropic.tools.codeExecution_20250825(),
+    code_execution: anthropic.tools.codeExecution_20260120(),
   },
   prompt: 'Create a presentation about renewable energy with 5 slides',
   providerOptions: {
@@ -821,7 +828,7 @@ You can also use custom skills by specifying `type: 'custom'`:
 const result = await generateText({
   model: anthropic('claude-sonnet-4-5'),
   tools: {
-    code_execution: anthropic.tools.codeExecution_20250825(),
+    code_execution: anthropic.tools.codeExecution_20260120(),
   },
   prompt: 'Use my custom skill to process this data',
   providerOptions: {

--- a/examples/ai-core/src/generate-text/anthropic-code-execution-tool.ts
+++ b/examples/ai-core/src/generate-text/anthropic-code-execution-tool.ts
@@ -9,7 +9,9 @@ run(async () => {
       'Write a Python script to calculate fibonacci number' +
       ' and then execute it to find the 10th fibonacci number',
     tools: {
-      code_execution: anthropic.tools.codeExecution_20250825(),
+      // code_execution: anthropic.tools.codeExecution_20250522(),
+      // code_execution: anthropic.tools.codeExecution_20250825(),
+      code_execution: anthropic.tools.codeExecution_20260120(),
     },
   });
 

--- a/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
@@ -634,6 +634,77 @@ Both files have been exported and are ready for download!",
 }
 `;
 
+exports[`AnthropicMessagesLanguageModel > doGenerate > code execution 20260120 > should include code execution tool call and result in content 1`] = `
+[
+  {
+    "text": "I'll create a Python script to calculate Fibonacci numbers and then execute it to find the 10th Fibonacci number.",
+    "type": "text",
+  },
+  {
+    "input": "{"type":"text_editor_code_execution","command":"create","path":"/tmp/fibonacci.py","file_text":"def fibonacci(n):\\n    \\"\\"\\"\\n    Calculate the nth Fibonacci number.\\n    \\n    Args:\\n        n: The position in the Fibonacci sequence (1-indexed)\\n    \\n    Returns:\\n        The nth Fibonacci number\\n    \\"\\"\\"\\n    if n <= 0:\\n        raise ValueError(\\"n must be a positive integer\\")\\n    elif n == 1 or n == 2:\\n        return 1\\n    \\n    # Using iterative approach for efficiency\\n    fib_prev = 1  # F(1)\\n    fib_curr = 1  # F(2)\\n    \\n    for i in range(3, n + 1):\\n        fib_next = fib_prev + fib_curr\\n        fib_prev = fib_curr\\n        fib_curr = fib_next\\n    \\n    return fib_curr\\n\\n\\nif __name__ == \\"__main__\\":\\n    # Calculate the 10th Fibonacci number\\n    n = 10\\n    result = fibonacci(n)\\n    print(f\\"The {n}th Fibonacci number is: {result}\\")\\n    \\n    # Display the first 10 Fibonacci numbers for reference\\n    print(f\\"\\\\nFirst {n} Fibonacci numbers:\\")\\n    for i in range(1, n + 1):\\n        print(f\\"F({i}) = {fibonacci(i)}\\")\\n"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_012LCpyzxGBy44bCW4zCxmH2",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "is_file_update": false,
+      "type": "text_editor_code_execution_create_result",
+    },
+    "toolCallId": "srvtoolu_012LCpyzxGBy44bCW4zCxmH2",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "text": "Now let me execute the script:",
+    "type": "text",
+  },
+  {
+    "input": "{"type":"bash_code_execution","command":"python /tmp/fibonacci.py"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_01KqzcSjepCqNjqeUVqnmEjj",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "content": [],
+      "return_code": 0,
+      "stderr": "",
+      "stdout": "The 10th Fibonacci number is: 55
+
+First 10 Fibonacci numbers:
+F(1) = 1
+F(2) = 1
+F(3) = 2
+F(4) = 3
+F(5) = 5
+F(6) = 8
+F(7) = 13
+F(8) = 21
+F(9) = 34
+F(10) = 55
+",
+      "type": "bash_code_execution_result",
+    },
+    "toolCallId": "srvtoolu_01KqzcSjepCqNjqeUVqnmEjj",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "text": "Perfect! The script has been created and executed successfully. 
+
+**Result: The 10th Fibonacci number is 55**
+
+The script uses an iterative approach to calculate Fibonacci numbers efficiently, which is better than a recursive approach for larger values of n (avoiding exponential time complexity). The Fibonacci sequence shown is: 1, 1, 2, 3, 5, 8, 13, 21, 34, 55...",
+    "type": "text",
+  },
+]
+`;
+
 exports[`AnthropicMessagesLanguageModel > doGenerate > memory 20250818 > should include memory tool call and result in content 1`] = `
 [
   {
@@ -10509,6 +10580,1302 @@ Error message: Unexpected end of JSON input],
 `;
 
 exports[`AnthropicMessagesLanguageModel > doStream > raw chunks > code execution 20250825 tool > should stream code execution tool results 1`] = `
+[
+  {
+    "type": "stream-start",
+    "warnings": [],
+  },
+  {
+    "id": "msg_01LEsrXVCLpf7xHaFdFTZNEJ",
+    "modelId": "claude-sonnet-4-5-20250929",
+    "type": "response-metadata",
+  },
+  {
+    "id": "0",
+    "type": "text-start",
+  },
+  {
+    "delta": "I'll create a Python script to calculate",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": " Fibonacci numbers and then execute it to fin",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "d the 10th Fibonacci number.",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "id": "0",
+    "type": "text-end",
+  },
+  {
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "text_editor_code_execution","",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "comma",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nd": "c",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "reate"",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "path": ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""/",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tmp/fi",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "bonacci.",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "py"",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "file_",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "text":",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " "def fib",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "onacci(n):",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n    \\"\\"\\",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""\\n    Calc",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ulate th",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "e nth Fibo",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nacc",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "i ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "numb",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "er.\\n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "    \\",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n    Ar",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "gs:",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n      ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "  n: T",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "he ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "positio",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n i",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n the Fibon",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "acci s",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "eq",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "uence (1-",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "indexe",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "d)\\n ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "       \\",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n   ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " Returns:\\",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n    ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "    The n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "th ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "Fibonac",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ci num",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "be",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "r\\n    \\"\\"\\",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""\\n ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "   if",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " n <= 0",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ":\\n       ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " return \\",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""Pleas",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "e enter a ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "positive int",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "eg",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "er",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\"\\n   ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " elif n ==",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " 1:\\n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "        retu",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "rn ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "0\\n    el",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "if n == 2:\\n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "       ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " return ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "1\\n  ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "  else:\\n ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "       # Usi",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ng",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " itera",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tive ap",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "proa",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ch ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "for effi",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ciency\\n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "        a,",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " b",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " = 0",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", 1",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n        ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "for _ in ra",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nge(2, n):\\",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n          ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "  a",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", b = b, ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "a + b\\n   ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "     ret",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "urn ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "b\\n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\ndef fi",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "bonacci_rec",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ursive(n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "):\\n   ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " \\"\\"\\"\\n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "    Ca",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "lcula",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "te the nth",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " Fibonacci",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " numb",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "er using r",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ecursion.\\n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "    \\n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "    Arg",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "s:\\n ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "      ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " n:",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " The po",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "si",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tion in ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "the Fibona",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "cci sequen",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ce (1-index",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ed)\\n   ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "     \\n   ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " Returns:\\n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "       ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " The nth F",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ibonacci n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "umber\\n    \\",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""\\"\\"\\n    ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "if n <",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "= 0:\\n ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "       retu",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "rn \\"Plea",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "se enter a",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " positive in",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "teger\\"\\n   ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " elif n ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "== 1",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ":\\n        r",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "et",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ur",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n 0\\n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "    elif n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " == 2:\\n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "     ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "   return",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " 1\\n    els",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "e:\\n        ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "return fib",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "onacci_recur",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "sive(n-1) +",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " fib",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "onacci_re",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "cursive(n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "-2)\\n\\nif ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "__name__ ==",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " \\"_",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "_main_",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "_\\":\\n   ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " # ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "Calcula",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "te ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "the 1",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "0th Fibonacc",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "i numb",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "er\\n    n = ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "10\\n    ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "result = fi",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "bonacc",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "i(n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ")\\n    \\n",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "    print(",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "f\\"The",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " {n}t",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "h Fibonac",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ci numb",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "er",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " is: {resul",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t}",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\")\\",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n    \\n ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "   # Sho",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "w the ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "first 10 ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "Fibona",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "cci numb",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ers\\n    p",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ri",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nt(f\\",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""\\\\nFirst ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "{n}",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " Fibon",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "acci numbe",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "rs:\\",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "")",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n    fo",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "r i in range",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "(1, n + ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "1):\\n      ",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "  pr",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "int(f\\",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""F({i",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "}) = {",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "fibonacci",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "(i)}\\")",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n"}",
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "text_editor_code_execution","command": "create", "path": "/tmp/fibonacci.py", "file_text": "def fibonacci(n):\\n    \\"\\"\\"\\n    Calculate the nth Fibonacci number.\\n    \\n    Args:\\n        n: The position in the Fibonacci sequence (1-indexed)\\n        \\n    Returns:\\n        The nth Fibonacci number\\n    \\"\\"\\"\\n    if n <= 0:\\n        return \\"Please enter a positive integer\\"\\n    elif n == 1:\\n        return 0\\n    elif n == 2:\\n        return 1\\n    else:\\n        # Using iterative approach for efficiency\\n        a, b = 0, 1\\n        for _ in range(2, n):\\n            a, b = b, a + b\\n        return b\\n\\ndef fibonacci_recursive(n):\\n    \\"\\"\\"\\n    Calculate the nth Fibonacci number using recursion.\\n    \\n    Args:\\n        n: The position in the Fibonacci sequence (1-indexed)\\n        \\n    Returns:\\n        The nth Fibonacci number\\n    \\"\\"\\"\\n    if n <= 0:\\n        return \\"Please enter a positive integer\\"\\n    elif n == 1:\\n        return 0\\n    elif n == 2:\\n        return 1\\n    else:\\n        return fibonacci_recursive(n-1) + fibonacci_recursive(n-2)\\n\\nif __name__ == \\"__main__\\":\\n    # Calculate the 10th Fibonacci number\\n    n = 10\\n    result = fibonacci(n)\\n    \\n    print(f\\"The {n}th Fibonacci number is: {result}\\")\\n    \\n    # Show the first 10 Fibonacci numbers\\n    print(f\\"\\\\nFirst {n} Fibonacci numbers:\\")\\n    for i in range(1, n + 1):\\n        print(f\\"F({i}) = {fibonacci(i)}\\")\\n"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "is_file_update": false,
+      "type": "text_editor_code_execution_create_result",
+    },
+    "toolCallId": "srvtoolu_0112cP8RpnKv67t2cscmN4ia",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "3",
+    "type": "text-start",
+  },
+  {
+    "delta": "Now let's",
+    "id": "3",
+    "type": "text-delta",
+  },
+  {
+    "delta": " execute the script to find the 10th Fibonacci",
+    "id": "3",
+    "type": "text-delta",
+  },
+  {
+    "delta": " number:",
+    "id": "3",
+    "type": "text-delta",
+  },
+  {
+    "id": "3",
+    "type": "text-end",
+  },
+  {
+    "id": "srvtoolu_01K2E2j5mkxbtLqNBc6RJHds",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "bash_code_execution","command",
+    "id": "srvtoolu_01K2E2j5mkxbtLqNBc6RJHds",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "": "python",
+    "id": "srvtoolu_01K2E2j5mkxbtLqNBc6RJHds",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " /tmp/fibon",
+    "id": "srvtoolu_01K2E2j5mkxbtLqNBc6RJHds",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ac",
+    "id": "srvtoolu_01K2E2j5mkxbtLqNBc6RJHds",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ci.py",
+    "id": "srvtoolu_01K2E2j5mkxbtLqNBc6RJHds",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""}",
+    "id": "srvtoolu_01K2E2j5mkxbtLqNBc6RJHds",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_01K2E2j5mkxbtLqNBc6RJHds",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "bash_code_execution","command": "python /tmp/fibonacci.py"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_01K2E2j5mkxbtLqNBc6RJHds",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "content": [],
+      "return_code": 0,
+      "stderr": "",
+      "stdout": "The 10th Fibonacci number is: 34
+
+First 10 Fibonacci numbers:
+F(1) = 0
+F(2) = 1
+F(3) = 1
+F(4) = 2
+F(5) = 3
+F(6) = 5
+F(7) = 8
+F(8) = 13
+F(9) = 21
+F(10) = 34
+",
+      "type": "bash_code_execution_result",
+    },
+    "toolCallId": "srvtoolu_01K2E2j5mkxbtLqNBc6RJHds",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "6",
+    "type": "text-start",
+  },
+  {
+    "delta": "Perfect",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "! The script has been created an",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "d executed successfully. 
+
+**Result",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": ": The 10th Fibonacci number is",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " 34**
+
+The script includes:
+1",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": ". An **iterative function** (\`",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "fibonacci\`) - efficient and fast, suitable for larger numbers",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "
+2. A **recursive function** (\`fibonacci_recursive\`) - sim",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "pler but less efficient for large values
+3. The main execution",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " block that calculates and displays the 10th Fibonacci number",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "
+4. A bonus display showing all",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " Fibonacci numbers from F(1) to F(10)",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "
+
+The Fibonacci sequence starts with 0, ",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "1, and each subsequent number is the sum of the",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " previous two numbers: ",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "0, 1, 1,",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " 2, 3, 5",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": ", 8, 13, ",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "21, 34, ...",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "id": "6",
+    "type": "text-end",
+  },
+  {
+    "finishReason": "stop",
+    "providerMetadata": {
+      "anthropic": {
+        "cacheCreationInputTokens": 0,
+        "container": {
+          "expiresAt": "2025-10-14T10:02:00.044495Z",
+          "id": "container_011CU6pTr2hLT47seQ5Xs4yj",
+          "skills": null,
+        },
+        "contextManagement": null,
+        "iterations": null,
+        "stopSequence": null,
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 0,
+          },
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "input_tokens": 8050,
+          "output_tokens": 771,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0,
+          },
+          "service_tier": "standard",
+        },
+      },
+    },
+    "type": "finish",
+    "usage": {
+      "cachedInputTokens": 0,
+      "inputTokens": 8050,
+      "outputTokens": 771,
+      "totalTokens": 8821,
+    },
+  },
+]
+`;
+
+exports[`AnthropicMessagesLanguageModel > doStream > raw chunks > code execution 20260120 tool > should stream code execution tool results without beta header 1`] = `
 [
   {
     "type": "stream-start",

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -278,6 +278,10 @@ export type AnthropicTool =
       name: string;
     }
   | {
+      type: 'code_execution_20260120';
+      name: string;
+    }
+  | {
       name: string;
       type: 'computer_20250124' | 'computer_20241022';
       display_width_px: number;

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -2562,6 +2562,74 @@ describe('AnthropicMessagesLanguageModel', () => {
       });
     });
 
+    describe('code execution 20260120', () => {
+      it('should send request body with tool and no beta header', async () => {
+        prepareJsonFixtureResponse('anthropic-code-execution-20250825.1');
+
+        await model.doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'anthropic.code_execution_20260120',
+              name: 'code_execution',
+              args: {},
+            },
+          ],
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "max_tokens": 4096,
+            "messages": [
+              {
+                "content": [
+                  {
+                    "text": "Hello",
+                    "type": "text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "claude-3-haiku-20240307",
+            "tools": [
+              {
+                "name": "code_execution",
+                "type": "code_execution_20260120",
+              },
+            ],
+          }
+        `);
+
+        expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+          {
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+            "x-api-key": "test-api-key",
+          }
+        `);
+      });
+
+      it('should include code execution tool call and result in content', async () => {
+        prepareJsonFixtureResponse('anthropic-code-execution-20250825.1');
+
+        const result = await model.doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'anthropic.code_execution_20260120',
+              name: 'code_execution',
+              args: {},
+            },
+          ],
+        });
+
+        expect(result.content).toMatchSnapshot();
+      });
+    });
+
     describe('code execution 20250522', () => {
       const TEST_PROMPT = [
         {
@@ -5354,6 +5422,27 @@ describe('AnthropicMessagesLanguageModel', () => {
             ],
           });
 
+          expect(
+            await convertReadableStreamToArray(result.stream),
+          ).toMatchSnapshot();
+        });
+      });
+
+      describe('code execution 20260120 tool', () => {
+        it('should stream code execution tool results without beta header', async () => {
+          prepareChunksFixtureResponse('anthropic-code-execution-20250825.1');
+
+          const result = await model.doStream({
+            prompt: TEST_PROMPT,
+            tools: [
+              {
+                type: 'provider-defined',
+                id: 'anthropic.code_execution_20260120',
+                name: 'code_execution',
+                args: {},
+              },
+            ],
+          });
           expect(
             await convertReadableStreamToArray(result.stream),
           ).toMatchSnapshot();

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -439,7 +439,8 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
         !tools?.some(
           tool =>
             tool.type === 'provider-defined' &&
-            tool.id === 'anthropic.code_execution_20250825',
+            (tool.id === 'anthropic.code_execution_20250825' ||
+              tool.id === 'anthropic.code_execution_20260120'),
         )
       ) {
         warnings.push({

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -295,6 +295,33 @@ describe('prepareTools', () => {
         }
       `);
     });
+
+    it('should correctly prepare code_execution_20260120 without beta header', async () => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'provider-defined',
+            id: 'anthropic.code_execution_20260120',
+            name: 'code_execution',
+            args: {},
+          },
+        ],
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "betas": Set {},
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "name": "code_execution",
+              "type": "code_execution_20260120",
+            },
+          ],
+        }
+      `);
+    });
   });
 
   it('should add warnings for unsupported tools', async () => {

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -90,6 +90,13 @@ export async function prepareTools({
             });
             break;
           }
+          case 'anthropic.code_execution_20260120': {
+            anthropicTools.push({
+              type: 'code_execution_20260120',
+              name: 'code_execution',
+            });
+            break;
+          }
           case 'anthropic.computer_20250124': {
             betas.add('computer-use-2025-01-24');
             anthropicTools.push({

--- a/packages/anthropic/src/anthropic-tools.ts
+++ b/packages/anthropic/src/anthropic-tools.ts
@@ -2,6 +2,7 @@ import { bash_20241022 } from './tool/bash_20241022';
 import { bash_20250124 } from './tool/bash_20250124';
 import { codeExecution_20250522 } from './tool/code-execution_20250522';
 import { codeExecution_20250825 } from './tool/code-execution_20250825';
+import { codeExecution_20260120 } from './tool/code-execution_20260120';
 import { computer_20241022 } from './tool/computer_20241022';
 import { computer_20250124 } from './tool/computer_20250124';
 import { memory_20250818 } from './tool/memory_20250818';
@@ -58,6 +59,20 @@ export const anthropicTools = {
    * Tool name must be `code_execution`.
    */
   codeExecution_20250825,
+
+  /**
+   * Claude can analyze data, create visualizations, perform complex calculations,
+   * run system commands, create and edit files, and process uploaded files directly within
+   * the API conversation.
+   *
+   * The code execution tool allows Claude to run both Python and Bash commands and manipulate files,
+   * including writing code, in a secure, sandboxed environment.
+   *
+   * This is the recommended version. Does not require a beta header.
+   *
+   * Supported models: Claude Opus 4.6, Sonnet 4.6, Sonnet 4.5, Opus 4.5
+   */
+  codeExecution_20260120,
 
   /**
    * Claude can interact with computer environments through the computer use tool, which

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -1286,6 +1286,133 @@ describe('assistant messages', () => {
       expect(warnings).toMatchInlineSnapshot(`[]`);
     });
   });
+
+  describe('code_execution 20260120', () => {
+    it('should convert anthropic code_execution tool call and result parts', async () => {
+      const warnings: LanguageModelV2CallWarning[] = [];
+      const result = await convertToAnthropicMessagesPrompt({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'srvtoolu_01Hq9rR6fZwwDGHkTYRafn7k',
+                toolName: 'code_execution',
+                input: {
+                  type: 'text_editor_code_execution',
+                  command: 'create',
+                  path: '/tmp/fibonacci.py',
+                  file_text: 'def..',
+                },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'srvtoolu_01Hq9rR6fZwwDGHkTYRafn7k',
+                toolName: 'code_execution',
+                output: {
+                  type: 'json',
+                  value: {
+                    type: 'text_editor_code_execution_create_result',
+                    is_file_update: false,
+                  },
+                },
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'srvtoolu_0193G3ttnkiTfZASwHQSKc2V',
+                toolName: 'code_execution',
+                input: {
+                  type: 'bash_code_execution',
+                  command: 'python /tmp/fibonacci.py',
+                },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'srvtoolu_0193G3ttnkiTfZASwHQSKc2V',
+                toolName: 'code_execution',
+                output: {
+                  type: 'json',
+                  value: {
+                    type: 'bash_code_execution_result',
+                    content: [],
+                    stdout: 'The 10th Fibonacci number is: 34\n',
+                    stderr: '',
+                    return_code: 0,
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        sendReasoning: false,
+        warnings,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "betas": Set {},
+          "prompt": {
+            "messages": [
+              {
+                "content": [
+                  {
+                    "cache_control": undefined,
+                    "id": "srvtoolu_01Hq9rR6fZwwDGHkTYRafn7k",
+                    "input": {
+                      "command": "create",
+                      "file_text": "def..",
+                      "path": "/tmp/fibonacci.py",
+                      "type": "text_editor_code_execution",
+                    },
+                    "name": "text_editor_code_execution",
+                    "type": "server_tool_use",
+                  },
+                  {
+                    "cache_control": undefined,
+                    "content": {
+                      "is_file_update": false,
+                      "type": "text_editor_code_execution_create_result",
+                    },
+                    "tool_use_id": "srvtoolu_01Hq9rR6fZwwDGHkTYRafn7k",
+                    "type": "text_editor_code_execution_tool_result",
+                  },
+                  {
+                    "cache_control": undefined,
+                    "id": "srvtoolu_0193G3ttnkiTfZASwHQSKc2V",
+                    "input": {
+                      "command": "python /tmp/fibonacci.py",
+                      "type": "bash_code_execution",
+                    },
+                    "name": "bash_code_execution",
+                    "type": "server_tool_use",
+                  },
+                  {
+                    "cache_control": undefined,
+                    "content": {
+                      "content": [],
+                      "return_code": 0,
+                      "stderr": "",
+                      "stdout": "The 10th Fibonacci number is: 34
+        ",
+                      "type": "bash_code_execution_result",
+                    },
+                    "tool_use_id": "srvtoolu_0193G3ttnkiTfZASwHQSKc2V",
+                    "type": "bash_code_execution_tool_result",
+                  },
+                ],
+                "role": "assistant",
+              },
+            ],
+            "system": undefined,
+          },
+        }
+      `);
+      expect(warnings).toMatchInlineSnapshot(`[]`);
+    });
+  });
 });
 
 describe('cache control', () => {

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -543,10 +543,15 @@ export async function convertToAnthropicMessagesPrompt({
                     break;
                   }
 
+                  // code_execution_20260120 returns 'code_execution_result'
+                  // for programmatic tool calls and 'bash_code_execution_*' /
+                  // 'text_editor_*' for direct execution, so it is handled
+                  // by both branches below.
+                  //
                   // to distinguish between code execution 20250522 and 20250825,
                   // we check if a type property is present in the output.value
                   if (output.value.type === 'code_execution_result') {
-                    // code execution 20250522
+                    // code execution 20250522 / 20260120
                     const codeExecutionOutput = await validateTypes({
                       value: output.value,
                       schema: codeExecution_20250522OutputSchema,
@@ -564,7 +569,7 @@ export async function convertToAnthropicMessagesPrompt({
                       cache_control: cacheControl,
                     });
                   } else {
-                    // code execution 20250825
+                    // code execution 20250825 / 20260120
                     const codeExecutionOutput = await validateTypes({
                       value: output.value,
                       schema: codeExecution_20250825OutputSchema,

--- a/packages/anthropic/src/tool/code-execution_20260120.ts
+++ b/packages/anthropic/src/tool/code-execution_20260120.ts
@@ -1,0 +1,277 @@
+import {
+  createProviderDefinedToolFactoryWithOutputSchema,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const codeExecution_20260120OutputSchema = lazySchema(() =>
+  zodSchema(
+    z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('code_execution_result'),
+        stdout: z.string(),
+        stderr: z.string(),
+        return_code: z.number(),
+        content: z
+          .array(
+            z.object({
+              type: z.literal('code_execution_output'),
+              file_id: z.string(),
+            }),
+          )
+          .optional()
+          .default([]),
+      }),
+      z.object({
+        type: z.literal('bash_code_execution_result'),
+        content: z.array(
+          z.object({
+            type: z.literal('bash_code_execution_output'),
+            file_id: z.string(),
+          }),
+        ),
+        stdout: z.string(),
+        stderr: z.string(),
+        return_code: z.number(),
+      }),
+      z.object({
+        type: z.literal('bash_code_execution_tool_result_error'),
+        error_code: z.string(),
+      }),
+      z.object({
+        type: z.literal('text_editor_code_execution_tool_result_error'),
+        error_code: z.string(),
+      }),
+      z.object({
+        type: z.literal('text_editor_code_execution_view_result'),
+        content: z.string(),
+        file_type: z.string(),
+        num_lines: z.number().nullable(),
+        start_line: z.number().nullable(),
+        total_lines: z.number().nullable(),
+      }),
+      z.object({
+        type: z.literal('text_editor_code_execution_create_result'),
+        is_file_update: z.boolean(),
+      }),
+      z.object({
+        type: z.literal('text_editor_code_execution_str_replace_result'),
+        lines: z.array(z.string()).nullable(),
+        new_lines: z.number().nullable(),
+        new_start: z.number().nullable(),
+        old_lines: z.number().nullable(),
+        old_start: z.number().nullable(),
+      }),
+    ]),
+  ),
+);
+
+export const codeExecution_20260120InputSchema = lazySchema(() =>
+  zodSchema(
+    z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('programmatic-tool-call'),
+        code: z.string(),
+      }),
+      z.object({
+        type: z.literal('bash_code_execution'),
+        command: z.string(),
+      }),
+      z.discriminatedUnion('command', [
+        z.object({
+          type: z.literal('text_editor_code_execution'),
+          command: z.literal('view'),
+          path: z.string(),
+        }),
+        z.object({
+          type: z.literal('text_editor_code_execution'),
+          command: z.literal('create'),
+          path: z.string(),
+          file_text: z.string().nullish(),
+        }),
+        z.object({
+          type: z.literal('text_editor_code_execution'),
+          command: z.literal('str_replace'),
+          path: z.string(),
+          old_str: z.string(),
+          new_str: z.string(),
+        }),
+      ]),
+    ]),
+  ),
+);
+
+const factory = createProviderDefinedToolFactoryWithOutputSchema<
+  | {
+      type: 'programmatic-tool-call';
+      /**
+       * Programmatic tool calling: Python code to execute when code_execution
+       * is used with allowedCallers to trigger client-executed tools.
+       */
+      code: string;
+    }
+  | {
+      type: 'bash_code_execution';
+
+      /**
+       * Shell command to execute.
+       */
+      command: string;
+    }
+  | {
+      type: 'text_editor_code_execution';
+      command: 'view';
+
+      /**
+       * The path to the file to view.
+       */
+      path: string;
+    }
+  | {
+      type: 'text_editor_code_execution';
+      command: 'create';
+
+      /**
+       * The path to the file to edit.
+       */
+      path: string;
+
+      /**
+       * The text of the file to edit.
+       */
+      file_text?: string | null;
+    }
+  | {
+      type: 'text_editor_code_execution';
+      command: 'str_replace';
+
+      /**
+       * The path to the file to edit.
+       */
+      path: string;
+
+      /**
+       * The string to replace.
+       */
+      old_str: string;
+
+      /**
+       * The new string to replace the old string with.
+       */
+      new_str: string;
+    },
+  | {
+      /**
+       * Programmatic tool calling result: returned when code_execution runs code
+       * that calls client-executed tools via allowedCallers.
+       */
+      type: 'code_execution_result';
+
+      /**
+       * Output from successful execution
+       */
+      stdout: string;
+
+      /**
+       * Error messages if execution fails
+       */
+      stderr: string;
+
+      /**
+       * 0 for success, non-zero for failure
+       */
+      return_code: number;
+
+      /**
+       * Output file Id list
+       */
+      content: Array<{ type: 'code_execution_output'; file_id: string }>;
+    }
+  | {
+      type: 'bash_code_execution_result';
+
+      /**
+       * Output file Id list
+       */
+      content: Array<{
+        type: 'bash_code_execution_output';
+        file_id: string;
+      }>;
+
+      /**
+       * Output from successful execution
+       */
+      stdout: string;
+
+      /**
+       * Error messages if execution fails
+       */
+      stderr: string;
+
+      /**
+       * 0 for success, non-zero for failure
+       */
+      return_code: number;
+    }
+  | {
+      type: 'bash_code_execution_tool_result_error';
+
+      /**
+       * Available options: invalid_tool_input, unavailable, too_many_requests,
+       * execution_time_exceeded, output_file_too_large.
+       */
+      error_code: string;
+    }
+  | {
+      type: 'text_editor_code_execution_tool_result_error';
+
+      /**
+       * Available options: invalid_tool_input, unavailable, too_many_requests,
+       * execution_time_exceeded, file_not_found.
+       */
+      error_code: string;
+    }
+  | {
+      type: 'text_editor_code_execution_view_result';
+
+      content: string;
+
+      /**
+       * The type of the file. Available options: text, image, pdf.
+       */
+      file_type: string;
+
+      num_lines: number | null;
+      start_line: number | null;
+      total_lines: number | null;
+    }
+  | {
+      type: 'text_editor_code_execution_create_result';
+
+      is_file_update: boolean;
+    }
+  | {
+      type: 'text_editor_code_execution_str_replace_result';
+
+      lines: string[] | null;
+      new_lines: number | null;
+      new_start: number | null;
+      old_lines: number | null;
+      old_start: number | null;
+    },
+  {
+    // no arguments
+  }
+>({
+  id: 'anthropic.code_execution_20260120',
+  name: 'code_execution',
+  inputSchema: codeExecution_20260120InputSchema,
+  outputSchema: codeExecution_20260120OutputSchema,
+});
+
+export const codeExecution_20260120 = (
+  args: Parameters<typeof factory>[0] = {},
+) => {
+  return factory(args);
+};


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

v7 and v6 supports new Anthropic's execution tool `code_execution_20260120` , but v5 currently doesn't.

## Summary

<!-- What did you change? -->

I'm largely referencing #12900 and adapted the PR to v5 interfaces and conventions.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

Tested with `examples/ai-core/src/generate-text/anthropic-code-execution-tool.ts` and modified a stream script locally to test the tool

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
