### PR TITLE
fix: use correct image field name for BFL Fill Pro inpainting

### DIFF
--- a/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
@@ -2,6 +2,7 @@ import { FetchFunction } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { describe, expect, it } from 'vitest';
 import { BlackForestLabsImageModel } from './black-forest-labs-image-model';
+import { BlackForestLabsImageModelId } from './black-forest-labs-image-settings';
 
 const prompt = 'A cute baby sea otter';
 
@@ -31,6 +32,14 @@ function createBasicModel({
   });
 }
 
+function createModelWithId(modelId: BlackForestLabsImageModelId) {
+  return new BlackForestLabsImageModel(modelId, {
+    provider: 'black-forest-labs.image',
+    baseURL: 'https://api.example.com/v1',
+    headers: () => ({ 'x-key': 'test-key' }),
+  });
+}
+
 describe('BlackForestLabsImageModel', () => {
   const server = createTestServer({
     'https://api.example.com/v1/test-model': {
@@ -38,6 +47,24 @@ describe('BlackForestLabsImageModel', () => {
         type: 'json-value',
         body: {
           id: 'req-123',
+          polling_url: 'https://api.example.com/poll',
+        },
+      },
+    },
+    'https://api.example.com/v1/flux-pro-1.0-fill': {
+      response: {
+        type: 'json-value',
+        body: {
+          id: 'req-fill-123',
+          polling_url: 'https://api.example.com/poll',
+        },
+      },
+    },
+    'https://api.example.com/v1/flux-pro-1.1': {
+      response: {
+        type: 'json-value',
+        body: {
+          id: 'req-img2img-123',
           polling_url: 'https://api.example.com/poll',
         },
       },
@@ -571,6 +598,153 @@ describe('BlackForestLabsImageModel', () => {
       expect(model.modelId).toBe('test-model');
       expect(model.specificationVersion).toBe('v4');
       expect(model.maxImagesPerCall).toBe(1);
+    });
+  });
+
+  describe('image field name mapping', () => {
+    it('sends "image" field for flux-pro-1.0-fill model (inpainting)', async () => {
+      const model = createModelWithId('flux-pro-1.0-fill');
+      const testImageBase64 = Buffer.from('test-image-data').toString('base64');
+
+      await model.doGenerate({
+        prompt,
+        files: [
+          {
+            type: 'base64',
+            data: testImageBase64,
+            mediaType: 'image/png',
+          },
+        ],
+        mask: {
+          type: 'base64',
+          data: Buffer.from('test-mask-data').toString('base64'),
+          mediaType: 'image/png',
+        },
+        n: 1,
+        size: undefined,
+        aspectRatio: '1:1',
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      // Fill model must use "image" not "input_image"
+      expect(requestBody).toHaveProperty('image');
+      expect(requestBody).not.toHaveProperty('input_image');
+      expect(requestBody.image).toBe(testImageBase64);
+      expect(requestBody).toHaveProperty('mask');
+    });
+
+    it('sends "input_image" field for flux-pro-1.1 model (img2img)', async () => {
+      const model = createModelWithId('flux-pro-1.1');
+      const testImageBase64 = Buffer.from('test-image-data').toString('base64');
+
+      await model.doGenerate({
+        prompt,
+        files: [
+          {
+            type: 'base64',
+            data: testImageBase64,
+            mediaType: 'image/png',
+          },
+        ],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: '1:1',
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      // Non-fill model must use "input_image"
+      expect(requestBody).toHaveProperty('input_image');
+      expect(requestBody).not.toHaveProperty('image');
+      expect(requestBody.input_image).toBe(testImageBase64);
+    });
+
+    it('sends "input_image" field for generic test-model', async () => {
+      const model = createBasicModel();
+      const testImageBase64 = Buffer.from('test-image-data').toString('base64');
+
+      await model.doGenerate({
+        prompt,
+        files: [
+          {
+            type: 'base64',
+            data: testImageBase64,
+            mediaType: 'image/png',
+          },
+        ],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: '1:1',
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).toHaveProperty('input_image');
+      expect(requestBody).not.toHaveProperty('image');
+    });
+
+    it('uses correct field suffixes for multiple images with fill model', async () => {
+      const model = createModelWithId('flux-pro-1.0-fill');
+      const img1 = Buffer.from('image-1').toString('base64');
+      const img2 = Buffer.from('image-2').toString('base64');
+      const img3 = Buffer.from('image-3').toString('base64');
+
+      await model.doGenerate({
+        prompt,
+        files: [
+          { type: 'base64', data: img1, mediaType: 'image/png' },
+          { type: 'base64', data: img2, mediaType: 'image/png' },
+          { type: 'base64', data: img3, mediaType: 'image/png' },
+        ],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: '1:1',
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      // Fill model: image, image_2, image_3
+      expect(requestBody).toHaveProperty('image', img1);
+      expect(requestBody).toHaveProperty('image_2', img2);
+      expect(requestBody).toHaveProperty('image_3', img3);
+      expect(requestBody).not.toHaveProperty('input_image');
+      expect(requestBody).not.toHaveProperty('input_image_2');
+      expect(requestBody).not.toHaveProperty('input_image_3');
+    });
+
+    it('uses correct field suffixes for multiple images with non-fill model', async () => {
+      const model = createModelWithId('flux-pro-1.1');
+      const img1 = Buffer.from('image-1').toString('base64');
+      const img2 = Buffer.from('image-2').toString('base64');
+
+      await model.doGenerate({
+        prompt,
+        files: [
+          { type: 'base64', data: img1, mediaType: 'image/png' },
+          { type: 'base64', data: img2, mediaType: 'image/png' },
+        ],
+        mask: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: '1:1',
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      // Non-fill model: input_image, input_image_2
+      expect(requestBody).toHaveProperty('input_image', img1);
+      expect(requestBody).toHaveProperty('input_image_2', img2);
+      expect(requestBody).not.toHaveProperty('image');
+      expect(requestBody).not.toHaveProperty('image_2');
     });
   });
 });

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.ts
@@ -125,10 +125,11 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
       throw new Error('Black Forest Labs supports up to 10 input images.');
     }
 
+    const imageFieldPrefix = getImageFieldPrefix(this.modelId);
     const inputImagesObj: Record<string, string> = inputImages.reduce<
       Record<string, string>
     >((acc, img, index) => {
-      acc[`input_image${index === 0 ? '' : `_${index + 1}`}`] = img;
+      acc[`${imageFieldPrefix}${index === 0 ? '' : `_${index + 1}`}`] = img;
       return acc;
     }, {});
 
@@ -394,6 +395,29 @@ export const blackForestLabsImageModelOptionsSchema = lazySchema(() =>
 export type BlackForestLabsImageModelOptions = InferSchema<
   typeof blackForestLabsImageModelOptionsSchema
 >;
+
+/**
+ * Models that use the BFL Fill API (e.g. `/flux-pro-1.0-fill`) expect the
+ * input image field to be named `image` instead of the default `input_image`
+ * used by other BFL models. This set tracks all known fill model IDs so the
+ * SDK sends the correct field name.
+ *
+ * @see https://docs.bfl.ml/api/fill – BFL Fill API reference
+ */
+const BFL_FILL_MODEL_IDS: ReadonlySet<string> = new Set(['flux-pro-1.0-fill']);
+
+/**
+ * Returns the correct image field prefix for a given BFL model.
+ *
+ * - Fill models (`flux-pro-1.0-fill`) → `"image"`
+ * - All other models → `"input_image"`
+ *
+ * The prefix is used to build keys like `image`, `image_2`, … or
+ * `input_image`, `input_image_2`, … depending on the model.
+ */
+function getImageFieldPrefix(modelId: string): string {
+  return BFL_FILL_MODEL_IDS.has(modelId) ? 'image' : 'input_image';
+}
 
 function convertSizeToAspectRatio(
   size: string,

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.ts
@@ -166,7 +166,7 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
       webhook_url: bflOptions?.webhookUrl,
     };
 
-    return { body, warnings };
+    return { body, warnings, bflOptions };
   }
 
   async doGenerate({
@@ -182,7 +182,7 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
   }: Parameters<ImageModelV4['doGenerate']>[0]): Promise<
     Awaited<ReturnType<ImageModelV4['doGenerate']>>
   > {
-    const { body, warnings } = await this.getArgs({
+    const { body, warnings, bflOptions } = await this.getArgs({
       prompt,
       files,
       mask,
@@ -194,12 +194,6 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
       headers,
       abortSignal,
     } as Parameters<ImageModelV4['doGenerate']>[0]);
-
-    const bflOptions = await parseProviderOptions({
-      provider: 'blackForestLabs',
-      providerOptions,
-      schema: blackForestLabsImageModelOptionsSchema,
-    });
 
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const combinedHeaders = combineHeaders(


### PR DESCRIPTION
## Summary

- Fix 422 Unprocessable Entity error when using `flux-pro-1.0-fill` for inpainting
- The BFL Fill API (`/flux-pro-1.0-fill`) expects `image` as the input image field name, but the SDK was sending `input_image` for all models
- Add `getImageFieldPrefix()` helper that returns the correct field name (`image` for fill models, `input_image` for all others)
- Add comprehensive tests covering fill vs non-fill models, single and multiple image inputs

Fixes #14351

## Root Cause

In `black-forest-labs-image-model.ts`, the `getArgs()` method hardcodes `input_image` as the field prefix for all models:

```typescript
acc[`input_image${index === 0 ? '' : `_${index + 1}`}`] = img;
```

However, the BFL Fill Pro endpoint (`/flux-pro-1.0-fill`) requires `image` instead of `input_image`. This causes the API to return:

```json
{"type": "missing", "loc": ["body", "image"], "msg": "Field required"}
```

## Fix

Added a `BFL_FILL_MODEL_IDS` set and `getImageFieldPrefix()` function that maps model IDs to their correct image field prefix:

- `flux-pro-1.0-fill` → `image` (fill models)
- All other models → `input_image` (default)

The set-based approach makes it easy to add future fill model variants.

## Test plan

- [x] Verify `flux-pro-1.0-fill` sends `image` field (not `input_image`)
- [x] Verify `flux-pro-1.1` continues to send `input_image` field
- [x] Verify generic models continue to send `input_image` field
- [x] Verify multiple images use correct suffixes for fill models (`image`, `image_2`, `image_3`)
- [x] Verify multiple images use correct suffixes for non-fill models (`input_image`, `input_image_2`)
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)