### PR TITLE
feat(ai/core): lazy tool discovery for token-efficient large tool sets

### DIFF
--- a/packages/ai/src/generate-text/filter-active-tool.ts
+++ b/packages/ai/src/generate-text/filter-active-tool.ts
@@ -1,4 +1,5 @@
 import type { ToolSet } from '@ai-sdk/provider-utils';
+import { LOAD_TOOL_SCHEMA_NAME } from './load-tool-schema';
 
 type ActiveTools<
   TOOLS extends ToolSet,
@@ -10,6 +11,8 @@ type ActiveTools<
 /**
  * Filters the tools to only include the active tools.
  * When activeTools is provided, we only include the tools that are in the list.
+ * The __load_tool_schema__ tool is always preserved when present, so that
+ * lazy tool discovery is not silently broken by activeTools filtering.
  *
  * @param tools - The tools to filter.
  * @param activeTools - The active tools to include.
@@ -34,8 +37,10 @@ export function filterActiveTools<
   }
 
   return Object.fromEntries(
-    Object.entries(tools).filter(([name]) =>
-      activeTools.includes(name as keyof TOOLS),
+    Object.entries(tools).filter(
+      ([name]) =>
+        name === LOAD_TOOL_SCHEMA_NAME ||
+        activeTools.includes(name as keyof TOOLS),
     ),
   ) as ActiveTools<TOOLS, ACTIVE_TOOL_NAMES>;
 }

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -86,6 +86,7 @@ import { TypedToolError } from './tool-error';
 import { ToolOutput } from './tool-output';
 import { TypedToolResult } from './tool-result';
 import type { ToolSet } from '@ai-sdk/provider-utils';
+import { buildEffectiveTools } from './load-tool-schema';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -466,6 +467,9 @@ export async function generateText<
     };
   }): Promise<GenerateTextResult<TOOLS, CONTEXT, OUTPUT>> {
   const model = resolveLanguageModel(modelArg);
+
+  const effectiveTools = buildEffectiveTools(tools);
+
   const createGlobalTelemetry = getGlobalTelemetryIntegration<any, OUTPUT>();
   const stopConditions = asArray(stopWhen);
 
@@ -565,7 +569,7 @@ export async function generateText<
         toolCalls: localApprovedToolApprovals.map(
           toolApproval => toolApproval.toolCall,
         ),
-        tools: tools as TOOLS,
+        tools: effectiveTools as TOOLS,
         telemetry,
         callId,
         messages: initialMessages,
@@ -605,7 +609,7 @@ export async function generateText<
         const modelOutput = await createToolModelOutput({
           toolCallId: output.toolCallId,
           input: output.input,
-          tool: tools?.[output.toolName],
+          tool: effectiveTools?.[output.toolName],
           output: output.type === 'tool-result' ? output.output : output.error,
           errorMode: output.type === 'tool-error' ? 'text' : 'none',
         });
@@ -717,7 +721,7 @@ export async function generateText<
           prepareStepResult?.experimental_context ?? experimental_context;
 
         const stepActiveTools = filterActiveTools({
-          tools,
+          tools: effectiveTools,
           activeTools: prepareStepResult?.activeTools ?? activeTools,
         });
 
@@ -807,7 +811,7 @@ export async function generateText<
             .map(toolCall =>
               parseToolCall({
                 toolCall,
-                tools,
+                tools: effectiveTools,
                 repairToolCall,
                 system,
                 messages: stepInputMessages,
@@ -825,7 +829,7 @@ export async function generateText<
             continue; // ignore invalid tool calls
           }
 
-          const tool = tools?.[toolCall.toolName];
+          const tool = effectiveTools?.[toolCall.toolName];
 
           if (tool == null) {
             // ignore tool calls for tools that are not available,
@@ -883,7 +887,7 @@ export async function generateText<
           toolCall => !toolCall.providerExecuted,
         );
 
-        if (tools != null) {
+        if (effectiveTools != null) {
           clientToolOutputs.push(
             ...(await executeTools({
               toolCalls: clientToolCalls.filter(
@@ -891,7 +895,7 @@ export async function generateText<
                   !toolCall.invalid &&
                   toolApprovalRequests[toolCall.toolCallId] == null,
               ),
-              tools,
+              tools: effectiveTools,
               telemetry,
               callId,
               messages: stepInputMessages,
@@ -932,7 +936,7 @@ export async function generateText<
         // the client tool's result is sent back.
         for (const toolCall of stepToolCalls) {
           if (!toolCall.providerExecuted) continue;
-          const tool = tools?.[toolCall.toolName];
+          const tool = effectiveTools?.[toolCall.toolName];
           if (tool?.type === 'provider' && tool.supportsDeferredResults) {
             // Check if this tool call already has a result in the current response
             const hasResultInResponse = currentModelResponse.content.some(
@@ -961,14 +965,14 @@ export async function generateText<
           toolCalls: stepToolCalls,
           toolOutputs: clientToolOutputs,
           toolApprovalRequests: Object.values(toolApprovalRequests),
-          tools,
+          tools: effectiveTools,
         });
 
         // append to messages for potential next step:
         responseMessages.push(
           ...(await toResponseMessages({
             content: stepContent,
-            tools,
+            tools: effectiveTools,
           })),
         );
 

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -19,6 +19,7 @@ export {
   type GenerateTextOnToolCallStartCallback,
 } from './generate-text';
 export type { GenerateTextResult } from './generate-text-result';
+export { LOAD_TOOL_SCHEMA_NAME } from './load-tool-schema';
 export {
   DefaultGeneratedFile,
   type GeneratedFile as Experimental_GeneratedImage, // Image for backwards compatibility, TODO remove in v7

--- a/packages/ai/src/generate-text/load-tool-schema.test.ts
+++ b/packages/ai/src/generate-text/load-tool-schema.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest';
+import { tool } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import {
+  buildEffectiveTools,
+  createLoadToolSchemaTool,
+  LOAD_TOOL_SCHEMA_NAME,
+} from './load-tool-schema';
+
+describe('LOAD_TOOL_SCHEMA_NAME', () => {
+  it("equals '__load_tool_schema__'", () => {
+    expect(LOAD_TOOL_SCHEMA_NAME).toBe('__load_tool_schema__');
+  });
+});
+
+describe('createLoadToolSchemaTool', () => {
+  it('returns tool with description listing lazy tool names', () => {
+    const lazyTools = {
+      getWeather: tool({
+        description: 'Get weather',
+        inputSchema: z.object({ city: z.string() }),
+        lazy: true,
+      }),
+      searchDocs: tool({
+        description: 'Search docs',
+        inputSchema: z.object({ query: z.string() }),
+        lazy: true,
+      }),
+    };
+
+    const loadTool = createLoadToolSchemaTool(lazyTools);
+
+    expect(loadTool.description).toContain('getWeather');
+    expect(loadTool.description).toContain('searchDocs');
+  });
+
+  it('execute returns full inputSchema for requested tools', async () => {
+    const lazyTools = {
+      getWeather: tool({
+        description: 'Get weather',
+        inputSchema: z.object({ city: z.string() }),
+        lazy: true,
+      }),
+    };
+
+    const loadTool = createLoadToolSchemaTool(lazyTools);
+
+    const result = await loadTool.execute!({ toolNames: ['getWeather'] }, {
+      toolCallId: 'test-id',
+      messages: [],
+      abortSignal: undefined,
+      experimental_context: undefined,
+    } as any);
+
+    expect(result).toBeDefined();
+    const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+
+    // Should contain the full schema for getWeather with city property
+    const weatherSchema = parsed.getWeather ?? parsed['getWeather'];
+    expect(weatherSchema).toBeDefined();
+    expect(weatherSchema.inputSchema).toBeDefined();
+    expect(weatherSchema.inputSchema.properties).toHaveProperty('city');
+  });
+
+  it('execute returns skill text when present', async () => {
+    const lazyTools = {
+      myTool: tool({
+        description: 'My tool',
+        inputSchema: z.object({ x: z.number() }),
+        lazy: true,
+        skill: 'detailed usage info',
+      }),
+    };
+
+    const loadTool = createLoadToolSchemaTool(lazyTools);
+
+    const result = await loadTool.execute!({ toolNames: ['myTool'] }, {
+      toolCallId: 'test-id',
+      messages: [],
+      abortSignal: undefined,
+      experimental_context: undefined,
+    } as any);
+
+    const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+    const toolResult = parsed.myTool ?? parsed['myTool'];
+    expect(toolResult).toBeDefined();
+    expect(toolResult.skill).toBe('detailed usage info');
+  });
+
+  it('execute returns inputExamples when present', async () => {
+    const lazyTools = {
+      myTool: tool({
+        description: 'My tool',
+        inputSchema: z.object({ city: z.string() }),
+        lazy: true,
+        inputExamples: [{ input: { city: 'NYC' } }],
+      }),
+    };
+
+    const loadTool = createLoadToolSchemaTool(lazyTools);
+
+    const result = await loadTool.execute!({ toolNames: ['myTool'] }, {
+      toolCallId: 'test-id',
+      messages: [],
+      abortSignal: undefined,
+      experimental_context: undefined,
+    } as any);
+
+    const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+    const toolResult = parsed.myTool ?? parsed['myTool'];
+    expect(toolResult).toBeDefined();
+    expect(toolResult.inputExamples).toEqual([{ input: { city: 'NYC' } }]);
+  });
+
+  it('execute returns error entry for unknown tool names', async () => {
+    const lazyTools = {
+      myTool: tool({
+        description: 'My tool',
+        inputSchema: z.object({ x: z.number() }),
+        lazy: true,
+      }),
+    };
+
+    const loadTool = createLoadToolSchemaTool(lazyTools);
+
+    const result = await loadTool.execute!({ toolNames: ['nonexistent'] }, {
+      toolCallId: 'test-id',
+      messages: [],
+      abortSignal: undefined,
+      experimental_context: undefined,
+    } as any);
+
+    const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+
+    expect(parsed.nonexistent).toEqual({
+      error: "Tool 'nonexistent' is not a lazy tool or does not exist",
+    });
+  });
+
+  it('execute handles mixed known and unknown names', async () => {
+    const lazyTools = {
+      validTool: tool({
+        description: 'Valid tool',
+        inputSchema: z.object({ name: z.string() }),
+        lazy: true,
+      }),
+    };
+
+    const loadTool = createLoadToolSchemaTool(lazyTools);
+
+    const result = await loadTool.execute!(
+      { toolNames: ['validTool', 'invalidTool'] },
+      {
+        toolCallId: 'test-id',
+        messages: [],
+        abortSignal: undefined,
+        experimental_context: undefined,
+      } as any,
+    );
+
+    const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+
+    const validResult = parsed.validTool ?? parsed['validTool'];
+    expect(validResult).toBeDefined();
+    expect(validResult.inputSchema).toBeDefined();
+
+    expect(parsed.invalidTool).toEqual({
+      error: "Tool 'invalidTool' is not a lazy tool or does not exist",
+    });
+  });
+});
+
+describe('buildEffectiveTools', () => {
+  it('returns undefined when tools is undefined', () => {
+    expect(buildEffectiveTools(undefined)).toBeUndefined();
+  });
+
+  it('returns tools unchanged when no lazy tools exist', () => {
+    const tools = {
+      eagerTool: tool({
+        description: 'Eager',
+        inputSchema: z.object({}),
+      }),
+    };
+
+    const result = buildEffectiveTools(tools);
+    expect(result).toBe(tools);
+  });
+
+  it('injects __load_tool_schema__ when lazy tools exist', () => {
+    const tools = {
+      eagerTool: tool({
+        description: 'Eager',
+        inputSchema: z.object({}),
+      }),
+      lazyTool: tool({
+        description: 'Lazy',
+        inputSchema: z.object({ q: z.string() }),
+        lazy: true,
+      }),
+    };
+
+    const result = buildEffectiveTools(tools) as Record<string, unknown>;
+    expect(result).toBeDefined();
+    expect(result[LOAD_TOOL_SCHEMA_NAME]).toBeDefined();
+    expect(result.eagerTool).toBe(tools.eagerTool);
+    expect(result.lazyTool).toBe(tools.lazyTool);
+  });
+
+  it('does not override user-provided __load_tool_schema__', () => {
+    const customLoader = tool({
+      description: 'Custom loader',
+      inputSchema: z.object({}),
+    });
+
+    const tools = {
+      [LOAD_TOOL_SCHEMA_NAME]: customLoader,
+      lazyTool: tool({
+        description: 'Lazy',
+        inputSchema: z.object({}),
+        lazy: true,
+      }),
+    };
+
+    const result = buildEffectiveTools(tools);
+    expect(result![LOAD_TOOL_SCHEMA_NAME]).toBe(customLoader);
+  });
+});

--- a/packages/ai/src/generate-text/load-tool-schema.ts
+++ b/packages/ai/src/generate-text/load-tool-schema.ts
@@ -14,9 +14,7 @@ export function createLoadToolSchemaTool(
   return tool({
     description: `Load the full input schema and usage details for tools before calling them. You MUST call this first for any of these tools: ${toolNames.join(', ')}. Always pass at least one tool name. After receiving the schema, proceed to call the tool with the correct arguments.`,
     inputSchema: z.object({
-      toolNames: z
-        .array(z.string())
-        .min(1, 'At least one tool name is required'),
+      toolNames: z.array(z.string()),
     }),
     async execute({ toolNames: requestedNames }) {
       if (requestedNames.length === 0) {

--- a/packages/ai/src/generate-text/load-tool-schema.ts
+++ b/packages/ai/src/generate-text/load-tool-schema.ts
@@ -4,15 +4,7 @@ import { z } from 'zod/v4';
 
 export const LOAD_TOOL_SCHEMA_NAME = '__load_tool_schema__';
 
-type LoadToolSchemaResult = Record<
-  string,
-  | {
-      inputSchema: unknown;
-      skill?: string;
-      inputExamples?: unknown[];
-    }
-  | { error: string }
->;
+type LoadToolSchemaResult = Record<string, unknown>;
 
 export function createLoadToolSchemaTool(
   lazyTools: ToolSet,
@@ -20,7 +12,7 @@ export function createLoadToolSchemaTool(
   const toolNames = Object.keys(lazyTools);
 
   return tool({
-    description: `Load the full input schema for lazy tools. Available lazy tools: ${toolNames.join(', ')}`,
+    description: `Load the full input schema and usage details for tools before calling them. You MUST call this first for any of these tools: ${toolNames.join(', ')}. After receiving the schema, proceed to call the tool with the correct arguments.`,
     inputSchema: z.object({
       toolNames: z.array(z.string()),
     }),
@@ -41,7 +33,9 @@ export function createLoadToolSchemaTool(
           skill?: string;
           inputExamples?: unknown[];
         } = {
-          inputSchema: await asSchema(t.inputSchema).jsonSchema,
+          inputSchema: JSON.parse(
+            JSON.stringify(await asSchema(t.inputSchema).jsonSchema),
+          ),
         };
 
         if (t.skill != null) {
@@ -55,6 +49,8 @@ export function createLoadToolSchemaTool(
         result[name] = entry;
       }
 
+      result._instruction =
+        'Schema loaded. Now call the tool(s) with the correct arguments based on the inputSchema above.';
       return result;
     },
   });

--- a/packages/ai/src/generate-text/load-tool-schema.ts
+++ b/packages/ai/src/generate-text/load-tool-schema.ts
@@ -56,7 +56,8 @@ export function createLoadToolSchemaTool(
       }
 
       result._instruction =
-        'Schema loaded. Now call the tool(s) with the correct arguments based on the inputSchema above.';
+        'Schema loaded. Now call the tool by passing a JSON-encoded string of all arguments in the jsonInput parameter. ' +
+        'Construct a valid JSON object matching the inputSchema above and pass it as a string value to jsonInput.';
       return result;
     },
   });

--- a/packages/ai/src/generate-text/load-tool-schema.ts
+++ b/packages/ai/src/generate-text/load-tool-schema.ts
@@ -12,11 +12,19 @@ export function createLoadToolSchemaTool(
   const toolNames = Object.keys(lazyTools);
 
   return tool({
-    description: `Load the full input schema and usage details for tools before calling them. You MUST call this first for any of these tools: ${toolNames.join(', ')}. After receiving the schema, proceed to call the tool with the correct arguments.`,
+    description: `Load the full input schema and usage details for tools before calling them. You MUST call this first for any of these tools: ${toolNames.join(', ')}. Always pass at least one tool name. After receiving the schema, proceed to call the tool with the correct arguments.`,
     inputSchema: z.object({
-      toolNames: z.array(z.string()),
+      toolNames: z
+        .array(z.string())
+        .min(1, 'At least one tool name is required'),
     }),
     async execute({ toolNames: requestedNames }) {
+      if (requestedNames.length === 0) {
+        return {
+          error: `No tool names provided. Pass at least one name from: ${toolNames.join(', ')}`,
+        } as LoadToolSchemaResult;
+      }
+
       const result: LoadToolSchemaResult = {};
 
       for (const name of requestedNames) {

--- a/packages/ai/src/generate-text/load-tool-schema.ts
+++ b/packages/ai/src/generate-text/load-tool-schema.ts
@@ -1,0 +1,84 @@
+import { asSchema, tool } from '@ai-sdk/provider-utils';
+import type { Tool, ToolSet } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const LOAD_TOOL_SCHEMA_NAME = '__load_tool_schema__';
+
+type LoadToolSchemaResult = Record<
+  string,
+  | {
+      inputSchema: unknown;
+      skill?: string;
+      inputExamples?: unknown[];
+    }
+  | { error: string }
+>;
+
+export function createLoadToolSchemaTool(
+  lazyTools: ToolSet,
+): Tool<{ toolNames: string[] }, LoadToolSchemaResult> {
+  const toolNames = Object.keys(lazyTools);
+
+  return tool({
+    description: `Load the full input schema for lazy tools. Available lazy tools: ${toolNames.join(', ')}`,
+    inputSchema: z.object({
+      toolNames: z.array(z.string()),
+    }),
+    async execute({ toolNames: requestedNames }) {
+      const result: LoadToolSchemaResult = {};
+
+      for (const name of requestedNames) {
+        const t = lazyTools[name];
+        if (t == null) {
+          result[name] = {
+            error: `Tool '${name}' is not a lazy tool or does not exist`,
+          };
+          continue;
+        }
+
+        const entry: {
+          inputSchema: unknown;
+          skill?: string;
+          inputExamples?: unknown[];
+        } = {
+          inputSchema: await asSchema(t.inputSchema).jsonSchema,
+        };
+
+        if (t.skill != null) {
+          entry.skill = t.skill;
+        }
+
+        if (t.inputExamples != null) {
+          entry.inputExamples = t.inputExamples;
+        }
+
+        result[name] = entry;
+      }
+
+      return result;
+    },
+  });
+}
+
+export function buildEffectiveTools<TOOLS extends ToolSet>(
+  tools: TOOLS | undefined,
+): TOOLS | undefined {
+  if (tools == null) {
+    return undefined;
+  }
+
+  const lazyTools = Object.fromEntries(
+    Object.entries(tools).filter(([_, t]) => t.lazy),
+  ) as ToolSet;
+
+  if (Object.keys(lazyTools).length === 0) {
+    return tools;
+  }
+
+  return {
+    ...tools,
+    ...(tools[LOAD_TOOL_SCHEMA_NAME]
+      ? {}
+      : { [LOAD_TOOL_SCHEMA_NAME]: createLoadToolSchemaTool(lazyTools) }),
+  } as TOOLS;
+}

--- a/packages/ai/src/generate-text/load-tool-schema.ts
+++ b/packages/ai/src/generate-text/load-tool-schema.ts
@@ -56,8 +56,7 @@ export function createLoadToolSchemaTool(
       }
 
       result._instruction =
-        'Schema loaded. Now call the tool by passing a JSON-encoded string of all arguments in the jsonInput parameter. ' +
-        'Construct a valid JSON object matching the inputSchema above and pass it as a string value to jsonInput.';
+        'Schema loaded. Now call the tool(s) with the correct arguments based on the inputSchema above.';
       return result;
     },
   });

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -150,19 +150,69 @@ async function doParseToolCall<TOOLS extends ToolSet>({
 
   const schema = asSchema(tool.inputSchema);
 
-  // when the tool call has no arguments, we try passing an empty object to the schema
-  // (many LLMs generate empty strings for tool calls with no arguments)
-  const parseResult =
-    toolCall.input.trim() === ''
-      ? await safeValidateTypes({ value: {}, schema })
-      : await safeParseJSON({ text: toolCall.input, schema });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let parsedInput: any;
 
-  if (parseResult.success === false) {
-    throw new InvalidToolInputError({
-      toolName,
-      toolInput: toolCall.input,
-      cause: parseResult.error,
+  if (tool.lazy) {
+    // Lazy tools receive { jsonInput: string } from the LLM.
+    // Unwrap the JSON string and validate against the real schema.
+    const wrapperResult =
+      toolCall.input.trim() === ''
+        ? await safeValidateTypes({ value: {}, schema })
+        : await safeParseJSON({ text: toolCall.input });
+
+    if (wrapperResult.success === false) {
+      throw new InvalidToolInputError({
+        toolName,
+        toolInput: toolCall.input,
+        cause: wrapperResult.error,
+      });
+    }
+
+    const wrapper = wrapperResult.value as Record<string, unknown>;
+    const jsonInputStr =
+      typeof wrapper?.jsonInput === 'string' ? wrapper.jsonInput : null;
+
+    if (jsonInputStr == null) {
+      throw new InvalidToolInputError({
+        toolName,
+        toolInput: toolCall.input,
+        cause: new Error(
+          'Lazy tool call missing jsonInput field. Call __load_tool_schema__ first to get the input structure.',
+        ),
+      });
+    }
+
+    const realParseResult = await safeParseJSON({
+      text: jsonInputStr,
+      schema,
     });
+
+    if (realParseResult.success === false) {
+      throw new InvalidToolInputError({
+        toolName,
+        toolInput: jsonInputStr,
+        cause: realParseResult.error,
+      });
+    }
+
+    parsedInput = realParseResult.value;
+  } else {
+    // Normal (non-lazy) tools: validate directly against schema
+    const parseResult =
+      toolCall.input.trim() === ''
+        ? await safeValidateTypes({ value: {}, schema })
+        : await safeParseJSON({ text: toolCall.input, schema });
+
+    if (parseResult.success === false) {
+      throw new InvalidToolInputError({
+        toolName,
+        toolInput: toolCall.input,
+        cause: parseResult.error,
+      });
+    }
+
+    parsedInput = parseResult.value;
   }
 
   return tool.type === 'dynamic'
@@ -170,7 +220,7 @@ async function doParseToolCall<TOOLS extends ToolSet>({
         type: 'tool-call',
         toolCallId: toolCall.toolCallId,
         toolName: toolCall.toolName,
-        input: parseResult.value,
+        input: parsedInput,
         providerExecuted: toolCall.providerExecuted,
         providerMetadata: toolCall.providerMetadata,
         dynamic: true,
@@ -180,7 +230,7 @@ async function doParseToolCall<TOOLS extends ToolSet>({
         type: 'tool-call',
         toolCallId: toolCall.toolCallId,
         toolName,
-        input: parseResult.value,
+        input: parsedInput,
         providerExecuted: toolCall.providerExecuted,
         providerMetadata: toolCall.providerMetadata,
         title: tool.title,

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -150,70 +150,37 @@ async function doParseToolCall<TOOLS extends ToolSet>({
 
   const schema = asSchema(tool.inputSchema);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let parsedInput: any;
+  // when the tool call has no arguments, we try passing an empty object to the schema
+  // (many LLMs generate empty strings for tool calls with no arguments)
+  let parseResult =
+    toolCall.input.trim() === ''
+      ? await safeValidateTypes({ value: {}, schema })
+      : await safeParseJSON({ text: toolCall.input, schema });
 
-  if (tool.lazy) {
-    // Lazy tools receive { jsonInput: string } from the LLM.
-    // Unwrap the JSON string and validate against the real schema.
-    const wrapperResult =
-      toolCall.input.trim() === ''
-        ? await safeValidateTypes({ value: {}, schema })
-        : await safeParseJSON({ text: toolCall.input });
-
-    if (wrapperResult.success === false) {
-      throw new InvalidToolInputError({
-        toolName,
-        toolInput: toolCall.input,
-        cause: wrapperResult.error,
-      });
+  // For lazy tools, the LLM may send strings for nested objects/arrays
+  // because it only sees a minimal schema. Try to repair by JSON.parsing
+  // string values that should be objects/arrays according to the real schema.
+  if (parseResult.success === false && tool.lazy) {
+    const rawParseResult = await safeParseJSON({ text: toolCall.input });
+    if (rawParseResult.success) {
+      const repaired = repairLazyToolInput(
+        rawParseResult.value as Record<string, unknown>,
+        (await schema.jsonSchema) as Record<string, unknown>,
+      );
+      parseResult = await safeValidateTypes({ value: repaired, schema });
     }
-
-    const wrapper = wrapperResult.value as Record<string, unknown>;
-    const jsonInputStr =
-      typeof wrapper?.jsonInput === 'string' ? wrapper.jsonInput : null;
-
-    if (jsonInputStr == null) {
-      throw new InvalidToolInputError({
-        toolName,
-        toolInput: toolCall.input,
-        cause: new Error(
-          'Lazy tool call missing jsonInput field. Call __load_tool_schema__ first to get the input structure.',
-        ),
-      });
-    }
-
-    const realParseResult = await safeParseJSON({
-      text: jsonInputStr,
-      schema,
-    });
-
-    if (realParseResult.success === false) {
-      throw new InvalidToolInputError({
-        toolName,
-        toolInput: jsonInputStr,
-        cause: realParseResult.error,
-      });
-    }
-
-    parsedInput = realParseResult.value;
-  } else {
-    // Normal (non-lazy) tools: validate directly against schema
-    const parseResult =
-      toolCall.input.trim() === ''
-        ? await safeValidateTypes({ value: {}, schema })
-        : await safeParseJSON({ text: toolCall.input, schema });
-
-    if (parseResult.success === false) {
-      throw new InvalidToolInputError({
-        toolName,
-        toolInput: toolCall.input,
-        cause: parseResult.error,
-      });
-    }
-
-    parsedInput = parseResult.value;
   }
+
+  if (parseResult.success === false) {
+    throw new InvalidToolInputError({
+      toolName,
+      toolInput: toolCall.input,
+      cause: parseResult.error,
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const parsedInput: any = parseResult.value;
 
   return tool.type === 'dynamic'
     ? {
@@ -235,4 +202,46 @@ async function doParseToolCall<TOOLS extends ToolSet>({
         providerMetadata: toolCall.providerMetadata,
         title: tool.title,
       };
+}
+
+/**
+ * Repairs lazy tool input by JSON.parsing string values that should be
+ * objects or arrays according to the JSON Schema. LLMs send strings for
+ * nested fields when the tool definition has a minimal schema.
+ */
+function repairLazyToolInput(
+  input: Record<string, unknown>,
+  jsonSchema: Record<string, unknown>,
+): Record<string, unknown> {
+  const properties = jsonSchema.properties as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+
+  if (properties == null) {
+    return input;
+  }
+
+  const repaired = { ...input };
+
+  for (const [key, value] of Object.entries(repaired)) {
+    if (typeof value !== 'string') {
+      continue;
+    }
+
+    const propSchema = properties[key];
+    if (propSchema == null) {
+      continue;
+    }
+
+    const expectedType = propSchema.type as string | undefined;
+    if (expectedType === 'object' || expectedType === 'array') {
+      try {
+        repaired[key] = JSON.parse(value);
+      } catch {
+        // keep original string if not valid JSON
+      }
+    }
+  }
+
+  return repaired;
 }

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -115,6 +115,7 @@ import { ToolOutput } from './tool-output';
 import { StaticToolOutputDenied } from './tool-output-denied';
 import type { GenerationContext } from './generation-context';
 import type { ToolSet } from '@ai-sdk/provider-utils';
