### PR TITLE
refactoring(otel): remove omit temperature on type

### DIFF
--- a/packages/otel/src/get-base-telemetry-attributes.ts
+++ b/packages/otel/src/get-base-telemetry-attributes.ts
@@ -8,7 +8,7 @@ export function getBaseTelemetryAttributes({
   headers,
 }: {
   model: { modelId: string; provider: string };
-  settings: Omit<LanguageModelCallOptions, 'temperature'>;
+  settings: LanguageModelCallOptions;
   telemetry: TelemetrySettings | undefined;
   headers: Record<string, string | undefined> | undefined;
 }): Attributes {


### PR DESCRIPTION
## Background

The input settings type in `packages/otel/src/get-base-telemetry-attributes.ts` was removing temperature but using it.

## Summary

Remove omit temperature on type.

## Related Issues
Follow up from #14417