### PR TITLE
fix(gateway): add 'reranking' to modelType validation schema and type

### DIFF
--- a/.changeset/fix-gateway-reranking-modeltype.md
+++ b/.changeset/fix-gateway-reranking-modeltype.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+fix (provider/gateway): add 'reranking' to modelType validation schema and type so getAvailableModels() accepts reranking models from the gateway API

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -110,7 +110,7 @@ const gatewayAvailableModelsResponseSchema = lazySchema(() =>
             modelId: z.string(),
           }),
           modelType: z
-            .enum(['embedding', 'image', 'language', 'video'])
+            .enum(['embedding', 'image', 'language', 'reranking', 'video'])
             .nullish(),
         }),
       ),

--- a/packages/gateway/src/gateway-model-entry.ts
+++ b/packages/gateway/src/gateway-model-entry.ts
@@ -49,7 +49,7 @@ export interface GatewayLanguageModelEntry {
   /**
    * Optional field to differentiate between model types.
    */
-  modelType?: 'language' | 'embedding' | 'image' | 'video' | null;
+  modelType?: 'language' | 'embedding' | 'image' | 'reranking' | 'video' | null;
 }
 
 export type GatewayLanguageModelSpecification = Pick<


### PR DESCRIPTION
## Summary
- The live gateway API now returns models with `modelType: "reranking"` (e.g. `cohere/rerank-v3.5`, `voyage/rerank-2.5`), but `getAvailableModels()` rejects them because the Zod validation schema and `GatewayLanguageModelEntry` type only allow `'embedding' | 'image' | 'language' | 'video'`.
- Adds `'reranking'` to the `z.enum()` in `gateway-fetch-metadata.ts` and the union type in `gateway-model-entry.ts`, aligning them with the reranking support already wired up in `gateway-provider.ts`.

## Test plan
- [x] Verify `getAvailableModels()` no longer throws when the gateway response includes reranking models
- [x] Existing test "should reject invalid top-level modelType values" still rejects truly invalid values (e.g. `'text'`)
- [x] Existing test "should accept top-level modelType when present" continues to pass for `'language'`