### PR TITLE
fix(providers): reconstruct auth headers after workflow deserialization

### DIFF
--- a/packages/anthropic/src/anthropic-auth.ts
+++ b/packages/anthropic/src/anthropic-auth.ts
@@ -1,0 +1,31 @@
+import { loadApiKey, withUserAgentSuffix } from '@ai-sdk/provider-utils';
+import { VERSION } from './version';
+
+/**
+ * Creates Anthropic auth headers. Used by both the provider factory and
+ * WORKFLOW_DESERIALIZE so the auth logic lives in a single place.
+ */
+export function createAnthropicHeaders(options?: {
+  apiKey?: string;
+  authToken?: string;
+  headers?: Record<string, string | undefined>;
+}): Record<string, string | undefined> {
+  const authHeaders: Record<string, string> = options?.authToken
+    ? { Authorization: `Bearer ${options.authToken}` }
+    : {
+        'x-api-key': loadApiKey({
+          apiKey: options?.apiKey,
+          environmentVariableName: 'ANTHROPIC_API_KEY',
+          description: 'Anthropic',
+        }),
+      };
+
+  return withUserAgentSuffix(
+    {
+      'anthropic-version': '2023-06-01',
+      ...authHeaders,
+      ...options?.headers,
+    },
+    `ai-sdk/anthropic/${VERSION}`,
+  );
+}

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -36,6 +36,7 @@ import {
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
 } from '@ai-sdk/provider-utils';
