### PR TITLE
fix(amazon-bedrock): preserve empty text blocks when reasoning content is present

### DIFF
--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -267,8 +267,13 @@ export async function convertToBedrockChatMessages(
 
             switch (part.type) {
               case 'text': {
-                // Skip empty text blocks
-                if (!part.text.trim()) {
+                // Skip empty text blocks, but only when no reasoning content
+                // is present. Bedrock requires content block indices to match
+                // the original response when reasoning blocks exist.
+                const hasReasoning = content.some(
+                  (p: any) => p.type === 'reasoning',
+                );
+                if (!part.text.trim() && !hasReasoning) {
                   break;
                 }
 


### PR DESCRIPTION
Fixes #14071

Bedrock validates that assistant message content block indices match the original response. The SDK currently strips empty text blocks (`!part.text.trim()`), which shifts indices when reasoning blocks are present, causing:
`The model cannot modify thinking or redacted_thinking blocks``n
This PR preserves empty text blocks when the message contains reasoning content.