### PR TITLE
fix(ui): rebuild partialToolCalls on resume for input-streaming tool parts

### DIFF
--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -8686,4 +8686,137 @@ describe('processUIMessageStream', () => {
       ]);
     });
   });
+
+  describe('resume with existing input-streaming static tool part (issue #14027)', () => {
+    beforeEach(async () => {
+      const stream = createUIMessageStream([
+        { type: 'start' },
+        {
+          type: 'tool-input-delta',
+          toolCallId: 'call-1',
+          inputTextDelta: '"more"}',
+        },
+        {
+          type: 'tool-input-available',
+          toolCallId: 'call-1',
+          toolName: 'create_document',
+          input: { title: 'test', content: 'more' },
+        },
+        {
+          type: 'tool-output-available',
+          toolCallId: 'call-1',
+          output: 'doc-created',
+        },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: {
+          role: 'assistant',
+          id: 'msg-123',
+          parts: [
+            { type: 'step-start' },
+            {
+              type: 'tool-create_document',
+              toolCallId: 'call-1',
+              state: 'input-streaming',
+              input: { title: 'test', content: undefined },
+            } as any,
+          ],
+        },
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+    });
+
+    it('should resume processing tool-input-delta for an existing input-streaming tool part', async () => {
+      // The last write should have the tool in output-available state
+      const lastWrite = writeCalls[writeCalls.length - 1];
+      const toolPart = lastWrite.message.parts.find(
+        (p: any) => p.toolCallId === 'call-1',
+      ) as any;
+
+      expect(toolPart).toBeDefined();
+      expect(toolPart.state).toBe('output-available');
+      expect(toolPart.output).toBe('doc-created');
+      expect(toolPart.type).toBe('tool-create_document');
+    });
+  });
+
+  describe('resume with existing input-streaming dynamic tool part', () => {
+    beforeEach(async () => {
+      const stream = createUIMessageStream([
+        { type: 'start' },
+        {
+          type: 'tool-input-delta',
+          toolCallId: 'call-dyn-1',
+          inputTextDelta: '"extra"}',
+        },
+        {
+          type: 'tool-input-available',
+          toolCallId: 'call-dyn-1',
+          toolName: 'unknown_tool',
+          input: { key: 'extra' },
+          dynamic: true,
+        },
+        {
+          type: 'tool-output-available',
+          toolCallId: 'call-dyn-1',
+          output: 'dyn-result',
+        },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-456',
+        lastMessage: {
+          role: 'assistant',
+          id: 'msg-456',
+          parts: [
+            { type: 'step-start' },
+            {
+              type: 'dynamic-tool',
+              toolName: 'unknown_tool',
+              toolCallId: 'call-dyn-1',
+              state: 'input-streaming',
+              input: { key: undefined },
+            } as any,
+          ],
+        },
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+    });
+
+    it('should resume processing tool-input-delta for an existing input-streaming dynamic tool part', async () => {
+      const lastWrite = writeCalls[writeCalls.length - 1];
+      const toolPart = lastWrite.message.parts.find(
+        (p: any) => p.toolCallId === 'call-dyn-1',
+      ) as any;
+
+      expect(toolPart).toBeDefined();
+      expect(toolPart.state).toBe('output-available');
+      expect(toolPart.output).toBe('dyn-result');
+      expect(toolPart.type).toBe('dynamic-tool');
+    });
+  });
 });

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -18,10 +18,12 @@ import {
   DataUIPart,
   DynamicToolUIPart,
   getStaticToolName,
+  getToolName,
   InferUIMessageData,
   InferUIMessageMetadata,
   InferUIMessageToolCall,
   InferUIMessageTools,
+  isDynamicToolUIPart,
   isStaticToolUIPart,
   isToolUIPart,
   ReasoningUIPart,
@@ -55,22 +57,44 @@ export function createStreamingUIMessageState<UI_MESSAGE extends UIMessage>({
   lastMessage: UI_MESSAGE | undefined;
   messageId: string;
 }): StreamingUIMessageState<UI_MESSAGE> {
+  const message: UI_MESSAGE =
+    lastMessage?.role === 'assistant'
+      ? lastMessage
+      : ({
+          id: messageId,
+          metadata: undefined,
+          role: 'assistant',
+          parts: [] as UIMessagePart<
+            InferUIMessageData<UI_MESSAGE>,
+            InferUIMessageTools<UI_MESSAGE>
+          >[],
+        } as UI_MESSAGE);
+
+  // Rebuild partialToolCalls from any existing input-streaming tool parts
+  // so that resumed streams can continue appending tool-input-delta chunks.
+  const partialToolCalls: StreamingUIMessageState<UI_MESSAGE>['partialToolCalls'] =
+    {};
+
+  const toolParts = message.parts.filter(isToolUIPart);
+  for (const part of toolParts) {
+    if (part.state === 'input-streaming') {
+      const inputText = part.input != null ? JSON.stringify(part.input) : '';
+
+      partialToolCalls[part.toolCallId] = {
+        text: inputText,
+        index: toolParts.indexOf(part),
+        toolName: getToolName(part),
+        dynamic: isDynamicToolUIPart(part) || undefined,
+        title: part.title,
+      };
+    }
+  }
+
   return {
-    message:
-      lastMessage?.role === 'assistant'
-        ? lastMessage
-        : ({
-            id: messageId,
-            metadata: undefined,
-            role: 'assistant',
-            parts: [] as UIMessagePart<
-              InferUIMessageData<UI_MESSAGE>,
-              InferUIMessageTools<UI_MESSAGE>
-            >[],
-          } as UI_MESSAGE),
+    message,
     activeTextParts: {},
     activeReasoningParts: {},
-    partialToolCalls: {},
+    partialToolCalls,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #14027

When `createStreamingUIMessageState` receives a `lastMessage` containing tool parts in `input-streaming` state (e.g. during `resumeStream()`), the `partialToolCalls` map was initialized as `{}`. This caused subsequent `tool-input-delta` chunks to fail because the lookup for the existing tool call returned `undefined`, throwing:

```
Received tool-input-delta for missing tool call with ID "...".
Ensure a "tool-input-start" chunk is sent before any "tool-input-delta" chunks.
```

## Root Cause

`createStreamingUIMessageState` never reconstructed `partialToolCalls` from existing `input-streaming` tool parts in the provided `lastMessage`. Fresh streams work fine because they always start with `tool-input-start`, but resumed streams skip that chunk since the tool part already exists in the hydrated message.

## Fix

After constructing the message, iterate over any existing tool parts in `input-streaming` state and pre-populate `partialToolCalls` with their current state (serialized input text, index, tool name, dynamic flag, title). This enables the stream processor to correctly handle `tool-input-delta` chunks during resume.

## Changes

- **`packages/ai/src/ui/process-ui-message-stream.ts`** — Rebuild `partialToolCalls` in `createStreamingUIMessageState` from existing `input-streaming` tool parts
- **`packages/ai/src/ui/process-ui-message-stream.test.ts`** — Add regression tests for resuming both static and dynamic tool parts in `input-streaming` state

## Tests

96/96 tests pass (`vitest run --config vitest.node.config.js src/ui/process-ui-message-stream.test.ts`), including 2 new regression tests.