### PR TITLE
chore(ai): remove deprecated ToolCallOptions type

### DIFF
--- a/.changeset/remove-tool-call-options-v7.md
+++ b/.changeset/remove-tool-call-options-v7.md
@@ -1,0 +1,8 @@
+---
+'ai': major
+'@ai-sdk/provider-utils': major
+---
+
+Remove the deprecated `ToolCallOptions` export.
+
+Use `ToolExecutionOptions` instead.

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -116,6 +116,28 @@ Potential breaking issues:
 - If you have helper types or wrappers that assumed `experimental_context` was `unknown`, update them to accept a generic `CONTEXT` type.
 - If you were relying on a tool callback seeing the entire runtime context object, that code may need to move to `prepareStep` or the tool's `contextSchema` may need to be expanded to include the required fields.
 
+### Tools: Remove Deprecated `ToolCallOptions` Type
+
+The deprecated `ToolCallOptions` type has been removed in AI SDK 7. Replace all remaining usages with `ToolExecutionOptions`.
+
+If you already migrated away from the deprecated name in AI SDK 6, no changes are needed. Otherwise, update imports and type references:
+
+```tsx filename="AI SDK 6"
+import { ToolCallOptions } from 'ai';
+
+function executeWithOptions(options: ToolCallOptions) {
+  // ...
+}
+```
+
+```tsx filename="AI SDK 7"
+import { ToolExecutionOptions } from 'ai';
+
+function executeWithOptions(options: ToolExecutionOptions) {
+  // ...
+}
+```
+
 ## MCP Package
 
 ### MCP Transport: `redirect` Default Changed from `'follow'` to `'error'`

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -18,7 +18,6 @@ export {
   type Tool,
   type ToolApprovalRequest,
   type ToolApprovalResponse,
-  type ToolCallOptions,
   type ToolExecutionOptions,
   type ToolExecuteFunction,
 } from '@ai-sdk/provider-utils';

--- a/packages/provider-utils/src/types/index.ts
+++ b/packages/provider-utils/src/types/index.ts
@@ -36,12 +36,3 @@ export type { ToolCall } from './tool-call';
 export type { ToolContent, ToolModelMessage } from './tool-model-message';
 export type { ToolResult } from './tool-result';
 export type { UserContent, UserModelMessage } from './user-model-message';
-
-import type { Context } from './context';
-import type { ToolExecutionOptions } from './tool';
-
-/**
- * @deprecated Use ToolExecutionOptions instead.
- */
-export type ToolCallOptions<CONTEXT extends Context> =
-  ToolExecutionOptions<CONTEXT>;


### PR DESCRIPTION
## Background

The `ToolCallOptions` type has been renamed to `ToolExecutionOptions` in AI SDK 6 and is deprecated.

## Summary

Remove the `ToolCallOptions` type.