### PR TITLE
fix(workflow): preserve provider tool identity across step boundaries

### DIFF
--- a/.changeset/fix-provider-tools-serialization.md
+++ b/.changeset/fix-provider-tools-serialization.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+fix(workflow): preserve provider tool identity across step boundaries
+
+Provider tools (like `anthropic.tools.webSearch`) now retain their `type`, `id`, and `args` when serialized across workflow step boundaries. Previously, `serializeToolSet` converted all tools into plain function tools, causing the Gateway to not recognize them as provider-executed tools.

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -12,143 +12,223 @@ import z from 'zod';
 // Tool step functions — these run as durable steps with full Node.js access
 // ============================================================================
 
-async function getWeather(input: { city: string }): Promise<{
-  city: string;
-  temperature: number;
-  unit: string;
-  condition: string;
-}> {
-  'use step';
-  // Fake weather data based on city name
-  const hash = input.city
-    .toLowerCase()
-    .split('')
-    .reduce((acc, c) => acc + c.charCodeAt(0), 0);
-  const temperature = 40 + (hash % 60); // 40-99°F
-  const conditions = [
-    'sunny',
-    'cloudy',
-    'rainy',
-    'snowy',
-    'windy',
-    'partly cloudy',
-  ];
-  const condition = conditions[hash % conditions.length];
-  return { city: input.city, temperature, unit: 'fahrenheit', condition };
-}
+// async function getWeather(input: { city: string }): Promise<{
+//   city: string;
+//   temperature: number;
+//   unit: string;
+//   condition: string;
+// }> {
+//   'use step';
+//   // Fake weather data based on city name
+//   const hash = input.city
+//     .toLowerCase()
+//     .split('')
+//     .reduce((acc, c) => acc + c.charCodeAt(0), 0);
+//   const temperature = 40 + (hash % 60); // 40-99°F
+//   const conditions = [
+//     'sunny',
+//     'cloudy',
+//     'rainy',
+//     'snowy',
+//     'windy',
+//     'partly cloudy',
+//   ];
+//   const condition = conditions[hash % conditions.length];
+//   return { city: input.city, temperature, unit: 'fahrenheit', condition };
+// }
 
-async function calculate(input: {
-  expression: string;
-}): Promise<{ expression: string; result: number }> {
-  'use step';
-  // Only allow numbers, operators, parentheses, and whitespace
-  const translated = input.expression.replace(/\s/g, '').replace(/\^/g, '**');
-  if (!/^[0-9+\-*/().]+$/.test(translated)) {
-    throw new Error(`Invalid expression: ${input.expression}`);
-  }
-  const result = new Function(`return (${translated})`)() as number;
-  return { expression: input.expression, result };
-}
+// async function calculate(input: {
+//   expression: string;
+// }): Promise<{ expression: string; result: number }> {
+//   'use step';
+//   // Only allow numbers, operators, parentheses, and whitespace
+//   const translated = input.expression.replace(/\s/g, '').replace(/\^/g, '**');
+//   if (!/^[0-9+\-*/().]+$/.test(translated)) {
+//     throw new Error(`Invalid expression: ${input.expression}`);
+//   }
+//   const result = new Function(`return (${translated})`)() as number;
+//   return { expression: input.expression, result };
+// }
 
-// ============================================================================
-// Chat workflow — orchestrates the WorkflowAgent
-// ============================================================================
+// // ============================================================================
+// // Chat workflow — orchestrates the WorkflowAgent
+// // ============================================================================
 
