### PR TITLE
fix(amazon-bedrock): avoid env AWS_SESSION_TOKEN with explicit static keys

### DIFF
--- a/.changeset/bedrock-static-keys-session-token.md
+++ b/.changeset/bedrock-static-keys-session-token.md
@@ -5,3 +5,5 @@
 fix(amazon-bedrock): do not merge AWS_SESSION_TOKEN from env with explicit access keys
 
 When `accessKeyId` and `secretAccessKey` are both passed as options, session credentials now use only `options.sessionToken` or omit the token — avoiding workload tokens (e.g. EKS IRSA) invalidating SigV4 for static IAM user keys.
+
+Docs: remove incorrect guidance that `sessionToken: undefined` blocks `AWS_SESSION_TOKEN`; describe static keys, env fallback, and `credentialProvider` workaround for older versions.

--- a/.changeset/bedrock-static-keys-session-token.md
+++ b/.changeset/bedrock-static-keys-session-token.md
@@ -6,4 +6,4 @@ fix(amazon-bedrock): do not merge AWS_SESSION_TOKEN from env with explicit acces
 
 When `accessKeyId` and `secretAccessKey` are both passed as options, session credentials now use only `options.sessionToken` or omit the token — avoiding workload tokens (e.g. EKS IRSA) invalidating SigV4 for static IAM user keys.
 
-Docs: remove incorrect guidance that `sessionToken: undefined` blocks `AWS_SESSION_TOKEN`; describe static keys, env fallback, and `credentialProvider` workaround for older versions.
+Docs: align Amazon Bedrock provider page with this behavior.

