### PR TITLE
docs(gateway): add required region field to Bedrock BYOK credential examples

### DIFF
--- a/.changeset/fix-bedrock-byok-region-docs.md
+++ b/.changeset/fix-bedrock-byok-region-docs.md
@@ -1,0 +1,14 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+docs(gateway): add required `region` field to Bedrock BYOK credential examples
+
+Updated documentation and JSDoc comments to include the `region` field in Amazon Bedrock BYOK credential examples. The `region` field is required for Bedrock to construct the correct endpoint URL (`https://bedrock-runtime.{region}.amazonaws.com`).
+
+Changes:
+- Updated BYOK example in AI Gateway documentation to include `region: 'us-east-1'` for Bedrock credentials
+- Added explicit note in gateway-provider-options.ts that `region` is required for Amazon Bedrock
+- Added new example file `request-byok-bedrock.ts` demonstrating proper Bedrock BYOK configuration
+
+This addresses issue #14096 where users experienced `getaddrinfo ENOTFOUND bedrock-runtime..amazonaws.com` errors due to missing region in BYOK credentials.

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -778,7 +778,7 @@ The following gateway provider options are available:
 
   - Single provider: `byok: { 'anthropic': [{ apiKey: 'sk-ant-...' }] }`
   - Multiple credentials: `byok: { 'vertex': [{ project: 'proj-1', googleCredentials: { privateKey: '...', clientEmail: '...' } }, { project: 'proj-2', googleCredentials: { privateKey: '...', clientEmail: '...' } }] }`
-  - Multiple providers: `byok: { 'anthropic': [{ apiKey: '...' }], 'bedrock': [{ accessKeyId: '...', secretAccessKey: '...' }] }`
+  - Multiple providers: `byok: { 'anthropic': [{ apiKey: '...' }], 'bedrock': [{ accessKeyId: '...', secretAccessKey: '...', region: 'us-east-1' }] }`
 
 - **zeroDataRetention** _boolean_
 

--- a/examples/ai-functions/src/generate-text/gateway/request-byok-bedrock.ts
+++ b/examples/ai-functions/src/generate-text/gateway/request-byok-bedrock.ts
@@ -1,0 +1,33 @@
+import { type GatewayProviderOptions } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { providerMetadata, text, usage } = await generateText({
+    model: 'anthropic/claude-haiku-4.5',
+    prompt: 'Invent a new holiday and describe its traditions.',
+    providerOptions: {
+      gateway: {
+        byok: {
+          bedrock: [
+            {
+              accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+              secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+              // region is required for Bedrock to construct the correct endpoint URL
+              region: process.env.AWS_REGION ?? 'us-east-1',
+              // sessionToken is optional, used for temporary credentials
+              ...(process.env.AWS_SESSION_TOKEN && {
+                sessionToken: process.env.AWS_SESSION_TOKEN,
+              }),
+            },
+          ],
+        },
+      } satisfies GatewayProviderOptions,
+    },
+  });
+
+  console.log(text);
+  console.log();
+  console.log('Usage:', usage);
+  console.log(JSON.stringify(providerMetadata, null, 2));
+});

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -47,7 +47,9 @@ const gatewayProviderOptions = lazySchema(() =>
        * Examples:
        * - Simple: `{ 'anthropic': [{ apiKey: 'sk-ant-...' }] }`
        * - Multiple: `{ 'vertex': [{ projectId: 'proj-1', privateKey: '...' }, { projectId: 'proj-2', privateKey: '...' }] }`
-       * - Multi-provider: `{ 'anthropic': [{ apiKey: '...' }], 'bedrock': [{ accessKeyId: '...', secretAccessKey: '...' }] }`
+       * - Multi-provider: `{ 'anthropic': [{ apiKey: '...' }], 'bedrock': [{ accessKeyId: '...', secretAccessKey: '...', region: 'us-east-1' }] }`
+       *
+       * Note: For Amazon Bedrock, the `region` field is required to construct the correct endpoint URL.
        */
       byok: z
         .record(z.string(), z.array(z.record(z.string(), z.unknown())))


### PR DESCRIPTION
## Summary

- Added `region` field to Bedrock BYOK credential examples in documentation
- Added explicit note in `gateway-provider-options.ts` explaining that `region` is required for Amazon Bedrock
- Added new example file `request-byok-bedrock.ts` demonstrating proper Bedrock BYOK configuration

## Problem

Users were experiencing `getaddrinfo ENOTFOUND bedrock-runtime..amazonaws.com` errors when using BYOK credentials for Amazon Bedrock through AI Gateway. The double dot in the URL indicates the region was empty/undefined when constructing the Bedrock endpoint URL.

The documentation examples showed Bedrock BYOK credentials without the required `region` field:
```ts
// Before (missing region)
byok: { 'bedrock': [{ accessKeyId: '...', secretAccessKey: '...' }] }
```

## Solution

Updated all documentation and code comments to include the required `region` field:
```ts
// After (with region)
byok: { 'bedrock': [{ accessKeyId: '...', secretAccessKey: '...', region: 'us-east-1' }] }
```

Fixes #14096

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)