### PR TITLE
fix(ai): filter reasoning-start and reasoning-end when sendReasoning is false

### DIFF
--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2290,13 +2290,15 @@ class DefaultStreamTextResult<
             }
 
             case 'reasoning-start': {
-              controller.enqueue({
-                type: 'reasoning-start',
-                id: part.id,
-                ...(part.providerMetadata != null
-                  ? { providerMetadata: part.providerMetadata }
-                  : {}),
-              });
+              if (sendReasoning) {
+                controller.enqueue({
+                  type: 'reasoning-start',
+                  id: part.id,
+                  ...(part.providerMetadata != null
+                    ? { providerMetadata: part.providerMetadata }
+                    : {}),
+                });
+              }
               break;
             }
 
@@ -2315,13 +2317,15 @@ class DefaultStreamTextResult<
             }
 
             case 'reasoning-end': {
-              controller.enqueue({
-                type: 'reasoning-end',
-                id: part.id,
-                ...(part.providerMetadata != null
-                  ? { providerMetadata: part.providerMetadata }
-                  : {}),
-              });
+              if (sendReasoning) {
+                controller.enqueue({
+                  type: 'reasoning-end',
+                  id: part.id,
+                  ...(part.providerMetadata != null
+                    ? { providerMetadata: part.providerMetadata }
+                    : {}),
+                });
+              }
               break;
             }
 

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -115,7 +115,7 @@ export async function prepareTools({
           },
         });
       } else {
-        toolWarnings.push({ type: 'unsupported', feature: 'tool ${tool.id}' });
+        toolWarnings.push({ type: 'unsupported', feature: `tool ${tool.id}` });
       }
     }
   } else {


### PR DESCRIPTION
## Summary

`toUIMessageStream({ sendReasoning: false })` suppresses `reasoning-delta` chunks but always enqueues `reasoning-start` and `reasoning-end` chunks. Providers like OpenRouter attach the full reasoning summary in `providerMetadata` on these events, leaking reasoning content to the client.

## Problem

In `stream-text.ts`, the `sendReasoning` flag guards:
- `reasoning-delta` (line 2304) ✓
- `reasoning-file` (line 2330) ✓
- `reasoning-start` (line 2292) ✗ **missing**
- `reasoning-end` (line 2317) ✗ **missing**

## Fix

Wrap `reasoning-start` and `reasoning-end` in the same `if (sendReasoning)` check.

Fixes #14496