### PR TITLE
fix(ai): skip data: URLs in downloadAssets to prevent unnecessary download

### DIFF
--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -1018,6 +1018,138 @@ describe('convertToLanguageModelPrompt', () => {
       ]);
     });
   });
+
+  describe('data URL handling (regression #13103)', () => {
+    it('should not pass data: URL image parts to the download function', async () => {
+      const mockDownload = vi.fn().mockResolvedValue([]);
+
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          messages: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'image',
+                  image: 'data:image/jpg;base64,/9j/3Q==',
+                },
+              ],
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: mockDownload,
+      });
+
+      expect(mockDownload).toHaveBeenCalledWith([]);
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: '/9j/3Q==',
+              mediaType: 'image/jpeg',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should not pass data: URL file parts to the download function', async () => {
+      const mockDownload = vi.fn().mockResolvedValue([]);
+
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          messages: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'file',
+                  data: 'data:application/pdf;base64,JVBERi0=',
+                  mediaType: 'application/pdf',
+                },
+              ],
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: mockDownload,
+      });
+
+      expect(mockDownload).toHaveBeenCalledWith([]);
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: 'JVBERi0=',
+              mediaType: 'application/pdf',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should still download http(s) URLs while skipping data: URLs', async () => {
+      const mockDownload = vi.fn().mockResolvedValue([
+        {
+          data: new Uint8Array([0xff, 0xd8, 0xff]),
+          mediaType: 'image/jpeg',
+        },
+      ]);
+
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          messages: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'image',
+                  image: 'data:image/jpg;base64,/9j/3Q==',
+                },
+                {
+                  type: 'image',
+                  image: 'https://example.com/photo.jpg',
+                },
+              ],
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: mockDownload,
+      });
+
+      // Only the https URL should be passed to download
+      expect(mockDownload).toHaveBeenCalledWith([
+        {
+          url: new URL('https://example.com/photo.jpg'),
+          isUrlSupportedByModel: false,
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: '/9j/3Q==',
+              mediaType: 'image/jpeg',
+            },
+            {
+              type: 'file',
+              data: new Uint8Array([0xff, 0xd8, 0xff]),
+              mediaType: 'image/jpeg',
+            },
+          ],
+        },
+      ]);
+    });
+  });
 });
 
 describe('convertToLanguageModelMessage', () => {

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -393,7 +393,7 @@ async function downloadAssets(
 
     .filter(
       (part): part is { mediaType: string | undefined; data: URL } =>
-        part.data instanceof URL,
+        part.data instanceof URL && part.data.protocol !== 'data:',
     )
     .map(part => ({
       url: part.data,


### PR DESCRIPTION
## Summary

Addresses #13103 — fixes the remaining root cause after the `validateDownloadUrl` patch.

### Evidence-based reproduction

The original crash (`URL scheme must be http or https, got data:`) was already fixed by the `validateDownloadUrl` patch (commit `ee6bbac34`), which added a `data:` protocol early-return. **The crash no longer reproduces on current main.**

However, the **root cause** in `downloadAssets()` remains: `data:` URLs still leak into the download pipeline. Reproduction on unfixed main shows:

```
data: URLs: 2 → ["data:image/jpeg;base64,/9j/4AAQ","data:text/plain;base64,aGVsbG8="]
http(s): URLs: 1 → ["https://example.com/photo.jpg"]
data: URLs leak into download pipeline: YES ← this is the bug surface
```

This means `fetch()` is called on inline data: URLs, which:
1. Is **wasteful** — no network fetch is needed for inline content
2. Is **fragile** — `fetch()` with data: URLs is not guaranteed across all runtimes (edge workers, older Node)
3. Is **architecturally wrong** — `convertToLanguageModelV4DataContent()` already handles data: URLs by extracting the base64 payload inline; the download result is never consumed

### Fix

Filter out `data:` URLs in `downloadAssets()` before they enter the download pipeline:

```diff
- part.data instanceof URL,
+ part.data instanceof URL && part.data.protocol !== 'data:',
```

### What stays intact

- All SSRF protections for `http(s)` URLs remain unchanged
- `validateDownloadUrl()` still blocks private IPs, localhost, non-http(s) protocols
- Redirect validation still catches SSRF via open redirects
- `data:` URLs still work correctly via `convertToLanguageModelV4DataContent()`

### Tests

Added 3 regression tests verifying:
- `data:` image parts are **not** passed to the download function
- `data:` file parts are **not** passed to the download function
- Mixed `data:` + `https:` URLs only download the `https:` ones

All 52 prompt conversion tests pass. All 29 SSRF validation tests pass. All 11 download tests pass.