### PR TITLE
feat(mcp): surface 'serverInfo' exposed from the MCP server

### DIFF
--- a/.changeset/gentle-snakes-flash.md
+++ b/.changeset/gentle-snakes-flash.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+feat(mcp): surface 'serverInfo' exposed from the MCP server

--- a/examples/mcp/src/server-info/client.ts
+++ b/examples/mcp/src/server-info/client.ts
@@ -1,0 +1,16 @@
+import { createMCPClient } from '@ai-sdk/mcp';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+async function main() {
+  const client = await createMCPClient({
+    transport: new StreamableHTTPClientTransport(
+      new URL('http://localhost:3000/mcp'),
+    ),
+  });
+
+  console.log('serverInfo:', client.serverInfo);
+
+  await client.close();
+}
+
+main().catch(console.error);

--- a/examples/mcp/src/server-info/server.ts
+++ b/examples/mcp/src/server-info/server.ts
@@ -1,0 +1,31 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+app.post('/mcp', async (req, res) => {
+  const server = new McpServer({
+    name: 'my-dumb-server',
+    version: '2.000.0',
+  });
+
+  server.tool('ping', 'A simple ping tool', async () => {
+    return { content: [{ type: 'text', text: 'pong' }] };
+  });
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
+  await server.connect(transport);
+  await transport.handleRequest(req, res, req.body);
+  res.on('close', () => {
+    transport.close();
+    server.close();
+  });
+});
+
+app.listen(3000, () => {
+  console.log('server-info example server listening on port 3000');
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -14,6 +14,7 @@ export {
 } from './tool/mcp-client';
 export { ElicitationRequestSchema, ElicitResultSchema } from './tool/types';
 export type {
+  Configuration,
   ElicitationRequest,
   ElicitResult,
   ListToolsResult,

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -924,6 +924,48 @@ describe('MCPClient', () => {
     }
   });
 
+  it('should expose serverInfo from initialization', async () => {
+    createMockTransport.mockImplementation(
+      () =>
+        new MockMCPTransport({
+          initializeResult: {
+            protocolVersion: '2025-11-25',
+            serverInfo: {
+              name: 'my-server',
+              version: '2.0.0',
+              title: 'My Server',
+            },
+            capabilities: { tools: {} },
+          },
+        }),
+    );
+
+    client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+    });
+
+    expect(client.serverInfo).toMatchInlineSnapshot(`
+      {
+        "name": "my-server",
+        "title": "My Server",
+        "version": "2.0.0",
+      }
+    `);
+  });
+
+  it('should expose serverInfo without title when server omits it', async () => {
+    client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+    });
+
+    expect(client.serverInfo).toMatchInlineSnapshot(`
+      {
+        "name": "mock-mcp-server",
+        "version": "1.0.0",
+      }
+    `);
+  });
+
   it('should close transport when client is closed', async () => {
     const mockTransport = new MockMCPTransport();
     const closeSpy = vi.spyOn(mockTransport, 'close');

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -29,6 +29,7 @@ import {
   CallToolResult,
   CallToolResultSchema,
   ClientCapabilities,
+  Configuration,
   Configuration as ClientConfiguration,
   ElicitationRequest,
   ElicitationRequestSchema,
@@ -119,6 +120,12 @@ export async function createMCPClient(
 }
 
 export interface MCPClient {
+  /**
+   * Information about the connected MCP server, as reported during initialization.
+   * @see https://modelcontextprotocol.io/specification/2025-11-25/schema#implementation
+   */
+  readonly serverInfo: Configuration;
+
   tools<TOOL_SCHEMAS extends ToolSchemas = 'automatic'>(options?: {
     schemas?: TOOL_SCHEMAS;
   }): Promise<McpToolSet<TOOL_SCHEMAS>>;
@@ -201,6 +208,7 @@ class DefaultMCPClient implements MCPClient {
     (response: JSONRPCResponse | Error) => void
   > = new Map();
   private serverCapabilities: ServerCapabilities = {};
+  private _serverInfo: Configuration = { name: '', version: '' };
   private isClosed = true;
   private elicitationRequestHandler?: (
     request: ElicitationRequest,
@@ -247,6 +255,10 @@ class DefaultMCPClient implements MCPClient {
     };
   }
 
+  get serverInfo(): Configuration {
+    return this._serverInfo;
+  }
+
   async init(): Promise<this> {
     try {
       await this.transport.start();
@@ -277,6 +289,7 @@ class DefaultMCPClient implements MCPClient {
       }
 
       this.serverCapabilities = result.capabilities;
+      this._serverInfo = result.serverInfo;
 
       // Complete initialization handshake:
       await this.notification({

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -56,8 +56,10 @@ export type McpToolSet<TOOL_SCHEMAS extends ToolSchemas = 'automatic'> =
 const ClientOrServerImplementationSchema = z.looseObject({
   name: z.string(),
   version: z.string(),
+  title: z.optional(z.string()),
 });
 
+// Maps to `Implementation` in the MCP specification
 export type Configuration = z.infer<typeof ClientOrServerImplementationSchema>;
 
 export const BaseParamsSchema = z.looseObject({


### PR DESCRIPTION
## Background

introduced in https://github.com/vercel/ai/pull/13825 

we used to capture the `serverInfo` in the schema but never surface it through to the client. only `result.capabilities` was stored and `result.serverInfo` was thrown away. there was no field on the client to hold it and no property on the MCPClient interface to access it

## Summary

- added `title` field to `ClientOrServerImplementationSchema` to align with [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25/schema#implementation) 
- exposed `serverInfo` via a getter function 

## Manual Verification

verified by running the client and server under `examples/mcp/src/server-info`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)