### PR TITLE
fix(openai): use template literals for error message interpolation

### DIFF
--- a/packages/openai-compatible/src/completion/convert-to-openai-compatible-completion-prompt.ts
+++ b/packages/openai-compatible/src/completion/convert-to-openai-compatible-completion-prompt.ts
@@ -29,7 +29,7 @@ export function convertToOpenAICompatibleCompletionPrompt({
     switch (role) {
       case 'system': {
         throw new InvalidPromptError({
-          message: 'Unexpected system message in prompt: ${content}',
+          message: `Unexpected system message in prompt: ${content}`,
           prompt,
         });
       }

--- a/packages/openai-compatible/src/openai-compatible-provider.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.test.ts
@@ -275,7 +275,7 @@ describe('OpenAICompatibleProvider', () => {
   });
 
   describe('supportsStructuredOutputs setting', () => {
-    it('should pass supportsStructuredOutputs to to .chatModel() and .languageModel() only', () => {
+    it('should pass supportsStructuredOutputs to .chatModel() and .languageModel() only', () => {
       const options = {
         baseURL: 'https://api.example.com',
         name: 'test-provider',

--- a/packages/openai/src/completion/convert-to-openai-completion-prompt.ts
+++ b/packages/openai/src/completion/convert-to-openai-completion-prompt.ts
@@ -29,7 +29,7 @@ export function convertToOpenAICompletionPrompt({
     switch (role) {
       case 'system': {
         throw new InvalidPromptError({
-          message: 'Unexpected system message in prompt: ${content}',
+          message: `Unexpected system message in prompt: ${content}`,
           prompt,
         });
       }


### PR DESCRIPTION
## Summary
- Fix `${content}` not being interpolated in error messages in both `openai` and `openai-compatible` completion prompt converters — single quotes were used instead of backticks, so the literal text `${content}` appears in error messages
- Fix duplicate word `to to` in test description

Same class of bug as #14006 (bedrock template literal fix).

## Test plan
- [ ] Verify error messages correctly show actual content values
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)