### PR TITLE
Add product extraction example with per-field confidence scoring (ShopGraph)

### DIFF
--- a/examples/next-shopgraph-extraction/.env.example
+++ b/examples/next-shopgraph-extraction/.env.example
@@ -1,0 +1,2 @@
+SHOPGRAPH_API_KEY=your-shopgraph-api-key
+OPENAI_API_KEY=your-openai-api-key

--- a/examples/next-shopgraph-extraction/README.md
+++ b/examples/next-shopgraph-extraction/README.md
@@ -1,12 +1,38 @@
-# ShopGraph: Per-Field Confidence Scoring for Commerce Data
+# Product Extraction with Per-Field Confidence Scoring
 
-Product extraction APIs return data. [ShopGraph](https://shopgraph.dev) returns data with per-field confidence scores (0.0 to 1.0) so your UI can show users which fields to trust and which to verify.
+When your app shows product data extracted from any URL, how does the UI
+tell users which fields to trust?
 
-This example uses the [AI SDK](https://ai-sdk.dev/docs) with [Next.js](https://nextjs.org/) and [OpenAI](https://openai.com) to build a product research chat interface. Fields extracted from structured Schema.org data get 0.93 confidence. Fields parsed by an LLM from page text get 0.70. The UI renders them differently — green for trusted, amber for "verification recommended."
+This example uses the [AI SDK](https://ai-sdk.dev/docs) with
+[Next.js](https://nextjs.org/) and [OpenAI](https://openai.com) to build
+a product research assistant. It extracts structured commerce data via the
+[ShopGraph API](https://shopgraph.dev) and renders per-field confidence
+scores so users can see which data points are reliable and which need
+verification.
+
+## The problem
+
+LLMs hallucinate product data. A price pulled from Schema.org markup is
+more reliable than a price inferred from page text. But most extraction
+APIs return flat JSON with no indication of source quality. Your app
+either trusts everything (risky) or trusts nothing (useless).
+
+## The pattern
+
+ShopGraph returns a confidence score (0.0 to 1.0) for every extracted
+field, based on extraction method and source quality. Your UI uses these
+scores to render trust indicators:
+
+- Confidence >= 0.85: display normally (extracted from structured data)
+- Confidence < 0.85: amber flag, "verification recommended"
+
+The confidence contract means your frontend makes rendering decisions
+based on data quality, not guesswork.
 
 ## How to use
 
-1. Sign up at [ShopGraph](https://shopgraph.dev) and get an API key.
+1. Get a ShopGraph API key at [shopgraph.dev](https://shopgraph.dev).
+   Playground: 50 calls/month, no signup. Starter: $99/month for 10K calls.
 2. Get an [OpenAI API key](https://platform.openai.com/account/api-keys).
 3. Copy `.env.example` to `.env.local` and fill in both keys.
 4. Install dependencies and start the dev server:
@@ -16,24 +42,40 @@ pnpm install
 pnpm dev
 ```
 
-5. Paste a product URL into the chat input. The assistant will extract structured data and report confidence scores for each field.
+5. Paste a product URL into the chat input. The assistant extracts
+   structured data and reports confidence scores for each field.
+
+Check [which sites extract successfully](https://shopgraph.dev/leaderboard)
+before trying a new domain.
 
 ## How it works
 
-- The `extract_product` tool calls the ShopGraph REST API (`POST /api/enrich`) with the product URL.
-- ShopGraph sends RFC 9421 signed requests to destination sites and returns structured product data with per-field confidence scores (0.0 to 1.0). Check [which sites extract successfully](https://shopgraph.dev/leaderboard) before using a new domain.
-- The assistant uses `streamText` with `stopWhen: isStepCount(3)` to allow tool calling and then summarize the results.
-- Fields with confidence below 0.85 are flagged in the UI with an amber indicator and a "verification recommended" note.
+1. The `extract_product` tool calls ShopGraph's REST API with the product URL.
+2. ShopGraph runs a three-tier extraction pipeline (structured markup, LLM,
+   headless browser) and returns product data with per-field confidence scores.
+3. The assistant uses `streamText` with `stopWhen: isStepCount(3)` to call
+   the tool, then summarize the results.
+4. The UI renders each field with a confidence badge. Fields below 0.85
+   get an amber indicator and "verification recommended" note.
 
-## ShopGraph API features not shown in this example
+## ShopGraph API features not used in this example
 
-- **Server-side confidence filtering**: `?strict_confidence_threshold=0.85` scrubs low-confidence fields to `null` with an explanation — the server does the filtering instead of the client.
-- **AgentReady scoring**: `?include_score=true` returns a 0-100 agent-readiness score across 6 dimensions (completeness, semantic richness, UCP compatibility, pricing clarity, inventory signals, access readiness).
-- **UCP-compatible output**: `?format=ucp` returns data in Universal Commerce Protocol schema (Google + Shopify + 25 partners).
-- **Leaderboard**: See which sites extract successfully at [shopgraph.dev/leaderboard](https://shopgraph.dev/leaderboard).
+These are available but intentionally omitted to keep the example focused
+on client-side confidence rendering:
+
+- **Server-side confidence filtering**: Add `?strict_confidence_threshold=0.85`
+  to scrub low-confidence fields from the response before they reach your app.
+  Use this when an agent acts autonomously on extracted data (no human review).
+  See the [LangChain procurement cookbook](https://github.com/langchain-ai/cookbooks)
+  for this pattern.
+- **AgentReady scoring**: Add `?include_score=true` for a 0-100 readiness
+  score across completeness, semantic richness, UCP compatibility, pricing
+  clarity, and inventory signals.
+- **UCP output**: Add `?format=ucp` for Universal Commerce Protocol schema.
 
 ## Learn More
 
 - [AI SDK docs](https://ai-sdk.dev/docs)
 - [ShopGraph docs](https://shopgraph.dev/docs)
-- [Next.js Documentation](https://nextjs.org/docs)
+- [ShopGraph Leaderboard](https://shopgraph.dev/leaderboard) (site compatibility)
+- [Next.js docs](https://nextjs.org/docs)

--- a/examples/next-shopgraph-extraction/README.md
+++ b/examples/next-shopgraph-extraction/README.md
@@ -1,8 +1,8 @@
-# ShopGraph Authenticated Extraction
+# ShopGraph: Per-Field Confidence Scoring for Commerce Data
 
-Authenticated product data extraction with per-field confidence scoring.
+Product extraction APIs return data. [ShopGraph](https://shopgraph.dev) returns data with per-field confidence scores (0.0 to 1.0) so your UI can show users which fields to trust and which to verify.
 
-This example uses the [AI SDK](https://ai-sdk.dev/docs) with [Next.js](https://nextjs.org/) and [OpenAI](https://openai.com) to build a product research assistant. It extracts structured commerce data from any product URL via the [ShopGraph API](https://shopgraph.dev) and displays per-field confidence scores so you can see which data points are reliable and which need verification.
+This example uses the [AI SDK](https://ai-sdk.dev/docs) with [Next.js](https://nextjs.org/) and [OpenAI](https://openai.com) to build a product research chat interface. Fields extracted from structured Schema.org data get 0.93 confidence. Fields parsed by an LLM from page text get 0.70. The UI renders them differently — green for trusted, amber for "verification recommended."
 
 ## How to use
 

--- a/examples/next-shopgraph-extraction/README.md
+++ b/examples/next-shopgraph-extraction/README.md
@@ -76,6 +76,6 @@ on client-side confidence rendering:
 ## Learn More
 
 - [AI SDK docs](https://ai-sdk.dev/docs)
-- [ShopGraph docs](https://shopgraph.dev/docs)
+- [ShopGraph](https://shopgraph.dev)
 - [ShopGraph Leaderboard](https://shopgraph.dev/leaderboard) (site compatibility)
 - [Next.js docs](https://nextjs.org/docs)

--- a/examples/next-shopgraph-extraction/README.md
+++ b/examples/next-shopgraph-extraction/README.md
@@ -21,9 +21,16 @@ pnpm dev
 ## How it works
 
 - The `extract_product` tool calls the ShopGraph REST API (`POST /api/enrich`) with the product URL.
-- ShopGraph authenticates through CDN security layers and returns structured product data with per-field confidence scores (0.0 to 1.0).
+- ShopGraph sends RFC 9421 signed requests to destination sites and returns structured product data with per-field confidence scores (0.0 to 1.0). Check [which sites extract successfully](https://shopgraph.dev/leaderboard) before using a new domain.
 - The assistant uses `streamText` with `stopWhen: isStepCount(3)` to allow tool calling and then summarize the results.
 - Fields with confidence below 0.85 are flagged in the UI with an amber indicator and a "verification recommended" note.
+
+## ShopGraph API features not shown in this example
+
+- **Server-side confidence filtering**: `?strict_confidence_threshold=0.85` scrubs low-confidence fields to `null` with an explanation — the server does the filtering instead of the client.
+- **AgentReady scoring**: `?include_score=true` returns a 0-100 agent-readiness score across 6 dimensions (completeness, semantic richness, UCP compatibility, pricing clarity, inventory signals, access readiness).
+- **UCP-compatible output**: `?format=ucp` returns data in Universal Commerce Protocol schema (Google + Shopify + 25 partners).
+- **Leaderboard**: See which sites extract successfully at [shopgraph.dev/leaderboard](https://shopgraph.dev/leaderboard).
 
 ## Learn More
 

--- a/examples/next-shopgraph-extraction/README.md
+++ b/examples/next-shopgraph-extraction/README.md
@@ -1,0 +1,32 @@
+# ShopGraph Authenticated Extraction
+
+Authenticated product data extraction with per-field confidence scoring.
+
+This example uses the [AI SDK](https://ai-sdk.dev/docs) with [Next.js](https://nextjs.org/) and [OpenAI](https://openai.com) to build a product research assistant. It extracts structured commerce data from any product URL via the [ShopGraph API](https://shopgraph.dev) and displays per-field confidence scores so you can see which data points are reliable and which need verification.
+
+## How to use
+
+1. Sign up at [ShopGraph](https://shopgraph.dev) and get an API key.
+2. Get an [OpenAI API key](https://platform.openai.com/account/api-keys).
+3. Copy `.env.example` to `.env.local` and fill in both keys.
+4. Install dependencies and start the dev server:
+
+```bash
+pnpm install
+pnpm dev
+```
+
+5. Paste a product URL into the chat input. The assistant will extract structured data and report confidence scores for each field.
+
+## How it works
+
+- The `extract_product` tool calls the ShopGraph REST API (`POST /api/enrich`) with the product URL.
+- ShopGraph authenticates through CDN security layers and returns structured product data with per-field confidence scores (0.0 to 1.0).
+- The assistant uses `streamText` with `stopWhen: isStepCount(3)` to allow tool calling and then summarize the results.
+- Fields with confidence below 0.85 are flagged in the UI with an amber indicator and a "verification recommended" note.
+
+## Learn More
+
+- [AI SDK docs](https://ai-sdk.dev/docs)
+- [ShopGraph docs](https://shopgraph.dev/docs)
+- [Next.js Documentation](https://nextjs.org/docs)

--- a/examples/next-shopgraph-extraction/app/api/chat/route.ts
+++ b/examples/next-shopgraph-extraction/app/api/chat/route.ts
@@ -1,0 +1,25 @@
+import {
+  convertToModelMessages,
+  isStepCount,
+  streamText,
+  UIMessage,
+} from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { extractProduct } from '@/lib/shopgraph';
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+
+  const result = streamText({
+    model: openai('gpt-4o'),
+    system:
+      'You are a product research assistant. When the user provides a product URL, use the extract_product tool to get structured data. Always report confidence scores alongside the data. If any field has confidence below 0.85, explicitly note that it should be verified.',
+    messages: await convertToModelMessages(messages),
+    tools: {
+      extract_product: extractProduct,
+    },
+    stopWhen: isStepCount(3),
+  });
+
+  return result.toUIMessageStreamResponse();
+}

--- a/examples/next-shopgraph-extraction/app/api/chat/route.ts
+++ b/examples/next-shopgraph-extraction/app/api/chat/route.ts
@@ -12,8 +12,15 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: openai('gpt-4o'),
-    system:
-      'You are a product research assistant. When the user provides a product URL, use the extract_product tool to get structured data. Always report confidence scores alongside the data. If any field has confidence below 0.85, explicitly note that it should be verified.',
+    system: `You are a product research assistant. When the user provides a product URL, use the extract_product tool to get structured data.
+
+For every field in the response, report the confidence score alongside the value. Confidence scores range from 0.0 (uncertain) to 1.0 (high certainty).
+
+If any field has confidence below 0.85, explicitly flag it: "This field has lower confidence and should be verified before relying on it."
+
+If a field is missing from the response, say so. A missing field is more useful than a guessed one.
+
+Do not invent or supplement data beyond what the extraction returns.`,
     messages: await convertToModelMessages(messages),
     tools: {
       extract_product: extractProduct,

--- a/examples/next-shopgraph-extraction/app/globals.css
+++ b/examples/next-shopgraph-extraction/app/globals.css
@@ -1,0 +1,12 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/examples/next-shopgraph-extraction/app/layout.tsx
+++ b/examples/next-shopgraph-extraction/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'ShopGraph Authenticated Extraction',
+  description:
+    'Authenticated product data extraction with per-field confidence scoring.',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/next-shopgraph-extraction/app/layout.tsx
+++ b/examples/next-shopgraph-extraction/app/layout.tsx
@@ -1,9 +1,9 @@
 import './globals.css';
 
 export const metadata = {
-  title: 'ShopGraph Authenticated Extraction',
+  title: 'Product Extraction with Confidence Scoring',
   description:
-    'Authenticated product data extraction with per-field confidence scoring.',
+    'Extract product data from any URL with per-field confidence scores.',
 };
 
 export default function RootLayout({

--- a/examples/next-shopgraph-extraction/app/page.tsx
+++ b/examples/next-shopgraph-extraction/app/page.tsx
@@ -4,28 +4,34 @@ import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport, isStaticToolUIPart } from 'ai';
 import { useState } from 'react';
 
-interface FieldWithConfidence {
-  value: unknown;
-  confidence: number;
-  decayed: boolean;
-}
-
-interface ExtractionResult {
+interface ShopGraphProduct {
   product_name: string | null;
   brand: string | null;
   price: { amount: number; currency: string } | null;
   availability: string;
-  overall_confidence: number;
-  fields_with_confidence: Record<string, FieldWithConfidence>;
+  confidence: { overall: number; per_field: Record<string, number> };
+  _shopgraph: {
+    field_confidence: Record<string, number>;
+    extraction_method: string;
+    data_source: string;
+  };
   [key: string]: unknown;
 }
 
-function isExtractionResult(data: unknown): data is ExtractionResult {
+interface ShopGraphResponse {
+  product: ShopGraphProduct;
+  cached: boolean;
+  credit_mode: string;
+}
+
+function isShopGraphResponse(data: unknown): data is ShopGraphResponse {
   return (
     typeof data === 'object' &&
     data !== null &&
-    'fields_with_confidence' in data &&
-    'overall_confidence' in data
+    'product' in data &&
+    typeof (data as ShopGraphResponse).product === 'object' &&
+    (data as ShopGraphResponse).product !== null &&
+    '_shopgraph' in (data as ShopGraphResponse).product
   );
 }
 
@@ -45,20 +51,26 @@ function ConfidenceBadge({ score }: { score: number }) {
         color: isLow ? 'rgb(180, 83, 9)' : 'rgb(22, 101, 52)',
       }}
     >
-      {(score * 100).toFixed(0)}%{isLow ? ' — verification recommended' : ''}
+      {(score * 100).toFixed(0)}%{isLow ? ' — verify' : ''}
     </span>
   );
 }
 
-function ProductCard({ data }: { data: ExtractionResult }) {
-  const fields = data.fields_with_confidence;
+function ProductCard({ data }: { data: ShopGraphResponse }) {
+  const product = data.product;
+  const confidence = product._shopgraph.field_confidence;
+
   const displayFields = [
-    { key: 'product_name', label: 'Product' },
-    { key: 'brand', label: 'Brand' },
-    { key: 'price', label: 'Price' },
-    { key: 'availability', label: 'Availability' },
-    { key: 'description', label: 'Description' },
-    { key: 'material', label: 'Material' },
+    { key: 'product_name', label: 'Product', value: product.product_name },
+    { key: 'brand', label: 'Brand', value: product.brand },
+    {
+      key: 'price',
+      label: 'Price',
+      value: product.price
+        ? `${product.price.currency} ${product.price.amount.toFixed(2)}`
+        : null,
+    },
+    { key: 'availability', label: 'Availability', value: product.availability },
   ];
 
   return (
@@ -76,25 +88,21 @@ function ProductCard({ data }: { data: ExtractionResult }) {
           fontSize: '0.75rem',
           color: '#6b7280',
           marginBottom: '0.75rem',
+          display: 'flex',
+          gap: '1rem',
         }}
       >
-        Overall confidence: {(data.overall_confidence * 100).toFixed(0)}%
+        <span>
+          Overall confidence: {(product.confidence.overall * 100).toFixed(0)}%
+        </span>
+        <span>Method: {product._shopgraph.extraction_method}</span>
+        <span>{data.cached ? 'Cached' : 'Live'}</span>
       </div>
 
-      {displayFields.map(({ key, label }) => {
-        const field = fields[key];
-        if (!field || field.value === null || field.value === 'unknown')
-          return null;
-
-        const isLow = field.confidence < 0.85;
-        let displayValue = String(field.value);
-        if (key === 'price' && data.price) {
-          displayValue = `${data.price.currency} ${data.price.amount.toFixed(2)}`;
-        }
-        if (Array.isArray(field.value)) {
-          if (field.value.length === 0) return null;
-          displayValue = field.value.join(', ');
-        }
+      {displayFields.map(({ key, label, value }) => {
+        if (value === null || value === 'unknown') return null;
+        const conf = confidence[key] ?? 0;
+        const isLow = conf < 0.85;
 
         return (
           <div
@@ -109,9 +117,7 @@ function ProductCard({ data }: { data: ExtractionResult }) {
             }}
           >
             <div>
-              <span
-                style={{ fontSize: '0.75rem', color: '#9ca3af' }}
-              >
+              <span style={{ fontSize: '0.75rem', color: '#9ca3af' }}>
                 {label}
               </span>
               <div
@@ -123,10 +129,10 @@ function ProductCard({ data }: { data: ExtractionResult }) {
                   whiteSpace: 'nowrap',
                 }}
               >
-                {displayValue}
+                {String(value)}
               </div>
             </div>
-            <ConfidenceBadge score={field.confidence} />
+            <ConfidenceBadge score={conf} />
           </div>
         );
       })}
@@ -149,8 +155,10 @@ export default function Page() {
         fontFamily: 'system-ui, -apple-system, sans-serif',
       }}
     >
-      <h1 style={{ fontSize: '1.25rem', fontWeight: 600, marginBottom: '1rem' }}>
-        ShopGraph Extraction
+      <h1
+        style={{ fontSize: '1.25rem', fontWeight: 600, marginBottom: '1rem' }}
+      >
+        Product Extraction with Confidence Scoring
       </h1>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
@@ -170,14 +178,17 @@ export default function Page() {
             {message.parts.map((part, index) => {
               if (part.type === 'text') {
                 return (
-                  <div key={index} style={{ fontSize: '0.875rem', lineHeight: 1.6 }}>
+                  <div
+                    key={index}
+                    style={{ fontSize: '0.875rem', lineHeight: 1.6 }}
+                  >
                     {part.text}
                   </div>
                 );
               }
               if (isStaticToolUIPart(part)) {
                 const result = part.result;
-                if (isExtractionResult(result)) {
+                if (isShopGraphResponse(result)) {
                   return <ProductCard key={index} data={result} />;
                 }
                 return (

--- a/examples/next-shopgraph-extraction/app/page.tsx
+++ b/examples/next-shopgraph-extraction/app/page.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport, isStaticToolUIPart } from 'ai';
+import { useState } from 'react';
+
+interface FieldWithConfidence {
+  value: unknown;
+  confidence: number;
+  decayed: boolean;
+}
+
+interface ExtractionResult {
+  product_name: string | null;
+  brand: string | null;
+  price: { amount: number; currency: string } | null;
+  availability: string;
+  overall_confidence: number;
+  fields_with_confidence: Record<string, FieldWithConfidence>;
+  [key: string]: unknown;
+}
+
+function isExtractionResult(data: unknown): data is ExtractionResult {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'fields_with_confidence' in data &&
+    'overall_confidence' in data
+  );
+}
+
+function ConfidenceBadge({ score }: { score: number }) {
+  const isLow = score < 0.85;
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        fontSize: '0.75rem',
+        padding: '0.125rem 0.375rem',
+        borderRadius: '0.25rem',
+        marginLeft: '0.5rem',
+        backgroundColor: isLow
+          ? 'rgba(217, 119, 6, 0.12)'
+          : 'rgba(22, 163, 74, 0.12)',
+        color: isLow ? 'rgb(180, 83, 9)' : 'rgb(22, 101, 52)',
+      }}
+    >
+      {(score * 100).toFixed(0)}%{isLow ? ' — verification recommended' : ''}
+    </span>
+  );
+}
+
+function ProductCard({ data }: { data: ExtractionResult }) {
+  const fields = data.fields_with_confidence;
+  const displayFields = [
+    { key: 'product_name', label: 'Product' },
+    { key: 'brand', label: 'Brand' },
+    { key: 'price', label: 'Price' },
+    { key: 'availability', label: 'Availability' },
+    { key: 'description', label: 'Description' },
+    { key: 'material', label: 'Material' },
+  ];
+
+  return (
+    <div
+      style={{
+        border: '1px solid #e5e7eb',
+        borderRadius: '0.5rem',
+        padding: '1rem',
+        marginTop: '0.5rem',
+        maxWidth: '32rem',
+      }}
+    >
+      <div
+        style={{
+          fontSize: '0.75rem',
+          color: '#6b7280',
+          marginBottom: '0.75rem',
+        }}
+      >
+        Overall confidence: {(data.overall_confidence * 100).toFixed(0)}%
+      </div>
+
+      {displayFields.map(({ key, label }) => {
+        const field = fields[key];
+        if (!field || field.value === null || field.value === 'unknown')
+          return null;
+
+        const isLow = field.confidence < 0.85;
+        let displayValue = String(field.value);
+        if (key === 'price' && data.price) {
+          displayValue = `${data.price.currency} ${data.price.amount.toFixed(2)}`;
+        }
+        if (Array.isArray(field.value)) {
+          if (field.value.length === 0) return null;
+          displayValue = field.value.join(', ');
+        }
+
+        return (
+          <div
+            key={key}
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'baseline',
+              padding: '0.375rem 0',
+              borderBottom: '1px solid #f3f4f6',
+              color: isLow ? 'rgb(180, 83, 9)' : 'inherit',
+            }}
+          >
+            <div>
+              <span
+                style={{ fontSize: '0.75rem', color: '#9ca3af' }}
+              >
+                {label}
+              </span>
+              <div
+                style={{
+                  fontSize: '0.875rem',
+                  maxWidth: '20rem',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {displayValue}
+              </div>
+            </div>
+            <ConfidenceBadge score={field.confidence} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function Page() {
+  const [input, setInput] = useState('');
+  const { messages, sendMessage } = useChat({
+    transport: new DefaultChatTransport({ api: '/api/chat' }),
+  });
+
+  return (
+    <div
+      style={{
+        maxWidth: '40rem',
+        margin: '0 auto',
+        padding: '2rem 1rem',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+      }}
+    >
+      <h1 style={{ fontSize: '1.25rem', fontWeight: 600, marginBottom: '1rem' }}>
+        ShopGraph Extraction
+      </h1>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        {messages.map(message => (
+          <div key={message.id}>
+            <div
+              style={{
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                color: '#6b7280',
+                marginBottom: '0.25rem',
+                textTransform: 'uppercase',
+              }}
+            >
+              {message.role}
+            </div>
+            {message.parts.map((part, index) => {
+              if (part.type === 'text') {
+                return (
+                  <div key={index} style={{ fontSize: '0.875rem', lineHeight: 1.6 }}>
+                    {part.text}
+                  </div>
+                );
+              }
+              if (isStaticToolUIPart(part)) {
+                const result = part.result;
+                if (isExtractionResult(result)) {
+                  return <ProductCard key={index} data={result} />;
+                }
+                return (
+                  <pre
+                    key={index}
+                    style={{
+                      fontSize: '0.75rem',
+                      background: '#f9fafb',
+                      padding: '0.5rem',
+                      borderRadius: '0.25rem',
+                      overflow: 'auto',
+                    }}
+                  >
+                    {JSON.stringify(result, null, 2)}
+                  </pre>
+                );
+              }
+              return null;
+            })}
+          </div>
+        ))}
+      </div>
+
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          if (!input.trim()) return;
+          sendMessage({ text: input });
+          setInput('');
+        }}
+        style={{
+          position: 'fixed',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          padding: '1rem',
+          background: 'white',
+          borderTop: '1px solid #e5e7eb',
+        }}
+      >
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Paste a product URL to extract data..."
+          style={{
+            width: '100%',
+            maxWidth: '40rem',
+            margin: '0 auto',
+            display: 'block',
+            padding: '0.75rem',
+            border: '1px solid #e5e7eb',
+            borderRadius: '0.5rem',
+            fontSize: '0.875rem',
+            outline: 'none',
+          }}
+        />
+      </form>
+    </div>
+  );
+}

--- a/examples/next-shopgraph-extraction/lib/shopgraph.ts
+++ b/examples/next-shopgraph-extraction/lib/shopgraph.ts
@@ -1,102 +1,27 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 
-interface ShopGraphPrice {
-  amount: number;
-  currency: string;
-  sale_price?: number;
-}
-
-interface ShopGraphFieldFreshness {
-  volatility_class: string;
-  age_seconds: number;
-  decayed: boolean;
-  original_confidence?: number;
-}
-
-interface ShopGraphMetadata {
-  source_url: string;
-  extraction_timestamp: string;
-  response_timestamp: string;
-  extraction_method: string;
-  data_source: 'live' | 'cache';
-  field_confidence: Record<string, number>;
-  field_freshness: Record<string, ShopGraphFieldFreshness>;
-  confidence_method: string;
-}
-
-interface ShopGraphProduct {
-  url: string;
-  extracted_at: string;
-  extraction_method: 'schema_org' | 'llm' | 'hybrid';
-  product_name: string | null;
-  brand: string | null;
-  description: string | null;
-  price: ShopGraphPrice | null;
-  availability: 'in_stock' | 'out_of_stock' | 'preorder' | 'unknown';
-  categories: string[];
-  image_urls: string[];
-  primary_image_url: string | null;
-  color: string[];
-  material: string[];
-  dimensions: Record<string, string> | null;
-  confidence: {
-    overall: number;
-    per_field: Record<string, number>;
-  };
-  _shopgraph: ShopGraphMetadata;
-}
-
-interface ShopGraphResponse {
-  product: ShopGraphProduct;
-  cached: boolean;
-  credit_mode: string;
-}
-
 /**
- * Maps product fields to their confidence scores from the _shopgraph metadata,
- * returning a combined view of data and confidence for each field.
+ * ShopGraph product extraction tool.
+ *
+ * Calls the ShopGraph REST API to extract structured product data from a
+ * commerce URL. Returns per-field confidence scores (0.0 to 1.0) so the
+ * calling agent or UI can decide which fields to trust.
+ *
+ * Confidence scores reflect extraction method and source quality:
+ * - 0.90+ : extracted from structured markup (Schema.org, JSON-LD)
+ * - 0.70-0.89 : extracted via LLM from page content
+ * - below 0.70 : inferred or partially matched, verify before using
+ *
+ * ShopGraph runs a three-tier pipeline (structured markup, LLM, headless
+ * browser) and reconciles across tiers. The confidence score reflects
+ * cross-tier agreement, not just one method's output probability.
  */
-function mapFieldsWithConfidence(product: ShopGraphProduct) {
-  const meta = product._shopgraph;
-  const fieldConfidence = meta.field_confidence;
-
-  const fields: Record<
-    string,
-    { value: unknown; confidence: number; decayed: boolean }
-  > = {};
-
-  const fieldMap: Record<string, unknown> = {
-    product_name: product.product_name,
-    brand: product.brand,
-    description: product.description,
-    price: product.price
-      ? `${product.price.amount} ${product.price.currency}`
-      : null,
-    availability: product.availability,
-    categories: product.categories,
-    primary_image_url: product.primary_image_url,
-    material: product.material,
-    dimensions: product.dimensions,
-  };
-
-  for (const [key, value] of Object.entries(fieldMap)) {
-    const confidenceKey = key === 'price' ? 'price' : key;
-    const confidence = fieldConfidence[confidenceKey] ?? 0;
-    const freshness = meta.field_freshness?.[confidenceKey];
-    const decayed = freshness?.decayed ?? false;
-
-    fields[key] = { value, confidence, decayed };
-  }
-
-  return fields;
-}
-
 export const extractProduct = tool({
   description:
-    'Extracts authenticated product data from a commerce URL. Returns product details and per-field confidence scores (0.0 to 1.0). You must check the confidence score for every field. If a field\'s confidence is below 0.85, you must explicitly flag to the user that the data requires verification.',
+    'Extract structured product data with per-field confidence scores from a commerce URL. Returns product name, price, availability, brand, specifications, and more. Each field includes a confidence score (0.0 to 1.0) indicating extraction reliability.',
   parameters: z.object({
-    url: z.string().url().describe('The product URL to extract data from'),
+    url: z.string().url().describe('Product page URL to extract data from'),
   }),
   execute: async ({ url }) => {
     const response = await fetch('https://shopgraph.dev/api/enrich', {
@@ -105,35 +30,18 @@ export const extractProduct = tool({
         'Content-Type': 'application/json',
         Authorization: `Bearer ${process.env.SHOPGRAPH_API_KEY}`,
       },
-      body: JSON.stringify({ url, format: 'json' }),
+      body: JSON.stringify({ url }),
     });
 
     if (!response.ok) {
-      const text = await response.text();
+      const error = await response.text();
       return {
-        error: `ShopGraph API returned ${response.status}: ${text}`,
+        error: true,
+        message: `Extraction failed (${response.status}): ${error}`,
+        url,
       };
     }
 
-    const data: ShopGraphResponse = await response.json();
-    const product = data.product;
-    const fields = mapFieldsWithConfidence(product);
-
-    return {
-      product_name: product.product_name,
-      brand: product.brand,
-      description: product.description,
-      price: product.price,
-      availability: product.availability,
-      categories: product.categories,
-      primary_image_url: product.primary_image_url,
-      material: product.material,
-      dimensions: product.dimensions,
-      extraction_method: product._shopgraph.extraction_method,
-      data_source: product._shopgraph.data_source,
-      overall_confidence: product.confidence.overall,
-      fields_with_confidence: fields,
-      cached: data.cached,
-    };
+    return response.json();
   },
 });

--- a/examples/next-shopgraph-extraction/lib/shopgraph.ts
+++ b/examples/next-shopgraph-extraction/lib/shopgraph.ts
@@ -1,0 +1,139 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+
+interface ShopGraphPrice {
+  amount: number;
+  currency: string;
+  sale_price?: number;
+}
+
+interface ShopGraphFieldFreshness {
+  volatility_class: string;
+  age_seconds: number;
+  decayed: boolean;
+  original_confidence?: number;
+}
+
+interface ShopGraphMetadata {
+  source_url: string;
+  extraction_timestamp: string;
+  response_timestamp: string;
+  extraction_method: string;
+  data_source: 'live' | 'cache';
+  field_confidence: Record<string, number>;
+  field_freshness: Record<string, ShopGraphFieldFreshness>;
+  confidence_method: string;
+}
+
+interface ShopGraphProduct {
+  url: string;
+  extracted_at: string;
+  extraction_method: 'schema_org' | 'llm' | 'hybrid';
+  product_name: string | null;
+  brand: string | null;
+  description: string | null;
+  price: ShopGraphPrice | null;
+  availability: 'in_stock' | 'out_of_stock' | 'preorder' | 'unknown';
+  categories: string[];
+  image_urls: string[];
+  primary_image_url: string | null;
+  color: string[];
+  material: string[];
+  dimensions: Record<string, string> | null;
+  confidence: {
+    overall: number;
+    per_field: Record<string, number>;
+  };
+  _shopgraph: ShopGraphMetadata;
+}
+
+interface ShopGraphResponse {
+  product: ShopGraphProduct;
+  cached: boolean;
+  credit_mode: string;
+}
+
+/**
+ * Maps product fields to their confidence scores from the _shopgraph metadata,
+ * returning a combined view of data and confidence for each field.
+ */
+function mapFieldsWithConfidence(product: ShopGraphProduct) {
+  const meta = product._shopgraph;
+  const fieldConfidence = meta.field_confidence;
+
+  const fields: Record<
+    string,
+    { value: unknown; confidence: number; decayed: boolean }
+  > = {};
+
+  const fieldMap: Record<string, unknown> = {
+    product_name: product.product_name,
+    brand: product.brand,
+    description: product.description,
+    price: product.price
+      ? `${product.price.amount} ${product.price.currency}`
+      : null,
+    availability: product.availability,
+    categories: product.categories,
+    primary_image_url: product.primary_image_url,
+    material: product.material,
+    dimensions: product.dimensions,
+  };
+
+  for (const [key, value] of Object.entries(fieldMap)) {
+    const confidenceKey = key === 'price' ? 'price' : key;
+    const confidence = fieldConfidence[confidenceKey] ?? 0;
+    const freshness = meta.field_freshness?.[confidenceKey];
+    const decayed = freshness?.decayed ?? false;
+
+    fields[key] = { value, confidence, decayed };
+  }
+
+  return fields;
+}
+
+export const extractProduct = tool({
+  description:
+    'Extracts authenticated product data from a commerce URL. Returns product details and per-field confidence scores (0.0 to 1.0). You must check the confidence score for every field. If a field\'s confidence is below 0.85, you must explicitly flag to the user that the data requires verification.',
+  parameters: z.object({
+    url: z.string().url().describe('The product URL to extract data from'),
+  }),
+  execute: async ({ url }) => {
+    const response = await fetch('https://shopgraph.dev/api/enrich', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.SHOPGRAPH_API_KEY}`,
+      },
+      body: JSON.stringify({ url, format: 'json' }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return {
+        error: `ShopGraph API returned ${response.status}: ${text}`,
+      };
+    }
+
+    const data: ShopGraphResponse = await response.json();
+    const product = data.product;
+    const fields = mapFieldsWithConfidence(product);
+
+    return {
+      product_name: product.product_name,
+      brand: product.brand,
+      description: product.description,
+      price: product.price,
+      availability: product.availability,
+      categories: product.categories,
+      primary_image_url: product.primary_image_url,
+      material: product.material,
+      dimensions: product.dimensions,
+      extraction_method: product._shopgraph.extraction_method,
+      data_source: product._shopgraph.data_source,
+      overall_confidence: product.confidence.overall,
+      fields_with_confidence: fields,
+      cached: data.cached,
+    };
+  },
+});

--- a/examples/next-shopgraph-extraction/next.config.js
+++ b/examples/next-shopgraph-extraction/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/examples/next-shopgraph-extraction/package.json
+++ b/examples/next-shopgraph-extraction/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@example/next-shopgraph-extraction",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "4.0.0-beta.28",
+    "@ai-sdk/react": "4.0.0-beta.82",
+    "ai": "7.0.0-beta.82",
+    "next": "^15.5.9",
+    "react": "^18",
+    "react-dom": "^18",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/next-shopgraph-extraction/package.json
+++ b/examples/next-shopgraph-extraction/package.json
@@ -9,9 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@ai-sdk/openai": "4.0.0-beta.28",
-    "@ai-sdk/react": "4.0.0-beta.82",
-    "ai": "7.0.0-beta.82",
+    "@ai-sdk/openai": "4.0.0-beta.32",
+    "@ai-sdk/react": "4.0.0-beta.91",
+    "ai": "7.0.0-beta.91",
     "next": "^15.5.9",
     "react": "^18",
     "react-dom": "^18",

--- a/examples/next-shopgraph-extraction/tsconfig.json
+++ b/examples/next-shopgraph-extraction/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "composite": true,
+    "noEmit": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"],
+  "references": [
+    { "path": "../../packages/ai" },
+    { "path": "../../packages/openai" },
+    { "path": "../../packages/react" }
+  ]
+}


### PR DESCRIPTION
## What

Adds a Next.js example showing how to build a product research assistant
that extracts commerce data from any product URL and renders per-field
confidence scores in the UI.

## Why this matters

Product extraction APIs return data. They don't tell you how much to trust
each field. When an LLM extracts a price from a product page, was it pulled
from structured Schema.org markup (high confidence) or inferred from
surrounding text (low confidence)? The answer determines whether your UI
should display it as fact or flag it for verification.

ShopGraph returns per-field confidence scores (0.0 to 1.0) alongside every
extracted field, so your frontend can render trust-aware UI: show reliable
fields normally, flag uncertain fields with a verification indicator.

This example demonstrates:

- Tool calling with the ShopGraph REST API via `fetch()` (no SDK dependency)
- Per-field confidence scores driving UI rendering decisions
- Trust-aware display: fields below 0.85 show an amber "verify" indicator
- `streamText` with `stopWhen: isStepCount(3)` for tool-call-then-summarize

## Setup

Requires a ShopGraph API key and an OpenAI API key.
ShopGraph Playground: 50 extractions/month, no signup required.
Starter tier: $99/month for 10K calls with API key.

## Test plan

- [ ] \`pnpm install\` succeeds
- [ ] \`pnpm dev\` starts without errors
- [ ] Sending a product URL in chat triggers ShopGraph extraction
- [ ] Response shows product data with per-field confidence indicators
- [ ] Fields below 0.85 confidence show amber verification badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)