### PR TITLE
fix(google): finalize streaming tool call when terminal chunk has partialArgs

### DIFF
--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -810,6 +810,16 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
                   part.functionCall.args == null &&
                   part.functionCall.partialArgs == null &&
                   part.functionCall.willContinue == null;
+                // Detect the final streaming chunk: has partialArgs but
+                // willContinue is absent (not explicitly true).  For array
+                // args the Vertex API omits the separate empty terminal
+                // chunk and instead sends the last data with no
+                // willContinue flag.
+                const isFinalStreamingChunk =
+                  part.functionCall.partialArgs != null &&
+                  part.functionCall.willContinue == null &&
+                  part.functionCall.name == null &&
+                  part.functionCall.args == null;
                 const isCompleteCall =
                   part.functionCall.name != null &&
                   part.functionCall.args != null &&
@@ -866,6 +876,40 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
                         id: active.toolCallId,
                         delta: textDelta,
                         providerMetadata: providerMeta,
+                      });
+                    }
+
+                    // If this is the final streaming chunk (no willContinue),
+                    // finalize the tool call immediately.  For array args the
+                    // Vertex API does not send a separate empty terminal chunk.
+                    if (isFinalStreamingChunk) {
+                      const finalized = activeStreamingToolCalls.pop()!;
+                      const { finalJSON, closingDelta } =
+                        finalized.accumulator.finalize();
+
+                      if (closingDelta.length > 0) {
+                        controller.enqueue({
+                          type: 'tool-input-delta',
+                          id: finalized.toolCallId,
+                          delta: closingDelta,
+                          providerMetadata: finalized.providerMetadata,
+                        });
+                      }
+
+                      controller.enqueue({
+                        type: 'tool-input-end',
+                        id: finalized.toolCallId,
+                        input: JSON.stringify(finalJSON),
+                        providerMetadata: finalized.providerMetadata,
+                      });
+
+                      controller.enqueue({
+                        type: 'tool-call',
+                        toolCallType: 'function',
+                        toolCallId: finalized.toolCallId,
+                        toolName: finalized.toolName,
+                        args: JSON.stringify(finalJSON),
+                        providerMetadata: finalized.providerMetadata,
                       });
                     }
                   }


### PR DESCRIPTION
## Summary

Fixes #14358

When using `streamFunctionCallArguments: true` with Vertex AI (Gemini), tool calls with **array-typed arguments** never produce `tool-call` events. The `tool-input-start` and `tool-input-delta` events fire correctly, but `tool-input-end` and `tool-call` are never emitted.

## Root Cause

The Vertex API's terminal streaming chunk for array args includes `partialArgs` but omits `willContinue` (instead of sending a separate empty terminal chunk):

```json
// Last chunk — has partialArgs but NO willContinue
{ "partialArgs": [{...}] }
```

The existing `isTerminalChunk` requires ALL of `name`, `args`, `partialArgs`, AND `willContinue` to be null:

```js
const isTerminalChunk =
  part.functionCall.name == null &&
  part.functionCall.args == null &&
  part.functionCall.partialArgs == null &&  // ← fails
  part.functionCall.willContinue == null;
```

This never matches because the last chunk still has `partialArgs`.

## Fix

Add `isFinalStreamingChunk` detection: a chunk with `partialArgs` present but `willContinue` absent. When detected, process the final `partialArgs` delta AND finalize the tool call (emit `tool-input-end` + `tool-call`) in one step.

Simple (non-array) args continue to work unchanged — they receive a separate empty terminal chunk.