### PR TITLE
docs: update deprecated model IDs in examples

### DIFF
--- a/content/docs/03-ai-sdk-core/45-provider-management.mdx
+++ b/content/docs/03-ai-sdk-core/45-provider-management.mdx
@@ -100,7 +100,7 @@ import {
 
 export const myProvider = customProvider({
   languageModels: {
-    'text-medium': gateway('anthropic/claude-3-5-sonnet-20240620'),
+    'text-medium': gateway('anthropic/claude-sonnet-4-5-20250929'),
     'text-small': gateway('openai/gpt-5-mini'),
     'reasoning-medium': wrapLanguageModel({
       model: gateway('openai/gpt-5.1'),

--- a/content/providers/05-observability/langfuse.mdx
+++ b/content/providers/05-observability/langfuse.mdx
@@ -178,7 +178,7 @@ langfuse.trace({
 
 for (let i = 0; i < 3; i++) {
   const result = await generateText({
-    model: openai('gpt-3.5-turbo'),
+    model: openai('gpt-4o-mini'),
     maxOutputTokens: 50,
     prompt: 'Invent a new holiday and describe its traditions.',
     experimental_telemetry: {

--- a/content/providers/05-observability/maxim.mdx
+++ b/content/providers/05-observability/maxim.mdx
@@ -219,7 +219,7 @@ import { wrapMaximAISDKModel } from '@maximai/maxim-js/vercel-ai-sdk';
 // Wrap different provider models
 const openaiModel = wrapMaximAISDKModel(openai('gpt-5'), logger);
 const anthropicModel = wrapMaximAISDKModel(
-  anthropic('claude-3-5-sonnet-20241022'),
+  anthropic('claude-sonnet-4-5-20250929'),
   logger,
 );
 const googleModel = wrapMaximAISDKModel(google('gemini-pro'), logger);


### PR DESCRIPTION
## Summary
- Updated `gpt-3.5-turbo` to `gpt-4o-mini` in the Langfuse observability example
- Updated `claude-3-5-sonnet-20241022` to `claude-sonnet-4-5-20250929` in the Maxim observability example
- Updated `claude-3-5-sonnet-20240620` to `claude-sonnet-4-5-20250929` in the provider management example

These model IDs were deprecated in favor of the Claude 4.5 family and GPT-4o series. Keeping examples current helps developers avoid using older models and reduces confusion.

## Files Changed
- `content/providers/05-observability/langfuse.mdx`
- `content/providers/05-observability/maxim.mdx`
- `content/docs/03-ai-sdk-core/45-provider-management.mdx`