### PR TITLE
feat(bedrock): support native structured output for anthropic models without reasoning

### DIFF
--- a/.changeset/olive-colts-sparkle.md
+++ b/.changeset/olive-colts-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+feat(bedrock): support native structured output for anthropic models without reasoning

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -4580,6 +4580,65 @@ describe('doGenerate', () => {
     expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(true);
   });
 
+  it('should use native output_config.format for models with structured output support even without thinking enabled', async () => {
+    server.urls[newerAnthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            content: [{ text: '{"name":"Test"}' }],
+            role: 'assistant',
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'end_turn',
+      },
+    };
+
+    await newerAnthropicModel.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Generate a name' }],
+        },
+      ],
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+          required: ['name'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.toolConfig).toBeUndefined();
+
+    expect(requestBody.additionalModelRequestFields?.output_config)
+      .toMatchInlineSnapshot(`
+      {
+        "format": {
+          "schema": {
+            "properties": {
+              "name": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "name",
+            ],
+            "type": "object",
+          },
+          "type": "json_schema",
+        },
+      }
+    `);
+  });
+
   it('should extract reasoning text with signature', async () => {
     server.urls[generateUrl].response = {
       type: 'json-value',

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -157,9 +157,12 @@ export class BedrockChatLanguageModel implements LanguageModelV4 {
       bedrockOptions.reasoningConfig?.type === 'enabled' ||
       bedrockOptions.reasoningConfig?.type === 'adaptive';
 
+    const { supportsStructuredOutput: modelSupportsStructuredOutput } =
+      getModelCapabilities(this.modelId);
+
     const useNativeStructuredOutput =
       isAnthropicModel &&
-      isThinkingEnabled &&
+      (modelSupportsStructuredOutput || isThinkingEnabled) &&
       responseFormat?.type === 'json' &&
       responseFormat.schema != null;
 


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/12980

The bedrock converse API path (bedrock('anthropic.claude-...')) only used native structured output when thinking/reasoning was enabled. Without thinking, it always fell back to a JSON tool workaround, even for models like Claude 4.5/4.6 that natively support structured output on bedrock.

## Summary

changed the condition to use model capability OR thinking enabled 9since we already have a function `getModelCapabilities()` to check if the model natively supports structured output

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #12980 