### PR TITLE
fix: prevent prototype pollution in MCP transports and mergeObjects

### DIFF
--- a/.changeset/fix-prototype-pollution.md
+++ b/.changeset/fix-prototype-pollution.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/mcp": patch
+"ai": patch
+---
+
+fix(security): prevent prototype pollution in MCP transports and mergeObjects

--- a/packages/ai/src/util/merge-objects.test.ts
+++ b/packages/ai/src/util/merge-objects.test.ts
@@ -116,3 +116,50 @@ describe('mergeObjects', () => {
     expect(mergeObjects(undefined, { b: 2 })).toEqual({ b: 2 });
   });
 });
+
+describe('mergeObjects prototype pollution protection', () => {
+  it('should not allow __proto__ key', () => {
+    const base = { a: 1 };
+    const overrides = JSON.parse('{"__proto__": {"polluted": true}}');
+    const result = mergeObjects(base, overrides);
+
+    expect(result).toEqual({ a: 1 });
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('should not allow constructor key', () => {
+    const base = { a: 1 };
+    const overrides = JSON.parse('{"constructor": {"prototype": {"polluted": true}}}');
+    const result = mergeObjects(base, overrides);
+
+    expect(result).toEqual({ a: 1 });
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('should not allow prototype key', () => {
+    const base = { a: 1 };
+    const overrides = JSON.parse('{"prototype": {"polluted": true}}');
+    const result = mergeObjects(base, overrides);
+
+    expect(result).toEqual({ a: 1 });
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('should filter dangerous keys in nested merges', () => {
+    const base = { a: { b: 1 } };
+    const overrides = { a: JSON.parse('{"__proto__": {"polluted": true}, "c": 2}') };
+    const result = mergeObjects(base, overrides);
+
+    expect(result).toEqual({ a: { b: 1, c: 2 } });
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('should still merge normal keys alongside filtered keys', () => {
+    const base = { x: 1 };
+    const overrides = JSON.parse('{"__proto__": {"bad": true}, "y": 2}');
+    const result = mergeObjects(base, overrides);
+
+    expect(result).toEqual({ x: 1, y: 2 });
+    expect(({} as any).bad).toBeUndefined();
+  });
+});

--- a/packages/ai/src/util/merge-objects.ts
+++ b/packages/ai/src/util/merge-objects.ts
@@ -36,6 +36,8 @@ export function mergeObjects<T extends object, U extends object>(
   // Iterate through all keys in the source object
   for (const key in overrides) {
     if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+      // Skip prototype pollution keys
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
       const overridesValue = overrides[key];
 
       // Skip if the overrides value is undefined

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -3,6 +3,7 @@ import {
   FetchFunction,
   withUserAgentSuffix,
   getRuntimeEnvironmentUserAgent,
+  secureJsonParse,
 } from '@ai-sdk/provider-utils';
 import { MCPClientError } from '../error/mcp-client-error';
 import { JSONRPCMessage, JSONRPCMessageSchema } from './json-rpc-message';
@@ -238,7 +239,7 @@ export class HttpMCPTransport implements MCPTransport {
                 const { event, data } = value;
                 if (event === 'message') {
                   try {
-                    const msg = JSONRPCMessageSchema.parse(JSON.parse(data));
+                    const msg = JSONRPCMessageSchema.parse(secureJsonParse(data));
                     this.onmessage?.(msg);
                   } catch (error) {
                     const e = new MCPClientError({
@@ -386,7 +387,7 @@ export class HttpMCPTransport implements MCPTransport {
 
             if (event === 'message') {
               try {
-                const msg = JSONRPCMessageSchema.parse(JSON.parse(data));
+                const msg = JSONRPCMessageSchema.parse(secureJsonParse(data));
                 this.onmessage?.(msg);
               } catch (error) {
                 const e = new MCPClientError({

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -3,6 +3,7 @@ import {
   FetchFunction,
   withUserAgentSuffix,
   getRuntimeEnvironmentUserAgent,
+  secureJsonParse,
 } from '@ai-sdk/provider-utils';
 import { MCPClientError } from '../error/mcp-client-error';
 import { JSONRPCMessage, JSONRPCMessageSchema } from './json-rpc-message';
@@ -169,7 +170,7 @@ export class SseMCPTransport implements MCPTransport {
                 } else if (event === 'message') {
                   try {
                     const message = JSONRPCMessageSchema.parse(
-                      JSON.parse(data),
+                      secureJsonParse(data),
                     );
                     this.onmessage?.(message);
                   } catch (error) {
@@ -281,5 +282,5 @@ export class SseMCPTransport implements MCPTransport {
 }
 
 export function deserializeMessage(line: string): JSONRPCMessage {
-  return JSONRPCMessageSchema.parse(JSON.parse(line));
+  return JSONRPCMessageSchema.parse(secureJsonParse(line));
 }

--- a/packages/mcp/src/tool/mcp-stdio/mcp-stdio-transport.ts
+++ b/packages/mcp/src/tool/mcp-stdio/mcp-stdio-transport.ts
@@ -1,3 +1,4 @@
+import { secureJsonParse } from '@ai-sdk/provider-utils';
 import type { ChildProcess, IOType } from 'node:child_process';
 import { Stream } from 'node:stream';
 import { JSONRPCMessage, JSONRPCMessageSchema } from '../json-rpc-message';
@@ -150,5 +151,5 @@ function serializeMessage(message: JSONRPCMessage): string {
 }
 
 export function deserializeMessage(line: string): JSONRPCMessage {
-  return JSONRPCMessageSchema.parse(JSON.parse(line));
+  return JSONRPCMessageSchema.parse(secureJsonParse(line));
 }

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -27,7 +27,7 @@ import {
   resourceUrlStripSlash,
 } from '../util/oauth-util';
 import { LATEST_PROTOCOL_VERSION } from './types';
-import { FetchFunction } from '@ai-sdk/provider-utils';
+import { FetchFunction, secureJsonParse } from '@ai-sdk/provider-utils';
 
 export type AuthResult = 'AUTHORIZED' | 'REDIRECT';
 
@@ -591,7 +591,7 @@ export async function parseErrorResponse(
   const body = input instanceof Response ? await input.text() : input;
 
   try {
-    const result = OAuthErrorResponseSchema.parse(JSON.parse(body));
+    const result = OAuthErrorResponseSchema.parse(secureJsonParse(body));
     const { error, error_description, error_uri } = result;
     const errorClass = OAUTH_ERRORS[error] || ServerError;
     return new errorClass({

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -62,6 +62,7 @@ export {
   type Schema,
   type ValidationResult,
 } from './schema';
+export { secureJsonParse } from './secure-json-parse';
 export { stripFileExtension } from './strip-file-extension';
 export * from './uint8-utils';
 export { validateDownloadUrl } from './validate-download-url';


### PR DESCRIPTION
## Background

Prototype pollution vulnerabilities exist in MCP transports and `mergeObjects`. MCP transports use raw `JSON.parse()` on data from untrusted MCP servers, and `mergeObjects` deep-merges without filtering dangerous keys like `__proto__`, `constructor`, or `prototype`. See #14309.

## Summary

Two prototype pollution vectors are addressed:

### 1. MCP transports: replace `JSON.parse()` with `secureJsonParse()`

All MCP transport files parse data from external, untrusted MCP servers using raw `JSON.parse()`. This allows a crafted MCP server to inject `__proto__` or `constructor.prototype` keys into parsed objects.

**Fix:** Replace `JSON.parse()` with `secureJsonParse()` (already available in `@ai-sdk/provider-utils` but not previously exported) in:
- `packages/mcp/src/tool/mcp-http-transport.ts`
- `packages/mcp/src/tool/mcp-sse-transport.ts`
- `packages/mcp/src/tool/mcp-stdio/mcp-stdio-transport.ts`
- `packages/mcp/src/tool/oauth.ts`

Also exports `secureJsonParse` from `@ai-sdk/provider-utils` so it can be consumed by `@ai-sdk/mcp`.

### 2. `mergeObjects`: filter dangerous keys

`mergeObjects()` deep-merges without filtering `__proto__`, `constructor`, or `prototype` keys. It is called from `process-ui-message-stream.ts` where `messageMetadata` from SSE chunks is merged, making it reachable from untrusted input.

**Fix:** Skip `__proto__`, `constructor`, and `prototype` keys during iteration in `mergeObjects()`.

## Manual Verification

- Confirmed `secureJsonParse` correctly strips `__proto__` keys from parsed JSON
- Confirmed `mergeObjects` skips `__proto__`, `constructor`, and `prototype` keys while preserving normal keys

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14309