### PR TITLE
feat (provider/bytedance): add seedance 2.0 support

### DIFF
--- a/.changeset/hot-colts-hide.md
+++ b/.changeset/hot-colts-hide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/bytedance": patch
+---
+
+feat (provider/bytedance): add seedance 2.0 support

--- a/content/providers/01-ai-sdk-providers/85-bytedance.mdx
+++ b/content/providers/01-ai-sdk-providers/85-bytedance.mdx
@@ -215,6 +215,85 @@ const { video } = await generateVideo({
 });
 ```
 
+### Reference Video
+
+Seedance 2.0 supports reference videos that guide the style, motion, or composition of the generated video:
+
+```ts
+import {
+  byteDance,
+  type ByteDanceVideoProviderOptions,
+} from '@ai-sdk/bytedance';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { video } = await generateVideo({
+  model: byteDance.video('dreamina-seedance-2-0-260128'),
+  prompt:
+    'First-person perspective promotional ad, using the composition and camera movement from the reference video',
+  aspectRatio: '16:9',
+  duration: 4,
+  providerOptions: {
+    bytedance: {
+      referenceVideos: ['https://example.com/reference-video.mp4'],
+      watermark: false,
+    } satisfies ByteDanceVideoProviderOptions,
+  },
+});
+```
+
+### Reference Audio
+
+Seedance 2.0 supports reference audio that is used as background music or sound for the generated video:
+
+```ts
+import {
+  byteDance,
+  type ByteDanceVideoProviderOptions,
+} from '@ai-sdk/bytedance';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { video } = await generateVideo({
+  model: byteDance.video('dreamina-seedance-2-0-260128'),
+  prompt:
+    'A serene mountain landscape at sunrise with gentle camera movement',
+  aspectRatio: '16:9',
+  duration: 4,
+  providerOptions: {
+    bytedance: {
+      referenceAudio: 'https://example.com/background-music.mp3',
+      generateAudio: true,
+      watermark: false,
+    } satisfies ByteDanceVideoProviderOptions,
+  },
+});
+```
+
+### Web Search Tool
+
+Seedance 2.0 supports enabling web search to improve the timeliness and accuracy of generated video content:
+
+```ts
+import {
+  byteDance,
+  type ByteDanceVideoProviderOptions,
+} from '@ai-sdk/bytedance';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { video } = await generateVideo({
+  model: byteDance.video('dreamina-seedance-2-0-260128'),
+  prompt:
+    'A news-style recap of the latest technology trends',
+  aspectRatio: '16:9',
+  duration: 4,
+  providerOptions: {
+    bytedance: {
+      tools: [{ type: 'web_search' }],
+      watermark: false,
+    } satisfies ByteDanceVideoProviderOptions,
+  },
+});
+```
+
 ### Video Provider Options
 
 The following provider options are available via `providerOptions.bytedance`:
@@ -255,6 +334,22 @@ The following provider options are available via `providerOptions.bytedance`:
 
   Array of reference image URLs (1-4 images) for multi-reference image-to-video generation. The model extracts key features from each image and reproduces them in the video. Use `[Image 1]`, `[Image 2]`, etc. in your prompt to reference specific images. Supported by Seedance 1.0 Lite I2V.
 
+#### Media Reference Options
+
+- **referenceVideos** _string[]_
+
+  Array of reference video URLs (up to 3 videos, max 15 seconds each) for reference-guided video generation. The model uses the referenced videos to guide style, motion, or composition. Supported by Seedance 2.0.
+
+- **referenceAudio** _string_
+
+  URL or data URI of reference audio (max 15 seconds) for audio-guided video generation. The model uses the referenced audio as background music or synchronized sound. Supports data URIs (e.g., `data:audio/wav;base64,...`). Supported by Seedance 2.0.
+
+#### Tool Options
+
+- **tools** _Array&lt;\{ type: string \}&gt;_
+
+  Array of tool configurations to enable during generation. Currently supports `{ type: 'web_search' }` for improved timeliness of generated content. May increase latency. Supported by Seedance 2.0.
+
 #### Polling Options
 
 - **pollIntervalMs** _number_
@@ -275,9 +370,10 @@ The following provider options are available via `providerOptions.bytedance`:
 
 ### Video Model Capabilities
 
-| Model                   | Model ID                       | Capabilities                                                                                                                  |
-| ----------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| Seedance 1.5 Pro        | `seedance-1-5-pro-251215`      | T2V, I2V (first frame), I2V (first+last frame), audio-video sync, draft mode. Duration: 4-12s. Resolution: 480p, 720p, 1080p. |
+| Model                   | Model ID                       | Capabilities                                                                                                                                           |
+| ----------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Seedance 2.0            | `dreamina-seedance-2-0-260128` | T2V, I2V, reference videos (up to 3), reference audio, web search tool, audio-video sync. Duration: 4s. Resolution: 480p, 720p.                        |
+| Seedance 1.5 Pro        | `seedance-1-5-pro-251215`      | T2V, I2V (first frame), I2V (first+last frame), audio-video sync, draft mode. Duration: 4-12s. Resolution: 480p, 720p, 1080p.                          |
 | Seedance 1.0 Pro        | `seedance-1-0-pro-250528`      | T2V, I2V (first frame), I2V (first+last frame). Duration: 2-12s. Resolution: 480p, 720p, 1080p.                               |
 | Seedance 1.0 Pro Fast   | `seedance-1-0-pro-fast-251015` | T2V, I2V (first frame). Optimized for speed and cost. Duration: 2-12s.                                                        |
 | Seedance 1.0 Lite (T2V) | `seedance-1-0-lite-t2v-250428` | Text-to-video only. Duration: 2-12s. Resolution: 480p, 720p, 1080p.                                                           |

--- a/content/providers/01-ai-sdk-providers/85-bytedance.mdx
+++ b/content/providers/01-ai-sdk-providers/85-bytedance.mdx
@@ -268,32 +268,6 @@ const { video } = await generateVideo({
 });
 ```
 
