### PR TITLE
fix(ai): fix `providerExecuted` tool approvals being passed to language model twice

### DIFF
--- a/.changeset/wise-dodos-help.md
+++ b/.changeset/wise-dodos-help.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): fix `providerExecuted` tool approvals being passed to language model twice

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -8227,7 +8227,7 @@ describe('generateText', () => {
           });
         });
 
-        it('should send tool-approval-response to the model', async () => {
+        it('should send tool-approval-response to the model exactly once', async () => {
           expect(prompts[0]).toMatchInlineSnapshot(`
             [
               {
@@ -8258,12 +8258,6 @@ describe('generateText', () => {
               },
               {
                 "content": [
-                  {
-                    "approvalId": "mcp-approval-1",
-                    "approved": true,
-                    "reason": undefined,
-                    "type": "tool-approval-response",
-                  },
                   {
                     "approvalId": "mcp-approval-1",
                     "approved": true,
@@ -8388,7 +8382,7 @@ describe('generateText', () => {
           });
         });
 
-        it('should send denied tool-approval-response to the model', async () => {
+        it('should send denied tool-approval-response to the model exactly once', async () => {
           expect(prompts[0]).toMatchInlineSnapshot(`
             [
               {
@@ -8439,12 +8433,6 @@ describe('generateText', () => {
                     "toolCallId": "mcp-call-1",
                     "toolName": "mcp_tool",
                     "type": "tool-result",
-                  },
-                  {
-                    "approvalId": "mcp-approval-1",
-                    "approved": false,
-                    "reason": "User denied the request",
-                    "type": "tool-approval-response",
                   },
                 ],
                 "providerOptions": undefined,

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -8,7 +8,6 @@ import {
   getErrorMessage,
   IdGenerator,
   ProviderOptions,
-  ToolApprovalResponse,
   withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
 import { NoOutputGeneratedError } from '../error';
@@ -646,28 +645,6 @@ export async function generateText<
       responseMessages.push({
         role: 'tool',
         content: toolContent,
-      });
-    }
-
-    // Forward provider-executed approval responses to the provider
-    const providerExecutedToolApprovals = [
-      ...approvedToolApprovals,
-      ...deniedToolApprovals,
-    ].filter(toolApproval => toolApproval.toolCall.providerExecuted);
-
-    if (providerExecutedToolApprovals.length > 0) {
-      responseMessages.push({
-        role: 'tool',
-        content: providerExecutedToolApprovals.map(
-          toolApproval =>
-            ({
-              type: 'tool-approval-response',
-              approvalId: toolApproval.approvalResponse.approvalId,
-              approved: toolApproval.approvalResponse.approved,
-              reason: toolApproval.approvalResponse.reason,
-              providerExecuted: true,
-            }) satisfies ToolApprovalResponse,
-        ),
       });
     }
 

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -22584,7 +22584,7 @@ describe('streamText', () => {
           });
         });
 
-        it('should send tool-approval-response to the model', async () => {
+        it('should send tool-approval-response to the model exactly once', async () => {
           await result.consumeStream();
           expect(prompts[0]).toMatchInlineSnapshot(`
             [
@@ -22616,12 +22616,6 @@ describe('streamText', () => {
               },
               {
                 "content": [
-                  {
-                    "approvalId": "mcp-approval-1",
-                    "approved": true,
-                    "reason": undefined,
-                    "type": "tool-approval-response",
-                  },
                   {
                     "approvalId": "mcp-approval-1",
                     "approved": true,
@@ -22760,7 +22754,7 @@ describe('streamText', () => {
           });
         });
 
-        it('should send denied tool-approval-response to the model', async () => {
+        it('should send denied tool-approval-response to the model exactly once', async () => {
           await result.consumeStream();
           expect(prompts[0]).toMatchInlineSnapshot(`
             [
@@ -22792,12 +22786,6 @@ describe('streamText', () => {
               },
               {
                 "content": [
-                  {
-                    "approvalId": "mcp-approval-1",
-                    "approved": false,
-                    "reason": "User denied the request",
-                    "type": "tool-approval-response",
-                  },
                   {
                     "approvalId": "mcp-approval-1",
                     "approved": false,

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -10,7 +10,6 @@ import {
   IdGenerator,
   isAbortError,
   ProviderOptions,
-  ToolApprovalResponse,
   ToolContent,
 } from '@ai-sdk/provider-utils';
 import { ServerResponse } from 'node:http';
@@ -1461,23 +1460,6 @@ class DefaultStreamTextResult<
               }
             }),
           );
-
-          // forward provider-executed approval responses to the provider (do not execute locally):
-          if (providerExecutedToolApprovals.length > 0) {
-            initialResponseMessages.push({
-              role: 'tool',
-              content: providerExecutedToolApprovals.map(
-                toolApproval =>
-                  ({
-                    type: 'tool-approval-response',
-                    approvalId: toolApproval.approvalResponse.approvalId,
-                    approved: toolApproval.approvalResponse.approved,
-                    reason: toolApproval.approvalResponse.reason,
-                    providerExecuted: true,
-                  }) satisfies ToolApprovalResponse,
-              ),
-            });
-          }
 
           // Local tool results (approved + denied) are sent as tool results:
           if (toolOutputs.length > 0 || localDeniedToolApprovals.length > 0) {


### PR DESCRIPTION
## Background

When a UI message history contains an approved `providerExecuted` tool invocation and the server does the standard pattern:

```ts
const modelMessages = await convertToModelMessages(messages);
return streamText({ model, messages: modelMessages });
```

the provider receives the same `tool-approval-response` **twice** for the same `approvalId` in one tool message. This can cause downstream providers to reject the prompt as invalid (one approval request must produce exactly one response).

## Summary

`collectToolApprovals` finds approval responses by reading the last tool message of `initialMessages`. Those responses are already present in `initialMessages` because `convertToModelMessages` placed them there. Both `generateText` and `streamText` then redundantly pushed the same responses into `responseMessages`/`initialResponseMessages`. When the step computed `stepInputMessages = [...initialMessages, ...responseMessages]`, the approval appeared twice, and `convertToLanguageModelPrompt` surfaced both copies inside a single merged tool message.

- Removed the redundant `providerExecutedToolApprovals` push in `generateText`
- Removed the same block in `streamText`
- Updated the four existing snapshots that already documented the bug (approved + denied cases for each function)

## Manual Verification

In `examples/ai-e2e-next`, navigate to `/chat/test-openai-responses-mcp-approval` and send `"Shorten the link https://ai-sdk.dev/"`. After approving the MCP tool call, the conversation should complete successfully.

To compare before/after, add a `console.log` of the prompt passed to the model in the mock or in the route handler. In `generateText`/`streamText`, you can log `stepInputMessages` (the variable at the top of the `do` loop / `streamStep` body) immediately before the language model call and confirm the tool message contains exactly one `tool-approval-response` entry after the fix.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)