--- a/.changeset/bedrock-static-keys-session-token.md
+++ b/.changeset/bedrock-static-keys-session-token.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): do not merge AWS_SESSION_TOKEN from env with explicit access keys
+
+When `accessKeyId` and `secretAccessKey` are both passed as options, session credentials now use only `options.sessionToken` or omit the token — avoiding workload tokens (e.g. EKS IRSA) invalidating SigV4 for static IAM user keys.

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -133,12 +133,17 @@ const bedrock = createAmazonBedrock({
 ```
 
 <Note>
-  The credentials settings fall back to environment variable defaults described
-  below. These may be set by your serverless environment without your awareness,
-  which can lead to merged/conflicting credential values and provider errors
-  around failed authentication. If you're experiencing issues be sure you are
-  explicitly specifying all settings (even if `undefined`) to avoid any
-  defaults.
+  Options fall back to the environment variables below when omitted. On
+  serverless / Kubernetes (e.g. EKS IRSA), `AWS_SESSION_TOKEN` is often set for
+  the **workload** identity. When **both** `accessKeyId` and `secretAccessKey`
+  are provided as strings, the provider treats them as a static key pair and
+  **does not** read `AWS_SESSION_TOKEN` from the environment for SigV4—you only
+  get a session token if you pass **`sessionToken`** as a string (e.g. temporary
+  credentials). If you need static keys on a host that sets
+  `AWS_SESSION_TOKEN` and you are on an older release where env was still merged,
+  pass a `credentialProvider` that returns only `accessKeyId` and
+  `secretAccessKey` instead of relying on `sessionToken: undefined` (that does
+  **not** disable env fallback in `loadOptionalSetting`).
 </Note>
 
 You can use the following optional settings to customize the Amazon Bedrock provider instance:
@@ -160,8 +165,12 @@ You can use the following optional settings to customize the Amazon Bedrock prov
 
 - **sessionToken** _string_
 
-  Optional. The AWS session token that you want to use for the API calls.
-  It uses the `AWS_SESSION_TOKEN` environment variable by default.
+  Optional. The AWS session token for temporary credentials. When **both**
+  `accessKeyId` and `secretAccessKey` are set as string options, only this field
+  supplies a session token; **`AWS_SESSION_TOKEN` is not read from the
+  environment** in that case. If either access key is omitted and resolved from
+  the environment, unset `sessionToken` lets the provider use
+  `AWS_SESSION_TOKEN` when present.
 
 - **credentialProvider** _() =&gt; Promise&lt;&#123; accessKeyId: string; secretAccessKey: string; sessionToken?: string; &#125;&gt;_
 
@@ -1359,8 +1368,12 @@ You can use the following optional settings to customize the Bedrock Anthropic p
 
 - **sessionToken** _string_
 
-  Optional. The AWS session token that you want to use for the API calls.
-  It uses the `AWS_SESSION_TOKEN` environment variable by default.
+  Optional. The AWS session token for temporary credentials. When **both**
+  `accessKeyId` and `secretAccessKey` are set as string options, only this field
+  supplies a session token; **`AWS_SESSION_TOKEN` is not read from the
+  environment** in that case. If either access key is omitted and resolved from
+  the environment, unset `sessionToken` lets the provider use
+  `AWS_SESSION_TOKEN` when present.
 
 - **apiKey** _string_
 
@@ -1619,8 +1632,8 @@ The `bedrockOptions` provider setting previously available has been removed. If
 you were using the `bedrockOptions` object, you should now use the `region`,
 `accessKeyId`, `secretAccessKey`, and `sessionToken` settings directly instead.
 
-Note that you may need to set all of these explicitly, e.g. even if you're not
-using `sessionToken`, set it to `undefined`. If you're running in a serverless
-environment, there may be default environment variables set by your containing
-environment that the Amazon Bedrock provider will then pick up and could
-conflict with the ones you're intending to use.
+If you pass static keys as strings, you do not need `sessionToken` for IAM user
+credentials. On older versions, **`sessionToken: undefined` did not stop**
+`AWS_SESSION_TOKEN` from being picked up when mixing env and options; use
+`credentialProvider` returning only `{ accessKeyId, secretAccessKey }` or
+upgrade to a release where explicit static keys skip env `AWS_SESSION_TOKEN`.

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -133,17 +133,10 @@ const bedrock = createAmazonBedrock({
 ```
 
 <Note>
-  Options fall back to the environment variables below when omitted. On
-  serverless / Kubernetes (e.g. EKS IRSA), `AWS_SESSION_TOKEN` is often set for
-  the **workload** identity. When **both** `accessKeyId` and `secretAccessKey`
-  are provided as strings, the provider treats them as a static key pair and
-  **does not** read `AWS_SESSION_TOKEN` from the environment for SigV4—you only
-  get a session token if you pass **`sessionToken`** as a string (e.g. temporary
-  credentials). If you need static keys on a host that sets
-  `AWS_SESSION_TOKEN` and you are on an older release where env was still merged,
-  pass a `credentialProvider` that returns only `accessKeyId` and
-  `secretAccessKey` instead of relying on `sessionToken: undefined` (that does
-  **not** disable env fallback in `loadOptionalSetting`).
+  Omitted options use the environment variables below. When **both**
+  `accessKeyId` and `secretAccessKey` are strings, SigV4 uses a **`sessionToken`
+  only if you pass one**—not `AWS_SESSION_TOKEN` from the environment—so static
+  keys are not mixed with workload tokens (e.g. EKS IRSA).
 </Note>
 
 You can use the following optional settings to customize the Amazon Bedrock provider instance:
@@ -165,12 +158,10 @@ You can use the following optional settings to customize the Amazon Bedrock prov
 
 - **sessionToken** _string_
 
-  Optional. The AWS session token for temporary credentials. When **both**
-  `accessKeyId` and `secretAccessKey` are set as string options, only this field
-  supplies a session token; **`AWS_SESSION_TOKEN` is not read from the
-  environment** in that case. If either access key is omitted and resolved from
-  the environment, unset `sessionToken` lets the provider use
-  `AWS_SESSION_TOKEN` when present.
+  Optional. For temporary credentials. With **both** access keys set as strings,
+  pass the token here if needed; `AWS_SESSION_TOKEN` from the environment is not
+  used. If either key is taken from the environment, omitting `sessionToken`
+  allows `AWS_SESSION_TOKEN`.
 
 - **credentialProvider** _() =&gt; Promise&lt;&#123; accessKeyId: string; secretAccessKey: string; sessionToken?: string; &#125;&gt;_
 
@@ -1368,12 +1359,10 @@ You can use the following optional settings to customize the Bedrock Anthropic p
 
 - **sessionToken** _string_
 
-  Optional. The AWS session token for temporary credentials. When **both**
-  `accessKeyId` and `secretAccessKey` are set as string options, only this field
-  supplies a session token; **`AWS_SESSION_TOKEN` is not read from the
-  environment** in that case. If either access key is omitted and resolved from
-  the environment, unset `sessionToken` lets the provider use
-  `AWS_SESSION_TOKEN` when present.
+  Optional. For temporary credentials. With **both** access keys set as strings,
+  pass the token here if needed; `AWS_SESSION_TOKEN` from the environment is not
+  used. If either key is taken from the environment, omitting `sessionToken`
+  allows `AWS_SESSION_TOKEN`.
 
 - **apiKey** _string_
 
@@ -1631,9 +1620,4 @@ dependency on the `@aws-sdk/client-bedrock-runtime` package.
 The `bedrockOptions` provider setting previously available has been removed. If
 you were using the `bedrockOptions` object, you should now use the `region`,
 `accessKeyId`, `secretAccessKey`, and `sessionToken` settings directly instead.
-
-If you pass static keys as strings, you do not need `sessionToken` for IAM user
-credentials. On older versions, **`sessionToken: undefined` did not stop**
-`AWS_SESSION_TOKEN` from being picked up when mixing env and options; use
-`credentialProvider` returning only `{ accessKeyId, secretAccessKey }` or
-upgrade to a release where explicit static keys skip env `AWS_SESSION_TOKEN`.
+Static IAM user keys do not require `sessionToken`.

--- a/packages/amazon-bedrock/src/bedrock-provider.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.test.ts
@@ -391,6 +391,49 @@ describe('AmazonBedrockProvider', () => {
         );
       });
 
+      it('does not use AWS_SESSION_TOKEN from env when both access keys are passed as options', async () => {
+        mockLoadOptionalSetting.mockImplementation(
+          ({ settingValue, environmentVariableName }) => {
+            if (environmentVariableName === 'AWS_BEARER_TOKEN_BEDROCK') {
+              return settingValue;
+            }
+            if (environmentVariableName === 'AWS_SESSION_TOKEN') {
+              return 'env-session-token-should-not-be-used';
+            }
+            return settingValue;
+          },
+        );
+
+        createAmazonBedrock({
+          region: 'us-east-1',
+          accessKeyId: 'from-options-ak',
+          secretAccessKey: 'from-options-sk',
+        });
+
+        const getCredentials = mockCreateSigV4FetchFunction.mock.calls[0][0];
+        await expect(getCredentials()).resolves.toMatchObject({
+          accessKeyId: 'from-options-ak',
+          secretAccessKey: 'from-options-sk',
+          sessionToken: undefined,
+        });
+      });
+
+      it('uses options.sessionToken when both access keys are passed as options', async () => {
+        mockLoadOptionalSetting.mockImplementation(() => undefined);
+
+        createAmazonBedrock({
+          region: 'us-east-1',
+          accessKeyId: 'from-options-ak',
+          secretAccessKey: 'from-options-sk',
+          sessionToken: 'explicit-session',
+        });
+
+        const getCredentials = mockCreateSigV4FetchFunction.mock.calls[0][0];
+        await expect(getCredentials()).resolves.toMatchObject({
+          sessionToken: 'explicit-session',
+        });
+      });
+
       it('should work with credential provider when no API key is provided', () => {
         // Mock loadOptionalSetting to return undefined (no API key)
         mockLoadOptionalSetting.mockImplementation(() => undefined);

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -74,8 +74,12 @@ export interface AmazonBedrockProviderSettings {
   secretAccessKey?: string;
 
   /**
-   * The AWS session token to use for the Bedrock provider. Defaults to the value of the
-   * `AWS_SESSION_TOKEN` environment variable.
+   * The AWS session token to use for the Bedrock provider. When `accessKeyId` and
+   * `secretAccessKey` are both passed explicitly as options, only this field is used
+   * for the session token — **`AWS_SESSION_TOKEN` is not read from the environment**
+   * (so workload tokens from e.g. EKS IRSA are not mixed with static access keys).
+   * If either access key field is omitted and resolved from the environment, the
+   * session token also falls back to `AWS_SESSION_TOKEN` when not set here.
    */
   sessionToken?: string;
 
@@ -221,10 +225,16 @@ export function createAmazonBedrock(
               environmentVariableName: 'AWS_SECRET_ACCESS_KEY',
               description: 'AWS secret access key',
             }),
-            sessionToken: loadOptionalSetting({
-              settingValue: options.sessionToken,
-              environmentVariableName: 'AWS_SESSION_TOKEN',
-            }),
+            sessionToken:
+              typeof options.accessKeyId === 'string' &&
+              typeof options.secretAccessKey === 'string'
+                ? typeof options.sessionToken === 'string'
+                  ? options.sessionToken
+                  : undefined
+                : loadOptionalSetting({
+                    settingValue: options.sessionToken,
+                    environmentVariableName: 'AWS_SESSION_TOKEN',
+                  }),
           };
         } catch (error) {
           // Provide helpful error message for missing AWS credentials


### PR DESCRIPTION
## Background

`createAmazonBedrock` merged explicit static `accessKeyId` / `secretAccessKey` with `AWS_SESSION_TOKEN` from the environment via `loadOptionalSetting`. On EKS IRSA (and similar), that token is for the workload—not the IAM user keys in options—so SigV4 fails with *invalid security token* (#14136).

The published docs also claimed that setting `sessionToken: undefined` avoids env defaults. **`undefined` does not skip env** in `loadOptionalSetting` (`settingValue != null` is false), which we **confirmed manually** (Hebo + fake `AWS_SESSION_TOKEN`). The bug is both **implementation** and **documentation**.

## Summary

- **Code:** When both `accessKeyId` and `secretAccessKey` are string options, `sessionToken` comes only from the `sessionToken` option (or omitted); **`AWS_SESSION_TOKEN` is not read** for that path. If either key is env-resolved, behavior is unchanged (`AWS_SESSION_TOKEN` still applies when needed).
- **Docs:** Updated `08-amazon-bedrock.mdx`: removed the incorrect `sessionToken: undefined` guidance; documented static keys vs env; pointed to `credentialProvider` for older releases / edge cases.
- **Changeset:** Patch for `@ai-sdk/amazon-bedrock`; body mentions doc correction.

## Manual Verification

- `pnpm build --filter=@ai-sdk/amazon-bedrock...`
- `pnpm --filter=@ai-sdk/amazon-bedrock test:node`
- Manual: with `AWS_SESSION_TOKEN=fake` and real static keys in options, Bedrock request should succeed after this change (and docs match behavior).

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

None required.

## Related Issues

Fixes #14136
