### PR TITLE
feat(provider-utils): add serializeModel and deserializeModelConfig

### DIFF
--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -78,3 +78,4 @@ export {
   EventSourceParserStream,
   type EventSourceMessage,
 } from 'eventsource-parser/stream';
+export { serializeModel, deserializeModelConfig } from './serialize-model';

--- a/packages/provider-utils/src/serialize-model.test.ts
+++ b/packages/provider-utils/src/serialize-model.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { serializeModel, deserializeModelConfig } from './serialize-model';
+
+describe('serializeModel', () => {
+  it('returns modelId and serializable config', () => {
+    const result = serializeModel({
+      modelId: 'claude-sonnet-4-20250514',
+      config: {
+        provider: 'anthropic.messages',
+        baseURL: 'https://api.anthropic.com/v1',
+        headers: () => ({ 'x-api-key': 'sk-test' }),
+        fetch: undefined,
+        generateId: () => 'id',
+        supportedUrls: () => ({}),
+        supportsNativeStructuredOutput: true,
+        supportsStrictTools: false,
+      },
+    });
+    expect(result).toEqual({
+      modelId: 'claude-sonnet-4-20250514',
+      config: {
+        provider: 'anthropic.messages',
+        baseURL: 'https://api.anthropic.com/v1',
+        headers: { 'x-api-key': 'sk-test' },
+        fetch: undefined,
+        supportsNativeStructuredOutput: true,
+        supportsStrictTools: false,
+      },
+    });
+  });
+
+  it('resolves headers functions but filters out other functions', () => {
+    const result = serializeModel({
+      modelId: 'gpt-4',
+      config: {
+        provider: 'openai',
+        headers: () => ({ authorization: 'Bearer sk-test' }),
+        url: () => 'https://api.openai.com/v1/chat/completions',
+      },
+    });
+    expect(result).toEqual({
+      modelId: 'gpt-4',
+      config: {
+        provider: 'openai',
+        headers: { authorization: 'Bearer sk-test' },
+      },
+    });
+  });
+
+  it('filters out objects containing functions', () => {
+    const result = serializeModel({
+      modelId: 'model',
+      config: {
+        provider: 'openai-compatible',
+        errorStructure: {
+          errorSchema: {},
+          errorToMessage: () => 'error',
+        },
+        metadataExtractor: {
+          extractMetadata: async () => undefined,
+          createStreamExtractor: () => ({}),
+        },
+      },
+    });
+    expect(result).toEqual({
+      modelId: 'model',
+      config: { provider: 'openai-compatible' },
+    });
+  });
+
+  it('keeps arrays of primitives', () => {
+    const result = serializeModel({
+      modelId: 'model',
+      config: {
+        provider: 'test',
+        tags: ['a', 'b'],
+        fn: () => {},
+      },
+    });
+    expect(result).toEqual({
+      modelId: 'model',
+      config: { provider: 'test', tags: ['a', 'b'] },
+    });
+  });
+
+  it('filters out class instances', () => {
+    const result = serializeModel({
+      modelId: 'model',
+      config: {
+        provider: 'test',
+        date: new Date(),
+        regex: /test/,
+      },
+    });
+    expect(result).toEqual({
+      modelId: 'model',
+      config: { provider: 'test' },
+    });
+  });
+});
+
+describe('deserializeModelConfig', () => {
+  it('wraps plain-object headers back into a function', () => {
+    const config = deserializeModelConfig({
+      provider: 'anthropic.messages',
+      headers: { 'x-api-key': 'sk-test' },
+    });
+    expect(typeof config.headers).toBe('function');
+    expect((config.headers as () => Record<string, string>)()).toEqual({
+      'x-api-key': 'sk-test',
+    });
+  });
+
+  it('preserves headers that are already functions', () => {
+    const headersFn = () => ({ 'x-api-key': 'sk-test' });
+    const config = deserializeModelConfig({
+      provider: 'test',
+      headers: headersFn,
+    });
+    expect(config.headers).toBe(headersFn);
+  });
+
+  it('passes through config without headers unchanged', () => {
+    const config = deserializeModelConfig({
+      provider: 'test',
+      baseURL: 'https://example.com',
+    });
+    expect(config).toEqual({
+      provider: 'test',
+      baseURL: 'https://example.com',
+    });
+  });
+});

