### PR TITLE
chore (gateway): add reranking to model settings generation config

### DIFF
--- a/packages/gateway/scripts/generate-model-settings.ts
+++ b/packages/gateway/scripts/generate-model-settings.ts
@@ -36,6 +36,10 @@ const MODALITY_CONFIG: Record<
     outputFile: 'gateway-video-model-settings.ts',
     typeName: 'GatewayVideoModelId',
   },
+  reranking: {
+    outputFile: 'gateway-reranking-model-settings.ts',
+    typeName: 'GatewayRerankingModelId',
+  },
 };
 
 async function fetchModels(): Promise<ModelsResponse> {


### PR DESCRIPTION
## Summary
Add `reranking` to `MODALITY_CONFIG` in the `generate-model-settings` script so the automated GH Action workflow correctly generates `gateway-reranking-model-settings.ts` when reranking models appear in the gateway API.

The fallback logic at line 79 would also work, but being explicit matches the pattern for language, embedding, image, and video.

## Test plan
- [x] `pnpm generate-model-settings` runs without error (no reranking models in prod yet, so no output change)