### PR TITLE
feat: support custom tags in reasoning middleware for models like gemma 4

### DIFF
--- a/.changeset/gemma4-reasoning-custom-tags.md
+++ b/.changeset/gemma4-reasoning-custom-tags.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai/middleware): add openingTag/closingTag options to extractReasoningMiddleware for non-XML delimiters (e.g. Gemma 4)

--- a/content/docs/07-reference/01-ai-sdk-core/66-extract-reasoning-middleware.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/66-extract-reasoning-middleware.mdx
@@ -1,18 +1,23 @@
 ---
 title: extractReasoningMiddleware
-description: Middleware that extracts XML-tagged reasoning sections from generated text
+description: Middleware that extracts reasoning sections from generated text using configurable delimiters
 ---
 
 # `extractReasoningMiddleware()`
 
-`extractReasoningMiddleware` is a middleware function that extracts XML-tagged reasoning sections from generated text and exposes them separately from the main text content. This is particularly useful when you want to separate an AI model's reasoning process from its final output.
+`extractReasoningMiddleware` is a middleware function that extracts a reasoning section from generated text and exposes it separately from the main text content. This is particularly useful when you want to separate an AI model's reasoning process from its final output.
 
 ```ts
 import { extractReasoningMiddleware } from 'ai';
 
+// XML-style tags (e.g. DeepSeek, Qwen) — pass a string
 const middleware = extractReasoningMiddleware({
-  tagName: 'reasoning',
-  separator: '\n',
+  tagName: 'think',
+});
+
+// Custom delimiters (e.g. Gemma 4) — pass an object
+const middleware = extractReasoningMiddleware({
+  tagName: { opening: '<|channel>thought\n', closing: '<channel|>' },
 });
 ```
 
