### PR TITLE
fix(openai): skip truncated Codex OAuth SSE events instead of failing stream

### DIFF
--- a/.changeset/skip-truncated-codex-sse.md
+++ b/.changeset/skip-truncated-codex-sse.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): skip truncated response.* SSE events instead of failing the stream
+
+The ChatGPT Codex OAuth endpoint returns `response.created`, `response.in_progress`, and `response.completed` SSE events that include a large `instructions` field (~30KB). These events frequently arrive with truncated JSON, causing `safeParseJSON` to return a `JSONParseError`. Previously, `doStream()` treated any parse failure as fatal, setting `finishReason` to `'error'` and terminating the stream.
+
+This change detects truncated `response.*` status events via `JSONParseError.isInstance()` and skips them instead of failing. These events are informational status updates and are not required for text streaming. This mirrors the strategy used by the official OpenAI Codex CLI (Rust).

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -9041,5 +9041,44 @@ describe('OpenAIResponsesLanguageModel', () => {
         });
       });
     });
+
+    it('should skip truncated response.* SSE events and still stream text', async () => {
+      server.urls['https://api.openai.com/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          // truncated response.created (simulates ~30KB instructions field cut off):
+          `data:{"type":"response.created","response":{"id":"resp_truncated","object":"response","created_at":1776224493,"status":"in_progress","instructions":"This is a very long system prompt that gets truncated by the SSE buffer before the JSON object is closed properly so JSON.parse will fail with Unterminated string\n\n`,
+          // truncated response.in_progress:
+          `data:{"type":"response.in_progress","response":{"id":"resp_truncated","object":"response","created_at":1776224493,"status":"in_progress","instructions":"Also truncated here\n\n`,
+          // normal streaming events:
+          `data:{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_001","type":"message","status":"in_progress","role":"assistant","content":[]}}\n\n`,
+          `data:{"type":"response.content_part.added","item_id":"msg_001","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}\n\n`,
+          `data:{"type":"response.output_text.delta","item_id":"msg_001","output_index":0,"content_index":0,"delta":"Hello"}\n\n`,
+          `data:{"type":"response.output_text.delta","item_id":"msg_001","output_index":0,"content_index":0,"delta":", world!"}\n\n`,
+          `data:{"type":"response.output_text.done","item_id":"msg_001","output_index":0,"content_index":0,"text":"Hello, world!"}\n\n`,
+          `data:{"type":"response.content_part.done","item_id":"msg_001","output_index":0,"content_index":0,"part":{"type":"output_text","text":"Hello, world!","annotations":[]}}\n\n`,
+          `data:{"type":"response.output_item.done","output_index":0,"item":{"id":"msg_001","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello, world!","annotations":[]}]}}\n\n`,
+          // truncated response.completed:
+          `data:{"type":"response.completed","response":{"id":"resp_truncated","object":"response","created_at":1776224493,"status":"completed","instructions":"Truncated again in completed event\n\n`,
+          `data: [DONE]\n\n`,
+        ],
+      };
+
+      const { stream } = await createModel('gpt-4o').doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+      const deltas = parts
+        .filter(
+          (p): p is LanguageModelV4StreamPart & { type: 'text-delta' } =>
+            p.type === 'text-delta',
+        )
+        .map(p => p.delta);
+
+      expect(deltas.join('')).toBe('Hello, world!');
+      expect(parts.some(p => p.type === 'error')).toBe(false);
+    });
   });
 });

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -1,5 +1,6 @@
 import {
   APICallError,
+  JSONParseError,
   JSONValue,
   LanguageModelV4,
   LanguageModelV4Prompt,
@@ -1171,6 +1172,18 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
 
             // handle failed chunk parsing / validation:
             if (!chunk.success) {
+              // Skip truncated response.* status events (e.g. Codex OAuth
+              // endpoint where ~30KB instructions field exceeds SSE buffer).
+              // Ref: https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/sse/responses.rs#L397
+              if (
+                JSONParseError.isInstance(chunk.error) &&
+                /^\s*\{\s*"type"\s*:\s*"response\.(created|in_progress|completed|failed|incomplete)"/.test(
+                  chunk.error.text,
+                )
+              ) {
+                return;
+              }
+
               finishReason = { unified: 'error', raw: undefined };
               controller.enqueue({ type: 'error', error: chunk.error });
               return;


### PR DESCRIPTION
Fixes #14473

The ChatGPT Codex OAuth endpoint returns `response.created` / `response.in_progress` / `response.completed` SSE events with a ~30KB `instructions` field that often arrives truncated. `safeParseJSON` returns `{ success: false }` and `doStream()` treats it as fatal.

This fix detects truncated `response.*` status events via `JSONParseError.isInstance()` and skips them. These events are informational and not needed for text streaming. Mirrors the [official Codex CLI (Rust)](https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/sse/responses.rs#L397) strategy.

### Changes

- `packages/openai/src/responses/openai-responses-language-model.ts` — 10 lines added in `doStream()` transform
- 1 regression test added (254/254 tests pass)

### How to verify

Run the test: `cd packages/openai && pnpm vitest run -t "truncated"`

Or use ChatGPT OAuth with `gpt-5.4` — the stream should complete instead of failing with `AI_JSONParseError`.