### PR TITLE
fix(anthropic): allow both temperature and topP for non-Anthropic models

### DIFF
--- a/.changeset/fix-anthropic-temperature-top-p.md
+++ b/.changeset/fix-anthropic-temperature-top-p.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): allow both temperature and topP for non-Anthropic models using the Anthropic-compatible API
+
+The temperature/topP mutual exclusivity check now only applies to known Anthropic models (model IDs starting with `claude-`). Non-Anthropic models using the Anthropic-compatible API (e.g. Minimax) can now send both parameters as required by their APIs.

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -1168,6 +1168,26 @@ describe('AnthropicMessagesLanguageModel', () => {
         expect(requestBody.temperature).toBeUndefined();
         expect(requestBody.top_p).toBeUndefined();
       });
+
+      it('should send both temperature and topP for non-Anthropic models', async () => {
+        prepareJsonFixtureResponse('anthropic-text');
+
+        const nonAnthropicModel = provider('MiniMax-M2.7');
+        const { warnings } = await nonAnthropicModel.doGenerate({
+          prompt: TEST_PROMPT,
+          temperature: 0.7,
+          topP: 0.9,
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.temperature).toBe(0.7);
+        expect(requestBody.top_p).toBe(0.9);
+        expect(warnings).not.toContainEqual(
+          expect.objectContaining({
+            feature: 'topP',
+          }),
+        );
+      });
     });
 
     it('should limit max output tokens to the model max and warn', async () => {

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -272,6 +272,9 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       isKnownAnthropicModel,
     } = getModelCapabilities(this.modelId);
 
+    const isAnthropicModel =
+      isKnownAnthropicModel || this.modelId.startsWith('claude-');
+
     const supportsStructuredOutput =
       (this.config.supportsNativeStructuredOutput ?? true) &&
       modelSupportsStructuredOutput;
@@ -538,7 +541,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       // Only check temperature/topP mutual exclusivity for known Anthropic models
       // when thinking is not enabled. Non-Anthropic models using the Anthropic-compatible
       // API (e.g. Minimax) may require both parameters to be set.
-      if (isKnownAnthropicModel && topP != null && temperature != null) {
+      if (isAnthropicModel && topP != null && temperature != null) {
         warnings.push({
           type: 'unsupported',
           feature: 'topP',
@@ -2331,7 +2334,7 @@ function getModelCapabilities(modelId: string): {
     return {
       maxOutputTokens: 4096,
       supportsStructuredOutput: false,
-      isKnownAnthropicModel: modelId.startsWith('claude-'),
+      isKnownAnthropicModel: false,
     };
   }
 }

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -269,7 +269,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     const {
       maxOutputTokens: maxOutputTokensForModel,
       supportsStructuredOutput: modelSupportsStructuredOutput,
-      isKnownModel,
+      isKnownAnthropicModel,
     } = getModelCapabilities(this.modelId);
 
     const supportsStructuredOutput =
@@ -535,8 +535,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       // adjust max tokens to account for thinking:
       baseArgs.max_tokens = maxTokens + (thinkingBudget ?? 0);
     } else {
-      // Only check temperature/topP mutual exclusivity when thinking is not enabled
-      if (topP != null && temperature != null) {
+      // Only check temperature/topP mutual exclusivity for known Anthropic models
+      // when thinking is not enabled. Non-Anthropic models using the Anthropic-compatible
+      // API (e.g. Minimax) may require both parameters to be set.
+      if (isKnownAnthropicModel && topP != null && temperature != null) {
         warnings.push({
           type: 'unsupported',
           feature: 'topP',
@@ -547,7 +549,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     }
 
     // limit to max output tokens for known models to enable model switching without breaking it:
-    if (isKnownModel && baseArgs.max_tokens > maxOutputTokensForModel) {
+    if (
+      isKnownAnthropicModel &&
+      baseArgs.max_tokens > maxOutputTokensForModel
+    ) {
       // only warn if max output tokens is provided as input:
       if (maxOutputTokens != null) {
         warnings.push({
@@ -2277,7 +2282,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
 function getModelCapabilities(modelId: string): {
   maxOutputTokens: number;
   supportsStructuredOutput: boolean;
-  isKnownModel: boolean;
+  isKnownAnthropicModel: boolean;
 } {
   if (
     modelId.includes('claude-sonnet-4-6') ||
@@ -2286,7 +2291,7 @@ function getModelCapabilities(modelId: string): {
     return {
       maxOutputTokens: 128000,
       supportsStructuredOutput: true,
-      isKnownModel: true,
+      isKnownAnthropicModel: true,
     };
   } else if (
     modelId.includes('claude-sonnet-4-5') ||
@@ -2296,37 +2301,37 @@ function getModelCapabilities(modelId: string): {
     return {
       maxOutputTokens: 64000,
       supportsStructuredOutput: true,
-      isKnownModel: true,
+      isKnownAnthropicModel: true,
     };
   } else if (modelId.includes('claude-opus-4-1')) {
     return {
       maxOutputTokens: 32000,
       supportsStructuredOutput: true,
-      isKnownModel: true,
+      isKnownAnthropicModel: true,
     };
   } else if (modelId.includes('claude-sonnet-4-')) {
     return {
       maxOutputTokens: 64000,
       supportsStructuredOutput: false,
-      isKnownModel: true,
+      isKnownAnthropicModel: true,
     };
   } else if (modelId.includes('claude-opus-4-')) {
     return {
       maxOutputTokens: 32000,
       supportsStructuredOutput: false,
-      isKnownModel: true,
+      isKnownAnthropicModel: true,
     };
   } else if (modelId.includes('claude-3-haiku')) {
     return {
       maxOutputTokens: 4096,
       supportsStructuredOutput: false,
-      isKnownModel: true,
+      isKnownAnthropicModel: true,
     };
   } else {
     return {
       maxOutputTokens: 4096,
       supportsStructuredOutput: false,
-      isKnownModel: false,
+      isKnownAnthropicModel: modelId.startsWith('claude-'),
     };
   }
 }

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -269,11 +269,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     const {
       maxOutputTokens: maxOutputTokensForModel,
       supportsStructuredOutput: modelSupportsStructuredOutput,
-      isKnownAnthropicModel,
+      isKnownModel,
     } = getModelCapabilities(this.modelId);
 
-    const isAnthropicModel =
-      isKnownAnthropicModel || this.modelId.startsWith('claude-');
+    const isAnthropicModel = isKnownModel || this.modelId.startsWith('claude-');
 
     const supportsStructuredOutput =
       (this.config.supportsNativeStructuredOutput ?? true) &&
@@ -552,10 +551,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     }
 
     // limit to max output tokens for known models to enable model switching without breaking it:
-    if (
-      isKnownAnthropicModel &&
-      baseArgs.max_tokens > maxOutputTokensForModel
-    ) {
+    if (isKnownModel && baseArgs.max_tokens > maxOutputTokensForModel) {
       // only warn if max output tokens is provided as input:
       if (maxOutputTokens != null) {
         warnings.push({
@@ -2285,7 +2281,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
 function getModelCapabilities(modelId: string): {
   maxOutputTokens: number;
   supportsStructuredOutput: boolean;
-  isKnownAnthropicModel: boolean;
+  isKnownModel: boolean;
 } {
   if (
     modelId.includes('claude-sonnet-4-6') ||
@@ -2294,7 +2290,7 @@ function getModelCapabilities(modelId: string): {
     return {
       maxOutputTokens: 128000,
       supportsStructuredOutput: true,
-      isKnownAnthropicModel: true,
+      isKnownModel: true,
     };
   } else if (
     modelId.includes('claude-sonnet-4-5') ||
@@ -2304,37 +2300,37 @@ function getModelCapabilities(modelId: string): {
     return {
       maxOutputTokens: 64000,
       supportsStructuredOutput: true,
-      isKnownAnthropicModel: true,
+      isKnownModel: true,
     };
   } else if (modelId.includes('claude-opus-4-1')) {
     return {
       maxOutputTokens: 32000,
       supportsStructuredOutput: true,
-      isKnownAnthropicModel: true,
+      isKnownModel: true,
     };
   } else if (modelId.includes('claude-sonnet-4-')) {
     return {
       maxOutputTokens: 64000,
       supportsStructuredOutput: false,
-      isKnownAnthropicModel: true,
+      isKnownModel: true,
     };
   } else if (modelId.includes('claude-opus-4-')) {
     return {
       maxOutputTokens: 32000,
       supportsStructuredOutput: false,
-      isKnownAnthropicModel: true,
+      isKnownModel: true,
     };
   } else if (modelId.includes('claude-3-haiku')) {
     return {
       maxOutputTokens: 4096,
       supportsStructuredOutput: false,
-      isKnownAnthropicModel: true,
+      isKnownModel: true,
     };
   } else {
     return {
       maxOutputTokens: 4096,
       supportsStructuredOutput: false,
-      isKnownAnthropicModel: false,
+      isKnownModel: false,
     };
   }
 }


### PR DESCRIPTION
## Background

The `@ai-sdk/anthropic` provider enforces temperature/topP mutual exclusivity for all models (#11458), matching a constraint in the Anthropic API. However, providers like Minimax use the Anthropic-compatible API endpoint with non-Anthropic models (e.g. `MiniMax-M2.7`) that require both `temperature` and `top_p` to be set simultaneously. The SDK currently drops `topP` whenever both are provided, with no way to override this behavior.

## Summary

- Renamed `isKnownModel` to `isKnownAnthropicModel` for clarity
- Updated the fallback in `getModelCapabilities` to return `true` for unknown models whose ID starts with `claude-` (forward-compatible with future Anthropic models)
- Added `isKnownAnthropicModel` as a guard for the temperature/topP mutual exclusivity check — non-Anthropic models using the Anthropic-compatible API can now send both parameters

## Manual Verification

Created a test using a non-Anthropic model ID (`MiniMax-M2.7`) that verifies both `temperature` and `top_p` are sent in the request body without warnings.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)