### PR TITLE
fix(gateway): enable retry support for Gateway errors

### DIFF
--- a/.changeset/fix-gateway-retry-support.md
+++ b/.changeset/fix-gateway-retry-support.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/gateway': patch
+'ai': patch
+---
+
+fix(gateway): enable retry support for Gateway errors
+
+Gateway errors (`GatewayInternalServerError`, `GatewayRateLimitError`, `GatewayTimeoutError`) are now retried according to `maxRetries`. Previously, `asGatewayError()` converted retryable `APICallError` instances into `GatewayError` subclasses that the retry logic did not recognize, silently disabling retries for all `@ai-sdk/gateway` users.

--- a/packages/ai/src/util/retry-with-exponential-backoff.test.ts
+++ b/packages/ai/src/util/retry-with-exponential-backoff.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { APICallError } from '@ai-sdk/provider';
+import {
+  GatewayInternalServerError,
+  GatewayRateLimitError,
+  GatewayAuthenticationError,
+} from '@ai-sdk/gateway';
 import { retryWithExponentialBackoffRespectingRetryHeaders } from './retry-with-exponential-backoff';
 
 describe('retryWithExponentialBackoffRespectingRetryHeaders', () => {
@@ -434,6 +439,118 @@ describe('retryWithExponentialBackoffRespectingRetryHeaders', () => {
 
       // Should use exponential backoff delay (2000ms) not the negative rate limit
       await vi.advanceTimersByTimeAsync(initialDelay - 100);
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(200);
+      expect(fn).toHaveBeenCalledTimes(2);
+
+      const result = await promise;
+      expect(result).toBe('success');
+    });
+  });
+
+  describe('with Gateway errors', () => {
+    it('should retry on GatewayInternalServerError', async () => {
+      let attempt = 0;
+      const initialDelay = 2000;
+
+      const fn = vi.fn().mockImplementation(async () => {
+        attempt++;
+        if (attempt === 1) {
+          throw new GatewayInternalServerError({
+            message: 'Internal server error',
+            statusCode: 503,
+          });
+        }
+        return 'success';
+      });
+
+      const promise = retryWithExponentialBackoffRespectingRetryHeaders({
+        initialDelayInMs: initialDelay,
+      })(fn);
+
+      await vi.advanceTimersByTimeAsync(initialDelay - 100);
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(200);
+      expect(fn).toHaveBeenCalledTimes(2);
+
+      const result = await promise;
+      expect(result).toBe('success');
+    });
+
+    it('should retry on GatewayRateLimitError', async () => {
+      let attempt = 0;
+      const initialDelay = 2000;
+
+      const fn = vi.fn().mockImplementation(async () => {
+        attempt++;
+        if (attempt === 1) {
+          throw new GatewayRateLimitError({
+            message: 'Rate limit exceeded',
+          });
+        }
+        return 'success';
+      });
+
+      const promise = retryWithExponentialBackoffRespectingRetryHeaders({
+        initialDelayInMs: initialDelay,
+      })(fn);
+
+      await vi.advanceTimersByTimeAsync(initialDelay - 100);
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(200);
+      expect(fn).toHaveBeenCalledTimes(2);
+
+      const result = await promise;
+      expect(result).toBe('success');
+    });
+
+    it('should not retry on non-retryable GatewayAuthenticationError', async () => {
+      const fn = vi.fn().mockImplementation(async () => {
+        throw new GatewayAuthenticationError({
+          message: 'Invalid API key',
+        });
+      });
+
+      await expect(
+        retryWithExponentialBackoffRespectingRetryHeaders()(fn),
+      ).rejects.toThrow('Invalid API key');
+
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use retry-after headers from APICallError cause', async () => {
+      let attempt = 0;
+      const retryAfterMs = 3000;
+
+      const fn = vi.fn().mockImplementation(async () => {
+        attempt++;
+        if (attempt === 1) {
+          const apiError = new APICallError({
+            message: 'Service unavailable',
+            url: 'https://api.example.com',
+            requestBodyValues: {},
+            statusCode: 503,
+            isRetryable: true,
+            responseHeaders: {
+              'retry-after-ms': retryAfterMs.toString(),
+            },
+          });
+
+          throw new GatewayInternalServerError({
+            message: 'Internal server error',
+            statusCode: 503,
+            cause: apiError,
+          });
+        }
+        return 'success';
+      });
+
+      const promise = retryWithExponentialBackoffRespectingRetryHeaders()(fn);
+
+      await vi.advanceTimersByTimeAsync(retryAfterMs - 100);
       expect(fn).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(200);

--- a/packages/ai/src/util/retry-with-exponential-backoff.ts
+++ b/packages/ai/src/util/retry-with-exponential-backoff.ts
@@ -1,4 +1,5 @@
 import { APICallError } from '@ai-sdk/provider';
+import { GatewayError } from '@ai-sdk/gateway';
 import { delay, getErrorMessage, isAbortError } from '@ai-sdk/provider-utils';
 import { RetryError } from './retry-error';
 
@@ -10,10 +11,14 @@ function getRetryDelayInMs({
   error,
   exponentialBackoffDelay,
 }: {
-  error: APICallError;
+  error: APICallError | GatewayError;
   exponentialBackoffDelay: number;
 }): number {
-  const headers = error.responseHeaders;
+  const headers = APICallError.isInstance(error)
+    ? error.responseHeaders
+    : APICallError.isInstance(error.cause)
+      ? (error.cause as APICallError).responseHeaders
+      : undefined;
 
   if (!headers) return exponentialBackoffDelay;
 
@@ -117,13 +122,13 @@ async function _retryWithExponentialBackoff<OUTPUT>(
 
     if (
       error instanceof Error &&
-      APICallError.isInstance(error) &&
-      error.isRetryable === true &&
+      ((APICallError.isInstance(error) && error.isRetryable === true) ||
+        (GatewayError.isInstance(error) && error.isRetryable === true)) &&
       tryNumber <= maxRetries
     ) {
       await delay(
         getRetryDelayInMs({
-          error,
+          error: error as APICallError | GatewayError,
           exponentialBackoffDelay: delayInMs,
         }),
         { abortSignal },

--- a/packages/gateway/src/errors/gateway-error-types.test.ts
+++ b/packages/gateway/src/errors/gateway-error-types.test.ts
@@ -7,6 +7,7 @@ import {
   GatewayModelNotFoundError,
   GatewayInternalServerError,
   GatewayResponseError,
+  GatewayTimeoutError,
 } from './index';
 
 describe('GatewayAuthenticationError', () => {
@@ -195,6 +196,48 @@ describe('GatewayInternalServerError', () => {
 
     expect(GatewayInternalServerError.isInstance(error)).toBe(true);
     expect(GatewayError.isInstance(error)).toBe(true);
+  });
+});
+
+describe('isRetryable', () => {
+  it('should be true for GatewayInternalServerError (500)', () => {
+    const error = new GatewayInternalServerError();
+    expect(error.isRetryable).toBe(true);
+  });
+
+  it('should be true for GatewayRateLimitError (429)', () => {
+    const error = new GatewayRateLimitError();
+    expect(error.isRetryable).toBe(true);
+  });
+
+  it('should be true for GatewayTimeoutError (408)', () => {
+    const error = new GatewayTimeoutError();
+    expect(error.isRetryable).toBe(true);
+  });
+
+  it('should be true for status codes >= 500', () => {
+    const error = new GatewayInternalServerError({ statusCode: 503 });
+    expect(error.isRetryable).toBe(true);
+  });
+
+  it('should be false for GatewayAuthenticationError (401)', () => {
+    const error = new GatewayAuthenticationError();
+    expect(error.isRetryable).toBe(false);
+  });
+
+  it('should be false for GatewayInvalidRequestError (400)', () => {
+    const error = new GatewayInvalidRequestError();
+    expect(error.isRetryable).toBe(false);
+  });
+
+  it('should be false for GatewayModelNotFoundError (404)', () => {
+    const error = new GatewayModelNotFoundError();
+    expect(error.isRetryable).toBe(false);
+  });
+
+  it('should be true for GatewayResponseError (502)', () => {
+    const error = new GatewayResponseError();
+    expect(error.isRetryable).toBe(true);
   });
 });
 

--- a/packages/gateway/src/errors/gateway-error.ts
+++ b/packages/gateway/src/errors/gateway-error.ts
@@ -9,22 +9,30 @@ export abstract class GatewayError extends Error {
   readonly statusCode: number;
   readonly cause?: unknown;
   readonly generationId?: string;
+  readonly isRetryable: boolean;
 
   constructor({
     message,
     statusCode = 500,
     cause,
     generationId,
+    isRetryable = statusCode != null &&
+      (statusCode === 408 || // request timeout
+        statusCode === 409 || // conflict
+        statusCode === 429 || // too many requests
+        statusCode >= 500), // server error
   }: {
     message: string;
     statusCode?: number;
     cause?: unknown;
     generationId?: string;
+    isRetryable?: boolean;
   }) {
     super(generationId ? `${message} [${generationId}]` : message);
     this.statusCode = statusCode;
     this.cause = cause;
     this.generationId = generationId;
+    this.isRetryable = isRetryable;
   }
 
   /**


### PR DESCRIPTION
## Background

Gateway errors (`GatewayInternalServerError`, `GatewayRateLimitError`, `GatewayTimeoutError`) were never retried by `maxRetries` because `asGatewayError()` converts the original `APICallError` into a `GatewayError` subclass before the retry logic sees it. The retry function only checked `APICallError.isInstance(error)`, which always returned false for Gateway errors.

## Summary

- Add `isRetryable` to `GatewayError` base class, derived from `statusCode` using the same logic as `APICallError` (408, 409, 429, >= 500)
- Extend `_retryWithExponentialBackoff` to also check `GatewayError.isInstance(error) && error.isRetryable`
- For retry-after header extraction, unwrap `error.cause` when the error is a `GatewayError` with an `APICallError` cause

## Manual Verification

Verified that `GatewayInternalServerError` (500), `GatewayRateLimitError` (429), and `GatewayTimeoutError` (408) now have `isRetryable === true`, and that `GatewayAuthenticationError` (401), `GatewayInvalidRequestError` (400), and `GatewayModelNotFoundError` (404) remain `isRetryable === false`.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14216

Made with [Cursor](https://cursor.com)