### PR TITLE
Enrich WorkflowAgent callback event shapes

### DIFF
--- a/.changeset/workflow-agent-enrich-callbacks.md
+++ b/.changeset/workflow-agent-enrich-callbacks.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Enrich WorkflowAgent callback event shapes to align with ToolLoopAgent:
+- Add `stepNumber` to `onToolCallStart` and `onToolCallFinish`
+- Add `steps` (previous step results) to `onStepStart`
+- Adopt discriminated union pattern (`success: true/false`) for `onToolCallFinish`
+- Add `durationMs` to `onToolCallFinish`

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -155,6 +155,11 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
               type: 'Array<ModelMessage>',
               description: 'The messages that will be sent to the model for this step.',
             },
+            {
+              name: 'steps',
+              type: 'ReadonlyArray<StepResult>',
+              description: 'Results from all previously finished steps.',
+            },
           ],
         },
       ],
@@ -174,6 +179,11 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
               type: '{ type: "tool-call"; toolCallId: string; toolName: string; input: unknown }',
               description: 'The tool call being executed.',
             },
+            {
+              name: 'stepNumber',
+              type: 'number',
+              description: 'Zero-based index of the current step.',
+            },
           ],
         },
       ],
@@ -183,7 +193,7 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
       type: 'WorkflowAgentOnToolCallFinishCallback',
       isOptional: true,
       description:
