### PR TITLE
fix: only exempt approved tool calls from MissingToolResultsError

### DIFF
--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -75,7 +75,10 @@ export async function convertToLanguageModelPrompt({
   for (const message of prompt.messages) {
     if (message.role === 'tool') {
       for (const part of message.content) {
-        if (part.type === 'tool-approval-response') {
+        if (
+          part.type === 'tool-approval-response' &&
+          part.approved === true
+        ) {
           const toolCallId = approvalIdToToolCallId.get(part.approvalId);
           if (toolCallId) {
             approvedToolCallIds.add(toolCallId);


### PR DESCRIPTION
## Summary

Fixes #14428.

**Root cause:** `approvedToolCallIds` was populated from all `tool-approval-response` parts regardless of their `approved` value. Denied tool calls (`approved: false`) were incorrectly added to the exemption set, causing their tool call IDs to be removed from the `toolCallIds` validation set. The provider then received a `function_call` without a matching `function_call_output`, triggering `Missing required parameter: 'input[N].output'`.

**Fix:** Added `part.approved === true` guard so only genuinely approved tool calls are exempted from the `MissingToolResultsError` check. Denied tool calls now correctly remain in the validation set and must have a corresponding tool result (e.g., `execution-denied`) before the prompt is sent to the provider.

## Changes

- `packages/ai/src/prompt/convert-to-language-model-prompt.ts`: Added `part.approved === true` condition when building `approvedToolCallIds`

## Testing

- Denied tool calls now correctly trigger `MissingToolResultsError` when no tool result is present
- Approved tool calls continue to be exempted as before
- Provider-executed tool approval responses are unaffected (handled by separate filter)

Made with [Cursor](https://cursor.com)