### PR TITLE
fix(amazon-bedrock): return request body from doGenerate and doStream

### DIFF
--- a/.changeset/bedrock-request-body.md
+++ b/.changeset/bedrock-request-body.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Return `request: { body }` from `doGenerate()` and `doStream()` in the Bedrock chat language model, matching the pattern used by other providers (e.g. `@ai-sdk/anthropic`). This enables observability frameworks to access the request body for tracing and debugging.

--- a/packages/amazon-bedrock/src/__snapshots__/bedrock-chat-language-model.test.ts.snap
+++ b/packages/amazon-bedrock/src/__snapshots__/bedrock-chat-language-model.test.ts.snap
@@ -35,6 +35,29 @@ There are 3 r's.",
       },
     },
   },
+  "request": {
+    "body": {
+      "additionalModelRequestFields": undefined,
+      "additionalModelResponseFieldPaths": [
+        "/delta/stop_sequence",
+      ],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "Hello",
+            },
+          ],
+          "role": "user",
+        },
+      ],
+      "system": [
+        {
+          "text": "System Prompt",
+        },
+      ],
+    },
+  },
   "response": {
     "headers": {
       "content-length": "865",
@@ -90,6 +113,29 @@ There are **3** "r"s in "strawberry."",
       "usage": {
         "cacheWriteInputTokens": 0,
       },
+    },
+  },
+  "request": {
+    "body": {
+      "additionalModelRequestFields": undefined,
+      "additionalModelResponseFieldPaths": [
+        "/delta/stop_sequence",
+      ],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "Hello",
+            },
+          ],
+          "role": "user",
+        },
+      ],
+      "system": [
+        {
+          "text": "System Prompt",
+        },
+      ],
     },
   },
   "response": {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -270,6 +270,19 @@ describe('doStream', () => {
         }
       `);
     });
+
+    it('should include request body', async () => {
+      const result = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      expect(result.request).toBeDefined();
+      expect(result.request?.body).toBeDefined();
+      expect(result.request?.body).toMatchObject({
+        messages: expect.any(Array),
+      });
+    });
   });
 
   describe('reasoning', () => {
@@ -3132,6 +3145,18 @@ describe('doGenerate', () => {
           "test-header": "test-value",
         }
       `);
+    });
+
+    it('should include request body', async () => {
+      const { request } = await model.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(request).toBeDefined();
+      expect(request?.body).toBeDefined();
+      expect(request?.body).toMatchObject({
+        messages: expect.any(Array),
+      });
     });
   });
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -575,6 +575,7 @@ export class BedrockChatLanguageModel implements LanguageModelV4 {
         raw: response.stopReason ?? undefined,
       },
       usage: convertBedrockUsage(response.usage),
+      request: { body: args },
       response: {
         id: responseHeaders?.['x-amzn-requestid'] ?? undefined,
         timestamp:
@@ -979,7 +980,7 @@ export class BedrockChatLanguageModel implements LanguageModelV4 {
           },
         }),
       ),
-      // TODO request?
+      request: { body: args },
       response: { headers: responseHeaders },
     };
   }


### PR DESCRIPTION
## Summary

`BedrockChatLanguageModel.doGenerate()` and `doStream()` were not returning a `request` field in their results. This meant consumers relying on `request.body` (e.g., for observability/tracing) received `undefined`.

There was an existing `// TODO request?` comment in the `doStream` return confirming this was a known gap.

## Changes

- Add `request: { body: args }` to the return object of `doGenerate()`
- Add `request: { body: args }` to the return object of `doStream()` (replacing the TODO comment)
- Add regression tests for both methods verifying the request body is present
- Update affected snapshots

This matches the pattern used by `@ai-sdk/anthropic` and other providers.

## Test Plan

- All 345 existing tests pass (node + edge)
- 2 new regression tests added (`should include request body` for both `doGenerate` and `doStream`)
- 2 snapshot updates (existing `result` snapshots now include the new `request` field)

Fixes #13927