### PR TITLE
docs: add Hashlock community provider

### DIFF
--- a/content/providers/03-community-providers/52-hashlock.mdx
+++ b/content/providers/03-community-providers/52-hashlock.mdx
@@ -5,7 +5,7 @@ description: Learn how to use the Hashlock tool provider for the AI SDK.
 
 # Hashlock Provider
 
-The [Hashlock](https://hashlock.ai) provider is a community-maintained tool provider for the AI SDK that enables AI agents to swap any asset — crypto, RWA, and stablecoins — using private sealed bids and verified counterparties.
+The [Hashlock](https://hashlock.markets) provider is a community-maintained tool provider for the AI SDK that enables AI agents to swap any asset — crypto, RWA, and stablecoins — using private sealed bids and verified counterparties.
 
 Unlike traditional DEX integrations that expose trades to front-running, Hashlock uses an intent-based architecture where counterparties submit sealed bids, ensuring best execution without MEV extraction.
 
@@ -36,7 +36,7 @@ To use Hashlock tools, import the `hashlockTools` function:
 import { hashlockTools } from 'hashlock-ai-sdk';
 
 const tools = hashlockTools({
-  baseUrl: 'https://api.hashlock.ai', // optional, defaults to https://api.hashlock.ai
+  baseUrl: 'https://api.hashlock.markets', // optional, defaults to https://api.hashlock.markets
 });
 ```
 
@@ -102,7 +102,7 @@ Hashlock is also available as an [MCP server](https://www.npmjs.com/package/hash
 
 ## References
 
-- [Hashlock Website](https://hashlock.ai)
+- [Hashlock Website](https://hashlock.markets)
 - [GitHub: hashlock-ai-sdk](https://github.com/Hashlock-Tech/hashlock-ai-sdk)
 - [npm: hashlock-ai-sdk](https://www.npmjs.com/package/hashlock-ai-sdk)
 - [MCP Registry](https://registry.modelcontextprotocol.io)

--- a/content/providers/03-community-providers/52-hashlock.mdx
+++ b/content/providers/03-community-providers/52-hashlock.mdx
@@ -1,0 +1,108 @@
+---
+title: Hashlock
+description: Learn how to use the Hashlock tool provider for the AI SDK.
+---
+
+# Hashlock Provider
+
+The [Hashlock](https://hashlock.ai) provider is a community-maintained tool provider for the AI SDK that enables AI agents to swap any asset — crypto, RWA, and stablecoins — using private sealed bids and verified counterparties.
+
+Unlike traditional DEX integrations that expose trades to front-running, Hashlock uses an intent-based architecture where counterparties submit sealed bids, ensuring best execution without MEV extraction.
+
+## Setup
+
+The Hashlock provider is available via the `hashlock-ai-sdk` module. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add hashlock-ai-sdk" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install hashlock-ai-sdk" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add hashlock-ai-sdk" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add hashlock-ai-sdk" dark />
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+To use Hashlock tools, import the `hashlockTools` function:
+
+```ts
+import { hashlockTools } from 'hashlock-ai-sdk';
+
+const tools = hashlockTools({
+  baseUrl: 'https://api.hashlock.ai', // optional, defaults to https://api.hashlock.ai
+});
+```
+
+## Available Tools
+
+The provider includes the following tools that AI agents can use:
+
+| Tool | Description |
+| --- | --- |
+| `create_intent` | Create a new swap intent (e.g. "swap 1 ETH for USDC on Arbitrum") |
+| `validate_intent` | Validate an intent before submission |
+| `commit_intent` | Submit a validated intent to the Hashlock network |
+| `explain_intent` | Get a human-readable explanation of an intent |
+| `parse_natural_language` | Parse natural language into a structured intent |
+
+## Example: Generate Text with Tools
+
+Use Hashlock tools with `generateText` to let an AI agent execute swaps:
+
+```ts
+import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { hashlockTools } from 'hashlock-ai-sdk';
+
+const { text } = await generateText({
+  model: openai('gpt-4o'),
+  tools: hashlockTools(),
+  maxSteps: 5,
+  prompt: 'Swap 1 ETH for USDC on Arbitrum',
+});
+```
+
+## Example: Streaming with Tools
+
+```ts
+import { streamText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { hashlockTools } from 'hashlock-ai-sdk';
+
+const result = streamText({
+  model: openai('gpt-4o'),
+  tools: hashlockTools(),
+  maxSteps: 5,
+  prompt: 'Parse this trade: sell 500 USDC for ETH on mainnet',
+});
+
+for await (const part of result.textStream) {
+  process.stdout.write(part);
+}
+```
+
+## Key Features
+
+- **Sealed-Bid Execution** — Trades are not visible on-chain until settled, preventing front-running and MEV extraction.
+- **Cross-Chain Support** — Swap assets across Ethereum, Arbitrum, Base, and other supported networks.
+- **RWA & Stablecoin Support** — Trade real-world assets and stablecoins alongside crypto.
+- **Intent Architecture** — Agents describe what they want; Hashlock finds the best counterparty.
+- **No Slippage** — Sealed bids mean the price you agree to is the price you get.
+
+## MCP Server
+
+Hashlock is also available as an [MCP server](https://www.npmjs.com/package/hashlock-mcp-server) for use with Claude, Cursor, and other MCP-compatible AI tools.
+
+## References
+
+- [Hashlock Website](https://hashlock.ai)
+- [GitHub: hashlock-ai-sdk](https://github.com/Hashlock-Tech/hashlock-ai-sdk)
+- [npm: hashlock-ai-sdk](https://www.npmjs.com/package/hashlock-ai-sdk)
+- [MCP Registry](https://registry.modelcontextprotocol.io)


### PR DESCRIPTION
Added documentation for the Hashlock tool provider, including setup instructions, available tools, and examples for usage.

## Background

Hashlock is an intent-based trading protocol that enables AI agents to swap any asset — crypto, RWA, and stablecoins — using private sealed bids and verified counterparties. This PR adds Hashlock as a community provider to the AI SDK documentation.

## Summary

Adds `content/providers/03-community-providers/52-hashlock.mdx` with:

- Overview of the Hashlock tool provider
- Setup and installation instructions (pnpm/npm/yarn/bun)
- Provider instance usage with `hashlockTools()`
- Available tools table (create_intent, validate_intent, commit_intent, explain_intent, parse_natural_language)
- Code examples for `generateText` and `streamText` with tools
- Key features (sealed-bid execution, cross-chain, RWA support)
- Links to npm package, GitHub repo, and MCP server

## Verification

- npm package: [hashlock-ai-sdk](https://www.npmjs.com/package/hashlock-ai-sdk)
- GitHub: [Hashlock-Tech/hashlock-ai-sdk](https://github.com/Hashlock-Tech/hashlock-ai-sdk)
- Website: [hashlock.markets](https://hashlock.markets)

## Additional context

Hashlock is also available as an MCP server on the [Model Context Protocol Registry](https://registry.modelcontextprotocol.io) and as a [LangChain integration](https://pypi.org/project/langchain-hashlock/).