@@ -31,10 +36,10 @@ const middleware = extractReasoningMiddleware({
   content={[
     {
       name: 'tagName',
-      type: 'string',
+      type: 'string | { opening: string; closing: string }',
       isOptional: false,
       description:
-        'The name of the XML tag to extract reasoning from (without angle brackets)',
+        'Specifies the reasoning delimiters. Pass a string to use symmetric XML-style tags (e.g. "think" → <think> / </think>), or an object with opening and closing strings for models that use non-XML delimiters (e.g. Gemma 4\'s { opening: \'<|channel>thought\\n\', closing: \'<channel|>\' }).',
     },
     {
       name: 'separator',
@@ -48,7 +53,7 @@ const middleware = extractReasoningMiddleware({
       type: 'boolean',
       isOptional: true,
       description:
-        'Starts with reasoning tokens. Set to true when the response always starts with reasoning and the initial tag is omitted. Defaults to false.',
+        'Starts with reasoning tokens. Set to true when the response always starts with reasoning and the opening delimiter is omitted by the model. Defaults to false.',
     },
   ]}
 />
@@ -58,8 +63,8 @@ const middleware = extractReasoningMiddleware({
 Returns a middleware object that:
 
 - Processes both streaming and non-streaming responses
-- Extracts content between specified XML tags as reasoning
-- Removes the XML tags and reasoning from the main text
+- Extracts content between the specified delimiters as reasoning
+- Removes the delimiters and reasoning from the main text
 - Adds a `reasoning` property to the result containing the extracted content
 - Maintains proper separation between text sections using the specified separator
 

--- a/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
@@ -1077,8 +1077,7 @@ describe('extractReasoningMiddleware', () => {
 
   describe('custom openingTag / closingTag (e.g. Gemma 4)', () => {
     const gemmaMiddleware = extractReasoningMiddleware({
-      openingTag: '<|channel>thought\n',
-      closingTag: '<channel|>',
+      tagName: { opening: '<|channel>thought\n', closing: '<channel|>' },
     });
 
     describe('wrapGenerate', () => {

--- a/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
@@ -1074,4 +1074,197 @@ describe('extractReasoningMiddleware', () => {
       expect(reasoningEndIndex).toBeGreaterThan(reasoningStartIndex);
     });
   });
+
+  describe('custom openingTag / closingTag (e.g. Gemma 4)', () => {
+    const gemmaMiddleware = extractReasoningMiddleware({
+      openingTag: '<|channel>thought\n',
+      closingTag: '<channel|>',
+    });
+
+    describe('wrapGenerate', () => {
+      it('should extract reasoning using custom tags', async () => {
+        const mockModel = new MockLanguageModelV4({
+          async doGenerate() {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: '<|channel>thought\nanalyzing the request<channel|>Here is the response',
+                },
+              ],
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+              warnings: [],
+            };
+          },
+        });
+
+        const result = await generateText({
+          model: wrapLanguageModel({
+            model: mockModel,
+            middleware: gemmaMiddleware,
+          }),
+          prompt: 'Hello',
+        });
+
+        expect(result.content).toMatchInlineSnapshot(`
+          [
+            {
+              "text": "analyzing the request",
+              "type": "reasoning",
+            },
+            {
+              "text": "Here is the response",
+              "type": "text",
+            },
+          ]
+        `);
+      });
+
+      it('should handle empty reasoning block (thinking disabled)', async () => {
+        const mockModel = new MockLanguageModelV4({
+          async doGenerate() {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: '<|channel>thought\n<channel|>Final answer',
+                },
+              ],
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+              warnings: [],
+            };
+          },
+        });
+
+        const result = await generateText({
+          model: wrapLanguageModel({
+            model: mockModel,
+            middleware: gemmaMiddleware,
+          }),
+          prompt: 'Hello',
+        });
+
+        expect(result.content).toMatchInlineSnapshot(`
+          [
+            {
+              "text": "",
+              "type": "reasoning",
+            },
+            {
+              "text": "Final answer",
+              "type": "text",
+            },
+          ]
+        `);
+      });
+    });
+
+    describe('wrapStream', () => {
+      it('should extract reasoning using custom tags in a stream', async () => {
+        const mockModel = new MockLanguageModelV4({
+          async doStream() {
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: '<|channel>thought\n' },
+                { type: 'text-delta', id: '1', delta: 'analyzing' },
+                { type: 'text-delta', id: '1', delta: ' the request' },
+                { type: 'text-delta', id: '1', delta: '<channel|>' },
+                { type: 'text-delta', id: '1', delta: 'Here is the response' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        });
+
+        const result = streamText({
+          model: wrapLanguageModel({
+            model: mockModel,
+            middleware: gemmaMiddleware,
+          }),
+          prompt: 'Hello',
+        });
+
+        const parts = await convertAsyncIterableToArray(result.fullStream);
+        const types = parts.map(p => p.type);
+
+        expect(types).toContain('reasoning-start');
+        expect(types).toContain('reasoning-delta');
+        expect(types).toContain('reasoning-end');
+        expect(types).toContain('text-delta');
+
+        const reasoningDeltas = parts
+          .filter(p => p.type === 'reasoning-delta')
+          .map(p => (p as { type: 'reasoning-delta'; text: string }).text)
+          .join('');
+        expect(reasoningDeltas).toBe('analyzing the request');
+
+        const textDeltas = parts
+          .filter(p => p.type === 'text-delta')
+          .map(p => (p as { type: 'text-delta'; text: string }).text)
+          .join('');
+        expect(textDeltas).toBe('Here is the response');
+      });
+
+      it('should handle empty reasoning block in stream (thinking disabled)', async () => {
+        const mockModel = new MockLanguageModelV4({
+          async doStream() {
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: '<|channel>thought\n' },
+                { type: 'text-delta', id: '1', delta: '<channel|>' },
+                { type: 'text-delta', id: '1', delta: 'Final answer' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        });
+
+        const result = streamText({
+          model: wrapLanguageModel({
+            model: mockModel,
+            middleware: gemmaMiddleware,
+          }),
+          prompt: 'Hello',
+        });
+
+        const parts = await convertAsyncIterableToArray(result.fullStream);
+        const types = parts.map(p => p.type);
+
+        expect(types).toContain('reasoning-start');
+        expect(types).toContain('reasoning-end');
+
+        const textDeltas = parts
+          .filter(p => p.type === 'text-delta')
+          .map(p => (p as { type: 'text-delta'; text: string }).text)
+          .join('');
+        expect(textDeltas).toBe('Final answer');
+      });
+    });
+  });
 });

--- a/packages/ai/src/middleware/extract-reasoning-middleware.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.ts
@@ -6,24 +6,48 @@ import { LanguageModelMiddleware } from '../types/language-model-middleware';
 import { getPotentialStartIndex } from '../util/get-potential-start-index';
 
 /**
- * Extracts an XML-tagged reasoning section from the generated text and exposes it
+ * Extracts a reasoning section from the generated text and exposes it
  * as a `reasoning` property on the result.
  *
+ * You can specify the delimiters either by providing a `tagName` (which
+ * constructs symmetric XML-style tags `<tagName>` / `</tagName>`) or by
+ * providing explicit `openingTag` and `closingTag` strings for models that
+ * use non-XML delimiters (e.g. Gemma 4's `<|channel>thought\n` / `<channel|>`).
+ *
  * @param tagName - The name of the XML tag to extract reasoning from.
+ * @param openingTag - Custom opening delimiter (alternative to tagName).
+ * @param closingTag - Custom closing delimiter (alternative to tagName).
  * @param separator - The separator to use between reasoning and text sections.
  * @param startWithReasoning - Whether to start with reasoning tokens.
  */
 export function extractReasoningMiddleware({
   tagName,
+  openingTag: openingTagOption,
+  closingTag: closingTagOption,
   separator = '\n',
   startWithReasoning = false,
-}: {
-  tagName: string;
-  separator?: string;
-  startWithReasoning?: boolean;
-}): LanguageModelMiddleware {
-  const openingTag = `<${tagName}>`;
-  const closingTag = `<\/${tagName}>`;
+}:
+  | {
+      tagName: string;
+      openingTag?: never;
+      closingTag?: never;
+      separator?: string;
+      startWithReasoning?: boolean;
+    }
+  | {
+      tagName?: never;
+      openingTag: string;
+      closingTag: string;
+      separator?: string;
+      startWithReasoning?: boolean;
+    }): LanguageModelMiddleware {
+  const openingTag = openingTagOption ?? `<${tagName}>`;
+  const closingTag = closingTagOption ?? `<\/${tagName}>`;
+
+  // Escape special regex characters so literal strings like `<|channel>thought\n`
+  // are matched verbatim rather than interpreted as regex operators.
+  const escapedOpeningTag = openingTag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escapedClosingTag = closingTag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
   return {
     specificationVersion: 'v4',
@@ -39,7 +63,10 @@ export function extractReasoningMiddleware({
 
         const text = startWithReasoning ? openingTag + part.text : part.text;
 
-        const regexp = new RegExp(`${openingTag}(.*?)${closingTag}`, 'gs');
+        const regexp = new RegExp(
+          `${escapedOpeningTag}(.*?)${escapedClosingTag}`,
+          'gs',
+        );
         const matches = Array.from(text.matchAll(regexp));
 
         if (!matches.length) {

--- a/packages/ai/src/middleware/extract-reasoning-middleware.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.ts
@@ -9,40 +9,26 @@ import { getPotentialStartIndex } from '../util/get-potential-start-index';
  * Extracts a reasoning section from the generated text and exposes it
  * as a `reasoning` property on the result.
  *
- * You can specify the delimiters either by providing a `tagName` (which
- * constructs symmetric XML-style tags `<tagName>` / `</tagName>`) or by
- * providing explicit `openingTag` and `closingTag` strings for models that
- * use non-XML delimiters (e.g. Gemma 4's `<|channel>thought\n` / `<channel|>`).
- *
- * @param tagName - The name of the XML tag to extract reasoning from.
- * @param openingTag - Custom opening delimiter (alternative to tagName).
- * @param closingTag - Custom closing delimiter (alternative to tagName).
+ * @param tagName - Either a plain string (constructs symmetric XML-style tags
+ *   `<tagName>` / `</tagName>`), or an object with `opening` and `closing`
+ *   strings for models that use non-XML delimiters
+ *   (e.g. Gemma 4: `{ opening: '<|channel>thought\n', closing: '<channel|>' }`).
  * @param separator - The separator to use between reasoning and text sections.
  * @param startWithReasoning - Whether to start with reasoning tokens.
  */
 export function extractReasoningMiddleware({
   tagName,
-  openingTag: openingTagOption,
-  closingTag: closingTagOption,
   separator = '\n',
   startWithReasoning = false,
-}:
-  | {
-      tagName: string;
-      openingTag?: never;
-      closingTag?: never;
-      separator?: string;
-      startWithReasoning?: boolean;
-    }
-  | {
-      tagName?: never;
-      openingTag: string;
-      closingTag: string;
-      separator?: string;
-      startWithReasoning?: boolean;
-    }): LanguageModelMiddleware {
-  const openingTag = openingTagOption ?? `<${tagName}>`;
-  const closingTag = closingTagOption ?? `<\/${tagName}>`;
+}: {
+  tagName: string | { opening: string; closing: string };
+  separator?: string;
+  startWithReasoning?: boolean;
+}): LanguageModelMiddleware {
+  const openingTag =
+    typeof tagName === 'string' ? `<${tagName}>` : tagName.opening;
+  const closingTag =
+    typeof tagName === 'string' ? `<\/${tagName}>` : tagName.closing;
 
   // Escape special regex characters so literal strings like `<|channel>thought\n`
   // are matched verbatim rather than interpreted as regex operators.


### PR DESCRIPTION
# feat(ai/middleware): support custom reasoning delimiters for Gemma 4

## Background

`extractReasoningMiddleware` only supported symmetric XML-style delimiters derived from a single `tagName` (e.g. `<think>` / `</think>`). Gemma 4 (available on Google Vertex AI) uses a non-XML, asymmetric format for its reasoning output:

- Opening: `<|channel>thought\n`
- Closing: `<channel|>`

There was no way to configure these delimiters without forking the middleware.

## Summary

`tagName` now accepts either a plain string (existing behaviour) or an object with `opening` and `closing` properties for models that use non-XML delimiters:

```ts
// existing — unchanged
extractReasoningMiddleware({ tagName: 'think' })

// new — Gemma 4
extractReasoningMiddleware({
  tagName: { opening: '<|channel>thought\n', closing: '<channel|>' },
})
```

Also added regex escaping for the tag strings used in `wrapGenerate`, so characters like `|` in Gemma's delimiters are matched literally instead of being interpreted as regex operators. The `wrapStream` path already used `indexOf`-based matching and required no changes.

## Manual Verification

Verified via the new unit tests covering both `generateText` and `streamText` paths with Gemma 4's delimiter format, including the empty-reasoning-block case (when thinking is disabled but the model still emits the tags).

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Add a `examples/ai-functions/src/stream-text/google-vertex/gemma4-reasoning.ts` example once Gemma 4 is accessible via the Vertex AI provider.

## Related Issues

Fix: https://github.com/vercel/ai/issues/14217 by