### PR TITLE
fix(ai): restore ToolLoopAgent onFinish callbacks

### DIFF
--- a/.changeset/fuzzy-cars-notice.md
+++ b/.changeset/fuzzy-cars-notice.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix `ToolLoopAgent` `onFinish` callbacks on the v6 release line so per-call `onFinish` is accepted again and merged with the constructor-level callback for `generate()` and `stream()`.

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -5,7 +5,10 @@ import { StreamTextTransform } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolSet } from '../generate-text/tool-set';
 import { TimeoutConfiguration } from '../prompt/call-settings';
-import type { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-settings';
+import type {
+  ToolLoopAgentOnFinishCallback,
+  ToolLoopAgentOnStepFinishCallback,
+} from './tool-loop-agent-settings';
 
 /**
  * Parameters for calling an agent.
@@ -61,6 +64,11 @@ export type AgentCallParameters<CALL_OPTIONS, TOOLS extends ToolSet = {}> = ([
      * Callback that is called when each step (LLM call) is finished, including intermediate steps.
      */
     onStepFinish?: ToolLoopAgentOnStepFinishCallback<TOOLS>;
+
+    /**
+     * Callback that is called when all steps are finished and the response is complete.
+     */
+    onFinish?: ToolLoopAgentOnFinishCallback<TOOLS>;
   };
 
 /**

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -83,6 +83,20 @@ describe('ToolLoopAgent', () => {
 
       expectTypeOf<typeof output>().toEqualTypeOf<{ value: string }>();
     });
+
+    it('should allow onFinish', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV3(),
+      });
+
+      await agent.generate({
+        prompt: 'Hello, world!',
+        onFinish: async event => {
+          const context: unknown = event.experimental_context;
+          context;
+        },
+      });
+    });
   });
 
   describe('stream', () => {
@@ -135,6 +149,20 @@ describe('ToolLoopAgent', () => {
       expectTypeOf<typeof partialOutputStream>().toEqualTypeOf<
         AsyncIterableStream<DeepPartial<{ value: string }>>
       >();
+    });
+
+    it('should allow onFinish', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV3(),
+      });
+
+      await agent.stream({
+        prompt: 'Hello, world!',
+        onFinish: async event => {
+          const context: unknown = event.experimental_context;
+          context;
+        },
+      });
     });
   });
 });

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -720,4 +720,226 @@ describe('ToolLoopAgent', () => {
       });
     });
   });
+
+  describe('onFinish', () => {
+    describe('generate', () => {
+      let mockModel: MockLanguageModelV3;
+
+      beforeEach(() => {
+        mockModel = new MockLanguageModelV3({
+          doGenerate: async () => {
+            return {
+              content: [{ type: 'text', text: 'reply' }],
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                cachedInputTokens: undefined,
+                inputTokens: {
+                  total: 3,
+                  noCache: 3,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: {
+                  total: 10,
+                  text: 10,
+                  reasoning: undefined,
+                },
+              },
+              warnings: [],
+            };
+          },
+        });
+      });
+
+      it('should call onFinish from constructor', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: mockModel,
+          onFinish: async () => {
+            calls.push('constructor');
+          },
+        });
+
+        await agent.generate({
+          prompt: 'Hello, world!',
+        });
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "constructor",
+          ]
+        `);
+      });
+
+      it('should call onFinish from generate method', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: mockModel,
+        });
+
+        await agent.generate({
+          prompt: 'Hello, world!',
+          onFinish: async () => {
+            calls.push('method');
+          },
+        });
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "method",
+          ]
+        `);
+      });
+
+      it('should call both constructor and method onFinish in correct order', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: mockModel,
+          onFinish: async () => {
+            calls.push('constructor');
+          },
+        });
+
+        await agent.generate({
+          prompt: 'Hello, world!',
+          onFinish: async () => {
+            calls.push('method');
+          },
+        });
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "constructor",
+            "method",
+          ]
+        `);
+      });
+    });
+
+    describe('stream', () => {
+      let mockModel: MockLanguageModelV3;
+
+      beforeEach(() => {
+        mockModel = new MockLanguageModelV3({
+          doStream: async () => {
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'stream-start',
+                  warnings: [],
+                },
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello' },
+                { type: 'text-delta', id: '1', delta: ', ' },
+                { type: 'text-delta', id: '1', delta: 'world!' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: {
+                    inputTokens: {
+                      total: 3,
+                      noCache: 3,
+                      cacheRead: undefined,
+                      cacheWrite: undefined,
+                    },
+                    outputTokens: {
+                      total: 10,
+                      text: 10,
+                      reasoning: undefined,
+                    },
+                  },
+                  providerMetadata: {
+                    testProvider: { testKey: 'testValue' },
+                  },
+                },
+              ]),
+            };
+          },
+        });
+      });
+
+      it('should call onFinish from constructor', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: mockModel,
+          onFinish: async () => {
+            calls.push('constructor');
+          },
+        });
+
+        const result = await agent.stream({
+          prompt: 'Hello, world!',
+        });
+
+        await result.consumeStream();
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "constructor",
+          ]
+        `);
+      });
+
+      it('should call onFinish from stream method', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: mockModel,
+        });
+
+        const result = await agent.stream({
+          prompt: 'Hello, world!',
+          onFinish: async () => {
+            calls.push('method');
+          },
+        });
+
+        await result.consumeStream();
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "method",
+          ]
+        `);
+      });
+
+      it('should call both constructor and method onFinish in correct order', async () => {
+        const calls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: mockModel,
+          onFinish: async () => {
+            calls.push('constructor');
+          },
+        });
+
+        const result = await agent.stream({
+          prompt: 'Hello, world!',
+          onFinish: async () => {
+            calls.push('method');
+          },
+        });
+
+        await result.consumeStream();
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "constructor",
+            "method",
+          ]
+        `);
+      });
+    });
+  });
 });

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -9,6 +9,7 @@ import { ToolSet } from '../generate-text/tool-set';
 import { Prompt } from '../prompt';
 import { Agent, AgentCallParameters, AgentStreamParameters } from './agent';
 import {
+  ToolLoopAgentOnFinishCallback,
   ToolLoopAgentOnStepFinishCallback,
   ToolLoopAgentSettings,
 } from './tool-loop-agent-settings';
@@ -58,12 +59,15 @@ export class ToolLoopAgent<
   }): Promise<
     Omit<
       ToolLoopAgentSettings<CALL_OPTIONS, TOOLS, OUTPUT>,
-      'prepareCall' | 'instructions' | 'onStepFinish'
+      'prepareCall' | 'instructions' | 'onStepFinish' | 'onFinish'
     > &
       Prompt
   > {
-    const { onStepFinish: _settingsOnStepFinish, ...settingsWithoutCallback } =
-      this.settings;
+    const {
+      onStepFinish: _settingsOnStepFinish,
+      onFinish: _settingsOnFinish,
+      ...settingsWithoutCallback
+    } = this.settings;
     const baseCallArgs = {
       ...settingsWithoutCallback,
       stopWhen: this.settings.stopWhen ?? stepCountIs(20),
@@ -104,6 +108,21 @@ export class ToolLoopAgent<
     return methodCallback ?? constructorCallback;
   }
 
+  private mergeOnFinishCallbacks(
+    methodCallback: ToolLoopAgentOnFinishCallback<TOOLS> | undefined,
+  ): ToolLoopAgentOnFinishCallback<TOOLS> | undefined {
+    const constructorCallback = this.settings.onFinish;
+
+    if (methodCallback && constructorCallback) {
+      return async event => {
+        await constructorCallback(event);
+        await methodCallback(event);
+      };
+    }
+
+    return methodCallback ?? constructorCallback;
+  }
+
   /**
    * Generates an output from the agent (non-streaming).
    */