-### Web Search Tool
-
-Seedance 2.0 supports enabling web search to improve the timeliness and accuracy of generated video content:
-
-```ts
-import {
-  byteDance,
-  type ByteDanceVideoProviderOptions,
-} from '@ai-sdk/bytedance';
-import { experimental_generateVideo as generateVideo } from 'ai';
-
-const { video } = await generateVideo({
-  model: byteDance.video('dreamina-seedance-2-0-260128'),
-  prompt:
-    'A news-style recap of the latest technology trends',
-  aspectRatio: '16:9',
-  duration: 4,
-  providerOptions: {
-    bytedance: {
-      tools: [{ type: 'web_search' }],
-      watermark: false,
-    } satisfies ByteDanceVideoProviderOptions,
-  },
-});
-```
-
 ### Video Provider Options
 
 The following provider options are available via `providerOptions.bytedance`:
@@ -344,12 +318,6 @@ The following provider options are available via `providerOptions.bytedance`:
 
   URL or data URI of reference audio (max 15 seconds) for audio-guided video generation. The model uses the referenced audio as background music or synchronized sound. Supports data URIs (e.g., `data:audio/wav;base64,...`). Supported by Seedance 2.0.
 
-#### Tool Options
-
-- **tools** _Array&lt;\{ type: string \}&gt;_
-
-  Array of tool configurations to enable during generation. Currently supports `{ type: 'web_search' }` for improved timeliness of generated content. May increase latency. Supported by Seedance 2.0.
-
 #### Polling Options
 
 - **pollIntervalMs** _number_
@@ -370,10 +338,11 @@ The following provider options are available via `providerOptions.bytedance`:
 
 ### Video Model Capabilities
 
