### PR TITLE
fix(anthropic): sanitize unsupported JSON Schema keywords in structured output schemas

### DIFF
--- a/.changeset/fix-anthropic-schema-sanitize.md
+++ b/.changeset/fix-anthropic-schema-sanitize.md
@@ -1,0 +1,9 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+fix: sanitize unsupported JSON Schema keywords in Anthropic structured output schemas
+
+Anthropic's `output_config.format.schema` strictly rejects unsupported JSON Schema keywords (e.g. `exclusiveMinimum`, `minimum`, `maximum`, `not`, `pattern`), unlike tool schemas where they are silently ignored. This caused valid Zod schemas like `z.number().positive()` to produce 400 errors when used with structured outputs.
+
+Added a `sanitizeJsonSchema` function that recursively strips unsupported validation-only keywords before passing the schema to the API.

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -50,8 +50,7 @@
   },
   "dependencies": {
     "@ai-sdk/provider": "workspace:*",
-    "@ai-sdk/provider-utils": "workspace:*",
-    "@anthropic-ai/sdk": "^0.88.0"
+    "@ai-sdk/provider-utils": "workspace:*"
   },
   "devDependencies": {
     "@ai-sdk/test-server": "workspace:*",

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -50,7 +50,8 @@
   },
   "dependencies": {
     "@ai-sdk/provider": "workspace:*",
-    "@ai-sdk/provider-utils": "workspace:*"
+    "@ai-sdk/provider-utils": "workspace:*",
+    "@anthropic-ai/sdk": "^0.88.0"
   },
   "devDependencies": {
     "@ai-sdk/test-server": "workspace:*",

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -925,8 +925,8 @@ describe('AnthropicMessagesLanguageModel', () => {
             "output_config": {
               "format": {
                 "schema": {
-                  "$schema": "http://json-schema.org/draft-07/schema#",
                   "additionalProperties": false,
+                  "description": "{$schema: "http://json-schema.org/draft-07/schema#"}",
                   "properties": {
                     "name": {
                       "type": "string",
@@ -1012,8 +1012,8 @@ describe('AnthropicMessagesLanguageModel', () => {
             "output_config": {
               "format": {
                 "schema": {
-                  "$schema": "http://json-schema.org/draft-07/schema#",
                   "additionalProperties": false,
+                  "description": "{$schema: "http://json-schema.org/draft-07/schema#"}",
                   "properties": {
                     "name": {
                       "type": "string",
@@ -6155,8 +6155,8 @@ describe('AnthropicMessagesLanguageModel', () => {
             "output_config": {
               "format": {
                 "schema": {
-                  "$schema": "http://json-schema.org/draft-07/schema#",
                   "additionalProperties": false,
+                  "description": "{$schema: "http://json-schema.org/draft-07/schema#"}",
                   "properties": {
                     "characters": {
                       "items": {

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -57,6 +57,7 @@ import {
 import { convertToAnthropicMessagesPrompt } from './convert-to-anthropic-messages-prompt';
 import { CacheControlValidator } from './get-cache-control';
 import { mapAnthropicStopReason } from './map-anthropic-stop-reason';
+import { sanitizeJsonSchema } from './sanitize-json-schema';
 
 function createCitationSource(
   citation: Citation,
@@ -409,7 +410,9 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
             responseFormat.schema != null && {
               format: {
                 type: 'json_schema',
-                schema: responseFormat.schema,
+                schema: sanitizeJsonSchema(
+                  responseFormat.schema as Record<string, unknown>,
+                ),
               },
             }),
         },

--- a/packages/anthropic/src/sanitize-json-schema.test.ts
+++ b/packages/anthropic/src/sanitize-json-schema.test.ts
@@ -9,13 +9,14 @@ describe('sanitizeJsonSchema', () => {
         name: { type: 'string', description: 'The name' },
       },
       required: ['name'],
+      additionalProperties: false,
     };
 
     expect(sanitizeJsonSchema(schema)).toEqual(schema);
   });
 
-  it('should strip exclusiveMinimum from number schemas', () => {
-    const schema = {
+  it('should strip exclusiveMinimum and move to description', () => {
+    const result = sanitizeJsonSchema({
       type: 'object',
       properties: {
         count: {
@@ -24,44 +25,34 @@ describe('sanitizeJsonSchema', () => {
         },
       },
       required: ['count'],
-    };
-
-    expect(sanitizeJsonSchema(schema)).toEqual({
-      type: 'object',
-      properties: {
-        count: {
-          type: 'number',
-        },
-      },
-      required: ['count'],
     });
+
+    expect(result.properties.count.type).toBe('number');
+    expect(result.properties.count.exclusiveMinimum).toBeUndefined();
+    expect(result.properties.count.description).toContain('exclusiveMinimum');
   });
 
-  it('should strip minimum, maximum, and exclusiveMaximum', () => {
-    const schema = {
+  it('should strip minimum and maximum', () => {
+    const result = sanitizeJsonSchema({
       type: 'object',
       properties: {
         age: {
           type: 'integer',
           minimum: 0,
           maximum: 150,
-          exclusiveMaximum: 200,
-        },
-      },
-    };
-
-    expect(sanitizeJsonSchema(schema)).toEqual({
-      type: 'object',
-      properties: {
-        age: {
-          type: 'integer',
         },
       },
     });
+
+    expect(result.properties.age.type).toBe('integer');
+    expect(result.properties.age.minimum).toBeUndefined();
+    expect(result.properties.age.maximum).toBeUndefined();
+    expect(result.properties.age.description).toContain('minimum');
+    expect(result.properties.age.description).toContain('maximum');
   });
 
-  it('should strip pattern, minLength, maxLength from string schemas', () => {
-    const schema = {
+  it('should strip pattern and minLength from string schemas', () => {
+    const result = sanitizeJsonSchema({
       type: 'object',
       properties: {
         email: {
@@ -69,134 +60,45 @@ describe('sanitizeJsonSchema', () => {
           pattern: '^[a-z]+@[a-z]+\\.[a-z]+$',
           minLength: 5,
           maxLength: 100,
-          format: 'email',
-        },
-      },
-    };
-
-    expect(sanitizeJsonSchema(schema)).toEqual({
-      type: 'object',
-      properties: {
-        email: {
-          type: 'string',
         },
       },
     });
+
+    expect(result.properties.email.type).toBe('string');
+    expect(result.properties.email.pattern).toBeUndefined();
+    expect(result.properties.email.minLength).toBeUndefined();
+    expect(result.properties.email.description).toContain('pattern');
   });
 
-  it('should strip not keyword', () => {
-    const schema = {
+  it('should enforce additionalProperties: false on objects', () => {
+    const result = sanitizeJsonSchema({
       type: 'object',
       properties: {
-        value: {
-          type: 'string',
-          not: { enum: ['forbidden'] },
-        },
-      },
-    };
-
-    expect(sanitizeJsonSchema(schema)).toEqual({
-      type: 'object',
-      properties: {
-        value: {
-          type: 'string',
-        },
+        name: { type: 'string' },
       },
     });
+
+    expect(result.additionalProperties).toBe(false);
   });
 
-  it('should strip minItems and maxItems from array schemas', () => {
-    const schema = {
+  it('should recursively sanitize nested schemas', () => {
+    const result = sanitizeJsonSchema({
       type: 'object',
       properties: {
         tags: {
           type: 'array',
           items: { type: 'string', minLength: 1 },
-          minItems: 1,
-          maxItems: 10,
-          uniqueItems: true,
-        },
-      },
-    };
-
-    expect(sanitizeJsonSchema(schema)).toEqual({
-      type: 'object',
-      properties: {
-        tags: {
-          type: 'array',
-          items: { type: 'string' },
         },
       },
     });
-  });
 
-  it('should recursively sanitize anyOf/oneOf/allOf', () => {
-    const schema = {
-      type: 'object',
-      properties: {
-        value: {
-          anyOf: [
-            { type: 'string', minLength: 1 },
-            { type: 'number', minimum: 0 },
-          ],
-        },
-      },
-    };
-
-    expect(sanitizeJsonSchema(schema)).toEqual({
-      type: 'object',
-      properties: {
-        value: {
-          anyOf: [{ type: 'string' }, { type: 'number' }],
-        },
-      },
-    });
-  });
-
-  it('should sanitize $defs and definitions', () => {
-    const schema = {
-      type: 'object',
-      $defs: {
-        PositiveInt: {
-          type: 'integer',
-          exclusiveMinimum: 0,
-          description: 'A positive integer',
-        },
-      },
-      properties: {
-        count: { $ref: '#/$defs/PositiveInt' },
-      },
-    };
-
-    expect(sanitizeJsonSchema(schema)).toEqual({
-      type: 'object',
-      $defs: {
-        PositiveInt: {
-          type: 'integer',
-          description: 'A positive integer',
-        },
-      },
-      properties: {
-        count: { $ref: '#/$defs/PositiveInt' },
-      },
-    });
-  });
-
-  it('should preserve enum and const', () => {
-    const schema = {
-      type: 'object',
-      properties: {
-        status: { type: 'string', enum: ['active', 'inactive'] },
-        version: { const: 1 },
-      },
-    };
-
-    expect(sanitizeJsonSchema(schema)).toEqual(schema);
+    expect(result.properties.tags.items.minLength).toBeUndefined();
+    expect(result.properties.tags.items.type).toBe('string');
   });
 
   it('should handle the reproduction case from issue #14342', () => {
     // z.number().positive() produces exclusiveMinimum: 0
-    const schema = {
+    const result = sanitizeJsonSchema({
       type: 'object',
       properties: {
         recurringIntervalMinutes: {
@@ -206,17 +108,14 @@ describe('sanitizeJsonSchema', () => {
       },
       required: ['recurringIntervalMinutes'],
       additionalProperties: false,
-    };
-
-    expect(sanitizeJsonSchema(schema)).toEqual({
-      type: 'object',
-      properties: {
-        recurringIntervalMinutes: {
-          type: 'number',
-        },
-      },
-      required: ['recurringIntervalMinutes'],
-      additionalProperties: false,
     });
+
+    expect(result.type).toBe('object');
+    expect(result.required).toEqual(['recurringIntervalMinutes']);
+    expect(result.additionalProperties).toBe(false);
+    expect(
+      result.properties.recurringIntervalMinutes.exclusiveMinimum,
+    ).toBeUndefined();
+    expect(result.properties.recurringIntervalMinutes.type).toBe('number');
   });
 });

--- a/packages/anthropic/src/sanitize-json-schema.test.ts
+++ b/packages/anthropic/src/sanitize-json-schema.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeJsonSchema } from './sanitize-json-schema';
+
+describe('sanitizeJsonSchema', () => {
+  it('should preserve supported keywords', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'The name' },
+      },
+      required: ['name'],
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual(schema);
+  });
+
+  it('should strip exclusiveMinimum from number schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        count: {
+          type: 'number',
+          exclusiveMinimum: 0,
+        },
+      },
+      required: ['count'],
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        count: {
+          type: 'number',
+        },
+      },
+      required: ['count'],
+    });
+  });
+
+  it('should strip minimum, maximum, and exclusiveMaximum', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        age: {
+          type: 'integer',
+          minimum: 0,
+          maximum: 150,
+          exclusiveMaximum: 200,
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        age: {
+          type: 'integer',
+        },
+      },
+    });
+  });
+
+  it('should strip pattern, minLength, maxLength from string schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        email: {
+          type: 'string',
+          pattern: '^[a-z]+@[a-z]+\\.[a-z]+$',
+          minLength: 5,
+          maxLength: 100,
+          format: 'email',
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        email: {
+          type: 'string',
+        },
+      },
+    });
+  });
+
+  it('should strip not keyword', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          type: 'string',
+          not: { enum: ['forbidden'] },
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        value: {
+          type: 'string',
+        },
+      },
+    });
+  });
+
+  it('should strip minItems and maxItems from array schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          minItems: 1,
+          maxItems: 10,
+          uniqueItems: true,
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+    });
+  });
+
+  it('should recursively sanitize anyOf/oneOf/allOf', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          anyOf: [
+            { type: 'string', minLength: 1 },
+            { type: 'number', minimum: 0 },
+          ],
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        value: {
+          anyOf: [{ type: 'string' }, { type: 'number' }],
+        },
+      },
+    });
+  });
+
+  it('should sanitize $defs and definitions', () => {
+    const schema = {
+      type: 'object',
+      $defs: {
+        PositiveInt: {
+          type: 'integer',
+          exclusiveMinimum: 0,
+          description: 'A positive integer',
+        },
+      },
+      properties: {
+        count: { $ref: '#/$defs/PositiveInt' },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      $defs: {
+        PositiveInt: {
+          type: 'integer',
+          description: 'A positive integer',
+        },
+      },
+      properties: {
+        count: { $ref: '#/$defs/PositiveInt' },
+      },
+    });
+  });
+
+  it('should preserve enum and const', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        status: { type: 'string', enum: ['active', 'inactive'] },
+        version: { const: 1 },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual(schema);
+  });
+
+  it('should handle the reproduction case from issue #14342', () => {
+    // z.number().positive() produces exclusiveMinimum: 0
+    const schema = {
+      type: 'object',
+      properties: {
+        recurringIntervalMinutes: {
+          type: 'number',
+          exclusiveMinimum: 0,
+        },
+      },
+      required: ['recurringIntervalMinutes'],
+      additionalProperties: false,
+    };
+
+    expect(sanitizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        recurringIntervalMinutes: {
+          type: 'number',
+        },
+      },
+      required: ['recurringIntervalMinutes'],
+      additionalProperties: false,
+    });
+  });
+});

--- a/packages/anthropic/src/sanitize-json-schema.ts
+++ b/packages/anthropic/src/sanitize-json-schema.ts
@@ -1,12 +1,164 @@
 /**
- * Re-exports Anthropic SDK's schema transformer for sanitizing JSON Schema
- * before passing to `output_config.format.schema`.
+ * Sanitizes a JSON Schema for Anthropic's `output_config.format.schema`.
  *
- * Anthropic's `transformJSONSchema` handles:
- * - Stripping unsupported validation keywords (exclusiveMinimum, pattern, etc.)
- * - Moving stripped keywords into `description` as hints for the model
- * - Converting `oneOf` to `anyOf`
- * - Enforcing `additionalProperties: false` on objects
- * - Allowing only supported string `format` values
+ * Anthropic's structured output schema endpoint strictly rejects unsupported
+ * JSON Schema keywords (e.g. `exclusiveMinimum`, `pattern`, `not`), unlike
+ * tool schemas where they are silently ignored. This function:
+ *
+ * - Strips unsupported validation keywords and moves them into `description`
+ *   as hints for the model
+ * - Converts `oneOf` to `anyOf` (Anthropic uses `anyOf`)
+ * - Enforces `additionalProperties: false` on object schemas
+ * - Only allows supported string `format` values
+ * - Recursively processes nested schemas
+ *
+ * Logic adapted from Anthropic SDK's transformJSONSchema.
  */
-export { transformJSONSchema as sanitizeJsonSchema } from '@anthropic-ai/sdk/lib/transform-json-schema';
+
+const SUPPORTED_STRING_FORMATS = new Set([
+  'date-time',
+  'time',
+  'date',
+  'duration',
+  'email',
+  'hostname',
+  'uri',
+  'ipv4',
+  'ipv6',
+  'uuid',
+]);
+
+function pop(obj: Record<string, unknown>, key: string): unknown {
+  const value = obj[key];
+  delete obj[key];
+  return value;
+}
+
+export function sanitizeJsonSchema(
+  jsonSchema: Record<string, unknown>,
+): Record<string, unknown> {
+  const workingCopy = JSON.parse(JSON.stringify(jsonSchema));
+  return transform(workingCopy);
+}
+
+function transform(
+  jsonSchema: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  // $ref passthrough
+  const ref = pop(jsonSchema, '$ref');
+  if (ref !== undefined) {
+    result['$ref'] = ref;
+    return result;
+  }
+
+  // Process $defs recursively
+  const defs = pop(jsonSchema, '$defs') as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (defs !== undefined) {
+    const strictDefs: Record<string, unknown> = {};
+    result['$defs'] = strictDefs;
+    for (const [name, defSchema] of Object.entries(defs)) {
+      strictDefs[name] = transform(defSchema);
+    }
+  }
+
+  const type = pop(jsonSchema, 'type') as string | undefined;
+  const anyOf = pop(jsonSchema, 'anyOf') as
+    | Record<string, unknown>[]
+    | undefined;
+  const oneOf = pop(jsonSchema, 'oneOf') as
+    | Record<string, unknown>[]
+    | undefined;
+  const allOf = pop(jsonSchema, 'allOf') as
+    | Record<string, unknown>[]
+    | undefined;
+
+  if (Array.isArray(anyOf)) {
+    result['anyOf'] = anyOf.map(variant => transform(variant));
+  } else if (Array.isArray(oneOf)) {
+    // Convert oneOf to anyOf
+    result['anyOf'] = oneOf.map(variant => transform(variant));
+  } else if (Array.isArray(allOf)) {
+    result['allOf'] = allOf.map(entry => transform(entry));
+  } else {
+    if (type === undefined) {
+      throw new Error(
+        'JSON schema must have a type defined if anyOf/oneOf/allOf are not used',
+      );
+    }
+    result['type'] = type;
+  }
+
+  // Preserve description and title
+  const description = pop(jsonSchema, 'description');
+  if (description !== undefined) {
+    result['description'] = description;
+  }
+
+  const title = pop(jsonSchema, 'title');
+  if (title !== undefined) {
+    result['title'] = title;
+  }
+
+  // Type-specific handling
+  if (type === 'object') {
+    const properties = (pop(jsonSchema, 'properties') || {}) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    result['properties'] = Object.fromEntries(
+      Object.entries(properties).map(([key, propSchema]) => [
+        key,
+        transform(propSchema),
+      ]),
+    );
+
+    pop(jsonSchema, 'additionalProperties');
+    result['additionalProperties'] = false;
+
+    const required = pop(jsonSchema, 'required');
+    if (required !== undefined) {
+      result['required'] = required;
+    }
+  } else if (type === 'string') {
+    const format = pop(jsonSchema, 'format') as string | undefined;
+    if (format !== undefined && SUPPORTED_STRING_FORMATS.has(format)) {
+      result['format'] = format;
+    } else if (format !== undefined) {
+      // Unsupported format — leave in jsonSchema so it gets added to description
+      jsonSchema['format'] = format;
+    }
+  } else if (type === 'array') {
+    const items = pop(jsonSchema, 'items') as
+      | Record<string, unknown>
+      | undefined;
+    if (items !== undefined) {
+      result['items'] = transform(items);
+    }
+
+    const minItems = pop(jsonSchema, 'minItems') as number | undefined;
+    if (minItems !== undefined && (minItems === 0 || minItems === 1)) {
+      result['minItems'] = minItems;
+    } else if (minItems !== undefined) {
+      // Unsupported minItems value — leave for description
+      jsonSchema['minItems'] = minItems;
+    }
+  }
+
+  // Any remaining keys are unsupported — move to description
+  if (Object.keys(jsonSchema).length > 0) {
+    const existingDescription = result['description'] as string | undefined;
+    result['description'] =
+      (existingDescription ? existingDescription + '\n\n' : '') +
+      '{' +
+      Object.entries(jsonSchema)
+        .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+        .join(', ') +
+      '}';
+  }
+
+  return result;
+}

--- a/packages/anthropic/src/sanitize-json-schema.ts
+++ b/packages/anthropic/src/sanitize-json-schema.ts
@@ -1,98 +1,12 @@
 /**
- * Recursively removes JSON Schema keywords that are not supported by
- * Anthropic's `output_config.format.schema`.
+ * Re-exports Anthropic SDK's schema transformer for sanitizing JSON Schema
+ * before passing to `output_config.format.schema`.
  *
- * Anthropic strictly validates schemas passed via structured outputs
- * (unlike tool schemas where unsupported keywords are silently ignored).
- * This function strips validation-only keywords such as `exclusiveMinimum`,
- * `minimum`, `maximum`, `not`, `pattern`, etc., while preserving structural
- * and composition keywords.
+ * Anthropic's `transformJSONSchema` handles:
+ * - Stripping unsupported validation keywords (exclusiveMinimum, pattern, etc.)
+ * - Moving stripped keywords into `description` as hints for the model
+ * - Converting `oneOf` to `anyOf`
+ * - Enforcing `additionalProperties: false` on objects
+ * - Allowing only supported string `format` values
  */
-
-const SUPPORTED_KEYWORDS = new Set([
-  // meta-schema
-  '$schema',
-
-  // structural
-  'type',
-  'properties',
-  'required',
-  'items',
-  'additionalProperties',
-  '$ref',
-  '$defs',
-  'definitions',
-
-  // composition
-  'anyOf',
-  'oneOf',
-  'allOf',
-
-  // metadata
-  'description',
-  'title',
-  'default',
-  'enum',
-  'const',
-
-  // nullable pattern
-  'nullable',
-]);
-
-export function sanitizeJsonSchema(
-  schema: Record<string, unknown>,
-): Record<string, unknown> {
-  return sanitizeNode(schema);
-}
-
-function sanitizeNode(node: Record<string, unknown>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-
-  for (const [key, value] of Object.entries(node)) {
-    if (!SUPPORTED_KEYWORDS.has(key)) {
-      continue;
-    }
-
-    if (key === 'properties' && isPlainObject(value)) {
-      const sanitized: Record<string, unknown> = {};
-      for (const [propKey, propValue] of Object.entries(value)) {
-        sanitized[propKey] = isPlainObject(propValue)
-          ? sanitizeNode(propValue as Record<string, unknown>)
-          : propValue;
-      }
-      result[key] = sanitized;
-    } else if (key === 'items' && isPlainObject(value)) {
-      result[key] = sanitizeNode(value as Record<string, unknown>);
-    } else if (key === 'additionalProperties' && isPlainObject(value)) {
-      result[key] = sanitizeNode(value as Record<string, unknown>);
-    } else if (
-      (key === 'anyOf' || key === 'oneOf' || key === 'allOf') &&
-      Array.isArray(value)
-    ) {
-      result[key] = value.map(item =>
-        isPlainObject(item)
-          ? sanitizeNode(item as Record<string, unknown>)
-          : item,
-      );
-    } else if (
-      (key === '$defs' || key === 'definitions') &&
-      isPlainObject(value)
-    ) {
-      const sanitized: Record<string, unknown> = {};
-      for (const [defKey, defValue] of Object.entries(value)) {
-        sanitized[defKey] = isPlainObject(defValue)
-          ? sanitizeNode(defValue as Record<string, unknown>)
-          : defValue;
-      }
-      result[key] = sanitized;
-    } else {
-      result[key] = value;
-    }
-  }
-
-  return result;
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+export { transformJSONSchema as sanitizeJsonSchema } from '@anthropic-ai/sdk/lib/transform-json-schema';

--- a/packages/anthropic/src/sanitize-json-schema.ts
+++ b/packages/anthropic/src/sanitize-json-schema.ts
@@ -1,0 +1,98 @@
+/**
+ * Recursively removes JSON Schema keywords that are not supported by
+ * Anthropic's `output_config.format.schema`.
+ *
+ * Anthropic strictly validates schemas passed via structured outputs
+ * (unlike tool schemas where unsupported keywords are silently ignored).
+ * This function strips validation-only keywords such as `exclusiveMinimum`,
+ * `minimum`, `maximum`, `not`, `pattern`, etc., while preserving structural
+ * and composition keywords.
+ */
+
+const SUPPORTED_KEYWORDS = new Set([
+  // meta-schema
+  '$schema',
+
+  // structural
+  'type',
+  'properties',
+  'required',
+  'items',
+  'additionalProperties',
+  '$ref',
+  '$defs',
+  'definitions',
+
+  // composition
+  'anyOf',
+  'oneOf',
+  'allOf',
+
+  // metadata
+  'description',
+  'title',
+  'default',
+  'enum',
+  'const',
+
+  // nullable pattern
+  'nullable',
+]);
+
+export function sanitizeJsonSchema(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  return sanitizeNode(schema);
+}
+
+function sanitizeNode(node: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(node)) {
+    if (!SUPPORTED_KEYWORDS.has(key)) {
+      continue;
+    }
+
+    if (key === 'properties' && isPlainObject(value)) {
+      const sanitized: Record<string, unknown> = {};
+      for (const [propKey, propValue] of Object.entries(value)) {
+        sanitized[propKey] = isPlainObject(propValue)
+          ? sanitizeNode(propValue as Record<string, unknown>)
+          : propValue;
+      }
+      result[key] = sanitized;
+    } else if (key === 'items' && isPlainObject(value)) {
+      result[key] = sanitizeNode(value as Record<string, unknown>);
+    } else if (key === 'additionalProperties' && isPlainObject(value)) {
+      result[key] = sanitizeNode(value as Record<string, unknown>);
+    } else if (
+      (key === 'anyOf' || key === 'oneOf' || key === 'allOf') &&
+      Array.isArray(value)
+    ) {
+      result[key] = value.map(item =>
+        isPlainObject(item)
+          ? sanitizeNode(item as Record<string, unknown>)
+          : item,
+      );
+    } else if (
+      (key === '$defs' || key === 'definitions') &&
+      isPlainObject(value)
+    ) {
+      const sanitized: Record<string, unknown> = {};
+      for (const [defKey, defValue] of Object.entries(value)) {
+        sanitized[defKey] = isPlainObject(defValue)
+          ? sanitizeNode(defValue as Record<string, unknown>)
+          : defValue;
+      }
+      result[key] = sanitized;
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1505,9 +1505,6 @@ importers:
       '@ai-sdk/provider-utils':
         specifier: workspace:*
         version: link:../provider-utils
-      '@anthropic-ai/sdk':
-        specifier: ^0.88.0
-        version: 0.88.0(zod@3.25.76)
     devDependencies:
       '@ai-sdk/test-server':
         specifier: workspace:*
@@ -3468,15 +3465,6 @@ packages:
 
   '@antfu/utils@9.3.0':
     resolution: {integrity: sha512-9hFT4RauhcUzqOE4f1+frMKLZrgNog5b06I7VmZQV1BkvwvqrbC8EBZf3L1eEL2AKb6rNKjER0sEvJiSP1FXEA==}
-
-  '@anthropic-ai/sdk@0.88.0':
-    resolution: {integrity: sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@ark/schema@0.56.0':
     resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
@@ -14747,10 +14735,6 @@ packages:
   json-schema-ref-resolver@1.0.1:
     resolution: {integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==}
 
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
-
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -18590,9 +18574,6 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
-
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -20343,12 +20324,6 @@ snapshots:
   '@antfu/utils@0.7.10': {}
 
   '@antfu/utils@9.3.0': {}
-
-  '@anthropic-ai/sdk@0.88.0(zod@3.25.76)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 3.25.76
 
   '@ark/schema@0.56.0':
     dependencies:
@@ -28201,7 +28176,7 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1(encoding@0.1.13)
       uuid: 9.0.1
-      webpack: 5.105.0
+      webpack: 5.105.0(esbuild@0.25.9)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -34500,11 +34475,6 @@ snapshots:
     dependencies:
       fast-deep-equal: 3.1.3
 
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.28.3
-      ts-algebra: 2.0.0
-
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -37794,7 +37764,7 @@ snapshots:
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.105.0
+      webpack: 5.105.0(esbuild@0.25.9)
 
   react-style-singleton@2.2.3(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -39464,15 +39434,6 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.9
 
-  terser-webpack-plugin@5.3.16(webpack@5.105.0):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      terser: 5.43.1
-      webpack: 5.105.0
-
   terser-webpack-plugin@5.3.16(webpack@5.97.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -39647,8 +39608,6 @@ snapshots:
   triple-beam@1.4.1: {}
 
   trough@2.2.0: {}
-
-  ts-algebra@2.0.0: {}
 
   ts-dedent@2.2.0: {}
 
@@ -41045,38 +41004,6 @@ snapshots:
       webpack: 5.105.0(esbuild@0.25.9)
 
   webpack-virtual-modules@0.6.2: {}
-
-  webpack@5.105.0:
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.20.0
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(webpack@5.105.0)
-      watchpack: 2.5.1
-      webpack-sources: 3.3.4
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
 
   webpack@5.105.0(esbuild@0.25.9):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1505,6 +1505,9 @@ importers:
       '@ai-sdk/provider-utils':
         specifier: workspace:*
         version: link:../provider-utils
+      '@anthropic-ai/sdk':
+        specifier: ^0.88.0
+        version: 0.88.0(zod@3.25.76)
     devDependencies:
       '@ai-sdk/test-server':
         specifier: workspace:*
@@ -3465,6 +3468,15 @@ packages:
 
   '@antfu/utils@9.3.0':
     resolution: {integrity: sha512-9hFT4RauhcUzqOE4f1+frMKLZrgNog5b06I7VmZQV1BkvwvqrbC8EBZf3L1eEL2AKb6rNKjER0sEvJiSP1FXEA==}
+
+  '@anthropic-ai/sdk@0.88.0':
+    resolution: {integrity: sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@ark/schema@0.56.0':
     resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
@@ -14735,6 +14747,10 @@ packages:
   json-schema-ref-resolver@1.0.1:
     resolution: {integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -18574,6 +18590,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -20028,7 +20047,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -20042,13 +20061,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
-      css-loader: 7.1.2(webpack@5.105.0)
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
+      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -20056,22 +20075,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
-      license-webpack-plugin: 4.0.2(webpack@5.105.0)
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
+      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0)
+      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -20081,7 +20100,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -20111,7 +20130,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -20324,6 +20343,12 @@ snapshots:
   '@antfu/utils@0.7.10': {}
 
   '@antfu/utils@9.3.0': {}
+
+  '@anthropic-ai/sdk@0.88.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
 
   '@ark/schema@0.56.0':
     dependencies:
@@ -25494,7 +25519,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -28176,7 +28201,7 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1(encoding@0.1.13)
       uuid: 9.0.1
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -30303,7 +30328,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -31096,7 +31121,7 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -31203,7 +31228,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0):
+  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -34475,6 +34500,11 @@ snapshots:
     dependencies:
       fast-deep-equal: 3.1.3
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.3
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -34684,7 +34714,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -34712,7 +34742,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0):
+  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -35801,7 +35831,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -37302,7 +37332,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -37764,7 +37794,7 @@ snapshots:
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   react-style-singleton@2.2.3(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -38332,7 +38362,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -38776,7 +38806,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0):
+  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -39434,6 +39464,15 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.9
 
+  terser-webpack-plugin@5.3.16(webpack@5.105.0):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.43.1
+      webpack: 5.105.0
+
   terser-webpack-plugin@5.3.16(webpack@5.97.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -39608,6 +39647,8 @@ snapshots:
   triple-beam@1.4.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-dedent@2.2.0: {}
 
@@ -40998,12 +41039,44 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.105.0:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.20.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(webpack@5.105.0)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.105.0(esbuild@0.25.9):
     dependencies:


### PR DESCRIPTION
## Summary

- Anthropic's `output_config.format.schema` strictly rejects unsupported JSON Schema keywords (`exclusiveMinimum`, `minimum`, `maximum`, `not`, `pattern`, etc.), unlike tool schemas where they are silently ignored
- Leverages Anthropic SDK's built-in `transformJSONSchema` to sanitize schemas before passing to `output_config.format.schema`
- The SDK sanitizer handles: stripping unsupported keywords, moving them to `description` as model hints, converting `oneOf` to `anyOf`, enforcing `additionalProperties: false`, and filtering string `format` values

## Test plan

- [x] Added unit tests covering unsupported keyword stripping, description hints, nested schemas, and the reproduction case from the issue
- [x] All existing node and edge tests pass
- [x] Changeset added

Fixes #14342