### PR TITLE
feat(workflow): export WorkflowChatTransport with stream reconnection support

### DIFF
--- a/.changeset/workflow-chat-transport.md
+++ b/.changeset/workflow-chat-transport.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Export `WorkflowChatTransport` with `initialStartIndex` support for resumable stream reconnection, including negative start index resolution via `x-workflow-stream-tail-index` header.

--- a/content/docs/03-agents/07-workflow-agent.mdx
+++ b/content/docs/03-agents/07-workflow-agent.mdx
@@ -194,6 +194,87 @@ return createUIMessageStreamResponse({
 });
 ```
 
+## Resumable Streaming with WorkflowChatTransport
+
+Workflow functions can time out or be interrupted by network failures. `WorkflowChatTransport` is a [`ChatTransport`](/docs/ai-sdk-ui/transport) implementation that handles these interruptions automatically — it detects when a stream ends without a `finish` event and reconnects to resume from where it left off.
+
+```tsx filename="app/page.tsx"
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { WorkflowChatTransport } from '@ai-sdk/workflow';
+import { useMemo } from 'react';
+
+export default function Chat() {
+  const transport = useMemo(
+    () =>
+      new WorkflowChatTransport({
+        api: '/api/chat',
+        maxConsecutiveErrors: 5,
+        initialStartIndex: -50, // On page refresh, fetch last 50 chunks
+      }),
+    [],
+  );
+
+  const { messages, sendMessage } = useChat({ transport });
+
+  // ... render chat UI
+}
+```
+
+The transport requires your POST endpoint to return an `x-workflow-run-id` response header, and a GET endpoint at `{api}/{runId}/stream` for reconnection:
+
+```ts filename="app/api/chat/route.ts"
+import { createModelCallToUIChunkTransform } from '@ai-sdk/workflow';
+import { createUIMessageStreamResponse, type UIMessage } from 'ai';
+import { start } from 'workflow/api';
+import { chat } from '@/workflow/agent-chat';
+
+export async function POST(request: Request) {
+  const { messages }: { messages: UIMessage[] } = await request.json();
+  const run = await start(chat, [messages]);
+
+  return createUIMessageStreamResponse({
+    stream: run.readable.pipeThrough(createModelCallToUIChunkTransform()),
+    headers: {
+      'x-workflow-run-id': run.runId,
+    },
+  });
+}
+```
+
+```ts filename="app/api/chat/[runId]/stream/route.ts"
+import { createModelCallToUIChunkTransform } from '@ai-sdk/workflow';
+import type { NextRequest } from 'next/server';
+import { getRun } from 'workflow/api';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> },
+) {
+  const { runId } = await params;
+  const startIndex = Number(
+    new URL(request.url).searchParams.get('startIndex') ?? '0',
+  );
+
+  const run = await getRun(runId);
+  const readable = run
+    .getReadable({ startIndex })
+    .pipeThrough(createModelCallToUIChunkTransform());
+
+  return new Response(readable, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'x-workflow-run-id': runId,
+    },
+  });
+}
+```
+
+For the full API reference, see [`WorkflowChatTransport`](/docs/reference/ai-sdk-workflow/workflow-chat-transport).
+
 ## Tools as Workflow Steps
 
 Mark tool execute functions with `'use step'` to make them durable workflow steps. This gives each tool call:
@@ -385,5 +466,6 @@ export type MyAgentUIMessage = InferWorkflowAgentUIMessage<typeof myAgent>;
 ## Next Steps
 
 - [WorkflowAgent API Reference](/docs/reference/ai-sdk-workflow/workflow-agent) for detailed parameter documentation
+- [WorkflowChatTransport API Reference](/docs/reference/ai-sdk-workflow/workflow-chat-transport) for stream reconnection options
 - [Building Agents](/docs/agents/building-agents) for the in-memory `ToolLoopAgent` alternative
 - [Loop Control](/docs/agents/loop-control) for advanced stop conditions

--- a/content/docs/04-ai-sdk-ui/21-transport.mdx
+++ b/content/docs/04-ai-sdk-ui/21-transport.mdx
@@ -156,6 +156,44 @@ const transport = new DirectChatTransport({
 
 For complete API details, see the [DirectChatTransport reference](/docs/reference/ai-sdk-ui/direct-chat-transport).
 
+## Workflow Transport
+
+For chat apps built on [Vercel Workflows](/docs/agents/workflow-agent), `WorkflowChatTransport` from `@ai-sdk/workflow` provides automatic stream reconnection. It handles the common scenario where a workflow function times out mid-stream — the transport detects the missing `finish` event and reconnects to resume from where it left off.
+
+```tsx
+import { useChat } from '@ai-sdk/react';
+import { WorkflowChatTransport } from '@ai-sdk/workflow';
+import { useMemo } from 'react';
+
+export default function Chat() {
+  const transport = useMemo(
+    () =>
+      new WorkflowChatTransport({
+        api: '/api/chat',
+        maxConsecutiveErrors: 5,
+        initialStartIndex: -50, // On page refresh, fetch last 50 chunks
+        onChatEnd: ({ chatId, chunkIndex }) => {
+          console.log(`Chat complete: ${chunkIndex} chunks`);
+        },
+      }),
+    [],
+  );
+
+  const { messages, sendMessage } = useChat({ transport });
+
+  // ... render chat UI
+}
+```
+
+Key features:
+
+- **Automatic reconnection**: Detects interrupted streams (no `finish` event) and reconnects via GET to `{api}/{runId}/stream`
+- **Page refresh recovery**: `initialStartIndex` with negative values (e.g., `-50`) fetches only the tail of the stream instead of replaying everything
+- **Configurable retries**: `maxConsecutiveErrors` controls how many consecutive reconnection failures to tolerate
+- **Lifecycle callbacks**: `onChatSendMessage` and `onChatEnd` for tracking chat state
+
+For the full API reference, see [`WorkflowChatTransport`](/docs/reference/ai-sdk-workflow/workflow-chat-transport). For server-side endpoint setup, see the [WorkflowAgent guide](/docs/agents/workflow-agent#resumable-streaming-with-workflowchattransport).
+
 ## Building Custom Transports
 
 To understand how to build your own transport, refer to the source code of the default implementation:

--- a/content/docs/07-reference/04-ai-sdk-workflow/02-workflow-chat-transport.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/02-workflow-chat-transport.mdx
@@ -1,0 +1,342 @@
+---
+title: WorkflowChatTransport
+description: API Reference for the WorkflowChatTransport class.
+---
+
+# `WorkflowChatTransport`
+
+A [`ChatTransport`](/docs/ai-sdk-ui/transport) implementation for [`useChat`](/docs/reference/ai-sdk-ui/use-chat) that enables automatic stream reconnection for workflow-based chat apps. It posts messages to a chat endpoint, extracts the `x-workflow-run-id` response header, and reconnects to a `/{runId}/stream` endpoint on interruption (network failures, page refreshes, function timeouts).
+
+Unlike [`DefaultChatTransport`](/docs/ai-sdk-ui/transport) which assumes the full response arrives in a single HTTP request, `WorkflowChatTransport` is designed for [Vercel Workflows](https://vercel.com/docs/workflow) where the initial response stream may be interrupted by function timeouts. The transport automatically detects missing `finish` events and reconnects to resume from where the stream left off.
+
+```tsx
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { WorkflowChatTransport } from '@ai-sdk/workflow';
+
+export default function Chat() {
+  const { messages, sendMessage } = useChat({
+    transport: new WorkflowChatTransport({
+      api: '/api/chat',
+      maxConsecutiveErrors: 5,
+      initialStartIndex: -50,
+    }),
+  });
+
+  // ... render chat UI
+}
+```
+
+## Import
+
+<Snippet text={`import { WorkflowChatTransport } from "@ai-sdk/workflow"`} prompt={false} />
+
+## Constructor
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'api',
+      type: 'string',
+      isOptional: true,
+      description:
+        "API endpoint for chat requests. The reconnection endpoint is derived from this as `{api}/{runId}/stream`. Default: '/api/chat'.",
+    },
+    {
+      name: 'fetch',
+      type: 'typeof fetch',
+      isOptional: true,
+      description:
+        'Custom fetch implementation to use for HTTP requests. Default: global fetch.',
+    },
+    {
+      name: 'maxConsecutiveErrors',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Maximum number of consecutive errors allowed during reconnection attempts before giving up. Default: 3.',
+    },
+    {
+      name: 'initialStartIndex',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Default chunk index to start from when reconnecting. Negative values read from the end of the stream (e.g., -50 fetches the last 50 chunks), useful for resuming after a page refresh without replaying the full conversation. Can be overridden per-call via reconnectToStream options. Default: 0.',
+    },
+    {
+      name: 'onChatSendMessage',
+      type: '(response: Response, options: SendMessagesOptions) => void | Promise<void>',
+      isOptional: true,
+      description:
+        'Callback invoked after the initial POST request succeeds. Useful for inspecting response headers (e.g., extracting workflow run ID) or tracking chat history on the client side.',
+    },
+    {
+      name: 'onChatEnd',
+      type: '({ chatId, chunkIndex }) => void | Promise<void>',
+      isOptional: true,
+      description:
+        'Callback invoked when the stream ends (receives a finish chunk). Receives the chat ID and total chunk count. Useful for cleanup or state updates.',
+    },
+    {
+      name: 'prepareSendMessagesRequest',
+      type: 'PrepareSendMessagesRequest',
+      isOptional: true,
+      description:
+        'Function to customize the POST request before sending. Can override the API endpoint, headers, credentials, and body.',
+    },
+    {
+      name: 'prepareReconnectToStreamRequest',
+      type: 'PrepareReconnectToStreamRequest',
+      isOptional: true,
+      description:
+        'Function to customize the reconnection GET request. Can override the API endpoint, headers, and credentials.',
+    },
+  ]}
+/>
+
+## Methods
+
+### `sendMessages()`
+
+Sends messages to the chat endpoint via POST and returns a streaming response. If the stream is interrupted (no `finish` event received), the transport automatically reconnects via GET to `{api}/{runId}/stream?startIndex={chunkIndex}` to resume from where it left off.
+
+The POST request includes the messages as JSON and expects the response to include an `x-workflow-run-id` header identifying the workflow run.
+
+```ts
+const stream = await transport.sendMessages({
+  chatId: 'chat-123',
+  trigger: 'submit-message',
+  messages: [...],
+  abortSignal: controller.signal,
+});
+```
+
+<PropertiesTable
+  content={[
+    {
+      name: 'chatId',
+      type: 'string',
+      description: 'Unique identifier for the chat session.',
+    },
+    {
+      name: 'trigger',
+      type: "'submit-message' | 'regenerate-message'",
+      description:
+        'The type of message submission.',
+    },
+    {
+      name: 'messageId',
+      type: 'string | undefined',
+      description:
+        'ID of the message to regenerate, or undefined for new messages.',
+    },
+    {
+      name: 'messages',
+      type: 'UIMessage[]',
+      description:
+        'Array of UI messages representing the conversation history.',
+    },
+    {
+      name: 'abortSignal',
+      type: 'AbortSignal | undefined',
+      description: 'Signal to abort the request. Propagated to both the initial POST and any reconnection GET requests.',
+    },
+  ]}
+/>
+
+#### Returns
+
+Returns a `Promise<ReadableStream<UIMessageChunk>>` that includes chunks from both the initial POST response and any automatic reconnection.
+
+### `reconnectToStream()`
+
+Reconnects to an existing chat stream that was previously interrupted. Useful for resuming after a page refresh or when the client needs to re-establish a connection.
+
+```ts
+const stream = await transport.reconnectToStream({
+  chatId: 'chat-123',
+  startIndex: -50, // Optional: fetch last 50 chunks
+});
+```
+
+<PropertiesTable
+  content={[
+    {
+      name: 'chatId',
+      type: 'string',
+      description: 'The chat ID to reconnect to. Used to construct the reconnection URL.',
+    },
+    {
+      name: 'abortSignal',
+      type: 'AbortSignal | undefined',
+      description: 'Signal to abort the reconnection request.',
+    },
+    {
+      name: 'startIndex',
+      type: 'number',
+      isOptional: true,
+      description: "Override the start index for this reconnection. Negative values read from the end of the stream. When omitted, falls back to the constructor's initialStartIndex.",
+    },
+  ]}
+/>
+
+#### Returns
+
+Returns a `Promise<ReadableStream<UIMessageChunk> | null>`.
+
+## How Reconnection Works
+
+The transport follows this flow:
+
+1. **POST** to `{api}` with messages. The response must include an `x-workflow-run-id` header.
+2. **Stream** the SSE response, counting chunks as they arrive.
+3. **Detect interruption**: If the stream closes without a `finish` event (e.g., function timeout, network error), the transport knows the response is incomplete.
+4. **Reconnect** via GET to `{api}/{runId}/stream?startIndex={chunkIndex}` to resume from the last received chunk.
+5. **Retry**: If the reconnection stream also interrupts, retry up to `maxConsecutiveErrors` times.
+6. **Complete**: Once a `finish` event is received, call `onChatEnd` and close the stream.
+
+### Negative Start Index
+
+When `initialStartIndex` is negative (e.g., `-50`), the transport sends it as-is in the first reconnection request. The server should resolve this to an absolute position and return the `x-workflow-stream-tail-index` response header so the transport can compute the correct position for subsequent retries.
+
+If the header is missing or invalid, the transport falls back to replaying from the beginning (`startIndex=0`).
+
+## Server Requirements
+
+For `WorkflowChatTransport` to work, your server must provide two endpoints:
+
+### POST `{api}` (e.g., `/api/chat`)
+
+- Accept messages as JSON body
+- Return an SSE stream of `UIMessageChunk` events
+- Include an `x-workflow-run-id` response header
+
+### GET `{api}/{runId}/stream` (e.g., `/api/chat/{runId}/stream`)
+
+- Accept a `startIndex` query parameter
+- Return the SSE stream starting from the given chunk index
+- For negative `startIndex`, resolve to the tail and include `x-workflow-stream-tail-index` response header
+
+See the [WorkflowAgent guide](/docs/agents/workflow-agent) for complete endpoint examples.
+
+## Examples
+
+### Basic Usage with useChat
+
+```tsx
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { WorkflowChatTransport } from '@ai-sdk/workflow';
+import { useMemo } from 'react';
+
+export default function Chat() {
+  const transport = useMemo(
+    () => new WorkflowChatTransport({ api: '/api/chat' }),
+    [],
+  );
+
+  const { messages, sendMessage, status } = useChat({ transport });
+
+  return (
+    <div>
+      {messages.map(message => (
+        <div key={message.id}>
+          {message.role === 'user' ? 'User: ' : 'AI: '}
+          {message.parts.map((part, index) =>
+            part.type === 'text' ? <span key={index}>{part.text}</span> : null,
+          )}
+        </div>
+      ))}
+      <button onClick={() => sendMessage({ text: 'Hello!' })}>Send</button>
+    </div>
+  );
+}
+```
+
+### With Callbacks and Page Refresh Recovery
+
+```tsx
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { WorkflowChatTransport } from '@ai-sdk/workflow';
+import { useMemo } from 'react';
+
+export default function Chat() {
+  const transport = useMemo(
+    () =>
+      new WorkflowChatTransport({
+        api: '/api/chat',
+        maxConsecutiveErrors: 5,
+        initialStartIndex: -50, // Resume from last 50 chunks on page refresh
+        onChatSendMessage: (response) => {
+          const runId = response.headers.get('x-workflow-run-id');
+          console.log('Workflow run started:', runId);
+        },
+        onChatEnd: ({ chatId, chunkIndex }) => {
+          console.log(`Chat ${chatId} complete, ${chunkIndex} chunks`);
+        },
+      }),
+    [],
+  );
+
+  const { messages, sendMessage } = useChat({ transport });
+
+  // ... render chat UI
+}
+```
+
+### Server-Side Endpoints (Next.js)
+
+```ts filename="app/api/chat/route.ts"
+import { createModelCallToUIChunkTransform } from '@ai-sdk/workflow';
+import { createUIMessageStreamResponse, type UIMessage } from 'ai';
+import { start } from 'workflow/api';
+import { chat } from '@/workflow/agent-chat';
+
+export async function POST(request: Request) {
+  const { messages }: { messages: UIMessage[] } = await request.json();
+  const run = await start(chat, [messages]);
+
+  return createUIMessageStreamResponse({
+    stream: run.readable.pipeThrough(createModelCallToUIChunkTransform()),
+    headers: {
+      'x-workflow-run-id': run.runId,
+    },
+  });
+}
+```
+
+```ts filename="app/api/chat/[runId]/stream/route.ts"
+import { createModelCallToUIChunkTransform } from '@ai-sdk/workflow';
+import type { NextRequest } from 'next/server';
+import { getRun } from 'workflow/api';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> },
+) {
+  const { runId } = await params;
+  const startIndex = Number(
+    new URL(request.url).searchParams.get('startIndex') ?? '0',
+  );
+
+  const run = await getRun(runId);
+  const readable = run
+    .getReadable({ startIndex })
+    .pipeThrough(createModelCallToUIChunkTransform());
+
+  return new Response(readable, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'x-workflow-run-id': runId,
+    },
+  });
+}
+```

--- a/content/docs/07-reference/04-ai-sdk-workflow/index.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/index.mdx
@@ -16,5 +16,11 @@ collapsed: true
         'Create durable AI agents with tool calling, streaming, and workflow integration.',
       href: '/docs/reference/ai-sdk-workflow/workflow-agent',
     },
+    {
+      title: 'WorkflowChatTransport',
+      description:
+        'Chat transport with automatic stream reconnection for workflow-based apps.',
+      href: '/docs/reference/ai-sdk-workflow/workflow-chat-transport',
+    },
   ]}
 />

--- a/examples/next-workflow/app/api/test-chat/[runId]/stream/route.ts
+++ b/examples/next-workflow/app/api/test-chat/[runId]/stream/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Test reconnection endpoint.
+ * Serves remaining chunks from a previously interrupted stream,
+ * starting from the given startIndex query parameter.
+ */
+import type { NextRequest } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> },
+) {
+  const { runId } = await params;
+  const startIndex = Number(
+    new URL(request.url).searchParams.get('startIndex') ?? '0',
+  );
+
+  const runs = (globalThis as any).__testRuns ?? {};
+  const allChunks = runs[runId];
+
+  if (!allChunks) {
+    return Response.json({ error: `Run ${runId} not found` }, { status: 404 });
+  }
+
+  // Resolve negative startIndex from the tail
+  const tailIndex = allChunks.length - 1;
+  const resolvedStart =
+    startIndex < 0 ? Math.max(0, allChunks.length + startIndex) : startIndex;
+  const remainingChunks = allChunks.slice(resolvedStart);
+
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const chunk of remainingChunks) {
+        controller.enqueue(
+          new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`),
+        );
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'x-workflow-run-id': runId,
+      'x-workflow-stream-tail-index': String(tailIndex),
+    },
+  });
+}