-| Model                   | Model ID                       | Capabilities                                                                                                                                           |
-| ----------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Seedance 2.0            | `dreamina-seedance-2-0-260128` | T2V, I2V, reference videos (up to 3), reference audio, web search tool, audio-video sync. Duration: 4s. Resolution: 480p, 720p.                        |
-| Seedance 1.5 Pro        | `seedance-1-5-pro-251215`      | T2V, I2V (first frame), I2V (first+last frame), audio-video sync, draft mode. Duration: 4-12s. Resolution: 480p, 720p, 1080p.                          |
+| Model                   | Model ID                            | Capabilities                                                                                                                   |
+| ----------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Seedance 2.0            | `dreamina-seedance-2-0-260128`      | T2V, I2V, reference videos (up to 3), reference audio, audio-video sync. Duration: 4s. Resolution: 480p, 720p.                 |
+| Seedance 2.0 Fast       | `dreamina-seedance-2-0-fast-260128` | T2V, I2V, reference videos (up to 3), reference audio, audio-video sync. Optimized for speed. Duration: 4s. Resolution: 480p, 720p. |
+| Seedance 1.5 Pro        | `seedance-1-5-pro-251215`           | T2V, I2V (first frame), I2V (first+last frame), audio-video sync, draft mode. Duration: 4-12s. Resolution: 480p, 720p, 1080p. |
 | Seedance 1.0 Pro        | `seedance-1-0-pro-250528`      | T2V, I2V (first frame), I2V (first+last frame). Duration: 2-12s. Resolution: 480p, 720p, 1080p.                               |
 | Seedance 1.0 Pro Fast   | `seedance-1-0-pro-fast-251015` | T2V, I2V (first frame). Optimized for speed and cost. Duration: 2-12s.                                                        |
 | Seedance 1.0 Lite (T2V) | `seedance-1-0-lite-t2v-250428` | Text-to-video only. Duration: 2-12s. Resolution: 480p, 720p, 1080p.                                                           |

