### PR TITLE
feat(workflow): handle tool approval resumption in WorkflowAgent

### DIFF
--- a/examples/next-workflow/workflow/agent-chat.ts
+++ b/examples/next-workflow/workflow/agent-chat.ts
@@ -3,7 +3,6 @@ import { WorkflowAgent, type ModelCallStreamPart } from '@ai-sdk/workflow';
 import {
   convertToModelMessages,
   ToolCallRepairFunction,
-  type ModelMessage,
   type UIMessage,
 } from 'ai';
 import { getWritable } from 'workflow';
@@ -94,152 +93,10 @@ const repairToolCall: ToolCallRepairFunction<typeof tools> = async ({
   return toolCall;
 };
 
-/**
- * Map of tool names to their step execute functions.
- * Used to execute approved tools in the workflow context.
- */
-const toolExecutors: Record<string, (input: any) => Promise<any>> = {
-  getWeather,
-  calculate,
-  deleteFile: deleteFileStep,
-};
-
-/**
- * Process approval responses in model messages.
- * Executes approved tools via step functions, strips approval parts,
- * and injects tool results into the conversation.
- */
-async function processApprovals(
-  messages: ModelMessage[],
-): Promise<ModelMessage[]> {
-  // Find tool-approval-response parts
-  const approvalResponses: Array<{
-    approvalId: string;
-    approved: boolean;
-    reason?: string;
-  }> = [];
-  const approvalRequestMap = new Map<string, string>(); // approvalId → toolCallId
-  const toolCallMap = new Map<string, { toolName: string; input: unknown }>(); // toolCallId → toolCall
-
-  for (const msg of messages) {
-    if (msg.role === 'assistant' && Array.isArray(msg.content)) {
-      for (const part of msg.content as any[]) {
-        if (part.type === 'tool-call') {
-          toolCallMap.set(part.toolCallId, {
-            toolName: part.toolName,
-            input: part.input ?? part.args,
-          });
-        }
-        if (part.type === 'tool-approval-request') {
-          approvalRequestMap.set(part.approvalId, part.toolCallId);
-        }
-      }
-    }
-    if (msg.role === 'tool') {
-      for (const part of msg.content as any[]) {
-        if (part.type === 'tool-approval-response') {
-          approvalResponses.push(part);
-        }
-      }
-    }
-  }
-
-  if (approvalResponses.length === 0) return messages;
-
-  // Execute approved tools and collect results
-  const toolResults: Array<{
-    toolCallId: string;
-    toolName: string;
-    output: any;
-  }> = [];
-  const denialResults: Array<{
-    toolCallId: string;
-    toolName: string;
-    reason?: string;
-  }> = [];
-
-  for (const response of approvalResponses) {
-    const toolCallId = approvalRequestMap.get(response.approvalId);
-    if (!toolCallId) continue;
-    const toolCall = toolCallMap.get(toolCallId);
-    if (!toolCall) continue;
-
-    if (response.approved) {
-      const executor = toolExecutors[toolCall.toolName];
-      if (executor) {
-        const result = await executor(toolCall.input);
-        toolResults.push({
-          toolCallId,
-          toolName: toolCall.toolName,
-          output: result,
-        });
-      }
-    } else {
-      denialResults.push({
-        toolCallId,
-        toolName: toolCall.toolName,
-        reason: response.reason,
-      });
-    }
-  }
-
-  // Rebuild messages: strip approval parts, add tool results
-  const cleanMessages: ModelMessage[] = [];
-  for (const msg of messages) {
-    if (msg.role === 'assistant' && Array.isArray(msg.content)) {
-      const content = (msg.content as any[]).filter(
-        (p: any) => p.type !== 'tool-approval-request',
-      );
-      if (content.length > 0) cleanMessages.push({ ...msg, content });
-    } else if (msg.role === 'tool') {
-      const content = (msg.content as any[]).filter(
-        (p: any) => p.type !== 'tool-approval-response',
-      );
-      if (content.length > 0) cleanMessages.push({ ...msg, content });
-    } else {
-      cleanMessages.push(msg);
-    }
-  }
-
-  // Add tool results
-  const toolContent: any[] = [];
-  for (const tr of toolResults) {
-    const output =
-      typeof tr.output === 'string'
-        ? { type: 'text' as const, value: tr.output }
-        : { type: 'json' as const, value: tr.output };
-    toolContent.push({
-      type: 'tool-result',
-      toolCallId: tr.toolCallId,
-      toolName: tr.toolName,
-      output,
-    });
-  }
-  for (const dr of denialResults) {
-    toolContent.push({
-      type: 'tool-result',
-      toolCallId: dr.toolCallId,
-      toolName: dr.toolName,
-      output: {
-        type: 'error-text',
-        value: dr.reason ?? 'Tool execution denied.',
-      },
-    });
-  }
-  if (toolContent.length > 0) {
-    cleanMessages.push({ role: 'tool', content: toolContent });
-  }
-
-  return cleanMessages;
-}
-
 export async function chat(messages: UIMessage[]) {
   'use workflow';
 
   const modelMessages = await convertToModelMessages(messages);
-
-  // Process any pending approvals before running the agent
-  const processedMessages = await processApprovals(modelMessages);
 
   const agent = new WorkflowAgent({
     model: anthropic('claude-sonnet-4-20250514'),
@@ -249,7 +106,7 @@ export async function chat(messages: UIMessage[]) {
   });
 
   const result = await agent.stream({
-    messages: processedMessages,
+    messages: modelMessages,
     writable: getWritable<ModelCallStreamPart>(),
     experimental_repairToolCall: repairToolCall as any,
   });

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -2356,4 +2356,197 @@ describe('WorkflowAgent', () => {
       expect(Array.isArray(result.uiMessages)).toBe(true);
     });
   */
+
+  describe('tool approval resumption', () => {
+    it('should execute approved tools and continue with results', async () => {
+      const toolResult = { city: 'London', temperature: 72 };
+      const executeFn = vi.fn().mockResolvedValue(toolResult);
+      const tools: ToolSet = {
+        getWeather: {
+          description: 'Get weather',
+          inputSchema: z.object({ city: z.string() }),
+          execute: executeFn,
+          needsApproval: true as const,
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      // Messages containing a tool call, approval request, and an approved response
+      await agent.stream({
+        messages: [
+          { role: 'user', content: "What's the weather in London?" },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'getWeather',
+                input: { city: 'London' },
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-call-1',
+                toolCallId: 'call-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: true,
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      // The tool should have been executed
+      expect(executeFn).toHaveBeenCalledTimes(1);
+      expect(executeFn).toHaveBeenCalledWith(
+        { city: 'London' },
+        expect.objectContaining({
+          toolCallId: 'call-1',
+        }),
+      );
+
+      // The streamTextIterator should have been called (the agent continues after approval)
+      expect(mockIterator.next).toHaveBeenCalled();
+    });
+
+    it('should create denial results for denied tools and continue', async () => {
+      const executeFn = vi.fn();
+      const tools: ToolSet = {
+        deleteFile: {
+          description: 'Delete a file',
+          inputSchema: z.object({ path: z.string() }),
+          execute: executeFn,
+          needsApproval: true as const,
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      // Messages containing a tool call, approval request, and a denied response
+      await agent.stream({
+        messages: [
+          { role: 'user', content: 'Delete /etc/passwd' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'deleteFile',
+                input: { path: '/etc/passwd' },
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-call-1',
+                toolCallId: 'call-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: false,
+                reason: 'Too dangerous',
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      // The tool should NOT have been executed
+      expect(executeFn).not.toHaveBeenCalled();
+
+      // The streamTextIterator should have been called (the agent continues with denial result)
+      expect(mockIterator.next).toHaveBeenCalled();
+    });
+
+    it('should pass through messages without approval responses unchanged', async () => {
+      const tools: ToolSet = {
+        getWeather: {
+          description: 'Get weather',
+          inputSchema: z.object({ city: z.string() }),
+          execute: async () => ({ temperature: 72 }),
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      // Normal messages without any approval parts
+      await agent.stream({
+        messages: [{ role: 'user', content: 'Hello' }],
+        writable: mockWritable,
+      });
+
+      // Should proceed normally without any approval processing
+      expect(mockIterator.next).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -18,6 +18,8 @@ import {
   type StopCondition,
   type StreamTextOnStepFinishCallback,
   type SystemModelMessage,
+  type ToolApprovalRequest,
+  type ToolApprovalResponse,
   type ToolCallRepairFunction,
   type ToolChoice,
   type ToolSet,
@@ -1040,6 +1042,105 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       messages: effectiveMessages,
     });
 
+    // Process tool approval responses before starting the agent loop.
+    // This mirrors how stream-text.ts handles tool-approval-response parts:
+    // approved tools are executed, denied tools get denial results, and
+    // approval parts are stripped from the messages.
+    const { approvedToolApprovals, deniedToolApprovals } =
+      collectToolApprovalsFromMessages(prompt.messages);
+
+    if (approvedToolApprovals.length > 0 || deniedToolApprovals.length > 0) {
+      const toolResultMessages: ModelMessage[] = [];
+      const toolResultContent: Array<{
+        type: 'tool-result';
+        toolCallId: string;
+        toolName: string;
+        output:
+          | { type: 'text'; value: string }
+          | { type: 'json'; value: JSONValue }
+          | { type: 'execution-denied'; reason: string | undefined };
+      }> = [];
+
+      // Execute approved tools
+      for (const approval of approvedToolApprovals) {
+        const tool = (this.tools as ToolSet)[approval.toolName];
+        if (tool && typeof tool.execute === 'function') {
+          try {
+            const { execute } = tool;
+            const toolResult = await execute(approval.input, {
+              toolCallId: approval.toolCallId,
+              messages: [],
+              context: effectiveExperimentalContext,
+            });
+            toolResultContent.push({
+              type: 'tool-result' as const,
+              toolCallId: approval.toolCallId,
+              toolName: approval.toolName,
+              output:
+                typeof toolResult === 'string'
+                  ? { type: 'text' as const, value: toolResult }
+                  : { type: 'json' as const, value: toolResult },
+            });
+          } catch (error) {
+            toolResultContent.push({
+              type: 'tool-result' as const,
+              toolCallId: approval.toolCallId,
+              toolName: approval.toolName,
+              output: {
+                type: 'text' as const,
+                value: getErrorMessage(error),
+              },
+            });
+          }
+        }
+      }
+
+      // Create denial results for denied tools
+      for (const denial of deniedToolApprovals) {
+        toolResultContent.push({
+          type: 'tool-result' as const,
+          toolCallId: denial.toolCallId,
+          toolName: denial.toolName,
+          output: {
+            type: 'execution-denied' as const,
+            reason: denial.reason,
+          },
+        });
+      }
+
+      // Strip approval parts from messages and inject tool results
+      const cleanedMessages: ModelMessage[] = [];
+      for (const msg of prompt.messages) {
+        if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+          const filtered = (msg.content as any[]).filter(
+            (p: any) => p.type !== 'tool-approval-request',
+          );
+          if (filtered.length > 0) {
+            cleanedMessages.push({ ...msg, content: filtered });
+          }
+        } else if (msg.role === 'tool') {
+          const filtered = (msg.content as any[]).filter(
+            (p: any) => p.type !== 'tool-approval-response',
+          );
+          if (filtered.length > 0) {
+            cleanedMessages.push({ ...msg, content: filtered });
+          }
+        } else {
+          cleanedMessages.push(msg);
+        }
+      }
+
+      // Add tool results as a new tool message
+      if (toolResultContent.length > 0) {
+        cleanedMessages.push({
+          role: 'tool',
+          content: toolResultContent,
+        } as ModelMessage);
+      }
+
+      prompt.messages = cleanedMessages;
+    }
+
     const modelPrompt = await convertToLanguageModelPrompt({
       prompt,
       supportedUrls: {},
@@ -1795,4 +1896,114 @@ async function executeTool(
       },
     };
   }
+}
+
+/**
+ * Collected tool approval information for a single tool call.
+ */
+interface CollectedApproval {
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  approvalId: string;
+  reason?: string;
+}
+
+/**
+ * Collect tool approval responses from model messages.
+ * Mirrors the logic from `collectToolApprovals` in the AI SDK core
+ * (`packages/ai/src/generate-text/collect-tool-approvals.ts`).
+ *
+ * Scans the last tool message for `tool-approval-response` parts,
+ * matches them with `tool-approval-request` parts in assistant messages
+ * and the corresponding `tool-call` parts.
+ */
+function collectToolApprovalsFromMessages(messages: ModelMessage[]): {
+  approvedToolApprovals: CollectedApproval[];
+  deniedToolApprovals: CollectedApproval[];
+} {
+  const lastMessage = messages.at(-1);
+
+  if (lastMessage?.role !== 'tool') {
+    return { approvedToolApprovals: [], deniedToolApprovals: [] };
+  }
+
+  // Gather tool calls from assistant messages
+  const toolCallsByToolCallId: Record<
+    string,
+    { toolName: string; input: unknown }
+  > = {};
+  for (const message of messages) {
+    if (message.role === 'assistant' && Array.isArray(message.content)) {
+      for (const part of message.content as any[]) {
+        if (part.type === 'tool-call') {
+          toolCallsByToolCallId[part.toolCallId] = {
+            toolName: part.toolName,
+            input: part.input ?? part.args,
+          };
+        }
+      }
+    }
+  }
+
+  // Gather approval requests from assistant messages
+  const approvalRequestsByApprovalId: Record<
+    string,
+    { approvalId: string; toolCallId: string }
+  > = {};
+  for (const message of messages) {
+    if (message.role === 'assistant' && Array.isArray(message.content)) {
+      for (const part of message.content as any[]) {
+        if (part.type === 'tool-approval-request') {
+          approvalRequestsByApprovalId[part.approvalId] = {
+            approvalId: part.approvalId,
+            toolCallId: part.toolCallId,
+          };
+        }
+      }
+    }
+  }
+
+  // Gather existing tool results to avoid re-executing
+  const existingToolResults = new Set<string>();
+  for (const part of lastMessage.content as any[]) {
+    if (part.type === 'tool-result') {
+      existingToolResults.add(part.toolCallId);
+    }
+  }
+
+  const approvedToolApprovals: CollectedApproval[] = [];
+  const deniedToolApprovals: CollectedApproval[] = [];
+
+  // Collect approval responses from the last tool message
+  const approvalResponses = (lastMessage.content as any[]).filter(
+    (part: any) => part.type === 'tool-approval-response',
+  );
+
+  for (const response of approvalResponses) {
+    const approvalRequest = approvalRequestsByApprovalId[response.approvalId];
+    if (approvalRequest == null) continue;
+
+    // Skip if there's already a tool result for this tool call
+    if (existingToolResults.has(approvalRequest.toolCallId)) continue;
+
+    const toolCall = toolCallsByToolCallId[approvalRequest.toolCallId];
+    if (toolCall == null) continue;
+
+    const approval: CollectedApproval = {
+      toolCallId: approvalRequest.toolCallId,
+      toolName: toolCall.toolName,
+      input: toolCall.input,
+      approvalId: response.approvalId,
+      reason: response.reason,
+    };
+
+    if (response.approved) {
+      approvedToolApprovals.push(approval);
+    } else {
+      deniedToolApprovals.push(approval);
+    }
+  }
+
+  return { approvedToolApprovals, deniedToolApprovals };
 }


### PR DESCRIPTION
## Summary

- Adds automatic tool approval resumption to `WorkflowAgent.stream()` so it processes `tool-approval-response` parts before the agent loop starts (executes approved tools, creates denial results for denied tools, strips approval parts from messages, and injects tool results)
- Removes the manual `processApprovals` function and `toolExecutors` map from the example, reducing ~140 lines of plumbing code
- Adds tests for approved tool execution resumption, denied tool handling, and passthrough of messages without approvals

## Test plan

- [x] `cd packages/workflow && pnpm test` passes (79 tests, 3 new)
- [x] `cd packages/workflow && pnpm build` succeeds
- [x] `pnpm check` passes (linting/formatting)
- [ ] Manual test with the `examples/next-workflow` app using the deleteFile tool with approval UI