### PR TITLE
Add id property to WorkflowAgent

### DIFF
--- a/.changeset/workflow-agent-add-id.md
+++ b/.changeset/workflow-agent-add-id.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Add `id` property to WorkflowAgent for telemetry identification, matching ToolLoopAgent's API surface.

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -54,7 +54,7 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
       name: 'id',
       type: 'string',
       isOptional: true,
-      description: 'The id of the agent. Used for telemetry identification.',
+      description: 'The id of the agent.',
     },
     {
       name: 'model',

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -51,6 +51,12 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
 <PropertiesTable
   content={[
     {
+      name: 'id',
+      type: 'string',
+      isOptional: true,
+      description: 'The id of the agent. Used for telemetry identification.',
+    },
+    {
       name: 'model',
       type: 'LanguageModel',
       isRequired: true,
@@ -294,6 +300,11 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
 
 <PropertiesTable
   content={[
+    {
+      name: 'id',
+      type: 'string | undefined',
+      description: 'The id of the agent. Used for telemetry identification. Read-only.',
+    },
     {
       name: 'tools',
       type: 'Record<string, Tool>',

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -55,6 +55,23 @@ type MockIterator = AsyncGenerator<
 >;
 
 describe('WorkflowAgent', () => {
+  describe('id property', () => {
+    it('should expose id when provided in constructor', () => {
+      const agent = new WorkflowAgent({
+        model: async () => createMockModel(),
+        id: 'my-agent',
+      });
+      expect(agent.id).toBe('my-agent');
+    });
+
+    it('should be undefined when not provided', () => {
+      const agent = new WorkflowAgent({
+        model: async () => createMockModel(),
+      });
+      expect(agent.id).toBeUndefined();
+    });
+  });
+
   describe('tool execution error handling', () => {
     it('should convert FatalError to tool error result', async () => {
       const errorMessage = 'This is a fatal error';

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -58,7 +58,7 @@ describe('WorkflowAgent', () => {
   describe('id property', () => {
     it('should expose id when provided in constructor', () => {
       const agent = new WorkflowAgent({
-        model: async () => createMockModel(),
+        model: createMockModel(),
         id: 'my-agent',
       });
       expect(agent.id).toBe('my-agent');
@@ -66,7 +66,7 @@ describe('WorkflowAgent', () => {
 
     it('should be undefined when not provided', () => {
       const agent = new WorkflowAgent({
-        model: async () => createMockModel(),
+        model: createMockModel(),
       });
       expect(agent.id).toBeUndefined();
     });

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -368,7 +368,7 @@ export interface WorkflowAgentOptions<
   TTools extends ToolSet = ToolSet,
 > extends GenerationSettings {
   /**
-   * The id of the agent. Used for telemetry identification.
+   * The id of the agent.
    */
   id?: string;
 

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -368,6 +368,11 @@ export interface WorkflowAgentOptions<
   TTools extends ToolSet = ToolSet,
 > extends GenerationSettings {
   /**
+   * The id of the agent. Used for telemetry identification.
+   */
+  id?: string;
+
+  /**
    * The model provider to use for the agent.
    *
    * This should be a string compatible with the Vercel AI Gateway (e.g., 'anthropic/claude-opus'),
@@ -889,6 +894,11 @@ export interface WorkflowAgentStreamResult<
  * ```
  */
 export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
+  /**
+   * The id of the agent.
+   */
+  public readonly id: string | undefined;
+
   private model: LanguageModel;
   /**
    * The tool set configured for this agent.
@@ -912,6 +922,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
   private prepareCall?: PrepareCallCallback<TBaseTools>;
 
   constructor(options: WorkflowAgentOptions<TBaseTools>) {
+    this.id = options.id;
     this.model = options.model;
     this.tools = (options.tools ?? {}) as TBaseTools;
     // `instructions` takes precedence over deprecated `system`


### PR DESCRIPTION
## Background

ToolLoopAgent has an `id` constructor parameter and a public `id` getter used for telemetry identification. WorkflowAgent lacks this entirely, creating an API inconsistency between the two agent types.

## Summary

- Added optional `id` parameter to `WorkflowAgentOptions`
- Exposed `id` as a read-only public property on the `WorkflowAgent` class
- Added unit tests for the new property
- Updated reference documentation

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Closes #14453