### PR TITLE
fix(amazon-bedrock): preserve ARN model IDs unencoded in URL paths

### DIFF
--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -22,6 +22,7 @@ import {
   createSigV4FetchFunction,
 } from '../bedrock-sigv4-fetch';
 import { createBedrockAnthropicFetch } from './bedrock-anthropic-fetch';
+import { bedrockEncodeModelId } from '../bedrock-encode-model-id';
 import { BedrockAnthropicModelId } from './bedrock-anthropic-options';
 import { VERSION } from '../version';
 
@@ -256,7 +257,7 @@ export function createBedrockAnthropic(
       fetch: fetchFunction,
 
       buildRequestUrl: (baseURL, isStreaming) =>
-        `${baseURL}/model/${encodeURIComponent(modelId)}/${
+        `${baseURL}/model/${bedrockEncodeModelId(modelId)}/${
           isStreaming ? 'invoke-with-response-stream' : 'invoke'
         }`,
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -12,6 +12,7 @@ import {
   SharedV4ProviderMetadata,
   SharedV4Warning,
 } from '@ai-sdk/provider';
+import { bedrockEncodeModelId } from './bedrock-encode-model-id';
 import {
   FetchFunction,
   ParseResult,
@@ -985,7 +986,7 @@ export class BedrockChatLanguageModel implements LanguageModelV4 {
   }
 
   private getUrl(modelId: string) {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = bedrockEncodeModelId(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}`;
   }
 }

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.ts
@@ -2,6 +2,7 @@ import {
   EmbeddingModelV4,
   TooManyEmbeddingValuesForCallError,
 } from '@ai-sdk/provider';
+import { bedrockEncodeModelId } from './bedrock-encode-model-id';
 import {
   FetchFunction,
   Resolvable,
@@ -39,7 +40,7 @@ export class BedrockEmbeddingModel implements EmbeddingModelV4 {
   ) {}
 
   private getUrl(modelId: string): string {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = bedrockEncodeModelId(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}/invoke`;
   }
 

--- a/packages/amazon-bedrock/src/bedrock-encode-model-id.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-encode-model-id.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { bedrockEncodeModelId } from './bedrock-encode-model-id';
+
+describe('bedrockEncodeModelId', () => {
+  it('should encode regular model IDs with encodeURIComponent', () => {
+    expect(bedrockEncodeModelId('us.amazon.nova-2-lite-v1:0')).toBe(
+      'us.amazon.nova-2-lite-v1%3A0',
+    );
+  });
+
+  it('should not encode ARN model IDs', () => {
+    const arn =
+      'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123xyz';
+    expect(bedrockEncodeModelId(arn)).toBe(arn);
+  });
+
+  it('should not encode cross-region inference profile ARNs', () => {
+    const arn =
+      'arn:aws:bedrock:us:123456789012:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0';
+    expect(bedrockEncodeModelId(arn)).toBe(arn);
+  });
+
+  it('should encode model IDs that contain colons but are not ARNs', () => {
+    expect(bedrockEncodeModelId('anthropic.claude-3:latest')).toBe(
+      'anthropic.claude-3%3Alatest',
+    );
+  });
+
+  it('should handle simple model IDs without special characters', () => {
+    expect(bedrockEncodeModelId('amazon.titan-embed-text-v1')).toBe(
+      'amazon.titan-embed-text-v1',
+    );
+  });
+});

--- a/packages/amazon-bedrock/src/bedrock-encode-model-id.ts
+++ b/packages/amazon-bedrock/src/bedrock-encode-model-id.ts
@@ -1,0 +1,13 @@
+/**
+ * Encodes a Bedrock model identifier for use in URL path segments.
+ *
+ * ARNs (e.g. inference-profile ARNs) must be kept unencoded because the
+ * Bedrock REST API expects the literal ARN in the path. Regular model IDs
+ * are percent-encoded as before so that characters like `:` are escaped.
+ */
+export function bedrockEncodeModelId(modelId: string): string {
+  if (modelId.startsWith('arn:')) {
+    return modelId;
+  }
+  return encodeURIComponent(modelId);
+}

--- a/packages/amazon-bedrock/src/bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.ts
@@ -3,6 +3,7 @@ import {
   ImageModelV4File,
   SharedV4Warning,
 } from '@ai-sdk/provider';
+import { bedrockEncodeModelId } from './bedrock-encode-model-id';
 import {
   FetchFunction,
   Resolvable,
@@ -38,7 +39,7 @@ export class BedrockImageModel implements ImageModelV4 {
   }
 
   private getUrl(modelId: string): string {
-    const encodedModelId = encodeURIComponent(modelId);
+    const encodedModelId = bedrockEncodeModelId(modelId);
     return `${this.config.baseUrl()}/model/${encodedModelId}/invoke`;
   }
 


### PR DESCRIPTION
## Summary

Fixes #14117

`encodeURIComponent(modelId)` breaks inference-profile ARNs because it encodes `:` → `%3A` and `/` → `%2F`, producing an invalid URL that Bedrock rejects with _"The provided model identifier is invalid"_.

## Changes

- **New utility** `bedrockEncodeModelId(modelId)` — returns the raw ARN when `modelId` starts with `arn:`, otherwise falls back to `encodeURIComponent`.
- **Applied** in all four `getUrl` / `buildRequestUrl` call sites:
  - `bedrock-chat-language-model.ts`
  - `bedrock-embedding-model.ts`
  - `bedrock-image-model.ts`
  - `anthropic/bedrock-anthropic-provider.ts`
- **Regression tests** in `bedrock-encode-model-id.test.ts` (5 cases: standard model IDs, application-inference-profile ARNs, cross-region inference-profile ARNs, non-ARN colons, plain IDs).

## Before / After

| Input | Before | After |
|---|---|---|
| `us.amazon.nova-2-lite-v1:0` | `.../model/us.amazon.nova-2-lite-v1%3A0` ✅ | `.../model/us.amazon.nova-2-lite-v1%3A0` ✅ |
| `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc` | `.../model/arn%3Aaws%3A...` ❌ | `.../model/arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc` ✅ |
