### PR TITLE
docs(content): add ToolLoopAgent testing examples

### DIFF
--- a/content/docs/03-ai-sdk-core/55-testing.mdx
+++ b/content/docs/03-ai-sdk-core/55-testing.mdx
@@ -179,6 +179,90 @@ const result = streamText({
 });
 ```
 
+### ToolLoopAgent
+
+You can test a [`ToolLoopAgent`](/docs/agents/loop-control) the same way you test
+`generateText` — pass a `MockLanguageModelV4` as the agent's `model`. The mock
+returns whatever content you script, so you can drive the agent through a
+deterministic loop in unit tests.
+
+```ts
+import { ToolLoopAgent } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
+
+const agent = new ToolLoopAgent({
+  model: new MockLanguageModelV4({
+    doGenerate: async () => ({
+      content: [{ type: 'text', text: 'Hello, world!' }],
+      finishReason: { unified: 'stop', raw: 'stop' },
+      usage: {
+        inputTokens: {
+          total: 3,
+          noCache: 3,
+          cacheRead: undefined,
+          cacheWrite: undefined,
+        },
+        outputTokens: {
+          total: 10,
+          text: 10,
+          reasoning: undefined,
+        },
+      },
+      warnings: [],
+    }),
+  }),
+});
+
+const result = await agent.generate({ prompt: 'Hello, test!' });
+```
+
+### ToolLoopAgent with streaming
+
+To test the streaming surface, swap `doGenerate` for `doStream` and use
+`simulateReadableStream` to script the chunk sequence — the same pattern
+`streamText` uses above.
+
+```ts
+import { ToolLoopAgent, simulateReadableStream } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
+
+const agent = new ToolLoopAgent({
+  model: new MockLanguageModelV4({
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: [
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+          { type: 'text-delta', id: 'text-1', delta: ', ' },
+          { type: 'text-delta', id: 'text-1', delta: 'world!' },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage: {
+              inputTokens: {
+                total: 3,
+                noCache: 3,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+              },
+              outputTokens: {
+                total: 10,
+                text: 10,
+                reasoning: undefined,
+              },
+            },
+          },
+        ],
+      }),
+    }),
+  }),
+});
+
+const result = await agent.stream({ prompt: 'Hello, test!' });
+await result.consumeStream();
+```
+
 ### Simulate UI Message Stream Responses
 
 You can also simulate [UI Message Stream](/docs/ai-sdk-ui/stream-protocol#ui-message-stream) responses for testing,


### PR DESCRIPTION
## Summary

The [testing docs page](https://ai-sdk.dev/docs/ai-sdk-core/testing) covers `generateText`, `streamText`, and the *with Output* variants but has no example for `ToolLoopAgent`, even though it's now part of the AI SDK Core surface. This adds two examples that mirror the existing `generateText` / `streamText` style:

1. **`### ToolLoopAgent`** — uses `MockLanguageModelV4` with `doGenerate` and calls `agent.generate({ prompt })`
2. **`### ToolLoopAgent with streaming`** — uses `MockLanguageModelV4` with `doStream` + `simulateReadableStream` and calls `agent.stream({ prompt })` followed by `result.consumeStream()`

The chunk shape, usage / finishReason fields, and import paths match the existing examples on the same page exactly so the section reads as a natural continuation rather than a stylistic outlier.

## Verification

- `ToolLoopAgent` is exported from `'ai'` via `packages/ai/src/agent/index.ts` (re-exported through `packages/ai/src/index.ts`)
- `simulateReadableStream` is exported from `'ai'` and already used by the existing `streamText` example on the same page
- `agent.generate({ prompt })` and `agent.stream({ prompt })` followed by `await result.consumeStream()` match the patterns in `packages/ai/src/agent/tool-loop-agent.test.ts`

## Closes

Closes #12616