### PR TITLE
fix: normalize deprecated `parameters` to `inputSchema` in tool()

### DIFF
--- a/.changeset/fix-tool-parameters-inputSchema.md
+++ b/.changeset/fix-tool-parameters-inputSchema.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+fix: support deprecated `parameters` property in tool() for backward compatibility
+
+When using `tool({ parameters: z.object({...}) })` (the v5 API), the schema was silently dropped because `prepareTools` and `doParseToolCall` only read `inputSchema`. The `tool()` helper now normalizes `parameters` to `inputSchema`, and consumers also fall back to `parameters` defensively.
+
+Fixes #13460

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -567,4 +567,62 @@ describe('parseToolCall', () => {
       expect(result.title).toBe('Invalid Tool');
     });
   });
+
+  describe('deprecated parameters fallback', () => {
+    it('should parse tool call using deprecated parameters property', async () => {
+      const result = await parseToolCall({
+        toolCall: {
+          type: 'tool-call',
+          toolName: 'testTool',
+          toolCallId: '123',
+          input: '{"query": "hello"}',
+        },
+        tools: {
+          testTool: {
+            description: 'test tool',
+            parameters: z.object({ query: z.string() }),
+          } as any,
+        },
+        repairToolCall: undefined,
+        messages: [],
+        system: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "input": {
+            "query": "hello",
+          },
+          "providerExecuted": undefined,
+          "providerMetadata": undefined,
+          "title": undefined,
+          "toolCallId": "123",
+          "toolName": "testTool",
+          "type": "tool-call",
+        }
+      `);
+    });
+
+    it('should reject invalid input against deprecated parameters schema', async () => {
+      const result = await parseToolCall({
+        toolCall: {
+          type: 'tool-call',
+          toolName: 'testTool',
+          toolCallId: '123',
+          input: '{"query": 42}',
+        },
+        tools: {
+          testTool: {
+            description: 'test tool',
+            parameters: z.object({ query: z.string() }),
+          } as any,
+        },
+        repairToolCall: undefined,
+        messages: [],
+        system: undefined,
+      });
+
+      expect(result.invalid).toBe(true);
+    });
+  });
 });

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -56,8 +56,9 @@ export async function parseToolCall<TOOLS extends ToolSet>({
           toolCall,
           tools,
           inputSchema: async ({ toolName }) => {
-            const { inputSchema } = tools[toolName];
-            return await asSchema(inputSchema).jsonSchema;
+            const tool = tools[toolName];
+            return await asSchema(tool.inputSchema ?? (tool as any).parameters)
+              .jsonSchema;
           },
           system,
           messages,
@@ -148,7 +149,7 @@ async function doParseToolCall<TOOLS extends ToolSet>({
     });
   }
 
-  const schema = asSchema(tool.inputSchema);
+  const schema = asSchema(tool.inputSchema ?? (tool as any).parameters);
 
   // when the tool call has no arguments, we try passing an empty object to the schema
   // (many LLMs generate empty strings for tool calls with no arguments)

--- a/packages/ai/src/prompt/prepare-tools.test.ts
+++ b/packages/ai/src/prompt/prepare-tools.test.ts
@@ -232,4 +232,74 @@ describe('prepareTools', () => {
       ]
     `);
   });
+
+  it('supports deprecated parameters property via tool() normalization', async () => {
+    const result = await prepareTools({
+      tools: {
+        myTool: tool({
+          description: 'A tool using deprecated parameters',
+          parameters: z.object({ query: z.string() }),
+        } as any),
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "description": "A tool using deprecated parameters",
+          "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "query": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "query",
+            ],
+            "type": "object",
+          },
+          "name": "myTool",
+          "providerOptions": undefined,
+          "type": "function",
+        },
+      ]
+    `);
+  });
+
+  it('handles tool with parameters but no inputSchema (not wrapped in tool())', async () => {
+    const result = await prepareTools({
+      tools: {
+        myTool: {
+          description: 'A raw tool using parameters',
+          parameters: z.object({ city: z.string() }),
+        } as any,
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "description": "A raw tool using parameters",
+          "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "city": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "city",
+            ],
+            "type": "object",
+          },
+          "name": "myTool",
+          "providerOptions": undefined,
+          "type": "function",
+        },
+      ]
+    `);
+  });
 });