-const tools = {
-  getWeather: {
-    description:
-      'Get the current weather for a city. Returns temperature in Fahrenheit and conditions.',
-    inputSchema: z.object({
-      city: z.string().describe('The city name to get weather for'),
-    }),
-    execute: getWeather,
-  },
-  calculate: {
-    description:
-      'Evaluate a simple math expression. Supports +, -, *, /, and parentheses.',
-    inputSchema: z.object({
-      expression: z
-        .string()
-        .describe('The math expression to evaluate, e.g. "2 + 3 * 4"'),
-    }),
-    execute: calculate,
-  },
-};
-const repairToolCall: ToolCallRepairFunction<typeof tools> = async ({
-  toolCall,
-}) => {
-  'use step';
+// const tools = {
+//   getWeather: {
+//     description:
+//       'Get the current weather for a city. Returns temperature in Fahrenheit and conditions.',
+//     inputSchema: z.object({
+//       city: z.string().describe('The city name to get weather for'),
+//     }),
+//     execute: getWeather,
+//   },
+//   calculate: {
+//     description:
+//       'Evaluate a simple math expression. Supports +, -, *, /, and parentheses.',
+//     inputSchema: z.object({
+//       expression: z
+//         .string()
+//         .describe('The math expression to evaluate, e.g. "2 + 3 * 4"'),
+//     }),
+//     execute: calculate,
+//   },
+// };
+// const repairToolCall: ToolCallRepairFunction<typeof tools> = async ({
+//   toolCall,
+// }) => {
+//   'use step';
 
-  console.log('Repairing tool call', { toolCall });
+//   console.log('Repairing tool call', { toolCall });
 
-  return toolCall;
-};
+//   return toolCall;
+// };
 
 export async function chat(messages: UIMessage[]) {
   'use workflow';
 
   const modelMessages = await convertToModelMessages(messages);
 
+  // const agent = new ToolLoopAgent({
+  //   model: openai('gpt-5'),
+  //   instructions: 'You are a helpful assistant.',
+  // });
+
+  // run(async () => {
+  //   const result = await agent.stream({
+  //     prompt: 'Invent a new holiday and describe its traditions.',
+  //   });
+
+  //   for await (const textPart of result.textStream) {
+  //     process.stdout.write(textPart);
+  //   }
+  // });
+
+  const providerOptions = {
+    anthropic: {
+      thinking: { type: 'adaptive' },
+      speed: 'fast',
+      contextManagement: {
+        edits: [
+          {
+            type: 'clear_tool_uses_20250919',
+            trigger: { type: 'input_tokens', value: 80_000 },
+            keep: { type: 'tool_uses', value: 5 },
+            clearAtLeast: { type: 'input_tokens', value: 5000 },
+            clearToolInputs: true,
+          },
+          {
+            type: 'compact_20260112',
+            trigger: { type: 'input_tokens', value: 100_000 },
+            instructions:
+              'Summarize the conversation concisely, preserving key decisions, tool results, and context.',
+            pauseAfterCompaction: false,
+          },
+        ],
+      },
+    },
+    gateway: {
+      models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+      // zeroDataRetention: true,
+      disallowPromptTraining: true,
+    },
+  };
+
+  const anthropicTools = {
+    webFetch: anthropic.tools.webFetch_20250910({
+      maxUses: 5,
+      allowedDomains: [
+        'vercel.com',
+        'nextjs.org',
+        'ai-sdk.dev',
+        'chat-sdk.dev',
+        'useworkflow.dev',
+      ],
+    }),
+    webSearch: anthropic.tools.webSearch_20250305({
+      maxUses: 5,
+      allowedDomains: [
+        'vercel.com',
+        'nextjs.org',
+        'ai-sdk.dev',
+        'chat-sdk.dev',
+        'useworkflow.dev',
+      ],
+    }),
+    codeExecution: anthropic.tools.codeExecution_20260120(),
+  };
+
   const agent = new WorkflowAgent({
-    model: anthropic('claude-sonnet-4-20250514'),
-    instructions:
-      'You are a helpful assistant with access to weather and calculator tools. Use them when the user asks about weather in a city or needs math calculations. Keep responses concise.',
-    tools,
-    prepareCall: async options => {
-      console.log('[prepareCall]', {
-        model: typeof options.model === 'string' ? options.model : 'factory',
-        messageCount: options.messages.length,
-        hasTools: Object.keys(options.tools).length > 0,
-      });
-      return options;
-    },
-    onStepFinish: async stepResult => {
-      console.log('[agent-chat] step finished:', {
-        finishReason: stepResult.finishReason,
-        text: stepResult.text?.slice(0, 100),
-      });
-    },
-    onFinish: async event => {
-      console.log('[agent-chat] finished:', {
-        finishReason: event.finishReason,
-        steps: event.steps.length,
-      });
-    },
-    experimental_onStart: async ({ model, messages }) => {
-      console.log('[onStart]', {
-        model: typeof model === 'string' ? model : 'factory',
-        messageCount: messages.length,
-      });
-    },
-    experimental_onStepStart: async ({ stepNumber, model }) => {
-      console.log('[onStepStart]', {
-        stepNumber,
-        model: typeof model === 'string' ? model : 'factory',
-      });
-    },
-    experimental_onToolCallStart: async ({ toolCall }) => {
-      console.log('[onToolCallStart]', {
-        toolName: toolCall.toolName,
-        toolCallId: toolCall.toolCallId,
-      });
-    },
-    experimental_onToolCallFinish: async ({ toolCall, result, error }) => {
-      console.log('[onToolCallFinish]', {
-        toolName: toolCall.toolName,
-        result: result !== undefined ? 'ok' : 'n/a',
-        error: error !== undefined,
-      });
-    },
+    model: 'anthropic/claude-opus-4.6',
+    instructions: 'you are a helpful assistant.',
+    tools: anthropicTools,
+    providerOptions,
   });
 
-  // WorkflowAgent streams ModelCallStreamPart chunks to the writable
-  // in real-time. The route handler converts to UIMessageChunks at the
-  // response boundary using createUIMessageChunkTransform().
   const result = await agent.stream({
     messages: modelMessages,
-    writable: getWritable<ModelCallStreamPart>(),
-    experimental_repairToolCall: repairToolCall as any,
   });
+
+  // const agent = new WorkflowAgent({
+  //   model: anthropic('claude-sonnet-4-20250514'),
+  //   instructions:
+  //     'You are a helpful assistant with access to weather and calculator tools. Use them when the user asks about weather in a city or needs math calculations. Keep responses concise.',
+  //   tools,
+  //   prepareCall: async options => {
+  //     console.log('[prepareCall]', {
+  //       model: typeof options.model === 'string' ? options.model : 'factory',
+  //       messageCount: options.messages.length,
+  //       hasTools: Object.keys(options.tools).length > 0,
+  //     });
+  //     return options;
+  //   },
+  //   onStepFinish: async stepResult => {
+  //     console.log('[agent-chat] step finished:', {
+  //       finishReason: stepResult.finishReason,
+  //       text: stepResult.text?.slice(0, 100),
+  //     });
+  //   },
+  //   onFinish: async event => {
+  //     console.log('[agent-chat] finished:', {
+  //       finishReason: event.finishReason,
+  //       steps: event.steps.length,
+  //     });
+  //   },
+  //   experimental_onStart: async ({ model, messages }) => {
+  //     console.log('[onStart]', {
+  //       model: typeof model === 'string' ? model : 'factory',
+  //       messageCount: messages.length,
+  //     });
+  //   },
+  //   experimental_onStepStart: async ({ stepNumber, model }) => {
+  //     console.log('[onStepStart]', {
+  //       stepNumber,
+  //       model: typeof model === 'string' ? model : 'factory',
+  //     });
+  //   },
+  //   experimental_onToolCallStart: async ({ toolCall }) => {
+  //     console.log('[onToolCallStart]', {
+  //       toolName: toolCall.toolName,
+  //       toolCallId: toolCall.toolCallId,
+  //     });
+  //   },
+  //   experimental_onToolCallFinish: async ({ toolCall, result, error }) => {
+  //     console.log('[onToolCallFinish]', {
+  //       toolName: toolCall.toolName,
+  //       result: result !== undefined ? 'ok' : 'n/a',
+  //       error: error !== undefined,
+  //     });
+  //   },
+  // });
+
+  // // WorkflowAgent streams ModelCallStreamPart chunks to the writable
+  // // in real-time. The route handler converts to UIMessageChunks at the
+  // // response boundary using createUIMessageChunkTransform().
+  // const result = await agent.stream({
+  //   messages: modelMessages,
+  //   writable: getWritable<ModelCallStreamPart>(),
+  //   experimental_repairToolCall: repairToolCall as any,
+  // });
 
   return { messages: result.messages };
 }

