### PR TITLE
chore(provider/google): update available models

### DIFF
--- a/.changeset/sweet-chefs-explain.md
+++ b/.changeset/sweet-chefs-explain.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/google-vertex": patch
+"@ai-sdk/google": patch
+---
+
+chore(provider/google): update available models

--- a/packages/google-vertex/src/google-vertex-options.ts
+++ b/packages/google-vertex/src/google-vertex-options.ts
@@ -21,7 +21,6 @@ export type GoogleVertexModelId =
   | 'gemini-1.0-pro-002'
   // Preview models
   | 'gemini-2.0-flash-lite-preview-02-05'
-  | 'gemini-2.5-flash-lite-preview-09-2025'
   | 'gemini-2.5-flash-preview-09-2025'
   | 'gemini-3-pro-preview'
   | 'gemini-3-pro-image-preview'

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -12,7 +12,6 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-2.5-flash'
   | 'gemini-2.5-flash-image'
   | 'gemini-2.5-flash-lite'
-  | 'gemini-2.5-flash-lite-preview-09-2025'
   | 'gemini-2.5-flash-preview-tts'
   | 'gemini-2.5-pro-preview-tts'
   | 'gemini-2.5-flash-native-audio-latest'
@@ -26,6 +25,7 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-3.1-pro-preview-customtools'
   | 'gemini-3.1-flash-image-preview'
   | 'gemini-3.1-flash-lite-preview'
+  | 'gemini-3.1-flash-tts-preview'
   // latest version
   // https://ai.google.dev/gemini-api/docs/models#latest
   | 'gemini-pro-latest'

--- a/packages/google/src/google-generative-ai-video-settings.ts
+++ b/packages/google/src/google-generative-ai-video-settings.ts
@@ -2,6 +2,7 @@ export type GoogleGenerativeAIVideoModelId =
   | 'veo-3.1-fast-generate-preview'
   | 'veo-3.1-generate-preview'
   | 'veo-3.1-generate'
+  | 'veo-3.1-lite-generate-preview'
   | 'veo-3.0-generate-001'
   | 'veo-3.0-fast-generate-001'
   | 'veo-2.0-generate-001'


### PR DESCRIPTION
## Background

Routine model list maintenance for the Google provider:
- Remove obsolete `gemini-2.5-flash-lite-preview-09-2025`
- Add new video model `veo-3.1-lite-generate-preview` to the Google provider
- Add new TTS model `gemini-3.1-flash-tts-preview` to the Google provider

Gateway doesn't support either of these, so no changes to the Gateway model lists are needed.

## Manual Verification

N/A

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Fixes #13965
Fixes #14033
Fixes #14484
