### PR TITLE
Add constructor-level defaults to WorkflowAgent for stream-only parameters

### DIFF
--- a/.changeset/workflow-agent-constructor-defaults.md
+++ b/.changeset/workflow-agent-constructor-defaults.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Add constructor-level defaults for `stopWhen`, `activeTools`, `output`, `experimental_repairToolCall`, and `experimental_download` to WorkflowAgent, matching ToolLoopAgent's pattern. Stream-level values override constructor defaults.

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -79,6 +79,36 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
         "Tool call selection strategy. Options: 'auto' | 'none' | 'required' | { type: 'tool', toolName: string }. Default: 'auto'.",
     },
     {
+      name: 'stopWhen',
+      type: 'StopCondition | StopCondition[]',
+      isOptional: true,
+      description: 'Default stop condition for the agent loop. Per-stream values override this default.',
+    },
+    {
+      name: 'activeTools',
+      type: 'Array<string>',
+      isOptional: true,
+      description: 'Default set of active tools. Limits which tools the model can call. Per-stream values override this default.',
+    },
+    {
+      name: 'output',
+      type: 'OutputSpecification',
+      isOptional: true,
+      description: 'Default structured output specification. Per-stream values override this default.',
+    },
+    {
+      name: 'experimental_repairToolCall',
+      type: 'ToolCallRepairFunction',
+      isOptional: true,
+      description: 'Default function to repair tool calls that fail to parse. Per-stream values override this default.',
+    },
+    {
+      name: 'experimental_download',
+      type: 'DownloadFunction',
+      isOptional: true,
+      description: 'Default custom download function for URLs. Per-stream values override this default.',
+    },
+    {
       name: 'prepareStep',
       type: 'PrepareStepCallback',
       isOptional: true,

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -1676,7 +1676,7 @@ describe('WorkflowAgent', () => {
       const stopWhenFn = vi.fn(() => false);
 
       const agent = new WorkflowAgent({
-        model: async () => mockModel,
+        model: mockModel,
         tools: {},
         stopWhen: stopWhenFn as any,
       });
@@ -1711,7 +1711,7 @@ describe('WorkflowAgent', () => {
       const streamStopWhen = vi.fn(() => true);
 
       const agent = new WorkflowAgent({
-        model: async () => mockModel,
+        model: mockModel,
         tools: {},
         stopWhen: constructorStopWhen as any,
       });
@@ -1758,7 +1758,7 @@ describe('WorkflowAgent', () => {
       const mockModel = createMockModel();
 
       const agent = new WorkflowAgent({
-        model: async () => mockModel,
+        model: mockModel,
         tools,
         activeTools: ['tool1'],
       });
@@ -1792,7 +1792,7 @@ describe('WorkflowAgent', () => {
       const repairFn: ToolCallRepairFunction<ToolSet> = vi.fn();
 
       const agent = new WorkflowAgent({
-        model: async () => mockModel,
+        model: mockModel,
         tools: {},
         experimental_repairToolCall: repairFn,
       });

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -1670,6 +1670,158 @@ describe('WorkflowAgent', () => {
     });
   });
 
+  describe('constructor-level defaults for stream-only parameters', () => {
+    it('should use constructor stopWhen when not specified in stream()', async () => {
+      const mockModel = createMockModel();
+      const stopWhenFn = vi.fn(() => false);
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools: {},
+        stopWhen: stopWhenFn as any,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockClear();
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: mockWritable,
+      });
+
+      const calls = vi.mocked(streamTextIterator).mock.calls;
+      const lastCall = calls[calls.length - 1][0];
+      expect(lastCall.stopConditions).toBe(stopWhenFn);
+    });
+
+    it('should allow stream options to override constructor stopWhen', async () => {
+      const mockModel = createMockModel();
+      const constructorStopWhen = vi.fn(() => false);
+      const streamStopWhen = vi.fn(() => true);
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools: {},
+        stopWhen: constructorStopWhen as any,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockClear();
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: mockWritable,
+        stopWhen: streamStopWhen as any,
+      });
+
+      const calls = vi.mocked(streamTextIterator).mock.calls;
+      const lastCall = calls[calls.length - 1][0];
+      expect(lastCall.stopConditions).toBe(streamStopWhen);
+    });
+
+    it('should use constructor activeTools when not specified in stream()', async () => {
+      const tools: ToolSet = {
+        tool1: {
+          description: 'Tool 1',
+          inputSchema: z.object({}),
+          execute: async () => ({}),
+        },
+        tool2: {
+          description: 'Tool 2',
+          inputSchema: z.object({}),
+          execute: async () => ({}),
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools,
+        activeTools: ['tool1'],
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockClear();
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: mockWritable,
+      });
+
+      const calls = vi.mocked(streamTextIterator).mock.calls;
+      const lastCall = calls[calls.length - 1][0];
+      expect(Object.keys(lastCall.tools)).toEqual(['tool1']);
+    });
+
+    it('should use constructor experimental_repairToolCall when not specified in stream()', async () => {
+      const mockModel = createMockModel();
+      const repairFn: ToolCallRepairFunction<ToolSet> = vi.fn();
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools: {},
+        experimental_repairToolCall: repairFn,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockClear();
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: mockWritable,
+      });
+
+      const calls = vi.mocked(streamTextIterator).mock.calls;
+      const lastCall = calls[calls.length - 1][0];
+      expect(lastCall.repairToolCall).toBe(repairFn);
+    });
+  });
+
   describe('callbacks', () => {
     it('should pass onError callback to streamTextIterator', async () => {
       const mockModel = createMockModel();

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -414,6 +414,46 @@ export interface WorkflowAgentOptions<
   experimental_context?: unknown;
 
   /**
+   * Default stop condition for the agent loop. When the condition is an array,
+   * any of the conditions can be met to stop the generation.
+   *
+   * Per-stream `stopWhen` values passed to `stream()` override this default.
+   */
+  stopWhen?:
+    | StopCondition<NoInfer<ToolSet>, any>
+    | Array<StopCondition<NoInfer<ToolSet>, any>>;
+
+  /**
+   * Default set of active tools that limits which tools the model can call,
+   * without changing the tool call and result types in the result.
+   *
+   * Per-stream `activeTools` values passed to `stream()` override this default.
+   */
+  activeTools?: Array<keyof NoInfer<TTools>>;
+
+  /**
+   * Default output specification for structured outputs.
+   * Use `Output.object({ schema })` for structured output or `Output.text()` for text output.
+   *
+   * Per-stream `output` values passed to `stream()` override this default.
+   */
+  output?: OutputSpecification<any, any>;
+
+  /**
+   * Default function that attempts to repair a tool call that failed to parse.
+   *
+   * Per-stream `experimental_repairToolCall` values passed to `stream()` override this default.
+   */
+  experimental_repairToolCall?: ToolCallRepairFunction<TTools>;
+
+  /**
+   * Default custom download function to use for URLs.
+   *
+   * Per-stream `experimental_download` values passed to `stream()` override this default.
+   */
+  experimental_download?: DownloadFunction;
+
+  /**
    * Default callback function called before each step in the agent loop.
    * Use this to modify settings, manage context, or inject messages dynamically
    * for every stream call on this agent instance.
@@ -902,6 +942,13 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
   private toolChoice?: ToolChoice<TBaseTools>;
   private telemetry?: TelemetrySettings;
   private experimentalContext: unknown;
+  private stopWhen?:
+    | StopCondition<ToolSet, any>
+    | Array<StopCondition<ToolSet, any>>;
+  private activeTools?: Array<keyof TBaseTools>;
+  private output?: OutputSpecification<any, any>;
+  private experimentalRepairToolCall?: ToolCallRepairFunction<TBaseTools>;
+  private experimentalDownload?: DownloadFunction;
   private prepareStep?: PrepareStepCallback<TBaseTools>;
   private constructorOnStepFinish?: WorkflowAgentOnStepFinishCallback<ToolSet>;
   private constructorOnFinish?: WorkflowAgentOnFinishCallback<ToolSet>;
@@ -919,6 +966,11 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
     this.toolChoice = options.toolChoice;
     this.telemetry = options.experimental_telemetry;
     this.experimentalContext = options.experimental_context;
+    this.stopWhen = options.stopWhen;
+    this.activeTools = options.activeTools;
+    this.output = options.output;
+    this.experimentalRepairToolCall = options.experimental_repairToolCall;
+    this.experimentalDownload = options.experimental_download;
     this.prepareStep = options.prepareStep;
     this.constructorOnStepFinish = options.onStepFinish;
     this.constructorOnFinish = options.onFinish;
@@ -1146,7 +1198,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
     const modelPrompt = await convertToLanguageModelPrompt({
       prompt,
       supportedUrls: {},
-      download: options.experimental_download,
+      download: options.experimental_download ?? this.experimentalDownload,
     });
 
     const effectiveAbortSignal = mergeAbortSignals(
@@ -1225,10 +1277,11 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
     // Merge telemetry settings
     const effectiveTelemetry = effectiveTelemetryFromPrepare;
 
-    // Filter tools if activeTools is specified
+    // Filter tools if activeTools is specified (stream-level overrides constructor default)
+    const effectiveActiveTools = options.activeTools ?? this.activeTools;
     const effectiveTools =
-      options.activeTools && options.activeTools.length > 0
-        ? filterTools(this.tools, options.activeTools as string[])
+      effectiveActiveTools && effectiveActiveTools.length > 0
+        ? filterTools(this.tools, effectiveActiveTools as string[])
         : this.tools;
 
     // Initialize context
@@ -1330,7 +1383,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       tools: effectiveTools as ToolSet,
       writable: options.writable,
       prompt: modelPrompt,
-      stopConditions: options.stopWhen,
+      stopConditions: options.stopWhen ?? this.stopWhen,
       maxSteps: options.maxSteps,
       onStepFinish: mergedOnStepFinish,
       onStepStart: mergedOnStepStart,
@@ -1343,9 +1396,11 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       experimental_context: experimentalContext,
       experimental_telemetry: effectiveTelemetry,
       includeRawChunks: options.includeRawChunks ?? false,
-      repairToolCall:
-        options.experimental_repairToolCall as ToolCallRepairFunction<ToolSet>,
-      responseFormat: await options.output?.responseFormat,
+      repairToolCall: (options.experimental_repairToolCall ??
+        this.experimentalRepairToolCall) as
+        | ToolCallRepairFunction<ToolSet>
+        | undefined,
+      responseFormat: await (options.output ?? this.output)?.responseFormat,
     });
 
     // Track the final conversation messages from the iterator
@@ -1627,14 +1682,15 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
     const messages = (finalMessages ??
       options.messages) as unknown as ModelMessage[];
 
-    // Parse structured output if output is specified
+    // Parse structured output if output is specified (stream-level overrides constructor default)
+    const effectiveOutput = options.output ?? this.output;
     let experimentalOutput: OUTPUT = undefined as OUTPUT;
-    if (options.output && steps.length > 0) {
+    if (effectiveOutput && steps.length > 0) {
       const lastStep = steps[steps.length - 1];
       const text = lastStep.text;
       if (text) {
         try {
-          experimentalOutput = await options.output.parseCompleteOutput(
+          experimentalOutput = await effectiveOutput.parseCompleteOutput(
             { text },
             {
               response: lastStep.response,


### PR DESCRIPTION
## Background

ToolLoopAgent accepts `stopWhen`, `activeTools`, `output`, `experimental_repairToolCall`, and `experimental_download` at construction time as defaults. WorkflowAgent only accepts these in `stream()`, forcing users to repeat them in every call.

## Summary

- Added `stopWhen`, `activeTools`, `output`, `experimental_repairToolCall`, and `experimental_download` as optional constructor parameters in `WorkflowAgentOptions`
- Stream-level values override constructor defaults (same precedence pattern as other settings like `toolChoice` and `experimental_context`)
- Added unit tests verifying constructor defaults are used and can be overridden
- Updated reference documentation

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Closes #14452