### PR TITLE
fix(amazon-bedrock): do not inherit env AWS_SESSION_TOKEN with explicit keys

### DIFF
--- a/.changeset/fix-bedrock-session-token-env.md
+++ b/.changeset/fix-bedrock-session-token-env.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): do not inherit AWS_SESSION_TOKEN from env when explicit accessKeyId/secretAccessKey are provided
+
+When both `accessKeyId` and `secretAccessKey` are passed as explicit options, the session token is now sourced only from `options.sessionToken`. Previously, `loadOptionalSetting` would fall back to `process.env.AWS_SESSION_TOKEN`, which on hosts with workload identity (EKS IRSA, ECS task role, Lambda) belongs to a different principal, causing "The security token included in the request is invalid" errors.

--- a/packages/amazon-bedrock/src/bedrock-provider.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.test.ts
@@ -391,6 +391,94 @@ describe('AmazonBedrockProvider', () => {
         );
       });
 
+      describe('Session Token Environment Isolation (#14136)', () => {
+        it('should NOT inherit AWS_SESSION_TOKEN from env when explicit accessKeyId and secretAccessKey are provided', async () => {
+          // Simulate environment where AWS_SESSION_TOKEN is set (e.g. EKS IRSA)
+          mockLoadOptionalSetting.mockImplementation(
+            ({ settingValue, environmentVariableName }) => {
+              if (environmentVariableName === 'AWS_BEARER_TOKEN_BEDROCK') {
+                return undefined; // no API key
+              }
+              if (environmentVariableName === 'AWS_SESSION_TOKEN') {
+                // env has a session token from workload identity
+                return settingValue ?? 'irsa-session-token-from-env';
+              }
+              return settingValue;
+            },
+          );
+
+          createAmazonBedrock({
+            region: 'us-east-1',
+            accessKeyId: 'explicit-static-key',
+            secretAccessKey: 'explicit-static-secret',
+            // sessionToken intentionally omitted
+          });
+
+          // Capture the credential resolver passed to createSigV4FetchFunction
+          const credentialResolver =
+            mockCreateSigV4FetchFunction.mock.calls[0]![0];
+          const creds = await credentialResolver();
+
+          expect(creds.accessKeyId).toBe('explicit-static-key');
+          expect(creds.secretAccessKey).toBe('explicit-static-secret');
+          // Must be undefined — must NOT pick up the env session token
+          expect(creds.sessionToken).toBeUndefined();
+        });
+
+        it('should use explicit sessionToken when explicit keys are provided', async () => {
+          mockLoadOptionalSetting.mockImplementation(
+            ({ settingValue, environmentVariableName }) => {
+              if (environmentVariableName === 'AWS_BEARER_TOKEN_BEDROCK') {
+                return undefined;
+              }
+              if (environmentVariableName === 'AWS_SESSION_TOKEN') {
+                return settingValue ?? 'irsa-session-token-from-env';
+              }
+              return settingValue;
+            },
+          );
+
+          createAmazonBedrock({
+            region: 'us-east-1',
+            accessKeyId: 'explicit-static-key',
+            secretAccessKey: 'explicit-static-secret',
+            sessionToken: 'explicit-session-token',
+          });
+
+          const credentialResolver =
+            mockCreateSigV4FetchFunction.mock.calls[0]![0];
+          const creds = await credentialResolver();
+
+          expect(creds.sessionToken).toBe('explicit-session-token');
+        });
+
+        it('should fall back to AWS_SESSION_TOKEN from env when keys come from env', async () => {
+          mockLoadOptionalSetting.mockImplementation(
+            ({ settingValue, environmentVariableName }) => {
+              if (environmentVariableName === 'AWS_BEARER_TOKEN_BEDROCK') {
+                return undefined;
+              }
+              if (environmentVariableName === 'AWS_SESSION_TOKEN') {
+                return settingValue ?? 'env-session-token';
+              }
+              return settingValue;
+            },
+          );
+
+          // No explicit keys — both will come from env via loadSetting
+          createAmazonBedrock({
+            region: 'us-east-1',
+          });
+
+          const credentialResolver =
+            mockCreateSigV4FetchFunction.mock.calls[0]![0];
+          const creds = await credentialResolver();
+
+          // Should pick up env session token since keys are also from env
+          expect(creds.sessionToken).toBe('env-session-token');
+        });
+      });
+
       it('should work with credential provider when no API key is provided', () => {
         // Mock loadOptionalSetting to return undefined (no API key)
         mockLoadOptionalSetting.mockImplementation(() => undefined);

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -221,10 +221,17 @@ export function createAmazonBedrock(
               environmentVariableName: 'AWS_SECRET_ACCESS_KEY',
               description: 'AWS secret access key',
             }),
-            sessionToken: loadOptionalSetting({
-              settingValue: options.sessionToken,
-              environmentVariableName: 'AWS_SESSION_TOKEN',
-            }),
+            // When explicit accessKeyId and secretAccessKey are provided,
+            // only use an explicitly provided sessionToken — do not fall back
+            // to AWS_SESSION_TOKEN from the environment, as it may belong to
+            // a different identity (e.g. EKS IRSA, ECS task role, Lambda).
+            sessionToken:
+              options.accessKeyId != null && options.secretAccessKey != null
+                ? options.sessionToken
+                : loadOptionalSetting({
+                    settingValue: options.sessionToken,
+                    environmentVariableName: 'AWS_SESSION_TOKEN',
+                  }),
           };
         } catch (error) {
           // Provide helpful error message for missing AWS credentials


### PR DESCRIPTION
## Summary

Fixes #14136

When both `accessKeyId` and `secretAccessKey` are provided as explicit options to `createAmazonBedrock`, the `sessionToken` is now sourced **only** from `options.sessionToken`. Previously, `loadOptionalSetting` would unconditionally fall back to `process.env.AWS_SESSION_TOKEN`, which on hosts with workload identity (EKS IRSA, ECS task role, Lambda) belongs to a different principal — producing mixed, invalid SigV4 credentials:

> "The security token included in the request is invalid."

## Changes

- **`packages/amazon-bedrock/src/bedrock-provider.ts`** — When `options.accessKeyId` and `options.secretAccessKey` are both explicitly provided, use `options.sessionToken` directly instead of falling through to `loadOptionalSetting` (which reads `AWS_SESSION_TOKEN` from the environment). When keys come from the environment, env session-token fallback is preserved.
- **`packages/amazon-bedrock/src/bedrock-provider.test.ts`** — Three regression tests exercising the credential-resolution callback:
  1. Explicit keys → env `AWS_SESSION_TOKEN` is **not** inherited
  2. Explicit keys + explicit `sessionToken` → works correctly
  3. No explicit keys → env `AWS_SESSION_TOKEN` fallback is preserved

## Behaviour matrix

| `accessKeyId` | `secretAccessKey` | `sessionToken` option | `AWS_SESSION_TOKEN` env | Result |
|---|---|---|---|---|
| explicit | explicit | omitted | set | ✅ `sessionToken` = `undefined` (no mixing) |
| explicit | explicit | explicit | set | ✅ `sessionToken` = option value |
| from env | from env | omitted | set | ✅ `sessionToken` = env value (preserved) |