+import { createAnthropicHeaders } from './anthropic-auth';
 import { anthropicFailedResponseHandler } from './anthropic-error';
 import { AnthropicMessageMetadata } from './anthropic-message-metadata';
 import {
@@ -161,7 +162,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
     modelId: AnthropicMessagesModelId;
     config: AnthropicMessagesConfig;
   }) {
-    return new AnthropicMessagesLanguageModel(options.modelId, options.config);
+    return new AnthropicMessagesLanguageModel(options.modelId, {
+      ...options.config,
+      headers: options.config.headers ?? createAnthropicHeaders,
+    });
   }
 
   constructor(

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -9,17 +9,15 @@ import {
 import {
   FetchFunction,
   generateId,
-  loadApiKey,
   loadOptionalSetting,
   withoutTrailingSlash,
-  withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
+import { createAnthropicHeaders } from './anthropic-auth';
 import { AnthropicFiles } from './anthropic-files';
 import { AnthropicMessagesLanguageModel } from './anthropic-messages-language-model';
 import { AnthropicMessagesModelId } from './anthropic-messages-options';
 import { anthropicTools } from './anthropic-tools';
 import { AnthropicSkills } from './skills/anthropic-skills';
-import { VERSION } from './version';
 
 export interface AnthropicProvider extends ProviderV4 {
   /**
@@ -120,26 +118,12 @@ export function createAnthropic(
     });
   }
 
-  const getHeaders = () => {
-    const authHeaders: Record<string, string> = options.authToken
-      ? { Authorization: `Bearer ${options.authToken}` }
-      : {
-          'x-api-key': loadApiKey({
-            apiKey: options.apiKey,
-            environmentVariableName: 'ANTHROPIC_API_KEY',
-            description: 'Anthropic',
-          }),
-        };
-
-    return withUserAgentSuffix(
-      {
-        'anthropic-version': '2023-06-01',
-        ...authHeaders,
-        ...options.headers,
-      },
-      `ai-sdk/anthropic/${VERSION}`,
-    );
-  };
+  const getHeaders = () =>
+    createAnthropicHeaders({
+      apiKey: options.apiKey,
+      authToken: options.authToken,
+      headers: options.headers,
+    });
 
   const createChatModel = (modelId: AnthropicMessagesModelId) =>
     new AnthropicMessagesLanguageModel(modelId, {

--- a/packages/google/src/google-auth.ts
+++ b/packages/google/src/google-auth.ts
@@ -1,0 +1,23 @@
+import { loadApiKey, withUserAgentSuffix } from '@ai-sdk/provider-utils';
+import { VERSION } from './version';
+
+/**
+ * Creates Google Generative AI auth headers. Used by both the provider
+ * factory and WORKFLOW_DESERIALIZE so the auth logic lives in a single place.
+ */
+export function createGoogleHeaders(options?: {
+  apiKey?: string;
+  headers?: Record<string, string | undefined>;
+}): Record<string, string | undefined> {
+  return withUserAgentSuffix(
+    {
+      'x-goog-api-key': loadApiKey({
+        apiKey: options?.apiKey,
+        environmentVariableName: 'GOOGLE_GENERATIVE_AI_API_KEY',
+        description: 'Google Generative AI',
+      }),
+      ...options?.headers,
+    },
+    `ai-sdk/google/${VERSION}`,
+  );
+}

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -33,6 +33,7 @@ import {
   zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
+import { createGoogleHeaders } from './google-auth';
 import {
   convertGoogleGenerativeAIUsage,
   GoogleGenerativeAIUsageMetadata,
@@ -81,7 +82,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
     modelId: string;
     config: GoogleGenerativeAIConfig;
   }) {
-    return new GoogleGenerativeAILanguageModel(options.modelId, options.config);
+    return new GoogleGenerativeAILanguageModel(options.modelId, {
+      ...options.config,
+      headers: options.config.headers ?? createGoogleHeaders,
+    });
   }
 
   constructor(

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -9,11 +9,9 @@ import {
 import {
   FetchFunction,
   generateId,
-  loadApiKey,
   withoutTrailingSlash,
-  withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
-import { VERSION } from './version';
+import { createGoogleHeaders } from './google-auth';
 import { GoogleGenerativeAIEmbeddingModel } from './google-generative-ai-embedding-model';
 import { GoogleGenerativeAIEmbeddingModelId } from './google-generative-ai-embedding-options';
 import { GoogleGenerativeAILanguageModel } from './google-generative-ai-language-model';
@@ -137,17 +135,10 @@ export function createGoogleGenerativeAI(
   const providerName = options.name ?? 'google.generative-ai';
 
   const getHeaders = () =>
-    withUserAgentSuffix(
-      {
-        'x-goog-api-key': loadApiKey({
-          apiKey: options.apiKey,
-          environmentVariableName: 'GOOGLE_GENERATIVE_AI_API_KEY',
-          description: 'Google Generative AI',
-        }),
-        ...options.headers,
-      },
-      `ai-sdk/google/${VERSION}`,
-    );
+    createGoogleHeaders({
+      apiKey: options.apiKey,
+      headers: options.headers,
+    });
 
   const createChatModel = (modelId: GoogleGenerativeAIModelId) =>
     new GoogleGenerativeAILanguageModel(modelId, {

--- a/packages/mistral/src/mistral-auth.ts
+++ b/packages/mistral/src/mistral-auth.ts
@@ -1,0 +1,23 @@
+import { loadApiKey, withUserAgentSuffix } from '@ai-sdk/provider-utils';
+import { VERSION } from './version';
+
+/**
+ * Creates Mistral auth headers. Used by both the provider factory and
+ * WORKFLOW_DESERIALIZE so the auth logic lives in a single place.
+ */
+export function createMistralHeaders(options?: {
+  apiKey?: string;
+  headers?: Record<string, string | undefined>;
+}): Record<string, string | undefined> {
+  return withUserAgentSuffix(
+    {
+      Authorization: `Bearer ${loadApiKey({
+        apiKey: options?.apiKey,
+        environmentVariableName: 'MISTRAL_API_KEY',
+        description: 'Mistral',
+      })}`,
+      ...options?.headers,
+    },
+    `ai-sdk/mistral/${VERSION}`,
+  );
+}

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -26,6 +26,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { convertMistralUsage, MistralUsage } from './convert-mistral-usage';
+import { createMistralHeaders } from './mistral-auth';
 import { convertToMistralChatMessages } from './convert-to-mistral-chat-messages';
 import { getResponseMetadata } from './get-response-metadata';
 import { mapMistralFinishReason } from './map-mistral-finish-reason';
@@ -60,7 +61,10 @@ export class MistralChatLanguageModel implements LanguageModelV4 {
     modelId: MistralChatModelId;
     config: MistralChatConfig;
   }) {
-    return new MistralChatLanguageModel(options.modelId, options.config);
+    return new MistralChatLanguageModel(options.modelId, {
+      ...options.config,
+      headers: options.config.headers ?? createMistralHeaders,
+    });
   }
 
   constructor(modelId: MistralChatModelId, config: MistralChatConfig) {

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -4,17 +4,12 @@ import {
   NoSuchModelError,
   ProviderV4,
 } from '@ai-sdk/provider';
-import {
-  FetchFunction,
-  loadApiKey,
-  withoutTrailingSlash,
-  withUserAgentSuffix,
-} from '@ai-sdk/provider-utils';
+import { FetchFunction, withoutTrailingSlash } from '@ai-sdk/provider-utils';
+import { createMistralHeaders } from './mistral-auth';
 import { MistralChatLanguageModel } from './mistral-chat-language-model';
 import { MistralChatModelId } from './mistral-chat-options';
 import { MistralEmbeddingModel } from './mistral-embedding-model';
 import { MistralEmbeddingModelId } from './mistral-embedding-options';
-import { VERSION } from './version';
 
 export interface MistralProvider extends ProviderV4 {
   (modelId: MistralChatModelId): LanguageModelV4;
@@ -87,17 +82,10 @@ export function createMistral(
     withoutTrailingSlash(options.baseURL) ?? 'https://api.mistral.ai/v1';
 
   const getHeaders = () =>
-    withUserAgentSuffix(
-      {
-        Authorization: `Bearer ${loadApiKey({
-          apiKey: options.apiKey,
-          environmentVariableName: 'MISTRAL_API_KEY',
-          description: 'Mistral',
-        })}`,
-        ...options.headers,
-      },
-      `ai-sdk/mistral/${VERSION}`,
-    );
+    createMistralHeaders({
+      apiKey: options.apiKey,
+      headers: options.headers,
+    });
 
   const createChatModel = (modelId: MistralChatModelId) =>
     new MistralChatLanguageModel(modelId, {

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -25,6 +25,7 @@ import {
   WORKFLOW_DESERIALIZE,
   WORKFLOW_SERIALIZE,
 } from '@ai-sdk/provider-utils';
+import { createOpenAIHeaders, createOpenAIURL } from '../openai-auth';
 import { openaiFailedResponseHandler } from '../openai-error';
 import { getOpenAILanguageModelCapabilities } from '../openai-language-model-capabilities';
 import {
@@ -71,7 +72,11 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
     modelId: OpenAIChatModelId;
     config: OpenAIChatConfig;
   }) {
-    return new OpenAIChatLanguageModel(options.modelId, options.config);
+    return new OpenAIChatLanguageModel(options.modelId, {
+      ...options.config,
+      headers: options.config.headers ?? createOpenAIHeaders,
+      url: options.config.url ?? createOpenAIURL(),
+    });
   }
 
   constructor(modelId: OpenAIChatModelId, config: OpenAIChatConfig) {

--- a/packages/openai/src/completion/openai-completion-language-model.ts
+++ b/packages/openai/src/completion/openai-completion-language-model.ts
@@ -20,6 +20,7 @@ import {
   WORKFLOW_DESERIALIZE,
   WORKFLOW_SERIALIZE,
 } from '@ai-sdk/provider-utils';
+import { createOpenAIHeaders, createOpenAIURL } from '../openai-auth';
 import { openaiFailedResponseHandler } from '../openai-error';
 import {
   convertOpenAICompletionUsage,
@@ -64,7 +65,11 @@ export class OpenAICompletionLanguageModel implements LanguageModelV4 {
     modelId: OpenAICompletionModelId;
     config: OpenAICompletionConfig;
   }) {
-    return new OpenAICompletionLanguageModel(options.modelId, options.config);
+    return new OpenAICompletionLanguageModel(options.modelId, {
+      ...options.config,
+      headers: options.config.headers ?? createOpenAIHeaders,
+      url: options.config.url ?? createOpenAIURL(),
+    });
   }
 
   constructor(

--- a/packages/openai/src/openai-auth.ts
+++ b/packages/openai/src/openai-auth.ts
@@ -1,0 +1,49 @@
+import {
+  loadApiKey,
+  loadOptionalSetting,
+  withoutTrailingSlash,
+  withUserAgentSuffix,
+} from '@ai-sdk/provider-utils';
+import { VERSION } from './version';
+
+/**
+ * Creates OpenAI auth headers. Used by both the provider factory and
+ * WORKFLOW_DESERIALIZE so the auth logic lives in a single place.
+ */
+export function createOpenAIHeaders(options?: {
+  apiKey?: string;
+  organization?: string;
+  project?: string;
+  headers?: Record<string, string | undefined>;
+}): Record<string, string | undefined> {
+  return withUserAgentSuffix(
+    {
+      Authorization: `Bearer ${loadApiKey({
+        apiKey: options?.apiKey,
+        environmentVariableName: 'OPENAI_API_KEY',
+        description: 'OpenAI',
+      })}`,
+      'OpenAI-Organization': options?.organization,
+      'OpenAI-Project': options?.project,
+      ...options?.headers,
+    },
+    `ai-sdk/openai/${VERSION}`,
+  );
+}
+
+/**
+ * Creates the default OpenAI URL resolver. Used by WORKFLOW_DESERIALIZE
+ * to reconstruct the url function stripped during serialization.
+ */
+export function createOpenAIURL(options?: {
+  baseURL?: string;
+}): (opts: { modelId: string; path: string }) => string {
+  const baseURL =
+    withoutTrailingSlash(
+      loadOptionalSetting({
+        settingValue: options?.baseURL,
+        environmentVariableName: 'OPENAI_BASE_URL',
+      }),
+    ) ?? 'https://api.openai.com/v1';
+  return ({ path }) => `${baseURL}${path}`;
+}

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -10,11 +10,10 @@ import {
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
-  loadApiKey,
   loadOptionalSetting,
   withoutTrailingSlash,
-  withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
+import { createOpenAIHeaders } from './openai-auth';
 import { OpenAIChatLanguageModel } from './chat/openai-chat-language-model';
 import { OpenAIChatModelId } from './chat/openai-chat-options';
 import { OpenAICompletionLanguageModel } from './completion/openai-completion-language-model';
@@ -32,7 +31,6 @@ import { OpenAISpeechModelId } from './speech/openai-speech-options';
 import { OpenAITranscriptionModel } from './transcription/openai-transcription-model';
 import { OpenAITranscriptionModelId } from './transcription/openai-transcription-options';
 import { OpenAISkills } from './skills/openai-skills';
-import { VERSION } from './version';
 
 export interface OpenAIProvider extends ProviderV4 {
   (modelId: OpenAIResponsesModelId): LanguageModelV4;
@@ -168,19 +166,12 @@ export function createOpenAI(
   const providerName = options.name ?? 'openai';
 
   const getHeaders = () =>
-    withUserAgentSuffix(
-      {
-        Authorization: `Bearer ${loadApiKey({
-          apiKey: options.apiKey,
-          environmentVariableName: 'OPENAI_API_KEY',
-          description: 'OpenAI',
-        })}`,
-        'OpenAI-Organization': options.organization,
-        'OpenAI-Project': options.project,
-        ...options.headers,
-      },
-      `ai-sdk/openai/${VERSION}`,
-    );
+    createOpenAIHeaders({
+      apiKey: options.apiKey,
+      organization: options.organization,
+      project: options.project,
+      headers: options.headers,
+    });
 
   const createChatModel = (modelId: OpenAIChatModelId) =>
     new OpenAIChatLanguageModel(modelId, {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -29,6 +29,7 @@ import {
   WORKFLOW_DESERIALIZE,
   WORKFLOW_SERIALIZE,
 } from '@ai-sdk/provider-utils';
+import { createOpenAIHeaders, createOpenAIURL } from '../openai-auth';
 import { OpenAIConfig } from '../openai-config';
 import { openaiFailedResponseHandler } from '../openai-error';
 import { getOpenAILanguageModelCapabilities } from '../openai-language-model-capabilities';
@@ -118,7 +119,11 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
     modelId: OpenAIResponsesModelId;
     config: OpenAIConfig;
   }) {
-    return new OpenAIResponsesLanguageModel(options.modelId, options.config);
+    return new OpenAIResponsesLanguageModel(options.modelId, {
+      ...options.config,
+      headers: options.config.headers ?? createOpenAIHeaders,
+      url: options.config.url ?? createOpenAIURL(),
+    });
   }
 
   constructor(modelId: OpenAIResponsesModelId, config: OpenAIConfig) {


### PR DESCRIPTION
## Summary

Fix `AI_APICallError: x-api-key header is required` when using provider models (e.g. `anthropic('claude-sonnet-4-20250514')`) inside workflow steps.

### Problem

When a language model crosses a `'use step'` boundary, `WORKFLOW_SERIALIZE` (via `serializeModel`) strips function-valued config — including the `headers` function that carries auth credentials. `WORKFLOW_DESERIALIZE` was passing the stripped config directly, so the deserialized model had no API key.

### Approach

Resolve headers at serialization time instead of stripping them:

```
Serialization:  config.headers = () => ({ 'x-api-key': 'sk-...' })
                        ↓ serializeModel calls headers()
Serialized:     config.headers = { 'x-api-key': 'sk-...' }
                        ↓ plain object survives step boundary
Deserialization: deserializeModelConfig wraps it back
Result:         config.headers = () => ({ 'x-api-key': 'sk-...' })
```

Two changes in `provider-utils/src/serialize-model.ts`:
- **`serializeModel`**: now calls `config.headers()` to resolve the function into a plain key-value object before serializing
- **`deserializeModelConfig`** (new): wraps plain-object headers back into a function so model code can continue calling `config.headers()`

Each model's `WORKFLOW_DESERIALIZE` wraps the config with `deserializeModelConfig(options.config)`. This works for all providers uniformly — no per-provider changes needed.

## Test plan

- [x] Verified fix with `examples/next-workflow` — submitting "hi" now gets a successful response instead of the `x-api-key` error
- [x] All provider-utils tests pass (491 tests, including new serialize/deserialize tests)
- [x] Type checking passes (`pnpm type-check:full`)