### PR TITLE
docs(ai-sdk-ui): fix cancellation heading typo

### DIFF
--- a/content/docs/04-ai-sdk-ui/05-completion.mdx
+++ b/content/docs/04-ai-sdk-ui/05-completion.mdx
@@ -116,7 +116,7 @@ return (
 );
 ```
 
-### Cancelation
+### Cancellation
 
 It's also a common use case to abort the response message while it's still streaming back from the AI provider. You can do this by calling the `stop` function returned by the `useCompletion` hook.
 


### PR DESCRIPTION
## Summary
- Correct the "Cancelation" heading in the `useCompletion` docs.

## Related issue
- N/A

## Guideline alignment
- Read `CONTRIBUTING.md` and kept this to one focused docs-only file change.
- No behavior, test, fixture, changeset, or generated-file changes.

## Validation
- `git diff --check`
- Not run: broader tests are unnecessary for this docs-only typo fix.
