### PR TITLE
fix(mcp): strip trailing slash from OAuth resource parameter

### DIFF
--- a/.changeset/ninety-icons-tease.md
+++ b/.changeset/ninety-icons-tease.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix(mcp): strip trailing slash from OAuth resource parameter

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -883,6 +883,21 @@ describe('startAuthorization', () => {
       }),
     ).rejects.toThrow(/does not support code challenge method/);
   });
+
+  it('does not add trailing slash to pathless resource URL', async () => {
+    const { authorizationUrl } = await startAuthorization(
+      'https://auth.example.com',
+      {
+        clientInformation: validClientInfo,
+        redirectUrl: 'http://localhost:3000/callback',
+        resource: new URL('https://mcp.example.com'),
+      },
+    );
+
+    expect(authorizationUrl.searchParams.get('resource')).toBe(
+      'https://mcp.example.com',
+    );
+  });
 });
 
 describe('exchangeAuthorization', () => {
@@ -1090,6 +1105,25 @@ describe('exchangeAuthorization', () => {
     expect(body.get('redirect_uri')).toBe('http://localhost:3000/callback');
     expect(body.get('resource')).toBe('https://api.example.com/mcp-server');
   });
+
+  it('does not add trailing slash to pathless resource URL', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => validTokens,
+    });
+
+    await exchangeAuthorization('https://auth.example.com', {
+      clientInformation: validClientInfo,
+      authorizationCode: 'code123',
+      codeVerifier: 'verifier123',
+      redirectUri: 'http://localhost:3000/callback',
+      resource: new URL('https://mcp.example.com'),
+    });
+
+    const body = mockFetch.mock.calls[0][1].body as URLSearchParams;
+    expect(body.get('resource')).toBe('https://mcp.example.com');
+  });
 });
 
 describe('refreshAuthorization', () => {
@@ -1265,6 +1299,23 @@ describe('refreshAuthorization', () => {
         refreshToken: 'refresh123',
       }),
     ).rejects.toThrow('Token refresh failed');
+  });
+
+  it('does not add trailing slash to pathless resource URL', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => validTokensWithNewRefreshToken,
+    });
+
+    await refreshAuthorization('https://auth.example.com', {
+      clientInformation: validClientInfo,
+      refreshToken: 'refresh123',
+      resource: new URL('https://mcp.example.com'),
+    });
+
+    const body = mockFetch.mock.calls[0][1].body as URLSearchParams;
+    expect(body.get('resource')).toBe('https://mcp.example.com');
   });
 });
 
@@ -1799,7 +1850,7 @@ describe('auth function', () => {
     const authUrl: URL = redirectCall[0];
     // Should use the PRM's resource value, not the full requested URL
     expect(authUrl.searchParams.get('resource')).toBe(
-      'https://api.example.com/',
+      'https://api.example.com',
     );
   });
 

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -24,6 +24,7 @@ import {
 import {
   resourceUrlFromServerUrl,
   checkResourceAllowed,
+  resourceUrlStripSlash,
 } from '../util/oauth-util';
 import { LATEST_PROTOCOL_VERSION } from './types';
 import { FetchFunction } from '@ai-sdk/provider-utils';
@@ -451,7 +452,10 @@ export async function startAuthorization(
   }
 
   if (resource) {
-    authorizationUrl.searchParams.set('resource', resource.href);
+    authorizationUrl.searchParams.set(
+      'resource',
+      resourceUrlStripSlash(resource),
+    );
   }
 
   return { authorizationUrl, codeVerifier };
@@ -675,7 +679,7 @@ export async function exchangeAuthorization(
   }
 
   if (resource) {
-    params.set('resource', resource.href);
+    params.set('resource', resourceUrlStripSlash(resource));
   }
 
   const response = await (fetchFn ?? fetch)(tokenUrl, {
@@ -762,7 +766,7 @@ export async function refreshAuthorization(
   }
 
   if (resource) {
-    params.set('resource', resource.href);
+    params.set('resource', resourceUrlStripSlash(resource));
   }
 
   const response = await (fetchFn ?? fetch)(tokenUrl, {

--- a/packages/mcp/src/util/oauth-util.ts
+++ b/packages/mcp/src/util/oauth-util.ts
@@ -15,6 +15,19 @@ export function resourceUrlFromServerUrl(url: URL | string): URL {
 }
 
 /**
+ * Serializes a resource URL to a string, removing the trailing slash that
+ * URL.href adds to pathless URLs. Per the MCP spec, implementations SHOULD
+ * use the form without the trailing slash for better interoperability.
+ */
+export function resourceUrlStripSlash(resource: URL): string {
+  const href = resource.href;
+  if (resource.pathname === '/' && href.endsWith('/')) {
+    return href.slice(0, -1);
+  }
+  return href;
+}
+
+/**
  * Checks if a requested resource URL matches a configured resource URL.
  * A requested resource matches if it has the same scheme, domain, port,
  * and its path starts with the configured resource's path.


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/13988

URL.href always appends a trailing slash to pathless URLs. When an MCP server's Protected Resource Metadata returns "resource": "https://mcp.example.com", the OAuth resource parameter gets sent as https://mcp.example.com/ — breaking auth servers that do exact string matching.

As specified in the [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#canonical-server-uri), there the resource pathname shouldn't just be a trailing slash

## Summary

added a utility function that strips the trailing slash if the pathname is just a slash

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #13988 