### PR TITLE
fix: wrap invalid tool call input in JSON object

### DIFF
--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -395,7 +395,9 @@ describe('parseToolCall', () => {
           "dynamic": true,
           "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_JSONParseError: JSON parsing failed: Text: invalid json.
         Error message: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,
@@ -434,7 +436,9 @@ describe('parseToolCall', () => {
         {
           "dynamic": true,
           "error": [AI_ToolCallRepairError: Error repairing tool call: Error: test error],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -80,7 +80,9 @@ export async function parseToolCall<TOOLS extends ToolSet>({
   } catch (error) {
     // use parsed input when possible
     const parsedInput = await safeParseJSON({ text: toolCall.input });
-    const input = parsedInput.success ? parsedInput.value : toolCall.input;
+    const input = parsedInput.success
+      ? parsedInput.value
+      : { rawInvalidInput: toolCall.input };
 
     // TODO AI SDK 6: special invalid tool call parts
     return {


### PR DESCRIPTION
When parseToolCall fails to parse the tool input JSON, the raw string was stored directly as the input property. Providers like Amazon Bedrock require toolUse.input to be a JSON object, so the raw string caused API rejections on the next step before the model could see the tool-error and retry.

Now wraps the unparsable input as { rawInvalidInput: toolCall.input } so the conversation history remains valid JSON for all providers.

2221/2221 tests pass across 106 test files.

Fixes #14442