### PR TITLE
fix(ai): skip global telemetry registration when local integration defined

### DIFF
--- a/.changeset/giant-garlics-roll.md
+++ b/.changeset/giant-garlics-roll.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): skip global telemetry registration when local integration defined

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -112,7 +112,7 @@ registerTelemetryIntegration(new OpenTelemetryIntegration());
 
 ### Per-call integrations
 
-You can also pass one or more integrations to individual `generateText` or `streamText` calls. Per-call integrations run after any globally registered integrations:
+You can also pass one or more integrations to individual `generateText` or `streamText` calls. When per-call integrations are provided, they replace the globally registered integrations for that call:
 
 ```ts highlight="6-8"
 import { streamText } from 'ai';

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -519,7 +519,7 @@ To see `generateText` in action, check out [these examples](#examples).
               isOptional: true,
               type: 'TelemetryIntegration | TelemetryIntegration[]',
               description:
-                'Per-call telemetry integrations that receive lifecycle events. These run after any globally registered integrations.',
+                'Per-call telemetry integrations that receive lifecycle events. When provided, these replace any globally registered integrations for this call.',
             },
           ],
         },

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -520,7 +520,7 @@ To see `streamText` in action, check out [these examples](#examples).
               isOptional: true,
               type: 'TelemetryIntegration | TelemetryIntegration[]',
               description:
-                'Per-call telemetry integrations that receive lifecycle events. These run after any globally registered integrations.',
+                'Per-call telemetry integrations that receive lifecycle events. When provided, these replace any globally registered integrations for this call.',
             },
           ],
         },

--- a/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
@@ -109,7 +109,7 @@ const { embedding } = await embed({
               isOptional: true,
               type: 'TelemetryIntegration | TelemetryIntegration[]',
               description:
-                'Per-call telemetry integrations that receive lifecycle events. These run after any globally registered integrations.',
+                'Per-call telemetry integrations that receive lifecycle events. When provided, these replace any globally registered integrations for this call.',
             },
           ],
         },

--- a/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
@@ -121,7 +121,7 @@ const { embeddings } = await embedMany({
               isOptional: true,
               type: 'TelemetryIntegration | TelemetryIntegration[]',
               description:
-                'Per-call telemetry integrations that receive lifecycle events. These run after any globally registered integrations.',
+                'Per-call telemetry integrations that receive lifecycle events. When provided, these replace any globally registered integrations for this call.',
             },
           ],
         },

--- a/content/docs/07-reference/01-ai-sdk-core/06-rerank.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-rerank.mdx
@@ -123,7 +123,7 @@ const { ranking } = await rerank({
               isOptional: true,
               type: 'TelemetryIntegration | TelemetryIntegration[]',
               description:
-                'Per-call telemetry integrations that receive lifecycle events. These run after any globally registered integrations.',
+                'Per-call telemetry integrations that receive lifecycle events. When provided, these replace any globally registered integrations for this call.',
             },
           ],
         },

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -8680,7 +8680,7 @@ describe('generateText', () => {
       ]);
     });
 
-    it('should call global integrations before per-call integrations', async () => {
+    it('should only call per-call integrations when both global and per-call integrations are provided', async () => {
       const events: string[] = [];
 
       globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = [
@@ -8708,7 +8708,7 @@ describe('generateText', () => {
         },
       });
 
-      expect(events).toEqual(['global', 'per-call']);
+      expect(events).toEqual(['per-call']);
     });
 
     it('should call integration listeners alongside user callbacks', async () => {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -23011,7 +23011,7 @@ describe('streamText', () => {
       ]);
     });
 
-    it('should call global integrations before per-call integrations', async () => {
+    it('should only call per-call integrations when both global and per-call integrations are provided', async () => {
       const events: string[] = [];
 
       globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = [
@@ -23037,7 +23037,7 @@ describe('streamText', () => {
 
       await result.consumeStream();
 
-      expect(events).toEqual(['global', 'per-call']);
+      expect(events).toEqual(['per-call']);
     });
 
     it('should call integration listeners alongside user callbacks', async () => {

--- a/packages/ai/src/telemetry/create-unified-telemetry.test.ts
+++ b/packages/ai/src/telemetry/create-unified-telemetry.test.ts
@@ -179,8 +179,8 @@ describe('createUnifiedTelemetry', () => {
     await expect(telemetry.onStart!(dummyEvent)).resolves.toBeUndefined();
   });
 
-  describe('global integration merging', () => {
-    it('includes globally registered integrations when no local integrations are provided', async () => {
+  describe('global vs local integration resolution', () => {
+    it('uses globally registered integrations when no local integrations are provided', async () => {
       const onStart = vi.fn();
       registerTelemetryIntegration({ onStart });
 
@@ -190,7 +190,7 @@ describe('createUnifiedTelemetry', () => {
       expect(onStart).toHaveBeenCalledWith(dummyEvent);
     });
 
-    it('merges global and local integrations', async () => {
+    it('uses only local integrations when provided, ignoring global', async () => {
       const globalOnStart = vi.fn();
       const localOnStart = vi.fn();
 
@@ -201,32 +201,11 @@ describe('createUnifiedTelemetry', () => {
       });
       await telemetry.onStart!(dummyEvent);
 
-      expect(globalOnStart).toHaveBeenCalledWith(dummyEvent);
+      expect(globalOnStart).not.toHaveBeenCalled();
       expect(localOnStart).toHaveBeenCalledWith(dummyEvent);
     });
 
-    it('invokes global integrations before local integrations', async () => {
-      const callOrder: string[] = [];
-
-      registerTelemetryIntegration({
-        onFinish: () => {
-          callOrder.push('global');
-        },
-      });
-
-      const telemetry = createUnifiedTelemetry({
-        integrations: {
-          onFinish: () => {
-            callOrder.push('local');
-          },
-        },
-      });
-      await telemetry.onFinish!(dummyEvent);
-
-      expect(callOrder).toEqual(['global', 'local']);
-    });
-
-    it('works with local integration arrays', async () => {
+    it('uses only local integration array when provided, ignoring global', async () => {
       const globalOnStart = vi.fn();
       const localOnStart1 = vi.fn();
       const localOnStart2 = vi.fn();
@@ -238,25 +217,27 @@ describe('createUnifiedTelemetry', () => {
       });
       await telemetry.onStart!(dummyEvent);
 
-      expect(globalOnStart).toHaveBeenCalledWith(dummyEvent);
+      expect(globalOnStart).not.toHaveBeenCalled();
       expect(localOnStart1).toHaveBeenCalledWith(dummyEvent);
       expect(localOnStart2).toHaveBeenCalledWith(dummyEvent);
     });
 
-    it('errors in global integrations do not affect local integrations', async () => {
-      registerTelemetryIntegration({
-        onStart: () => {
-          throw new Error('global boom');
-        },
-      });
-
+    it('global integrations still work for calls without local integrations', async () => {
+      const globalOnStart = vi.fn();
       const localOnStart = vi.fn();
-      const telemetry = createUnifiedTelemetry({
+
+      registerTelemetryIntegration({ onStart: globalOnStart });
+
+      const withLocal = createUnifiedTelemetry({
         integrations: { onStart: localOnStart },
       });
-      await telemetry.onStart!(dummyEvent);
+      const withoutLocal = createUnifiedTelemetry({});
 
-      expect(localOnStart).toHaveBeenCalledWith(dummyEvent);
+      await withLocal.onStart!(dummyEvent);
+      await withoutLocal.onStart!(dummyEvent);
+
+      expect(localOnStart).toHaveBeenCalledOnce();
+      expect(globalOnStart).toHaveBeenCalledOnce();
     });
 
     it('auto-binds class-based global integrations', async () => {
@@ -354,7 +335,7 @@ describe('createUnifiedTelemetry', () => {
       expect(execute).toHaveBeenCalledOnce();
     });
 
-    it('composes global and local executeTool wrappers', async () => {
+    it('uses only local executeTool when provided, ignoring global', async () => {
       const callOrder: string[] = [];
 
       registerTelemetryIntegration({
@@ -387,13 +368,34 @@ describe('createUnifiedTelemetry', () => {
       });
 
       expect(result).toBe('done');
-      expect(callOrder).toEqual([
-        'local-before',
-        'global-before',
-        'execute',
-        'global-after',
-        'local-after',
-      ]);
+      expect(callOrder).toEqual(['local-before', 'execute', 'local-after']);
+    });
+
+    it('uses global executeTool when no local integrations are provided', async () => {
+      const callOrder: string[] = [];
+
+      registerTelemetryIntegration({
+        executeTool: async ({ execute }) => {
+          callOrder.push('global-before');
+          const result = await execute();
+          callOrder.push('global-after');
+          return result;
+        },
+      });
+
+      const telemetry = createUnifiedTelemetry({});
+
+      const result = await telemetry.executeTool!({
+        callId: 'call-1',
+        toolCallId: 'tool-1',
+        execute: async () => {
+          callOrder.push('execute');
+          return 'done';
+        },
+      });
+
+      expect(result).toBe('done');
+      expect(callOrder).toEqual(['global-before', 'execute', 'global-after']);
     });
 
     it('auto-binds class-based executeTool integrations', async () => {

--- a/packages/ai/src/telemetry/create-unified-telemetry.ts
+++ b/packages/ai/src/telemetry/create-unified-telemetry.ts
@@ -27,23 +27,26 @@ type TelemetryEvent<K extends TelemetryCallbackKey> =
 
 /**
  * Creates a unified telemetry target that sends telemetry events
- * to all registered global telemetry integrations and to
- * any per-call integrations passed to the function.
+ * to the resolved set of integrations.
  *
- * @param args.integrations - Optional per-call integrations to send telemetry events to.
+ * When per-call integrations are provided, they take precedence over the globally
+ * registered integrations for that call. When no per-call integrations are
+ * provided, the globally registered integrations are used.
  *
- * @returns A telemetry target that sends telemetry events to all registered global telemetry integrations and to
- * any per-call integrations passed to the function.
+ * @param args.integrations - Optional per-call integrations to onlysend telemetry events to.
+ *
+ * @returns A telemetry target that fans out lifecycle events to the resolved
+ * set of integrations.
  */
 export function createUnifiedTelemetry({
   integrations: localIntegrations,
 }: {
   integrations?: TelemetryIntegration | Array<TelemetryIntegration>;
 }): TelemetryIntegration {
-  const integrations: Array<TelemetryIntegration> = [
-    ...getGlobalTelemetryIntegrations(),
-    ...asArray(localIntegrations),
-  ];
+  const integrations: Array<TelemetryIntegration> =
+    localIntegrations != null
+      ? asArray(localIntegrations)
+      : getGlobalTelemetryIntegrations();
 
   const mergeTelemetryCallback = <KEY extends TelemetryCallbackKey>(
     key: KEY,

--- a/packages/ai/src/telemetry/telemetry-settings.ts
+++ b/packages/ai/src/telemetry/telemetry-settings.ts
@@ -33,8 +33,8 @@ export type TelemetrySettings = {
   /**
    * Per-call telemetry integrations that receive lifecycle events during generation.
    *
-   * These integrations run after any globally registered integrations
-   * (see `registerTelemetryIntegration`).
+   * When provided, these integrations will take precedence over the globally registered
+   * integrations for this call.
    */
   integrations?: TelemetryIntegration | TelemetryIntegration[];
 };


### PR DESCRIPTION
## Background

`createUnifiedTelemetry` would merge global and per-call integrations together and both always ran for every call. this came in the way of ideal UX when user's may only want a particular telemetry integration for a particular model call.

## Summary

the new behavior:

- no per-call integrations provided - global integrations are used (same as before)
- when per-call integrations provided - only those run, global integrations are skipped for that call

## Manual Verification

verified by running this example `examples/ai-functions/src/generate-text/anthropic/subagent-with-telemetry.ts`

<details>
<summary>example:</summary>

```ts
import { anthropic } from '@ai-sdk/anthropic';
import { generateText, ToolLoopAgent, registerTelemetryIntegration } from 'ai';
import {
  GenAIOpenTelemetryIntegration,
  OpenTelemetryIntegration,
} from '@ai-sdk/otel';
import { DevToolsTelemetry } from '@ai-sdk/devtools';
import { LangfuseSpanProcessor } from '@langfuse/otel';
import { NodeSDK } from '@opentelemetry/sdk-node';
import { run } from '../../lib/run';
import { z } from 'zod';

