### PR TITLE
fix(mcp): use negotiated protocol version in transport request headers

### DIFF
--- a/.changeset/faf4ab1e.md
+++ b/.changeset/faf4ab1e.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+fix(mcp): use negotiated protocol version in transport request headers
+
+After a successful `initialize` handshake, `HttpMCPTransport` and `SseMCPTransport` were hardcoding `LATEST_PROTOCOL_VERSION` (2025-11-25) in every subsequent request header instead of the version actually negotiated with the server. This caused 400 errors against servers that only support older versions — notably Figma Dev Mode MCP (supports up to 2025-06-18).
+
+The fix stores the negotiated `protocolVersion` from the `initialize` result on the transport, and both transports now fall back to `LATEST_PROTOCOL_VERSION` only when no negotiated version has been set yet.
+
+Fixes #14413. Thanks to @stevering for the detailed report and local validation of this fix.

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -290,6 +290,7 @@ class DefaultMCPClient implements MCPClient {
 
       this.serverCapabilities = result.capabilities;
       this._serverInfo = result.serverInfo;
+      this.transport.protocolVersion = result.protocolVersion;
 
       // Complete initialization handshake:
       await this.notification({

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -52,6 +52,38 @@ describe('HttpMCPTransport', () => {
     });
   });
 
+  it('should use negotiated protocol version in POST headers after protocolVersion is set', async () => {
+    // Call 0: GET from start returns 405 (skip inbound SSE)
+    // Call 1: POST with the negotiated version header
+    server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return { type: 'error', status: 405 };
+        default:
+          return {
+            type: 'json-value',
+            body: { jsonrpc: '2.0', id: 1, result: { ok: true } },
+          };
+      }
+    };
+
+    await transport.start();
+
+    // Simulate what DefaultMCPClient does after successful initialize
+    transport.protocolVersion = '2025-06-18';
+
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'notifications/initialized',
+      params: {},
+      id: 1,
+    });
+
+    expect(server.calls[1].requestHeaders['mcp-protocol-version']).toBe(
+      '2025-06-18',
+    );
+  });
+
   it('should handle text/event-stream responses', async () => {
     transport = new HttpMCPTransport({ url: 'http://localhost:4000/stream' });
     const controller = new TestResponseController();

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -47,6 +47,7 @@ export class HttpMCPTransport implements MCPTransport {
   onclose?: () => void;
   onerror?: (error: unknown) => void;
   onmessage?: (message: JSONRPCMessage) => void;
+  protocolVersion: string | null = null;
 
   constructor({
     url,
@@ -74,7 +75,7 @@ export class HttpMCPTransport implements MCPTransport {
     const headers: Record<string, string> = {
       ...this.headers,
       ...base,
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version': this.protocolVersion ?? LATEST_PROTOCOL_VERSION,
     };
 
     if (this.sessionId) {

--- a/packages/mcp/src/tool/mcp-sse-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.test.ts
@@ -165,6 +165,38 @@ describe('SseMCPTransport', () => {
     await transport.close();
   });
 
+  it('should use negotiated protocol version in POST headers after protocolVersion is set', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['http://localhost:3000/sse'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    const connectPromise = transport.start();
+    controller.write(
+      'event: endpoint\ndata: http://localhost:3000/messages\n\n',
+    );
+    await connectPromise;
+
+    // Simulate what DefaultMCPClient does after a successful initialize handshake
+    // where the server negotiated down to an older version.
+    transport.protocolVersion = '2025-06-18';
+
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'notifications/initialized',
+      params: {},
+      id: '1',
+    });
+
+    expect(server.calls[1].requestHeaders['mcp-protocol-version']).toBe(
+      '2025-06-18',
+    );
+
+    await transport.close();
+  });
+
   it('should handle POST request errors', async () => {
     const controller = new TestResponseController();
 

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -33,6 +33,7 @@ export class SseMCPTransport implements MCPTransport {
   onclose?: () => void;
   onerror?: (error: unknown) => void;
   onmessage?: (message: JSONRPCMessage) => void;
+  protocolVersion: string | null = null;
 
   constructor({
     url,
@@ -60,7 +61,7 @@ export class SseMCPTransport implements MCPTransport {
     const headers: Record<string, string> = {
       ...this.headers,
       ...base,
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version': this.protocolVersion ?? LATEST_PROTOCOL_VERSION,
     };
 
     if (this.authProvider) {

--- a/packages/mcp/src/tool/mcp-transport.ts
+++ b/packages/mcp/src/tool/mcp-transport.ts
@@ -40,6 +40,14 @@ export interface MCPTransport {
    * Event handler for received messages
    */
   onmessage?: (message: JSONRPCMessage) => void;
+
+  /**
+   * The protocol version negotiated during initialization.
+   * Set by the MCP client after a successful `initialize` handshake.
+   * When set, transports SHOULD use this version in the `mcp-protocol-version`
+   * request header instead of the latest supported version.
+   */
+  protocolVersion?: string | null;
 }
 
 export type MCPTransportConfig = {


### PR DESCRIPTION
## Summary

Fixes #14413.

After a successful `initialize` handshake, `HttpMCPTransport` and `SseMCPTransport` were sending `mcp-protocol-version: 2025-11-25` (`LATEST_PROTOCOL_VERSION`) in **every** subsequent request header — ignoring the version the server actually negotiated down to. The MCP spec says the client SHOULD use the negotiated version in all post-init requests.

## Real-world impact

Two confirmed broken server types:

**Figma Dev Mode MCP** (supports up to `2025-06-18`) — reported by @stevering in #14413.

**FastMCP < 2.12.0** (supports up to `2025-06-18`) — the failure always occurs on `notifications/initialized`, the very first post-init message:

```
Error [MCPClientError]: MCP HTTP Transport Error: POSTing to endpoint (HTTP 400):
{"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":
"Bad Request: Unsupported protocol version: 2025-11-25.
Supported versions: 2024-11-05, 2025-03-26, 2025-06-18"}}
    at async tv.send (...)
    at async t_.notification (...)   ← notifications/initialized
    at async t_.init (...)
```

The server correctly negotiates down to `2025-06-18` during `initialize`, but the client ignores that and keeps sending `2025-11-25` in subsequent headers — causing the server to reject every post-init request.

## What changed

- **`MCPTransport` interface** — added optional `protocolVersion?: string | null` field so the client can inject the negotiated version into any transport after init. Custom transports that don't set it are unaffected.
- **`SseMCPTransport` + `HttpMCPTransport`** — added `protocolVersion: string | null = null`; `commonHeaders()` now uses `this.protocolVersion ?? LATEST_PROTOCOL_VERSION` (falls back to latest only before the handshake completes).
- **`DefaultMCPClient.init()`** — after the `SUPPORTED_PROTOCOL_VERSIONS` check and capability storage, sets `this.transport.protocolVersion = result.protocolVersion`.
- **Tests** — added regression tests in both transport test files that set `protocolVersion` and assert subsequent request headers use the negotiated value.

## Test plan

- [x] `pnpm test` in `packages/mcp` — 181 tests pass (node + edge)
- [x] Regression tests added: `should use negotiated protocol version in POST headers after protocolVersion is set` in both `mcp-sse-transport.test.ts` and `mcp-http-transport.test.ts`
- [ ] No example added under `examples/` — the bug requires a live third-party MCP server, which cannot run in CI. The regression tests cover the same code path.

---

Credit: @stevering filed the detailed report, provided the repro trace against a real Figma Desktop MCP server, and validated this exact patch locally via `pnpm patch`. Thank you!

> This PR was developed with AI assistance. All contribution guidelines — branch naming, patch-only changeset, PR title format, test coverage, pre-commit hooks — were followed as specified in `CONTRIBUTING.md` and `CLAUDE.md`.