### PR TITLE
chore(ai): test and jsdoc stop conditions

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/70-is-step-count.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/70-is-step-count.mdx
@@ -5,7 +5,7 @@ description: API Reference for isStepCount.
 
 # `isStepCount()`
 
-Creates a stop condition that stops when the number of steps reaches a specified count.
+Creates a stop condition that stops when the number of completed steps equals a specified count.
 
 This function is used with `stopWhen` in `generateText` and `streamText` to control when a tool-calling loop should stop based on the number of steps executed.
 
@@ -34,17 +34,17 @@ const result = await generateText({
 <PropertiesTable
   content={[
     {
-      name: 'count',
+      name: 'stepCount',
       type: 'number',
       description:
-        'The maximum number of steps to execute before stopping the tool-calling loop.',
+        'The number of completed steps that should trigger the stop condition.',
     },
   ]}
 />
 
 ### Returns
 
-A `StopCondition` function that returns `true` when the step count reaches the specified number. The function can be used with the `stopWhen` parameter in `generateText` and `streamText`.
+A `StopCondition` function that returns `true` when the number of completed steps equals the specified number. The function can be used with the `stopWhen` parameter in `generateText` and `streamText`.
 
 ## Examples
 

--- a/content/docs/07-reference/01-ai-sdk-core/71-has-tool-call.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/71-has-tool-call.mdx
@@ -5,7 +5,7 @@ description: API Reference for hasToolCall.
 
 # `hasToolCall()`
 
-Creates a stop condition that stops when a specific tool is called.
+Creates a stop condition that stops when a specific tool is called in the most recent step.
 
 This function is used with `stopWhen` in `generateText` and `streamText` to control when a tool-calling loop should stop based on whether a particular tool has been invoked.
 
@@ -45,7 +45,7 @@ const result = await generateText({
 
 ### Returns
 
-A `StopCondition` function that returns `true` when the specified tool is called in the current step. The function can be used with the `stopWhen` parameter in `generateText` and `streamText`.
+A `StopCondition` function that returns `true` when the specified tool is called in the most recent step. The function can be used with the `stopWhen` parameter in `generateText` and `streamText`.
 
 ## Examples
 

--- a/examples/ai-functions/src/generate-text/openai/tool-call-stop-condition.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-call-stop-condition.ts
@@ -1,0 +1,63 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, hasToolCall, tool } from 'ai';
+import { z } from 'zod';
+import { weatherTool } from '../../tools/weather-tool';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: openai('gpt-5.1'),
+    tools: {
+      weather: weatherTool,
+      cityAttractions: tool({
+        inputSchema: z.object({ city: z.string() }),
+      }),
+    },
+    // stopWhen: hasToolCall('cityAttractions'),
+    prompt:
+      'What is the weather in San Francisco and what attractions should I visit?',
+  });
+
+  // typed tool calls:
+  for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
+    switch (toolCall.toolName) {
+      case 'cityAttractions': {
+        toolCall.input.city; // string
+        break;
+      }
+
+      case 'weather': {
+        toolCall.input.location; // string
+        break;
+      }
+    }
+  }
+
+  // typed tool results for tools with execute method:
+  for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
+    switch (toolResult.toolName) {
+      case 'cityAttractions': {
+        toolResult.input.city; // string
+        toolResult.output; // any since no outputSchema is provided
+        break;
+      }
+
+      case 'weather': {
+        toolResult.input.location; // string
+        toolResult.output.location; // string
+        toolResult.output.temperature; // number
+        break;
+      }
+    }
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+});