--- a/examples/next-workflow/app/api/test-chat/route.ts
+++ b/examples/next-workflow/app/api/test-chat/route.ts
@@ -1,0 +1,83 @@
+/**
+ * Test endpoint that simulates an interrupted stream.
+ * Sends a few SSE chunks but deliberately omits the "finish" event,
+ * forcing WorkflowChatTransport to reconnect via the GET stream endpoint.
+ */
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const runId = `test-run-${Date.now()}`;
+  const lastMessage = messages?.[messages.length - 1];
+  const userText =
+    lastMessage?.parts?.find((p: { type: string }) => p.type === 'text')
+      ?.text ??
+    lastMessage?.content ??
+    '';
+
+  // Store the run data in a global map so the reconnection endpoint can find it
+  const allChunks = buildResponseChunks(userText);
+  (globalThis as any).__testRuns = (globalThis as any).__testRuns ?? {};
+  (globalThis as any).__testRuns[runId] = allChunks;
+
+  // Only send a partial stream (first 2 chunks) to simulate interruption
+  const partialChunks = allChunks.slice(0, 2);
+
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const chunk of partialChunks) {
+        controller.enqueue(
+          new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`),
+        );
+      }
+      // Close WITHOUT sending "finish" — simulates a timeout/disconnect
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'x-workflow-run-id': runId,
+    },
+  });
+}
+
+function buildResponseChunks(userText: string) {
+  const textId = `text-${Date.now()}`;
+
+  return [
+    // Chunk 0: start of assistant message
+    {
+      type: 'start',
+      messageId: `msg-${Date.now()}`,
+    },
+    // Chunk 1: text-start (this is all the POST stream sends before "interruption")
+    {
+      type: 'text-start',
+      id: textId,
+    },
+    // Chunk 2: first text delta (reconnection picks up from here)
+    {
+      type: 'text-delta',
+      id: textId,
+      delta: `You asked: "${userText}". `,
+    },
+    // Chunk 3: second text delta
+    {
+      type: 'text-delta',
+      id: textId,
+      delta:
+        'This response was interrupted and recovered via WorkflowChatTransport reconnection!',
+    },
+    // Chunk 4: text-end
+    {
+      type: 'text-end',
+      id: textId,
+    },
+    // Chunk 5: finish
+    {
+      type: 'finish',
+    },
+  ];
+}

--- a/examples/next-workflow/app/page.tsx
+++ b/examples/next-workflow/app/page.tsx
@@ -1,11 +1,23 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
+import { WorkflowChatTransport } from '@ai-sdk/workflow';
 import { lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai';
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useMemo } from 'react';
 
 export default function Chat() {
+  const transport = useMemo(
+    () =>
+      new WorkflowChatTransport({
+        api: '/api/chat',
+        maxConsecutiveErrors: 5,
+        initialStartIndex: -50,
+      }),
+    [],
+  );
+
   const { status, sendMessage, messages, addToolApprovalResponse } = useChat({
+    transport,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
   });
   const messagesEndRef = useRef<HTMLDivElement>(null);

--- a/examples/next-workflow/app/test/page.tsx
+++ b/examples/next-workflow/app/test/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { WorkflowChatTransport } from '@ai-sdk/workflow';
+import { useRef, useEffect, useMemo, useState } from 'react';
+
+export default function TestChat() {
+  const [log, setLog] = useState<string[]>([]);
+
+  const addLog = (msg: string) => {
+    const ts = new Date().toISOString().split('T')[1].split('.')[0];
+    setLog(prev => [...prev, `[${ts}] ${msg}`]);
+  };
+
+  const transport = useMemo(
+    () =>
+      new WorkflowChatTransport({
+        api: '/api/test-chat',
+        maxConsecutiveErrors: 5,
+        initialStartIndex: -50,
+        onChatSendMessage: response => {
+          const runId = response.headers.get('x-workflow-run-id');
+          addLog(`POST response received, runId=${runId}`);
+        },
+        onChatEnd: ({ chatId, chunkIndex }) => {
+          addLog(`Chat ended: chatId=${chatId}, total chunks=${chunkIndex}`);
+        },
+      }),
+    [],
+  );
+
+  const { status, sendMessage, messages } = useChat({
+    transport,
+  });
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  useEffect(() => {
+    if (status === 'streaming') {
+      addLog('Status: streaming');
+    } else if (status === 'submitted') {
+      addLog('Status: submitted');
+    } else if (status === 'ready') {
+      addLog('Status: ready');
+    }
+  }, [status]);
+
+  return (
+    <div className="flex flex-col h-screen max-w-4xl mx-auto">
+      <header className="p-4 border-b">
+        <h1 className="text-lg font-semibold">
+          WorkflowChatTransport Test Page
+        </h1>
+        <p className="text-sm text-gray-500">
+          Tests stream interruption recovery. The POST endpoint sends a partial
+          stream (no finish event), forcing the transport to reconnect via GET.
+        </p>
+      </header>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Chat panel */}
+        <div className="flex-1 flex flex-col overflow-y-auto p-4 space-y-4">
+          {messages.length === 0 && (
+            <p className="text-gray-400 text-center mt-8">
+              Send a message to test stream interruption + reconnection
+            </p>
+          )}
+          {messages.map(message => (
+            <div
+              key={message.id}
+              className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
+            >
+              <div
+                className={`max-w-[80%] rounded-lg px-4 py-2 ${
+                  message.role === 'user'
+                    ? 'bg-blue-500 text-white'
+                    : 'bg-gray-100 text-gray-900'
+                }`}
+              >
+                {message.parts.map((part, index) => {
+                  if (part.type === 'text') {
+                    return (
+                      <div key={index} className="whitespace-pre-wrap">
+                        {part.text}
+                      </div>
+                    );
+                  }
+                  return null;
+                })}
+              </div>
+            </div>
+          ))}
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Log panel */}
+        <div className="w-80 border-l bg-gray-50 flex flex-col">
+          <div className="p-2 border-b bg-gray-100 font-mono text-xs font-semibold">
+            Transport Log
+          </div>
+          <div
+            id="log-panel"
+            className="flex-1 overflow-y-auto p-2 font-mono text-xs space-y-1"
+          >
+            {log.map((entry, i) => (
+              <div
+                key={i}
+                className={`${
+                  entry.includes('POST response')
+                    ? 'text-blue-600'
+                    : entry.includes('Chat ended')
+                      ? 'text-green-600'
+                      : entry.includes('error') || entry.includes('Error')
+                        ? 'text-red-600'
+                        : 'text-gray-600'
+                }`}
+              >
+                {entry}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <form
+        className="p-4 border-t flex gap-2"
+        onSubmit={e => {
+          e.preventDefault();
+          const input = e.currentTarget.elements.namedItem(
+            'message',
+          ) as HTMLInputElement;
+          if (input.value.trim()) {
+            addLog(`Sending: "${input.value}"`);
+            sendMessage({ text: input.value });
+            input.value = '';
+          }
+        }}
+      >
+        <input
+          name="message"
+          type="text"
+          placeholder="Type a message to test reconnection..."
+          className="flex-1 rounded-lg border border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          disabled={status === 'streaming' || status === 'submitted'}
+        />
+        <button
+          type="submit"
+          className="rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 disabled:opacity-50"
+          disabled={status === 'streaming' || status === 'submitted'}
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/packages/workflow/src/get-error-message.ts
+++ b/packages/workflow/src/get-error-message.ts
@@ -1,0 +1,24 @@
+/**
+ * Safely extract a human-readable message from an unknown error value.
+ *
+ * Avoids the `String(error)` pitfall that produces `"[object Object]"`
+ * when the thrown value is a plain object rather than an Error instance.
+ *
+ * Matches the behaviour of AI SDK's `getErrorMessage` from
+ * `@ai-sdk/provider-utils`.
+ */
+export function getErrorMessage(error: unknown): string {
+  if (error == null) {
+    return 'unknown error';
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return JSON.stringify(error);
+}

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -35,3 +35,10 @@ export {
 } from './to-ui-message-chunk.js';
 
 export type { ModelCallStreamPart } from './do-stream-step.js';
+
+export {
+  WorkflowChatTransport,
+  type WorkflowChatTransportOptions,
+  type SendMessagesOptions,
+  type ReconnectToStreamOptions,
+} from './workflow-chat-transport.js';

--- a/packages/workflow/src/workflow-chat-transport.test.ts
+++ b/packages/workflow/src/workflow-chat-transport.test.ts
@@ -1,0 +1,610 @@
+/**
+ * Tests for WorkflowChatTransport
+ *
+ * These tests focus on testing the transport's behavior through its options
+ * and callback functions rather than complex mocking.
+ */
+import type { UIMessage } from 'ai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WorkflowChatTransport } from './workflow-chat-transport.js';
+
+describe('WorkflowChatTransport', () => {
+  let mockFetch: ReturnType<typeof vi.fn> & typeof fetch;
+  let transport: WorkflowChatTransport<UIMessage>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn() as ReturnType<typeof vi.fn> & typeof fetch;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should use default fetch when not provided', () => {
+      const transport = new WorkflowChatTransport();
+      expect(transport).toBeDefined();
+    });
+
+    it('should use custom fetch when provided', () => {
+      const customFetch = vi.fn();
+      const transport = new WorkflowChatTransport({ fetch: customFetch });
+      expect(transport).toBeDefined();
+    });
+
+    it('should accept and store callback functions', () => {
+      const onChatSendMessage = vi.fn();
+      const onChatEnd = vi.fn();
+      const prepareSendMessagesRequest = vi.fn();
+      const prepareReconnectToStreamRequest = vi.fn();
+
+      const transport = new WorkflowChatTransport({
+        onChatSendMessage,
+        onChatEnd,
+        prepareSendMessagesRequest,
+        prepareReconnectToStreamRequest,
+      });
+
+      expect(transport).toBeDefined();
+    });
+
+    it('should use default maxConsecutiveErrors of 3', () => {
+      const transport = new WorkflowChatTransport();
+      expect(transport).toBeDefined();
+    });
+
+    it('should accept custom maxConsecutiveErrors', () => {
+      const transport = new WorkflowChatTransport({
+        maxConsecutiveErrors: 5,
+      });
+      expect(transport).toBeDefined();
+    });
+  });
+
+  describe('prepareSendMessagesRequest', () => {
+    it('should use custom API endpoint when provided', async () => {
+      const prepareSendMessagesRequest = vi.fn().mockResolvedValue({
+        api: '/custom/chat',
+        body: { custom: 'body' },
+      });
+
+      const transport = new WorkflowChatTransport({
+        fetch: mockFetch,
+        prepareSendMessagesRequest,
+      });
+
+      // Mock a successful response with simple stream
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ 'x-workflow-run-id': 'test-workflow-123' }),
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode('data: {"type":"finish"}\n\n'),
+            );
+            controller.close();
+          },
+        }),
+      });
+
+      const messages = [] as UIMessage[];
+
+      const stream = await transport.sendMessages({
+        trigger: 'submit-message',
+        chatId: 'test-chat',
+        messages,
+      });
+
+      // Consume the stream to ensure fetch is called
+      const reader = stream.getReader();
+      try {
+        while (true) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      expect(prepareSendMessagesRequest).toHaveBeenCalledWith({
+        id: 'test-chat',
+        messages,
+        requestMetadata: undefined,
+        body: undefined,
+        credentials: undefined,
+        headers: undefined,
+        api: '/api/chat',
+        trigger: 'submit-message',
+        messageId: undefined,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith('/custom/chat', {
+        method: 'POST',
+        body: JSON.stringify({ custom: 'body' }),
+        headers: undefined,
+        credentials: undefined,
+        signal: undefined,
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      transport = new WorkflowChatTransport({ fetch: mockFetch });
+    });
+
+    it('should handle response errors', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      const stream = await transport.sendMessages({
+        trigger: 'submit-message',
+        chatId: 'test-chat',
+        messages: [],
+      });
+
+      const reader = stream.getReader();
+      await expect(reader.read()).rejects.toThrow(
+        'Failed to fetch chat: 500 Internal Server Error',
+      );
+    });
+  });
+
+  describe('prepareReconnectToStreamRequest', () => {
+    it('should use custom reconnect endpoint', async () => {
+      const prepareReconnectToStreamRequest = vi.fn().mockResolvedValue({
+        api: '/custom/reconnect',
+        headers: { 'X-Custom': 'header' },
+      });
+
+      const transport = new WorkflowChatTransport({
+        fetch: mockFetch,
+        prepareReconnectToStreamRequest,
+      });
+
+      // Mock a successful response with simple stream
+      mockFetch.mockResolvedValue({
+        ok: true,
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode('data: {"type":"finish"}\n\n'),
+            );
+            controller.close();
+          },
+        }),
+      });
+
+      const stream = await transport.reconnectToStream({
+        chatId: 'test-chat',
+      });
+
+      // Consume the stream
+      const reader = stream!.getReader();
+      try {
+        while (true) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      expect(prepareReconnectToStreamRequest).toHaveBeenCalledWith({
+        id: 'test-chat',
+        requestMetadata: undefined,
+        body: undefined,
+        credentials: undefined,
+        headers: undefined,
+        api: '/api/chat/test-chat/stream',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith('/custom/reconnect?startIndex=0', {
+        headers: { 'X-Custom': 'header' },
+        credentials: undefined,
+        signal: undefined,
+      });
+    });
+  });
+
+  describe('abort signal propagation', () => {
+    it('should pass abortSignal to reconnect fetch calls', async () => {
+      const controller = new AbortController();
+
+      transport = new WorkflowChatTransport({ fetch: mockFetch });
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        body: new ReadableStream({
+          start(streamController) {
+            streamController.enqueue(
+              new TextEncoder().encode('data: {"type":"finish"}\n\n'),
+            );
+            streamController.close();
+          },
+        }),
+      });
+
+      const stream = await transport.reconnectToStream({
+        chatId: 'test-chat',
+        abortSignal: controller.signal,
+      });
+
+      const reader = stream!.getReader();
+      try {
+        while (true) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/chat/test-chat/stream?startIndex=0',
+        {
+          headers: undefined,
+          credentials: undefined,
+          signal: controller.signal,
+        },
+      );
+    });
+
+    it('should reuse abortSignal for reconnect fetch after sendMessages interruption', async () => {
+      const controller = new AbortController();
+
+      transport = new WorkflowChatTransport({ fetch: mockFetch });
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers({
+            'x-workflow-run-id': 'test-workflow-reconnect',
+          }),
+          body: new ReadableStream({
+            start(streamController) {
+              streamController.close();
+            },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          body: new ReadableStream({
+            start(streamController) {
+              streamController.enqueue(
+                new TextEncoder().encode('data: {"type":"finish"}\n\n'),
+              );
+              streamController.close();
+            },
+          }),
+        });
+
+      const stream = await transport.sendMessages({
+        trigger: 'submit-message',
+        chatId: 'test-chat',
+        messages: [],
+        abortSignal: controller.signal,
+      });
+
+      const reader = stream.getReader();
+      try {
+        while (true) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenNthCalledWith(1, '/api/chat', {
+        method: 'POST',
+        body: JSON.stringify({ messages: [] }),
+        headers: undefined,
+        credentials: undefined,
+        signal: controller.signal,
+      });
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        '/api/chat/test-workflow-reconnect/stream?startIndex=0',
+        {
+          headers: undefined,
+          credentials: undefined,
+          signal: controller.signal,
+        },
+      );
+    });
+  });
+
+  describe('negative initialStartIndex', () => {
+    function makeSSEStream(...events: string[]) {
+      return new ReadableStream({
+        start(controller) {
+          for (const event of events) {
+            controller.enqueue(new TextEncoder().encode(`data: ${event}\n\n`));
+          }
+          controller.close();
+        },
+      });
+    }
+
+    it('should resolve absolute chunkIndex from x-workflow-stream-tail-index header', async () => {
+      const transport = new WorkflowChatTransport({
+        fetch: mockFetch,
+        initialStartIndex: -20,
+      });
+
+      // First call: stream with tail-index header, closes immediately (simulating
+      // a timeout with no data) -> triggers retry at the resolved absolute position
+      // Second call: retry completes with finish
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers({
+            'x-workflow-stream-tail-index': '499',
+          }),
+          body: makeSSEStream(), // empty — simulates immediate disconnect
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers(),
+          body: makeSSEStream('{"type":"finish"}'),
+        });
+
+      const stream = await transport.reconnectToStream({
+        chatId: 'test-chat',
+      });
+
+      const reader = stream!.getReader();
+      while (!(await reader.read()).done) {}
+
+      // First call: negative startIndex
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        '/api/chat/test-chat/stream?startIndex=-20',
+        expect.any(Object),
+      );
+      // Second call: resolved absolute position = max(0, 499 + 1 + (-20)) = 480
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        '/api/chat/test-chat/stream?startIndex=480',
+        expect.any(Object),
+      );
+    });
+
+    it('should fall back to startIndex=0 when header is missing', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const transport = new WorkflowChatTransport({
+        fetch: mockFetch,
+        initialStartIndex: -10,
+      });
+
+      // First call: no tail-index header, closes immediately -> triggers retry
+      // Second call: retry should use startIndex=0
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers(),
+          body: makeSSEStream(), // empty — simulates immediate disconnect
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers(),
+          body: makeSSEStream('{"type":"finish"}'),
+        });
+
+      const stream = await transport.reconnectToStream({
+        chatId: 'test-chat',
+      });
+
+      const reader = stream!.getReader();
+      while (!(await reader.read()).done) {}
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Negative initialStartIndex is configured'),
+      );
+
+      // First call: negative startIndex
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        '/api/chat/test-chat/stream?startIndex=-10',
+        expect.any(Object),
+      );
+      // Second call: falls back to 0
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        '/api/chat/test-chat/stream?startIndex=0',
+        expect.any(Object),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('should fall back to startIndex=0 when header value is not a number', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const transport = new WorkflowChatTransport({
+        fetch: mockFetch,
+        initialStartIndex: -5,
+      });
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers({
+            'x-workflow-stream-tail-index': 'not-a-number',
+          }),
+          body: makeSSEStream(),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers(),
+          body: makeSSEStream('{"type":"finish"}'),
+        });
+
+      const stream = await transport.reconnectToStream({
+        chatId: 'test-chat',
+      });
+
+      const reader = stream!.getReader();
+      while (!(await reader.read()).done) {}
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('valid "x-workflow-stream-tail-index"'),
+      );
+
+      // Retry falls back to 0
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        '/api/chat/test-chat/stream?startIndex=0',
+        expect.any(Object),
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('reconnection error formatting', () => {
+    it('should format object errors with JSON instead of [object Object]', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const transport = new WorkflowChatTransport({
+        fetch: mockFetch,
+        maxConsecutiveErrors: 1,
+      });
+
+      // Return a stream that throws a plain-object error on parse
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers(),
+        body: new ReadableStream({
+          start(controller) {
+            // Send malformed data to trigger a parse error
+            controller.enqueue(
+              new TextEncoder().encode('data: INVALID_JSON\n\n'),
+            );
+            controller.close();
+          },
+        }),
+      });
+
+      const stream = await transport.reconnectToStream({
+        chatId: 'test-chat',
+      });
+
+      const reader = stream!.getReader();
+      await expect(reader.read()).rejects.toThrow(
+        /Failed to reconnect after 1 consecutive errors/,
+      );
+      // Crucially, the error message should never contain [object Object]
+      await expect(
+        reader.read().catch((e: Error) => e.message),
+      ).resolves.not.toContain?.('[object Object]');
+
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('callbacks', () => {
+    it('should call onChatSendMessage callback', async () => {
+      const onChatSendMessage = vi.fn();
+
+      transport = new WorkflowChatTransport({
+        fetch: mockFetch,
+        onChatSendMessage,
+      });
+
+      const mockResponse = {
+        ok: true,
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode('data: {"type":"finish"}\n\n'),
+            );
+            controller.close();
+          },
+        }),
+        headers: new Headers({
+          'x-request-id': '123',
+          'x-workflow-run-id': 'test-workflow-456',
+        }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const messages = [] as UIMessage[];
+      const options = {
+        trigger: 'submit-message' as const,
+        chatId: 'test-chat',
+        messages,
+      };
+
+      const stream = await transport.sendMessages(options);
+
+      // Consume the stream to ensure callbacks are called
+      const reader = stream.getReader();
+      try {
+        while (true) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      expect(onChatSendMessage).toHaveBeenCalledWith(mockResponse, options);
+    });
+
+    it('should call onChatEnd callback when stream ends', async () => {
+      const onChatEnd = vi.fn();
+
+      transport = new WorkflowChatTransport({
+        fetch: mockFetch,
+        onChatEnd,
+      });
+
+      // Mock a successful response with a finish chunk
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ 'x-workflow-run-id': 'test-workflow-789' }),
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode('data: {"type":"finish"}\n\n'),
+            );
+            controller.close();
+          },
+        }),
+      });
+
+      const stream = await transport.sendMessages({
+        trigger: 'submit-message',
+        chatId: 'test-chat',
+        messages: [],
+      });
+
+      // Consume the stream
+      const reader = stream.getReader();
+      try {
+        while (true) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      // Give some time for the callback to be called
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(onChatEnd).toHaveBeenCalledWith({
+        chatId: 'test-chat',
+        chunkIndex: expect.any(Number),
+      });
+    });
+  });
+});

--- a/packages/workflow/src/workflow-chat-transport.test.ts
+++ b/packages/workflow/src/workflow-chat-transport.test.ts
@@ -320,6 +320,60 @@ describe('WorkflowChatTransport', () => {
     });
   });
 
+  describe('positive initialStartIndex', () => {
+    function makeSSEStream(...events: string[]) {
+      return new ReadableStream({
+        start(controller) {
+          for (const event of events) {
+            controller.enqueue(new TextEncoder().encode(`data: ${event}\n\n`));
+          }
+          controller.close();
+        },
+      });
+    }
+
+    it('should adjust chunkIndex so retries resume from the correct position', async () => {
+      const transport = new WorkflowChatTransport({
+        fetch: mockFetch,
+        initialStartIndex: 100,
+      });
+
+      // First call: starts at 100, stream disconnects after delivering 0 chunks
+      // Second call: retry should resume from startIndex=100 (not 0)
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers(),
+          body: makeSSEStream(), // empty — simulates immediate disconnect
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers(),
+          body: makeSSEStream('{"type":"finish"}'),
+        });
+
+      const stream = await transport.reconnectToStream({
+        chatId: 'test-chat',
+      });
+
+      const reader = stream!.getReader();
+      while (!(await reader.read()).done) {}
+
+      // First call: positive startIndex
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        '/api/chat/test-chat/stream?startIndex=100',
+        expect.any(Object),
+      );
+      // Second call: chunkIndex was set to 100, so retry resumes from 100
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        '/api/chat/test-chat/stream?startIndex=100',
+        expect.any(Object),
+      );
+    });
+  });
+
   describe('negative initialStartIndex', () => {
     function makeSSEStream(...events: string[]) {
       return new ReadableStream({

--- a/packages/workflow/src/workflow-chat-transport.ts
+++ b/packages/workflow/src/workflow-chat-transport.ts
@@ -356,7 +356,12 @@ export class WorkflowChatTransport<
       // When using a negative startIndex, the server resolves it to an
       // absolute position. The reconnection endpoint should return the tail
       // index so we can compute the resolved position for subsequent retries.
-      if (useExplicitStartIndex && explicitStartIndex < 0) {
+      if (useExplicitStartIndex && explicitStartIndex > 0) {
+        // Positive startIndex: the first request starts at this absolute
+        // position, so set chunkIndex to match so subsequent retries
+        // resume from (explicitStartIndex + chunks received).
+        chunkIndex = explicitStartIndex;
+      } else if (useExplicitStartIndex && explicitStartIndex < 0) {
         const tailIndexHeader = res.headers.get('x-workflow-stream-tail-index');
         const tailIndex =
           tailIndexHeader !== null ? parseInt(tailIndexHeader, 10) : NaN;

--- a/packages/workflow/src/workflow-chat-transport.ts
+++ b/packages/workflow/src/workflow-chat-transport.ts
@@ -8,6 +8,7 @@ import {
   type UIMessageChunk,
   uiMessageChunkSchema,
 } from 'ai';
+import { getErrorMessage } from './get-error-message.js';
 import { iteratorToStream, streamToIterator } from './stream-iterator.js';
 
 export interface SendMessagesOptions<UI_MESSAGE extends UIMessage> {
@@ -21,6 +22,12 @@ export interface SendMessagesOptions<UI_MESSAGE extends UIMessage> {
 export interface ReconnectToStreamOptions {
   chatId: string;
   abortSignal?: AbortSignal;
+  /**
+   * Override the `startIndex` for this reconnection.
+   * Negative values read from the end of the stream.
+   * When omitted, falls back to the constructor's `initialStartIndex`.
+   */
+  startIndex?: number;
 }
 
 type OnChatSendMessage<UI_MESSAGE extends UIMessage> = (
@@ -80,6 +87,19 @@ export interface WorkflowChatTransportOptions<UI_MESSAGE extends UIMessage> {
   maxConsecutiveErrors?: number;
 
   /**
+   * Default `startIndex` to use when reconnecting to a stream without a known
+   * chunk position (i.e. the initial reconnection, not a retry).
+   * Negative values read from the end of the stream (e.g. `-10` fetches the
+   * last 10 chunks), which is useful for resuming a chat UI after a page
+   * refresh without replaying the full conversation.
+   *
+   * Can be overridden per-call via `ReconnectToStreamOptions.startIndex`.
+   *
+   * Defaults to `0` (replay from the beginning).
+   */
+  initialStartIndex?: number;
+
+  /**
    * Function to prepare the request for sending messages.
    * Allows customizing the API endpoint, headers, credentials, and body.
    */
@@ -113,6 +133,7 @@ export class WorkflowChatTransport<
   private readonly onChatSendMessage?: OnChatSendMessage<UI_MESSAGE>;
   private readonly onChatEnd?: OnChatEnd;
   private readonly maxConsecutiveErrors: number;
+  private readonly initialStartIndex: number;
   private readonly prepareSendMessagesRequest?: PrepareSendMessagesRequest<UI_MESSAGE>;
   private readonly prepareReconnectToStreamRequest?: PrepareReconnectToStreamRequest;
 
@@ -134,6 +155,7 @@ export class WorkflowChatTransport<
     this.onChatSendMessage = options.onChatSendMessage;
     this.onChatEnd = options.onChatEnd;
     this.maxConsecutiveErrors = options.maxConsecutiveErrors ?? 3;
+    this.initialStartIndex = options.initialStartIndex ?? 0;
     this.prepareSendMessagesRequest = options.prepareSendMessagesRequest;
     this.prepareReconnectToStreamRequest =
       options.prepareReconnectToStreamRequest;
@@ -278,6 +300,16 @@ export class WorkflowChatTransport<
   ): AsyncGenerator<UIMessageChunk> {
     let chunkIndex = initialChunkIndex;
 
+    // When called from the public reconnectToStream (initialChunkIndex === 0),
+    // honour the caller's startIndex (or the constructor default) for the
+    // first request. This enables negative values so the client can read only
+    // the tail of the stream (e.g. the last 10 chunks) instead of replaying
+    // everything. After the first request, fall back to the running chunkIndex
+    // so that retries resume from the correct position.
+    const explicitStartIndex = options.startIndex ?? this.initialStartIndex;
+    let useExplicitStartIndex =
+      initialChunkIndex === 0 && explicitStartIndex !== 0;
+
     const defaultApi = `${this.api}/${encodeURIComponent(workflowRunId ?? options.chatId)}/stream`;
 
     // Prepare the request using the configurator if provided
@@ -296,9 +328,19 @@ export class WorkflowChatTransport<
 
     let gotFinish = false;
     let consecutiveErrors = 0;
+    // When a negative startIndex is used but the tail-index header is absent,
+    // retries fall back to startIndex 0 (replay everything) instead of using
+    // the incremental chunkIndex which would be wrong.
+    let replayFromStart = false;
 
     while (!gotFinish) {
-      const url = `${baseUrl}?startIndex=${chunkIndex}`;
+      const startIndex = useExplicitStartIndex
+        ? explicitStartIndex
+        : replayFromStart
+          ? 0
+          : chunkIndex;
+
+      const url = `${baseUrl}?startIndex=${startIndex}`;
       const res = await this.fetch(url, {
         headers: requestConfig?.headers,
         credentials: requestConfig?.credentials,
@@ -310,6 +352,32 @@ export class WorkflowChatTransport<
           `Failed to fetch chat: ${res.status} ${await res.text()}`,
         );
       }
+
+      // When using a negative startIndex, the server resolves it to an
+      // absolute position. The reconnection endpoint should return the tail
+      // index so we can compute the resolved position for subsequent retries.
+      if (useExplicitStartIndex && explicitStartIndex < 0) {
+        const tailIndexHeader = res.headers.get('x-workflow-stream-tail-index');
+        const tailIndex =
+          tailIndexHeader !== null ? parseInt(tailIndexHeader, 10) : NaN;
+
+        if (!Number.isNaN(tailIndex)) {
+          // Resolve: e.g. tailIndex=499, startIndex=-20 → 500 + (-20) = 480
+          chunkIndex = Math.max(0, tailIndex + 1 + explicitStartIndex);
+        } else {
+          // Header missing or unparseable — fall back to replaying from the
+          // beginning so retries don't resume from a wrong position.
+          console.warn(
+            '[WorkflowChatTransport] Negative initialStartIndex is configured ' +
+              `(${explicitStartIndex}) but the reconnection endpoint did not ` +
+              'return a valid "x-workflow-stream-tail-index" header. Retries ' +
+              'will replay the stream from the beginning. See: ' +
+              'https://workflow.dev/docs/ai/resumable-streams#resuming-from-the-end-of-the-stream',
+          );
+          replayFromStart = true;
+        }
+      }
+      useExplicitStartIndex = false;
 
       try {
         const chunkStream = parseJsonEventStream({
@@ -337,7 +405,7 @@ export class WorkflowChatTransport<
 
         if (consecutiveErrors >= this.maxConsecutiveErrors) {
           throw new Error(
-            `Failed to reconnect after ${this.maxConsecutiveErrors} consecutive errors. Last error: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to reconnect after ${this.maxConsecutiveErrors} consecutive errors. Last error: ${getErrorMessage(error)}`,
           );
         }
       }


### PR DESCRIPTION
## Background

The `WorkflowChatTransport` class was implemented in `@ai-sdk/workflow` but not exported, making it unavailable to consumers. This transport is needed for `useChat` to enable automatic stream reconnection in workflow-based chat apps — handling network failures, page refreshes, and function timeouts by reconnecting to the workflow's stream endpoint.

Reference: [DurableChatTransport](https://useworkflow.dev/docs/api-reference/workflow-ai/workflow-chat-transport)

## Summary

- Export `WorkflowChatTransport` class and related types (`WorkflowChatTransportOptions`, `SendMessagesOptions`, `ReconnectToStreamOptions`) from `@ai-sdk/workflow`
- Add `initialStartIndex` option for resuming streams from the tail (negative values like `-50` fetch only the last 50 chunks, useful for page refresh recovery without replaying the full conversation)
- Implement `x-workflow-stream-tail-index` header resolution to compute absolute chunk positions from negative start indices, with graceful fallback to replay-from-start when the header is missing
- Fix positive `startIndex` reconnection: set `chunkIndex` to match the explicit start position so retries after disconnection resume correctly
- Add `startIndex` per-call override on `ReconnectToStreamOptions`
- Extract `getErrorMessage` utility for proper error formatting in reconnection failures (avoids `[object Object]` in error messages)
- Update `examples/next-workflow` main page to use `WorkflowChatTransport` with `useChat`
- Add `examples/next-workflow/test` page with mock API routes that simulate stream interruption and verify reconnection recovery end-to-end

## Documentation

- **API reference**: New `WorkflowChatTransport` reference page at `docs/reference/ai-sdk-workflow/workflow-chat-transport` with constructor parameters, methods, reconnection flow, server requirements, and examples
- **Workflow agent guide**: New "Resumable Streaming" section with client and server endpoint examples
- **Transport guide**: New "Workflow Transport" section linking to the reference
- **Workflow reference index**: Added `WorkflowChatTransport` card

## Manual Verification

1. Started `examples/next-workflow` dev server (`pnpm next dev`)
2. **Happy path** (`/`): Sent "What is the weather in San Francisco?" — WorkflowAgent called `getWeather` tool, responded with "86°F and windy". Sent "What is 42 * 17?" — called `calculate` tool, responded "714". Both messages used `WorkflowChatTransport`.
3. **Stream interruption + reconnection** (`/test`): The test page uses mock API routes where the POST endpoint sends only 2 of 6 SSE chunks (no `finish` event), simulating a function timeout. The transport detected the missing `finish` chunk, automatically reconnected via GET to `/api/test-chat/{runId}/stream?startIndex=2`, received the remaining chunks, and displayed the complete message. The transport log panel confirmed the full lifecycle:
   - `POST response received` (`onChatSendMessage` callback fired)
   - `Status: streaming` (partial stream consumed)
   - Auto-reconnect via GET (transparent to the user)
   - `Chat ended: total chunks=6` (`onChatEnd` callback fired)
   - `Status: ready`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Follow-up to #12165