### PR TITLE
feat(google): add fileData support to embedding model

### DIFF
--- a/.changeset/healthy-files-jam.md
+++ b/.changeset/healthy-files-jam.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+feat(google): add `fileData` support to embedding model

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1555,7 +1555,7 @@ The following optional provider options are available for Google embedding model
 
 - **content**: _array_
 
-  Optional. Per-value multimodal content parts for embedding non-text content (images, video, PDF, audio). Each entry corresponds to the embedding value at the same index — its parts are merged with the text value in the request. Use `null` for entries that are text-only. The array length must match the number of values being embedded. Each non-null entry is an array of parts, where each part can be either `{ text: string }` or `{ inlineData: { mimeType: string, data: string } }`. Supported by `gemini-embedding-2-preview`.
+  Optional. Per-value multimodal content parts for embedding non-text content (images, video, PDF, audio). Each entry corresponds to the embedding value at the same index — its parts are merged with the text value in the request. Use `null` for entries that are text-only. The array length must match the number of values being embedded. Each non-null entry is an array of parts, where each part can be `{ text: string }`, `{ inlineData: { mimeType: string, data: string } }` for inline base64 data, or `{ fileData: { fileUri: string, mimeType: string } }` to reference remote content via HTTP URL or Google Cloud Storage URI (`gs://...`). Supported by `gemini-embedding-2-preview`.
 
 ### Model Capabilities
 

--- a/examples/ai-functions/src/embed/google/gemini-embedding-2-preview-filedata.ts
+++ b/examples/ai-functions/src/embed/google/gemini-embedding-2-preview-filedata.ts
@@ -1,0 +1,30 @@
+import { google, type GoogleEmbeddingModelOptions } from '@ai-sdk/google';
+import { embed } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { embedding, usage, warnings } = await embed({
+    model: google.embeddingModel('gemini-embedding-2-preview'),
+    value: 'describe this video',
+    providerOptions: {
+      google: {
+        content: [
+          [
+            {
+              fileData: {
+                fileUri:
+                  'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
+                mimeType: 'application/pdf',
+              },
+            },
+          ],
+        ],
+      } satisfies GoogleEmbeddingModelOptions,
+    },
+  });
+
+  console.log('embedding length:', embedding.length);
+  console.log('first 5:', embedding.slice(0, 5));
+  console.log('usage:', usage);
+  console.log('warnings:', warnings);
+});

--- a/examples/ai-functions/src/embed/google/gemini-embedding-2-preview-filedata.ts
+++ b/examples/ai-functions/src/embed/google/gemini-embedding-2-preview-filedata.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const { embedding, usage, warnings } = await embed({
     model: google.embeddingModel('gemini-embedding-2-preview'),
-    value: 'describe this video',
+    value: 'a dummy PDF file',
     providerOptions: {
       google: {
         content: [
@@ -24,7 +24,7 @@ run(async () => {
   });
 
   console.log('embedding length:', embedding.length);
-  console.log('first 5:', embedding.slice(0, 5));
-  console.log('usage:', usage);
-  console.log('warnings:', warnings);
+  console.log(embedding);
+  console.log(usage);
+  console.log(warnings);
 });

--- a/examples/ai-functions/src/embed/google/gemini-embedding-2-preview-multimodal.ts
+++ b/examples/ai-functions/src/embed/google/gemini-embedding-2-preview-multimodal.ts
@@ -25,6 +25,7 @@ run(async () => {
     },
   });
 
+  console.log('embedding length:', embedding.length);
   console.log(embedding);
   console.log(usage);
   console.log(warnings);

--- a/examples/ai-functions/src/embed/google/gemini-embedding-2-preview.ts
+++ b/examples/ai-functions/src/embed/google/gemini-embedding-2-preview.ts
@@ -8,6 +8,7 @@ run(async () => {
     value: 'sunny day at the beach',
   });
 
+  console.log('embedding length:', embedding.length);
   console.log(embedding);
   console.log(usage);
   console.log(warnings);

--- a/packages/google/src/google-embedding-model-options.ts
+++ b/packages/google/src/google-embedding-model-options.ts
@@ -18,6 +18,12 @@ const googleEmbeddingContentPartSchema = z.union([
       data: z.string(),
     }),
   }),