--- a/packages/ai/src/prompt/prepare-tools.ts
+++ b/packages/ai/src/prompt/prepare-tools.ts
@@ -31,7 +31,9 @@ export async function prepareTools<TOOLS extends ToolSet>({
           type: 'function' as const,
           name,
           description: tool.description,
-          inputSchema: await asSchema(tool.inputSchema).jsonSchema,
+          inputSchema: await asSchema(
+            tool.inputSchema ?? (tool as any).parameters,
+          ).jsonSchema,
           ...(tool.inputExamples != null
             ? { inputExamples: tool.inputExamples }
             : {}),

--- a/packages/provider-utils/src/types/tool.test.ts
+++ b/packages/provider-utils/src/types/tool.test.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod/v4';
+import { describe, expect, it } from 'vitest';
+import { tool } from './tool';
+
+describe('tool()', () => {
+  it('passes through tool with inputSchema unchanged', () => {
+    const schema = z.object({ query: z.string() });
+    const result = tool({
+      description: 'test tool',
+      inputSchema: schema,
+      execute: async () => 'result',
+    });
+
+    expect(result.inputSchema).toBe(schema);
+    expect(result.description).toBe('test tool');
+  });
+
+  it('normalizes deprecated parameters to inputSchema', () => {
+    const schema = z.object({ query: z.string() });
+    const result = tool({
+      description: 'test tool',
+      parameters: schema,
+      execute: async () => 'result',
+    } as any);
+
+    expect(result.inputSchema).toBe(schema);
+    expect(result.description).toBe('test tool');
+    expect(result.parameters).toBeUndefined();
+  });
+
+  it('prefers inputSchema over parameters when both are present', () => {
+    const inputSchema = z.object({ a: z.string() });
+    const parameters = z.object({ b: z.number() });
+    const result = tool({
+      description: 'test tool',
+      inputSchema,
+      parameters,
+      execute: async () => 'result',
+    } as any);
+
+    expect(result.inputSchema).toBe(inputSchema);
+  });
+
+  it('preserves all other properties when normalizing parameters', () => {
+    const schema = z.object({ query: z.string() });
+    const execute = async () => 'result';
+    const result = tool({
+      description: 'a test tool',
+      title: 'Test Tool',
+      parameters: schema,
+      execute,
+    } as any);
+
+    expect(result.inputSchema).toBe(schema);
+    expect(result.description).toBe('a test tool');
+    expect(result.title).toBe('Test Tool');
+    expect(result.execute).toBe(execute);
+  });
+});

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -303,6 +303,11 @@ export function tool<CONTEXT extends Context>(
   tool: Tool<never, never, CONTEXT>,
 ): Tool<never, never, CONTEXT>;
 export function tool(tool: any): any {
+  // Normalize deprecated 'parameters' to 'inputSchema' for backward compat
+  if (tool.inputSchema === undefined && tool.parameters !== undefined) {
+    const { parameters, ...rest } = tool;
+    return { ...rest, inputSchema: parameters };
+  }
   return tool;
 }
 


### PR DESCRIPTION
## Summary

Fixes #13460

`tool({ parameters: z.object({...}) })` (the v5 API) silently produces an empty input schema because `prepareTools` and `doParseToolCall` only read `inputSchema`, which is `undefined` when `parameters` is used.

## Changes

### Source fix (`@ai-sdk/provider-utils`)
- **`tool()`** now normalizes deprecated `parameters` → `inputSchema` at creation time, so all downstream consumers work without changes.

### Defensive fallback (`ai`)
- **`prepareTools`**: falls back to `parameters` when `inputSchema` is `undefined` (covers tools not created via `tool()`).
- **`doParseToolCall`**: same fallback for validation.
- **`parseToolCall` repair callback**: same fallback.

### Regression tests
- `tool.test.ts`: verifies normalization, precedence when both are present, property preservation.
- `prepare-tools.test.ts`: verifies schema emission via `tool()` and raw object with `parameters`.
- `parse-tool-call.test.ts`: verifies parsing and validation against `parameters` schema.

## Validation

- **487/487** provider-utils tests pass
- **1229/1229** ai package tests pass (22 pre-existing failures from missing `@ai-sdk/test-server` build, unrelated)
- All 6 new regression tests pass