### PR TITLE
fix(amazon-bedrock): use template literal for tool warning message

### DIFF
--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -115,7 +115,7 @@ export async function prepareTools({
           },
         });
       } else {
-        toolWarnings.push({ type: 'unsupported', feature: 'tool ${tool.id}' });
+        toolWarnings.push({ type: 'unsupported', feature: `tool ${tool.id}` });
       }
     }
   } else {


### PR DESCRIPTION
## Summary

In `bedrock-prepare-tools.ts:118`, a single-quoted string `'tool ${tool.id}'` is used instead of a template literal. The tool ID is never interpolated, so the warning message displays the literal text `tool ${tool.id}` instead of the actual tool identifier.

Line 124 has the same pattern but correctly uses backticks.

## Change

```diff
- toolWarnings.push({ type: 'unsupported', feature: 'tool ${tool.id}' });
+ toolWarnings.push({ type: 'unsupported', feature: `tool ${tool.id}` });
```