### PR TITLE
fix(ui): restore partial tool state on stream resume

### DIFF
--- a/.changeset/resume-static-tool-partial-input.md
+++ b/.changeset/resume-static-tool-partial-input.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ui): restore partial static tool call state when resuming a UI message stream

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -8686,4 +8686,62 @@ describe('processUIMessageStream', () => {
       ]);
     });
   });
+
+  describe('createStreamingUIMessageState resume', () => {
+    it('should rebuild partialToolCalls for static tool parts in input-streaming state', () => {
+      const lastMessage: UIMessage = {
+        id: 'msg-resume',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-create_document',
+            toolCallId: 'tc-1',
+            state: 'input-streaming',
+            input: { title: 'partial' },
+          },
+        ],
+      };
+
+      const state = createStreamingUIMessageState({
+        lastMessage,
+        messageId: 'msg-resume',
+      });
+
+      expect(state.partialToolCalls['tc-1']).toEqual({
+        text: JSON.stringify({ title: 'partial' }),
+        toolName: 'create_document',
+        index: 0,
+        title: undefined,
+        dynamic: undefined,
+      });
+    });
+
+    it('should rebuild partialToolCalls for dynamic tool parts in input-streaming state', () => {
+      const lastMessage: UIMessage = {
+        id: 'msg-resume',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'dynamic-tool',
+            toolName: 'my_tool',
+            toolCallId: 'tc-d',
+            state: 'input-streaming',
+            input: { x: 1 },
+          },
+        ],
+      };
+
+      const state = createStreamingUIMessageState({
+        lastMessage,
+        messageId: 'msg-resume',
+      });
+
+      expect(state.partialToolCalls['tc-d']).toMatchObject({
+        text: JSON.stringify({ x: 1 }),
+        toolName: 'my_tool',
+        index: 0,
+        dynamic: true,
+      });
+    });
+  });
 });

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -22,6 +22,7 @@ import {
   InferUIMessageMetadata,
   InferUIMessageToolCall,
   InferUIMessageTools,
+  isDynamicToolUIPart,
   isStaticToolUIPart,
   isToolUIPart,
   ReasoningUIPart,
@@ -48,6 +49,54 @@ export type StreamingUIMessageState<UI_MESSAGE extends UIMessage> = {
   finishReason?: FinishReason;
 };
 
+function partialToolCallsFromAssistantMessage<UI_MESSAGE extends UIMessage>(
+  lastMessage: UI_MESSAGE,
+): StreamingUIMessageState<UI_MESSAGE>['partialToolCalls'] {
+  const partialToolCalls: StreamingUIMessageState<UI_MESSAGE>['partialToolCalls'] =
+    {};
+
+  for (let partIndex = 0; partIndex < lastMessage.parts.length; partIndex++) {
+    const part = lastMessage.parts[partIndex];
+
+    if (!isToolUIPart(part) || part.state !== 'input-streaming') {
+      continue;
+    }
+
+    let staticToolCountBefore = 0;
+    for (let j = 0; j < partIndex; j++) {
+      if (isStaticToolUIPart(lastMessage.parts[j])) {
+        staticToolCountBefore++;
+      }
+    }
+
+    const anyPart = part as { rawInput?: unknown; input?: unknown };
+    let text = '';
+    if (typeof anyPart.rawInput === 'string') {
+      text = anyPart.rawInput;
+    } else if (anyPart.input !== undefined) {
+      try {
+        text = JSON.stringify(anyPart.input);
+      } catch {
+        text = '';
+      }
+    }
+
+    const toolName = isDynamicToolUIPart(part)
+      ? String(part.toolName ?? '')
+      : getStaticToolName(part);
+
+    partialToolCalls[part.toolCallId] = {
+      text,
+      toolName,
+      index: staticToolCountBefore,
+      dynamic: isDynamicToolUIPart(part) ? true : undefined,
+      title: part.title,
+    };
+  }
+
+  return partialToolCalls;
+}
+
 export function createStreamingUIMessageState<UI_MESSAGE extends UIMessage>({
   lastMessage,
   messageId,
@@ -55,22 +104,27 @@ export function createStreamingUIMessageState<UI_MESSAGE extends UIMessage>({
   lastMessage: UI_MESSAGE | undefined;
   messageId: string;
 }): StreamingUIMessageState<UI_MESSAGE> {
+  const message =
+    lastMessage?.role === 'assistant'
+      ? lastMessage
+      : ({
+          id: messageId,
+          metadata: undefined,
+          role: 'assistant',
+          parts: [] as UIMessagePart<
+            InferUIMessageData<UI_MESSAGE>,
+            InferUIMessageTools<UI_MESSAGE>
+          >[],
+        } as UI_MESSAGE);
+
   return {
-    message:
-      lastMessage?.role === 'assistant'
-        ? lastMessage
-        : ({
-            id: messageId,
-            metadata: undefined,
-            role: 'assistant',
-            parts: [] as UIMessagePart<
-              InferUIMessageData<UI_MESSAGE>,
-              InferUIMessageTools<UI_MESSAGE>
-            >[],
-          } as UI_MESSAGE),
+    message,
     activeTextParts: {},
     activeReasoningParts: {},
-    partialToolCalls: {},
+    partialToolCalls:
+      lastMessage?.role === 'assistant'
+        ? partialToolCallsFromAssistantMessage(lastMessage)
+        : {},
   };
 }
 


### PR DESCRIPTION
### Background

- Resume crashed for partial static tool calls.

### Summary

- Fix resume state rebuild for input-streaming tool parts.
- Fix static tool name extraction.
- Add regression tests and patch changeset.

### Related Issues
Fixes #14027