### PR TITLE
refactoring: executeTool uses tool as parameter

### DIFF
--- a/.changeset/plenty-plums-learn.md
+++ b/.changeset/plenty-plums-learn.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/provider-utils": patch
+"ai": patch
+---
+
+refactoring: executeTool uses tool as parameter

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -1,9 +1,15 @@
 import type {
   Context,
+  InferToolContext,
+  InferToolInput,
   InferToolSetContext,
   ToolSet,
 } from '@ai-sdk/provider-utils';
-import { executeTool, ModelMessage } from '@ai-sdk/provider-utils';
+import {
+  executeTool,
+  isExecutableTool,
+  ModelMessage,
+} from '@ai-sdk/provider-utils';
 import {
   getToolTimeoutMs,
   TimeoutConfiguration,
@@ -78,7 +84,7 @@ export async function executeToolCall<
   const { toolName, toolCallId, input } = toolCall;
   const tool = tools?.[toolName];
 
-  if (tool?.execute == null) {
+  if (!isExecutableTool(tool)) {
     return undefined;
   }
 
@@ -119,13 +125,13 @@ export async function executeToolCall<
       toolCallId,
       execute: async () => {
         const stream = executeTool({
-          execute: tool.execute!.bind(tool),
-          input,
+          tool,
+          input: input as InferToolInput<typeof tool>,
           options: {
             toolCallId,
             messages,
             abortSignal: toolAbortSignal,
-            context,
+            context: context as InferToolContext<typeof tool>,
           },
         });
 

--- a/packages/provider-utils/src/types/executable-tool.test-d.ts
+++ b/packages/provider-utils/src/types/executable-tool.test-d.ts
@@ -1,0 +1,88 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { z } from 'zod/v4';
+import { executeTool } from './execute-tool';
+import { ExecutableTool, isExecutableTool } from './executable-tool';
+import { tool } from './tool';
+
+describe('isExecutableTool', () => {
+  it('narrows tools with execute to ExecutableTool', () => {
+    const weatherTool = tool({
+      inputSchema: z.object({
+        city: z.string(),
+      }),
+      contextSchema: z.object({
+        requestId: z.string(),
+      }),
+      execute: async (input, options) => {
+        expectTypeOf(input).toEqualTypeOf<{ city: string }>();
+        expectTypeOf(options.context).toEqualTypeOf<{ requestId: string }>();
+
+        return {
+          city: input.city,
+          requestId: options.context.requestId,
+        };
+      },
+    });
+
+    if (isExecutableTool(weatherTool)) {
+      expectTypeOf(weatherTool).toMatchTypeOf<
+        ExecutableTool<typeof weatherTool>
+      >();
+      expectTypeOf(weatherTool.execute).not.toEqualTypeOf<undefined>();
+
+      const result = executeTool({
+        tool: weatherTool,
+        input: { city: 'Berlin' },
+        options: {
+          toolCallId: 'tool-call-1',
+          messages: [],
+          context: { requestId: 'req-1' },
+        },
+      });
+
+      expectTypeOf<typeof result>().toEqualTypeOf<
+        AsyncGenerator<
+          | {
+              type: 'preliminary';
+              output: { city: string; requestId: string };
+            }
+          | {
+              type: 'final';
+              output: { city: string; requestId: string };
+            }
+        >
+      >();
+    }
+  });
+
+  it('narrows executable tool unions that include undefined', () => {
+    const weatherTool = tool({
+      inputSchema: z.object({
+        city: z.string(),
+      }),
+      execute: async () => 'sunny' as const,
+    });
+
+    const maybeWeatherTool: typeof weatherTool | undefined =
+      Math.random() > 0.5 ? weatherTool : undefined;
+
+    if (isExecutableTool(maybeWeatherTool)) {
+      expectTypeOf(maybeWeatherTool).toMatchTypeOf<
+        ExecutableTool<typeof weatherTool>
+      >();
+      expectTypeOf(maybeWeatherTool.execute).not.toEqualTypeOf<undefined>();
+    }
+  });
+
+  it('preserves undefined execute for non-executable tools', () => {
+    const weatherTool = tool({
+      inputSchema: z.object({
+        city: z.string(),
+      }),
+    });
+
+    if (!isExecutableTool(weatherTool)) {
+      expectTypeOf(weatherTool.execute).toEqualTypeOf<undefined>();
+    }
+  });
+});

--- a/packages/provider-utils/src/types/executable-tool.test.ts
+++ b/packages/provider-utils/src/types/executable-tool.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { executeTool } from './execute-tool';
+import { isExecutableTool } from './executable-tool';
+import { tool } from './tool';
+
+describe('isExecutableTool', () => {
+  it('returns true for tools with an execute function', () => {
+    const weatherTool = tool({
+      inputSchema: z.object({
+        city: z.string(),
+      }),
+      execute: async () => 'sunny',
+    });
+
+    expect(isExecutableTool(weatherTool)).toBe(true);
+  });
+
+  it('returns false for tools without an execute function', () => {
+    const weatherTool = tool({
+      inputSchema: z.object({
+        city: z.string(),
+      }),
+    });
+
+    expect(isExecutableTool(weatherTool)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isExecutableTool(undefined)).toBe(false);
+  });
+
+  it('allows executable tools to be passed to executeTool after narrowing', async () => {
+    const weatherTool = tool({
+      inputSchema: z.object({
+        city: z.string(),
+      }),
+      contextSchema: z.object({
+        requestId: z.string(),
+      }),
+      execute: async (input, options) => ({
+        city: input.city,
+        requestId: options.context.requestId,
+      }),
+    });
+
+    if (!isExecutableTool(weatherTool)) {
+      throw new Error('Expected weatherTool to be executable');
+    }
+
+    const results: Array<{
+      type: 'preliminary' | 'final';
+      output: { city: string; requestId: string };
+    }> = [];
+
+    for await (const result of executeTool({
+      tool: weatherTool,
+      input: { city: 'Berlin' },
+      options: {
+        toolCallId: 'tool-call-1',
+        messages: [],
+        context: { requestId: 'req-1' },
+      },
+    })) {
+      results.push(result);
+    }
+
+    expect(results).toEqual([
+      {
+        type: 'final',
+        output: { city: 'Berlin', requestId: 'req-1' },
+      },
+    ]);
+  });
+});

--- a/packages/provider-utils/src/types/executable-tool.ts
+++ b/packages/provider-utils/src/types/executable-tool.ts
@@ -1,0 +1,17 @@
+import { Tool } from './tool';
+
+/**
+ * A tool that is guaranteed to expose an execute function.
+ */
+export type ExecutableTool<TOOL extends Tool = Tool> = TOOL & {
+  execute: NonNullable<TOOL['execute']>;
+};
+
+/**
+ * Checks whether a tool exposes an execute function.
+ */
+export function isExecutableTool<TOOL extends Tool>(
+  tool: TOOL | undefined,
+): tool is ExecutableTool<TOOL> {
+  return tool != null && typeof tool.execute === 'function';
+}

--- a/packages/provider-utils/src/types/execute-tool.test-d.ts
+++ b/packages/provider-utils/src/types/execute-tool.test-d.ts
@@ -1,0 +1,102 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { z } from 'zod/v4';
+import { executeTool } from './execute-tool';
+import { ExecutableTool } from './executable-tool';
+import { tool } from './tool';
+
+describe('executeTool', () => {
+  it('infers the generator output type for non-streaming tools', () => {
+    const weatherTool = tool({
+      inputSchema: z.object({
+        city: z.string(),
+      }),
+      contextSchema: z.object({
+        requestId: z.string(),
+      }),
+      execute: async (input, options) => {
+        expectTypeOf(input).toEqualTypeOf<{ city: string }>();
+        expectTypeOf(options.context).toEqualTypeOf<{ requestId: string }>();
+
+        return {
+          city: input.city,
+          requestId: options.context.requestId,
+        };
+      },
+    });
+
+    const result = executeTool({
+      tool: weatherTool as ExecutableTool<typeof weatherTool>,
+      input: { city: 'Berlin' },
+      options: {
+        toolCallId: 'tool-call-1',
+        messages: [],
+        context: { requestId: 'req-1' },
+      },
+    });
+
+    expectTypeOf<typeof result>().toEqualTypeOf<
+      AsyncGenerator<
+        | {
+            type: 'preliminary';
+            output: { city: string; requestId: string };
+          }
+        | {
+            type: 'final';
+            output: { city: string; requestId: string };
+          }
+      >
+    >();
+  });
+
+  it('infers streamed tool outputs from async generator execute functions', () => {
+    const weatherTool = tool({
+      inputSchema: z.object({
+        city: z.string(),
+      }),
+      contextSchema: z.object({
+        requestId: z.string(),
+      }),
+      execute: async function* (input, options) {
+        expectTypeOf(input).toEqualTypeOf<{ city: string }>();
+        expectTypeOf(options.context).toEqualTypeOf<{ requestId: string }>();
+
+        yield {
+          city: input.city,
+          requestId: options.context.requestId,
+          step: 1 as const,
+        };
+      },
+    });
+
+    const result = executeTool({
+      tool: weatherTool as ExecutableTool<typeof weatherTool>,
+      input: { city: 'Berlin' },
+      options: {
+        toolCallId: 'tool-call-2',
+        messages: [],
+        context: { requestId: 'req-2' },
+      },
+    });
+
+    expectTypeOf<typeof result>().toEqualTypeOf<
+      AsyncGenerator<
+        | {
+            type: 'preliminary';
+            output: {
+              city: string;
+              requestId: string;
+              step: 1;
+            };
+          }
+        | {
+            type: 'final';
+            output: {
+              city: string;
+              requestId: string;
+              step: 1;
+            };
+          }
+      >
+    >();
+  });
+});

--- a/packages/provider-utils/src/types/execute-tool.test.ts
+++ b/packages/provider-utils/src/types/execute-tool.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { executeTool } from './execute-tool';
+import { ExecutableTool } from './executable-tool';
+import { tool, ToolExecutionOptions } from './tool';
+
+describe('executeTool', () => {
+  it('yields a single final output for non-streaming tools', async () => {
+    const weatherTool = tool({
+      inputSchema: z.object({
+        city: z.string(),
+      }),
+      contextSchema: z.object({
+        requestId: z.string(),
+      }),
+      execute: async (input, options) => ({
+        city: input.city,
+        requestId: options.context.requestId,
+      }),
+    });
+
+    const results: Array<{
+      type: 'preliminary' | 'final';
+      output: { city: string; requestId: string };
+    }> = [];
+
+    for await (const result of executeTool({
+      tool: weatherTool as ExecutableTool<typeof weatherTool>,
+      input: { city: 'Berlin' },
+      options: {
+        toolCallId: 'tool-call-1',
+        messages: [],
+        context: { requestId: 'req-1' },
+      },
+    })) {
+      results.push(result);
+    }
+
+    expect(results).toEqual([
+      {
+        type: 'final',
+        output: { city: 'Berlin', requestId: 'req-1' },
+      },
+    ]);
+  });
+
+  it('yields streamed values as preliminary output and repeats the last one as final', async () => {
+    const executionOptions: ToolExecutionOptions<{ requestId: string }> = {
+      toolCallId: 'tool-call-2',
+      messages: [],
+      context: { requestId: 'req-2' },
+    };
+
+    const weatherTool = tool({
+      inputSchema: z.object({
+        city: z.string(),
+      }),
+      contextSchema: z.object({
+        requestId: z.string(),
+      }),
+      execute: async function* (input, options) {
+        yield `${input.city}:${options.context.requestId}:1`;
+        yield `${input.city}:${options.context.requestId}:2`;
+      },
+    });
+
+    const results: Array<{ type: 'preliminary' | 'final'; output: string }> =
+      [];
+
+    for await (const result of executeTool({
+      tool: weatherTool as ExecutableTool<typeof weatherTool>,
+      input: { city: 'Berlin' },
+      options: executionOptions,
+    })) {
+      results.push(result);
+    }
+
+    expect(results).toEqual([
+      { type: 'preliminary', output: 'Berlin:req-2:1' },
+      { type: 'preliminary', output: 'Berlin:req-2:2' },
+      { type: 'final', output: 'Berlin:req-2:2' },
+    ]);
+  });
+});

--- a/packages/provider-utils/src/types/execute-tool.ts
+++ b/packages/provider-utils/src/types/execute-tool.ts
@@ -1,4 +1,5 @@
 import { isAsyncIterable } from '../is-async-iterable';
+import { ExecutableTool } from './executable-tool';
 import { InferToolContext } from './infer-tool-context';
 import { InferToolInput } from './infer-tool-input';
 import { InferToolOutput } from './infer-tool-output';
@@ -18,14 +19,12 @@ import { Tool, ToolExecutionOptions } from './tool';
  * @yields A preliminary output for each streamed value, followed by a final output, or a single final
  * output for non-streaming tools.
  */
-export async function* executeTool<
-  TOOL extends Tool & { execute: NonNullable<Tool['execute']> },
->({
+export async function* executeTool<TOOL extends Tool>({
   tool,
   input,
   options,
 }: {
-  tool: TOOL;
+  tool: ExecutableTool<TOOL>;
   input: InferToolInput<TOOL>;
   options: ToolExecutionOptions<InferToolContext<TOOL>>;
 }): AsyncGenerator<

--- a/packages/provider-utils/src/types/execute-tool.ts
+++ b/packages/provider-utils/src/types/execute-tool.ts
@@ -1,6 +1,8 @@
 import { isAsyncIterable } from '../is-async-iterable';
-import { Context } from './context';
-import { ToolExecuteFunction, ToolExecutionOptions } from './tool';
+import { InferToolContext } from './infer-tool-context';
+import { InferToolInput } from './infer-tool-input';
+import { InferToolOutput } from './infer-tool-output';
+import { Tool, ToolExecutionOptions } from './tool';
 
 /**
  * Executes a tool function, supporting both synchronous and streaming/asynchronous results.
@@ -21,21 +23,24 @@ import { ToolExecuteFunction, ToolExecutionOptions } from './tool';
  * @param params.options Additional options for tool execution.
  * @yields An object containing either a preliminary or final output from the tool.
  */
-export async function* executeTool<INPUT, OUTPUT, CONTEXT extends Context>({
-  execute,
+export async function* executeTool<
+  TOOL extends Tool & { execute: NonNullable<Tool['execute']> },
+>({
+  tool,
   input,
   options,
 }: {
-  execute: ToolExecuteFunction<INPUT, OUTPUT, CONTEXT>;
-  input: INPUT;
-  options: ToolExecutionOptions<NoInfer<CONTEXT>>;
+  tool: TOOL;
+  input: InferToolInput<TOOL>;
+  options: ToolExecutionOptions<InferToolContext<TOOL>>;
 }): AsyncGenerator<
-  { type: 'preliminary'; output: OUTPUT } | { type: 'final'; output: OUTPUT }
+  | { type: 'preliminary'; output: InferToolOutput<TOOL> }
+  | { type: 'final'; output: InferToolOutput<TOOL> }
 > {
-  const result = execute(input, options);
+  const result = tool.execute(input, options);
 
   if (isAsyncIterable(result)) {
-    let lastOutput: OUTPUT | undefined;
+    let lastOutput: InferToolOutput<TOOL> | undefined;
     for await (const output of result) {
       lastOutput = output;
       yield { type: 'preliminary', output };

--- a/packages/provider-utils/src/types/execute-tool.ts
+++ b/packages/provider-utils/src/types/execute-tool.ts
@@ -5,23 +5,18 @@ import { InferToolOutput } from './infer-tool-output';
 import { Tool, ToolExecutionOptions } from './tool';
 
 /**
- * Executes a tool function, supporting both synchronous and streaming/asynchronous results.
+ * Executes a tool function and normalizes its results into a stream of outputs.
  *
- * This generator yields intermediate ("preliminary") outputs as they're produced, allowing callers
- * to stream partial tool results before completion. When execution is finished, it yields a final output,
- * ensuring all consumers receive a conclusive result.
- *
- * - If the tool's `execute` function returns an `AsyncIterable`, all intermediate values are yielded
- *   as `{ type: "preliminary", output }` except the last, which is yielded as `{ type: "final", output }`.
+ * - If the tool's `execute` function returns an `AsyncIterable`, each yielded value is emitted as
+ *   `{ type: "preliminary", output }`. After iteration completes, the last yielded value is emitted
+ *   again as `{ type: "final", output }`.
  * - If the tool returns a direct value or Promise, a single `{ type: "final", output }` is yielded.
  *
- * @template INPUT Input type for the tool execution.
- * @template OUTPUT Output type for the tool execution.
- * @template CONTEXT Context object extension for execution (extends Context).
- * @param params.execute The tool execute function.
- * @param params.input Input value to pass to the execute function.
+ * @param params.tool The tool whose `execute` function should be invoked.
+ * @param params.input The input value to pass to the tool.
  * @param params.options Additional options for tool execution.
- * @yields An object containing either a preliminary or final output from the tool.
+ * @yields A preliminary output for each streamed value, followed by a final output, or a single final
+ * output for non-streaming tools.
  */
 export async function* executeTool<
   TOOL extends Tool & { execute: NonNullable<Tool['execute']> },

--- a/packages/provider-utils/src/types/index.ts
+++ b/packages/provider-utils/src/types/index.ts
@@ -16,6 +16,7 @@ export type {
 export type { Context } from './context';
 export type { DataContent } from './data-content';
 export { executeTool } from './execute-tool';
+export { isExecutableTool, type ExecutableTool } from './executable-tool';
 export type { InferToolContext } from './infer-tool-context';
 export type { InferToolInput } from './infer-tool-input';
 export type { InferToolOutput } from './infer-tool-output';


### PR DESCRIPTION
## Background

`executeTool` in provider utils was working on the execute function level. This lead to having to push `bind` into `executeToolCall` and weakened type checking since any input, context etc could be sent.

## Summary

* `executeTool` works on a tool level with tighter type validation
* add `ExecutableTool` type and `isExecutableTool` helper for type narrowing

## Related Work
Discovered during #14515