### PR TITLE
chore(groq): lazy-load chat response and chunk schemas

### DIFF
--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -12,6 +12,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
+  InferSchema,
   ParseResult,
   combineHeaders,
   createEventSourceResponseHandler,
@@ -19,9 +20,11 @@ import {
   generateId,
   isCustomReasoning,
   isParsableJson,
+  lazySchema,
   mapReasoningToProviderEffort,
   parseProviderOptions,
   postJsonToApi,
+  zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { convertGroqUsage } from './convert-groq-usage';
@@ -316,7 +319,7 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
     return {
       stream: response.pipeThrough(
         new TransformStream<
-          ParseResult<z.infer<typeof groqChatChunkSchema>>,
+          ParseResult<GroqChatChunk>,
           LanguageModelV4StreamPart
         >({
           start(controller) {
@@ -572,104 +575,116 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
 
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-const groqChatResponseSchema = z.object({
-  id: z.string().nullish(),
-  created: z.number().nullish(),
-  model: z.string().nullish(),
-  choices: z.array(
+const groqChatResponseSchema = lazySchema(() =>
+  zodSchema(
     z.object({
-      message: z.object({
-        content: z.string().nullish(),
-        reasoning: z.string().nullish(),
-        tool_calls: z
-          .array(
-            z.object({
-              id: z.string().nullish(),
-              type: z.literal('function'),
-              function: z.object({
-                name: z.string(),
-                arguments: z.string(),
-              }),
-            }),
-          )
-          .nullish(),
-      }),
-      index: z.number(),
-      finish_reason: z.string().nullish(),
-    }),
-  ),
-  usage: z
-    .object({
-      prompt_tokens: z.number().nullish(),
-      completion_tokens: z.number().nullish(),
-      total_tokens: z.number().nullish(),
-      prompt_tokens_details: z
-        .object({
-          cached_tokens: z.number().nullish(),
-        })
-        .nullish(),
-      completion_tokens_details: z
-        .object({
-          reasoning_tokens: z.number().nullish(),
-        })
-        .nullish(),
-    })
-    .nullish(),
-});
-
-// limited version of the schema, focussed on what is needed for the implementation
-// this approach limits breakages when the API changes and increases efficiency
-const groqChatChunkSchema = z.union([
-  z.object({
-    id: z.string().nullish(),
-    created: z.number().nullish(),
-    model: z.string().nullish(),
-    choices: z.array(
-      z.object({
-        delta: z
-          .object({
+      id: z.string().nullish(),
+      created: z.number().nullish(),
+      model: z.string().nullish(),
+      choices: z.array(
+        z.object({
+          message: z.object({
             content: z.string().nullish(),
             reasoning: z.string().nullish(),
             tool_calls: z
               .array(
                 z.object({
-                  index: z.number(),
                   id: z.string().nullish(),
-                  type: z.literal('function').optional(),
+                  type: z.literal('function'),
                   function: z.object({
-                    name: z.string().nullish(),
-                    arguments: z.string().nullish(),
+                    name: z.string(),
+                    arguments: z.string(),
                   }),
                 }),
               )
               .nullish(),
-          })
-          .nullish(),
-        finish_reason: z.string().nullable().optional(),
-        index: z.number(),
-      }),
-    ),
-    x_groq: z
-      .object({
-        usage: z
+          }),
+          index: z.number(),
+          finish_reason: z.string().nullish(),
+        }),
+      ),
+      usage: z
+        .object({
+          prompt_tokens: z.number().nullish(),
+          completion_tokens: z.number().nullish(),
+          total_tokens: z.number().nullish(),
+          prompt_tokens_details: z
+            .object({
+              cached_tokens: z.number().nullish(),
+            })
+            .nullish(),
+          completion_tokens_details: z
+            .object({
+              reasoning_tokens: z.number().nullish(),
+            })
+            .nullish(),
+        })
+        .nullish(),
+    }),
+  ),
+);
+
+type GroqChatResponse = InferSchema<typeof groqChatResponseSchema>;
+
+// limited version of the schema, focussed on what is needed for the implementation
+// this approach limits breakages when the API changes and increases efficiency
+const groqChatChunkSchema = lazySchema(() =>
+  zodSchema(
+    z.union([
+      z.object({
+        id: z.string().nullish(),
+        created: z.number().nullish(),
+        model: z.string().nullish(),
+        choices: z.array(
+          z.object({
+            delta: z
+              .object({
+                content: z.string().nullish(),
+                reasoning: z.string().nullish(),
+                tool_calls: z
+                  .array(
+                    z.object({
+                      index: z.number(),
+                      id: z.string().nullish(),
+                      type: z.literal('function').optional(),
+                      function: z.object({
+                        name: z.string().nullish(),
+                        arguments: z.string().nullish(),
+                      }),
+                    }),
+                  )
+                  .nullish(),
+              })
+              .nullish(),
+            finish_reason: z.string().nullable().optional(),
+            index: z.number(),
+          }),
+        ),
+        x_groq: z
           .object({
-            prompt_tokens: z.number().nullish(),
-            completion_tokens: z.number().nullish(),
-            total_tokens: z.number().nullish(),
-            prompt_tokens_details: z
+            usage: z
               .object({
-                cached_tokens: z.number().nullish(),
-              })
-              .nullish(),
-            completion_tokens_details: z
-              .object({
-                reasoning_tokens: z.number().nullish(),
+                prompt_tokens: z.number().nullish(),
+                completion_tokens: z.number().nullish(),
+                total_tokens: z.number().nullish(),
+                prompt_tokens_details: z
+                  .object({
+                    cached_tokens: z.number().nullish(),
+                  })
+                  .nullish(),
+                completion_tokens_details: z
+                  .object({
+                    reasoning_tokens: z.number().nullish(),
+                  })
+                  .nullish(),
               })
               .nullish(),
           })
           .nullish(),
-      })
-      .nullish(),
-  }),
-  groqErrorDataSchema,
-]);
+      }),
+      groqErrorDataSchema,
+    ]),
+  ),
+);
+
+type GroqChatChunk = InferSchema<typeof groqChatChunkSchema>;


### PR DESCRIPTION
## Summary

Wraps `groqChatResponseSchema` and `groqChatChunkSchema` in `lazySchema(() => zodSchema(...))` so the Zod schema objects are only constructed on first use, reducing startup overhead for consumers that import `@ai-sdk/groq` without immediately using the chat model.

This follows the same pattern already applied to `@ai-sdk/openai` and `@ai-sdk/openai-compatible`.

Part of #9339.

## Test plan

- [x] All 90 existing tests pass (node + edge) — no behavioral changes