### PR TITLE
fix(black-forest-labs): use correct image field name for flux-pro-1.0-fill

### DIFF
--- a/packages/black-forest-labs/src/black-forest-labs-image-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.ts
@@ -108,10 +108,14 @@ export class BlackForestLabsImageModel implements ImageModelV4 {
       throw new Error('Black Forest Labs supports up to 10 input images.');
     }
 
+    // The flux-pro-1.0-fill endpoint expects the image field to be named
+    // "image", while all other BFL models expect "input_image".
+    const imageFieldPrefix = this.modelId === 'flux-pro-1.0-fill' ? 'image' : 'input_image';
+
     const inputImagesObj: Record<string, string> = inputImages.reduce<
       Record<string, string>
     >((acc, img, index) => {
-      acc[`input_image${index === 0 ? '' : `_${index + 1}`}`] = img;
+      acc[`${imageFieldPrefix}${index === 0 ? '' : `_${index + 1}`}`] = img;
       return acc;
     }, {});
 


### PR DESCRIPTION
## Summary

Fixes #14351

The BFL Fill Pro API endpoint (`/flux-pro-1.0-fill`) expects the inpainting image field to be named `image`, but the SDK sends `input_image` (which is correct for other BFL models like `flux-pro-1.1` img2img). This causes a 422 error:

```json
{"type": "missing", "loc": ["body", "image"], "msg": "Field required"}
```

## Fix

Map the image field name based on `modelId`:
- `flux-pro-1.0-fill` → `image`
- All other models → `input_image` (unchanged)