-        "Callback called right after a tool's execute function completes or errors. If also specified in `stream()`, both callbacks fire (constructor first). Experimental (can break in patch releases).",
+        "Callback called right after a tool's execute function completes or errors. Uses a discriminated union: check `success` to determine whether `output` or `error` is available. If also specified in `stream()`, both callbacks fire (constructor first). Experimental (can break in patch releases).",
       properties: [
         {
           type: 'OnToolCallFinishEvent',
@@ -194,14 +204,29 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
               description: 'The tool call that was executed.',
             },
             {
-              name: 'result',
+              name: 'stepNumber',
+              type: 'number',
+              description: 'Zero-based index of the current step.',
+            },
+            {
+              name: 'durationMs',
+              type: 'number',
+              description: 'Tool execution time in milliseconds.',
+            },
+            {
+              name: 'success',
+              type: 'boolean',
+              description: 'Whether the tool call succeeded. When true, `output` is available. When false, `error` is available.',
+            },
+            {
+              name: 'output',
               type: 'unknown',
-              description: 'The tool result (undefined if execution failed).',
+              description: 'The tool result (only when success is true).',
             },
             {
               name: 'error',
               type: 'unknown',
-              description: 'The error if execution failed.',
+              description: 'The error that occurred (only when success is false).',
             },
           ],
         },

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -242,6 +242,7 @@ export async function* streamTextIterator({
         stepNumber,
         model: currentModel,
         messages: conversationPrompt as unknown as ModelMessage[],
+        steps: [...steps],
       });
     }
 

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -723,7 +723,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         `);
       });
 
-      // GAP: WorkflowAgent's onStepStart event doesn't include system, steps,
+      // GAP: WorkflowAgent's onStepStart event doesn't include system,
       // experimental_context, or resolved model yet.
       // These fields need to be added to match ToolLoopAgent's OnStepStartEvent.
       it('should pass correct event information', async () => {
@@ -804,7 +804,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
               "specificationVersion": "v4",
             },
             "stepNumber": 0,
-            "steps": undefined,
+            "steps": [],
             "system": undefined,
           }
         `);

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -1903,7 +1903,7 @@ describe('WorkflowAgent', () => {
       const onToolCallFinish = vi.fn();
 
       const agent = new WorkflowAgent({
-        model: async () => mockModel,
+        model: mockModel,
         tools,
         experimental_onToolCallStart: onToolCallStart,
         experimental_onToolCallFinish: onToolCallFinish,
@@ -1988,7 +1988,7 @@ describe('WorkflowAgent', () => {
       const onToolCallFinish = vi.fn();
 
       const agent = new WorkflowAgent({
-        model: async () => mockModel,
+        model: mockModel,
         tools,
         experimental_onToolCallFinish: onToolCallFinish,
       });
@@ -2047,7 +2047,7 @@ describe('WorkflowAgent', () => {
       const onStepStart = vi.fn();
 
       const agent = new WorkflowAgent({
-        model: async () => mockModel,
+        model: mockModel,
         tools: {},
         experimental_onStepStart: onStepStart,
       });

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -1887,6 +1887,196 @@ describe('WorkflowAgent', () => {
 
       expect(onAbort).toHaveBeenCalledWith({ steps: [] });
     });
+
+    it('should pass stepNumber to onToolCallStart and use discriminated union in onToolCallFinish', async () => {
+      const tools: ToolSet = {
+        testTool: {
+          description: 'A test tool',
+          inputSchema: z.object({}),
+          execute: async () => ({ result: 'ok' }),
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const onToolCallStart = vi.fn();
+      const onToolCallFinish = vi.fn();
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools,
+        experimental_onToolCallStart: onToolCallStart,
+        experimental_onToolCallFinish: onToolCallFinish,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const mockMessages: LanguageModelV4Prompt = [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ];
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi
+          .fn()
+          .mockResolvedValueOnce({
+            done: false,
+            value: {
+              toolCalls: [
+                {
+                  toolCallId: 'call-1',
+                  toolName: 'testTool',
+                  input: '{}',
+                } as LanguageModelV4ToolCall,
+              ],
+              messages: mockMessages,
+            },
+          })
+          .mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: mockWritable,
+      });
+
+      // Verify onToolCallStart includes stepNumber
+      expect(onToolCallStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stepNumber: 0,
+          toolCall: expect.objectContaining({
+            toolCallId: 'call-1',
+            toolName: 'testTool',
+          }),
+        }),
+      );
+
+      // Verify onToolCallFinish uses discriminated union with success: true
+      expect(onToolCallFinish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stepNumber: 0,
+          success: true,
+          output: { result: 'ok' },
+          durationMs: expect.any(Number),
+          toolCall: expect.objectContaining({
+            toolCallId: 'call-1',
+            toolName: 'testTool',
+          }),
+        }),
+      );
+    });
+
+    it('should pass success: false in onToolCallFinish when tool errors', async () => {
+      const tools: ToolSet = {
+        failTool: {
+          description: 'A tool that fails',
+          inputSchema: z.object({}),
+          execute: async () => {
+            throw new Error('tool failed');
+          },
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const onToolCallFinish = vi.fn();
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools,
+        experimental_onToolCallFinish: onToolCallFinish,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const mockMessages: LanguageModelV4Prompt = [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ];
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi
+          .fn()
+          .mockResolvedValueOnce({
+            done: false,
+            value: {
+              toolCalls: [
+                {
+                  toolCallId: 'call-1',
+                  toolName: 'failTool',
+                  input: '{}',
+                } as LanguageModelV4ToolCall,
+              ],
+              messages: mockMessages,
+            },
+          })
+          .mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: mockWritable,
+      });
+
+      // Verify onToolCallFinish uses discriminated union with success: false
+      expect(onToolCallFinish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stepNumber: 0,
+          success: false,
+          error: 'tool failed',
+          durationMs: expect.any(Number),
+        }),
+      );
+    });
+
+    it('should pass steps to onStepStart callback', async () => {
+      const mockModel = createMockModel();
+
+      const onStepStart = vi.fn();
+
+      const agent = new WorkflowAgent({
+        model: async () => mockModel,
+        tools: {},
+        experimental_onStepStart: onStepStart,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: mockWritable,
+      });
+
+      // Verify onStepStart is passed to streamTextIterator (it will be called internally)
+      expect(streamTextIterator).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onStepStart: expect.any(Function),
+        }),
+      );
+    });
   });
 
   describe('experimental_context', () => {

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1574,7 +1574,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
                   effectiveTools as ToolSet,
                   iterMessages,
                   experimentalContext,
-                  steps.length,
+                  currentStepNumber,
                 ),
             ),
           );

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1409,6 +1409,8 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
           context,
           providerExecutedToolResults,
         } = result.value;
