### PR TITLE
fix: default undefined tool-call input to empty object in convertToModelMessages

### DIFF
--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -206,7 +206,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                       part.state === 'output-error'
                         ? (part.input ??
                           ('rawInput' in part ? part.rawInput : undefined))
-                        : part.input,
+                        : (part.input ?? {}),
                     providerExecuted: part.providerExecuted,
                     ...(part.callProviderMetadata != null
                       ? { providerOptions: part.callProviderMetadata }


### PR DESCRIPTION
## Summary

Fixes #14349

When a tool UI part has `state: 'output-available'` but no `input` field (e.g. a tool with no parameters, or input not persisted to DB), `convertToModelMessages` produces a `tool-call` part with `input: undefined`. The OpenAI provider then serializes this without `arguments`, causing:

> Missing required parameter: 'input[N].arguments'

This breaks chat history replay permanently — once such a message is persisted, the conversation is stuck.

## Fix

Default `part.input` to `{}` when undefined in the non-error path (line 209):

```diff
- : part.input,
+ : (part.input ?? {}),
```

The `output-error` path already had a fallback chain (`part.input ?? rawInput ?? undefined`); this adds the same safety to the normal path.