+  z.object({
+    fileData: z.object({
+      fileUri: z.string(),
+      mimeType: z.string(),
+    }),
+  }),
 ]);
 
 export const googleEmbeddingModelOptions = lazySchema(() =>

--- a/packages/google/src/google-embedding-model.test.ts
+++ b/packages/google/src/google-embedding-model.test.ts
@@ -430,6 +430,43 @@ describe('GoogleEmbeddingModel', () => {
     `);
   });
 
+  it('should merge fileData content for single embedding', async () => {
+    prepareSingleJsonResponse();
+
+    await model.doEmbed({
+      values: [testValues[0]],
+      providerOptions: {
+        google: {
+          content: [
+            [
+              {
+                fileData: {
+                  fileUri: 'gs://bucket/video.mp4',
+                  mimeType: 'video/mp4',
+                },
+              },
+            ],
+          ],
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      content: {
+        parts: [
+          { text: 'sunny day at the beach' },
+          {
+            fileData: {
+              fileUri: 'gs://bucket/video.mp4',
+              mimeType: 'video/mp4',
+            },
+          },
+        ],
+      },
+      model: 'models/gemini-embedding-001',
+    });
+  });
+
   it('should throw error when content length does not match values length', async () => {
     prepareBatchJsonResponse();
 

--- a/packages/google/src/google-embedding-model.test.ts
+++ b/packages/google/src/google-embedding-model.test.ts
@@ -16,23 +16,29 @@ const testValues = ['sunny day at the beach', 'rainy day in the city'];
 
 const provider = createGoogle({ apiKey: 'test-api-key' });
 const model = provider.embeddingModel('gemini-embedding-001');
+const multimodalModel = provider.embeddingModel('gemini-embedding-2-preview');
 
 const URL =
   'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:something';
+const MULTIMODAL_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:something';
 
 const server = createTestServer({
   [URL]: {},
+  [MULTIMODAL_URL]: {},
 });
 
 describe('GoogleEmbeddingModel', () => {
   function prepareBatchJsonResponse({
     embeddings = dummyEmbeddings,
     headers,
+    url = URL,
   }: {
     embeddings?: EmbeddingModelV4Embedding[];
     headers?: Record<string, string>;
+    url?: typeof URL | typeof MULTIMODAL_URL;
   } = {}) {
-    server.urls[URL].response = {
+    server.urls[url].response = {
       type: 'json-value',
       headers,
       body: {
@@ -44,11 +50,13 @@ describe('GoogleEmbeddingModel', () => {
   function prepareSingleJsonResponse({
     embeddings = dummyEmbeddings,
     headers,
+    url = URL,
   }: {
     embeddings?: EmbeddingModelV4Embedding[];
     headers?: Record<string, string>;
+    url?: typeof URL | typeof MULTIMODAL_URL;
   } = {}) {
-    server.urls[URL].response = {
+    server.urls[url].response = {
       type: 'json-value',
       headers,
       body: {
@@ -431,9 +439,9 @@ describe('GoogleEmbeddingModel', () => {
   });
 
   it('should merge fileData content for single embedding', async () => {
-    prepareSingleJsonResponse();
+    prepareSingleJsonResponse({ url: MULTIMODAL_URL });
 
-    await model.doEmbed({
+    await multimodalModel.doEmbed({
       values: [testValues[0]],
       providerOptions: {
         google: {
@@ -463,7 +471,57 @@ describe('GoogleEmbeddingModel', () => {
           },
         ],
       },
-      model: 'models/gemini-embedding-001',
+      model: 'models/gemini-embedding-2-preview',
+    });
+  });
+
+  it('should merge fileData content for batch embedding', async () => {
+    prepareBatchJsonResponse({ url: MULTIMODAL_URL });
+
+    await multimodalModel.doEmbed({
+      values: testValues,
+      providerOptions: {
+        google: {
+          content: [
+            [
+              {
+                fileData: {
+                  fileUri: 'gs://bucket/video.mp4',
+                  mimeType: 'video/mp4',
+                },
+              },
+            ],
+            null,
+          ],
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      requests: [
+        {
+          content: {
+            parts: [
+              { text: 'sunny day at the beach' },
+              {
+                fileData: {
+                  fileUri: 'gs://bucket/video.mp4',
+                  mimeType: 'video/mp4',
+                },
+              },
+            ],
+            role: 'user',
+          },
+          model: 'models/gemini-embedding-2-preview',
+        },
+        {
+          content: {
+            parts: [{ text: 'rainy day in the city' }],
+            role: 'user',
+          },
+          model: 'models/gemini-embedding-2-preview',
+        },
+      ],
     });
   });
 


### PR DESCRIPTION
What's this?

Google Embedding models support HTTP public links, but there's no way to use it through AI SDK! This enables it.

## Summary
- Add `fileData` (with `fileUri` and `mimeType`) to the Google embedding content part schema, enabling embedding of remote video, audio, and PDF content via Google Cloud Storage URIs
- Add test verifying fileData parts are correctly merged into the embedContent request body

## Test plan
- [x] New test `should merge fileData content for single embedding` passes
- [x] All existing embedding model tests continue to pass
- [x] Package builds successfully