### PR TITLE
fix(ui): add missing optional chaining for activeResponse in makeRequest finally block

### DIFF
--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -172,7 +172,7 @@ export type ChatOnDataCallback<UI_MESSAGE extends UIMessage> = (
  * @param finishReason The reason why the generation finished.
  */
 export type ChatOnFinishCallback<UI_MESSAGE extends UIMessage> = (options: {
-  message: UI_MESSAGE;
+  message: UI_MESSAGE | undefined;
   messages: UI_MESSAGE[];
   isAbort: boolean;
   isDisconnect: boolean;
@@ -758,12 +758,12 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     } finally {
       try {
         this.onFinish?.({
-          message: this.activeResponse!.state.message,
+          message: this.activeResponse?.state?.message,
           messages: this.state.messages,
           isAbort,
           isDisconnect,
           isError,
-          finishReason: this.activeResponse?.state.finishReason,
+          finishReason: this.activeResponse?.state?.finishReason,
         });
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Bug

When two `makeRequest` calls run concurrently (e.g. `sendMessage` + `resumeStream`), the first to complete sets `this.activeResponse = undefined` in its `finally` block. The second call's `finally` block then crashes:

```
TypeError: Cannot read properties of undefined (reading 'state')
```

This is caused by an inconsistency in `packages/ai/src/ui/chat.ts` — the `onFinish` callback in the `finally` block uses a non-null assertion (`!`) for `message` but optional chaining (`?.`) for `finishReason`:

```typescript
// Before (broken)
this.onFinish?.({
  message: this.activeResponse!.state.message,     // ← non-null assertion crashes
  // ...
  finishReason: this.activeResponse?.state.finishReason,  // ← has ?. but .state doesn't
});
```

## Fix

- Replace `this.activeResponse!.state.message` with `this.activeResponse?.state?.message`
- Add `?.` to `.state?.finishReason` for full safety
- Update `ChatOnFinishCallback` type to allow `message: UI_MESSAGE | undefined`

```typescript
// After (safe)
this.onFinish?.({
  message: this.activeResponse?.state?.message,
  // ...
  finishReason: this.activeResponse?.state?.finishReason,
});
```

## Affected Versions

This bug exists from at least 6.0.x through the current 7.0.0-beta — any version with the `AbstractChat` class and its `makeRequest` method.

## Reproduction

1. Create a chat instance with `onFinish` callback
2. Trigger two concurrent `makeRequest` calls (e.g. call `sendMessage()` and `resumeStream()` without awaiting the first)
3. The first to resolve sets `this.activeResponse = undefined`
4. The second hits the `finally` block → `TypeError`

## Test Plan

- [x] All 26 existing tests in `chat.test.ts` pass
- [x] Full monorepo build succeeds (69/69 tasks)
- [x] Lint (ultracite) passes via pre-commit hook