### PR TITLE
fix: guard against undefined warnings in embed/embedMany (#14425)

### DIFF
--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -340,7 +340,9 @@ export async function embedMany({
 
       for (const result of results) {
         embeddings.push(...result.embeddings);
-        warnings.push(...result.warnings);
+        if (result.warnings) {
+          warnings.push(...result.warnings);
+        }
         responses.push(result.response);
         tokens += result.usage.tokens;
         if (result.providerMetadata) {

--- a/packages/ai/src/logger/log-warnings.ts
+++ b/packages/ai/src/logger/log-warnings.ts
@@ -100,8 +100,8 @@ let hasLoggedBefore = false;
  * @param options.model - The model id used for the call.
  */
 export const logWarnings: LogWarningsFunction = options => {
-  // if the warnings array is empty, do nothing
-  if (options.warnings.length === 0) {
+  // if the warnings array is empty or undefined, do nothing
+  if (!options.warnings || options.warnings.length === 0) {
     return;
   }
 


### PR DESCRIPTION
## What

Fixes #14425 — `embed()` and `embedMany()` crash at runtime when used with `EmbeddingModelV2` providers (e.g. `@ai-sdk/google-vertex@3.x`) that don't return a `warnings` property from `doEmbed`.

## Root cause

1. `logWarnings` in `log-warnings.ts:97` accesses `options.warnings.length` without a null check — `TypeError: Cannot read properties of undefined (reading 'length')`
2. `embedMany` in `embed-many.ts:312` spreads `result.warnings` — `TypeError: result.warnings is not iterable`

The `EmbeddingModelV2` protocol does not include `warnings` in its `doEmbed` return type, so v2 providers return `undefined` for this field.

## Fix

- **`packages/ai/src/logger/log-warnings.ts:97`**: Guard with `!options.warnings ||` before accessing `.length`
- **`packages/ai/src/embed/embed-many.ts:312`**: Guard with `if (result.warnings)` before spreading

## Testing

The existing test suite should continue to pass since these guards are no-ops when `warnings` is present (the common case). The fix handles the edge case where `warnings` is `undefined`.