### PR TITLE
fix(ai): fix `lastAssistantMessageIsCompleteWithApprovalResponses` to no longer ignore `providerExecuted` tool approvals

### DIFF
--- a/.changeset/metal-terms-change.md
+++ b/.changeset/metal-terms-change.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): fix `lastAssistantMessageIsCompleteWithApprovalResponses` to no longer ignore `providerExecuted` tool approvals

--- a/examples/ai-e2e-next/app/chat/test-openai-responses-mcp-approval/page.tsx
+++ b/examples/ai-e2e-next/app/chat/test-openai-responses-mcp-approval/page.tsx
@@ -4,43 +4,11 @@ import ChatInput from '@/components/chat-input';
 import DynamicToolView from '@/components/tool/dynamic-tool-view';
 import OpenAIMCPApprovalView from '@/components/tool/openai-mcp-approval-view';
 import { useChat } from '@ai-sdk/react';
-import { DefaultChatTransport, UIMessage, isToolUIPart } from 'ai';
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithApprovalResponses,
+} from 'ai';
 import { OpenAIResponsesMCPApprovalMessage } from '@/app/api/chat/openai-responses-mcp-approval/route';
-
-// Custom helper that handles provider-executed tools (like OpenAI MCP)
-function lastAssistantMessageIsCompleteWithProviderExecutedApprovalResponses({
-  messages,
-}: {
-  messages: UIMessage[];
-}): boolean {
-  const message = messages[messages.length - 1];
-
-  if (!message || message.role !== 'assistant') {
-    return false;
-  }
-
-  const lastStepStartIndex = message.parts.reduce((lastIndex, part, index) => {
-    return part.type === 'step-start' ? index : lastIndex;
-  }, -1);
-
-  // Include provider-executed tools (unlike the default helper)
-  const lastStepToolInvocations = message.parts
-    .slice(lastStepStartIndex + 1)
-    .filter(isToolUIPart);
-
-  return (
-    // has at least one tool approval response
-    lastStepToolInvocations.filter(part => part.state === 'approval-responded')
-      .length > 0 &&
-    // all tool approvals must have a response
-    lastStepToolInvocations.every(
-      part =>
-        part.state === 'output-available' ||
-        part.state === 'output-error' ||
-        part.state === 'approval-responded',
-    )
-  );
-}
 
 export default function TestOpenAIResponsesMCPApproval() {
   const { status, sendMessage, messages, addToolApprovalResponse } =
@@ -49,7 +17,7 @@ export default function TestOpenAIResponsesMCPApproval() {
         api: '/api/chat/openai-responses-mcp-approval',
       }),
       sendAutomaticallyWhen:
-        lastAssistantMessageIsCompleteWithProviderExecutedApprovalResponses,
+        lastAssistantMessageIsCompleteWithApprovalResponses,
     });
 
   return (

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1381,11 +1381,6 @@ class DefaultStreamTextResult<
 
       // initial tool execution step stream
       if (deniedToolApprovals.length > 0 || approvedToolApprovals.length > 0) {
-        const providerExecutedToolApprovals = [
-          ...approvedToolApprovals,
-          ...deniedToolApprovals,
-        ].filter(toolApproval => toolApproval.toolCall.providerExecuted);
-
         const localApprovedToolApprovals = approvedToolApprovals.filter(
           toolApproval => !toolApproval.toolCall.providerExecuted,
         );

--- a/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.test.ts
+++ b/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+import { lastAssistantMessageIsCompleteWithApprovalResponses } from './last-assistant-message-is-complete-with-approval-responses';
+
+describe('lastAssistantMessageIsCompleteWithApprovalResponses', () => {
+  it('should return false if messages is empty', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({ messages: [] }),
+    ).toBe(false);
+  });
+
+  it('should return false if last message is a user message', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [{ id: '1', role: 'user', parts: [] }],
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false if there are no tool invocations in the last step', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              { type: 'text', text: 'Hello', state: 'done' },
+            ],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false if no tool has approval-responded state', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_1',
+                state: 'approval-requested',
+                input: { city: 'Tokyo' },
+                approval: { id: 'approval_1' },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false if some tools still have approval-requested state', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_1',
+                state: 'approval-responded',
+                input: { city: 'Tokyo' },
+                approval: { id: 'approval_1', approved: true },
+              },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_2',
+                state: 'approval-requested',
+                input: { city: 'Paris' },
+                approval: { id: 'approval_2' },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('should return true when a non-provider-executed tool has approval-responded', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_1',
+                state: 'approval-responded',
+                input: { city: 'Tokyo' },
+                approval: { id: 'approval_1', approved: true },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('should return true when a provider-executed tool has approval-responded', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'dynamic-tool',
+                toolName: 'mcp.shorten_url',
+                toolCallId: 'call_1',
+                state: 'approval-responded',
+                input: { url: 'https://ai-sdk.dev/' },
+                approval: { id: 'approval_1', approved: true },
+                providerExecuted: true,
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('should return true when all tools have a terminal state and at least one is approval-responded', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_1',
+                state: 'approval-responded',
+                input: { city: 'Tokyo' },
+                approval: { id: 'approval_1', approved: true },
+              },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_2',
+                state: 'output-available',
+                input: { city: 'Paris' },
+                output: { temperature: 20, weather: 'cloudy' },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('should return true mixing provider-executed (approval-responded) and regular (output-available)', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'dynamic-tool',
+                toolName: 'mcp.shorten_url',
+                toolCallId: 'call_1',
+                state: 'approval-responded',
+                input: { url: 'https://ai-sdk.dev/' },
+                approval: { id: 'approval_1', approved: true },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_2',
+                state: 'output-available',
+                input: { city: 'Tokyo' },
+                output: { temperature: 25, weather: 'sunny' },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false when provider-executed tool is approval-responded but regular tool is still approval-requested', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'dynamic-tool',
+                toolName: 'mcp.shorten_url',
+                toolCallId: 'call_1',
+                state: 'approval-responded',
+                input: { url: 'https://ai-sdk.dev/' },
+                approval: { id: 'approval_1', approved: true },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_2',
+                state: 'approval-requested',
+                input: { city: 'Tokyo' },
+                approval: { id: 'approval_2' },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('should only consider the last step in a multi-step message', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_1',
+                state: 'approval-responded',
+                input: { city: 'Tokyo' },
+                approval: { id: 'approval_1', approved: true },
+              },
+              { type: 'step-start' },
+              { type: 'text', text: 'Done.', state: 'done' },
+            ],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.ts
+++ b/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.ts
@@ -26,8 +26,7 @@ export function lastAssistantMessageIsCompleteWithApprovalResponses({
 
   const lastStepToolInvocations = message.parts
     .slice(lastStepStartIndex + 1)
-    .filter(isToolUIPart)
-    .filter(part => !part.providerExecuted);
+    .filter(isToolUIPart);
 
   return (
     // has at least one tool approval response


### PR DESCRIPTION
## Summary

`lastAssistantMessageIsCompleteWithApprovalResponses()` so far ignores `providerExecuted` tools. There's no good reason for that, and we already had to work around it in one of the Next.js E2E examples.

This PR removes the condition so that `providerExecuted` tools are also considered.

## Manual Verification

run the modified example, where the custom workaround helper was replaced with the function from `ai`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

includes a follow-up cleanup of an unused variable from #14289 (which for some reason wasn't flagged by CI in that PR)
