### PR TITLE
fix (packages/gateway): clarify sort docs

### DIFF
--- a/.changeset/rich-garlics-push.md
+++ b/.changeset/rich-garlics-push.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+fix (packages/gateway): clarify sort docs

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -782,7 +782,7 @@ The following gateway provider options are available:
 
   Sorts available providers by a performance or cost metric before routing. The gateway will try the best-scoring provider first and fall back through the rest in sorted order. If unspecified, providers are ordered using the gateway's default system ranking.
 
-  - `'cost'` — lowest input cost per token first
+  - `'cost'` — lowest cost first
   - `'ttft'` — lowest time-to-first-token first
   - `'tps'` — highest tokens-per-second first
 

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -20,7 +20,7 @@ const gatewayProviderOptions = lazySchema(() =>
       /**
        * Sort providers by a performance or cost metric before routing.
        *
-       * - `'cost'`: lowest input cost first
+       * - `'cost'`: lowest cost first
        * - `'ttft'`: lowest time-to-first-token first
        * - `'tps'`: highest tokens-per-second first
        */


### PR DESCRIPTION
## Background

The documentation for the `sort` option in the AI Gateway provider was unclear about what "cost" specifically referred to, mentioning "input cost per token" which could be confusing since it doesn't clarify the overall cost optimization behavior.

## Changes

Clarified the documentation for the `'cost'` sort option in both the gateway provider options TypeScript code and the AI Gateway documentation to simply state "lowest cost first" instead of the more specific "lowest input cost per token first".

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)