### PR TITLE
feat (provider/anthropic): add support for inference_geo provider option

### DIFF
--- a/.changeset/red-colts-complain.md
+++ b/.changeset/red-colts-complain.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+feat (provider/anthropic): add support for inference_geo provider option

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -130,6 +130,10 @@ The following optional provider options are available for Anthropic models:
 
   Optional. See [Fast Mode section](#fast-mode) for more details.
 
+- `inferenceGeo` _"us" | "global"_
+
+  Optional. See [Data Residency section](#data-residency) for more details.
+
 - `thinking` _object_
 
   Optional. See [Reasoning section](#reasoning) for more details.
@@ -223,6 +227,27 @@ const { text } = await generateText({
 ```
 
 The `speed` option accepts `'fast'` or `'standard'` (default behavior).
+
+### Data Residency
+
+Anthropic supports an [`inferenceGeo` option](https://platform.claude.com/docs/en/build-with-claude/data-residency) that controls where model inference runs for a request.
+
+```ts highlight="8-10"
+import { anthropic, AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: anthropic('claude-opus-4-6'),
+  prompt: 'Summarize the key points of this document.',
+  providerOptions: {
+    anthropic: {
+      inferenceGeo: 'us',
+    } satisfies AnthropicLanguageModelOptions,
+  },
+});
+```
+
+The `inferenceGeo` option accepts `'us'` (US-only infrastructure) or `'global'` (default, any available geography).
 
 ### Reasoning
 

--- a/examples/ai-functions/src/generate-text/anthropic/inference-geo.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/inference-geo.ts
@@ -1,0 +1,23 @@
+import {
+  anthropic,
+  type AnthropicLanguageModelOptions,
+} from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+import { print } from '../../lib/print';
+
+run(async () => {
+  const result = await generateText({
+    model: anthropic('claude-opus-4-6'),
+    prompt: 'Summarize the key points of data residency.',
+    providerOptions: {
+      anthropic: {
+        inferenceGeo: 'us',
+      } satisfies AnthropicLanguageModelOptions,
+    },
+  });
+
+  print('Content:', result.content);
+  print('Usage:', result.usage);
+  print('Finish reason:', result.finishReason);
+});

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -4841,6 +4841,47 @@ describe('AnthropicMessagesLanguageModel', () => {
       expect(result.warnings).toStrictEqual([]);
     });
 
+    it('should set inference_geo in request body', async () => {
+      prepareJsonFixtureResponse('anthropic-text');
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            inferenceGeo: 'us',
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "inference_geo": "us",
+          "max_tokens": 4096,
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "claude-3-haiku-20240307",
+        }
+      `);
+      expect(await server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+        {
+          "anthropic-version": "2023-06-01",
+          "content-type": "application/json",
+          "x-api-key": "test-api-key",
+        }
+      `);
+
+      expect(result.warnings).toStrictEqual([]);
+    });
+
     it('should pass cache_control to request body', async () => {
       prepareJsonFixtureResponse('anthropic-text');
 

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -417,6 +417,9 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
       ...(anthropicOptions?.speed && {
         speed: anthropicOptions.speed,
       }),
+      ...(anthropicOptions?.inferenceGeo && {
+        inference_geo: anthropicOptions.inferenceGeo,
+      }),
       ...(anthropicOptions?.cacheControl && {
         cache_control: anthropicOptions.cacheControl,
       }),

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -198,6 +198,16 @@ export const anthropicLanguageModelOptions = z.object({
   speed: z.enum(['fast', 'standard']).optional(),
 
   /**
+   * Controls where model inference runs for this request.
+   *
+   * - `"global"`: Inference may run in any available geography (default).
+   * - `"us"`: Inference runs only in US-based infrastructure.
+   *
+   * See https://platform.claude.com/docs/en/build-with-claude/data-residency
+   */
+  inferenceGeo: z.enum(['us', 'global']).optional(),
+
+  /**
    * A set of beta features to enable.
    * Allow a provider to receive the full `betas` set if it needs it.
    */


### PR DESCRIPTION
## Background

Anthropic supports data residency controls through an `inference_geo` parameter that allows developers to specify where model inference should run for compliance and data governance requirements. See https://platform.claude.com/docs/en/build-with-claude/data-residency

## Changes

Added support for the `inferenceGeo` provider option to the Anthropic provider, allowing users to control where model inference runs by specifying either `'us'` (US-only infrastructure) or `'global'` (any available geography, default).

The implementation includes:

- New `inferenceGeo` option in `AnthropicLanguageModelOptions` with proper validation
- Request body mapping to Anthropic's `inference_geo` parameter
- Documentation with usage examples
- Test coverage for the new functionality
- Example implementation demonstrating the feature

## Manual Verification

Tested the feature by running the provided example with `inferenceGeo: 'us'` and verified that the parameter is correctly passed to Anthropic's API in the request body as `inference_geo`.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)