@@ -111,6 +130,7 @@ export class ToolLoopAgent<
     abortSignal,
     timeout,
     onStepFinish,
+    onFinish,
     ...options
   }: AgentCallParameters<CALL_OPTIONS, TOOLS>): Promise<
     GenerateTextResult<TOOLS, OUTPUT>
@@ -120,6 +140,7 @@ export class ToolLoopAgent<
       abortSignal,
       timeout,
       onStepFinish: this.mergeOnStepFinishCallbacks(onStepFinish),
+      onFinish: this.mergeOnFinishCallbacks(onFinish),
     });
   }
 
@@ -131,6 +152,7 @@ export class ToolLoopAgent<
     timeout,
     experimental_transform,
     onStepFinish,
+    onFinish,
     ...options
   }: AgentStreamParameters<CALL_OPTIONS, TOOLS>): Promise<
     StreamTextResult<TOOLS, OUTPUT>
@@ -141,6 +163,7 @@ export class ToolLoopAgent<
       timeout,
       experimental_transform,
       onStepFinish: this.mergeOnStepFinishCallbacks(onStepFinish),
+      onFinish: this.mergeOnFinishCallbacks(onFinish),
     });
   }
 }


### PR DESCRIPTION
## Summary

This fixes a v6 regression where `ToolLoopAgent` stopped forwarding `onFinish` to `generateText()` / `streamText()`.

As a result:
- constructor-level `onFinish` callbacks in `ToolLoopAgentSettings` no longer fired
- per-call `agent.generate({ onFinish })` / `agent.stream({ onFinish })` were no longer accepted in the agent call types

This PR:
- re-adds `onFinish` to `AgentCallParameters` and `AgentStreamParameters`
- restores `onFinish` forwarding in `ToolLoopAgent.generate()` and `stream()`
- merges constructor-level and per-call `onFinish` callbacks, invoking the constructor callback first to match `onStepFinish`
- adds runtime and type regression tests covering callback acceptance and invocation order

Fixes #14330.

## Manual Verification

- `pnpm --filter ai test:node src/agent/tool-loop-agent.test.ts`
- `pnpm --filter ai test:node src/agent/tool-loop-agent.test-d.ts`
- `pnpm type-check:full`
- `pnpm check`