--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -12,223 +12,143 @@ import z from 'zod';
 // Tool step functions — these run as durable steps with full Node.js access
 // ============================================================================
 
-// async function getWeather(input: { city: string }): Promise<{
-//   city: string;
-//   temperature: number;
-//   unit: string;
-//   condition: string;
-// }> {
-//   'use step';
-//   // Fake weather data based on city name
-//   const hash = input.city
-//     .toLowerCase()
-//     .split('')
-//     .reduce((acc, c) => acc + c.charCodeAt(0), 0);
-//   const temperature = 40 + (hash % 60); // 40-99°F
-//   const conditions = [
-//     'sunny',
-//     'cloudy',
-//     'rainy',
-//     'snowy',
-//     'windy',
-//     'partly cloudy',
-//   ];
-//   const condition = conditions[hash % conditions.length];
-//   return { city: input.city, temperature, unit: 'fahrenheit', condition };
-// }
+async function getWeather(input: { city: string }): Promise<{
+  city: string;
+  temperature: number;
+  unit: string;
+  condition: string;
+}> {
+  'use step';
+  // Fake weather data based on city name
+  const hash = input.city
+    .toLowerCase()
+    .split('')
+    .reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  const temperature = 40 + (hash % 60); // 40-99°F
+  const conditions = [
+    'sunny',
+    'cloudy',
+    'rainy',
+    'snowy',
+    'windy',
+    'partly cloudy',
+  ];
+  const condition = conditions[hash % conditions.length];
+  return { city: input.city, temperature, unit: 'fahrenheit', condition };
+}
 
