### PR TITLE
docs(content): fix stale v5 branch links in language model middleware

### DIFF
--- a/content/docs/03-ai-sdk-core/40-middleware.mdx
+++ b/content/docs/03-ai-sdk-core/40-middleware.mdx
@@ -271,15 +271,15 @@ Find more examples at this [link](https://github.com/minpeter/ai-sdk-tool-call-m
 <Note>
   Implementing language model middleware is advanced functionality and requires
   a solid understanding of the [language model
-  specification](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+  specification](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v2/language-model-v2.ts).
 </Note>
 
 You can implement any of the following three function to modify the behavior of the language model:
 
 1. `transformParams`: Transforms the parameters before they are passed to the language model, for both `doGenerate` and `doStream`.
-2. `wrapGenerate`: Wraps the `doGenerate` method of the [language model](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+2. `wrapGenerate`: Wraps the `doGenerate` method of the [language model](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v2/language-model-v2.ts).
    You can modify the parameters, call the language model, and modify the result.
-3. `wrapStream`: Wraps the `doStream` method of the [language model](https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts).
+3. `wrapStream`: Wraps the `doStream` method of the [language model](https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v2/language-model-v2.ts).
    You can modify the parameters, call the language model, and modify the result.
 
 Here are some examples of how to implement language model middleware:


### PR DESCRIPTION
## Summary

The language model middleware docs link to `https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts` in three places, but the `v5` branch no longer exists and all three links 404. The file itself still lives at the same path on `main`.

This swaps `/blob/v5/` for `/blob/main/` in those three occurrences in `content/docs/03-ai-sdk-core/40-middleware.mdx`.

## Verification

- `curl https://github.com/vercel/ai/blob/v5/packages/provider/src/language-model/v2/language-model-v2.ts` → `404`
- `curl https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v2/language-model-v2.ts` → `200`
- `git grep blob/v5/ content/` → no remaining occurrences

## Closes

Closes #12617