### PR TITLE
chore: fix v7 changesets to mark them as major

### DIFF
--- a/.changeset/cyan-chefs-build.md
+++ b/.changeset/cyan-chefs-build.md
@@ -1,6 +1,6 @@
 ---
-"@ai-sdk/provider-utils": patch
-"ai": patch
+"@ai-sdk/provider-utils": major
+"ai": major
 ---
 
 chore(ai): remove deprecated `media` type part from `ToolResultOutput`

--- a/.changeset/lazy-books-poke.md
+++ b/.changeset/lazy-books-poke.md
@@ -1,8 +1,8 @@
 ---
-'@ai-sdk/provider-utils': patch
-'@ai-sdk/provider': patch
-'@ai-sdk/google': patch
-'@ai-sdk/xai': patch
+'@ai-sdk/provider-utils': major
+'@ai-sdk/provider': major
+'@ai-sdk/google': major
+'@ai-sdk/xai': major
 ---
 
 feat(provider): add support for `reasoning-file` type for files that are part of reasoning

--- a/.changeset/mean-windows-impress.md
+++ b/.changeset/mean-windows-impress.md
@@ -1,8 +1,8 @@
 ---
-'@ai-sdk/anthropic': patch
-'@ai-sdk/provider': patch
-'@ai-sdk/openai': patch
-'ai': patch
+'@ai-sdk/anthropic': major
+'@ai-sdk/provider': major
+'@ai-sdk/openai': major
+'ai': major
 ---
 
 feat(ai): add support for uploading provider skills using the provider references abstraction

--- a/.changeset/poor-kids-joke.md
+++ b/.changeset/poor-kids-joke.md
@@ -1,5 +1,5 @@
 ---
-"ai": patch
+"ai": major
 ---
 
 feat(ai): rename `stepCountIs` to `isStepCount`

--- a/.changeset/silly-rockets-watch.md
+++ b/.changeset/silly-rockets-watch.md
@@ -1,22 +1,22 @@
 ---
-"@ai-sdk/openai-compatible": patch
-"@ai-sdk/amazon-bedrock": patch
-"@ai-sdk/open-responses": patch
-"@ai-sdk/provider-utils": patch
-"@ai-sdk/huggingface": patch
-"@ai-sdk/perplexity": patch
-"@ai-sdk/anthropic": patch
-"@ai-sdk/provider": patch
-"@ai-sdk/alibaba": patch
-"@ai-sdk/mistral": patch
-"@ai-sdk/cohere": patch
-"@ai-sdk/google": patch
-"@ai-sdk/openai": patch
-"@ai-sdk/prodia": patch
-"@ai-sdk/azure": patch
-"@ai-sdk/groq": patch
-"@ai-sdk/xai": patch
-"ai": patch
+"@ai-sdk/openai-compatible": major
+"@ai-sdk/amazon-bedrock": major
+"@ai-sdk/open-responses": major
+"@ai-sdk/provider-utils": major
+"@ai-sdk/huggingface": major
+"@ai-sdk/perplexity": major
+"@ai-sdk/anthropic": major
+"@ai-sdk/provider": major
+"@ai-sdk/alibaba": major
+"@ai-sdk/mistral": major
+"@ai-sdk/cohere": major
+"@ai-sdk/google": major
+"@ai-sdk/openai": major
+"@ai-sdk/prodia": major
+"@ai-sdk/azure": major
+"@ai-sdk/groq": major
+"@ai-sdk/xai": major
+"ai": major
 ---
 
 feat(provider): add support for provider references and uploading files as supported per provider

--- a/.changeset/sixty-coats-shout.md
+++ b/.changeset/sixty-coats-shout.md
@@ -1,11 +1,11 @@
 ---
-'@ai-sdk/amazon-bedrock': patch
-'@ai-sdk/provider-utils': patch
-'@ai-sdk/anthropic': patch
-'@ai-sdk/provider': patch
-'@ai-sdk/google': patch
-'@ai-sdk/openai': patch
-'ai': patch
+'@ai-sdk/amazon-bedrock': major
+'@ai-sdk/provider-utils': major
+'@ai-sdk/anthropic': major
+'@ai-sdk/provider': major
+'@ai-sdk/google': major
+'@ai-sdk/openai': major
+'ai': major
 ---
 
 feat(provider): add new top-level reasoning parameter to spec and support it in `generateText` and `streamText`


### PR DESCRIPTION
## Summary

Fixes the changesets for the following v7 major PRs after the fact to mark them as `major`, for proper referencing in future changelog / docs:
- #13352 
- #13816
- #12880 
- #13553
- #13971
- #14150