+import { buildEffectiveTools } from './load-tool-schema';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -858,6 +859,9 @@ class DefaultStreamTextResult<
   }) {
     this.outputSpecification = output;
     this.includeRawChunks = includeRawChunks;
+
+    const effectiveTools = buildEffectiveTools(tools);
+    tools = effectiveTools ?? tools;
     this.tools = tools;
 
     const createGlobalTelemetry = getGlobalTelemetryIntegration<

--- a/packages/ai/src/prompt/prepare-tools.test.ts
+++ b/packages/ai/src/prompt/prepare-tools.test.ts
@@ -233,7 +233,7 @@ describe('prepareTools', () => {
     `);
   });
 
-  it('emits minimal schema for lazy tools', async () => {
+  it('emits jsonInput schema for lazy tools', async () => {
     const result = await prepareTools({
       tools: {
         lazyTool: tool({
@@ -244,15 +244,21 @@ describe('prepareTools', () => {
       },
     });
 
-    expect(result).toEqual([
-      {
-        type: 'function',
-        name: 'lazyTool',
-        description: 'A lazy tool',
-        inputSchema: { type: 'object', properties: {} },
-        providerOptions: undefined,
-      },
-    ]);
+    expect(result).toHaveLength(1);
+    const t = result![0] as {
+      type: string;
+      name: string;
+      inputSchema: Record<string, unknown>;
+      description: string;
+    };
+    expect(t.type).toBe('function');
+    expect(t.name).toBe('lazyTool');
+    expect(t.description).toContain('__load_tool_schema__');
+
+    const props = t.inputSchema.properties as Record<string, { type: string }>;
+    expect(props.jsonInput).toBeDefined();
+    expect(props.jsonInput.type).toBe('string');
+    expect(t.inputSchema.required).toEqual(['jsonInput']);
   });
 
   it('handles mixed lazy and non-lazy tools', async () => {
@@ -275,30 +281,25 @@ describe('prepareTools', () => {
 
     const eager = result!.find(
       t => t.type === 'function' && t.name === 'eagerTool',
-    );
+    ) as unknown as { inputSchema: Record<string, unknown> };
     const lazy = result!.find(
       t => t.type === 'function' && t.name === 'lazyTool',
-    );
+    ) as unknown as { inputSchema: Record<string, unknown> };
 
     expect(eager).toBeDefined();
     expect(lazy).toBeDefined();
 
     // Eager tool should have full schema with properties
-    const eagerFunc = eager as unknown as {
-      inputSchema: Record<string, unknown>;
-    };
-    expect(eagerFunc.inputSchema).toHaveProperty('properties');
     expect(
-      (eagerFunc.inputSchema.properties as Record<string, unknown>).name,
+      (eager.inputSchema.properties as Record<string, unknown>).name,
     ).toBeDefined();
 
-    // Lazy tool should have minimal schema (no real properties)
-    const lazyFunc = lazy as unknown as {
-      inputSchema: Record<string, unknown>;
-    };
-    expect(lazyFunc.inputSchema).toEqual({
-      type: 'object',
-      properties: {},
-    });
+    // Lazy tool should have jsonInput string property
+    const lazyProps = lazy.inputSchema.properties as Record<
+      string,
+      { type: string }
+    >;
+    expect(lazyProps.jsonInput).toBeDefined();
+    expect(lazyProps.jsonInput.type).toBe('string');
   });
 });

--- a/packages/ai/src/prompt/prepare-tools.test.ts
+++ b/packages/ai/src/prompt/prepare-tools.test.ts
@@ -233,7 +233,7 @@ describe('prepareTools', () => {
     `);
   });
 
