### PR TITLE
fix(ai): filter prototype-polluting keys in mergeObjects

### DIFF
--- a/packages/ai/src/util/merge-objects.ts
+++ b/packages/ai/src/util/merge-objects.ts
@@ -33,9 +33,14 @@ export function mergeObjects<T extends object, U extends object>(
   // Create a new object to avoid mutating the inputs
   const result = { ...base } as T & U;
 
+  // Dangerous keys that could lead to prototype pollution
+  const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
   // Iterate through all keys in the source object
   for (const key in overrides) {
     if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+      // Skip keys that could cause prototype pollution
+      if (UNSAFE_KEYS.has(key)) continue;
       const overridesValue = overrides[key];
 
       // Skip if the overrides value is undefined


### PR DESCRIPTION
## Summary

Partial fix for #14309

`mergeObjects` performs deep merge without filtering `__proto__`, `constructor`, or `prototype` keys. Since `mergeObjects` is called from `process-ui-message-stream.ts` where `messageMetadata` from SSE chunks is merged, a crafted SSE response could achieve prototype pollution.

## Fix

Add an `UNSAFE_KEYS` set check to skip `__proto__`, `constructor`, and `prototype` during the merge loop:

```ts
const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);

for (const key in overrides) {
  if (Object.prototype.hasOwnProperty.call(overrides, key)) {
    if (UNSAFE_KEYS.has(key)) continue;  // ← new guard
    // ... existing merge logic
  }
}
```

## Scope

This PR addresses vector #2 (mergeObjects) from the issue. Vector #1 (MCP transports using raw `JSON.parse`) would require exporting `secureJsonParse` from `@ai-sdk/provider-utils` or duplicating it — best addressed separately.