### PR TITLE
fix(ai): pass abortSignal to reconnectToStream so stop() works after resumeStream()

### DIFF
--- a/.changeset/reconnect-stream-abort-signal.md
+++ b/.changeset/reconnect-stream-abort-signal.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Pass `abortSignal` to `reconnectToStream` so that `stop()` works after `resumeStream()`

--- a/packages/ai/src/ui/chat-transport.ts
+++ b/packages/ai/src/ui/chat-transport.ts
@@ -78,6 +78,8 @@ export interface ChatTransport<UI_MESSAGE extends UIMessage> {
     options: {
       /** Unique identifier for the chat session to reconnect to */
       chatId: string;
+      /** Signal to abort the reconnected stream if needed */
+      abortSignal?: AbortSignal | undefined;
     } & ChatRequestOptions,
   ) => Promise<ReadableStream<UIMessageChunk> | null>;
 }

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -892,6 +892,92 @@ describe('Chat', () => {
     });
   });
 
+  describe('stop should abort a resumed stream', () => {
+    let chat: TestChat;
+    let letOnFinishArgs: any[] = [];
+    let receivedAbortSignal: AbortSignal | undefined;
+
+    beforeEach(async () => {
+      let controller: ReadableStreamDefaultController<UIMessageChunk>;
+      const responseStream = new ReadableStream<UIMessageChunk>({
+        start: controllerArg => {
+          controller = controllerArg;
+
+          controller.enqueue({ type: 'start' });
+          controller.enqueue({ type: 'start-step' });
+          controller.enqueue({ type: 'text-start', id: 'text-1' });
+          controller.enqueue({
+            type: 'text-delta',
+            id: 'text-1',
+            delta: 'Hello',
+          });
+        },
+      });
+
+      const finishPromise = createResolvablePromise<void>();
+      letOnFinishArgs = [];
+
+      chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport: {
+          sendMessages: async () => {
+            throw new Error('not implemented');
+          },
+          reconnectToStream: async options => {
+            receivedAbortSignal = options.abortSignal ?? undefined;
+
+            // Wire up the abort signal to error the stream,
+            // matching the pattern from the sendMessages stop test.
+            options.abortSignal?.addEventListener('abort', () => {
+              controller.error(
+                new DOMException('Aborted', 'AbortError'),
+              );
+            });
+
+            return responseStream;
+          },
+        },
+        onFinish: (...args) => {
+          letOnFinishArgs = args;
+          return finishPromise.resolve();
+        },
+      });
+
+      chat.resumeStream();
+
+      // wait until the stream is consumed before stopping
+      while ((chat.messages[0]?.parts[1] as any)?.text !== 'Hello') {
+        await delay();
+      }
+
+      await chat.stop();
+
+      await finishPromise.promise;
+    });
+
+    it('should pass abortSignal to reconnectToStream', () => {
+      expect(receivedAbortSignal).toBeInstanceOf(AbortSignal);
+      expect(receivedAbortSignal!.aborted).toBe(true);
+    });
+
+    it('should call onFinish with isAbort true', () => {
+      expect(letOnFinishArgs[0].isAbort).toBe(true);
+      expect(letOnFinishArgs[0].isDisconnect).toBe(false);
+      expect(letOnFinishArgs[0].isError).toBe(false);
+    });
+
+    it('should keep partial messages', () => {
+      expect(chat.messages).toHaveLength(1);
+      expect(chat.messages[0].role).toBe('assistant');
+      expect((chat.messages[0].parts[1] as any).text).toBe('Hello');
+    });
+
+    it('should have ready status', () => {
+      expect(chat.status).toBe('ready');
+    });
+  });
+
   it('should include the metadata of text message', async () => {
     server.urls['http://localhost:3000/api/chat'].response = {
       type: 'stream-chunks',

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -617,6 +617,11 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     trigger: 'submit-message' | 'resume-stream' | 'regenerate-message';
     messageId?: string;
   } & ChatRequestOptions) {
+    // Create the AbortController early so it can be passed to both
+    // reconnectToStream and sendMessages. This ensures that stop()
+    // can abort a resumed stream, not just a newly created one.
+    const abortController = new AbortController();
+
     // For resume-stream, check if there's an active stream before
     // changing status. This avoids a brief flash of 'submitted' status
     // when there is no stream to resume (e.g. on page load).
@@ -625,6 +630,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       try {
         const reconnect = await this.transport.reconnectToStream({
           chatId: this.id,
+          abortSignal: abortController.signal,
           metadata,
           headers,
           body,
@@ -658,7 +664,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           lastMessage: this.state.snapshot(lastMessage),
           messageId: this.generateId(),
         }),
-        abortController: new AbortController(),
+        abortController,
       } as ActiveResponse<UI_MESSAGE>;
 
       activeResponse.abortController.signal.addEventListener('abort', () => {

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -247,6 +247,7 @@ export abstract class HttpChatTransport<
       method: 'GET',
       headers,
       credentials,
+      signal: options.abortSignal ?? undefined,
     });
 
     // no active stream found, so we do not resume


### PR DESCRIPTION
## Background

When a user calls `resumeStream()` (e.g. to reconnect to an active chat after a page refresh), the `stop()` method has no effect. This is because the `AbortController` is created _after_ `reconnectToStream()` returns, so the abort signal is never connected to the resumed stream.

## Summary

- Create the `AbortController` before calling `reconnectToStream()` in `makeRequest`
- Add optional `abortSignal` parameter to the `ChatTransport.reconnectToStream` interface
- Pass the signal through in `HttpChatTransport.reconnectToStream` (to the `fetch` call)
- Add tests verifying `stop()` works correctly on resumed streams

## Checklist

- [x] Tests added (`stop should abort a resumed stream` — 4 test cases)
- [x] Patch changeset added
- [x] Self-reviewed