-// async function calculate(input: {
-//   expression: string;
-// }): Promise<{ expression: string; result: number }> {
-//   'use step';
-//   // Only allow numbers, operators, parentheses, and whitespace
-//   const translated = input.expression.replace(/\s/g, '').replace(/\^/g, '**');
-//   if (!/^[0-9+\-*/().]+$/.test(translated)) {
-//     throw new Error(`Invalid expression: ${input.expression}`);
-//   }
-//   const result = new Function(`return (${translated})`)() as number;
-//   return { expression: input.expression, result };
-// }
+async function calculate(input: {
+  expression: string;
+}): Promise<{ expression: string; result: number }> {
+  'use step';
+  // Only allow numbers, operators, parentheses, and whitespace
+  const translated = input.expression.replace(/\s/g, '').replace(/\^/g, '**');
+  if (!/^[0-9+\-*/().]+$/.test(translated)) {
+    throw new Error(`Invalid expression: ${input.expression}`);
+  }
+  const result = new Function(`return (${translated})`)() as number;
+  return { expression: input.expression, result };
+}
 
-// // ============================================================================
-// // Chat workflow — orchestrates the WorkflowAgent
-// // ============================================================================
+// ============================================================================
+// Chat workflow — orchestrates the WorkflowAgent
+// ============================================================================
 
