### PR TITLE
fix(devtools): avoid double-serializing raw payloads

### DIFF
--- a/.changeset/devtools-raw-payload-serialization.md
+++ b/.changeset/devtools-raw-payload-serialization.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/devtools': patch
+---
+
+Preserve string request and response payloads in devtools raw logging instead of JSON-stringifying them a second time.

--- a/packages/devtools/src/middleware.ts
+++ b/packages/devtools/src/middleware.ts
@@ -13,6 +13,14 @@ import {
 
 const generateId = () => crypto.randomUUID();
 
+const serializeRawPayload = (value: unknown) => {
+  if (value == null) {
+    return null;
+  }
+
+  return typeof value === 'string' ? value : JSON.stringify(value);
+};
+
 // Track active streaming steps for cleanup on process exit
 const activeSteps = new Map<
   string,
@@ -46,10 +54,10 @@ const registerSignalHandlers = () => {
             data.request &&
             typeof data.request === 'object' &&
             'body' in data.request
-              ? JSON.stringify((data.request as { body: unknown }).body)
+              ? serializeRawPayload((data.request as { body: unknown }).body)
               : null,
-          raw_response: JSON.stringify(data.fullStreamChunks),
-          raw_chunks: JSON.stringify(data.rawChunks),
+          raw_response: serializeRawPayload(data.fullStreamChunks),
+          raw_chunks: serializeRawPayload(data.rawChunks),
         });
       },
     );
@@ -174,12 +182,8 @@ export const devToolsMiddleware = (): LanguageModelV4Middleware => {
           }),
           usage: result.usage ? JSON.stringify(result.usage) : null,
           error: null,
-          raw_request: result.request?.body
-            ? JSON.stringify(result.request.body)
-            : null,
-          raw_response: result.response?.body
-            ? JSON.stringify(result.response.body)
-            : null,
+          raw_request: serializeRawPayload(result.request?.body),
+          raw_response: serializeRawPayload(result.response?.body),
         });
 
         return result;
@@ -340,9 +344,9 @@ export const devToolsMiddleware = (): LanguageModelV4Middleware => {
                 ? JSON.stringify(collectedOutput.usage)
                 : null,
               error: null,
-              raw_request: request?.body ? JSON.stringify(request.body) : null,
-              raw_response: JSON.stringify(fullStreamChunks),
-              raw_chunks: JSON.stringify(rawChunks),
+              raw_request: serializeRawPayload(request?.body),
+              raw_response: serializeRawPayload(fullStreamChunks),
+              raw_chunks: serializeRawPayload(rawChunks),
             });
           },
 
@@ -359,9 +363,9 @@ export const devToolsMiddleware = (): LanguageModelV4Middleware => {
                 ? JSON.stringify(collectedOutput.usage)
                 : null,
               error: 'Request aborted',
-              raw_request: request?.body ? JSON.stringify(request.body) : null,
-              raw_response: JSON.stringify(fullStreamChunks),
-              raw_chunks: JSON.stringify(rawChunks),
+              raw_request: serializeRawPayload(request?.body),
+              raw_response: serializeRawPayload(fullStreamChunks),
+              raw_chunks: serializeRawPayload(rawChunks),
             });
           },
         });


### PR DESCRIPTION
## Summary

- avoid double-serializing string request payloads in devtools raw logging
- preserve existing JSON serialization for object and array payloads through a shared helper
- add a patch changeset for `@ai-sdk/devtools`

## Root Cause

`raw_request` and related devtools fields always used `JSON.stringify(...)`, even when the provider payload was already a serialized JSON string. That wrapped request bodies in an extra layer of quotes, so `raw_request` could render as a quoted JSON string while `raw_response` rendered as plain JSON.

## Before

<img width="984" height="430" alt="image" src="https://github.com/user-attachments/assets/d069d586-3e19-4c31-82c4-d9735de44ede" />


`raw_request` is shown as a JSON string literal with an extra layer of quotes and escaping.

## After

<img width="986" height="480" alt="image" src="https://github.com/user-attachments/assets/877ac432-e0c1-4087-8656-13f03fe08d67" />


`raw_request` is preserved as the original string payload, so the UI renders it as formatted JSON instead of a doubly-serialized string.

## Testing

- verified the branch diff contains only `packages/devtools/src/middleware.ts` and the new changeset
