### PR TITLE
fix (provider/xai): handle error chunks in responses api

### DIFF
--- a/.changeset/dirty-moles-jog.md
+++ b/.changeset/dirty-moles-jog.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/xai": patch
+---
+
+fix (provider/xai): handle mid-stream error chunks

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -543,6 +543,12 @@ export const xaiResponsesChunkSchema = z.union([
     }),
   }),
   z.object({
+    type: z.literal('error'),
+    code: z.string().nullish(),
+    message: z.string(),
+    param: z.string().nullish(),
+  }),
+  z.object({
     type: z.literal('response.done'),
     response: xaiResponsesResponseSchema,
   }),

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -3173,4 +3173,45 @@ describe('XaiResponsesLanguageModel', () => {
       });
     });
   });
+
+  describe('error event handling', () => {
+    it('should emit error chunk for server error events', async () => {
+      prepareStreamChunks([
+        JSON.stringify({
+          type: 'response.created',
+          response: {
+            id: 'resp_123',
+            object: 'response',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+          },
+        }),
+        JSON.stringify({
+          type: 'error',
+          code: null,
+          message:
+            'Service temporarily unavailable. The model did not respond to this request.',
+          param: null,
+        }),
+      ]);
+
+      const { stream } = await createModel().doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+      const errorPart = parts.find(part => part.type === 'error');
+
+      expect(errorPart).toMatchObject({
+        type: 'error',
+        error: {
+          type: 'error',
+          code: null,
+          message:
+            'Service temporarily unavailable. The model did not respond to this request.',
+          param: null,
+        },
+      });
+    });
+  });
 });

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -717,6 +717,11 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
               return;
             }
 
+            if (event.type === 'error') {
+              controller.enqueue({ type: 'error', error: event });
+              return;
+            }
+
             // Custom tool call input streaming - already handled by output_item events
             if (
               event.type === 'response.custom_tool_call_input.delta' ||


### PR DESCRIPTION
## Background

The XAI provider was not properly handling error events.

## Changes

Added support for handling `error` type chunks in the XAI responses streaming implementation. The error chunks are now properly parsed through the schema validation and emitted as error events in the stream, allowing applications to handle service errors gracefully.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)