-// const tools = {
-//   getWeather: {
-//     description:
-//       'Get the current weather for a city. Returns temperature in Fahrenheit and conditions.',
-//     inputSchema: z.object({
-//       city: z.string().describe('The city name to get weather for'),
-//     }),
-//     execute: getWeather,
-//   },
-//   calculate: {
-//     description:
-//       'Evaluate a simple math expression. Supports +, -, *, /, and parentheses.',
-//     inputSchema: z.object({
-//       expression: z
-//         .string()
-//         .describe('The math expression to evaluate, e.g. "2 + 3 * 4"'),
-//     }),
-//     execute: calculate,
-//   },
-// };
-// const repairToolCall: ToolCallRepairFunction<typeof tools> = async ({
-//   toolCall,
-// }) => {
-//   'use step';
+const tools = {
+  getWeather: {
+    description:
+      'Get the current weather for a city. Returns temperature in Fahrenheit and conditions.',
+    inputSchema: z.object({
+      city: z.string().describe('The city name to get weather for'),
+    }),
+    execute: getWeather,
+  },
+  calculate: {
+    description:
+      'Evaluate a simple math expression. Supports +, -, *, /, and parentheses.',
+    inputSchema: z.object({
+      expression: z
+        .string()
+        .describe('The math expression to evaluate, e.g. "2 + 3 * 4"'),
+    }),
+    execute: calculate,
+  },
+};
+const repairToolCall: ToolCallRepairFunction<typeof tools> = async ({
+  toolCall,
+}) => {
+  'use step';
 
-//   console.log('Repairing tool call', { toolCall });
+  console.log('Repairing tool call', { toolCall });
 
-//   return toolCall;
-// };
+  return toolCall;
+};
 
 export async function chat(messages: UIMessage[]) {
   'use workflow';
 
   const modelMessages = await convertToModelMessages(messages);
 
-  // const agent = new ToolLoopAgent({
-  //   model: openai('gpt-5'),
-  //   instructions: 'You are a helpful assistant.',
-  // });
-
-  // run(async () => {
-  //   const result = await agent.stream({
-  //     prompt: 'Invent a new holiday and describe its traditions.',
-  //   });
-
-  //   for await (const textPart of result.textStream) {
-  //     process.stdout.write(textPart);
-  //   }
-  // });
-
-  const providerOptions = {
-    anthropic: {
-      thinking: { type: 'adaptive' },
-      speed: 'fast',
-      contextManagement: {
-        edits: [
-          {
-            type: 'clear_tool_uses_20250919',
-            trigger: { type: 'input_tokens', value: 80_000 },
-            keep: { type: 'tool_uses', value: 5 },
-            clearAtLeast: { type: 'input_tokens', value: 5000 },
-            clearToolInputs: true,
-          },
-          {
-            type: 'compact_20260112',
-            trigger: { type: 'input_tokens', value: 100_000 },
-            instructions:
-              'Summarize the conversation concisely, preserving key decisions, tool results, and context.',
-            pauseAfterCompaction: false,
-          },
-        ],
-      },
-    },
-    gateway: {
-      models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
-      // zeroDataRetention: true,
-      disallowPromptTraining: true,
-    },
-  };
-
-  const anthropicTools = {
-    webFetch: anthropic.tools.webFetch_20250910({
-      maxUses: 5,
-      allowedDomains: [
-        'vercel.com',
-        'nextjs.org',
-        'ai-sdk.dev',
-        'chat-sdk.dev',
-        'useworkflow.dev',
-      ],
-    }),
-    webSearch: anthropic.tools.webSearch_20250305({
-      maxUses: 5,
-      allowedDomains: [
-        'vercel.com',
-        'nextjs.org',
-        'ai-sdk.dev',
-        'chat-sdk.dev',
-        'useworkflow.dev',
-      ],
-    }),
-    codeExecution: anthropic.tools.codeExecution_20260120(),
-  };
-
   const agent = new WorkflowAgent({
-    model: 'anthropic/claude-opus-4.6',
-    instructions: 'you are a helpful assistant.',
-    tools: anthropicTools,
-    providerOptions,
+    model: anthropic('claude-sonnet-4-20250514'),
+    instructions:
+      'You are a helpful assistant with access to weather and calculator tools. Use them when the user asks about weather in a city or needs math calculations. Keep responses concise.',
+    tools,
+    prepareCall: async options => {
+      console.log('[prepareCall]', {
+        model: typeof options.model === 'string' ? options.model : 'factory',
+        messageCount: options.messages.length,
+        hasTools: Object.keys(options.tools).length > 0,
+      });
+      return options;
+    },
+    onStepFinish: async stepResult => {
+      console.log('[agent-chat] step finished:', {
+        finishReason: stepResult.finishReason,
+        text: stepResult.text?.slice(0, 100),
+      });
+    },
+    onFinish: async event => {
+      console.log('[agent-chat] finished:', {
+        finishReason: event.finishReason,
+        steps: event.steps.length,
+      });
+    },
+    experimental_onStart: async ({ model, messages }) => {
+      console.log('[onStart]', {
+        model: typeof model === 'string' ? model : 'factory',
+        messageCount: messages.length,
+      });
+    },
+    experimental_onStepStart: async ({ stepNumber, model }) => {
+      console.log('[onStepStart]', {
+        stepNumber,
+        model: typeof model === 'string' ? model : 'factory',
+      });
+    },
+    experimental_onToolCallStart: async ({ toolCall }) => {
+      console.log('[onToolCallStart]', {
+        toolName: toolCall.toolName,
+        toolCallId: toolCall.toolCallId,
+      });
+    },
+    experimental_onToolCallFinish: async ({ toolCall, result, error }) => {
+      console.log('[onToolCallFinish]', {
+        toolName: toolCall.toolName,
+        result: result !== undefined ? 'ok' : 'n/a',
+        error: error !== undefined,
+      });
+    },
   });
 
+  // WorkflowAgent streams ModelCallStreamPart chunks to the writable
+  // in real-time. The route handler converts to UIMessageChunks at the
+  // response boundary using createUIMessageChunkTransform().
   const result = await agent.stream({
     messages: modelMessages,
+    writable: getWritable<ModelCallStreamPart>(),
+    experimental_repairToolCall: repairToolCall as any,
   });
-
-  // const agent = new WorkflowAgent({
-  //   model: anthropic('claude-sonnet-4-20250514'),
-  //   instructions:
-  //     'You are a helpful assistant with access to weather and calculator tools. Use them when the user asks about weather in a city or needs math calculations. Keep responses concise.',
-  //   tools,
-  //   prepareCall: async options => {
-  //     console.log('[prepareCall]', {
-  //       model: typeof options.model === 'string' ? options.model : 'factory',
-  //       messageCount: options.messages.length,
-  //       hasTools: Object.keys(options.tools).length > 0,
-  //     });
-  //     return options;
-  //   },
-  //   onStepFinish: async stepResult => {
-  //     console.log('[agent-chat] step finished:', {
-  //       finishReason: stepResult.finishReason,
-  //       text: stepResult.text?.slice(0, 100),
-  //     });
-  //   },
-  //   onFinish: async event => {
-  //     console.log('[agent-chat] finished:', {
-  //       finishReason: event.finishReason,
-  //       steps: event.steps.length,
-  //     });
-  //   },
-  //   experimental_onStart: async ({ model, messages }) => {
-  //     console.log('[onStart]', {
-  //       model: typeof model === 'string' ? model : 'factory',
-  //       messageCount: messages.length,
-  //     });
-  //   },
-  //   experimental_onStepStart: async ({ stepNumber, model }) => {
-  //     console.log('[onStepStart]', {
-  //       stepNumber,
-  //       model: typeof model === 'string' ? model : 'factory',
-  //     });
-  //   },
-  //   experimental_onToolCallStart: async ({ toolCall }) => {
-  //     console.log('[onToolCallStart]', {
-  //       toolName: toolCall.toolName,
-  //       toolCallId: toolCall.toolCallId,
-  //     });
-  //   },
-  //   experimental_onToolCallFinish: async ({ toolCall, result, error }) => {
-  //     console.log('[onToolCallFinish]', {
-  //       toolName: toolCall.toolName,
-  //       result: result !== undefined ? 'ok' : 'n/a',
-  //       error: error !== undefined,
-  //     });
-  //   },
-  // });
-
-  // // WorkflowAgent streams ModelCallStreamPart chunks to the writable
-  // // in real-time. The route handler converts to UIMessageChunks at the
-  // // response boundary using createUIMessageChunkTransform().
-  // const result = await agent.stream({
-  //   messages: modelMessages,
-  //   writable: getWritable<ModelCallStreamPart>(),
-  //   experimental_repairToolCall: repairToolCall as any,
-  // });
 
   return { messages: result.messages };
 }

