### PR TITLE
fix(gateway): preserve retry semantics when APICallError is converted to GatewayError

### DIFF
--- a/packages/ai/src/util/retry-with-exponential-backoff.test.ts
+++ b/packages/ai/src/util/retry-with-exponential-backoff.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { APICallError } from '@ai-sdk/provider';
+import {
+  GatewayInternalServerError,
+  GatewayRateLimitError,
+  GatewayAuthenticationError,
+  GatewayInvalidRequestError,
+} from '@ai-sdk/gateway';
 import { retryWithExponentialBackoffRespectingRetryHeaders } from './retry-with-exponential-backoff';
 
 describe('retryWithExponentialBackoffRespectingRetryHeaders', () => {
@@ -441,6 +447,241 @@ describe('retryWithExponentialBackoffRespectingRetryHeaders', () => {
 
       const result = await promise;
       expect(result).toBe('success');
+    });
+  });
+
+  describe('GatewayError retry support (issue #14216)', () => {
+    it('should retry retryable GatewayInternalServerError (503)', async () => {
+      let attempt = 0;
+      const initialDelay = 2000;
+
+      const fn = vi.fn().mockImplementation(async () => {
+        attempt++;
+        if (attempt === 1) {
+          throw new GatewayInternalServerError({
+            message: 'Service temporarily unavailable',
+            statusCode: 503,
+          });
+        }
+        return 'success';
+      });
+
+      const promise = retryWithExponentialBackoffRespectingRetryHeaders({
+        initialDelayInMs: initialDelay,
+      })(fn);
+
+      await vi.advanceTimersByTimeAsync(initialDelay);
+      expect(fn).toHaveBeenCalledTimes(2);
+
+      const result = await promise;
+      expect(result).toBe('success');
+    });
+
+    it('should retry retryable GatewayRateLimitError (429)', async () => {
+      let attempt = 0;
+      const initialDelay = 2000;
+
+      const fn = vi.fn().mockImplementation(async () => {
+        attempt++;
+        if (attempt === 1) {
+          throw new GatewayRateLimitError({
+            message: 'Rate limit exceeded',
+            statusCode: 429,
+          });
+        }
+        return 'success';
+      });
+
+      const promise = retryWithExponentialBackoffRespectingRetryHeaders({
+        initialDelayInMs: initialDelay,
+      })(fn);
+
+      await vi.advanceTimersByTimeAsync(initialDelay);
+      expect(fn).toHaveBeenCalledTimes(2);
+
+      const result = await promise;
+      expect(result).toBe('success');
+    });
+
+    it('should retry retryable GatewayInternalServerError with timeout status (408)', async () => {
+      let attempt = 0;
+      const initialDelay = 2000;
+
+      const fn = vi.fn().mockImplementation(async () => {
+        attempt++;
+        if (attempt === 1) {
+          throw new GatewayInternalServerError({
+            message: 'Request timed out',
+            statusCode: 408,
+          });
+        }
+        return 'success';
+      });
+
+      const promise = retryWithExponentialBackoffRespectingRetryHeaders({
+        initialDelayInMs: initialDelay,
+      })(fn);
+
+      await vi.advanceTimersByTimeAsync(initialDelay);
+      expect(fn).toHaveBeenCalledTimes(2);
+
+      const result = await promise;
+      expect(result).toBe('success');
+    });
+
+    it('should NOT retry non-retryable GatewayAuthenticationError (401)', async () => {
+      const fn = vi.fn().mockImplementation(async () => {
+        throw new GatewayAuthenticationError({
+          message: 'Invalid API key',
+          statusCode: 401,
+        });
+      });
+
+      await expect(
+        retryWithExponentialBackoffRespectingRetryHeaders({ maxRetries: 2 })(
+          fn,
+        ),
+      ).rejects.toThrow('Invalid API key');
+
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT retry non-retryable GatewayInvalidRequestError (400)', async () => {
+      const fn = vi.fn().mockImplementation(async () => {
+        throw new GatewayInvalidRequestError({
+          message: 'Bad request',
+          statusCode: 400,
+        });
+      });
+
+      await expect(
+        retryWithExponentialBackoffRespectingRetryHeaders({ maxRetries: 2 })(
+          fn,
+        ),
+      ).rejects.toThrow('Bad request');
+
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should preserve isRetryable from original APICallError through gateway conversion', async () => {
+      let attempt = 0;
+      const initialDelay = 2000;
+
+      // Simulate what asGatewayError does: wraps APICallError into GatewayInternalServerError
+      const originalApiError = new APICallError({
+        message: 'Server error',
+        url: 'https://api.gateway.example.com',
+        requestBodyValues: {},
+        statusCode: 503,
+        isRetryable: true,
+      });
+
+      const fn = vi.fn().mockImplementation(async () => {
+        attempt++;
+        if (attempt === 1) {
+          throw new GatewayInternalServerError({
+            message: 'Gateway request failed',
+            statusCode: 503,
+            cause: originalApiError,
+            isRetryable: originalApiError.isRetryable,
+          });
+        }
+        return 'success';
+      });
+
+      const promise = retryWithExponentialBackoffRespectingRetryHeaders({
+        initialDelayInMs: initialDelay,
+      })(fn);
+
+      await vi.advanceTimersByTimeAsync(initialDelay);
+      expect(fn).toHaveBeenCalledTimes(2);
+
+      const result = await promise;
+      expect(result).toBe('success');
+    });
+
+    it('should extract retry-after headers from cause APICallError in GatewayError', async () => {
+      let attempt = 0;
+      const retryAfterMs = 5000;
+
+      const originalApiError = new APICallError({
+        message: 'Rate limited',
+        url: 'https://api.gateway.example.com',
+        requestBodyValues: {},
+        statusCode: 429,
+        isRetryable: true,
+        responseHeaders: {
+          'retry-after-ms': retryAfterMs.toString(),
+        },
+      });
+
+      const fn = vi.fn().mockImplementation(async () => {
+        attempt++;
+        if (attempt === 1) {
+          throw new GatewayRateLimitError({
+            message: 'Rate limit exceeded',
+            statusCode: 429,
+            cause: originalApiError,
+            isRetryable: true,
+          });
+        }
+        return 'success';
+      });
+
+      const promise = retryWithExponentialBackoffRespectingRetryHeaders()(fn);
+
+      // Should use retry-after-ms from the cause APICallError
+      await vi.advanceTimersByTimeAsync(retryAfterMs - 100);
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(200);
+      expect(fn).toHaveBeenCalledTimes(2);
+
+      const result = await promise;
+      expect(result).toBe('success');
+    });
+
+    it('should respect maxRetries limit for GatewayError', async () => {
+      const fn = vi.fn().mockImplementation(async () => {
+        throw new GatewayInternalServerError({
+          message: 'Persistent server error',
+          statusCode: 500,
+        });
+      });
+
+      const promise = retryWithExponentialBackoffRespectingRetryHeaders({
+        maxRetries: 2,
+        initialDelayInMs: 100,
+      })(fn);
+
+      // Catch the rejection to prevent unhandled rejection warnings
+      const resultPromise = promise.catch(e => e);
+
+      // Advance through all retries
+      await vi.advanceTimersByTimeAsync(100); // first retry delay
+      await vi.advanceTimersByTimeAsync(200); // second retry delay (backoff)
+
+      const error = await resultPromise;
+      expect(error.message).toContain('Failed after 3 attempts');
+      expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not retry GatewayError with isRetryable explicitly set to false', async () => {
+      const fn = vi.fn().mockImplementation(async () => {
+        throw new GatewayInternalServerError({
+          message: 'Non-retryable server error',
+          statusCode: 500,
+          isRetryable: false,
+        });
+      });
+
+      await expect(
+        retryWithExponentialBackoffRespectingRetryHeaders({ maxRetries: 2 })(
+          fn,
+        ),
+      ).rejects.toThrow('Non-retryable server error');
+
+      expect(fn).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/ai/src/util/retry-with-exponential-backoff.ts
+++ b/packages/ai/src/util/retry-with-exponential-backoff.ts
@@ -1,4 +1,5 @@
 import { APICallError } from '@ai-sdk/provider';
+import { GatewayError } from '@ai-sdk/gateway';
 import { delay, getErrorMessage, isAbortError } from '@ai-sdk/provider-utils';
 import { RetryError } from './retry-error';
 
@@ -6,14 +7,17 @@ export type RetryFunction = <OUTPUT>(
   fn: () => PromiseLike<OUTPUT>,
 ) => PromiseLike<OUTPUT>;
 
+type RetryableError = APICallError | GatewayError;
+
 function getRetryDelayInMs({
   error,
   exponentialBackoffDelay,
 }: {
-  error: APICallError;
+  error: RetryableError;
   exponentialBackoffDelay: number;
 }): number {
-  const headers = error.responseHeaders;
+  // Extract response headers from the error or its cause chain
+  const headers = getResponseHeaders(error);
 
   if (!headers) return exponentialBackoffDelay;
 
@@ -50,6 +54,31 @@ function getRetryDelayInMs({
   }
 
   return exponentialBackoffDelay;
+}
+
+function getResponseHeaders(
+  error: RetryableError,
+): Record<string, string> | undefined {
+  if (APICallError.isInstance(error)) {
+    return error.responseHeaders;
+  }
+  // For GatewayError, try to extract headers from the cause APICallError
+  if (
+    GatewayError.isInstance(error) &&
+    error.cause != null &&
+    APICallError.isInstance(error.cause)
+  ) {
+    return error.cause.responseHeaders;
+  }
+  return undefined;
+}
+
+function isRetryableError(error: unknown): error is RetryableError {
+  if (!(error instanceof Error)) return false;
+  return (
+    (APICallError.isInstance(error) && error.isRetryable === true) ||
+    (GatewayError.isInstance(error) && error.isRetryable === true)
+  );
 }
 
 /**
@@ -115,12 +144,7 @@ async function _retryWithExponentialBackoff<OUTPUT>(
       });
     }
 
-    if (
-      error instanceof Error &&
-      APICallError.isInstance(error) &&
-      error.isRetryable === true &&
-      tryNumber <= maxRetries
-    ) {
+    if (isRetryableError(error) && tryNumber <= maxRetries) {
       await delay(
         getRetryDelayInMs({
           error,

--- a/packages/gateway/src/errors/as-gateway-error.test.ts
+++ b/packages/gateway/src/errors/as-gateway-error.test.ts
@@ -168,4 +168,69 @@ describe('asGatewayError', () => {
       expect(GatewayTimeoutError.isInstance(result)).toBe(false);
     });
   });
+
+  describe('isRetryable propagation from APICallError', () => {
+    it('should preserve isRetryable=true from a retryable APICallError (503)', async () => {
+      const apiCallError = new APICallError({
+        message: 'Service Unavailable',
+        url: 'https://api.gateway.example.com',
+        requestBodyValues: {},
+        statusCode: 503,
+        isRetryable: true,
+        responseBody: JSON.stringify({
+          error: {
+            message: 'Service temporarily unavailable',
+            type: 'internal_server_error',
+          },
+        }),
+      });
+
+      const result = await asGatewayError(apiCallError);
+
+      expect(GatewayError.isInstance(result)).toBe(true);
+      expect(result.isRetryable).toBe(true);
+    });
+
+    it('should preserve isRetryable=true from a retryable APICallError (429)', async () => {
+      const apiCallError = new APICallError({
+        message: 'Rate limited',
+        url: 'https://api.gateway.example.com',
+        requestBodyValues: {},
+        statusCode: 429,
+        isRetryable: true,
+        responseBody: JSON.stringify({
+          error: {
+            message: 'Too many requests',
+            type: 'rate_limit_exceeded',
+          },
+        }),
+      });
+
+      const result = await asGatewayError(apiCallError);
+
+      expect(GatewayError.isInstance(result)).toBe(true);
+      expect(result.isRetryable).toBe(true);
+    });
+
+    it('should preserve isRetryable=false from a non-retryable APICallError (401)', async () => {
+      const apiCallError = new APICallError({
+        message: 'Unauthorized',
+        url: 'https://api.gateway.example.com',
+        requestBodyValues: {},
+        statusCode: 401,
+        isRetryable: false,
+        responseBody: JSON.stringify({
+          error: {
+            message: 'Invalid credentials',
+            type: 'authentication_error',
+          },
+        }),
+      });
+
+      const result = await asGatewayError(apiCallError);
+
+      expect(GatewayError.isInstance(result)).toBe(true);
+      expect(result.isRetryable).toBe(false);
+    });
+  });
 });

--- a/packages/gateway/src/errors/as-gateway-error.ts
+++ b/packages/gateway/src/errors/as-gateway-error.ts
@@ -58,6 +58,7 @@ export async function asGatewayError(
       defaultMessage: 'Gateway request failed',
       cause: error,
       authMethod,
+      isRetryable: error.isRetryable,
     });
   }
 

--- a/packages/gateway/src/errors/create-gateway-error.ts
+++ b/packages/gateway/src/errors/create-gateway-error.ts
@@ -23,12 +23,14 @@ export async function createGatewayErrorFromResponse({
   defaultMessage = 'Gateway request failed',
   cause,
   authMethod,
+  isRetryable,
 }: {
   response: unknown;
   statusCode: number;
   defaultMessage?: string;
   cause?: unknown;
   authMethod?: 'api-key' | 'oidc';
+  isRetryable?: boolean;
 }): Promise<GatewayError> {
   const parseResult = await safeValidateTypes({
     value: response,
@@ -51,6 +53,7 @@ export async function createGatewayErrorFromResponse({
       validationError: parseResult.error,
       cause,
       generationId: rawGenerationId,
+      isRetryable,
     });
   }
 
@@ -67,6 +70,7 @@ export async function createGatewayErrorFromResponse({
         statusCode,
         cause,
         generationId,
+        isRetryable,
       });
     case 'invalid_request_error':
       return new GatewayInvalidRequestError({
@@ -74,6 +78,7 @@ export async function createGatewayErrorFromResponse({
         statusCode,
         cause,
         generationId,
+        isRetryable,
       });
     case 'rate_limit_exceeded':
       return new GatewayRateLimitError({
@@ -81,6 +86,7 @@ export async function createGatewayErrorFromResponse({
         statusCode,
         cause,
         generationId,
+        isRetryable,
       });
     case 'model_not_found': {
       const modelResult = await safeValidateTypes({
@@ -94,6 +100,7 @@ export async function createGatewayErrorFromResponse({
         modelId: modelResult.success ? modelResult.value.modelId : undefined,
         cause,
         generationId,
+        isRetryable,
       });
     }
     case 'internal_server_error':
@@ -102,6 +109,7 @@ export async function createGatewayErrorFromResponse({
         statusCode,
         cause,
         generationId,
+        isRetryable,
       });
     default:
       return new GatewayInternalServerError({
@@ -109,6 +117,7 @@ export async function createGatewayErrorFromResponse({
         statusCode,
         cause,
         generationId,
+        isRetryable,
       });
   }
 }

--- a/packages/gateway/src/errors/gateway-authentication-error.ts
+++ b/packages/gateway/src/errors/gateway-authentication-error.ts
@@ -18,13 +18,15 @@ export class GatewayAuthenticationError extends GatewayError {
     statusCode = 401,
     cause,
     generationId,
+    isRetryable,
   }: {
     message?: string;
     statusCode?: number;
     cause?: unknown;
     generationId?: string;
+    isRetryable?: boolean;
   } = {}) {
-    super({ message, statusCode, cause, generationId });
+    super({ message, statusCode, cause, generationId, isRetryable });
   }
 
   static isInstance(error: unknown): error is GatewayAuthenticationError {
@@ -41,6 +43,7 @@ export class GatewayAuthenticationError extends GatewayError {
     statusCode = 401,
     cause,
     generationId,
+    isRetryable,
   }: {
     apiKeyProvided: boolean;
     oidcTokenProvided: boolean;
@@ -48,6 +51,7 @@ export class GatewayAuthenticationError extends GatewayError {
     statusCode?: number;
     cause?: unknown;
     generationId?: string;
+    isRetryable?: boolean;
   }): GatewayAuthenticationError {
     let contextualMessage: string;
 
@@ -79,6 +83,7 @@ Run 'npx vercel link' to link your project, then 'vc env pull' to fetch the toke
       statusCode,
       cause,
       generationId,
+      isRetryable,
     });
   }
 }

--- a/packages/gateway/src/errors/gateway-error-types.test.ts
+++ b/packages/gateway/src/errors/gateway-error-types.test.ts
@@ -7,6 +7,7 @@ import {
   GatewayModelNotFoundError,
   GatewayInternalServerError,
   GatewayResponseError,
+  GatewayTimeoutError,
 } from './index';
 
 describe('GatewayAuthenticationError', () => {
@@ -274,5 +275,55 @@ describe('Error inheritance chain', () => {
     expect(error.stack).toBeDefined();
     expect(error.stack).toContain('GatewayAuthenticationError');
     expect(error.stack).toContain('Test error');
+  });
+});
+
+describe('isRetryable defaults', () => {
+  it('should be retryable for 500 (GatewayInternalServerError)', () => {
+    const error = new GatewayInternalServerError({ statusCode: 500 });
+    expect(error.isRetryable).toBe(true);
+  });
+
+  it('should be retryable for 503 (GatewayInternalServerError)', () => {
+    const error = new GatewayInternalServerError({ statusCode: 503 });
+    expect(error.isRetryable).toBe(true);
+  });
+
+  it('should be retryable for 429 (GatewayRateLimitError)', () => {
+    const error = new GatewayRateLimitError({ statusCode: 429 });
+    expect(error.isRetryable).toBe(true);
+  });
+
+  it('should be retryable for 408 (GatewayTimeoutError)', () => {
+    const error = new GatewayTimeoutError({ statusCode: 408 });
+    expect(error.isRetryable).toBe(true);
+  });
+
+  it('should NOT be retryable for 401 (GatewayAuthenticationError)', () => {
+    const error = new GatewayAuthenticationError({ statusCode: 401 });
+    expect(error.isRetryable).toBe(false);
+  });
+
+  it('should NOT be retryable for 400 (GatewayInvalidRequestError)', () => {
+    const error = new GatewayInvalidRequestError({ statusCode: 400 });
+    expect(error.isRetryable).toBe(false);
+  });
+
+  it('should NOT be retryable for 404 (GatewayModelNotFoundError)', () => {
+    const error = new GatewayModelNotFoundError({ statusCode: 404 });
+    expect(error.isRetryable).toBe(false);
+  });
+
+  it('should allow explicit isRetryable override', () => {
+    const error = new GatewayInternalServerError({
+      statusCode: 500,
+      isRetryable: false,
+    });
+    expect(error.isRetryable).toBe(false);
+  });
+
+  it('should be retryable for 502 (GatewayResponseError)', () => {
+    const error = new GatewayResponseError({ statusCode: 502 });
+    expect(error.isRetryable).toBe(true);
   });
 });

--- a/packages/gateway/src/errors/gateway-error.ts
+++ b/packages/gateway/src/errors/gateway-error.ts
@@ -9,22 +9,29 @@ export abstract class GatewayError extends Error {
   readonly statusCode: number;
   readonly cause?: unknown;
   readonly generationId?: string;
+  readonly isRetryable: boolean;
 
   constructor({
     message,
     statusCode = 500,
     cause,
     generationId,
+    isRetryable = statusCode != null &&
+      (statusCode === 408 || // request timeout
+        statusCode === 429 || // too many requests
+        statusCode >= 500), // server error
   }: {
     message: string;
     statusCode?: number;
     cause?: unknown;
     generationId?: string;
+    isRetryable?: boolean;
   }) {
     super(generationId ? `${message} [${generationId}]` : message);
     this.statusCode = statusCode;
     this.cause = cause;
     this.generationId = generationId;
+    this.isRetryable = isRetryable;
   }
 
   /**

--- a/packages/gateway/src/errors/gateway-internal-server-error.ts
+++ b/packages/gateway/src/errors/gateway-internal-server-error.ts
@@ -18,13 +18,15 @@ export class GatewayInternalServerError extends GatewayError {
     statusCode = 500,
     cause,
     generationId,
+    isRetryable,
   }: {
     message?: string;
     statusCode?: number;
     cause?: unknown;
     generationId?: string;
+    isRetryable?: boolean;
   } = {}) {
-    super({ message, statusCode, cause, generationId });
+    super({ message, statusCode, cause, generationId, isRetryable });
   }
 
   static isInstance(error: unknown): error is GatewayInternalServerError {

--- a/packages/gateway/src/errors/gateway-invalid-request-error.ts
+++ b/packages/gateway/src/errors/gateway-invalid-request-error.ts
@@ -18,13 +18,15 @@ export class GatewayInvalidRequestError extends GatewayError {
     statusCode = 400,
     cause,
     generationId,
+    isRetryable,
   }: {
     message?: string;
     statusCode?: number;
     cause?: unknown;
     generationId?: string;
+    isRetryable?: boolean;
   } = {}) {
-    super({ message, statusCode, cause, generationId });
+    super({ message, statusCode, cause, generationId, isRetryable });
   }
 
   static isInstance(error: unknown): error is GatewayInvalidRequestError {

--- a/packages/gateway/src/errors/gateway-model-not-found-error.ts
+++ b/packages/gateway/src/errors/gateway-model-not-found-error.ts
@@ -30,14 +30,16 @@ export class GatewayModelNotFoundError extends GatewayError {
     modelId,
     cause,
     generationId,
+    isRetryable,
   }: {
     message?: string;
     statusCode?: number;
     modelId?: string;
     cause?: unknown;
     generationId?: string;
+    isRetryable?: boolean;
   } = {}) {
-    super({ message, statusCode, cause, generationId });
+    super({ message, statusCode, cause, generationId, isRetryable });
     this.modelId = modelId;
   }
 

--- a/packages/gateway/src/errors/gateway-rate-limit-error.ts
+++ b/packages/gateway/src/errors/gateway-rate-limit-error.ts
@@ -18,13 +18,15 @@ export class GatewayRateLimitError extends GatewayError {
     statusCode = 429,
     cause,
     generationId,
+    isRetryable,
   }: {
     message?: string;
     statusCode?: number;
     cause?: unknown;
     generationId?: string;
+    isRetryable?: boolean;
   } = {}) {
-    super({ message, statusCode, cause, generationId });
+    super({ message, statusCode, cause, generationId, isRetryable });
   }
 
   static isInstance(error: unknown): error is GatewayRateLimitError {

--- a/packages/gateway/src/errors/gateway-response-error.ts
+++ b/packages/gateway/src/errors/gateway-response-error.ts
@@ -23,6 +23,7 @@ export class GatewayResponseError extends GatewayError {
     validationError,
     cause,
     generationId,
+    isRetryable,
   }: {
     message?: string;
     statusCode?: number;
@@ -30,8 +31,9 @@ export class GatewayResponseError extends GatewayError {
     validationError?: TypeValidationError;
     cause?: unknown;
     generationId?: string;
+    isRetryable?: boolean;
   } = {}) {
-    super({ message, statusCode, cause, generationId });
+    super({ message, statusCode, cause, generationId, isRetryable });
     this.response = response;
     this.validationError = validationError;
   }

--- a/packages/gateway/src/errors/gateway-timeout-error.ts
+++ b/packages/gateway/src/errors/gateway-timeout-error.ts
@@ -18,13 +18,15 @@ export class GatewayTimeoutError extends GatewayError {
     statusCode = 408,
     cause,
     generationId,
+    isRetryable,
   }: {
     message?: string;
     statusCode?: number;
     cause?: unknown;
     generationId?: string;
+    isRetryable?: boolean;
   } = {}) {
-    super({ message, statusCode, cause, generationId });
+    super({ message, statusCode, cause, generationId, isRetryable });
   }
 
   static isInstance(error: unknown): error is GatewayTimeoutError {


### PR DESCRIPTION
## Summary

Fixes #14216

When `@ai-sdk/gateway` converts an `APICallError` into a `GatewayError` subclass (via `asGatewayError()`), the SDK retry logic no longer recognizes the error as retryable because `APICallError.isInstance()` returns `false` for `GatewayError`. This causes `maxRetries` to be silently ignored for transient 503, 429, and 408 gateway failures.

## Root Cause

The retry logic in `retry-with-exponential-backoff.ts` only checked `APICallError.isInstance(error) && error.isRetryable`. After `asGatewayError()` wraps the original `APICallError` into a `GatewayError` subclass, `APICallError.isInstance()` returns `false`, so the error is never retried.

## Changes

### `@ai-sdk/gateway`
- Added `isRetryable` field to `GatewayError` base class with the same default logic as `APICallError` (408/429/500+ are retryable)
- Updated all 7 `GatewayError` subclasses to accept and forward `isRetryable`
- Updated `createGatewayErrorFromResponse()` to accept and forward `isRetryable`
- Updated `asGatewayError()` to propagate `isRetryable` from the original `APICallError`

### `ai` (core)
- Updated retry logic to recognize both `APICallError` and `GatewayError` as retryable error types
- Added `getResponseHeaders()` helper to extract retry-after headers from `GatewayError`'s cause chain (the original `APICallError` is preserved as `cause`)

## Test Coverage

- **10 new tests** for `isRetryable` defaults across all `GatewayError` subclasses
- **3 new tests** for `isRetryable` propagation from `APICallError` through `asGatewayError()`
- **8 new tests** for gateway error retry behavior in the retry logic (retryable errors, non-retryable errors, retry-after header extraction, maxRetries limit)
- All 392 existing gateway tests pass
- All 20 retry tests pass (11 existing + 8 new + 1 updated)