--- a/packages/ai/src/generate-text/stop-condition.test.ts
+++ b/packages/ai/src/generate-text/stop-condition.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import type { StepResult } from './step-result';
+import {
+  hasToolCall,
+  isLoopFinished,
+  isStepCount,
+  isStopConditionMet,
+} from './stop-condition';
+
+function createStepResult({
+  toolCalls = [],
+}: {
+  toolCalls?: StepResult<any, any>['toolCalls'];
+} = {}): StepResult<any, any> {
+  return {
+    toolCalls,
+  } as StepResult<any, any>;
+}
+
+describe('stop conditions', () => {
+  describe('isStepCount', () => {
+    it('should return true when the step count matches exactly', () => {
+      const stopCondition = isStepCount(2);
+
+      expect(
+        stopCondition({
+          steps: [createStepResult(), createStepResult()],
+        }),
+      ).toBe(true);
+    });
+
+    it('should return false when the step count does not match exactly', () => {
+      const stopCondition = isStepCount(2);
+
+      expect(stopCondition({ steps: [createStepResult()] })).toBe(false);
+      expect(
+        stopCondition({
+          steps: [createStepResult(), createStepResult(), createStepResult()],
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('isLoopFinished', () => {
+    it('should always return false', () => {
+      const stopCondition = isLoopFinished();
+
+      expect(stopCondition({ steps: [] })).toBe(false);
+      expect(stopCondition({ steps: [createStepResult()] })).toBe(false);
+    });
+  });
+
+  describe('hasToolCall', () => {
+    it('should return true when the last step contains the specified tool call', () => {
+      const stopCondition = hasToolCall('finalAnswer');
+
+      expect(
+        stopCondition({
+          steps: [
+            createStepResult(),
+            createStepResult({
+              toolCalls: [{ toolName: 'finalAnswer' }] as any,
+            }),
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    it('should return false when the specified tool call only appears in earlier steps', () => {
+      const stopCondition = hasToolCall('finalAnswer');
+
+      expect(
+        stopCondition({
+          steps: [
+            createStepResult({
+              toolCalls: [{ toolName: 'finalAnswer' }] as any,
+            }),
+            createStepResult(),
+          ],
+        }),
+      ).toBe(false);
+    });
+
+    it('should return false when there are no steps', () => {
+      const stopCondition = hasToolCall('finalAnswer');
+
+      expect(stopCondition({ steps: [] })).toBe(false);
+    });
+  });
+
+  describe('isStopConditionMet', () => {
+    it('should return true when any stop condition returns true', async () => {
+      await expect(
+        isStopConditionMet({
+          stopConditions: [() => false, () => true, () => false],
+          steps: [createStepResult()],
+        }),
+      ).resolves.toBe(true);
+    });
+
+    it('should return false when all stop conditions return false', async () => {
+      await expect(
+        isStopConditionMet({
+          stopConditions: [() => false, () => false],
+          steps: [createStepResult()],
+        }),
+      ).resolves.toBe(false);
+    });
+
+    it('should support asynchronous stop conditions', async () => {
+      await expect(
+        isStopConditionMet({
+          stopConditions: [
+            async () => false,
+            async ({ steps }) => steps.length === 2,
+          ],
+          steps: [createStepResult(), createStepResult()],
+        }),
+      ).resolves.toBe(true);
+    });
+
+    it('should reject when a stop condition rejects', async () => {
+      await expect(
+        isStopConditionMet({
+          stopConditions: [
+            () => false,
+            async () => {
+              throw new Error('stop condition failed');
+            },
+          ],
+          steps: [createStepResult()],
+        }),
+      ).rejects.toThrow('stop condition failed');
+    });
+  });
+});

--- a/packages/ai/src/generate-text/stop-condition.ts
+++ b/packages/ai/src/generate-text/stop-condition.ts
@@ -1,6 +1,16 @@
 import type { Context, ToolSet } from '@ai-sdk/provider-utils';
 import { StepResult } from './step-result';
 
+/**
+ * A predicate that decides whether a tool-calling loop should stop after the
+ * current step.
+ *
+ * A tool calling loop continues until one of the following conditions is met:
+ * - The model returns a finish reason other than `tool-calls`
+ * - A tool without an execute function is called
+ * - A tool call needs approval
+ * - One of the provided stop conditions returns `true`
+ */
 export type StopCondition<
   TOOLS extends ToolSet,
   USER_CONTEXT extends Context = Context,
@@ -8,14 +18,32 @@ export type StopCondition<
   steps: Array<StepResult<TOOLS, USER_CONTEXT>>;
 }) => PromiseLike<boolean> | boolean;
 
+/**
+ * Creates a stop condition that returns `true` when the number of completed
+ * steps equals `stepCount`.
+ *
+ * @param stepCount - The number of steps to allow before stopping.
+ */
 export function isStepCount(stepCount: number): StopCondition<any, any> {
   return ({ steps }) => steps.length === stepCount;
 }
 
+/**
+ * Creates a stop condition that never returns `true`.
+ *
+ * This lets the tool-calling loop continue until it reaches one of its
+ * natural termination conditions.
+ */
 export function isLoopFinished(): StopCondition<any, any> {
   return () => false;
 }
 
+/**
+ * Creates a stop condition that returns `true` when the most recent step
+ * contains a tool call with the specified name.
+ *
+ * @param toolName - The name of the tool that should stop the loop.
+ */
 export function hasToolCall(toolName: string): StopCondition<any, any> {
   return ({ steps }) =>
     steps[steps.length - 1]?.toolCalls?.some(
@@ -23,6 +51,14 @@ export function hasToolCall(toolName: string): StopCondition<any, any> {
     ) ?? false;
 }
 
+/**
+ * Evaluates the provided stop conditions for the current list of steps.
+ *
+ * Returns `true` as soon as any stop condition is met.
+ *
+ * @param stopConditions - The stop conditions to evaluate.
+ * @param steps - The completed steps accumulated so far.
+ */
 export async function isStopConditionMet<
   TOOLS extends ToolSet,
   USER_CONTEXT extends Context = Context,

--- a/packages/ai/src/generate-text/stop-condition.ts
+++ b/packages/ai/src/generate-text/stop-condition.ts
@@ -44,7 +44,9 @@ export function isLoopFinished(): StopCondition<any, any> {
  *
  * @param toolName - The name of the tool that should stop the loop.
  */
-export function hasToolCall(toolName: string): StopCondition<any, any> {
+export function hasToolCall<TOOLS extends ToolSet>(
+  toolName: keyof TOOLS | (string & {}), // autocomplete support for tool names
+): StopCondition<TOOLS, any> {
   return ({ steps }) =>
     steps[steps.length - 1]?.toolCalls?.some(
       toolCall => toolCall.toolName === toolName,


### PR DESCRIPTION
## Background

Stop conditions were lacking jsdoc and had no unit tests.

## Summary

- add jsdoc to stop conditions
- add unit tests for stop conditions
- add toolname autocomplete in `hasToolCall` stop condition