### PR TITLE
docs(ai): add toolMs and per-tool timeout docs

### DIFF
--- a/content/docs/03-ai-sdk-core/25-settings.mdx
+++ b/content/docs/03-ai-sdk-core/25-settings.mdx
@@ -129,11 +129,13 @@ An optional timeout in milliseconds. The call will be aborted if it takes longer
 
 This is a convenience parameter that creates an abort signal internally. It can be used alongside `abortSignal` - if both are provided, the call will abort when either condition is met.
 
-You can specify the timeout either as a number (milliseconds) or as an object with `totalMs`, `stepMs`, and/or `chunkMs` properties:
+You can specify the timeout either as a number (milliseconds) or as an object with the following properties:
 
 - `totalMs`: The total timeout for the entire call including all steps.
 - `stepMs`: The timeout for each individual step (LLM call). This is useful for multi-step generations where you want to limit the time spent on each step independently.
 - `chunkMs`: The timeout between stream chunks (streaming only). The call will abort if no new chunk is received within this duration. This is useful for detecting stalled streams.
+- `toolMs`: The default timeout for all tool executions. If a tool takes longer, it aborts and returns a tool-error so the model can respond or retry.
+- `tools`: Per-tool timeout overrides using `{toolName}Ms` keys (e.g. `weatherMs`, `slowApiMs`). Takes precedence over `toolMs`. Tool names are type-checked for autocomplete.
 
 #### Example: 5 second timeout (number format)
 
@@ -185,6 +187,36 @@ const result = streamText({
   model: __MODEL__,
   prompt: 'Invent a new holiday and describe its traditions.',
   timeout: { chunkMs: 5000 }, // abort if no chunk received for 5 seconds
+});
+```
+
+#### Example: Tool execution timeout
+
+```ts
+const result = await generateText({
+  model: __MODEL__,
+  tools: { weather: weatherTool, slowApi: slowApiTool },
+  timeout: {
+    toolMs: 5000, // 5 seconds default for all tools
+  },
+  prompt: 'What is the weather in San Francisco?',
+});
+```
+
+#### Example: Per-tool timeout overrides
+
+```ts
+const result = await generateText({
+  model: __MODEL__,
+  tools: { weather: weatherTool, slowApi: slowApiTool },
+  timeout: {
+    toolMs: 5000, // default for all tools
+    tools: {
+      weatherMs: 3000, // 3 seconds for weather tool
+      slowApiMs: 10000, // 10 seconds for slow API tool
+    },
+  },
+  prompt: 'What is the weather in San Francisco?',
 });
 ```
 

--- a/packages/ai/src/generate-text/core-events.ts
+++ b/packages/ai/src/generate-text/core-events.ts
@@ -91,7 +91,7 @@ export interface OnStartEvent<
 
   /**
    * Timeout configuration for the generation.
-   * Can be a number (milliseconds) or an object with totalMs, stepMs, chunkMs.
+   * Can be a number (milliseconds) or an object with totalMs, stepMs, chunkMs, toolMs, and per-tool overrides via tools.
    */
   readonly timeout: TimeoutConfiguration<TOOLS> | undefined;
 
@@ -200,7 +200,7 @@ export interface OnStepStartEvent<
 
   /**
    * Timeout configuration for the generation.
-   * Can be a number (milliseconds) or an object with totalMs, stepMs, chunkMs.
+   * Can be a number (milliseconds) or an object with totalMs, stepMs, chunkMs, toolMs, and per-tool overrides via tools.
    */
   readonly timeout: TimeoutConfiguration<TOOLS> | undefined;
 

--- a/packages/ai/src/prompt/call-settings.ts
+++ b/packages/ai/src/prompt/call-settings.ts
@@ -7,6 +7,8 @@ import type { ToolSet } from '@ai-sdk/provider-utils';
  * - An object with `totalMs` property for the total timeout in milliseconds
  * - An object with `stepMs` property for the timeout of each step in milliseconds
  * - An object with `chunkMs` property for the timeout between stream chunks (streaming only)
+ * - An object with `toolMs` property for the default timeout for all tool executions
+ * - An object with `tools` property for per-tool timeout overrides using `{toolName}Ms` keys
  */
 export type TimeoutConfiguration<TOOLS extends ToolSet> =
   | number


### PR DESCRIPTION
## background

adds docs for the tool timeout feature (#13365, #13536)

## summary

- add `toolMs` and `tools` to timeout configuration JSDoc comments in `call-settings.ts` and `core-events.ts`
- add tool timeout examples to settings guide (`content/docs/03-ai-sdk-core/25-settings.mdx`)

## checklist

- [ ] tests have been added / updated (for bug fixes / features)
- [x] documentation has been added / updated (for bug fixes / features)
- [ ] a _patch_ changeset for relevant packages has been added (run `pnpm changeset` in root)
- [x] i have reviewed this pull request (self-review)