--- a/packages/provider-utils/src/serialize-model.ts
+++ b/packages/provider-utils/src/serialize-model.ts
@@ -1,0 +1,86 @@
+/**
+ * Serializes a language model instance for workflow step boundaries.
+ * Extracts the modelId and only the serializable config properties,
+ * filtering out functions (headers, fetch, generateId, etc.) and
+ * objects containing functions (errorStructure, metadataExtractor, etc.).
+ *
+ * Used as the body of `static [WORKFLOW_SERIALIZE]` in provider models.
+ *
+ * @example
+ * ```ts
+ * static [WORKFLOW_SERIALIZE](inst: MyLanguageModel) {
+ *   return serializeModel(inst);
+ * }
+ * ```
+ */
+// Parameter uses `any` because provider model classes declare `config` as
+// private, making it invisible to external type checks.  The static
+// WORKFLOW_SERIALIZE method has runtime access to the field regardless.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function serializeModel(inst: any): {
+  modelId: string;
+  config: Record<string, unknown>;
+} {
+  const config: Record<string, unknown> = {};
+  for (const key of Object.keys(inst.config)) {
+    const value = inst.config[key];
+    if (isSerializable(value)) {
+      config[key] = value;
+    } else if (key === 'headers' && typeof value === 'function') {
+      // Resolve headers at serialization time so auth credentials
+      // survive the workflow step boundary. On deserialization the
+      // resolved object is wrapped back into a function.
+      const resolved = value();
+      if (isSerializable(resolved)) {
+        config[key] = resolved;
+      }
+    }
+  }
+  return { modelId: inst.modelId, config };
+}
+
+/**
+ * Prepares a deserialized model config for use with a model constructor.
+ * Wraps plain-object `headers` back into a function, since model code
+ * expects `config.headers()` to be callable.
+ *
+ * Used inside `static [WORKFLOW_DESERIALIZE]` in provider models.
+ *
+ * @example
+ * ```ts
+ * static [WORKFLOW_DESERIALIZE](options: { modelId: string; config: MyConfig }) {
+ *   return new MyLanguageModel(options.modelId, deserializeModelConfig(options.config));
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function deserializeModelConfig<T>(config: T): T {
+  const result = { ...config } as any;
+  if (result.headers != null && typeof result.headers !== 'function') {
+    const resolvedHeaders = result.headers;
+    result.headers = () => resolvedHeaders;
+  }
+  return result;
+}
+
+function isSerializable(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+
+  const type = typeof value;
+  if (type === 'string' || type === 'number' || type === 'boolean') return true;
+  if (type === 'function' || type === 'symbol' || type === 'bigint')
+    return false;
+
+  if (Array.isArray(value)) {
+    return value.every(isSerializable);
+  }
+
+  // Only allow plain objects (not class instances like RegExp, Date, etc.)
+  if (Object.getPrototypeOf(value) === Object.prototype) {
+    return Object.values(value as Record<string, unknown>).every(
+      isSerializable,
+    );
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

Add utilities for workflow step boundary serialization of language models:

- **`serializeModel`**: Extracts `modelId` and serializable config from a model instance. Resolves `config.headers()` at serialization time so auth credentials survive the step boundary as plain key-value objects (instead of being stripped as functions).
- **`deserializeModelConfig`**: Wraps plain-object `headers` back into a function so model code can continue calling `config.headers()` after deserialization.

These are used by `WORKFLOW_SERIALIZE`/`WORKFLOW_DESERIALIZE` in provider model classes (added in #14210).

### How it works

```
Serialization:  config.headers = () => ({ 'x-api-key': 'sk-...' })
                        ↓ serializeModel calls headers()
Serialized:     config.headers = { 'x-api-key': 'sk-...' }
                        ↓ JSON survives step boundary
Deserialization: deserializeModelConfig wraps it back
Result:         config.headers = () => ({ 'x-api-key': 'sk-...' })
```

## Test plan

- [x] Unit tests for `serializeModel` (headers resolution, function filtering, class instance filtering)
- [x] Unit tests for `deserializeModelConfig` (wrapping, preserving existing functions, passthrough)
- [x] All 491 provider-utils tests pass