### PR TITLE
docs: add model mappings to BYOK provider options

### DIFF
--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -159,7 +159,7 @@ You can connect your own provider credentials to use with Vercel AI Gateway. Thi
 
 To set up BYOK, add your provider credentials in your Vercel team's AI Gateway settings. Once configured, AI Gateway automatically uses your credentials. No code changes are needed.
 
-For providers like Azure where you use custom deployment names, you can configure model mappings to map gateway model slugs to your deployment names. See [model mappings](https://vercel.com/docs/ai-gateway/byok#model-mappings) for details.
+For providers like Azure where you can use custom deployment names, you can configure model mappings to map gateway model slugs to your deployment names. See [model mappings](https://vercel.com/docs/ai-gateway/byok#model-mappings) for details.
 
 Learn more in the [BYOK documentation](https://vercel.com/docs/ai-gateway/byok).
 

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -159,7 +159,7 @@ You can connect your own provider credentials to use with Vercel AI Gateway. Thi
 
 To set up BYOK, add your provider credentials in your Vercel team's AI Gateway settings. Once configured, AI Gateway automatically uses your credentials. No code changes are needed.
 
-For providers like Azure where deployment names may differ from AI Gateway model slugs, you can configure model mappings to map gateway model slugs to your custom deployment names. See [model mappings](https://vercel.com/docs/ai-gateway/byok#model-mappings) for details.
+For providers like Azure where you use custom deployment names, you can configure model mappings to map gateway model slugs to your deployment names. See [model mappings](https://vercel.com/docs/ai-gateway/byok#model-mappings) for details.
 
 Learn more in the [BYOK documentation](https://vercel.com/docs/ai-gateway/byok).
 
@@ -804,7 +804,7 @@ The following gateway provider options are available:
 
   Each provider can have multiple credentials (tried in order). The structure is a record where keys are provider slugs and values are arrays of credential objects.
 
-  Each credential can optionally include a `modelMappings` array to map AI Gateway model slugs to custom deployment names (for example, Azure deployments with non-default names). If a BYOK request fails, the gateway falls back to system credentials using the default model name.
+  Each credential can optionally include a `modelMappings` array to map AI Gateway model slugs to your deployment names (for example, custom Azure deployment names). If a BYOK request fails, the gateway falls back to system credentials using the default model name.
 
   Examples:
 

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -159,6 +159,8 @@ You can connect your own provider credentials to use with Vercel AI Gateway. Thi
 
 To set up BYOK, add your provider credentials in your Vercel team's AI Gateway settings. Once configured, AI Gateway automatically uses your credentials. No code changes are needed.
 
+For providers like Azure where deployment names may differ from AI Gateway model slugs, you can configure model mappings to map gateway model slugs to your custom deployment names. See [model mappings](https://vercel.com/docs/ai-gateway/byok#model-mappings) for details.
+
 Learn more in the [BYOK documentation](https://vercel.com/docs/ai-gateway/byok).
 
 ## Language Models
@@ -802,11 +804,14 @@ The following gateway provider options are available:
 
   Each provider can have multiple credentials (tried in order). The structure is a record where keys are provider slugs and values are arrays of credential objects.
 
+  Each credential can optionally include a `modelMappings` array to map AI Gateway model slugs to custom deployment names (for example, Azure deployments with non-default names). If a BYOK request fails, the gateway falls back to system credentials using the default model name.
+
   Examples:
 
   - Single provider: `byok: { 'anthropic': [{ apiKey: 'sk-ant-...' }] }`
   - Multiple credentials: `byok: { 'vertex': [{ project: 'proj-1', googleCredentials: { privateKey: '...', clientEmail: '...' } }, { project: 'proj-2', googleCredentials: { privateKey: '...', clientEmail: '...' } }] }`
   - Multiple providers: `byok: { 'anthropic': [{ apiKey: '...' }], 'bedrock': [{ accessKeyId: '...', secretAccessKey: '...' }] }`
+  - With model mappings: `byok: { 'azure': [{ apiKey: '...', resourceName: '...', modelMappings: [{ gatewayModelSlug: 'openai/gpt-5.4-nano', customModelId: 'my-deployment' }] }] }`
 
 - **zeroDataRetention** _boolean_
 

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -44,10 +44,15 @@ const gatewayProviderOptions = lazySchema(() =>
        *
        * Each provider can have multiple credentials (tried in order).
        *
+       * Each credential can optionally include a `modelMappings` array to map
+       * AI Gateway model slugs to custom deployment names (e.g., for Azure
+       * deployments with non-default names).
+       *
        * Examples:
        * - Simple: `{ 'anthropic': [{ apiKey: 'sk-ant-...' }] }`
        * - Multiple: `{ 'vertex': [{ projectId: 'proj-1', privateKey: '...' }, { projectId: 'proj-2', privateKey: '...' }] }`
        * - Multi-provider: `{ 'anthropic': [{ apiKey: '...' }], 'bedrock': [{ accessKeyId: '...', secretAccessKey: '...' }] }`
+       * - With model mappings: `{ 'azure': [{ apiKey: '...', resourceName: '...', modelMappings: [{ gatewayModelSlug: 'openai/gpt-5.4-nano', customModelId: 'my-deployment' }] }] }`
        */
       byok: z
         .record(z.string(), z.array(z.record(z.string(), z.unknown())))

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -44,15 +44,10 @@ const gatewayProviderOptions = lazySchema(() =>
        *
        * Each provider can have multiple credentials (tried in order).
        *
-       * Each credential can optionally include a `modelMappings` array to map
-       * AI Gateway model slugs to custom deployment names (e.g., for Azure
-       * deployments with non-default names).
-       *
        * Examples:
        * - Simple: `{ 'anthropic': [{ apiKey: 'sk-ant-...' }] }`
        * - Multiple: `{ 'vertex': [{ projectId: 'proj-1', privateKey: '...' }, { projectId: 'proj-2', privateKey: '...' }] }`
        * - Multi-provider: `{ 'anthropic': [{ apiKey: '...' }], 'bedrock': [{ accessKeyId: '...', secretAccessKey: '...' }] }`
-       * - With model mappings: `{ 'azure': [{ apiKey: '...', resourceName: '...', modelMappings: [{ gatewayModelSlug: 'openai/gpt-5.4-nano', customModelId: 'my-deployment' }] }] }`
        */
       byok: z
         .record(z.string(), z.array(z.record(z.string(), z.unknown())))


### PR DESCRIPTION
## Summary
Add `modelMappings` documentation to the `byok` JSDoc in `gateway-provider-options.ts`.

Model mappings allow BYOK credentials to include custom deployment name mappings (e.g., for Azure deployments with non-default names). Each credential in the `byok` record can optionally include a `modelMappings` array.

## Example
```ts
byok: {
  azure: [{
    apiKey: '...',
    resourceName: '...',
    modelMappings: [
      { gatewayModelSlug: 'openai/gpt-5.4-nano', customModelId: 'my-deployment' }
    ]
  }]
}
```