### PR TITLE
refactoring(ai): move ToolSet re-export to root index file

### DIFF
--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -88,4 +88,3 @@ export type {
   StaticToolResult,
   TypedToolResult,
 } from './tool-result';
-export type { ToolSet } from '@ai-sdk/provider-utils';

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -20,8 +20,8 @@ export {
   type ToolApprovalResponse,
   type ToolExecuteFunction,
   type ToolExecutionOptions,
+  type ToolSet,
 } from '@ai-sdk/provider-utils';
-export type { ToolSet } from '@ai-sdk/provider-utils';
 
 // directory exports
 export * from './agent';

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -18,9 +18,10 @@ export {
   type Tool,
   type ToolApprovalRequest,
   type ToolApprovalResponse,
-  type ToolExecutionOptions,
   type ToolExecuteFunction,
+  type ToolExecutionOptions,
 } from '@ai-sdk/provider-utils';
+export type { ToolSet } from '@ai-sdk/provider-utils';
 
 // directory exports
 export * from './agent';
@@ -36,15 +37,15 @@ export * from './middleware';
 export * from './prompt';
 export * from './registry';
 export * from './rerank';
-export * from './upload-skill';
+export * from './telemetry';
 export * from './text-stream';
 export * from './transcribe';
 export * from './types';
 export * from './ui';
-export * from './upload-file';
 export * from './ui-message-stream';
+export * from './upload-file';
+export * from './upload-skill';
 export * from './util';
-export * from './telemetry';
 
 // import globals
 import './global';

--- a/packages/ai/src/prompt/prepare-tools.ts
+++ b/packages/ai/src/prompt/prepare-tools.ts
@@ -2,8 +2,7 @@ import {
   LanguageModelV4FunctionTool,
   LanguageModelV4ProviderTool,
 } from '@ai-sdk/provider';
-import { asSchema } from '@ai-sdk/provider-utils';
-import { ToolSet } from '../generate-text';
+import { asSchema, ToolSet } from '@ai-sdk/provider-utils';
 import { isNonEmptyObject } from '../util/is-non-empty-object';
 
 export async function prepareTools<TOOLS extends ToolSet>({

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -3,8 +3,8 @@ import {
   InferToolOutput,
   Tool,
   ToolCall,
+  ToolSet,
 } from '@ai-sdk/provider-utils';
-import { ToolSet } from '../generate-text';
 import { ProviderMetadata } from '../types/provider-metadata';
 import { ProviderReference } from '../types/provider-reference';
 import { DeepPartial } from '../util/deep-partial';


### PR DESCRIPTION
## Background

Re-exports should be centralized in the root index file. The `ToolSet` re-export was in the `generate-text` index file instead.

## Summary

Move `ToolSet` re-export.