### PR TITLE
fix: normalize non-object rawInput in convertToModelMessages

### DIFF
--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -784,6 +784,98 @@ describe('convertToModelMessages', () => {
         ]
       `);
       });
+
+      it('should normalize string rawInput to empty object (issue #13645)', async () => {
+        const result = await convertToModelMessages([
+          {
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-calculator',
+                state: 'output-error',
+                toolCallId: 'call1',
+                errorText: 'Invalid JSON arguments',
+                input: undefined,
+                rawInput: 'not valid json',
+              },
+            ],
+          },
+        ]);
+
+        // rawInput was a bare string — must become {} so providers
+        // like Anthropic don't reject it with a 400.
+        const assistantMsg = result[0];
+        expect(assistantMsg.role).toBe('assistant');
+        const toolCall = (assistantMsg as any).content[0];
+        expect(toolCall.type).toBe('tool-call');
+        expect(toolCall.input).toEqual({});
+      });
+
+      it('should normalize array rawInput to empty object', async () => {
+        const result = await convertToModelMessages([
+          {
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-calculator',
+                state: 'output-error',
+                toolCallId: 'call1',
+                errorText: 'Invalid arguments',
+                input: undefined,
+                rawInput: [1, 2, 3],
+              },
+            ],
+          },
+        ]);
+
+        const toolCall = (result[0] as any).content[0];
+        expect(toolCall.input).toEqual({});
+      });
+
+      it('should preserve object rawInput as-is', async () => {
+        const result = await convertToModelMessages([
+          {
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-calculator',
+                state: 'output-error',
+                toolCallId: 'call1',
+                errorText: 'Runtime error',
+                input: undefined,
+                rawInput: { operation: 'add', numbers: [1, 2] },
+              },
+            ],
+          },
+        ]);
+
+        const toolCall = (result[0] as any).content[0];
+        expect(toolCall.input).toEqual({ operation: 'add', numbers: [1, 2] });
+      });
+
+      it('should normalize undefined rawInput to empty object when input is also undefined', async () => {
+        const result = await convertToModelMessages([
+          {
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-calculator',
+                state: 'output-error',
+                toolCallId: 'call1',
+                errorText: 'Some error',
+                input: undefined,
+              },
+            ],
+          },
+        ]);
+
+        const toolCall = (result[0] as any).content[0];
+        expect(toolCall.input).toEqual({});
+      });
     });
 
     it('should handle assistant message with provider-executed tool output available', async () => {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -198,15 +198,23 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                 const toolName = getToolName(part);
 
                 if (part.state !== 'input-streaming') {
+                  // When state is output-error and input is undefined, rawInput
+                  // may be a raw string (e.g. invalid JSON from the model).
+                  // Providers like Anthropic require tool_use.input to be a
+                  // JSON object, so we normalise non-object values to {}.
+                  const toolInput =
+                    part.state === 'output-error'
+                      ? (part.input ??
+                        normalizeToolInput(
+                          'rawInput' in part ? part.rawInput : undefined,
+                        ))
+                      : part.input;
+
                   content.push({
                     type: 'tool-call' as const,
                     toolCallId: part.toolCallId,
                     toolName,
-                    input:
-                      part.state === 'output-error'
-                        ? (part.input ??
-                          ('rawInput' in part ? part.rawInput : undefined))
-                        : part.input,
+                    input: toolInput,
                     providerExecuted: part.providerExecuted,
                     ...(part.callProviderMetadata != null
                       ? { providerOptions: part.callProviderMetadata }
@@ -400,4 +408,18 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
   }
 
   return modelMessages;
+}
+
+/**
+ * Ensures tool call input is a plain object.
+ * Providers (e.g. Anthropic) require tool_use.input to be a JSON object.
+ * When rawInput is a non-object value (e.g. an unparseable string from the
+ * model), we fall back to an empty object so the conversation can be replayed
+ * without triggering a 400 error.
+ */
+function normalizeToolInput(value: unknown): Record<string, unknown> {
+  if (value != null && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
 }


### PR DESCRIPTION
## Fix

Closes #13645

### Problem

When a tool UI part is in `output-error` state with `input: undefined`, `convertToModelMessages` falls back to `rawInput`. If `rawInput` is a string (e.g. invalid JSON generated by the model), the bare string flows through as `tool_use.input`. Anthropic requires `tool_use.input` to be a JSON object — replaying that history causes a 400 error and traps the conversation in an unrecoverable loop.

### Root cause

`convert-to-model-messages.ts` lines 205-209 used `rawInput` without type checking:
```ts
input: part.state === 'output-error'
  ? (part.input ?? ('rawInput' in part ? part.rawInput : undefined))
  : part.input,
```

### Fix

Add `normalizeToolInput()` that ensures the fallback value is always a plain object. Non-object values (strings, arrays, `null`, `undefined`) are normalised to `{}`.

### Files changed

- `packages/ai/src/ui/convert-to-model-messages.ts` — normalise `rawInput` fallback
- `packages/ai/src/ui/convert-to-model-messages.test.ts` — 4 regression tests

### Tests

All 62 tests in `convert-to-model-messages.test.ts` pass.