### PR TITLE
fix(amazon-bedrock): resolve globalThis.fetch lazily to support telemetry and fetch patching

### DIFF
--- a/.changeset/bedrock-lazy-fetch.md
+++ b/.changeset/bedrock-lazy-fetch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Fix `createAmazonBedrock()` capturing `globalThis.fetch` at initialization time, which caused telemetry instrumentation (e.g. OpenTelemetry, Datadog) and other `globalThis.fetch` patches applied after provider creation to be silently ignored.

--- a/packages/amazon-bedrock/src/amazon-bedrock-sigv4-fetch.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-sigv4-fetch.test.ts
@@ -620,6 +620,35 @@ describe('createApiKeyFetchFunction', () => {
     }
   });
 
+  it('should resolve default fetch lazily when no custom fetch provided', async () => {
+    const originalFetch = globalThis.fetch;
+    const initialFetch = vi.fn().mockResolvedValue(new Response('Initial'));
+    const patchedFetch = vi.fn().mockResolvedValue(new Response('Patched'));
+
+    globalThis.fetch = initialFetch;
+    const fetchFn = createApiKeyFetchFunction('test-api-key-lazy');
+    globalThis.fetch = patchedFetch;
+
+    try {
+      await fetchFn('http://example.com', {
+        method: 'POST',
+        body: '{"test": "data"}',
+      });
+
+      expect(initialFetch).not.toHaveBeenCalled();
+      expect(patchedFetch).toHaveBeenCalledWith('http://example.com', {
+        method: 'POST',
+        body: '{"test": "data"}',
+        headers: {
+          Authorization: 'Bearer test-api-key-lazy',
+          'user-agent': 'ai-sdk/amazon-bedrock/0.0.0-test runtime/testenv',
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('should handle empty string API key', async () => {
     const dummyResponse = new Response('OK', { status: 200 });
     const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);

--- a/packages/amazon-bedrock/src/amazon-bedrock-sigv4-fetch.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-sigv4-fetch.ts
@@ -26,12 +26,14 @@ export function createSigV4FetchFunction(
   getCredentials: () =>
     | AmazonBedrockCredentials
     | PromiseLike<AmazonBedrockCredentials>,
-  fetch: FetchFunction = globalThis.fetch,
+  fetch?: FetchFunction,
 ): FetchFunction {
   return async (
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> => {
+    // avoid caching globalThis.fetch in case it is patched by other libraries
+    const effectiveFetch = fetch ?? globalThis.fetch;
     const request = input instanceof Request ? input : undefined;
     const originalHeaders = combineHeaders(
       normalizeHeaders(request?.headers),
@@ -53,7 +55,7 @@ export function createSigV4FetchFunction(
     const effectiveMethod = init?.method ?? request?.method;
 
     if (effectiveMethod?.toUpperCase() !== 'POST' || !effectiveBody) {
-      return fetch(input, {
+      return effectiveFetch(input, {
         ...init,
         headers: headersWithUserAgent as HeadersInit,
       });
@@ -86,7 +88,7 @@ export function createSigV4FetchFunction(
     // Use the combined headers directly as HeadersInit
     const combinedHeaders = combineHeaders(headersWithUserAgent, signedHeaders);
 
-    return fetch(input, {
+    return effectiveFetch(input, {
       ...init,
       body,
       headers: combinedHeaders as HeadersInit,
@@ -115,12 +117,14 @@ function prepareBodyString(body: BodyInit | undefined): string {
  */
 export function createApiKeyFetchFunction(
   apiKey: string,
-  fetch: FetchFunction = globalThis.fetch,
+  fetch?: FetchFunction,
 ): FetchFunction {
   return async (
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> => {
+    // avoid caching globalThis.fetch in case it is patched by other libraries
+    const effectiveFetch = fetch ?? globalThis.fetch;
     const originalHeaders = normalizeHeaders(init?.headers);
     const headersWithUserAgent = withUserAgentSuffix(
       originalHeaders,
@@ -132,7 +136,7 @@ export function createApiKeyFetchFunction(
       Authorization: `Bearer ${apiKey}`,
     });
 
-    return fetch(input, {
+    return effectiveFetch(input, {
       ...init,
       headers: finalHeaders as HeadersInit,
     });


### PR DESCRIPTION
## Background

`createAmazonBedrock()` calls either `createSigV4FetchFunction` or `createApiKeyFetchFunction` at provider initialization time. Both functions accepted the underlying fetch implementation via a default parameter:

\`\`\`ts
fetch: FetchFunction = globalThis.fetch
\`\`\`

JavaScript default parameters are evaluated at call time — meaning \`globalThis.fetch\` is read and captured the moment \`createAmazonBedrock()\` is called. Any patch to \`globalThis.fetch\` applied after that point is silently ignored for all Bedrock requests.

The most common real-world impact is **telemetry instrumentation** (e.g. OpenTelemetry, Datadog, custom tracing), which typically patches \`globalThis.fetch\` at startup to intercept outgoing HTTP requests. Because Bedrock snapshots fetch before those patches are applied, all Bedrock requests bypass instrumentation. Test setups that patch \`globalThis.fetch\` after imports are equally affected.

Every other provider in the SDK avoids this by deferring the \`globalThis.fetch\` lookup to request time. The comment in \`http-chat-transport.ts\` captures the intent explicitly: *"avoid caching globalThis.fetch in case it is patched by other libraries"*.

## Summary

This PR makes \`createSigV4FetchFunction\` and \`createApiKeyFetchFunction\` resolve \`globalThis.fetch\` lazily inside the returned closure instead of at function call time.

Changes included:
- Removed the \`= globalThis.fetch\` default parameter from both functions, making \`fetch\` optional
- Added \`const effectiveFetch = fetch ?? globalThis.fetch\` inside each returned closure, so the lookup happens at request time
- Added a patch changeset for \`@ai-sdk/amazon-bedrock\`

## Manual Verification

I manually verified by inspecting the call path from \`createAmazonBedrock()\` through to the SigV4 and API key fetch wrappers:

- confirmed the default parameter no longer captures \`globalThis.fetch\` at provider initialization
- confirmed each request-time closure now resolves \`globalThis.fetch\` fresh on every call, consistent with how \`post-to-api.ts\` and \`http-chat-transport.ts\` handle this

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run \`pnpm changeset\` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issue

Fixes: https://github.com/vercel/ai/issues/14364