registerTelemetryIntegration(DevToolsTelemetry());
registerTelemetryIntegration(new OpenTelemetryIntegration());

const sdk = new NodeSDK({
  spanProcessors: [new LangfuseSpanProcessor()],
});

sdk.start();

const weatherAgent = new ToolLoopAgent({
  model: anthropic('claude-sonnet-4-5-20250929'),
  instructions: 'You compare weather across cities. Use the researchCity tool.',
  tools: {
    researchCity: {
      description:
        'Research detailed weather information for a city using a sub-agent',
      inputSchema: z.object({
        city: z.string().describe('The city to research'),
      }),
      execute: async ({ city }: { city: string }) => {
        const subResult = await generateText({
          model: anthropic('claude-sonnet-4-5-20250929'),
          prompt: `You are a weather expert. Provide a brief weather report for ${city} including temperature, conditions, and a fun fact about the climate.`,
          experimental_telemetry: {
            isEnabled: true,
            functionId: `weather-subagent-${city.toLowerCase()}`,
            integrations: [new GenAIOpenTelemetryIntegration()],
          },
        });
        return subResult.text;
      },
    },
  },
  experimental_telemetry: {
    isEnabled: true,
    functionId: 'weather-comparison-agent',
  },
});

run(async () => {
  const result = await weatherAgent.generate({
    prompt: 'Research the weather in Tokyo and Paris, then compare them.',
  });

  console.log('Text:');
  console.log(result.text);

  await sdk.shutdown();
});

```

</details>

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)