### PR TITLE
fix: avoid quadratic memory growth in streamText text() without breaking chunk streaming

### DIFF
--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -629,6 +629,7 @@ function createOutputTransformStream<
   let textChunk = '';
   let textProviderMetadata: ProviderMetadata | undefined = undefined;
   let lastPublishedJson = '';
+  const isTextOutput = output.name === 'text';
 
   function publishTextChunk({
     controller,
@@ -695,6 +696,17 @@ function createOutputTransformStream<
       text += chunk.text;
       textChunk += chunk.text;
       textProviderMetadata = chunk.providerMetadata ?? textProviderMetadata;
+
+      // For text output, every text-delta always changes the partial output,
+      // so we can publish immediately and avoid the expensive JSON.stringify
+      // comparison that causes O(n²) memory growth with large responses.
+      if (isTextOutput) {
+        publishTextChunk({
+          controller,
+          partialOutput: text as InferPartialOutput<OUTPUT>,
+        });
+        return;
+      }
 
       // only publish if partial json can be parsed:
       const result = await output.parsePartialOutput({ text });


### PR DESCRIPTION
## Summary

Follows up on #13878 which was closed because returning `undefined` from `parsePartialOutput()` broke incremental chunk publishing.

This PR takes a different approach — instead of suppressing partial output entirely, it avoids the expensive `JSON.stringify(result.partial)` path for text-type outputs while preserving incremental text-delta chunk streaming.

The original issue: for a ~110KB response arriving in ~13,000 chunks, `JSON.stringify` was called on the accumulated text string on every chunk, creating ~350MB of intermediate string copies that landed in V8's large_object_space.

**The fix:** For plain text output, every `text-delta` always changes the partial result, so the JSON.stringify-based dedup comparison is unnecessary. We short-circuit it and publish immediately. Structured outputs (object, array, choice, json) still use the existing JSON.stringify dedup path since partial JSON parsing can produce identical results across consecutive chunks.

## How did you test this?
- Verified text-delta chunks still stream incrementally (not batched at end)
- Confirmed memory usage doesn't grow quadratically with response size
- All existing stream-text tests pass (337 tests)
- All output tests pass (60 tests)