### PR TITLE
fix(provider/google): fix Gemini service tier enum after upstream update

### DIFF
--- a/.changeset/cold-avocados-tap.md
+++ b/.changeset/cold-avocados-tap.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(provider/google): fix Gemini service tier enum after upstream update

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -245,11 +245,11 @@ The following optional provider options are available for Google Generative AI m
   Optional. Defines labels used in billing reports. Available on Vertex AI only.
   See [Google Cloud labels documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/add-labels-to-api-calls).
 
-- **serviceTier** _'SERVICE_TIER_STANDARD' | 'SERVICE_TIER_FLEX' | 'SERVICE_TIER_PRIORITY'_
+- **serviceTier** _'standard' | 'flex' | 'priority'_
 
   Optional. The service tier to use for the request.
-  Set to 'SERVICE_TIER_FLEX' for 50% cheaper processing at the cost of increased latency.
-  Set to 'SERVICE_TIER_PRIORITY' for ultra-low latency at a 75-100% price premium over 'SERVICE_TIER_STANDARD'.
+  Set to 'flex' for 50% cheaper processing at the cost of increased latency.
+  Set to 'priority' for ultra-low latency at a 75-100% price premium over 'standard'.
 
 - **threshold** _string_
 

--- a/examples/ai-functions/src/generate-text/google/service-tier.ts
+++ b/examples/ai-functions/src/generate-text/google/service-tier.ts
@@ -8,7 +8,7 @@ run(async () => {
     prompt: 'What color is the sky in one word?',
     providerOptions: {
       google: {
-        serviceTier: 'SERVICE_TIER_FLEX',
+        serviceTier: 'flex',
       } satisfies GoogleLanguageModelOptions,
     },
   });

--- a/examples/ai-functions/src/stream-text/google/service-tier.ts
+++ b/examples/ai-functions/src/stream-text/google/service-tier.ts
@@ -8,7 +8,7 @@ run(async () => {
     prompt: 'What color is the sky in one word?',
     providerOptions: {
       google: {
-        serviceTier: 'SERVICE_TIER_FLEX',
+        serviceTier: 'priority',
       } satisfies GoogleLanguageModelOptions,
     },
   });

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -582,13 +582,13 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
       providerOptions: {
         google: {
-          serviceTier: 'SERVICE_TIER_FLEX',
+          serviceTier: 'flex',
         },
       },
     });
 
     expect(await server.calls[0].requestBodyJson).toMatchObject({
-      serviceTier: 'SERVICE_TIER_FLEX',
+      serviceTier: 'flex',
     });
   });
 
@@ -622,7 +622,7 @@ describe('doGenerate', () => {
           candidatesTokenCount: 2,
           totalTokenCount: 3,
         },
-        serviceTier: 'SERVICE_TIER_FLEX',
+        serviceTier: 'flex',
       },
     };
 
@@ -630,7 +630,7 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(providerMetadata?.google.serviceTier).toBe('SERVICE_TIER_FLEX');
+    expect(providerMetadata?.google.serviceTier).toBe('flex');
   });
 
   it('should expose null serviceTier in provider metadata when not present', async () => {
@@ -4367,7 +4367,7 @@ describe('doStream', () => {
             candidatesTokenCount: 2,
             totalTokenCount: 3,
           },
-          serviceTier: 'SERVICE_TIER_FLEX',
+          serviceTier: 'flex',
         })}\n\n`,
       ],
     };
@@ -4382,7 +4382,7 @@ describe('doStream', () => {
     expect(
       finishEvent?.type === 'finish' &&
         finishEvent.providerMetadata?.google.serviceTier,
-    ).toBe('SERVICE_TIER_FLEX');
+    ).toBe('flex');
   });
 
   it('should expose null serviceTier in provider metadata on finish when not present', async () => {

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -192,13 +192,7 @@ export const googleLanguageModelOptions = lazySchema(() =>
       /**
        * Optional. The service tier to use for the request.
        */
-      serviceTier: z
-        .enum([
-          'SERVICE_TIER_STANDARD',
-          'SERVICE_TIER_FLEX',
-          'SERVICE_TIER_PRIORITY',
-        ])
-        .optional(),
+      serviceTier: z.enum(['standard', 'flex', 'priority']).optional(),
     }),
   ),
 );


### PR DESCRIPTION
## Background

Google updated their Gemini API to use lowercase service tier values (`standard`, `flex`, `priority`) instead of the previous uppercase prefixed format (`SERVICE_TIER_STANDARD`, `SERVICE_TIER_FLEX`, `SERVICE_TIER_PRIORITY`). The old values no longer work. See [googleapis/js-genai@9bdc2ae](https://github.com/googleapis/js-genai/commit/9bdc2ae519e7e34af48593b69093b703f3871f15).

Also outlined in their docs:
- https://ai.google.dev/gemini-api/docs/priority-inference
- https://ai.google.dev/gemini-api/docs/flex-inference

## Summary

- Updated the `serviceTier` provider option enum in google to accept `'standard' | 'flex' | 'priority'`
- Updated tests, examples, and documentation to reflect the new values

## Manual Verification

Ran the `generate-text` and `stream-text` service tier examples against the live Gemini API.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