+        // Capture current step number before pushing (0-based)
+        const currentStepNumber = steps.length;
         if (step) {
           steps.push(step as unknown as StepResult<TTools, any>);
         }
@@ -1472,7 +1474,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
                     effectiveTools as ToolSet,
                     iterMessages,
                     experimentalContext,
-                    steps.length,
+                    currentStepNumber,
                   ),
               ),
             );

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -535,13 +535,17 @@ export type WorkflowAgentOnStartCallback = (event: {
 /**
  * Callback that is called before each step (LLM call) begins.
  */
-export type WorkflowAgentOnStepStartCallback = (event: {
+export type WorkflowAgentOnStepStartCallback<
+  TTools extends ToolSet = ToolSet,
+> = (event: {
   /** The current step number (0-based) */
   readonly stepNumber: number;
   /** The model being used for this step */
   readonly model: LanguageModel;
   /** The messages being sent for this step */
   readonly messages: ModelMessage[];
+  /** Results from all previously finished steps */
+  readonly steps: ReadonlyArray<StepResult<TTools, any>>;
 }) => PromiseLike<void> | void;
 
 /**
@@ -550,19 +554,44 @@ export type WorkflowAgentOnStepStartCallback = (event: {
 export type WorkflowAgentOnToolCallStartCallback = (event: {
   /** The tool call being executed */
   readonly toolCall: ToolCall;
+  /** The current step number (0-based) */
+  readonly stepNumber: number;
 }) => PromiseLike<void> | void;
 
 /**
  * Callback that is called after a tool execution completes.
+ * Uses a discriminated union pattern: check `success` to determine
+ * whether `output` or `error` is available.
  */
-export type WorkflowAgentOnToolCallFinishCallback = (event: {
-  /** The tool call that was executed */
-  readonly toolCall: ToolCall;
-  /** The tool result (undefined if execution failed) */
-  readonly result?: unknown;
-  /** The error if execution failed */
-  readonly error?: unknown;
-}) => PromiseLike<void> | void;
+export type WorkflowAgentOnToolCallFinishCallback = (
+  event:
+    | {
+        /** The tool call that was executed */
+        readonly toolCall: ToolCall;
+        /** The current step number (0-based) */
+        readonly stepNumber: number;
+        /** Execution time in milliseconds */
+        readonly durationMs: number;
+        /** Whether the tool call succeeded */
+        readonly success: true;
+        /** The tool result */
+        readonly output: unknown;
+        readonly error?: never;
+      }
+    | {
+        /** The tool call that was executed */
+        readonly toolCall: ToolCall;
+        /** The current step number (0-based) */
+        readonly stepNumber: number;
+        /** Execution time in milliseconds */
+        readonly durationMs: number;
+        /** Whether the tool call succeeded */
+        readonly success: false;
+        /** The error that occurred */
+        readonly error: unknown;
+        readonly output?: never;
+      },
+) => PromiseLike<void> | void;
 
 /**
  * Options for the {@link WorkflowAgent.stream} method.
@@ -1254,59 +1283,67 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       tools: ToolSet,
       messages: LanguageModelV4Prompt,
       context?: unknown,
+      currentStepNumber: number = 0,
     ): Promise<LanguageModelV4ToolResultPart> => {
+      const toolCallEvent: ToolCall = {
+        type: 'tool-call',
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
+        input: toolCall.input,
+      };
+
       if (mergedOnToolCallStart) {
         await mergedOnToolCallStart({
-          toolCall: {
-            type: 'tool-call',
-            toolCallId: toolCall.toolCallId,
-            toolName: toolCall.toolName,
-            input: toolCall.input,
-          },
+          toolCall: toolCallEvent,
+          stepNumber: currentStepNumber,
         });
       }
+
+      const startTime = Date.now();
       let result: LanguageModelV4ToolResultPart;
       try {
         result = await executeTool(toolCall, tools, messages, context);
       } catch (err) {
+        const durationMs = Date.now() - startTime;
         if (mergedOnToolCallFinish) {
           await mergedOnToolCallFinish({
-            toolCall: {
-              type: 'tool-call',
-              toolCallId: toolCall.toolCallId,
-              toolName: toolCall.toolName,
-              input: toolCall.input,
-            },
+            toolCall: toolCallEvent,
+            stepNumber: currentStepNumber,
+            durationMs,
+            success: false,
             error: err,
           });
         }
         throw err;
       }
+
+      const durationMs = Date.now() - startTime;
       if (mergedOnToolCallFinish) {
         const isError =
           result.output &&
           'type' in result.output &&
           (result.output.type === 'error-text' ||
             result.output.type === 'error-json');
-        await mergedOnToolCallFinish({
-          toolCall: {
-            type: 'tool-call',
-            toolCallId: toolCall.toolCallId,
-            toolName: toolCall.toolName,
-            input: toolCall.input,
-          },
-          ...(isError
-            ? {
-                error:
-                  'value' in result.output ? result.output.value : undefined,
-              }
-            : {
-                result:
-                  result.output && 'value' in result.output
-                    ? result.output.value
-                    : undefined,
-              }),
-        });
+        if (isError) {
+          await mergedOnToolCallFinish({
+            toolCall: toolCallEvent,
+            stepNumber: currentStepNumber,
+            durationMs,
+            success: false,
+            error: 'value' in result.output ? result.output.value : undefined,
+          });
+        } else {
+          await mergedOnToolCallFinish({
+            toolCall: toolCallEvent,
+            stepNumber: currentStepNumber,
+            durationMs,
+            success: true,
+            output:
+              result.output && 'value' in result.output
+                ? result.output.value
+                : undefined,
+          });
+        }
       }
       return result;
     };
@@ -1435,6 +1472,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
                     effectiveTools as ToolSet,
                     iterMessages,
                     experimentalContext,
+                    steps.length,
                   ),
               ),
             );
@@ -1535,6 +1573,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
                   effectiveTools as ToolSet,
                   iterMessages,
                   experimentalContext,
+                  steps.length,
                 ),
             ),
           );

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -535,18 +535,17 @@ export type WorkflowAgentOnStartCallback = (event: {
 /**
  * Callback that is called before each step (LLM call) begins.
  */
-export type WorkflowAgentOnStepStartCallback<
-  TTools extends ToolSet = ToolSet,
-> = (event: {
-  /** The current step number (0-based) */
-  readonly stepNumber: number;
-  /** The model being used for this step */
-  readonly model: LanguageModel;
-  /** The messages being sent for this step */
-  readonly messages: ModelMessage[];
-  /** Results from all previously finished steps */
-  readonly steps: ReadonlyArray<StepResult<TTools, any>>;
-}) => PromiseLike<void> | void;
+export type WorkflowAgentOnStepStartCallback<TTools extends ToolSet = ToolSet> =
+  (event: {
+    /** The current step number (0-based) */
+    readonly stepNumber: number;
+    /** The model being used for this step */
+    readonly model: LanguageModel;
+    /** The messages being sent for this step */
+    readonly messages: ModelMessage[];
+    /** Results from all previously finished steps */
+    readonly steps: ReadonlyArray<StepResult<TTools, any>>;
+  }) => PromiseLike<void> | void;
 
 /**
  * Callback that is called before a tool's execute function runs.


### PR DESCRIPTION
## Background

WorkflowAgent callback events are sparser than ToolLoopAgent's. For example, `onToolCallStart` only receives the tool call, while ToolLoopAgent also provides `stepNumber`. `onToolCallFinish` uses optional `result`/`error` fields rather than a discriminated union.

## Summary

- Added `stepNumber` to `onToolCallStart` and `onToolCallFinish` events
- Added `steps` (previous step results) to `onStepStart` event
- Adopted discriminated union pattern (`success: true/false`) for `onToolCallFinish`, replacing optional `result`/`error` fields
- Added `durationMs` to `onToolCallFinish` for tool execution timing
- Added unit tests for the enriched event shapes
- Updated reference documentation

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Closes #14454