### PR TITLE
fix(anthropic): move claude-haiku-4-5 to correct model group in getModelCapabilities

### DIFF
--- a/.changeset/fix-anthropic-temperature-top-p.md
+++ b/.changeset/fix-anthropic-temperature-top-p.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): move claude-haiku-4-5 to the 4-5 model group in getModelCapabilities
+
+Moves `claude-haiku-4-5` from the `claude-sonnet-4-`/`claude-3-7-sonnet` group (structured output: false) to the `claude-sonnet-4-5`/`claude-opus-4-5` group (structured output: true), aligning with main and release-v6.0.

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -1799,7 +1799,8 @@ function getModelCapabilities(modelId: string): {
     };
   } else if (
     modelId.includes('claude-sonnet-4-5') ||
-    modelId.includes('claude-opus-4-5')
+    modelId.includes('claude-opus-4-5') ||
+    modelId.includes('claude-haiku-4-5')
   ) {
     return {
       maxOutputTokens: 64000,
@@ -1814,8 +1815,7 @@ function getModelCapabilities(modelId: string): {
     };
   } else if (
     modelId.includes('claude-sonnet-4-') ||
-    modelId.includes('claude-3-7-sonnet') ||
-    modelId.includes('claude-haiku-4-5')
+    modelId.includes('claude-3-7-sonnet')
   ) {
     return {
       maxOutputTokens: 64000,


### PR DESCRIPTION
## Background

The `claude-haiku-4-5` model was grouped with `claude-sonnet-4-`/`claude-3-7-sonnet` in `getModelCapabilities`, which set `supportsStructuredOutput: false`. However, `claude-haiku-4-5` supports structured output and should be in the `claude-sonnet-4-5`/`claude-opus-4-5` group (`supportsStructuredOutput: true`), matching the implementation in `main` and `release-v6.0`.

## Summary

- Move `claude-haiku-4-5` from the `claude-sonnet-4-`/`claude-3-7-sonnet` group to the `claude-sonnet-4-5`/`claude-opus-4-5` group in `getModelCapabilities`
- This aligns the model capabilities across `main`, `release-v6.0`, and `release-v5.0`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)