### PR TITLE
fix: add experimental_onToolCallStart/Finish to AgentCallParameters type

### DIFF
--- a/.changeset/fix-agent-call-parameters-type.md
+++ b/.changeset/fix-agent-call-parameters-type.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Added missing `experimental_onToolCallStart` and `experimental_onToolCallFinish` callback properties to the `AgentCallParameters` type. These callbacks were already supported at runtime (flowing through the rest spread into `generateText`/`streamText`) but caused TypeScript errors when passed to `agent.generate()` or `agent.stream()`.

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -5,6 +5,10 @@ import { StreamTextTransform } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolSet } from '../generate-text/tool-set';
 import { TimeoutConfiguration } from '../prompt/call-settings';
+import type {
+  OnToolCallFinishEvent,
+  OnToolCallStartEvent,
+} from '../generate-text/callback-events';
 import type { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-settings';
 
 /**
@@ -56,6 +60,20 @@ export type AgentCallParameters<CALL_OPTIONS, TOOLS extends ToolSet = {}> = ([
      * Timeout in milliseconds. Can be specified as a number or as an object with `totalMs`.
      */
     timeout?: TimeoutConfiguration;
+
+    /**
+     * Callback that is called before each tool execution begins.
+     */
+    experimental_onToolCallStart?: (
+      event: OnToolCallStartEvent<TOOLS>,
+    ) => PromiseLike<void> | void;
+
+    /**
+     * Callback that is called after each tool execution completes.
+     */
+    experimental_onToolCallFinish?: (
+      event: OnToolCallFinishEvent<TOOLS>,
+    ) => PromiseLike<void> | void;
 
     /**
      * Callback that is called when each step (LLM call) is finished, including intermediate steps.

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -35,6 +35,23 @@ describe('ToolLoopAgent', () => {
   });
 
   describe('generate', () => {
+    it('should accept experimental_onToolCallStart and experimental_onToolCallFinish', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV3(),
+      });
+
+      // Should compile without error
+      await agent.generate({
+        prompt: 'Hello',
+        experimental_onToolCallStart: async ({ toolCall }) => {
+          toolCall;
+        },
+        experimental_onToolCallFinish: async ({ toolCall }) => {
+          toolCall;
+        },
+      });
+    });
+
     it('should not allow system prompt', async () => {
       const agent = new ToolLoopAgent({
         model: new MockLanguageModelV3(),


### PR DESCRIPTION
## Summary

- Added missing `experimental_onToolCallStart` and `experimental_onToolCallFinish` optional callback properties to the `AgentCallParameters` type
- Added type test confirming the callbacks are accepted by `agent.generate()`
- Added changeset

These callbacks already worked at runtime (flowing through the `...options` rest spread into `generateText`/`streamText`) but were missing from the TypeScript type, forcing consumers to use `as any`.

Fixes #14278

## Test plan

- [ ] Verify type test in `tool-loop-agent.test-d.ts` passes
- [ ] Confirm no new type errors introduced (existing pre-existing errors in v6 branch unaffected)