--- a/content/providers/01-ai-sdk-providers/85-bytedance.mdx
+++ b/content/providers/01-ai-sdk-providers/85-bytedance.mdx
@@ -260,7 +260,7 @@ const { video } = await generateVideo({
   duration: 4,
   providerOptions: {
     bytedance: {
-      referenceAudio: 'https://example.com/background-music.mp3',
+      referenceAudio: ['https://example.com/background-music.mp3'],
       generateAudio: true,
       watermark: false,
     } satisfies ByteDanceVideoProviderOptions,
@@ -314,9 +314,9 @@ The following provider options are available via `providerOptions.bytedance`:
 
   Array of reference video URLs (up to 3 videos, max 15 seconds each) for reference-guided video generation. The model uses the referenced videos to guide style, motion, or composition. Supported by Seedance 2.0.
 
-- **referenceAudio** _string_
+- **referenceAudio** _string[]_
 
-  URL or data URI of reference audio (max 15 seconds) for audio-guided video generation. The model uses the referenced audio as background music or synchronized sound. Supports data URIs (e.g., `data:audio/wav;base64,...`). Supported by Seedance 2.0.
+  Array of reference audio URLs (up to 3, max 15 seconds each) for audio-guided video generation. The model uses the referenced audio as background music or synchronized sound. Supports data URIs (e.g., `data:audio/wav;base64,...`). Supported by Seedance 2.0.
 
 #### Polling Options
 
@@ -340,8 +340,8 @@ The following provider options are available via `providerOptions.bytedance`:
 
 | Model                   | Model ID                            | Capabilities                                                                                                                   |
 | ----------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Seedance 2.0            | `dreamina-seedance-2-0-260128`      | T2V, I2V, reference videos (up to 3), reference audio, audio-video sync. Duration: 4s. Resolution: 480p, 720p.                 |
-| Seedance 2.0 Fast       | `dreamina-seedance-2-0-fast-260128` | T2V, I2V, reference videos (up to 3), reference audio, audio-video sync. Optimized for speed. Duration: 4s. Resolution: 480p, 720p. |
+| Seedance 2.0            | `dreamina-seedance-2-0-260128`      | T2V, I2V, reference videos (up to 3), reference audio (up to 3), audio-video sync. Duration: 4-15s. Resolution: 480p, 720p.                 |
+| Seedance 2.0 Fast       | `dreamina-seedance-2-0-fast-260128` | T2V, I2V, reference videos (up to 3), reference audio (up to 3), audio-video sync. Optimized for speed. Duration: 4-15s. Resolution: 480p, 720p. |
 | Seedance 1.5 Pro        | `seedance-1-5-pro-251215`           | T2V, I2V (first frame), I2V (first+last frame), audio-video sync, draft mode. Duration: 4-12s. Resolution: 480p, 720p, 1080p. |
 | Seedance 1.0 Pro        | `seedance-1-0-pro-250528`      | T2V, I2V (first frame), I2V (first+last frame). Duration: 2-12s. Resolution: 480p, 720p, 1080p.                               |
 | Seedance 1.0 Pro Fast   | `seedance-1-0-pro-fast-251015` | T2V, I2V (first frame). Optimized for speed and cost. Duration: 2-12s.                                                        |

--- a/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-edit.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-edit.ts
@@ -1,0 +1,37 @@
+import {
+  type ByteDanceVideoProviderOptions,
+  byteDance,
+} from '@ai-sdk/bytedance';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Editing video with seedance-2-0...',
+    () =>
+      generateVideo({
+        model: byteDance.video('dreamina-seedance-2-0-260128'),
+        prompt:
+          "Replace the cat in [Video 1] with the lion from [Image 1]. The lion lies on its side across the girl's legs, gently interacting with her in a warm and tender way.",
+        aspectRatio: '16:9',
+        duration: 12,
+        providerOptions: {
+          bytedance: {
+            referenceImages: [
+              'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_image/r2v_edit_pic1.jpg',
+            ],
+            referenceVideos: [
+              'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_video/r2v_edit_video1.mp4',
+            ],
+            generateAudio: true,
+            watermark: false,
+            pollTimeoutMs: 600000,
+          } satisfies ByteDanceVideoProviderOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-extend.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-extend.ts
@@ -1,0 +1,36 @@
+import {
+  type ByteDanceVideoProviderOptions,
+  byteDance,
+} from '@ai-sdk/bytedance';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Extending video with seedance-2-0...',
+    () =>
+      generateVideo({
+        model: byteDance.video('dreamina-seedance-2-0-260128'),
+        prompt:
+          'The arched window in [Video 1] opens, and the camera moves into the interior of the art museum, transitioning into [Video 2]. After that, the camera enters the painting itself, transitioning into [Video 3].',
+        aspectRatio: '16:9',
+        duration: 8,
+        providerOptions: {
+          bytedance: {
+            referenceVideos: [
+              'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_video/r2v_extend_video1.mp4',
+              'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_video/r2v_extend_video2.mp4',
+              'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_video/r2v_extend_video3.mp4',
+            ],
+            generateAudio: true,
+            watermark: false,
+            pollTimeoutMs: 600000,
+          } satisfies ByteDanceVideoProviderOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-i2v.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-i2v.ts
@@ -1,0 +1,32 @@
+import {
+  type ByteDanceVideoProviderOptions,
+  byteDance,
+} from '@ai-sdk/bytedance';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating image-to-video with seedance-2-0...',
+    () =>
+      generateVideo({
+        model: byteDance.video('dreamina-seedance-2-0-260128'),
+        prompt: {
+          image:
+            'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+          text: 'The cat slowly turns its head and blinks, then yawns lazily',
+        },
+        duration: 5,
+        providerOptions: {
+          bytedance: {
+            watermark: false,
+            pollTimeoutMs: 600000,
+          } satisfies ByteDanceVideoProviderOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-reference-audio.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/seedance-2-0-reference-audio.ts
@@ -1,0 +1,41 @@
+import {
+  type ByteDanceVideoProviderOptions,
+  byteDance,
+} from '@ai-sdk/bytedance';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating video with reference audio using seedance-2-0...',
+    () =>
+      generateVideo({
+        model: byteDance.video('dreamina-seedance-2-0-260128'),
+        prompt:
+          'Use the first-person POV framing from [Video 1] throughout, and use [Audio 1] as the background music throughout. First-person POV fruit tea promotional ad, opening frame is [Image 1], your hand picks a dew-covered red apple with a light crisp tapping sound. The fruit tea from [Image 2] is raised toward the camera at the end.',
+        aspectRatio: '16:9',
+        duration: 8,
+        providerOptions: {
+          bytedance: {
+            referenceImages: [
+              'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_image/r2v_tea_pic1.jpg',
+              'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_image/r2v_tea_pic2.jpg',
+            ],
+            referenceVideos: [
+              'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_video/r2v_tea_video1.mp4',
+            ],
+            referenceAudio: [
+              'https://ark-doc.tos-ap-southeast-1.bytepluses.com/doc_audio/r2v_tea_audio1.mp3',
+            ],
+            generateAudio: true,
+            watermark: false,
+            pollTimeoutMs: 600000,
+          } satisfies ByteDanceVideoProviderOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/bytedance/seedance-2-0.ts
+++ b/examples/ai-functions/src/generate-video/bytedance/seedance-2-0.ts
@@ -1,0 +1,30 @@
+import {
+  type ByteDanceVideoProviderOptions,
+  byteDance,
+} from '@ai-sdk/bytedance';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating text-to-video with seedance-2-0...',
+    () =>
+      generateVideo({
+        model: byteDance.video('dreamina-seedance-2-0-260128'),
+        prompt:
+          'Photorealistic style: A vibrant street market at golden hour, with warm light filtering through colorful awnings. The camera slowly moves through the crowd, focusing on a flower vendor arranging fresh bouquets.',
+        aspectRatio: '16:9',
+        duration: 4,
+        providerOptions: {
+          bytedance: {
+            watermark: false,
+            pollTimeoutMs: 600000,
+          } satisfies ByteDanceVideoProviderOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/packages/bytedance/src/bytedance-video-model.test.ts
+++ b/packages/bytedance/src/bytedance-video-model.test.ts
@@ -652,6 +652,152 @@ describe('ByteDanceVideoModel', () => {
       ]);
     });
 
+    it('should add reference videos with role', async () => {
+      const model = createBasicModel({
+        modelId: 'dreamina-seedance-2-0-260128',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          bytedance: {
+            referenceVideos: [
+              'https://example.com/ref1.mp4',
+              'https://example.com/ref2.mp4',
+            ],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.content).toStrictEqual([
+        {
+          type: 'text',
+          text: prompt,
+        },
+        {
+          type: 'video_url',
+          video_url: { url: 'https://example.com/ref1.mp4' },
+          role: 'reference_video',
+        },
+        {
+          type: 'video_url',
+          video_url: { url: 'https://example.com/ref2.mp4' },
+          role: 'reference_video',
+        },
+      ]);
+    });
+
+    it('should add reference audio with role', async () => {
+      const model = createBasicModel({
+        modelId: 'dreamina-seedance-2-0-260128',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          bytedance: {
+            referenceAudio: 'https://example.com/audio.mp3',
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.content).toStrictEqual([
+        {
+          type: 'text',
+          text: prompt,
+        },
+        {
+          type: 'audio_url',
+          audio_url: { url: 'https://example.com/audio.mp3' },
+          role: 'reference_audio',
+        },
+      ]);
+    });
+
+    it('should support data URI for reference audio', async () => {
+      const model = createBasicModel({
+        modelId: 'dreamina-seedance-2-0-260128',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          bytedance: {
+            referenceAudio: 'data:audio/mp3;base64,SGVsbG8=',
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.content).toStrictEqual([
+        {
+          type: 'text',
+          text: prompt,
+        },
+        {
+          type: 'audio_url',
+          audio_url: { url: 'data:audio/mp3;base64,SGVsbG8=' },
+          role: 'reference_audio',
+        },
+      ]);
+    });
+
+    it('should pass tools option in body', async () => {
+      const model = createBasicModel({
+        modelId: 'dreamina-seedance-2-0-260128',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          bytedance: {
+            tools: [{ type: 'web_search' }],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.tools).toStrictEqual([{ type: 'web_search' }]);
+    });
+
+    it('should support reference videos, audio, and tools together', async () => {
+      const model = createBasicModel({
+        modelId: 'dreamina-seedance-2-0-260128',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          bytedance: {
+            referenceVideos: ['https://example.com/ref.mp4'],
+            referenceAudio: 'https://example.com/audio.mp3',
+            tools: [{ type: 'web_search' }],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.content).toStrictEqual([
+        {
+          type: 'text',
+          text: prompt,
+        },
+        {
+          type: 'video_url',
+          video_url: { url: 'https://example.com/ref.mp4' },
+          role: 'reference_video',
+        },
+        {
+          type: 'audio_url',
+          audio_url: { url: 'https://example.com/audio.mp3' },
+          role: 'reference_audio',
+        },
+      ]);
+      expect(requestBody.tools).toStrictEqual([{ type: 'web_search' }]);
+    });
+
     it('should pass through additional options', async () => {
       const model = createBasicModel();
 

--- a/packages/bytedance/src/bytedance-video-model.test.ts
+++ b/packages/bytedance/src/bytedance-video-model.test.ts
@@ -697,7 +697,7 @@ describe('ByteDanceVideoModel', () => {
         ...defaultOptions,
         providerOptions: {
           bytedance: {
-            referenceAudio: 'https://example.com/audio.mp3',
+            referenceAudio: ['https://example.com/audio.mp3'],
           },
         },
       });
@@ -716,6 +716,48 @@ describe('ByteDanceVideoModel', () => {
       ]);
     });
 
+    it('should add multiple reference audios', async () => {
+      const model = createBasicModel({
+        modelId: 'dreamina-seedance-2-0-260128',
+      });
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          bytedance: {
+            referenceAudio: [
+              'https://example.com/audio1.mp3',
+              'https://example.com/audio2.mp3',
+              'https://example.com/audio3.mp3',
+            ],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.content).toStrictEqual([
+        {
+          type: 'text',
+          text: prompt,
+        },
+        {
+          type: 'audio_url',
+          audio_url: { url: 'https://example.com/audio1.mp3' },
+          role: 'reference_audio',
+        },
+        {
+          type: 'audio_url',
+          audio_url: { url: 'https://example.com/audio2.mp3' },
+          role: 'reference_audio',
+        },
+        {
+          type: 'audio_url',
+          audio_url: { url: 'https://example.com/audio3.mp3' },
+          role: 'reference_audio',
+        },
+      ]);
+    });
+
     it('should support data URI for reference audio', async () => {
       const model = createBasicModel({
         modelId: 'dreamina-seedance-2-0-260128',
@@ -725,7 +767,7 @@ describe('ByteDanceVideoModel', () => {
         ...defaultOptions,
         providerOptions: {
           bytedance: {
-            referenceAudio: 'data:audio/mp3;base64,SGVsbG8=',
+            referenceAudio: ['data:audio/mp3;base64,SGVsbG8='],
           },
         },
       });
@@ -754,7 +796,7 @@ describe('ByteDanceVideoModel', () => {
         providerOptions: {
           bytedance: {
             referenceVideos: ['https://example.com/ref.mp4'],
-            referenceAudio: 'https://example.com/audio.mp3',
+            referenceAudio: ['https://example.com/audio.mp3'],
           },
         },
       });

--- a/packages/bytedance/src/bytedance-video-model.test.ts
+++ b/packages/bytedance/src/bytedance-video-model.test.ts
@@ -744,25 +744,7 @@ describe('ByteDanceVideoModel', () => {
       ]);
     });
 
-    it('should pass tools option in body', async () => {
-      const model = createBasicModel({
-        modelId: 'dreamina-seedance-2-0-260128',
-      });
-
-      await model.doGenerate({
-        ...defaultOptions,
-        providerOptions: {
-          bytedance: {
-            tools: [{ type: 'web_search' }],
-          },
-        },
-      });
-
-      const requestBody = await server.calls[0].requestBodyJson;
-      expect(requestBody.tools).toStrictEqual([{ type: 'web_search' }]);
-    });
-
-    it('should support reference videos, audio, and tools together', async () => {
+    it('should support reference videos and audio together', async () => {
       const model = createBasicModel({
         modelId: 'dreamina-seedance-2-0-260128',
       });
@@ -773,7 +755,6 @@ describe('ByteDanceVideoModel', () => {
           bytedance: {
             referenceVideos: ['https://example.com/ref.mp4'],
             referenceAudio: 'https://example.com/audio.mp3',
-            tools: [{ type: 'web_search' }],
           },
         },
       });
@@ -795,7 +776,6 @@ describe('ByteDanceVideoModel', () => {
           role: 'reference_audio',
         },
       ]);
-      expect(requestBody.tools).toStrictEqual([{ type: 'web_search' }]);
     });
 
     it('should pass through additional options', async () => {

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -31,7 +31,6 @@ export type ByteDanceVideoProviderOptions = {
   referenceImages?: string[] | null;
   referenceVideos?: string[] | null;
   referenceAudio?: string | null;
-  tools?: Array<{ type: string }> | null;
   pollIntervalMs?: number | null;
   pollTimeoutMs?: number | null;
   [key: string]: unknown;
@@ -48,7 +47,6 @@ const HANDLED_PROVIDER_OPTIONS = new Set([
   'referenceImages',
   'referenceVideos',
   'referenceAudio',
-  'tools',
   'pollIntervalMs',
   'pollTimeoutMs',
 ]);
@@ -67,7 +65,6 @@ export const byteDanceVideoProviderOptionsSchema = lazySchema(() =>
         referenceImages: z.array(z.string()).nullish(),
         referenceVideos: z.array(z.string()).nullish(),
         referenceAudio: z.string().nullish(),
-        tools: z.array(z.object({ type: z.string() }).passthrough()).nullish(),
         pollIntervalMs: z.number().positive().nullish(),
         pollTimeoutMs: z.number().positive().nullish(),
       })
@@ -276,10 +273,6 @@ export class ByteDanceVideoModel implements Experimental_VideoModelV4 {
       if (byteDanceOptions.draft != null) {
         body.draft = byteDanceOptions.draft;
       }
-      if (byteDanceOptions.tools != null) {
-        body.tools = byteDanceOptions.tools;
-      }
-
       // Pass through any additional options not explicitly handled
       for (const [key, value] of Object.entries(byteDanceOptions)) {
         if (!HANDLED_PROVIDER_OPTIONS.has(key)) {

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -30,7 +30,7 @@ export type ByteDanceVideoProviderOptions = {
   lastFrameImage?: string | null;
   referenceImages?: string[] | null;
   referenceVideos?: string[] | null;
-  referenceAudio?: string | null;
+  referenceAudio?: string[] | null;
   pollIntervalMs?: number | null;
   pollTimeoutMs?: number | null;
   [key: string]: unknown;
@@ -64,7 +64,7 @@ export const byteDanceVideoProviderOptionsSchema = lazySchema(() =>
         lastFrameImage: z.string().nullish(),
         referenceImages: z.array(z.string()).nullish(),
         referenceVideos: z.array(z.string()).nullish(),
-        referenceAudio: z.string().nullish(),
+        referenceAudio: z.array(z.string()).nullish(),
         pollIntervalMs: z.number().positive().nullish(),
         pollTimeoutMs: z.number().positive().nullish(),
       })
@@ -220,12 +220,17 @@ export class ByteDanceVideoModel implements Experimental_VideoModelV4 {
     }
 
     // Add reference audio if provided
-    if (byteDanceOptions?.referenceAudio != null) {
-      content.push({
-        type: 'audio_url',
-        audio_url: { url: byteDanceOptions.referenceAudio },
-        role: 'reference_audio',
-      });
+    if (
+      byteDanceOptions?.referenceAudio != null &&
+      byteDanceOptions.referenceAudio.length > 0
+    ) {
+      for (const audioUrl of byteDanceOptions.referenceAudio) {
+        content.push({
+          type: 'audio_url',
+          audio_url: { url: audioUrl },
+          role: 'reference_audio',
+        });
+      }
     }
 
     const body: Record<string, unknown> = {

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -29,6 +29,9 @@ export type ByteDanceVideoProviderOptions = {
   draft?: boolean | null;
   lastFrameImage?: string | null;
   referenceImages?: string[] | null;
+  referenceVideos?: string[] | null;
+  referenceAudio?: string | null;
+  tools?: Array<{ type: string }> | null;
   pollIntervalMs?: number | null;
   pollTimeoutMs?: number | null;
   [key: string]: unknown;
@@ -43,6 +46,9 @@ const HANDLED_PROVIDER_OPTIONS = new Set([
   'draft',
   'lastFrameImage',
   'referenceImages',
+  'referenceVideos',
+  'referenceAudio',
+  'tools',
   'pollIntervalMs',
   'pollTimeoutMs',
 ]);
@@ -59,6 +65,9 @@ export const byteDanceVideoProviderOptionsSchema = lazySchema(() =>
         draft: z.boolean().nullish(),
         lastFrameImage: z.string().nullish(),
         referenceImages: z.array(z.string()).nullish(),
+        referenceVideos: z.array(z.string()).nullish(),
+        referenceAudio: z.string().nullish(),
+        tools: z.array(z.object({ type: z.string() }).passthrough()).nullish(),
         pollIntervalMs: z.number().positive().nullish(),
         pollTimeoutMs: z.number().positive().nullish(),
       })
@@ -199,6 +208,29 @@ export class ByteDanceVideoModel implements Experimental_VideoModelV4 {
       }
     }
 
+    // Add reference videos if provided
+    if (
+      byteDanceOptions?.referenceVideos != null &&
+      byteDanceOptions.referenceVideos.length > 0
+    ) {
+      for (const videoUrl of byteDanceOptions.referenceVideos) {
+        content.push({
+          type: 'video_url',
+          video_url: { url: videoUrl },
+          role: 'reference_video',
+        });
+      }
+    }
+
+    // Add reference audio if provided
+    if (byteDanceOptions?.referenceAudio != null) {
+      content.push({
+        type: 'audio_url',
+        audio_url: { url: byteDanceOptions.referenceAudio },
+        role: 'reference_audio',
+      });
+    }
+
     const body: Record<string, unknown> = {
       model: this.modelId,
       content,
@@ -243,6 +275,9 @@ export class ByteDanceVideoModel implements Experimental_VideoModelV4 {
       }
       if (byteDanceOptions.draft != null) {
         body.draft = byteDanceOptions.draft;
+      }
+      if (byteDanceOptions.tools != null) {
+        body.tools = byteDanceOptions.tools;
       }
 
       // Pass through any additional options not explicitly handled

--- a/packages/bytedance/src/bytedance-video-settings.ts
+++ b/packages/bytedance/src/bytedance-video-settings.ts
@@ -1,4 +1,5 @@
 export type ByteDanceVideoModelId =
+  | 'dreamina-seedance-2-0-260128'
   | 'seedance-1-5-pro-251215'
   | 'seedance-1-0-pro-250528'
   | 'seedance-1-0-pro-fast-251015'

--- a/packages/bytedance/src/bytedance-video-settings.ts
+++ b/packages/bytedance/src/bytedance-video-settings.ts
@@ -1,4 +1,5 @@
 export type ByteDanceVideoModelId =
+  | 'dreamina-seedance-2-0-fast-260128'
   | 'dreamina-seedance-2-0-260128'
   | 'seedance-1-5-pro-251215'
   | 'seedance-1-0-pro-250528'


### PR DESCRIPTION
## Background

ByteDance has released Seedance 2.0, which introduces new capabilities for video generation including reference video and reference audio support. This enhancement allows users to guide video generation using existing videos and audio files.

## Changes

Added support for Seedance 2.0 models (`dreamina-seedance-2-0-260128` and `dreamina-seedance-2-0-fast-260128`) with the following new features:

- **Reference Videos**: Support for up to 3 reference videos (max 15 seconds each) to guide style, motion, or composition
- **Reference Audio**: Support for up to 3 reference audio files (max 15 seconds each) for background music or synchronized sound, including data URI support
- **Enhanced Documentation**: Added comprehensive examples for reference video, reference audio, video editing, and video extension use cases
- **New Provider Options**: Added `referenceVideos` and `referenceAudio` arrays to `ByteDanceVideoProviderOptions`

The implementation includes proper content formatting with role-based media references and maintains backward compatibility with existing Seedance models.

## Manual Verification

Created and tested example scripts demonstrating:

- Basic text-to-video generation with Seedance 2.0
- Reference video usage for style and motion guidance
- Reference audio integration for background music
- Video editing workflows combining reference images and videos
- Video extension using multiple reference videos

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)