### PR TITLE
fix(ai): handle escape sequences in INSIDE_OBJECT_KEY state of fixJson

### DIFF
--- a/packages/ai/src/util/fix-json.test.ts
+++ b/packages/ai/src/util/fix-json.test.ts
@@ -175,6 +175,24 @@ describe('object', () => {
   test('should handle closing after empty object', () => {
     assert.strictEqual(fixJson('{"a": {"b": {}'), '{"a": {"b": {}}}');
   });
+
+  test('should handle escape sequences in object keys', () => {
+    assert.strictEqual(
+      fixJson('{"key\\"name": "value"}'),
+      '{"key\\"name": "value"}',
+    );
+  });
+
+  test('should handle backslash escape in object keys', () => {
+    assert.strictEqual(
+      fixJson('{"key\\\\name": "value"}'),
+      '{"key\\\\name": "value"}',
+    );
+  });
+
+  test('should handle incomplete object with escaped key', () => {
+    assert.strictEqual(fixJson('{"key\\"name": "val'), '{"key\\"name": "val"}');
+  });
 });
 
 describe('nesting', () => {

--- a/packages/ai/src/util/fix-json.ts
+++ b/packages/ai/src/util/fix-json.ts
@@ -166,6 +166,11 @@ export function fixJson(input: string): string {
             stack.push('INSIDE_OBJECT_AFTER_KEY');
             break;
           }
+
+          case '\\': {
+            stack.push('INSIDE_STRING_ESCAPE');
+            break;
+          }
         }
         break;
       }


### PR DESCRIPTION
## Summary

- The `INSIDE_OBJECT_KEY` state in `fixJson` did not handle backslash escape sequences (`\\`), while the `INSIDE_STRING` state properly handled them by pushing `INSIDE_STRING_ESCAPE` onto the stack
- This caused the parser to incorrectly identify the end of an object key when the key contained escape sequences like `\"`, `\\`, or `\n` — the escaped quote was treated as the closing delimiter
- Added `\\` case to `INSIDE_OBJECT_KEY` matching the existing `INSIDE_STRING` behavior, and added test cases covering escaped object keys

## Bug

For input like `{"key\"name": "value"}`, the parser in `INSIDE_OBJECT_KEY` state encounters `\"` and treats the escaped `"` as the end of the key. It then transitions to `INSIDE_OBJECT_AFTER_KEY`, expecting a `:` next — but instead finds `name`, causing incorrect truncation/parsing.

The `INSIDE_STRING` state (lines 195-214) already handles this correctly:

```typescript
case '\\': {
  stack.push('INSIDE_STRING_ESCAPE');
  break;
}
```

This PR adds the same handling to `INSIDE_OBJECT_KEY`.

## Test plan

- [x] Added test: object key with escaped quote (`\"`)
- [x] Added test: object key with escaped backslash (`\\`)
- [x] Added test: incomplete object with escaped key
- [x] All existing 46 tests continue to pass (49 total with new tests)