### PR TITLE
Backport: fix(anthropic): allow both temperature and topP for non-Anthropic models

### DIFF
--- a/.changeset/fix-anthropic-temperature-top-p.md
+++ b/.changeset/fix-anthropic-temperature-top-p.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): allow both temperature and topP for non-Anthropic models using the Anthropic-compatible API
+
+The temperature/topP mutual exclusivity check now only applies to known Anthropic models (model IDs starting with `claude-`). Non-Anthropic models using the Anthropic-compatible API (e.g. Minimax) can now send both parameters as required by their APIs.

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -1527,6 +1527,26 @@ describe('AnthropicMessagesLanguageModel', () => {
         expect(requestBody.temperature).toBeUndefined();
         expect(requestBody.top_p).toBeUndefined();
       });
+
+      it('should send both temperature and topP for non-Anthropic models', async () => {
+        prepareJsonFixtureResponse('anthropic-text');
+
+        const nonAnthropicModel = provider('MiniMax-M2.7');
+        const { warnings } = await nonAnthropicModel.doGenerate({
+          prompt: TEST_PROMPT,
+          temperature: 0.7,
+          topP: 0.9,
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.temperature).toBe(0.7);
+        expect(requestBody.top_p).toBe(0.9);
+        expect(warnings).not.toContainEqual(
+          expect.objectContaining({
+            feature: 'topP',
+          }),
+        );
+      });
     });
 
     it('should limit max output tokens to the model max and warn', async () => {

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -278,6 +278,8 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
       isKnownModel,
     } = getModelCapabilities(this.modelId);
 
+    const isAnthropicModel = isKnownModel || this.modelId.startsWith('claude-');
+
     const supportsStructuredOutput =
       (this.config.supportsNativeStructuredOutput ?? true) &&
       modelSupportsStructuredOutput;
@@ -564,8 +566,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
       // adjust max tokens to account for thinking:
       baseArgs.max_tokens = maxTokens + (thinkingBudget ?? 0);
     } else {
-      // Only check temperature/topP mutual exclusivity when thinking is not enabled
-      if (topP != null && temperature != null) {
+      // Only check temperature/topP mutual exclusivity for known Anthropic models
+      // when thinking is not enabled. Non-Anthropic models using the Anthropic-compatible
+      // API (e.g. Minimax) may require both parameters to be set.
+      if (isAnthropicModel && topP != null && temperature != null) {
         warnings.push({
           type: 'unsupported',
           feature: 'topP',


### PR DESCRIPTION
## Background

Port of #14052 to `main`.

The `@ai-sdk/anthropic` provider enforces temperature/topP mutual exclusivity for all models, matching a constraint in the Anthropic API. However, providers like Minimax use the Anthropic-compatible API endpoint with non-Anthropic models (e.g. `MiniMax-M2.7`) that require both `temperature` and `top_p` to be set simultaneously.

## Summary

- Introduce `isAnthropicModel` variable derived from `isKnownModel || modelId.startsWith('claude-')`
- Only enforce temperature/topP mutual exclusivity for Anthropic models
- Non-Anthropic models using the Anthropic-compatible API can now send both parameters

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Backport of #14052