### PR TITLE
fix(openai-compatible): handle reused tool call index from Ollama

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -1,0 +1,7 @@
+# INDEX
+
+<!-- cc: 自動維護。hook 自動 append 新檔，/pm index 全量更新，/pm bye 清理掃描 -->
+
+| 檔名 | 用途 | 狀態 | 日期 | 來源 |
+|---|---|---|---|---|
+| (整個 repo，5511 files) | Vercel AI SDK 整包 fork（上游 monorepo 原始碼，非本地產出；比照 node_modules 整包收合，不逐檔列出） | one-off | 2026-04-10 | — |

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2414,6 +2414,74 @@ describe('doStream', () => {
     ).toBeUndefined();
   });
 
+  it('should handle parallel tool calls with reused index (Ollama bug)', async () => {
+    // Ollama sends all tool calls with index: 0 instead of incrementing.
+    // The parser should detect different IDs and treat them as separate calls.
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        // First tool call: index 0, full arguments in one chunk
+        `data: {"id":"chatcmpl-ollama","object":"chat.completion.chunk","created":1711357598,"model":"qwen3",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":"",` +
+          `"tool_calls":[{"id":"call-hello","type":"function","function":{"name":"file_write","arguments":"{\\"filePath\\":\\"hello.py\\",\\"content\\":\\"print(\\\\\\"hello\\\\\\")\\"}"},"index":0}]},` +
+          `"finish_reason":null}]}\n\n`,
+        // Second tool call: ALSO index 0 (Ollama bug), different id
+        `data: {"id":"chatcmpl-ollama","object":"chat.completion.chunk","created":1711357598,"model":"qwen3",` +
+          `"choices":[{"index":0,"delta":{"content":"",` +
+          `"tool_calls":[{"id":"call-world","type":"function","function":{"name":"file_write","arguments":"{\\"filePath\\":\\"world.py\\",\\"content\\":\\"print(\\\\\\"world\\\\\\")\\"}"},"index":0}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-ollama","object":"chat.completion.chunk","created":1711357598,"model":"qwen3",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],` +
+          `"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'file_write',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              filePath: { type: 'string' },
+              content: { type: 'string' },
+            },
+            required: ['filePath', 'content'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const result = await convertReadableStreamToArray(stream);
+
+    const toolCallEvents = result.filter(
+      (event: { type: string }) => event.type === 'tool-call',
+    );
+
+    // Both tool calls should be emitted despite having the same index
+    expect(toolCallEvents).toHaveLength(2);
+
+    expect(toolCallEvents[0]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'call-hello',
+      toolName: 'file_write',
+      input: '{"filePath":"hello.py","content":"print(\\"hello\\")"}',
+    });
+
+    expect(toolCallEvents[1]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'call-world',
+      toolName: 'file_write',
+      input: '{"filePath":"world.py","content":"print(\\"world\\")"}',
+    });
+  });
+
   it('should stream tool call deltas when tool call arguments are passed in the first chunk', async () => {
     server.urls['https://my.api.com/v1/chat/completions'].response = {
       type: 'stream-chunks',

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -550,7 +550,20 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
               }
 
               for (const toolCallDelta of delta.tool_calls) {
-                const index = toolCallDelta.index ?? toolCalls.length;
+                let index = toolCallDelta.index ?? toolCalls.length;
+
+                // Some providers (e.g. Ollama) reuse index 0 for all tool
+                // calls in a single response. When the slot is already
+                // occupied by a *different* tool call (different id), treat
+                // this delta as a brand-new tool call to avoid silently
+                // dropping it or corrupting the existing one.
+                if (
+                  toolCalls[index] != null &&
+                  toolCallDelta.id != null &&
+                  toolCalls[index].id !== toolCallDelta.id
+                ) {
+                  index = toolCalls.length;
+                }
 
                 if (toolCalls[index] == null) {
                   if (toolCallDelta.id == null) {


### PR DESCRIPTION
## Summary

- Fix streaming parser to handle providers (Ollama) that reuse `index: 0` for all tool calls in a single response
- Add test case for parallel tool calls with reused indices

## Problem

Ollama's OpenAI-compatible streaming API sends **all tool calls with `index: 0`** instead of incrementing (0, 1, 2...). This causes the `@ai-sdk/openai-compatible` streaming parser to either:
1. Skip the 2nd+ tool calls (when the first has already `hasFinished`)
2. Merge their arguments into the first call (corrupting the JSON)

This results in a **100% failure rate** on any task requiring multiple tool calls in one response.

**Verified with:** Ollama 0.20.2/0.20.4, models: qwen3-coder:30b, gemma4:e4b, qwen2.5-coder:7b

Ollama issue: https://github.com/ollama/ollama/issues/15457

## Fix

When `toolCalls[index]` is already occupied by a **different** tool call (different `id`), treat the incoming delta as a new tool call by assigning `index = toolCalls.length`.

This is backwards-compatible: providers that send correct indices are unaffected since the `id` will match the existing entry.

## Test plan

- [x] Added test: `should handle parallel tool calls with reused index (Ollama bug)`
- [x] Verified with real Ollama streaming: dual-file write goes from 0/12 to 12/12 pass
- [x] Existing parallel tool call tests still pass (correct indices unaffected)