### PR TITLE
feat(workflow): add needsApproval support for tools

### DIFF
--- a/examples/next-workflow/.gitignore
+++ b/examples/next-workflow/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+public/.well-known/

--- a/examples/next-workflow/app/api/chat/route.ts
+++ b/examples/next-workflow/app/api/chat/route.ts
@@ -7,8 +7,6 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
   const run = await start(chat, [messages]);
 
-  // The workflow streams ModelCallStreamPart chunks.
-  // Convert to UIMessageChunks at the response boundary.
   return createUIMessageStreamResponse({
     stream: run.readable.pipeThrough(createModelCallToUIChunkTransform()),
     headers: {

--- a/examples/next-workflow/app/page.tsx
+++ b/examples/next-workflow/app/page.tsx
@@ -1,81 +1,23 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { useRef, useEffect, useState, useCallback } from 'react';
-
-interface PendingApproval {
-  toolCallId: string;
-  toolName: string;
-  input: unknown;
-}
+import { useRef, useEffect } from 'react';
 
 export default function Chat() {
-  const { status, sendMessage, messages } = useChat();
+  const { status, sendMessage, messages, addToolApprovalResponse } = useChat({
+    sendAutomaticallyWhen: message =>
+      message.parts.some(
+        part =>
+          'state' in part &&
+          (part.state === 'approval-responded' ||
+            part.state === 'output-denied'),
+      ),
+  });
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const [pendingApprovals, setPendingApprovals] = useState<PendingApproval[]>(
-    [],
-  );
-  const [resolvedToolCallIds, setResolvedToolCallIds] = useState<Set<string>>(
-    new Set(),
-  );
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages, pendingApprovals]);
-
-  // Detect paused tools: tool-* parts without output after streaming ends
-  useEffect(() => {
-    if (status !== 'ready') return;
-
-    const newApprovals: PendingApproval[] = [];
-    for (const msg of messages) {
-      if (msg.role !== 'assistant') continue;
-      for (const part of msg.parts) {
-        const p = part as any;
-        if (
-          p.type?.startsWith('tool-') &&
-          p.state !== 'output-available' &&
-          p.toolCallId &&
-          !resolvedToolCallIds.has(p.toolCallId)
-        ) {
-          newApprovals.push({
-            toolCallId: p.toolCallId,
-            toolName: p.type.replace('tool-', ''),
-            input: p.input,
-          });
-        }
-      }
-    }
-
-    if (newApprovals.length > 0) {
-      setPendingApprovals(prev => {
-        const existing = new Set(prev.map(a => a.toolCallId));
-        const fresh = newApprovals.filter(a => !existing.has(a.toolCallId));
-        return fresh.length > 0 ? [...prev, ...fresh] : prev;
-      });
-    }
-  }, [status, messages, resolvedToolCallIds]);
-
-  const handleApproval = useCallback(
-    async (approval: PendingApproval, approved: boolean) => {
-      // Remove from pending and mark as resolved
-      setPendingApprovals(prev =>
-        prev.filter(a => a.toolCallId !== approval.toolCallId),
-      );
-      setResolvedToolCallIds(prev => new Set([...prev, approval.toolCallId]));
-
-      if (approved) {
-        sendMessage({
-          text: `Approved. Go ahead and execute ${approval.toolName}.`,
-        });
-      } else {
-        sendMessage({
-          text: `Denied. Do not execute ${approval.toolName}.`,
-        });
-      }
-    },
-    [sendMessage],
-  );
+  }, [messages]);
 
   return (
     <div className="flex flex-col h-screen max-w-2xl mx-auto">
@@ -110,10 +52,80 @@ export default function Chat() {
                 }
                 if (p.type?.startsWith('tool-') && p.toolCallId) {
                   const toolName = p.type.replace('tool-', '');
-                  const isPending = pendingApprovals.some(
-                    a => a.toolCallId === p.toolCallId,
-                  );
-                  const isResolved = resolvedToolCallIds.has(p.toolCallId);
+
+                  // Approval requested — show approve/deny UI
+                  if (p.state === 'approval-requested' && p.approval?.id) {
+                    return (
+                      <div
+                        key={index}
+                        className="my-2 p-3 bg-amber-50 rounded border border-amber-200"
+                      >
+                        <div className="flex items-center gap-2 mb-2">
+                          <span className="text-amber-600 text-lg">
+                            &#9888;
+                          </span>
+                          <span className="font-semibold text-amber-800">
+                            Approval Required
+                          </span>
+                        </div>
+                        <p className="text-sm text-gray-700 mb-1">
+                          The assistant wants to use{' '}
+                          <code className="bg-amber-100 px-1 rounded font-semibold">
+                            {toolName}
+                          </code>
+                        </p>
+                        <pre className="text-xs bg-white rounded p-2 mb-3 border overflow-x-auto">
+                          {JSON.stringify(p.input, null, 2)}
+                        </pre>
+                        <div className="flex gap-2">
+                          <button
+                            onClick={() =>
+                              addToolApprovalResponse({
+                                id: p.approval.id,
+                                approved: true,
+                              })
+                            }
+                            className="rounded-lg bg-green-500 px-4 py-1.5 text-sm text-white hover:bg-green-600 transition-colors"
+                          >
+                            Approve
+                          </button>
+                          <button
+                            onClick={() =>
+                              addToolApprovalResponse({
+                                id: p.approval.id,
+                                approved: false,
+                                reason: 'User denied the operation.',
+                              })
+                            }
+                            className="rounded-lg bg-red-500 px-4 py-1.5 text-sm text-white hover:bg-red-600 transition-colors"
+                          >
+                            Deny
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  }
+
+                  // Approval responded (waiting for resubmission)
+                  if (p.state === 'approval-responded') {
+                    return (
+                      <div
+                        key={index}
+                        className={`my-2 p-2 rounded text-sm border ${
+                          p.approval?.approved
+                            ? 'bg-green-50 border-green-200 text-green-800'
+                            : 'bg-red-50 border-red-200 text-red-800'
+                        }`}
+                      >
+                        <code>{toolName}</code>{' '}
+                        {p.approval?.approved
+                          ? 'approved — executing...'
+                          : 'denied'}
+                      </div>
+                    );
+                  }
+
+                  // Normal tool display
                   return (
                     <div
                       key={index}
@@ -121,14 +133,6 @@ export default function Chat() {
                     >
                       <div className="font-mono text-xs text-gray-500">
                         {toolName}
-                        {isPending && (
-                          <span className="ml-2 text-amber-600">
-                            (awaiting approval)
-                          </span>
-                        )}
-                        {isResolved && p.state !== 'output-available' && (
-                          <span className="ml-2 text-gray-400">(resolved)</span>
-                        )}
                       </div>
                       {p.state === 'output-available' && (
                         <pre className="mt-1 text-xs overflow-x-auto">
@@ -143,44 +147,6 @@ export default function Chat() {
             </div>
           </div>
         ))}
-
-        {/* Pending approval cards */}
-        {pendingApprovals.map(approval => (
-          <div key={approval.toolCallId} className="flex justify-start">
-            <div className="max-w-[80%] rounded-lg px-4 py-3 bg-amber-50 border border-amber-200">
-              <div className="flex items-center gap-2 mb-2">
-                <span className="text-amber-600 text-lg">&#9888;</span>
-                <span className="font-semibold text-amber-800">
-                  Approval Required
-                </span>
-              </div>
-              <p className="text-sm text-gray-700 mb-1">
-                The assistant wants to use{' '}
-                <code className="bg-amber-100 px-1 rounded font-semibold">
-                  {approval.toolName}
-                </code>
-              </p>
-              <pre className="text-xs bg-white rounded p-2 mb-3 border overflow-x-auto">
-                {JSON.stringify(approval.input, null, 2)}
-              </pre>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => handleApproval(approval, true)}
-                  className="rounded-lg bg-green-500 px-4 py-1.5 text-sm text-white hover:bg-green-600 transition-colors"
-                >
-                  Approve
-                </button>
-                <button
-                  onClick={() => handleApproval(approval, false)}
-                  className="rounded-lg bg-red-500 px-4 py-1.5 text-sm text-white hover:bg-red-600 transition-colors"
-                >
-                  Deny
-                </button>
-              </div>
-            </div>
-          </div>
-        ))}
-
         <div ref={messagesEndRef} />
       </div>
 
@@ -194,8 +160,6 @@ export default function Chat() {
           if (input.value.trim()) {
             sendMessage({ text: input.value });
             input.value = '';
-            setPendingApprovals([]);
-            setResolvedToolCallIds(new Set());
           }
         }}
       >

--- a/examples/next-workflow/app/page.tsx
+++ b/examples/next-workflow/app/page.tsx
@@ -4,20 +4,22 @@ import { useChat } from '@ai-sdk/react';
 import { useRef, useEffect } from 'react';
 
 export default function Chat() {
-  const { status, sendMessage, messages, addToolApprovalResponse } = useChat({
-    sendAutomaticallyWhen: message =>
-      message.parts.some(
-        part =>
-          'state' in part &&
-          (part.state === 'approval-responded' ||
-            part.state === 'output-denied'),
-      ),
-  });
+  const { status, sendMessage, messages, addToolApprovalResponse } = useChat();
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
+
+  const handleApproval = async (
+    approvalId: string,
+    approved: boolean,
+    reason?: string,
+  ) => {
+    await addToolApprovalResponse({ id: approvalId, approved, reason });
+    // Manually trigger resubmission after approval response is set
+    sendMessage({ text: '' });
+  };
 
   return (
     <div className="flex flex-col h-screen max-w-2xl mx-auto">
@@ -53,7 +55,6 @@ export default function Chat() {
                 if (p.type?.startsWith('tool-') && p.toolCallId) {
                   const toolName = p.type.replace('tool-', '');
 
-                  // Approval requested — show approve/deny UI
                   if (p.state === 'approval-requested' && p.approval?.id) {
                     return (
                       <div
@@ -79,23 +80,18 @@ export default function Chat() {
                         </pre>
                         <div className="flex gap-2">
                           <button
-                            onClick={() =>
-                              addToolApprovalResponse({
-                                id: p.approval.id,
-                                approved: true,
-                              })
-                            }
+                            onClick={() => handleApproval(p.approval.id, true)}
                             className="rounded-lg bg-green-500 px-4 py-1.5 text-sm text-white hover:bg-green-600 transition-colors"
                           >
                             Approve
                           </button>
                           <button
                             onClick={() =>
-                              addToolApprovalResponse({
-                                id: p.approval.id,
-                                approved: false,
-                                reason: 'User denied the operation.',
-                              })
+                              handleApproval(
+                                p.approval.id,
+                                false,
+                                'User denied the operation.',
+                              )
                             }
                             className="rounded-lg bg-red-500 px-4 py-1.5 text-sm text-white hover:bg-red-600 transition-colors"
                           >
@@ -106,7 +102,6 @@ export default function Chat() {
                     );
                   }
 
-                  // Approval responded (waiting for resubmission)
                   if (p.state === 'approval-responded') {
                     return (
                       <div
@@ -125,7 +120,6 @@ export default function Chat() {
                     );
                   }
 
-                  // Normal tool display
                   return (
                     <div
                       key={index}

--- a/examples/next-workflow/app/page.tsx
+++ b/examples/next-workflow/app/page.tsx
@@ -1,22 +1,88 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState, useCallback } from 'react';
+
+interface PendingApproval {
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+}
 
 export default function Chat() {
   const { status, sendMessage, messages } = useChat();
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const [pendingApprovals, setPendingApprovals] = useState<PendingApproval[]>(
+    [],
+  );
+  const [resolvedToolCallIds, setResolvedToolCallIds] = useState<Set<string>>(
+    new Set(),
+  );
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+  }, [messages, pendingApprovals]);
+
+  // Detect paused tools: tool-* parts without output after streaming ends
+  useEffect(() => {
+    if (status !== 'ready') return;
+
+    const newApprovals: PendingApproval[] = [];
+    for (const msg of messages) {
+      if (msg.role !== 'assistant') continue;
+      for (const part of msg.parts) {
+        const p = part as any;
+        if (
+          p.type?.startsWith('tool-') &&
+          p.state !== 'output-available' &&
+          p.toolCallId &&
+          !resolvedToolCallIds.has(p.toolCallId)
+        ) {
+          newApprovals.push({
+            toolCallId: p.toolCallId,
+            toolName: p.type.replace('tool-', ''),
+            input: p.input,
+          });
+        }
+      }
+    }
+
+    if (newApprovals.length > 0) {
+      setPendingApprovals(prev => {
+        const existing = new Set(prev.map(a => a.toolCallId));
+        const fresh = newApprovals.filter(a => !existing.has(a.toolCallId));
+        return fresh.length > 0 ? [...prev, ...fresh] : prev;
+      });
+    }
+  }, [status, messages, resolvedToolCallIds]);
+
+  const handleApproval = useCallback(
+    async (approval: PendingApproval, approved: boolean) => {
+      // Remove from pending and mark as resolved
+      setPendingApprovals(prev =>
+        prev.filter(a => a.toolCallId !== approval.toolCallId),
+      );
+      setResolvedToolCallIds(prev => new Set([...prev, approval.toolCallId]));
+
+      if (approved) {
+        sendMessage({
+          text: `Approved. Go ahead and execute ${approval.toolName}.`,
+        });
+      } else {
+        sendMessage({
+          text: `Denied. Do not execute ${approval.toolName}.`,
+        });
+      }
+    },
+    [sendMessage],
+  );
 
   return (
     <div className="flex flex-col h-screen max-w-2xl mx-auto">
       <header className="p-4 border-b">
         <h1 className="text-lg font-semibold">WorkflowAgent Chat</h1>
         <p className="text-sm text-gray-500">
-          A workflow AI agent with weather and calculator tools
+          A workflow AI agent with weather, calculator, and file tools
         </p>
       </header>
 
@@ -34,36 +100,87 @@ export default function Chat() {
               }`}
             >
               {message.parts.map((part, index) => {
-                switch (part.type) {
-                  case 'text':
-                    return (
-                      <div key={index} className="whitespace-pre-wrap">
-                        {part.text}
-                      </div>
-                    );
-                  case 'dynamic-tool':
-                    return (
-                      <div
-                        key={index}
-                        className="my-2 p-2 bg-white/50 rounded text-sm border"
-                      >
-                        <div className="font-mono text-xs text-gray-500">
-                          {part.toolName}
-                        </div>
-                        {part.state === 'output-available' && (
-                          <pre className="mt-1 text-xs overflow-x-auto">
-                            {JSON.stringify(part.output, null, 2)}
-                          </pre>
+                const p = part as any;
+                if (part.type === 'text') {
+                  return (
+                    <div key={index} className="whitespace-pre-wrap">
+                      {part.text}
+                    </div>
+                  );
+                }
+                if (p.type?.startsWith('tool-') && p.toolCallId) {
+                  const toolName = p.type.replace('tool-', '');
+                  const isPending = pendingApprovals.some(
+                    a => a.toolCallId === p.toolCallId,
+                  );
+                  const isResolved = resolvedToolCallIds.has(p.toolCallId);
+                  return (
+                    <div
+                      key={index}
+                      className="my-2 p-2 bg-white/50 rounded text-sm border"
+                    >
+                      <div className="font-mono text-xs text-gray-500">
+                        {toolName}
+                        {isPending && (
+                          <span className="ml-2 text-amber-600">
+                            (awaiting approval)
+                          </span>
+                        )}
+                        {isResolved && p.state !== 'output-available' && (
+                          <span className="ml-2 text-gray-400">(resolved)</span>
                         )}
                       </div>
-                    );
-                  default:
-                    return null;
+                      {p.state === 'output-available' && (
+                        <pre className="mt-1 text-xs overflow-x-auto">
+                          {JSON.stringify(p.output, null, 2)}
+                        </pre>
+                      )}
+                    </div>
+                  );
                 }
+                return null;
               })}
             </div>
           </div>
         ))}
+
+        {/* Pending approval cards */}
+        {pendingApprovals.map(approval => (
+          <div key={approval.toolCallId} className="flex justify-start">
+            <div className="max-w-[80%] rounded-lg px-4 py-3 bg-amber-50 border border-amber-200">
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-amber-600 text-lg">&#9888;</span>
+                <span className="font-semibold text-amber-800">
+                  Approval Required
+                </span>
+              </div>
+              <p className="text-sm text-gray-700 mb-1">
+                The assistant wants to use{' '}
+                <code className="bg-amber-100 px-1 rounded font-semibold">
+                  {approval.toolName}
+                </code>
+              </p>
+              <pre className="text-xs bg-white rounded p-2 mb-3 border overflow-x-auto">
+                {JSON.stringify(approval.input, null, 2)}
+              </pre>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => handleApproval(approval, true)}
+                  className="rounded-lg bg-green-500 px-4 py-1.5 text-sm text-white hover:bg-green-600 transition-colors"
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => handleApproval(approval, false)}
+                  className="rounded-lg bg-red-500 px-4 py-1.5 text-sm text-white hover:bg-red-600 transition-colors"
+                >
+                  Deny
+                </button>
+              </div>
+            </div>
+          </div>
+        ))}
+
         <div ref={messagesEndRef} />
       </div>
 
@@ -77,13 +194,15 @@ export default function Chat() {
           if (input.value.trim()) {
             sendMessage({ text: input.value });
             input.value = '';
+            setPendingApprovals([]);
+            setResolvedToolCallIds(new Set());
           }
         }}
       >
         <input
           name="message"
           type="text"
-          placeholder="Ask about weather or math..."
+          placeholder="Ask about weather, math, or file operations..."
           className="flex-1 rounded-lg border border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
           disabled={status === 'streaming' || status === 'submitted'}
         />

--- a/examples/next-workflow/app/page.tsx
+++ b/examples/next-workflow/app/page.tsx
@@ -1,25 +1,18 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
+import { lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai';
 import { useRef, useEffect } from 'react';
 
 export default function Chat() {
-  const { status, sendMessage, messages, addToolApprovalResponse } = useChat();
+  const { status, sendMessage, messages, addToolApprovalResponse } = useChat({
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+  });
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
-
-  const handleApproval = async (
-    approvalId: string,
-    approved: boolean,
-    reason?: string,
-  ) => {
-    await addToolApprovalResponse({ id: approvalId, approved, reason });
-    // Manually trigger resubmission after approval response is set
-    sendMessage({ text: '' });
-  };
 
   return (
     <div className="flex flex-col h-screen max-w-2xl mx-auto">
@@ -80,18 +73,23 @@ export default function Chat() {
                         </pre>
                         <div className="flex gap-2">
                           <button
-                            onClick={() => handleApproval(p.approval.id, true)}
+                            onClick={() =>
+                              addToolApprovalResponse({
+                                id: p.approval.id,
+                                approved: true,
+                              })
+                            }
                             className="rounded-lg bg-green-500 px-4 py-1.5 text-sm text-white hover:bg-green-600 transition-colors"
                           >
                             Approve
                           </button>
                           <button
                             onClick={() =>
-                              handleApproval(
-                                p.approval.id,
-                                false,
-                                'User denied the operation.',
-                              )
+                              addToolApprovalResponse({
+                                id: p.approval.id,
+                                approved: false,
+                                reason: 'User denied the operation.',
+                              })
                             }
                             className="rounded-lg bg-red-500 px-4 py-1.5 text-sm text-white hover:bg-red-600 transition-colors"
                           >

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -3,7 +3,6 @@ import { WorkflowAgent, type ModelCallStreamPart } from '@ai-sdk/workflow';
 import {
   convertToModelMessages,
   ToolCallRepairFunction,
-  type ModelMessage,
   type UIMessage,
 } from 'ai';
 import { getWritable } from 'workflow';
@@ -94,152 +93,10 @@ const repairToolCall: ToolCallRepairFunction<typeof tools> = async ({
   return toolCall;
 };
 
-/**
- * Map of tool names to their step execute functions.
- * Used to execute approved tools in the workflow context.
- */
-const toolExecutors: Record<string, (input: any) => Promise<any>> = {
-  getWeather,
-  calculate,
-  deleteFile: deleteFileStep,
-};
-
-/**
- * Process approval responses in model messages.
- * Executes approved tools via step functions, strips approval parts,
- * and injects tool results into the conversation.
- */
-async function processApprovals(
-  messages: ModelMessage[],
-): Promise<ModelMessage[]> {
-  // Find tool-approval-response parts
-  const approvalResponses: Array<{
-    approvalId: string;
-    approved: boolean;
-    reason?: string;
-  }> = [];
-  const approvalRequestMap = new Map<string, string>(); // approvalId → toolCallId
-  const toolCallMap = new Map<string, { toolName: string; input: unknown }>(); // toolCallId → toolCall
-
-  for (const msg of messages) {
-    if (msg.role === 'assistant' && Array.isArray(msg.content)) {
-      for (const part of msg.content as any[]) {
-        if (part.type === 'tool-call') {
-          toolCallMap.set(part.toolCallId, {
-            toolName: part.toolName,
-            input: part.input ?? part.args,
-          });
-        }
-        if (part.type === 'tool-approval-request') {
-          approvalRequestMap.set(part.approvalId, part.toolCallId);
-        }
-      }
-    }
-    if (msg.role === 'tool') {
-      for (const part of msg.content as any[]) {
-        if (part.type === 'tool-approval-response') {
-          approvalResponses.push(part);
-        }
-      }
-    }
-  }
-
-  if (approvalResponses.length === 0) return messages;
-
-  // Execute approved tools and collect results
-  const toolResults: Array<{
-    toolCallId: string;
-    toolName: string;
-    output: any;
-  }> = [];
-  const denialResults: Array<{
-    toolCallId: string;
-    toolName: string;
-    reason?: string;
-  }> = [];
-
-  for (const response of approvalResponses) {
-    const toolCallId = approvalRequestMap.get(response.approvalId);
-    if (!toolCallId) continue;
-    const toolCall = toolCallMap.get(toolCallId);
-    if (!toolCall) continue;
-
-    if (response.approved) {
-      const executor = toolExecutors[toolCall.toolName];
-      if (executor) {
-        const result = await executor(toolCall.input);
-        toolResults.push({
-          toolCallId,
-          toolName: toolCall.toolName,
-          output: result,
-        });
-      }
-    } else {
-      denialResults.push({
-        toolCallId,
-        toolName: toolCall.toolName,
-        reason: response.reason,
-      });
-    }
-  }
-
-  // Rebuild messages: strip approval parts, add tool results
-  const cleanMessages: ModelMessage[] = [];
-  for (const msg of messages) {
-    if (msg.role === 'assistant' && Array.isArray(msg.content)) {
-      const content = (msg.content as any[]).filter(
-        (p: any) => p.type !== 'tool-approval-request',
-      );
-      if (content.length > 0) cleanMessages.push({ ...msg, content });
-    } else if (msg.role === 'tool') {
-      const content = (msg.content as any[]).filter(
-        (p: any) => p.type !== 'tool-approval-response',
-      );
-      if (content.length > 0) cleanMessages.push({ ...msg, content });
-    } else {
-      cleanMessages.push(msg);
-    }
-  }
-
-  // Add tool results
-  const toolContent: any[] = [];
-  for (const tr of toolResults) {
-    const output =
-      typeof tr.output === 'string'
-        ? { type: 'text' as const, value: tr.output }
-        : { type: 'json' as const, value: tr.output };
-    toolContent.push({
-      type: 'tool-result',
-      toolCallId: tr.toolCallId,
-      toolName: tr.toolName,
-      output,
-    });
-  }
-  for (const dr of denialResults) {
-    toolContent.push({
-      type: 'tool-result',
-      toolCallId: dr.toolCallId,
-      toolName: dr.toolName,
-      output: {
-        type: 'error-text',
-        value: dr.reason ?? 'Tool execution denied.',
-      },
-    });
-  }
-  if (toolContent.length > 0) {
-    cleanMessages.push({ role: 'tool', content: toolContent });
-  }
-
-  return cleanMessages;
-}
-
 export async function chat(messages: UIMessage[]) {
   'use workflow';
 
   const modelMessages = await convertToModelMessages(messages);
-
-  // Process any pending approvals before running the agent
-  const processedMessages = await processApprovals(modelMessages);
 
   const agent = new WorkflowAgent({
     model: anthropic('claude-sonnet-4-20250514'),
@@ -249,7 +106,7 @@ export async function chat(messages: UIMessage[]) {
   });
 
   const result = await agent.stream({
-    messages: processedMessages,
+    messages: modelMessages,
     writable: getWritable<ModelCallStreamPart>(),
     experimental_repairToolCall: repairToolCall as any,
   });

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -102,6 +102,20 @@ export async function chat(messages: UIMessage[]) {
 
   const modelMessages = await convertToModelMessages(messages);
 
+  // Debug: check for approval-related parts
+  for (const m of modelMessages) {
+    if (typeof m.content !== 'string' && m.content) {
+      for (const p of m.content) {
+        if (
+          p.type === 'tool-approval-request' ||
+          p.type === 'tool-approval-response'
+        ) {
+          console.log('[chat] approval part found:', JSON.stringify(p));
+        }
+      }
+    }
+  }
+
   const agent = new WorkflowAgent({
     model: anthropic('claude-sonnet-4-20250514'),
     instructions:

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -73,6 +73,40 @@ const tools = {
     }),
     execute: calculate,
   },
+  deleteFile: {
+    description: 'Delete a file from the filesystem. Always requires approval.',
+    inputSchema: z.object({
+      path: z.string().describe('The file path to delete'),
+    }),
+    execute: async (input: { path: string }) => {
+      'use step';
+      console.log('[deleteFile] Would delete:', input.path);
+      return { deleted: input.path };
+    },
+    needsApproval: true as const,
+  },
+  sendEmail: {
+    description:
+      'Send an email. Requires approval only for external recipients.',
+    inputSchema: z.object({
+      to: z.string().describe('Email recipient'),
+      subject: z.string().describe('Email subject'),
+    }),
+    execute: async (input: { to: string; subject: string }) => {
+      'use step';
+      console.log('[sendEmail] Would send to:', input.to);
+      return { sent: true, to: input.to, subject: input.subject };
+    },
+    needsApproval: async (input: { to: string; subject: string }) => {
+      const isExternal = !input.to.endsWith('@company.com');
+      console.log(
+        '[sendEmail needsApproval]',
+        input.to,
+        isExternal ? '→ needs approval' : '→ auto-approved',
+      );
+      return isExternal;
+    },
+  },
 };
 const repairToolCall: ToolCallRepairFunction<typeof tools> = async ({
   toolCall,

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -97,56 +97,10 @@ const repairToolCall: ToolCallRepairFunction<typeof tools> = async ({
   return toolCall;
 };
 
-/**
- * Patch UIMessages to add placeholder tool results for any unresolved
- * tool calls. This prevents AI_MissingToolResultsError when the user
- * approves/denies a tool that was paused by needsApproval.
- */
-function patchUnresolvedToolCalls(messages: UIMessage[]): UIMessage[] {
-  // Collect all tool call IDs and tool result IDs
-  const toolCallIds = new Set<string>();
-  const toolResultIds = new Set<string>();
-
-  for (const msg of messages) {
-    for (const part of msg.parts) {
-      const p = part as any;
-      if (
-        p.type?.startsWith('tool-') &&
-        p.toolCallId &&
-        p.state !== undefined
-      ) {
-        toolCallIds.add(p.toolCallId);
-        if (p.state === 'output-available') {
-          toolResultIds.add(p.toolCallId);
-        }
-      }
-    }
-  }
-
-  // Find unresolved tool calls
-  const unresolvedIds = [...toolCallIds].filter(id => !toolResultIds.has(id));
-  if (unresolvedIds.length === 0) return messages;
-
-  // Strip assistant messages that contain only unresolved tool calls
-  return messages.filter(msg => {
-    if (msg.role !== 'assistant') return true;
-    const hasOnlyUnresolvedTools = msg.parts.every(part => {
-      const p = part as any;
-      if (p.type?.startsWith('tool-') && p.toolCallId) {
-        return unresolvedIds.includes(p.toolCallId);
-      }
-      // Keep step-start and other non-content parts
-      return p.type === 'step-start';
-    });
-    return !hasOnlyUnresolvedTools;
-  });
-}
-
 export async function chat(messages: UIMessage[]) {
   'use workflow';
 
-  const patchedMessages = patchUnresolvedToolCalls(messages);
-  const modelMessages = await convertToModelMessages(patchedMessages);
+  const modelMessages = await convertToModelMessages(messages);
 
   const agent = new WorkflowAgent({
     model: anthropic('claude-sonnet-4-20250514'),
@@ -161,9 +115,5 @@ export async function chat(messages: UIMessage[]) {
     experimental_repairToolCall: repairToolCall as any,
   });
 
-  return {
-    messages: result.messages,
-    toolCalls: result.toolCalls,
-    toolResults: result.toolResults,
-  };
+  return { messages: result.messages };
 }

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -183,25 +183,12 @@ async function processApprovals(
     }
   }
 
-  // Rebuild messages: strip approval parts, add tool results
-  const cleanMessages: ModelMessage[] = [];
-  for (const msg of messages) {
-    if (msg.role === 'assistant' && Array.isArray(msg.content)) {
-      const content = (msg.content as any[]).filter(
-        (p: any) => p.type !== 'tool-approval-request',
-      );
-      if (content.length > 0) cleanMessages.push({ ...msg, content });
-    } else if (msg.role === 'tool') {
-      const content = (msg.content as any[]).filter(
-        (p: any) => p.type !== 'tool-approval-response',
-      );
-      if (content.length > 0) cleanMessages.push({ ...msg, content });
-    } else {
-      cleanMessages.push(msg);
-    }
-  }
+  // Build a set of tool call IDs that have been resolved (approved or denied)
+  const resolvedToolCallIds = new Set<string>();
+  for (const tr of toolResults) resolvedToolCallIds.add(tr.toolCallId);
+  for (const dr of denialResults) resolvedToolCallIds.add(dr.toolCallId);
 
-  // Add tool results
+  // Build tool result content parts
   const toolContent: any[] = [];
   for (const tr of toolResults) {
     const output =
@@ -221,13 +208,42 @@ async function processApprovals(
       toolCallId: dr.toolCallId,
       toolName: dr.toolName,
       output: {
-        type: 'error-text',
-        value: dr.reason ?? 'Tool execution denied.',
+        type: 'execution-denied',
+        reason: dr.reason ?? 'Tool execution denied.',
       },
     });
   }
-  if (toolContent.length > 0) {
-    cleanMessages.push({ role: 'tool', content: toolContent });
+
+  // Rebuild messages:
+  // - Strip approval-request / approval-response parts
+  // - Insert tool results immediately after the assistant message containing the tool calls
+  // - Remove trailing empty user messages (from sendMessage({ text: '' }))
+  const cleanMessages: ModelMessage[] = [];
+  for (const msg of messages) {
+    if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+      const content = (msg.content as any[]).filter(
+        (p: any) => p.type !== 'tool-approval-request',
+      );
+      if (content.length > 0) {
+        cleanMessages.push({ ...msg, content });
+
+        // Check if this assistant message has any resolved tool calls
+        const hasResolvedToolCalls = (msg.content as any[]).some(
+          (p: any) =>
+            p.type === 'tool-call' && resolvedToolCallIds.has(p.toolCallId),
+        );
+        if (hasResolvedToolCalls && toolContent.length > 0) {
+          cleanMessages.push({ role: 'tool', content: toolContent });
+        }
+      }
+    } else if (msg.role === 'tool') {
+      const content = (msg.content as any[]).filter(
+        (p: any) => p.type !== 'tool-approval-response',
+      );
+      if (content.length > 0) cleanMessages.push({ ...msg, content });
+    } else {
+      cleanMessages.push(msg);
+    }
   }
 
   return cleanMessages;

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -3,13 +3,14 @@ import { WorkflowAgent, type ModelCallStreamPart } from '@ai-sdk/workflow';
 import {
   convertToModelMessages,
   ToolCallRepairFunction,
+  type ModelMessage,
   type UIMessage,
 } from 'ai';
 import { getWritable } from 'workflow';
 import z from 'zod';
 
 // ============================================================================
-// Tool step functions — these run as durable steps with full Node.js access
+// Tool step functions
 // ============================================================================
 
 async function getWeather(input: { city: string }): Promise<{
@@ -32,8 +33,12 @@ async function getWeather(input: { city: string }): Promise<{
     'windy',
     'partly cloudy',
   ];
-  const condition = conditions[hash % conditions.length];
-  return { city: input.city, temperature, unit: 'fahrenheit', condition };
+  return {
+    city: input.city,
+    temperature,
+    unit: 'fahrenheit',
+    condition: conditions[hash % conditions.length],
+  };
 }
 
 async function calculate(input: {
@@ -41,11 +46,12 @@ async function calculate(input: {
 }): Promise<{ expression: string; result: number }> {
   'use step';
   const translated = input.expression.replace(/\s/g, '').replace(/\^/g, '**');
-  if (!/^[0-9+\-*/().]+$/.test(translated)) {
+  if (!/^[0-9+\-*/().]+$/.test(translated))
     throw new Error(`Invalid expression: ${input.expression}`);
-  }
-  const result = new Function(`return (${translated})`)() as number;
-  return { expression: input.expression, result };
+  return {
+    expression: input.expression,
+    result: new Function(`return (${translated})`)() as number,
+  };
 }
 
 async function deleteFileStep(input: {
@@ -57,33 +63,25 @@ async function deleteFileStep(input: {
 }
 
 // ============================================================================
-// Chat workflow
+// Tools and workflow
 // ============================================================================
 
 const tools = {
   getWeather: {
-    description:
-      'Get the current weather for a city. Returns temperature in Fahrenheit and conditions.',
-    inputSchema: z.object({
-      city: z.string().describe('The city name to get weather for'),
-    }),
+    description: 'Get the current weather for a city.',
+    inputSchema: z.object({ city: z.string().describe('The city name') }),
     execute: getWeather,
   },
   calculate: {
-    description:
-      'Evaluate a simple math expression. Supports +, -, *, /, and parentheses.',
+    description: 'Evaluate a math expression.',
     inputSchema: z.object({
-      expression: z
-        .string()
-        .describe('The math expression to evaluate, e.g. "2 + 3 * 4"'),
+      expression: z.string().describe('The expression'),
     }),
     execute: calculate,
   },
   deleteFile: {
     description: 'Delete a file from the filesystem.',
-    inputSchema: z.object({
-      path: z.string().describe('The file path to delete'),
-    }),
+    inputSchema: z.object({ path: z.string().describe('The file path') }),
     execute: deleteFileStep,
     needsApproval: true as const,
   },
@@ -93,28 +91,155 @@ const repairToolCall: ToolCallRepairFunction<typeof tools> = async ({
   toolCall,
 }) => {
   'use step';
-  console.log('Repairing tool call', { toolCall });
   return toolCall;
 };
+
+/**
+ * Map of tool names to their step execute functions.
+ * Used to execute approved tools in the workflow context.
+ */
+const toolExecutors: Record<string, (input: any) => Promise<any>> = {
+  getWeather,
+  calculate,
+  deleteFile: deleteFileStep,
+};
+
+/**
+ * Process approval responses in model messages.
+ * Executes approved tools via step functions, strips approval parts,
+ * and injects tool results into the conversation.
+ */
+async function processApprovals(
+  messages: ModelMessage[],
+): Promise<ModelMessage[]> {
+  // Find tool-approval-response parts
+  const approvalResponses: Array<{
+    approvalId: string;
+    approved: boolean;
+    reason?: string;
+  }> = [];
+  const approvalRequestMap = new Map<string, string>(); // approvalId → toolCallId
+  const toolCallMap = new Map<string, { toolName: string; input: unknown }>(); // toolCallId → toolCall
+
+  for (const msg of messages) {
+    if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+      for (const part of msg.content as any[]) {
+        if (part.type === 'tool-call') {
+          toolCallMap.set(part.toolCallId, {
+            toolName: part.toolName,
+            input: part.input ?? part.args,
+          });
+        }
+        if (part.type === 'tool-approval-request') {
+          approvalRequestMap.set(part.approvalId, part.toolCallId);
+        }
+      }
+    }
+    if (msg.role === 'tool') {
+      for (const part of msg.content as any[]) {
+        if (part.type === 'tool-approval-response') {
+          approvalResponses.push(part);
+        }
+      }
+    }
+  }
+
+  if (approvalResponses.length === 0) return messages;
+
+  // Execute approved tools and collect results
+  const toolResults: Array<{
+    toolCallId: string;
+    toolName: string;
+    output: any;
+  }> = [];
+  const denialResults: Array<{
+    toolCallId: string;
+    toolName: string;
+    reason?: string;
+  }> = [];
+
+  for (const response of approvalResponses) {
+    const toolCallId = approvalRequestMap.get(response.approvalId);
+    if (!toolCallId) continue;
+    const toolCall = toolCallMap.get(toolCallId);
+    if (!toolCall) continue;
+
+    if (response.approved) {
+      const executor = toolExecutors[toolCall.toolName];
+      if (executor) {
+        const result = await executor(toolCall.input);
+        toolResults.push({
+          toolCallId,
+          toolName: toolCall.toolName,
+          output: result,
+        });
+      }
+    } else {
+      denialResults.push({
+        toolCallId,
+        toolName: toolCall.toolName,
+        reason: response.reason,
+      });
+    }
+  }
+
+  // Rebuild messages: strip approval parts, add tool results
+  const cleanMessages: ModelMessage[] = [];
+  for (const msg of messages) {
+    if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+      const content = (msg.content as any[]).filter(
+        (p: any) => p.type !== 'tool-approval-request',
+      );
+      if (content.length > 0) cleanMessages.push({ ...msg, content });
+    } else if (msg.role === 'tool') {
+      const content = (msg.content as any[]).filter(
+        (p: any) => p.type !== 'tool-approval-response',
+      );
+      if (content.length > 0) cleanMessages.push({ ...msg, content });
+    } else {
+      cleanMessages.push(msg);
+    }
+  }
+
+  // Add tool results
+  const toolContent: any[] = [];
+  for (const tr of toolResults) {
+    const output =
+      typeof tr.output === 'string'
+        ? { type: 'text' as const, value: tr.output }
+        : { type: 'json' as const, value: tr.output };
+    toolContent.push({
+      type: 'tool-result',
+      toolCallId: tr.toolCallId,
+      toolName: tr.toolName,
+      output,
+    });
+  }
+  for (const dr of denialResults) {
+    toolContent.push({
+      type: 'tool-result',
+      toolCallId: dr.toolCallId,
+      toolName: dr.toolName,
+      output: {
+        type: 'error-text',
+        value: dr.reason ?? 'Tool execution denied.',
+      },
+    });
+  }
+  if (toolContent.length > 0) {
+    cleanMessages.push({ role: 'tool', content: toolContent });
+  }
+
+  return cleanMessages;
+}
 
 export async function chat(messages: UIMessage[]) {
   'use workflow';
 
   const modelMessages = await convertToModelMessages(messages);
 
-  // Debug: check for approval-related parts
-  for (const m of modelMessages) {
-    if (typeof m.content !== 'string' && m.content) {
-      for (const p of m.content) {
-        if (
-          p.type === 'tool-approval-request' ||
-          p.type === 'tool-approval-response'
-        ) {
-          console.log('[chat] approval part found:', JSON.stringify(p));
-        }
-      }
-    }
-  }
+  // Process any pending approvals before running the agent
+  const processedMessages = await processApprovals(modelMessages);
 
   const agent = new WorkflowAgent({
     model: anthropic('claude-sonnet-4-20250514'),
@@ -124,7 +249,7 @@ export async function chat(messages: UIMessage[]) {
   });
 
   const result = await agent.stream({
-    messages: modelMessages,
+    messages: processedMessages,
     writable: getWritable<ModelCallStreamPart>(),
     experimental_repairToolCall: repairToolCall as any,
   });

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -19,12 +19,11 @@ async function getWeather(input: { city: string }): Promise<{
   condition: string;
 }> {
   'use step';
-  // Fake weather data based on city name
   const hash = input.city
     .toLowerCase()
     .split('')
     .reduce((acc, c) => acc + c.charCodeAt(0), 0);
-  const temperature = 40 + (hash % 60); // 40-99°F
+  const temperature = 40 + (hash % 60);
   const conditions = [
     'sunny',
     'cloudy',
@@ -41,7 +40,6 @@ async function calculate(input: {
   expression: string;
 }): Promise<{ expression: string; result: number }> {
   'use step';
-  // Only allow numbers, operators, parentheses, and whitespace
   const translated = input.expression.replace(/\s/g, '').replace(/\^/g, '**');
   if (!/^[0-9+\-*/().]+$/.test(translated)) {
     throw new Error(`Invalid expression: ${input.expression}`);
@@ -50,8 +48,16 @@ async function calculate(input: {
   return { expression: input.expression, result };
 }
 
+async function deleteFileStep(input: {
+  path: string;
+}): Promise<{ deleted: string }> {
+  'use step';
+  console.log('[deleteFile] Deleting:', input.path);
+  return { deleted: input.path };
+}
+
 // ============================================================================
-// Chat workflow — orchestrates the WorkflowAgent
+// Chat workflow
 // ============================================================================
 
 const tools = {
@@ -74,115 +80,90 @@ const tools = {
     execute: calculate,
   },
   deleteFile: {
-    description: 'Delete a file from the filesystem. Always requires approval.',
+    description: 'Delete a file from the filesystem.',
     inputSchema: z.object({
       path: z.string().describe('The file path to delete'),
     }),
-    execute: async (input: { path: string }) => {
-      'use step';
-      console.log('[deleteFile] Would delete:', input.path);
-      return { deleted: input.path };
-    },
+    execute: deleteFileStep,
     needsApproval: true as const,
   },
-  sendEmail: {
-    description:
-      'Send an email. Requires approval only for external recipients.',
-    inputSchema: z.object({
-      to: z.string().describe('Email recipient'),
-      subject: z.string().describe('Email subject'),
-    }),
-    execute: async (input: { to: string; subject: string }) => {
-      'use step';
-      console.log('[sendEmail] Would send to:', input.to);
-      return { sent: true, to: input.to, subject: input.subject };
-    },
-    needsApproval: async (input: { to: string; subject: string }) => {
-      const isExternal = !input.to.endsWith('@company.com');
-      console.log(
-        '[sendEmail needsApproval]',
-        input.to,
-        isExternal ? '→ needs approval' : '→ auto-approved',
-      );
-      return isExternal;
-    },
-  },
 };
+
 const repairToolCall: ToolCallRepairFunction<typeof tools> = async ({
   toolCall,
 }) => {
   'use step';
-
   console.log('Repairing tool call', { toolCall });
-
   return toolCall;
 };
+
+/**
+ * Patch UIMessages to add placeholder tool results for any unresolved
+ * tool calls. This prevents AI_MissingToolResultsError when the user
+ * approves/denies a tool that was paused by needsApproval.
+ */
+function patchUnresolvedToolCalls(messages: UIMessage[]): UIMessage[] {
+  // Collect all tool call IDs and tool result IDs
+  const toolCallIds = new Set<string>();
+  const toolResultIds = new Set<string>();
+
+  for (const msg of messages) {
+    for (const part of msg.parts) {
+      const p = part as any;
+      if (
+        p.type?.startsWith('tool-') &&
+        p.toolCallId &&
+        p.state !== undefined
+      ) {
+        toolCallIds.add(p.toolCallId);
+        if (p.state === 'output-available') {
+          toolResultIds.add(p.toolCallId);
+        }
+      }
+    }
+  }
+
+  // Find unresolved tool calls
+  const unresolvedIds = [...toolCallIds].filter(id => !toolResultIds.has(id));
+  if (unresolvedIds.length === 0) return messages;
+
+  // Strip assistant messages that contain only unresolved tool calls
+  return messages.filter(msg => {
+    if (msg.role !== 'assistant') return true;
+    const hasOnlyUnresolvedTools = msg.parts.every(part => {
+      const p = part as any;
+      if (p.type?.startsWith('tool-') && p.toolCallId) {
+        return unresolvedIds.includes(p.toolCallId);
+      }
+      // Keep step-start and other non-content parts
+      return p.type === 'step-start';
+    });
+    return !hasOnlyUnresolvedTools;
+  });
+}
 
 export async function chat(messages: UIMessage[]) {
   'use workflow';
 
-  const modelMessages = await convertToModelMessages(messages);
+  const patchedMessages = patchUnresolvedToolCalls(messages);
+  const modelMessages = await convertToModelMessages(patchedMessages);
 
   const agent = new WorkflowAgent({
     model: anthropic('claude-sonnet-4-20250514'),
     instructions:
-      'You are a helpful assistant with access to weather and calculator tools. Use them when the user asks about weather in a city or needs math calculations. Keep responses concise.',
+      'You are a helpful assistant with access to weather, calculator, and file deletion tools. Always use the appropriate tool when the user asks to perform an action — never just say you will do it, actually call the tool. Keep responses concise.',
     tools,
-    prepareCall: async options => {
-      console.log('[prepareCall]', {
-        model: typeof options.model === 'string' ? options.model : 'factory',
-        messageCount: options.messages.length,
-        hasTools: Object.keys(options.tools).length > 0,
-      });
-      return options;
-    },
-    onStepFinish: async stepResult => {
-      console.log('[agent-chat] step finished:', {
-        finishReason: stepResult.finishReason,
-        text: stepResult.text?.slice(0, 100),
-      });
-    },
-    onFinish: async event => {
-      console.log('[agent-chat] finished:', {
-        finishReason: event.finishReason,
-        steps: event.steps.length,
-      });
-    },
-    experimental_onStart: async ({ model, messages }) => {
-      console.log('[onStart]', {
-        model: typeof model === 'string' ? model : 'factory',
-        messageCount: messages.length,
-      });
-    },
-    experimental_onStepStart: async ({ stepNumber, model }) => {
-      console.log('[onStepStart]', {
-        stepNumber,
-        model: typeof model === 'string' ? model : 'factory',
-      });
-    },
-    experimental_onToolCallStart: async ({ toolCall }) => {
-      console.log('[onToolCallStart]', {
-        toolName: toolCall.toolName,
-        toolCallId: toolCall.toolCallId,
-      });
-    },
-    experimental_onToolCallFinish: async ({ toolCall, result, error }) => {
-      console.log('[onToolCallFinish]', {
-        toolName: toolCall.toolName,
-        result: result !== undefined ? 'ok' : 'n/a',
-        error: error !== undefined,
-      });
-    },
   });
 
-  // WorkflowAgent streams ModelCallStreamPart chunks to the writable
-  // in real-time. The route handler converts to UIMessageChunks at the
-  // response boundary using createUIMessageChunkTransform().
   const result = await agent.stream({
     messages: modelMessages,
     writable: getWritable<ModelCallStreamPart>(),
     experimental_repairToolCall: repairToolCall as any,
   });
 
-  return { messages: result.messages };
+  return {
+    messages: result.messages,
+    toolCalls: result.toolCalls,
+    toolResults: result.toolResults,
+  };
 }

--- a/packages/ai/internal/index.ts
+++ b/packages/ai/internal/index.ts
@@ -12,4 +12,3 @@ export { asLanguageModelUsage } from '../src/types/usage';
 export { resolveLanguageModel } from '../src/model/resolve-model';
 export { mergeAbortSignals } from '../src/util/merge-abort-signals';
 export { mergeCallbacks } from '../src/agent/merge-callbacks';
-export { collectToolApprovals } from '../src/generate-text/collect-tool-approvals';

--- a/packages/ai/internal/index.ts
+++ b/packages/ai/internal/index.ts
@@ -12,7 +12,4 @@ export { asLanguageModelUsage } from '../src/types/usage';
 export { resolveLanguageModel } from '../src/model/resolve-model';
 export { mergeAbortSignals } from '../src/util/merge-abort-signals';
 export { mergeCallbacks } from '../src/agent/merge-callbacks';
-export {
-  collectToolApprovals,
-  type CollectedToolApprovals,
-} from '../src/generate-text/collect-tool-approvals';
+export { collectToolApprovals } from '../src/generate-text/collect-tool-approvals';

--- a/packages/ai/internal/index.ts
+++ b/packages/ai/internal/index.ts
@@ -12,3 +12,7 @@ export { asLanguageModelUsage } from '../src/types/usage';
 export { resolveLanguageModel } from '../src/model/resolve-model';
 export { mergeAbortSignals } from '../src/util/merge-abort-signals';
 export { mergeCallbacks } from '../src/agent/merge-callbacks';
+export {
+  collectToolApprovals,
+  type CollectedToolApprovals,
+} from '../src/generate-text/collect-tool-approvals';

--- a/packages/workflow/src/to-ui-message-chunk.ts
+++ b/packages/workflow/src/to-ui-message-chunk.ts
@@ -183,7 +183,11 @@ export function toUIMessageChunk(
       return undefined;
 
     default: {
-      // Pass through tool-approval-request and other chunks as-is
+      // Pass through tool-approval-request, step boundaries, and other
+      // chunks as-is. Step boundaries (finish-step/start-step) are not
+      // standard ModelCallStreamPart types but are written by the
+      // WorkflowAgent between tool execution and the next model step
+      // to ensure proper message splitting in convertToModelMessages.
       const p = part as any;
       if (p.type === 'tool-approval-request') {
         return {
@@ -191,6 +195,13 @@ export function toUIMessageChunk(
           approvalId: p.approvalId,
           toolCallId: p.toolCallId,
         } as UIMessageChunk;
+      }
+      if (
+        p.type === 'finish-step' ||
+        p.type === 'start-step' ||
+        p.type === 'tool-output-denied'
+      ) {
+        return p as UIMessageChunk;
       }
       return undefined;
     }

--- a/packages/workflow/src/to-ui-message-chunk.ts
+++ b/packages/workflow/src/to-ui-message-chunk.ts
@@ -1,4 +1,4 @@
-import { generateId, type ToolSet, type UIMessageChunk } from 'ai';
+import { type ToolSet, type UIMessageChunk } from 'ai';
 import type { Experimental_ModelCallStreamPart as ModelCallStreamPart } from 'ai';
 
 /**
@@ -207,7 +207,7 @@ export function createModelCallToUIChunkTransform(): TransformStream<
 > {
   return new TransformStream<ModelCallStreamPart<ToolSet>, UIMessageChunk>({
     start: controller => {
-      controller.enqueue({ type: 'start', messageId: generateId() });
+      controller.enqueue({ type: 'start' });
       controller.enqueue({ type: 'start-step' });
     },
     flush: controller => {

--- a/packages/workflow/src/to-ui-message-chunk.ts
+++ b/packages/workflow/src/to-ui-message-chunk.ts
@@ -182,8 +182,18 @@ export function toUIMessageChunk(
     case 'raw':
       return undefined;
 
-    default:
+    default: {
+      // Pass through tool-approval-request and other chunks as-is
+      const p = part as any;
+      if (p.type === 'tool-approval-request') {
+        return {
+          type: 'tool-approval-request',
+          approvalId: p.approvalId,
+          toolCallId: p.toolCallId,
+        } as UIMessageChunk;
+      }
       return undefined;
+    }
   }
 }
 

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -1478,10 +1478,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
 
   describe('tool approval', () => {
     describe('stream', () => {
-      it.fails('should pause agent when tool has needsApproval: true', async () => {
-        // GAP: WorkflowAgent does not support tool approval.
-        // When a tool has needsApproval: true, the agent should pause
-        // and emit a tool-approval-request before executing the tool.
+      it('should pause agent when tool has needsApproval: true', async () => {
         const agent = new WorkflowAgent({
           model: asModelFactory(createToolCallStreamMockModel()),
           tools: {
@@ -1509,9 +1506,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         expect(result.toolResults.length).toBe(0);
       });
 
-      it.fails('should support needsApproval as a function', async () => {
-        // GAP: needsApproval can be a function that receives the tool input
-        // and returns a boolean (or promise of boolean).
+      it('should support needsApproval as a function', async () => {
         let approvalInput: any = null;
 
         const agent = new WorkflowAgent({

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -2356,4 +2356,197 @@ describe('WorkflowAgent', () => {
       expect(Array.isArray(result.uiMessages)).toBe(true);
     });
   */
+
+  describe('tool approval resumption', () => {
+    it('should execute approved tools and continue with results', async () => {
+      const toolResult = { city: 'London', temperature: 72 };
+      const executeFn = vi.fn().mockResolvedValue(toolResult);
+      const tools: ToolSet = {
+        getWeather: {
+          description: 'Get weather',
+          inputSchema: z.object({ city: z.string() }),
+          execute: executeFn,
+          needsApproval: true as const,
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      // Messages containing a tool call, approval request, and an approved response
+      await agent.stream({
+        messages: [
+          { role: 'user', content: "What's the weather in London?" },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'getWeather',
+                input: { city: 'London' },
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-call-1',
+                toolCallId: 'call-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: true,
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      // The tool should have been executed
+      expect(executeFn).toHaveBeenCalledTimes(1);
+      expect(executeFn).toHaveBeenCalledWith(
+        { city: 'London' },
+        expect.objectContaining({
+          toolCallId: 'call-1',
+        }),
+      );
+
+      // The streamTextIterator should have been called (the agent continues after approval)
+      expect(mockIterator.next).toHaveBeenCalled();
+    });
+
+    it('should create denial results for denied tools and continue', async () => {
+      const executeFn = vi.fn();
+      const tools: ToolSet = {
+        deleteFile: {
+          description: 'Delete a file',
+          inputSchema: z.object({ path: z.string() }),
+          execute: executeFn,
+          needsApproval: true as const,
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      // Messages containing a tool call, approval request, and a denied response
+      await agent.stream({
+        messages: [
+          { role: 'user', content: 'Delete /etc/passwd' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'deleteFile',
+                input: { path: '/etc/passwd' },
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-call-1',
+                toolCallId: 'call-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: false,
+                reason: 'Too dangerous',
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      // The tool should NOT have been executed
+      expect(executeFn).not.toHaveBeenCalled();
+
+      // The streamTextIterator should have been called (the agent continues with denial result)
+      expect(mockIterator.next).toHaveBeenCalled();
+    });
+
+    it('should pass through messages without approval responses unchanged', async () => {
+      const tools: ToolSet = {
+        getWeather: {
+          description: 'Get weather',
+          inputSchema: z.object({ city: z.string() }),
+          execute: async () => ({ temperature: 72 }),
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      // Normal messages without any approval parts
+      await agent.stream({
+        messages: [{ role: 'user', content: 'Hello' }],
+        writable: mockWritable,
+      });
+
+      // Should proceed normally without any approval processing
+      expect(mockIterator.next).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1284,22 +1284,45 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
           );
           const providerToolCalls = toolCalls.filter(tc => tc.providerExecuted);
 
-          // Further split non-provider tool calls into executable (has execute function)
-          // and client-side (no execute function, needs external resolution)
-          // Note: missing tools (!tool) are left to executeTool which will throw —
-          // only tools that exist but lack execute are treated as client-side.
-          const executableToolCalls = nonProviderToolCalls.filter(tc => {
+          // Check which tools need approval (can be async)
+          const approvalNeeded = await Promise.all(
+            nonProviderToolCalls.map(async tc => {
+              const tool = (effectiveTools as ToolSet)[tc.toolName];
+              if (!tool) return false;
+              if (tool.needsApproval == null) return false;
+              if (typeof tool.needsApproval === 'boolean')
+                return tool.needsApproval;
+              return tool.needsApproval(tc.input, {
+                toolCallId: tc.toolCallId,
+                messages: iterMessages as unknown as ModelMessage[],
+                experimental_context: experimentalContext,
+              });
+            }),
+          );
+
+          // Further split non-provider tool calls into:
+          // - executable: has execute function and doesn't need approval
+          // - paused: no execute function (client-side) OR needs approval
+          // Note: missing tools (!tool) are left to executeTool which will throw.
+          const executableToolCalls = nonProviderToolCalls.filter((tc, i) => {
             const tool = (effectiveTools as ToolSet)[tc.toolName];
-            return !tool || typeof tool.execute === 'function';
+            return (
+              (!tool || typeof tool.execute === 'function') &&
+              !approvalNeeded[i]
+            );
           });
-          const clientSideToolCalls = nonProviderToolCalls.filter(tc => {
+          const pausedToolCalls = nonProviderToolCalls.filter((tc, i) => {
             const tool = (effectiveTools as ToolSet)[tc.toolName];
-            return tool && typeof tool.execute !== 'function';
+            return (
+              (tool && typeof tool.execute !== 'function') || approvalNeeded[i]
+            );
           });
 
-          // If there are client-side tool calls, stop the loop and return them
-          // This matches AI SDK behavior: tools without execute pause the agent loop
-          if (clientSideToolCalls.length > 0) {
+          // If there are paused tool calls (client-side or needing approval),
+          // stop the loop and return them.
+          // This matches AI SDK behavior: tools without execute or needing
+          // approval pause the agent loop.
+          if (pausedToolCalls.length > 0) {
             // Execute any executable tools that were also called in this step
             const executableResults = await Promise.all(
               executableToolCalls.map(

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1295,7 +1295,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
               return tool.needsApproval(tc.input, {
                 toolCallId: tc.toolCallId,
                 messages: iterMessages as unknown as ModelMessage[],
-                experimental_context: experimentalContext,
+                context: experimentalContext,
               });
             }),
           );

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1139,6 +1139,30 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       }
 
       prompt.messages = cleanedMessages;
+
+      // Write tool results and step boundaries to the stream so the UI
+      // can transition approved/denied tool parts to the correct state
+      // and properly separate them from the subsequent model step.
+      if (options.writable && toolResultContent.length > 0) {
+        const approvedResults = toolResultContent
+          .filter(r => r.output.type !== 'execution-denied')
+          .map(r => ({
+            toolCallId: r.toolCallId,
+            toolName: r.toolName,
+            input: approvedToolApprovals.find(
+              a => a.toolCallId === r.toolCallId,
+            )?.input,
+            output: 'value' in r.output ? r.output.value : undefined,
+          }));
+        const deniedResults = toolResultContent
+          .filter(r => r.output.type === 'execution-denied')
+          .map(r => ({ toolCallId: r.toolCallId }));
+        await writeApprovalToolResults(
+          options.writable,
+          approvedResults,
+          deniedResults,
+        );
+      }
     }
 
     const modelPrompt = await convertToLanguageModelPrompt({
@@ -1562,6 +1586,22 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
             };
           });
 
+          // Write tool results and step boundaries to the stream so the
+          // UI can transition tool parts to output-available state and
+          // properly separate multi-step model calls in the message history.
+          if (options.writable) {
+            await writeToolResultsWithStepBoundary(
+              options.writable,
+              toolResults.map(r => ({
+                toolCallId: r.toolCallId,
+                toolName: r.toolName,
+                input: toolCalls.find(tc => tc.toolCallId === r.toolCallId)
+                  ?.input,
+                output: 'value' in r.output ? r.output.value : undefined,
+              })),
+            );
+          }
+
           // Track the tool calls and results for this step
           lastStepToolCalls = toolCalls.map(tc => ({
             type: 'tool-call' as const,
@@ -1729,6 +1769,73 @@ async function writeApprovalRequests(
         toolCallId: tc.toolCallId,
       });
     }
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+async function writeToolResultsWithStepBoundary(
+  writable: WritableStream<any>,
+  results: Array<{
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+    output: unknown;
+  }>,
+) {
+  'use step';
+  const writer = writable.getWriter();
+  try {
+    for (const r of results) {
+      await writer.write({
+        type: 'tool-result',
+        toolCallId: r.toolCallId,
+        toolName: r.toolName,
+        input: r.input,
+        output: r.output,
+      });
+    }
+    // Emit step boundaries so the UI message history properly separates
+    // the tool call step from the subsequent text step. This ensures
+    // convertToModelMessages creates separate assistant messages for
+    // tool calls and text responses.
+    await writer.write({ type: 'finish-step' });
+    await writer.write({ type: 'start-step' });
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+async function writeApprovalToolResults(
+  writable: WritableStream<any>,
+  approvedResults: Array<{
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+    output: unknown;
+  }>,
+  deniedResults: Array<{ toolCallId: string }>,
+) {
+  'use step';
+  const writer = writable.getWriter();
+  try {
+    for (const r of approvedResults) {
+      await writer.write({
+        type: 'tool-result',
+        toolCallId: r.toolCallId,
+        toolName: r.toolName,
+        input: r.input,
+        output: r.output,
+      });
+    }
+    for (const r of deniedResults) {
+      await writer.write({
+        type: 'tool-output-denied',
+        toolCallId: r.toolCallId,
+      });
+    }
+    await writer.write({ type: 'finish-step' });
+    await writer.write({ type: 'start-step' });
   } finally {
     writer.releaseLock();
   }

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -18,6 +18,8 @@ import {
   type StopCondition,
   type StreamTextOnStepFinishCallback,
   type SystemModelMessage,
+  type ToolApprovalRequest,
+  type ToolApprovalResponse,
   type ToolCallRepairFunction,
   type ToolChoice,
   type ToolSet,
@@ -1040,6 +1042,105 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       messages: effectiveMessages,
     });
 
+    // Process tool approval responses before starting the agent loop.
+    // This mirrors how stream-text.ts handles tool-approval-response parts:
+    // approved tools are executed, denied tools get denial results, and
+    // approval parts are stripped from the messages.
+    const { approvedToolApprovals, deniedToolApprovals } =
+      collectToolApprovalsFromMessages(prompt.messages);
+
+    if (approvedToolApprovals.length > 0 || deniedToolApprovals.length > 0) {
+      const toolResultMessages: ModelMessage[] = [];
+      const toolResultContent: Array<{
+        type: 'tool-result';
+        toolCallId: string;
+        toolName: string;
+        output:
+          | { type: 'text'; value: string }
+          | { type: 'json'; value: JSONValue }
+          | { type: 'execution-denied'; reason: string | undefined };
+      }> = [];
+
+      // Execute approved tools
+      for (const approval of approvedToolApprovals) {
+        const tool = (this.tools as ToolSet)[approval.toolName];
+        if (tool && typeof tool.execute === 'function') {
+          try {
+            const { execute } = tool;
+            const toolResult = await execute(approval.input, {
+              toolCallId: approval.toolCallId,
+              messages: [],
+              context: effectiveExperimentalContext,
+            });
+            toolResultContent.push({
+              type: 'tool-result' as const,
+              toolCallId: approval.toolCallId,
+              toolName: approval.toolName,
+              output:
+                typeof toolResult === 'string'
+                  ? { type: 'text' as const, value: toolResult }
+                  : { type: 'json' as const, value: toolResult },
+            });
+          } catch (error) {
+            toolResultContent.push({
+              type: 'tool-result' as const,
+              toolCallId: approval.toolCallId,
+              toolName: approval.toolName,
+              output: {
+                type: 'text' as const,
+                value: getErrorMessage(error),
+              },
+            });
+          }
+        }
+      }
+
+      // Create denial results for denied tools
+      for (const denial of deniedToolApprovals) {
+        toolResultContent.push({
+          type: 'tool-result' as const,
+          toolCallId: denial.toolCallId,
+          toolName: denial.toolName,
+          output: {
+            type: 'execution-denied' as const,
+            reason: denial.reason,
+          },
+        });
+      }
+
+      // Strip approval parts from messages and inject tool results
+      const cleanedMessages: ModelMessage[] = [];
+      for (const msg of prompt.messages) {
+        if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+          const filtered = (msg.content as any[]).filter(
+            (p: any) => p.type !== 'tool-approval-request',
+          );
+          if (filtered.length > 0) {
+            cleanedMessages.push({ ...msg, content: filtered });
+          }
+        } else if (msg.role === 'tool') {
+          const filtered = (msg.content as any[]).filter(
+            (p: any) => p.type !== 'tool-approval-response',
+          );
+          if (filtered.length > 0) {
+            cleanedMessages.push({ ...msg, content: filtered });
+          }
+        } else {
+          cleanedMessages.push(msg);
+        }
+      }
+
+      // Add tool results as a new tool message
+      if (toolResultContent.length > 0) {
+        cleanedMessages.push({
+          role: 'tool',
+          content: toolResultContent,
+        } as ModelMessage);
+      }
+
+      prompt.messages = cleanedMessages;
+    }
+
     const modelPrompt = await convertToLanguageModelPrompt({
       prompt,
       supportedUrls: {},
@@ -1795,4 +1896,114 @@ async function executeTool(
       },
     };
   }
+}
+
+/**
+ * Collected tool approval information for a single tool call.
+ */
+interface CollectedApproval {
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  approvalId: string;
+  reason?: string;
+}
+
+/**
+ * Collect tool approval responses from model messages.
+ * Mirrors the logic from `collectToolApprovals` in the AI SDK core
+ * (`packages/ai/src/generate-text/collect-tool-approvals.ts`).
+ *
+ * Scans the last tool message for `tool-approval-response` parts,
+ * matches them with `tool-approval-request` parts in assistant messages
+ * and the corresponding `tool-call` parts.
+ */
+function collectToolApprovalsFromMessages(messages: ModelMessage[]): {
+  approvedToolApprovals: CollectedApproval[];
+  deniedToolApprovals: CollectedApproval[];
+} {
+  const lastMessage = messages.at(-1);
+
+  if (lastMessage?.role !== 'tool') {
+    return { approvedToolApprovals: [], deniedToolApprovals: [] };
+  }
+
+  // Gather tool calls from assistant messages
+  const toolCallsByToolCallId: Record<
+    string,
+    { toolName: string; input: unknown }
+  > = {};
+  for (const message of messages) {
+    if (message.role === 'assistant' && Array.isArray(message.content)) {
+      for (const part of message.content as any[]) {
+        if (part.type === 'tool-call') {
+          toolCallsByToolCallId[part.toolCallId] = {
+            toolName: part.toolName,
+            input: part.input ?? part.args,
+          };
+        }
+      }
+    }
+  }
+
+  // Gather approval requests from assistant messages
+  const approvalRequestsByApprovalId: Record<
+    string,
+    { approvalId: string; toolCallId: string }
+  > = {};
+  for (const message of messages) {
+    if (message.role === 'assistant' && Array.isArray(message.content)) {
+      for (const part of message.content as any[]) {
+        if (part.type === 'tool-approval-request') {
+          approvalRequestsByApprovalId[part.approvalId] = {
+            approvalId: part.approvalId,
+            toolCallId: part.toolCallId,
+          };
+        }
+      }
+    }
+  }
+
+  // Gather existing tool results to avoid re-executing
+  const existingToolResults = new Set<string>();
+  for (const part of lastMessage.content as any[]) {
+    if (part.type === 'tool-result') {
+      existingToolResults.add(part.toolCallId);
+    }
+  }
+
+  const approvedToolApprovals: CollectedApproval[] = [];
+  const deniedToolApprovals: CollectedApproval[] = [];
+
+  // Collect approval responses from the last tool message
+  const approvalResponses = (lastMessage.content as any[]).filter(
+    (part: any) => part.type === 'tool-approval-response',
+  );
+
+  for (const response of approvalResponses) {
+    const approvalRequest = approvalRequestsByApprovalId[response.approvalId];
+    if (approvalRequest == null) continue;
+
+    // Skip if there's already a tool result for this tool call
+    if (existingToolResults.has(approvalRequest.toolCallId)) continue;
+
+    const toolCall = toolCallsByToolCallId[approvalRequest.toolCallId];
+    if (toolCall == null) continue;
+
+    const approval: CollectedApproval = {
+      toolCallId: approvalRequest.toolCallId,
+      toolName: toolCall.toolName,
+      input: toolCall.input,
+      approvalId: response.approvalId,
+      reason: response.reason,
+    };
+
+    if (response.approved) {
+      approvedToolApprovals.push(approval);
+    } else {
+      deniedToolApprovals.push(approval);
+    }
+  }
+
+  return { approvedToolApprovals, deniedToolApprovals };
 }

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -8,6 +8,7 @@ import type {
 } from '@ai-sdk/provider';
 import {
   asSchema,
+  convertToModelMessages,
   type Experimental_ModelCallStreamPart as ModelCallStreamPart,
   type FinishReason,
   type LanguageModelResponseMetadata,
@@ -24,11 +25,12 @@ import {
   type UIMessage,
 } from 'ai';
 import {
+  collectToolApprovals,
   convertToLanguageModelPrompt,
   mergeAbortSignals,
+  mergeCallbacks,
   standardizePrompt,
 } from 'ai/internal';
-import { mergeCallbacks } from 'ai/internal';
 import { recordSpan } from './telemetry.js';
 import { streamTextIterator } from './stream-text-iterator.js';
 import type { CompatibleLanguageModel } from './types.js';
@@ -1035,6 +1037,64 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
         effectiveGenerationSettings.providerOptions = prepared.providerOptions;
     }
 
+    // Handle tool approval responses from previous turns.
+    // convertToModelMessages transforms UIMessage approval parts into
+    // tool-approval-request / tool-approval-response ModelMessage parts.
+    // collectToolApprovals then finds these and tells us which tools to execute.
+    const modelMessagesForApproval = await convertToModelMessages(
+      effectiveMessages as UIMessage[],
+    );
+    const { approvedToolApprovals, deniedToolApprovals } = collectToolApprovals(
+      { messages: modelMessagesForApproval },
+    );
+
+    if (approvedToolApprovals.length > 0 || deniedToolApprovals.length > 0) {
+      const toolContent: Array<any> = [];
+
+      for (const approval of approvedToolApprovals) {
+        const tool = (this.tools as ToolSet)[approval.toolCall.toolName];
+        if (tool && typeof tool.execute === 'function') {
+          const { execute } = tool;
+          const result = await execute(approval.toolCall.input, {
+            toolCallId: approval.toolCall.toolCallId,
+            messages: modelMessagesForApproval,
+            experimental_context:
+              options.experimental_context ?? this.experimentalContext,
+          });
+          const output =
+            typeof result === 'string'
+              ? { type: 'text' as const, value: result }
+              : { type: 'json' as const, value: result };
+          toolContent.push({
+            type: 'tool-result' as const,
+            toolCallId: approval.toolCall.toolCallId,
+            toolName: approval.toolCall.toolName,
+            output,
+          });
+        }
+      }
+
+      for (const denial of deniedToolApprovals) {
+        toolContent.push({
+          type: 'tool-result' as const,
+          toolCallId: denial.toolCall.toolCallId,
+          toolName: denial.toolCall.toolName,
+          output: {
+            type: 'error-text' as const,
+            value: denial.approvalResponse.reason ?? 'Tool execution denied.',
+          },
+        });
+      }
+
+      if (toolContent.length > 0) {
+        // Append tool results to the model messages and use those directly
+        effectiveMessages = [
+          ...modelMessagesForApproval,
+          { role: 'tool', content: toolContent },
+        ] as any;
+      }
+    }
+
     const prompt = await standardizePrompt({
       system: effectiveInstructions,
       messages: effectiveMessages,
@@ -1385,6 +1445,26 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
               });
             }
 
+            // Emit tool-approval-request chunks for tools that need approval
+            // so useChat can show the approval UI
+            if (options.writable) {
+              const approvalToolCalls = pausedToolCalls.filter((_, i) => {
+                const tcIndex = nonProviderToolCalls.indexOf(
+                  pausedToolCalls[i],
+                );
+                return approvalNeeded[tcIndex];
+              });
+              if (approvalToolCalls.length > 0) {
+                await writeApprovalRequests(
+                  options.writable,
+                  approvalToolCalls.map(tc => ({
+                    toolCallId: tc.toolCallId,
+                    toolName: tc.toolName,
+                  })),
+                );
+              }
+            }
+
             // Close the stream before returning for paused tools
             if (options.writable) {
               const sendFinish = options.sendFinish ?? true;
@@ -1587,6 +1667,29 @@ async function closeStream(
   }
   if (!preventClose) {
     await writable.close();
+  }
+}
+
+/**
+ * Write tool-approval-request chunks to the writable stream.
+ * These are consumed by useChat to show the approval UI.
+ */
+async function writeApprovalRequests(
+  writable: WritableStream<any>,
+  toolCalls: Array<{ toolCallId: string; toolName: string }>,
+) {
+  'use step';
+  const writer = writable.getWriter();
+  try {
+    for (const tc of toolCalls) {
+      await writer.write({
+        type: 'tool-approval-request',
+        approvalId: `approval-${tc.toolCallId}`,
+        toolCallId: tc.toolCallId,
+      });
+    }
+  } finally {
+    writer.releaseLock();
   }
 }
 

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -24,7 +24,6 @@ import {
   type UIMessage,
 } from 'ai';
 import {
-  collectToolApprovals,
   convertToLanguageModelPrompt,
   mergeAbortSignals,
   mergeCallbacks,
@@ -1034,85 +1033,6 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
         effectiveGenerationSettings.headers = prepared.headers;
       if (prepared.providerOptions !== undefined)
         effectiveGenerationSettings.providerOptions = prepared.providerOptions;
-    }
-
-    // Handle tool approval responses from previous turns.
-    // Messages are already ModelMessage[] (converted by the workflow function).
-    // collectToolApprovals scans for tool-approval-response parts in the
-    // last tool message and matches them with tool-approval-request parts
-    // in assistant messages.
-    const { approvedToolApprovals, deniedToolApprovals } = collectToolApprovals(
-      { messages: effectiveMessages as unknown as ModelMessage[] },
-    );
-
-    if (approvedToolApprovals.length > 0 || deniedToolApprovals.length > 0) {
-      const toolContent: Array<any> = [];
-
-      for (const approval of approvedToolApprovals) {
-        const tool = (this.tools as ToolSet)[approval.toolCall.toolName];
-        if (tool && typeof tool.execute === 'function') {
-          const { execute } = tool;
-          const result = await execute(approval.toolCall.input, {
-            toolCallId: approval.toolCall.toolCallId,
-            messages: effectiveMessages as unknown as ModelMessage[],
-            experimental_context:
-              options.experimental_context ?? this.experimentalContext,
-          });
-          const output =
-            typeof result === 'string'
-              ? { type: 'text' as const, value: result }
-              : { type: 'json' as const, value: result };
-          toolContent.push({
-            type: 'tool-result' as const,
-            toolCallId: approval.toolCall.toolCallId,
-            toolName: approval.toolCall.toolName,
-            output,
-          });
-        }
-      }
-
-      for (const denial of deniedToolApprovals) {
-        toolContent.push({
-          type: 'tool-result' as const,
-          toolCallId: denial.toolCall.toolCallId,
-          toolName: denial.toolCall.toolName,
-          output: {
-            type: 'error-text' as const,
-            value: denial.approvalResponse.reason ?? 'Tool execution denied.',
-          },
-        });
-      }
-
-      if (toolContent.length > 0) {
-        // Rebuild messages: strip approval-related parts from assistant and tool
-        // messages, replace with clean tool-call + tool-result pairs
-        const msgs: ModelMessage[] = [];
-        for (const m of effectiveMessages as unknown as ModelMessage[]) {
-          if (m.role === 'assistant' && typeof m.content !== 'string') {
-            // Keep tool-call parts, strip approval-request parts
-            const content = m.content.filter(
-              (p: any) => p.type !== 'tool-approval-request',
-            );
-            if (content.length > 0) {
-              msgs.push({ ...m, content });
-            }
-          } else if (m.role === 'tool') {
-            // Strip approval-response parts from tool messages
-            const content = (m.content as any[]).filter(
-              (p: any) => p.type !== 'tool-approval-response',
-            );
-            if (content.length > 0) {
-              msgs.push({ ...m, content });
-            }
-            // Skip empty tool messages (only had approval responses)
-          } else {
-            msgs.push(m);
-          }
-        }
-        // Append the actual tool results
-        msgs.push({ role: 'tool' as const, content: toolContent });
-        effectiveMessages = msgs as any;
-      }
     }
 
     const prompt = await standardizePrompt({

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -8,7 +8,6 @@ import type {
 } from '@ai-sdk/provider';
 import {
   asSchema,
-  convertToModelMessages,
   type Experimental_ModelCallStreamPart as ModelCallStreamPart,
   type FinishReason,
   type LanguageModelResponseMetadata,
@@ -1038,14 +1037,12 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
     }
 
     // Handle tool approval responses from previous turns.
-    // convertToModelMessages transforms UIMessage approval parts into
-    // tool-approval-request / tool-approval-response ModelMessage parts.
-    // collectToolApprovals then finds these and tells us which tools to execute.
-    const modelMessagesForApproval = await convertToModelMessages(
-      effectiveMessages as UIMessage[],
-    );
+    // Messages are already ModelMessage[] (converted by the workflow function).
+    // collectToolApprovals scans for tool-approval-response parts in the
+    // last tool message and matches them with tool-approval-request parts
+    // in assistant messages.
     const { approvedToolApprovals, deniedToolApprovals } = collectToolApprovals(
-      { messages: modelMessagesForApproval },
+      { messages: effectiveMessages as unknown as ModelMessage[] },
     );
 
     if (approvedToolApprovals.length > 0 || deniedToolApprovals.length > 0) {
@@ -1057,7 +1054,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
           const { execute } = tool;
           const result = await execute(approval.toolCall.input, {
             toolCallId: approval.toolCall.toolCallId,
-            messages: modelMessagesForApproval,
+            messages: effectiveMessages as unknown as ModelMessage[],
             experimental_context:
               options.experimental_context ?? this.experimentalContext,
           });
@@ -1087,11 +1084,34 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       }
 
       if (toolContent.length > 0) {
-        // Append tool results to the model messages and use those directly
-        effectiveMessages = [
-          ...modelMessagesForApproval,
-          { role: 'tool', content: toolContent },
-        ] as any;
+        // Rebuild messages: strip approval-related parts from assistant and tool
+        // messages, replace with clean tool-call + tool-result pairs
+        const msgs: ModelMessage[] = [];
+        for (const m of effectiveMessages as unknown as ModelMessage[]) {
+          if (m.role === 'assistant' && typeof m.content !== 'string') {
+            // Keep tool-call parts, strip approval-request parts
+            const content = m.content.filter(
+              (p: any) => p.type !== 'tool-approval-request',
+            );
+            if (content.length > 0) {
+              msgs.push({ ...m, content });
+            }
+          } else if (m.role === 'tool') {
+            // Strip approval-response parts from tool messages
+            const content = (m.content as any[]).filter(
+              (p: any) => p.type !== 'tool-approval-response',
+            );
+            if (content.length > 0) {
+              msgs.push({ ...m, content });
+            }
+            // Skip empty tool messages (only had approval responses)
+          } else {
+            msgs.push(m);
+          }
+        }
+        // Append the actual tool results
+        msgs.push({ role: 'tool' as const, content: toolContent });
+        effectiveMessages = msgs as any;
       }
     }
 


### PR DESCRIPTION
## Background

Phase 3 of the ToolLoopAgent parity plan (see #12165). WorkflowAgent didn't support the `needsApproval` property on tools, which allows tools to require approval before execution.

## Summary

- Check `needsApproval` (boolean or async function) before executing each tool
- When approval is needed, pause the agent loop and return the unresolved tool call in `result.toolCalls` without executing it (no entry in `result.toolResults`)
- Uses the same pause mechanism as client-side tools (tools without `execute`)
- The `needsApproval` function receives tool input, `toolCallId`, `messages`, and `context` — matching the AI SDK's `ToolNeedsApprovalFunction` signature
- Handle tool approval **resumption** in `WorkflowAgent.stream()`: when input messages contain `tool-approval-response` parts, automatically execute approved tools and create denial results, matching ToolLoopAgent behavior
- Fix duplicate "approved — executing" UI message caused by `createModelCallToUIChunkTransform` generating a new `messageId` on each workflow run
- Convert 2 `it.fails()` tests to passing tests

## Manual Verification

- 76 tests pass, 5 expected fail
- Type check clean
- Build succeeds
- Tested approval flow end-to-end in `examples/next-workflow` — single "approved — executing" message, no duplication

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Part of #12165 (ToolLoopAgent parity plan, Phase 3)