### PR TITLE
fix(ai): skip passing invalid JSON inputs to response messages

### DIFF
--- a/.changeset/nervous-gorillas-own.md
+++ b/.changeset/nervous-gorillas-own.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): skip passing invalid JSON inputs to response messages

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -971,6 +971,132 @@ describe('toResponseMessages', () => {
     });
   });
 
+  it('should sanitize invalid tool call with non-object input to empty object', async () => {
+    const result = await toResponseMessages({
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'weather',
+          input: '{ city: San Francisco, }',
+          dynamic: true,
+          invalid: true,
+          error: new Error('JSON parsing failed'),
+        },
+        {
+          type: 'tool-error',
+          toolCallId: 'call-1',
+          toolName: 'weather',
+          input: '{ city: San Francisco, }',
+          error: 'Invalid input for tool weather: JSON parsing failed',
+          dynamic: true,
+        },
+      ],
+      tools: {
+        weather: tool({
+          description: 'Get weather',
+          inputSchema: z.object({ city: z.string() }),
+        }),
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "input": {},
+              "providerExecuted": undefined,
+              "providerOptions": undefined,
+              "toolCallId": "call-1",
+              "toolName": "weather",
+              "type": "tool-call",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "output": {
+                "type": "error-text",
+                "value": "Invalid input for tool weather: JSON parsing failed",
+              },
+              "toolCallId": "call-1",
+              "toolName": "weather",
+              "type": "tool-result",
+            },
+          ],
+          "role": "tool",
+        },
+      ]
+    `);
+  });
+
+  it('should preserve valid object input on invalid tool call', async () => {
+    const result = await toResponseMessages({
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'weather',
+          input: { cities: 'San Francisco' },
+          dynamic: true,
+          invalid: true,
+          error: new Error('Type validation failed'),
+        },
+        {
+          type: 'tool-error',
+          toolCallId: 'call-1',
+          toolName: 'weather',
+          input: { cities: 'San Francisco' },
+          error: 'Invalid input for tool weather: Type validation failed',
+          dynamic: true,
+        },
+      ],
+      tools: {
+        weather: tool({
+          description: 'Get weather',
+          inputSchema: z.object({ city: z.string() }),
+        }),
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "input": {
+                "cities": "San Francisco",
+              },
+              "providerExecuted": undefined,
+              "providerOptions": undefined,
+              "toolCallId": "call-1",
+              "toolName": "weather",
+              "type": "tool-call",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "output": {
+                "type": "error-text",
+                "value": "Invalid input for tool weather: Type validation failed",
+              },
+              "toolCallId": "call-1",
+              "toolName": "weather",
+              "type": "tool-result",
+            },
+          ],
+          "role": "tool",
+        },
+      ]
+    `);
+  });
+
   it('should include provider metadata in the text parts', async () => {
     const result = await toResponseMessages({
       content: [

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -83,7 +83,8 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
           type: 'tool-call',
           toolCallId: part.toolCallId,
           toolName: part.toolName,
-          input: part.input,
+          input:
+            part.invalid && typeof part.input !== 'object' ? {} : part.input,
           providerExecuted: part.providerExecuted,
           providerOptions: part.providerMetadata,
         });


### PR DESCRIPTION
## Background

if a model returns an invalid input for a tool call, the AISDK properly attaches it as a tool-error and sends it back to the model.
however, when sending the message history back, the tool-input field still refers the broken json input and thus breaks any future model response (observed in Anthropic as : `invalid_request_error `)

https://github.com/vercel/ai/issues/13892

## Summary

when building the response messages, if a tool cal input is invalid + is not a valid JSON, we pass an empty `{ }` back as tool input so that model response doesn't break.

## Manual Verification

verified by running the repro below

<details>
<summary> repro </summary>

```ts
import { anthropic } from '@ai-sdk/anthropic';
import { generateText, isStepCount, tool } from 'ai';
import { MockLanguageModelV3 } from 'ai/test';
import { z } from 'zod';
import { run } from '../../lib/run';

run(async () => {
  // Turn 1: Mock LLM returns a tool call with invalid JSON args.
  const result1 = await generateText({
    model: new MockLanguageModelV3({
      doGenerate: async () => ({
        warnings: [],
        usage: {
          inputTokens: {
            total: 10,
            noCache: 10,
            cacheRead: undefined,
            cacheWrite: undefined,
          },
          outputTokens: {
            total: 20,
            text: 20,
            reasoning: undefined,
          },
        },
        finishReason: { raw: undefined, unified: 'tool-calls' },
        content: [
          {
            type: 'tool-call',
            toolCallType: 'function',
            toolCallId: 'call-1',
            toolName: 'weather',
            input: `{ city: San Francisco, }`,
          },
        ],
      }),
    }),
    tools: {
      weather: tool({
        inputSchema: z.object({ city: z.string() }),
        execute: async ({ city }) => `Sunny in ${city}`,
      }),
    },
    prompt: 'What is the weather in San Francisco?',
    stopWhen: isStepCount(1),
  });


  // Turn 2: Send the (potentially poisoned) messages to real Anthropic API.
  console.log('Turn 2: round-trip to Anthropic');

  try {
    const result2 = await generateText({
      model: anthropic('claude-sonnet-4-20250514'),
      messages: [
        { role: 'user', content: 'What is the weather in San Francisco?' },
        ...result1.response.messages,
      ],
      tools: {
        weather: tool({
          inputSchema: z.object({ city: z.string() }),
          execute: async ({ city }) => `Sunny in ${city}`,
        }),
      },
      stopWhen: isStepCount(4),
    });

    console.log(`Anthropic responded: "${result2.text.slice(0, 200)}"`);
    console.log(
      '\nRequest body:',
      JSON.stringify(result2.request.body, null, 2),
    );
    console.log(
      '\nResponse body:',
      JSON.stringify(result2.response, null, 2),
    );
  } catch (error: any) {
    console.error('Anthropic rejected the request!');
    console.error(`  Status: ${error.statusCode ?? 'unknown'}`);
    console.error(`  Message: ${JSON.stringify(error, null, 2)}`);
  }
});

```
</details>

before: we get an API error `Input should be a valid dictionary`
after: model response with weather

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes https://github.com/vercel/ai/issues/13892