-  it('emits jsonInput schema for lazy tools', async () => {
+  it('emits minimal schema for lazy tools', async () => {
     const result = await prepareTools({
       tools: {
         lazyTool: tool({
@@ -254,11 +254,7 @@ describe('prepareTools', () => {
     expect(t.type).toBe('function');
     expect(t.name).toBe('lazyTool');
     expect(t.description).toContain('__load_tool_schema__');
-
-    const props = t.inputSchema.properties as Record<string, { type: string }>;
-    expect(props.jsonInput).toBeDefined();
-    expect(props.jsonInput.type).toBe('string');
-    expect(t.inputSchema.required).toEqual(['jsonInput']);
+    expect(t.inputSchema).toEqual({ type: 'object', properties: {} });
   });
 
   it('handles mixed lazy and non-lazy tools', async () => {
@@ -289,17 +285,10 @@ describe('prepareTools', () => {
     expect(eager).toBeDefined();
     expect(lazy).toBeDefined();
 
-    // Eager tool should have full schema with properties
     expect(
       (eager.inputSchema.properties as Record<string, unknown>).name,
     ).toBeDefined();
 
-    // Lazy tool should have jsonInput string property
-    const lazyProps = lazy.inputSchema.properties as Record<
-      string,
-      { type: string }
-    >;
-    expect(lazyProps.jsonInput).toBeDefined();
-    expect(lazyProps.jsonInput.type).toBe('string');
+    expect(lazy.inputSchema).toEqual({ type: 'object', properties: {} });
   });
 });

--- a/packages/ai/src/prompt/prepare-tools.test.ts
+++ b/packages/ai/src/prompt/prepare-tools.test.ts
@@ -232,4 +232,73 @@ describe('prepareTools', () => {
       ]
     `);
   });
+
+  it('emits minimal schema for lazy tools', async () => {
+    const result = await prepareTools({
+      tools: {
+        lazyTool: tool({
+          description: 'A lazy tool',
+          inputSchema: z.object({ query: z.string(), limit: z.number() }),
+          lazy: true,
+        }),
+      },
+    });
+
+    expect(result).toEqual([
+      {
+        type: 'function',
+        name: 'lazyTool',
+        description: 'A lazy tool',
+        inputSchema: { type: 'object', properties: {} },
+        providerOptions: undefined,
+      },
+    ]);
+  });
+
+  it('handles mixed lazy and non-lazy tools', async () => {
+    const result = await prepareTools({
+      tools: {
+        eagerTool: tool({
+          description: 'Eager tool',
+          inputSchema: z.object({ name: z.string() }),
+        }),
+        lazyTool: tool({
+          description: 'Lazy tool',
+          inputSchema: z.object({ query: z.string() }),
+          lazy: true,
+        }),
+      },
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(2);
+
+    const eager = result!.find(
+      t => t.type === 'function' && t.name === 'eagerTool',
+    );
+    const lazy = result!.find(
+      t => t.type === 'function' && t.name === 'lazyTool',
+    );
+
+    expect(eager).toBeDefined();
+    expect(lazy).toBeDefined();
+
+    // Eager tool should have full schema with properties
+    const eagerFunc = eager as unknown as {
+      inputSchema: Record<string, unknown>;
+    };
+    expect(eagerFunc.inputSchema).toHaveProperty('properties');
+    expect(
+      (eagerFunc.inputSchema.properties as Record<string, unknown>).name,
+    ).toBeDefined();
+
+    // Lazy tool should have minimal schema (no real properties)
+    const lazyFunc = lazy as unknown as {
+      inputSchema: Record<string, unknown>;
+    };
+    expect(lazyFunc.inputSchema).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
 });

--- a/packages/ai/src/prompt/prepare-tools.ts
+++ b/packages/ai/src/prompt/prepare-tools.ts
@@ -31,24 +31,8 @@ export async function prepareTools<TOOLS extends ToolSet>({
           languageModelTools.push({
             type: 'function' as const,
             name,
-            description: `${tool.description}. IMPORTANT: Call __load_tool_schema__ with this tool's name first to get the required input structure, then pass it as a JSON string in jsonInput.`,
-            inputSchema: {
-              type: 'object' as const,
-              properties: {
-                jsonInput: {
-                  type: 'string' as const,
-                  description:
-                    'A JSON-encoded string containing all arguments for this tool. ' +
-                    'Before calling this tool, you MUST first call __load_tool_schema__ ' +
-                    "with this tool's name to retrieve the full input structure (required fields, " +
-                    'types, nested objects, enums, etc.). Then construct a valid JSON object ' +
-                    'matching that structure and pass it here as a string. ' +
-                    'Example: if the schema has { slug: string, labels: { en: string, ptBR: string } }, ' +
-                    'pass jsonInput: \'{"slug":"my_entity","labels":{"en":"My Entity","ptBR":"Minha Entidade"}}\'',
-                },
-              },
-              required: ['jsonInput'] as const,
-            },
+            description: `${tool.description}. IMPORTANT: Call __load_tool_schema__ with this tool's name first to get the required input format before calling this tool.`,
+            inputSchema: { type: 'object' as const, properties: {} },
             providerOptions: tool.providerOptions,
           });
         } else {

--- a/packages/ai/src/prompt/prepare-tools.ts
+++ b/packages/ai/src/prompt/prepare-tools.ts
@@ -31,8 +31,24 @@ export async function prepareTools<TOOLS extends ToolSet>({
           languageModelTools.push({
             type: 'function' as const,
             name,
-            description: tool.description,
-            inputSchema: { type: 'object' as const, properties: {} },
+            description: `${tool.description}. IMPORTANT: Call __load_tool_schema__ with this tool's name first to get the required input structure, then pass it as a JSON string in jsonInput.`,
+            inputSchema: {
+              type: 'object' as const,
+              properties: {
+                jsonInput: {
+                  type: 'string' as const,
+                  description:
+                    'A JSON-encoded string containing all arguments for this tool. ' +
+                    'Before calling this tool, you MUST first call __load_tool_schema__ ' +
+                    "with this tool's name to retrieve the full input structure (required fields, " +
+                    'types, nested objects, enums, etc.). Then construct a valid JSON object ' +
+                    'matching that structure and pass it here as a string. ' +
+                    'Example: if the schema has { slug: string, labels: { en: string, ptBR: string } }, ' +
+                    'pass jsonInput: \'{"slug":"my_entity","labels":{"en":"My Entity","ptBR":"Minha Entidade"}}\'',
+                },
+              },
+              required: ['jsonInput'] as const,
+            },
             providerOptions: tool.providerOptions,
           });
         } else {

--- a/packages/ai/src/prompt/prepare-tools.ts
+++ b/packages/ai/src/prompt/prepare-tools.ts
@@ -27,17 +27,27 @@ export async function prepareTools<TOOLS extends ToolSet>({
       case undefined:
       case 'dynamic':
       case 'function':
-        languageModelTools.push({
-          type: 'function' as const,
-          name,
-          description: tool.description,
-          inputSchema: await asSchema(tool.inputSchema).jsonSchema,
-          ...(tool.inputExamples != null
-            ? { inputExamples: tool.inputExamples }
-            : {}),
-          providerOptions: tool.providerOptions,
-          ...(tool.strict != null ? { strict: tool.strict } : {}),
-        });
+        if (tool.lazy) {
+          languageModelTools.push({
+            type: 'function' as const,
+            name,
+            description: tool.description,
+            inputSchema: { type: 'object' as const, properties: {} },
+            providerOptions: tool.providerOptions,
+          });
+        } else {
+          languageModelTools.push({
+            type: 'function' as const,
+            name,
+            description: tool.description,
+            inputSchema: await asSchema(tool.inputSchema).jsonSchema,
+            ...(tool.inputExamples != null
+              ? { inputExamples: tool.inputExamples }
+              : {}),
+            providerOptions: tool.providerOptions,
+            ...(tool.strict != null ? { strict: tool.strict } : {}),
+          });
+        }
         break;
       case 'provider':
         languageModelTools.push({

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -141,6 +141,20 @@ export type Tool<
   providerOptions?: ProviderOptions;
 
   /**
+   * When true, only the tool's name and description are sent to the LLM.
+   * The full inputSchema and details can be loaded on demand via
+   * the __load_tool_schema__ utility tool.
+   */
+  lazy?: boolean;
+
+  /**
+   * Extended documentation for the tool, loaded on demand when the LLM
+   * calls __load_tool_schema__. Only used when lazy is true.
+   * Use this for detailed usage instructions, examples, edge cases, etc.
+   */
+  skill?: string;
+
+  /**
    * The schema of the input that the tool expects.
    * The language model will use this to generate the input.
    * It is also used to validate the output of the language model.


### PR DESCRIPTION
## Summary

Implements lazy tool discovery as requested in #13423. Tools marked with `lazy: true` send only their name and description to the LLM — the full `inputSchema` is omitted. A synthetic `__load_tool_schema__` tool is auto-injected so the LLM can fetch full schemas on demand before calling a tool.

**How it works:**
1. Lazy tools are sent to the LLM with a minimal empty schema (`{ type: 'object', properties: {} }`) instead of their full inputSchema
2. The LLM calls `__load_tool_schema__` to get the full schema as a tool result (text)
3. The LLM calls the lazy tool with arguments based on the loaded schema
4. If the LLM sends strings for nested objects/arrays (common with empty schemas), the SDK auto-repairs by JSON.parsing those values against the real schema, then validates and executes

This reduces token usage and improves tool selection accuracy for apps with large tool sets (20-50+ tools).

**Prior art:** [TanStack AI lazy tool discovery](https://tanstack.com/blog/tanstack-ai-lazy-tool-discovery), [Cursor dynamic context discovery](https://cursor.com/blog/dynamic-context-discovery) (46.9% token reduction in A/B test).

### Design principles
- **Stateless** — no tracking of what's been loaded, no message scanning
- **Cache-friendly** — same tool list every step, preserves LLM prompt cache
- **All tools always visible** (name + description) and always executable
- **Overridable** — users can define their own `__load_tool_schema__` tool
- **`skill` field** — optional extended docs loaded on demand for lazy tools

### Key implementation details
- `prepareTools`: lazy tools emit minimal empty schema with instruction to load schema first
- `parseToolCall`: for lazy tools, auto-repairs string→object/array mismatches using the real schema
- `__load_tool_schema__`: returns serialized JSON Schema (stripped of Zod internals via JSON.parse/stringify)
- `buildEffectiveTools`: shared helper used by both `generateText` and `streamText`
- `filterActiveTools`: preserves `__load_tool_schema__` when `activeTools` filtering is used

### Changes
- `@ai-sdk/provider-utils`: Add `lazy?: boolean` and `skill?: string` to `Tool` type
- `ai`: New `load-tool-schema.ts` — synthetic tool factory + `buildEffectiveTools` helper
- `ai`: `prepareTools` emits minimal empty schema for lazy tools
- `ai`: `parseToolCall` auto-repairs lazy tool inputs (JSON.parse strings that should be objects/arrays)
- `ai`: `filterActiveTools` preserves `__load_tool_schema__` through activeTools filtering
- `ai`: Auto-inject `__load_tool_schema__` when lazy tools exist (overridable)

## Test plan
- [x] Unit tests for `createLoadToolSchemaTool` (schema return, skill, inputExamples, error entries)
- [x] Unit tests for `buildEffectiveTools` (no-op without lazy, injection, user override)
- [x] Unit tests for `prepareTools` (minimal schema for lazy, mixed lazy/eager)
- [x] All 2210 existing tests pass
- [x] Full monorepo build (69/69 tasks)
- [x] Lint/format clean
- [x] Tested in real app (legbi) with 33 tools, 17 lazy

Closes #13423

🤖 Generated with [Claude Code](https://claude.com/claude-code)