### PR TITLE
refactoring: move retry behavior from streamModelCall into streamText

### DIFF
--- a/packages/ai/src/generate-text/stream-model-call.ts
+++ b/packages/ai/src/generate-text/stream-model-call.ts
@@ -116,7 +116,6 @@ export async function streamModelCall<
   system,
   messages,
   download,
-  maxRetries,
   abortSignal,
   headers,
   includeRawChunks,
@@ -148,7 +147,7 @@ export async function streamModelCall<
     promptMessages: LanguageModelV4Prompt;
   }) => Promise<void> | void;
 } & Prompt &
-  CallSettings): Promise<{
+  Omit<CallSettings, 'maxRetries'>): Promise<{
   stream: AsyncIterableStream<ModelCallStreamPart<TOOLS>>;
   request?: {
     /**
@@ -164,8 +163,6 @@ export async function streamModelCall<
   };
 }> {
   const resolvedModel = resolveLanguageModel(model);
-
-  const { retry } = prepareRetries({ maxRetries, abortSignal });
 
   const standardizedPrompt = await standardizePrompt({
     system,
@@ -199,19 +196,17 @@ export async function streamModelCall<
     stream: languageModelStream,
     response,
     request,
-  } = await retry(async () =>
-    resolvedModel.doStream({
-      ...callSettings,
-      tools: stepTools,
-      toolChoice: stepToolChoice,
-      responseFormat: await output?.responseFormat,
-      prompt: promptMessages,
-      providerOptions,
-      abortSignal,
-      headers,
-      includeRawChunks,
-    }),
-  );
+  } = await resolvedModel.doStream({
+    ...callSettings,
+    tools: stepTools,
+    toolChoice: stepToolChoice,
+    responseFormat: await output?.responseFormat,
+    prompt: promptMessages,
+    providerOptions,
+    abortSignal,
+    headers,
+    includeRawChunks,
+  });
 
   const standardizedStream = languageModelStream.pipeThrough(
     createLanguageModelStreamPartToModelCallStreamPartTransform({

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -1,4 +1,5 @@
 import {
+  APICallError,
   LanguageModelV4,
   LanguageModelV4CallOptions,
   LanguageModelV4FunctionTool,
@@ -2203,6 +2204,50 @@ describe('streamText', () => {
       await expect(result.text).rejects.toThrow(
         'No output generated. Check the stream for errors.',
       );
+    });
+  });
+
+  describe('retries', () => {
+    it('should retry after a 500 error and stream the successful response', async () => {
+      const doStream = vi
+        .fn<LanguageModelV4['doStream']>()
+        .mockImplementationOnce(async () => {
+          throw new APICallError({
+            message: 'Internal Server Error',
+            url: 'https://api.example.com/v1/chat',
+            requestBodyValues: { prompt: 'test-input' },
+            statusCode: 500,
+            responseHeaders: {
+              'retry-after-ms': '1',
+            },
+          });
+        })
+        .mockImplementationOnce(async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'hello' },
+            { type: 'text-delta', id: '1', delta: ' ' },
+            { type: 'text-delta', id: '1', delta: 'world' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+            },
+          ]),
+        }));
+
+      const result = streamText({
+        model: new MockLanguageModelV4({ doStream }),
+        prompt: 'test-input',
+      });
+
+      const textStreamPromise = convertAsyncIterableToArray(result.textStream);
+
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(await textStreamPromise).toStrictEqual(['hello', ' ', 'world']);
+      expect(doStream).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1604,61 +1604,64 @@ class DefaultStreamTextResult<
 
           const stepStartTimestampMs = now();
 
+          const { retry } = prepareRetries({ maxRetries, abortSignal });
+
           const {
             stream: languageModelStream,
             request,
             response,
-          } = await streamModelCall({
-            model: prepareStepResult?.model ?? model,
-            tools: stepActiveTools,
-            activeTools: prepareStepResult?.activeTools ?? activeTools,
-            toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
-            system: stepSystem,
-            messages: stepMessages,
-            repairToolCall,
-            abortSignal,
-            headers,
-            includeRawChunks,
-            providerOptions: stepProviderOptions,
-            download,
-            maxRetries,
-            output,
-            onStart: async ({ promptMessages }) => {
-              await notify({
-                event: {
-                  callId,
-                  stepNumber: recordedSteps.length,
-                  provider: stepModel.provider,
-                  modelId: stepModel.modelId,
-                  system: stepSystem,
-                  messages: stepMessages,
-                  tools,
-                  toolChoice: stepToolChoice,
-                  activeTools: prepareStepResult?.activeTools ?? activeTools,
-                  steps: [...recordedSteps],
-                  providerOptions: stepProviderOptions,
-                  timeout,
-                  headers,
-                  stopWhen,
-                  output,
-                  abortSignal: originalAbortSignal,
-                  include,
-                  ...callbackTelemetryProps,
-                  experimental_context,
-                  promptMessages,
-                  stepTools,
-                  stepToolChoice,
-                },
-                callbacks: [
-                  onStepStart,
-                  globalTelemetry.onStepStart as
-                    | undefined
-                    | StreamTextOnStepStartCallback<TOOLS, CONTEXT, OUTPUT>,
-                ],
-              });
-            },
-            ...callSettings,
-          });
+          } = await retry(async () =>
+            streamModelCall({
+              model: prepareStepResult?.model ?? model,
+              tools: stepActiveTools,
+              activeTools: prepareStepResult?.activeTools ?? activeTools,
+              toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
+              system: stepSystem,
+              messages: stepMessages,
+              repairToolCall,
+              abortSignal,
+              headers,
+              includeRawChunks,
+              providerOptions: stepProviderOptions,
+              download,
+              output,
+              onStart: async ({ promptMessages }) => {
+                await notify({
+                  event: {
+                    callId,
+                    stepNumber: recordedSteps.length,
+                    provider: stepModel.provider,
+                    modelId: stepModel.modelId,
+                    system: stepSystem,
+                    messages: stepMessages,
+                    tools,
+                    toolChoice: stepToolChoice,
+                    activeTools: prepareStepResult?.activeTools ?? activeTools,
+                    steps: [...recordedSteps],
+                    providerOptions: stepProviderOptions,
+                    timeout,
+                    headers,
+                    stopWhen,
+                    output,
+                    abortSignal: originalAbortSignal,
+                    include,
+                    ...callbackTelemetryProps,
+                    experimental_context,
+                    promptMessages,
+                    stepTools,
+                    stepToolChoice,
+                  },
+                  callbacks: [
+                    onStepStart,
+                    globalTelemetry.onStepStart as
+                      | undefined
+                      | StreamTextOnStepStartCallback<TOOLS, CONTEXT, OUTPUT>,
+                  ],
+                });
+              },
+              ...callSettings,
+            }),
+          );
 
           const stream2 = invokeToolCallbacksFromStream({
             stream: languageModelStream,


### PR DESCRIPTION
## Background

`streamModelCall` implements the retry behavior. However, for external loop control, it should be simple and the retry concern should be handled outside of it.

## Summary

Move `retry` behavior from `streamModelCall` to `streamText`. Add a regression test.

## Related Issues

Towards #13570 