### PR TITLE
fix: reuse google auth per provider instance

### DIFF
--- a/.changeset/tall-peaches-tease.md
+++ b/.changeset/tall-peaches-tease.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+fix(provider/google-vertex): avoid recreating Node GoogleAuth clients for repeated requests
+
+Create Google auth token generators per provider instance instead of using a
+module-level shared `GoogleAuth` cache. This avoids unnecessary `GoogleAuth`
+recreation when `googleAuthOptions` are omitted or when multiple provider
+instances use equivalent auth settings.

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.test.ts
@@ -1,12 +1,14 @@
 import { resolve } from '@ai-sdk/provider-utils';
+import { createAuthTokenGenerator } from '../google-vertex-auth-google-auth-library';
 import { createGoogleVertexAnthropic as createVertexAnthropicOriginal } from './google-vertex-anthropic-provider';
 import { createGoogleVertexAnthropic as createVertexAnthropicNode } from './google-vertex-anthropic-provider-node';
-import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
 import { describe, beforeEach, expect, it, vi } from 'vitest';
 
 // Mock the imported modules
 vi.mock('../google-vertex-auth-google-auth-library', () => ({
-  generateAuthToken: vi.fn().mockResolvedValue('mock-auth-token'),
+  createAuthTokenGenerator: vi.fn(() =>
+    vi.fn().mockResolvedValue('mock-auth-token'),
+  ),
 }));
 
 vi.mock('./google-vertex-anthropic-provider', () => ({
@@ -51,7 +53,7 @@ describe('google-vertex-anthropic-provider-node', () => {
     });
   });
 
-  it('passes googleAuthOptions to generateAuthToken', async () => {
+  it('passes googleAuthOptions to createAuthTokenGenerator', async () => {
     createVertexAnthropicNode({
       googleAuthOptions: {
         scopes: ['https://www.googleapis.com/auth/cloud-platform'],
@@ -63,9 +65,9 @@ describe('google-vertex-anthropic-provider-node', () => {
     const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
       .calls[0][0];
 
-    await resolve(passedOptions?.headers); // call the headers function
+    await resolve(passedOptions?.headers);
 
-    expect(generateAuthToken).toHaveBeenCalledWith({
+    expect(createAuthTokenGenerator).toHaveBeenCalledWith({
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
       keyFile: 'path/to/key.json',
     });
@@ -86,7 +88,7 @@ describe('google-vertex-anthropic-provider-node', () => {
       Authorization: 'Bearer custom-token',
     });
     expect(customGenerate).toHaveBeenCalledTimes(1);
-    expect(generateAuthToken).not.toHaveBeenCalled();
+    expect(createAuthTokenGenerator).not.toHaveBeenCalled();
   });
 
   it('merges custom generateAuthToken with user-provided headers', async () => {
@@ -180,5 +182,19 @@ describe('google-vertex-anthropic-provider-node', () => {
     expect(await resolve(passedOptions?.headers)).toEqual({
       Authorization: 'Bearer null',
     });
+  });
+
+  it('creates the auth token generator once per provider instance', async () => {
+    createVertexAnthropicNode({ project: 'test-project' });
+
+    expect(createAuthTokenGenerator).toHaveBeenCalledTimes(1);
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    await resolve(passedOptions?.headers);
+    await resolve(passedOptions?.headers);
+
+    expect(createAuthTokenGenerator).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.ts
@@ -1,6 +1,6 @@
 import { resolve } from '@ai-sdk/provider-utils';
 import type { GoogleAuthOptions } from 'google-auth-library';
-import { generateAuthToken as defaultGenerateAuthToken } from '../google-vertex-auth-google-auth-library';
+import { createAuthTokenGenerator } from '../google-vertex-auth-google-auth-library';
 import {
   createGoogleVertexAnthropic as createVertexAnthropicOriginal,
   type GoogleVertexAnthropicProvider,
@@ -28,7 +28,8 @@ export function createGoogleVertexAnthropic(
 ): GoogleVertexAnthropicProvider {
   const generateAuthToken =
     options.generateAuthToken ??
-    (() => defaultGenerateAuthToken(options.googleAuthOptions));
+    createAuthTokenGenerator(options.googleAuthOptions);
+
   return createVertexAnthropicOriginal({
     ...options,
     headers: async () => ({

--- a/packages/google-vertex/src/google-vertex-auth-google-auth-library.test.ts
+++ b/packages/google-vertex/src/google-vertex-auth-google-auth-library.test.ts
@@ -1,58 +1,80 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import {
-  generateAuthToken,
-  _resetAuthInstance,
-} from './google-vertex-auth-google-auth-library';
+import { createAuthTokenGenerator } from './google-vertex-auth-google-auth-library';
 import { GoogleAuth } from 'google-auth-library';
+
+const getAccessToken = vi.fn().mockResolvedValue({ token: 'mocked-token' });
+const getClient = vi.fn().mockResolvedValue({ getAccessToken });
 
 vi.mock('google-auth-library', () => {
   return {
     GoogleAuth: vi.fn(function () {
       return {
-        getClient: vi.fn().mockResolvedValue({
-          getAccessToken: vi.fn().mockResolvedValue({ token: 'mocked-token' }),
-        }),
+        getClient,
       };
     }),
   };
 });
 
-describe('generateAuthToken', () => {
+describe('createAuthTokenGenerator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    _resetAuthInstance();
+    getAccessToken.mockResolvedValue({ token: 'mocked-token' });
   });
 
   it('should generate a valid auth token', async () => {
+    const generateAuthToken = createAuthTokenGenerator();
+
     const token = await generateAuthToken();
+
     expect(token).toBe('mocked-token');
   });
 
   it('should return null if no token is received', async () => {
-    // Reset the mock completely
-    vi.mocked(GoogleAuth).mockReset();
+    getAccessToken.mockResolvedValueOnce({ token: null });
 
-    // Create a new mock implementation
-    vi.mocked(GoogleAuth).mockImplementation(function () {
-      return {
-        getClient: vi.fn().mockResolvedValue({
-          getAccessToken: vi.fn().mockResolvedValue({ token: null }),
-        }),
-        isGCE: vi.fn(),
-      } as unknown as GoogleAuth;
-    });
-
+    const generateAuthToken = createAuthTokenGenerator();
     const token = await generateAuthToken();
+
     expect(token).toBeNull();
   });
 
-  it('should create new auth instance with provided options', async () => {
-    const options = { keyFile: 'test-key.json' };
-    await generateAuthToken(options);
+  it('should create a new auth instance with provided options', () => {
+    createAuthTokenGenerator({ keyFile: 'test-key.json' });
 
     expect(GoogleAuth).toHaveBeenCalledWith({
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
       keyFile: 'test-key.json',
+    });
+  });
+
+  it('should create only one GoogleAuth instance for repeated calls', async () => {
+    const generateAuthToken = createAuthTokenGenerator();
+
+    await generateAuthToken();
+    await generateAuthToken();
+
+    expect(GoogleAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('should create independent generators for separate option sets', async () => {
+    const generateFirstAuthToken = createAuthTokenGenerator({
+      keyFile: 'first-key.json',
+    });
+    const generateSecondAuthToken = createAuthTokenGenerator({
+      keyFile: 'second-key.json',
+    });
+
+    await generateFirstAuthToken();
+    await generateSecondAuthToken();
+
+    expect(GoogleAuth).toHaveBeenCalledTimes(2);
+    expect(GoogleAuth).toHaveBeenNthCalledWith(1, {
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      keyFile: 'first-key.json',
+    });
+    expect(GoogleAuth).toHaveBeenNthCalledWith(2, {
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      keyFile: 'second-key.json',
     });
   });
 });

--- a/packages/google-vertex/src/google-vertex-auth-google-auth-library.ts
+++ b/packages/google-vertex/src/google-vertex-auth-google-auth-library.ts
@@ -1,26 +1,14 @@
 import { GoogleAuth, type GoogleAuthOptions } from 'google-auth-library';
-let authInstance: GoogleAuth | null = null;
-let authOptions: GoogleAuthOptions | null = null;
 
-function getAuth(options: GoogleAuthOptions) {
-  if (!authInstance || options !== authOptions) {
-    authInstance = new GoogleAuth({
-      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
-      ...options,
-    });
-    authOptions = options;
-  }
-  return authInstance;
-}
+export function createAuthTokenGenerator(options?: GoogleAuthOptions) {
+  const auth = new GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    ...options,
+  });
 
-export async function generateAuthToken(options?: GoogleAuthOptions) {
-  const auth = getAuth(options || {});
-  const client = await auth.getClient();
-  const token = await client.getAccessToken();
-  return token?.token || null;
-}
-
-// For testing purposes only
-export function _resetAuthInstance() {
-  authInstance = null;
+  return async function generateAuthToken() {
+    const client = await auth.getClient();
+    const token = await client.getAccessToken();
+    return token?.token ?? null;
+  };
 }

--- a/packages/google-vertex/src/google-vertex-provider.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider.test.ts
@@ -1,12 +1,14 @@
 import { resolve } from '@ai-sdk/provider-utils';
+import { createAuthTokenGenerator } from './google-vertex-auth-google-auth-library';
 import { createGoogleVertex as createGoogleVertexOriginal } from './google-vertex-provider-base';
 import { createGoogleVertex as createVertexNode } from './google-vertex-provider';
-import { generateAuthToken } from './google-vertex-auth-google-auth-library';
 import { describe, beforeEach, afterEach, expect, it, vi } from 'vitest';
 
 // Mock the imported modules
 vi.mock('./google-vertex-auth-google-auth-library', () => ({
-  generateAuthToken: vi.fn().mockResolvedValue('mock-auth-token'),
+  createAuthTokenGenerator: vi.fn(() =>
+    vi.fn().mockResolvedValue('mock-auth-token'),
+  ),
 }));
 
 vi.mock('./google-vertex-provider-base', () => ({
@@ -56,7 +58,7 @@ describe('google-vertex-provider', () => {
     });
   });
 
-  it('passes googleAuthOptions to generateAuthToken', async () => {
+  it('passes googleAuthOptions to createAuthTokenGenerator', async () => {
     createVertexNode({
       googleAuthOptions: {
         scopes: ['https://www.googleapis.com/auth/cloud-platform'],
@@ -70,7 +72,7 @@ describe('google-vertex-provider', () => {
 
     await resolve(passedOptions?.headers); // call the headers function
 
-    expect(generateAuthToken).toHaveBeenCalledWith({
+    expect(createAuthTokenGenerator).toHaveBeenCalledWith({
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
       keyFile: 'path/to/key.json',
     });
@@ -87,6 +89,20 @@ describe('google-vertex-provider', () => {
 
     expect(passedOptions?.apiKey).toBe('test-api-key');
     expect(passedOptions?.headers).toBeUndefined();
-    expect(generateAuthToken).not.toHaveBeenCalled();
+    expect(createAuthTokenGenerator).not.toHaveBeenCalled();
+  });
+
+  it('creates the auth token generator once per provider instance', async () => {
+    createVertexNode({ project: 'test-project' });
+
+    expect(createAuthTokenGenerator).toHaveBeenCalledTimes(1);
+
+    const passedOptions = vi.mocked(createGoogleVertexOriginal).mock
+      .calls[0][0];
+
+    await resolve(passedOptions?.headers);
+    await resolve(passedOptions?.headers);
+
+    expect(createAuthTokenGenerator).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -1,6 +1,6 @@
 import { loadOptionalSetting, resolve } from '@ai-sdk/provider-utils';
 import type { GoogleAuthOptions } from 'google-auth-library';
-import { generateAuthToken } from './google-vertex-auth-google-auth-library';
+import { createAuthTokenGenerator } from './google-vertex-auth-google-auth-library';
 import {
   createGoogleVertex as createGoogleVertexOriginal,
   type GoogleVertexProvider,
@@ -30,12 +30,12 @@ export function createGoogleVertex(
     return createGoogleVertexOriginal(options);
   }
 
+  const generateAuthToken = createAuthTokenGenerator(options.googleAuthOptions);
+
   return createGoogleVertexOriginal({
     ...options,
     headers: async () => ({
-      Authorization: `Bearer ${await generateAuthToken(
-        options.googleAuthOptions,
-      )}`,
+      Authorization: `Bearer ${await generateAuthToken()}`,
       ...(await resolve(options.headers)),
     }),
   });

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider-node.test.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider-node.test.ts
@@ -3,11 +3,15 @@ import {
   createGoogleVertexMaas,
   googleVertexMaas,
 } from './google-vertex-maas-provider-node';
-import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
+import { createAuthTokenGenerator } from '../google-vertex-auth-google-auth-library';
+
+const { generateAuthToken } = vi.hoisted(() => ({
+  generateAuthToken: vi.fn(),
+}));
 
 // Mock the imported modules
 vi.mock('../google-vertex-auth-google-auth-library', () => ({
-  generateAuthToken: vi.fn(),
+  createAuthTokenGenerator: vi.fn(() => generateAuthToken),
 }));
 
 vi.mock('./google-vertex-maas-provider', () => ({
@@ -29,6 +33,7 @@ vi.mock('@ai-sdk/provider-utils', () => ({
 describe('google-vertex-maas-provider-node', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    generateAuthToken.mockReset();
   });
 
   it('should create provider with auth wrapper', async () => {
@@ -66,7 +71,8 @@ describe('google-vertex-maas-provider-node', () => {
       headers: { 'Content-Type': 'application/json' },
     });
 
-    expect(generateAuthToken).toHaveBeenCalledWith(undefined);
+    expect(createAuthTokenGenerator).toHaveBeenCalledWith(undefined);
+    expect(generateAuthToken).toHaveBeenCalledWith();
 
     expect(mockFetch).toHaveBeenCalledWith('https://example.com/test', {
       method: 'POST',
@@ -77,7 +83,7 @@ describe('google-vertex-maas-provider-node', () => {
     });
   });
 
-  it('should pass googleAuthOptions to generateAuthToken', async () => {
+  it('should pass googleAuthOptions to createAuthTokenGenerator', async () => {
     vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
     const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
     global.fetch = mockFetch;
@@ -91,7 +97,8 @@ describe('google-vertex-maas-provider-node', () => {
     const customFetch = (provider as any).fetch;
     await customFetch('https://example.com/test', {});
 
-    expect(generateAuthToken).toHaveBeenCalledWith(googleAuthOptions);
+    expect(createAuthTokenGenerator).toHaveBeenCalledWith(googleAuthOptions);
+    expect(generateAuthToken).toHaveBeenCalledWith();
   });
 
   it('should merge custom headers with auth header', async () => {
@@ -198,6 +205,25 @@ describe('google-vertex-maas-provider-node', () => {
   it('should export default googleVertexMaas instance', () => {
     expect(googleVertexMaas).toBeDefined();
     expect(typeof googleVertexMaas).toBe('function');
+  });
+
+  it('creates the auth token generator once per provider instance', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const provider = createGoogleVertexMaas({
+      project: 'test-project',
+    });
+
+    expect(createAuthTokenGenerator).toHaveBeenCalledTimes(1);
+
+    const customFetch = (provider as any).fetch;
+    await customFetch('https://example.com/test-1', {});
+    await customFetch('https://example.com/test-2', {});
+
+    expect(createAuthTokenGenerator).toHaveBeenCalledTimes(1);
+    expect(generateAuthToken).toHaveBeenCalledTimes(2);
   });
 
   it('should set headers to undefined in base provider call', async () => {

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider-node.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider-node.ts
@@ -1,6 +1,6 @@
 import { resolve, type FetchFunction } from '@ai-sdk/provider-utils';
 import type { GoogleAuthOptions } from 'google-auth-library';
-import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
+import { createAuthTokenGenerator } from '../google-vertex-auth-google-auth-library';
 import {
   createGoogleVertexMaas as createVertexMaasOriginal,
   type GoogleVertexMaasProvider,
@@ -28,9 +28,11 @@ export interface GoogleVertexMaasProviderSettings extends GoogleVertexMaasProvid
 export function createGoogleVertexMaas(
   options: GoogleVertexMaasProviderSettings = {},
 ): GoogleVertexMaasProvider {
+  const generateAuthToken = createAuthTokenGenerator(options.googleAuthOptions);
+
   // Create a custom fetch wrapper that adds auth headers
   const customFetch: FetchFunction = async (url, init) => {
-    const token = await generateAuthToken(options.googleAuthOptions);
+    const token = await generateAuthToken();
     const resolvedHeaders = await resolve(options.headers);
     const authHeaders = {
       ...resolvedHeaders,


### PR DESCRIPTION
## Background

`@ai-sdk/google-vertex` used a module-level `GoogleAuth` cache in the shared Node auth helper. That cache was invalidated by object reference equality, which caused unnecessary `GoogleAuth` recreation in two cases:

1. Multiple provider instances with equivalent `googleAuthOptions` would recreate auth when requests alternated between them.
2. When `googleAuthOptions` was omitted, `generateAuthToken(options || {})` created a new empty object on every call, so auth could be recreated on every request even for a single provider.

Because `GoogleAuth` caches the resolved auth client on the instance, recreating it discards warm auth state and can add avoidable auth overhead.


## Summary

This PR removes the module-level `GoogleAuth` singleton from `@ai-sdk/google-vertex`'s shared Node auth helper and replaces it with a per-provider auth token generator.

Changes included:
- Replaced the shared `generateAuthToken(options)` helper with `createAuthTokenGenerator(options)`, which creates one `GoogleAuth` instance and returns a reusable token generator closure.
- Updated the Node provider entry points for:
  - `@ai-sdk/google-vertex`
  - `@ai-sdk/google-vertex/anthropic`
  - `@ai-sdk/google-vertex/maas`
- Added regression tests covering:
  - repeated calls with omitted `googleAuthOptions`
  - repeated calls on a single provider instance
  - per-provider generator creation for the Node provider variants
- Added a patch changeset for `@ai-sdk/google-vertex`


## Manual Verification

I manually verified the change by inspecting the Node auth flow and confirming the auth generator is now created once during provider construction rather than on each request path.

Concretely:
- confirmed each Node provider now creates `createAuthTokenGenerator(options.googleAuthOptions)` once at provider initialization
- confirmed request-time header/fetch code now calls the returned generator with no options, so the `undefined -> {}` invalidation path is gone
- confirmed the shared helper no longer stores module-level auth state

I also verified behavior through automated coverage:
- `pnpm --filter @ai-sdk/google-vertex test:node`
- `pnpm type-check:full`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)


## Future Work

A follow-up PR could evaluate whether the Edge auth path should also cache tokens or auth state more aggressively, since it uses a different implementation and is not addressed here.

## Related Issues

Fixes #14101 