--- a/packages/workflow/src/serializable-schema.test.ts
+++ b/packages/workflow/src/serializable-schema.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { tool } from 'ai';
+import { jsonSchema } from '@ai-sdk/provider-utils';
+import {
+  serializeToolSet,
+  resolveSerializableTools,
+} from './serializable-schema';
+
+describe('serializeToolSet', () => {
+  it('serializes function tools with description and inputSchema', () => {
+    const tools = {
+      getWeather: tool({
+        description: 'Get weather for a city',
+        inputSchema: jsonSchema({
+          type: 'object',
+          properties: { city: { type: 'string' } },
+          required: ['city'],
+        }),
+      }),
+    };
+
+    const serialized = serializeToolSet(tools);
+
+    expect(serialized).toEqual({
+      getWeather: {
+        description: 'Get weather for a city',
+        inputSchema: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+          required: ['city'],
+        },
+      },
+    });
+  });
+
+  it.fails('preserves provider tool type, id, and args', () => {
+    // Provider tools (like anthropic.tools.webSearch) have type: 'provider',
+    // an id, and args. These must survive serialization so the Gateway can
+    // recognize them as provider-executed tools, not plain function tools.
+    const tools = {
+      webSearch: tool({
+        type: 'provider' as const,
+        id: 'anthropic.web_search_20250305' as const,
+        args: {
+          maxUses: 5,
+          allowedDomains: ['vercel.com', 'nextjs.org'],
+        },
+        inputSchema: jsonSchema({
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        }),
+      }),
+    };
+
+    const serialized = serializeToolSet(tools);
+
+    expect(serialized.webSearch).toMatchObject({
+      type: 'provider',
+      id: 'anthropic.web_search_20250305',
+      args: {
+        maxUses: 5,
+        allowedDomains: ['vercel.com', 'nextjs.org'],
+      },
+    });
+  });
+});
+
+describe('resolveSerializableTools', () => {
+  it('reconstructs function tools with Ajv validation', () => {
+    const serialized = {
+      getWeather: {
+        description: 'Get weather for a city',
+        inputSchema: {
+          type: 'object' as const,
+          properties: { city: { type: 'string' as const } },
+          required: ['city'] as string[],
+          additionalProperties: false,
+        },
+      },
+    };
+
+    const tools = resolveSerializableTools(serialized);
+
+    expect(tools.getWeather).toBeDefined();
+    expect(tools.getWeather.description).toBe('Get weather for a city');
+  });
+
+  it.fails('reconstructs provider tools preserving type, id, and args', () => {
+    const serialized = {
+      webSearch: {
+        type: 'provider' as const,
+        id: 'anthropic.web_search_20250305' as const,
+        args: {
+          maxUses: 5,
+          allowedDomains: ['vercel.com'],
+        },
+        inputSchema: {
+          type: 'object' as const,
+          properties: { query: { type: 'string' as const } },
+          required: ['query'] as string[],
+        },
+      },
+    };
+
+    const tools = resolveSerializableTools(serialized);
+    const webSearch = tools.webSearch;
+
+    expect(webSearch).toBeDefined();
+    expect(webSearch.type).toBe('provider');
+    expect((webSearch as any).id).toBe('anthropic.web_search_20250305');
+    expect((webSearch as any).args).toEqual({
+      maxUses: 5,
+      allowedDomains: ['vercel.com'],
+    });
+  });
+});

