### PR TITLE
fix(amazon-bedrock): resolve globalThis.fetch lazily to preserve telemetry patches

### DIFF
--- a/packages/amazon-bedrock/src/bedrock-sigv4-fetch.ts
+++ b/packages/amazon-bedrock/src/bedrock-sigv4-fetch.ts
@@ -24,12 +24,16 @@ export interface BedrockCredentials {
  */
 export function createSigV4FetchFunction(
   getCredentials: () => BedrockCredentials | PromiseLike<BedrockCredentials>,
-  fetch: FetchFunction = globalThis.fetch,
+  fetch?: FetchFunction,
 ): FetchFunction {
   return async (
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> => {
+    // Resolve fetch lazily to avoid caching globalThis.fetch at
+    // initialization time.  Telemetry libraries (OpenTelemetry, Datadog)
+    // and test frameworks often patch globalThis.fetch after imports.
+    const effectiveFetch = fetch ?? globalThis.fetch;
     const request = input instanceof Request ? input : undefined;
     const originalHeaders = combineHeaders(
       normalizeHeaders(request?.headers),
@@ -51,7 +55,7 @@ export function createSigV4FetchFunction(
     const effectiveMethod = init?.method ?? request?.method;
 
     if (effectiveMethod?.toUpperCase() !== 'POST' || !effectiveBody) {
-      return fetch(input, {
+      return effectiveFetch(input, {
         ...init,
         headers: headersWithUserAgent as HeadersInit,
       });
@@ -84,7 +88,7 @@ export function createSigV4FetchFunction(
     // Use the combined headers directly as HeadersInit
     const combinedHeaders = combineHeaders(headersWithUserAgent, signedHeaders);
 
-    return fetch(input, {
+    return effectiveFetch(input, {
       ...init,
       body,
       headers: combinedHeaders as HeadersInit,
@@ -113,12 +117,14 @@ function prepareBodyString(body: BodyInit | undefined): string {
  */
 export function createApiKeyFetchFunction(
   apiKey: string,
-  fetch: FetchFunction = globalThis.fetch,
+  fetch?: FetchFunction,
 ): FetchFunction {
   return async (
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> => {
+    // Resolve fetch lazily — see createSigV4FetchFunction for rationale.
+    const effectiveFetch = fetch ?? globalThis.fetch;
     const originalHeaders = normalizeHeaders(init?.headers);
     const headersWithUserAgent = withUserAgentSuffix(
       originalHeaders,
@@ -130,7 +136,7 @@ export function createApiKeyFetchFunction(
       Authorization: `Bearer ${apiKey}`,
     });
 
-    return fetch(input, {
+    return effectiveFetch(input, {
       ...init,
       headers: finalHeaders as HeadersInit,
     });


### PR DESCRIPTION
## Summary

Fixes #14364

`createSigV4FetchFunction` and `createApiKeyFetchFunction` both capture `globalThis.fetch` via a JS default parameter, evaluated at provider initialization time:

```ts
fetch: FetchFunction = globalThis.fetch  // captured once, at init
```

Any patch applied after initialization (OpenTelemetry, Datadog, test frameworks) is silently ignored. All Bedrock requests bypass telemetry instrumentation.

## Fix

Change both functions to accept an optional `fetch?` parameter and resolve `globalThis.fetch` lazily inside the returned closure:

```ts
const effectiveFetch = fetch ?? globalThis.fetch;  // resolved per-request
```

This matches the pattern used in `http-chat-transport.ts` (which carries the comment *"avoid caching globalThis.fetch in case it is patched by other libraries"*).

## Changes

- `createSigV4FetchFunction`: `fetch: FetchFunction = globalThis.fetch` → `fetch?: FetchFunction` + lazy resolve (2 call sites)
- `createApiKeyFetchFunction`: same pattern (1 call site)