### PR TITLE
fix(google-vertex): use per-instance auth token generator to avoid cache thrashing

### DIFF
--- a/packages/google-vertex/src/google-vertex-auth-google-auth-library.ts
+++ b/packages/google-vertex/src/google-vertex-auth-google-auth-library.ts
@@ -1,27 +1,32 @@
 import { GoogleAuth, GoogleAuthOptions } from 'google-auth-library';
 
-let authInstance: GoogleAuth | null = null;
-let authOptions: GoogleAuthOptions | null = null;
+/**
+ * Creates a auth token generator function for the given options.
+ * This avoids reference-equality cache invalidation issues.
+ */
+export function createAuthTokenGenerator(options?: GoogleAuthOptions) {
+  const auth = new GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    ...options,
+  });
 
-function getAuth(options: GoogleAuthOptions) {
-  if (!authInstance || options !== authOptions) {
-    authInstance = new GoogleAuth({
-      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
-      ...options,
-    });
-    authOptions = options;
-  }
-  return authInstance;
+  return async function generateAuthToken() {
+    const client = await auth.getClient();
+    const token = await client.getAccessToken();
+    return token?.token ?? null;
+  };
 }
 
+/**
+ * @deprecated Use createAuthTokenGenerator instead.
+ * This function is kept for backward compatibility.
+ */
 export async function generateAuthToken(options?: GoogleAuthOptions) {
-  const auth = getAuth(options || {});
+  const auth = new GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    ...options,
+  });
   const client = await auth.getClient();
   const token = await client.getAccessToken();
   return token?.token || null;
-}
-
-// For testing purposes only
-export function _resetAuthInstance() {
-  authInstance = null;
 }

--- a/packages/google-vertex/src/google-vertex-provider-node.ts
+++ b/packages/google-vertex/src/google-vertex-provider-node.ts
@@ -1,6 +1,6 @@
 import { loadOptionalSetting, resolve } from '@ai-sdk/provider-utils';
 import { GoogleAuthOptions } from 'google-auth-library';
-import { generateAuthToken } from './google-vertex-auth-google-auth-library';
+import { createAuthTokenGenerator } from './google-vertex-auth-google-auth-library';
 import {
   createVertex as createVertexOriginal,
   GoogleVertexProvider,
@@ -28,6 +28,9 @@ export function createVertex(
     environmentVariableName: 'GOOGLE_VERTEX_API_KEY',
   });
 
+  // Create a per-instance auth token generator to avoid reference-equality issues
+  const generateAuthToken = createAuthTokenGenerator(options.googleAuthOptions);
+
   if (apiKey) {
     return createVertexOriginal(options);
   }
@@ -35,9 +38,7 @@ export function createVertex(
   return createVertexOriginal({
     ...options,
     headers: async () => ({
-      Authorization: `Bearer ${await generateAuthToken(
-        options.googleAuthOptions,
-      )}`,
+      Authorization: `Bearer ${await generateAuthToken()}`,
       ...(await resolve(options.headers)),
     }),
   });


### PR DESCRIPTION
Closes #14101

The previous module-level singleton used reference equality to detect
options changes, which caused two issues:

1. Multiple provider instances with equivalent googleAuthOptions would
   thrash the singleton when alternating between them
2. Omitted googleAuthOptions would create a new empty object each call,
   causing unnecessary recreation

This fix replaces the shared helper with a factory function that creates
a per-instance auth token generator. Each provider instance now gets
stable auth/client caching without requiring structural serialization.

---

**Changes:**
- Added  factory function in 
- Updated  to use per-instance auth generator
- Kept backward-compatible  function for other consumers