### PR TITLE
fix(ai): default missing tool-call input to {} in convertToModelMessages

### DIFF
--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -205,8 +205,9 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                     input:
                       part.state === 'output-error'
                         ? (part.input ??
-                          ('rawInput' in part ? part.rawInput : undefined))
-                        : part.input,
+                          ('rawInput' in part ? part.rawInput : undefined) ??
+                          {})
+                        : (part.input ?? {}),
                     providerExecuted: part.providerExecuted,
                     ...(part.callProviderMetadata != null
                       ? { providerOptions: part.callProviderMetadata }


### PR DESCRIPTION
## Summary

Fixes #14349

When a UI tool part has `state: 'output-available'` but no `input` field (e.g. a tool that takes no parameters, or whose input wasn't persisted), `convertToModelMessages` produces a `tool-call` ModelMessage part without `input`. The OpenAI provider then sends this without `arguments`, and OpenAI rejects with:

> Missing required parameter: 'input[N].arguments'

This breaks chat history replay — once such a message is persisted and replayed, the conversation is permanently stuck.

## Fix

Default missing `input` to `{}` in both the normal and `output-error` branches of tool-call construction, so providers always receive a valid arguments object.

```ts
// Before
: part.input,                    // undefined when input is missing

// After
: (part.input ?? {}),            // always a valid object
```