### PR TITLE
fix(amazon-bedrock): skip encodeURIComponent for ARN model IDs

### DIFF
--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -255,10 +255,14 @@ export function createBedrockAnthropic(
       headers: getHeaders,
       fetch: fetchFunction,
 
-      buildRequestUrl: (baseURL, isStreaming) =>
-        `${baseURL}/model/${encodeURIComponent(modelId)}/${
+      buildRequestUrl: (baseURL, isStreaming) => {
+        const encodedModelId = modelId.startsWith('arn:')
+          ? modelId
+          : encodeURIComponent(modelId);
+        return `${baseURL}/model/${encodedModelId}/${
           isStreaming ? 'invoke-with-response-stream' : 'invoke'
-        }`,
+        }`;
+      },
 
       transformRequestBody: (args, betas) => {
         const { model, stream, tool_choice, tools, ...rest } = args;

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -982,7 +982,9 @@ export class BedrockChatLanguageModel implements LanguageModelV4 {
   }
 
   private getUrl(modelId: string) {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = modelId.startsWith('arn:')
+      ? modelId
+      : encodeURIComponent(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}`;
   }
 }

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.ts
@@ -39,7 +39,9 @@ export class BedrockEmbeddingModel implements EmbeddingModelV4 {
   ) {}
 
   private getUrl(modelId: string): string {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = modelId.startsWith('arn:')
+      ? modelId
+      : encodeURIComponent(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}/invoke`;
   }
 

--- a/packages/amazon-bedrock/src/bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.ts
@@ -38,7 +38,9 @@ export class BedrockImageModel implements ImageModelV4 {
   }
 
   private getUrl(modelId: string): string {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = modelId.startsWith('arn:')
+      ? modelId
+      : encodeURIComponent(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}/invoke`;
   }
 


### PR DESCRIPTION
## What
Fixes #14117 - `@ai-sdk/amazon-bedrock` fails with `The provided model identifier is invalid` when using application inference profile ARNs as model IDs.

## Root Cause
The provider constructs REST API URLs by passing model IDs through `encodeURIComponent`. For standard model IDs like `us.amazon.nova-2-lite-v1:0`, this produces valid URLs. For ARN-style IDs like `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123xyz`, the slashes and colons get percent-encoded, which Bedrock's API rejects.

## Fix
When the model ID starts with `arn:`, skip `encodeURIComponent` and use the raw ARN directly in the URL path. Standard model IDs continue to be encoded as before.

Applied to all four URL construction sites:
- `bedrock-chat-language-model.ts`  
- `bedrock-image-model.ts`  
- `bedrock-embedding-model.ts`  
- `anthropic/bedrock-anthropic-provider.ts`