### PR TITLE
fix(prompt): skip generating download requests for data URLs

### DIFF
--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -420,7 +420,7 @@ async function downloadAssets(
 
     .filter(
       (part): part is { mediaType: string | undefined; data: URL } =>
-        part.data instanceof URL,
+        part.data instanceof URL && part.data.protocol !== 'data:',
     )
     .map(part => ({
       url: part.data,


### PR DESCRIPTION
Fixes #13103

### Description
This fixes a critical regression where valid \`data:\` URLs (e.g. inline images, pdfs) are rejected due to stricter SSRF URL validation in \`downloadAssets\`. 

Since \`data:\` URLs represent inline data and are not remote resources that need downloading, they should be filtered out from the \`plannedDownloads\` array altogether rather than being passed into the \`download\` map.

### Changes
*   Updated the filter in \`packages/ai/src/prompt/convert-to-language-model-prompt.ts\` inside \`downloadAssets\` to check for \`part.data.protocol !== 'data:'\` before adding it to \`plannedDownloads\`.