### PR TITLE
chore(openai): fix the changeset package name

### DIFF
--- a/.changeset/late-walls-fly.md
+++ b/.changeset/late-walls-fly.md
@@ -1,5 +1,5 @@
 ---
-"openai": patch
+"@ai-sdk/openai": patch
 ---
 
 fix(openai): default undefined tool-call input to empty object before serializing tool arguments


### PR DESCRIPTION
## Background

the changeset published as a part of https://github.com/vercel/ai/pull/14415 had the incorrect package name. 

## Summary

rename package and delete the older changeset

## Manual Verification

na

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)