### PR TITLE
fix(amazon-bedrock): preserve empty text blocks when reasoning content is present

### DIFF
--- a/.changeset/friendly-schools-drum.md
+++ b/.changeset/friendly-schools-drum.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(amazon-bedrock): preserve empty text blocks when reasoning content is present

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -4628,6 +4628,76 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should preserve empty text blocks between reasoning blocks', async () => {
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                reasoningContent: {
+                  reasoningText: {
+                    text: 'thinking...',
+                    signature: 'sig-1',
+                  },
+                },
+              },
+              { text: '' },
+              {
+                reasoningContent: {
+                  reasoningText: {
+                    text: 'more thinking...',
+                    signature: 'sig-2',
+                  },
+                },
+              },
+              { text: 'The answer is 42.' },
+            ],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
+        stopReason: 'stop_sequence',
+      },
+    };
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.content).toMatchInlineSnapshot(`
+      [
+        {
+          "providerMetadata": {
+            "bedrock": {
+              "signature": "sig-1",
+            },
+          },
+          "text": "thinking...",
+          "type": "reasoning",
+        },
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "providerMetadata": {
+            "bedrock": {
+              "signature": "sig-2",
+            },
+          },
+          "text": "more thinking...",
+          "type": "reasoning",
+        },
+        {
+          "text": "The answer is 42.",
+          "type": "text",
+        },
+      ]
+    `);
+  });
+
   it('should extract reasoning text without signature', async () => {
     server.urls[generateUrl].response = {
       type: 'json-value',

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -462,7 +462,7 @@ export class BedrockChatLanguageModel implements LanguageModelV4 {
     // map response content to content array
     for (const part of response.output.message.content) {
       // text
-      if (part.text) {
+      if (part.text != null) {
         content.push({ type: 'text', text: part.text });
       }
 

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -1037,6 +1037,70 @@ describe('assistant messages', () => {
       system: [],
     });
   });
+
+  it('should preserve empty text blocks when reasoning blocks are present', async () => {
+    const result = await convertToBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'thinking...',
+            providerOptions: {
+              bedrock: { signature: 'sig-1' },
+            },
+          },
+          { type: 'text', text: '' },
+          {
+            type: 'reasoning',
+            text: 'more thinking...',
+            providerOptions: {
+              bedrock: { signature: 'sig-2' },
+            },
+          },
+          { type: 'text', text: 'response text' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-123',
+            toolName: 'test',
+            input: {},
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Hello' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              reasoningContent: {
+                reasoningText: { text: 'thinking...', signature: 'sig-1' },
+              },
+            },
+            { text: '' },
+            {
+              reasoningContent: {
+                reasoningText: { text: 'more thinking...', signature: 'sig-2' },
+              },
+            },
+            { text: 'response text' },
+            { toolUse: { toolUseId: 'call-123', name: 'test', input: {} } },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
 });
 
 describe('tool messages', () => {

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -260,6 +260,9 @@ export async function convertToBedrockChatMessages(
           const message = block.messages[j];
           const isLastMessage = j === block.messages.length - 1;
           const { content } = message;
+          const hasReasoningBlocks = content.some(
+            part => part.type === 'reasoning',
+          );
 
           for (let k = 0; k < content.length; k++) {
             const part = content[k];
@@ -267,8 +270,8 @@ export async function convertToBedrockChatMessages(
 
             switch (part.type) {
               case 'text': {
-                // Skip empty text blocks
-                if (!part.text.trim()) {
+                // Skip empty text blocks unless reasoning blocks are present
+                if (!part.text.trim() && !hasReasoningBlocks) {
                   break;
                 }
 


### PR DESCRIPTION
## Background

#14071 

bedrock's claude models can return assistant messages with empty text blocks sandwiched between reasoning blocks. their API strictly validates that when you replay assistant messages in conversation history, the content blocks must appear in the exact same order. 

AI SDK was dropping those empty text blocks

## Summary

- Added a `hasReasoningBlocks` check so that empty text blocks are only skipped when the message does not contain reasoning blocks. When reasoning blocks are present, empty text blocks are preserved to maintain correct indices.
- changed `if (part.text)` to `if (part.text != null)` : the old check silently dropped empty text blocks from the response before they ever entered the SDK's message history

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #14071