### PR TITLE
fix: preserve providerMetadata in smoothStream chunked output

### DIFF
--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -151,7 +151,12 @@ export function smoothStream<TOOLS extends ToolSet>({
         let match;
 
         while ((match = detectChunk(buffer)) != null) {
-          controller.enqueue({ type, text: match, id });
+          controller.enqueue({
+            type,
+            text: match,
+            id,
+            ...(providerMetadata != null ? { providerMetadata } : {}),
+          });
           buffer = buffer.slice(match.length);
 
           await delay(delayInMs);


### PR DESCRIPTION
## Problem\n\nsmooth-stream.ts silently drops providerMetadata from stream parts emitted via the chunking while loop. The while loop that emits word/line-boundary chunks does not include providerMetadata, but the flushBuffer function does, causing inconsistent behavior.\n\n## Impact\n\nWhen smoothStream is used with providers that attach metadata to streaming delta chunks (e.g., Anthropic extended thinking with providerMetadata containing thinking block signatures), that metadata is silently dropped for every chunk emitted via the chunking loop. Only the final flushed chunk retains the metadata.\n\n## Fix\n\nInclude providerMetadata in the controller.enqueue call within the while loop, consistent with flushBuffer behavior.\n\nCloses #14373