--- a/packages/workflow/src/serializable-schema.test.ts
+++ b/packages/workflow/src/serializable-schema.test.ts
@@ -33,7 +33,7 @@ describe('serializeToolSet', () => {
     });
   });
 
-  it.fails('preserves provider tool type, id, and args', () => {
+  it('preserves provider tool type, id, and args', () => {
     // Provider tools (like anthropic.tools.webSearch) have type: 'provider',
     // an id, and args. These must survive serialization so the Gateway can
     // recognize them as provider-executed tools, not plain function tools.
@@ -86,7 +86,7 @@ describe('resolveSerializableTools', () => {
     expect(tools.getWeather.description).toBe('Get weather for a city');
   });
 
-  it.fails('reconstructs provider tools preserving type, id, and args', () => {
+  it('reconstructs provider tools preserving type, id, and args', () => {
     const serialized = {
       webSearch: {
         type: 'provider' as const,

--- a/packages/workflow/src/serializable-schema.ts
+++ b/packages/workflow/src/serializable-schema.ts
@@ -21,6 +21,12 @@ import Ajv from 'ajv';
 export type SerializableToolDef = {
   description?: string;
   inputSchema: JSONSchema7;
+  /** Present on provider tools (e.g. anthropic.tools.webSearch). */
+  type?: 'provider';
+  /** Provider tool ID, e.g. 'anthropic.web_search_20250305'. */
+  id?: `${string}.${string}`;
+  /** Provider tool configuration args (maxUses, allowedDomains, etc.). */
+  args?: Record<string, unknown>;
 };
 
 /**
@@ -33,13 +39,22 @@ export function serializeToolSet(
   tools: ToolSet,
 ): Record<string, SerializableToolDef> {
   return Object.fromEntries(
-    Object.entries(tools).map(([name, t]) => [
-      name,
-      {
+    Object.entries(tools).map(([name, t]) => {
+      const def: SerializableToolDef = {
         description: t.description,
         inputSchema: asSchema(t.inputSchema).jsonSchema as JSONSchema7,
-      },
-    ]),
+      };
+
+      // Preserve provider tool identity so the Gateway can recognize
+      // them as provider-executed tools (e.g. anthropic webSearch).
+      if ((t as any).type === 'provider') {
+        def.type = 'provider';
+        def.id = (t as any).id;
+        def.args = (t as any).args;
+      }
+
+      return [name, def];
+    }),
   );
 }
 
@@ -57,6 +72,20 @@ export function resolveSerializableTools(
 
   return Object.fromEntries(
     Object.entries(tools).map(([name, t]) => {
+      // Provider tools are executed server-side — pass them through
+      // with their identity intact, no client-side validation needed.
+      if (t.type === 'provider') {
+        return [
+          name,
+          tool({
+            type: 'provider' as const,
+            id: t.id!,
+            args: t.args ?? {},
+            inputSchema: jsonSchema(t.inputSchema),
+          }),
+        ];
+      }
+
       const validateFn = ajv.compile(t.inputSchema);
 
       return [


### PR DESCRIPTION
## Background

Provider tools (like `anthropic.tools.webSearch`, `webFetch`, `codeExecution`) lose their identity when crossing workflow step boundaries. `serializeToolSet()` converts all tools into plain function tools with only `description` and `inputSchema`, stripping the `type: 'provider'`, `id`, and `args` fields.

This causes the Gateway to not recognize them as provider-executed tools, leading to `GatewayInternalServerError: Unexpected value(s) for the anthropic-beta header` when used with provider-specific features like `contextManagement` and `speed`.

## Summary

Update `serializeToolSet` and `resolveSerializableTools` in `serializable-schema.ts` to handle provider tools:

- **`SerializableToolDef`**: add optional `type`, `id`, and `args` fields
- **`serializeToolSet`**: check `tool.type === 'provider'` and preserve `type`, `id`, `args`
- **`resolveSerializableTools`**: reconstruct provider tools with their identity intact, without Ajv wrapping (provider tools are executed server-side)

| Field | Before | After |
|---|---|---|
| `type` | `"function"` | `"provider"` |
| `id` | *(stripped)* | `"anthropic.web_search_20250305"` |
| `args` | *(stripped)* | `{ "maxUses": 5, "allowedDomains": [...] }` |

## Manual Verification

Updated `examples/next-workflow/workflow/agent-chat.ts` to

```ts
import { anthropic } from '@ai-sdk/anthropic';
import { WorkflowAgent, type ModelCallStreamPart } from '@ai-sdk/workflow';
import { type UIMessage } from 'ai';
import { getWritable } from 'workflow';

export async function chat(messages: UIMessage[]) {
  'use workflow';

  const providerOptions = {
    anthropic: {
      thinking: { type: 'adaptive' },
      speed: 'fast',
      contextManagement: {
        edits: [
          {
            type: 'clear_tool_uses_20250919',
            trigger: { type: 'input_tokens', value: 80_000 },
            keep: { type: 'tool_uses', value: 5 },
            clearAtLeast: { type: 'input_tokens', value: 5000 },
            clearToolInputs: true,
          },
          {
            type: 'compact_20260112',
            trigger: { type: 'input_tokens', value: 100_000 },
            instructions:
              'Summarize the conversation concisely, preserving key decisions, tool results, and context.',
            pauseAfterCompaction: false,
          },
        ],
      },
    },
    gateway: {
      models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
      // zeroDataRetention: true,
      disallowPromptTraining: true,
    },
  };

  const anthropicTools = {
    webFetch: anthropic.tools.webFetch_20250910({
      maxUses: 5,
      allowedDomains: [
        'vercel.com',
        'nextjs.org',
        'ai-sdk.dev',
        'chat-sdk.dev',
        'useworkflow.dev',
      ],
    }),
    webSearch: anthropic.tools.webSearch_20250305({
      maxUses: 5,
      allowedDomains: [
        'vercel.com',
        'nextjs.org',
        'ai-sdk.dev',
        'chat-sdk.dev',
        'useworkflow.dev',
      ],
    }),
    codeExecution: anthropic.tools.codeExecution_20260120(),
  };

  const agent = new WorkflowAgent({
    model: 'anthropic/claude-opus-4.6',
    instructions: 'you are a helpful assistant.',
    tools: anthropicTools,
    providerOptions,
  });

  const result = await agent.stream({
    messages: modelMessages,
    writable: getWritable<ModelCallStreamPart>(),
  });

  return { messages: result.messages };
}
```

And send the following message to the `next-workflow` example

> What are the latest vercel news? Use   webSearch to find out, and if you find any links, use webFetch to get more details from those pages.

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/b843c208-9899-4954-bc6f-fd732d6223bd" />

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Part of #12165