### PR TITLE
docs: update telemetry docs to show enabled by default

### DIFF
--- a/content/docs/02-getting-started/09-coding-agents.mdx
+++ b/content/docs/02-getting-started/09-coding-agents.mdx
@@ -98,15 +98,14 @@ import { DevToolsTelemetry } from '@ai-sdk/devtools';
 registerTelemetryIntegration(DevToolsTelemetry());
 ```
 
-Then enable [telemetry](/docs/ai-sdk-core/telemetry) on your AI SDK calls:
+Once an integration is registered, [telemetry](/docs/ai-sdk-core/telemetry) is enabled automatically for all your AI SDK calls:
 
-```ts highlight="5"
+```ts
 import { generateText } from 'ai';
 
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'What cities are in the United States?',
-  experimental_telemetry: { isEnabled: true },
 });
 ```
 

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -37,39 +37,54 @@ For Next.js applications, place this in your `instrumentation.ts` file alongside
 
 For Node.js applications (without Next.js), register the integration at the top level of your entry file.
 
-### Step 2: Enable telemetry on individual calls
+### Step 2: Enabling Telemetry
 
-Use the `experimental_telemetry` option to enable telemetry on specific function calls:
+Once a telemetry integration is registered, all AI SDK calls emit telemetry events by default.
+You can still pass `experimental_telemetry` to attach metadata (like `functionId`) or to opt out of a specific call:
 
-```ts highlight="4"
+```ts highlight="4-6"
 const result = await generateText({
   model: __MODEL__,
   prompt: 'Write a short story about a cat.',
-  experimental_telemetry: { isEnabled: true },
+  experimental_telemetry: {
+    functionId: `story-agent`,
+  },
 });
 ```
 
-When telemetry is enabled, you can also control if you want to record the input values and the output values for the function.
-By default, both are enabled. You can disable them by setting the `recordInputs` and `recordOutputs` options to `false`.
+By default, both inputs and outputs are recorded. You can disable them by setting the `recordInputs` and `recordOutputs` options to `false`.
 
 Disabling the recording of inputs and outputs can be useful for privacy, data transfer, and performance reasons.
 You might for example want to disable recording inputs if they contain sensitive information.
+
+### Opting out
+
+Telemetry is opt-out. To disable telemetry for a specific call, set `isEnabled: false`:
+
+```ts
+const result = await generateText({
+  model: __MODEL__,
+  prompt: 'Write a short story about a cat.',
+  experimental_telemetry: { isEnabled: false },
+});
+```
+
+To disable telemetry globally, do not register any telemetry integrations via the `registerTelemetryIntegration()` function.
 
 ## Telemetry Metadata
 
 You can provide a `functionId` to identify the function that the telemetry data is for,
 and `context` to include additional information in the telemetry data.
 
-```ts highlight="6-10"
+```ts highlight="4-10"
 const result = await generateText({
   model: __MODEL__,
   prompt: 'Write a short story about a cat.',
   context: {
     something: 'custom',
     someOtherThing: 'other-value',
-  }
+  },
   experimental_telemetry: {
-    isEnabled: true,
     functionId: 'my-awesome-function',
   },
 });
@@ -122,7 +137,6 @@ const result = streamText({
   model: openai('gpt-4o'),
   prompt: 'Hello!',
   experimental_telemetry: {
-    isEnabled: true,
     integrations: [DevToolsTelemetry()],
   },
 });
@@ -132,7 +146,6 @@ You can combine multiple integrations — they all receive the same lifecycle ev
 
 ```ts
 experimental_telemetry: {
-  isEnabled: true,
   integrations: [DevToolsTelemetry(), customLogger()],
 },
 ```

--- a/content/docs/03-ai-sdk-core/65-devtools.mdx
+++ b/content/docs/03-ai-sdk-core/65-devtools.mdx
@@ -43,15 +43,14 @@ import { DevToolsTelemetry } from '@ai-sdk/devtools';
 registerTelemetryIntegration(DevToolsTelemetry());
 ```
 
-Then enable telemetry on your AI SDK calls:
+Telemetry is enabled automatically once an integration is registered — no per-call configuration is needed:
 
-```ts highlight="5"
+```ts
 import { generateText } from 'ai';
 
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'What cities are in the United States?',
-  experimental_telemetry: { isEnabled: true },
 });
 ```
 
@@ -65,7 +64,6 @@ const result = streamText({
   model: openai('gpt-4o'),
   prompt: 'Hello!',
   experimental_telemetry: {
-    isEnabled: true,
     integrations: [DevToolsTelemetry()],
   },
 });

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -491,7 +491,7 @@ To see `generateText` in action, check out [these examples](#examples).
               type: 'boolean',
               isOptional: true,
               description:
-                'Enable or disable telemetry. Disabled by default while experimental.',
+                'Enable or disable telemetry. Enabled by default. Set to `false` to opt out.',
             },
             {
               name: 'recordInputs',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -492,7 +492,7 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'boolean',
               isOptional: true,
               description:
-                'Enable or disable telemetry. Disabled by default while experimental.',
+                'Enable or disable telemetry. Enabled by default. Set to `false` to opt out.',
             },
             {
               name: 'recordInputs',

--- a/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
@@ -81,7 +81,7 @@ const { embedding } = await embed({
               type: 'boolean',
               isOptional: true,
               description:
-                'Enable or disable telemetry. Disabled by default while experimental.',
+                'Enable or disable telemetry. Enabled by default. Set to `false` to opt out.',
             },
             {
               name: 'recordInputs',

--- a/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
@@ -93,7 +93,7 @@ const { embeddings } = await embedMany({
               type: 'boolean',
               isOptional: true,
               description:
-                'Enable or disable telemetry. Disabled by default while experimental.',
+                'Enable or disable telemetry. Enabled by default. Set to `false` to opt out.',
             },
             {
               name: 'recordInputs',

--- a/content/docs/07-reference/01-ai-sdk-core/06-rerank.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-rerank.mdx
@@ -95,7 +95,7 @@ const { ranking } = await rerank({
               type: 'boolean',
               isOptional: true,
               description:
-                'Enable or disable telemetry. Disabled by default while experimental.',
+                'Enable or disable telemetry. Enabled by default. Set to `false` to opt out.',
             },
             {
               name: 'recordInputs',

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -76,6 +76,70 @@ For Node.js applications (without Next.js), register the integration at the top 
 
 This applies to all AI SDK functions that accept `experimental_telemetry`, including `generateText`, `streamText`, `ToolLoopAgent`, `embed`, `embedMany`, and `rerank`.
 
+### Telemetry: Enabled by Default When an Integration Is Registered
+
+In AI SDK 6, telemetry was opt-in — you had to set `experimental_telemetry: { isEnabled: true }` on every call to emit events. In AI SDK 7, telemetry is opt-out: once you register a telemetry integration (for example `OpenTelemetryIntegration` or `DevToolsTelemetry`), all AI SDK calls emit telemetry events by default.
+
+```tsx filename="AI SDK 6"
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello',
+  experimental_telemetry: { isEnabled: true },
+});
+```
+
+```tsx filename="AI SDK 7"
+import { generateText } from 'ai';
+import { registerTelemetryIntegration } from 'ai';
+import { OpenTelemetryIntegration } from '@ai-sdk/otel';
+
+registerTelemetryIntegration(new OpenTelemetryIntegration());
+
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello',
+});
+```
+
+You can safely remove `experimental_telemetry: { isEnabled: true }` from all of your calls. If you are already passing other fields like `functionId` or `integrations`, keep them — only `isEnabled: true` is redundant:
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello',
+  experimental_telemetry: {
+    isEnabled: true,
+    functionId: 'my-awesome-function',
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello',
+  experimental_telemetry: {
+    functionId: 'my-awesome-function',
+  },
+});
+```
+
+To opt out of telemetry for a specific call, set `isEnabled: false`:
+
+```tsx
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello',
+  experimental_telemetry: { isEnabled: false },
+});
+```
+
+To disable telemetry globally, do not register any telemetry integrations.
+
+This applies to all AI SDK functions that accept `experimental_telemetry`, including `generateText`, `streamText`, `ToolLoopAgent`, `embed`, `embedMany`, and `rerank`.
+
 ### Telemetry: `tracer` Property Removed from `experimental_telemetry`
 
 The `tracer` property on `experimental_telemetry` has been removed. If you were passing a custom OpenTelemetry `Tracer`, pass it to the `OpenTelemetryIntegration` constructor instead:

--- a/content/providers/05-observability/arize-ax.mdx
+++ b/content/providers/05-observability/arize-ax.mdx
@@ -75,7 +75,7 @@ export function register() {
 
 Spans will show up in Arize AX under the project specified in the `model_id` field above.
 
-Set the `experimental_telemetry` flag to true in all calls using the AI SDK:
+Once the integration is registered, telemetry is emitted automatically for all AI SDK calls:
 
 ```typescript
 import { generateText } from 'ai';
@@ -84,9 +84,6 @@ import { openai } from '@ai-sdk/openai';
 const result = await generateText({
   model: openai('gpt-5-mini'),
   prompt: 'Please write a haiku.',
-  experimental_telemetry: {
-    isEnabled: true,
-  },
 });
 ```
 
@@ -140,15 +137,12 @@ registerTelemetryIntegration(new OpenTelemetryIntegration());
 
 Spans will show up in Arize AX under the project specified in the `model_id` field above.
 
-You must set the `experimental_telemetry` flag to true in all calls using the AI SDK.
+Once the integration is registered, telemetry is emitted automatically for all AI SDK calls:
 
 ```typescript
 const result = await generateText({
   model: openai('gpt-5-mini'),
   prompt: 'Please write a haiku.',
-  experimental_telemetry: {
-    isEnabled: true,
-  },
 });
 ```
 
@@ -197,15 +191,12 @@ registerTelemetryIntegration(new OpenTelemetryIntegration());
 
 Spans will show up in Arize AX under the project specified in the `model_id` field above.
 
-You must set the `experimental_telemetry` flag to true in all calls using the AI SDK.
+Once the integration is registered, telemetry is emitted automatically for all AI SDK calls:
 
 ```typescript
 const result = await generateText({
   model: openai('gpt-5-mini'),
   prompt: 'Please write a haiku.',
-  experimental_telemetry: {
-    isEnabled: true,
-  },
 });
 ```
 

--- a/content/providers/05-observability/braintrust.mdx
+++ b/content/providers/05-observability/braintrust.mdx
@@ -36,7 +36,7 @@ export function register() {
 
 Traced LLM calls will appear under the Braintrust project or experiment provided in the `parent` field.
 
-When you call the AI SDK, set `experimental_telemetry`:
+Once the integration is registered, telemetry is captured automatically. You can pass additional metadata via the `context` option:
 
 ```typescript
 import { generateText } from 'ai';
@@ -45,12 +45,9 @@ import { openai } from '@ai-sdk/openai';
 const result = await generateText({
   model: openai('gpt-4o-mini'),
   prompt: 'What is 2 + 2?',
-  experimental_telemetry: {
-    isEnabled: true,
-    metadata: {
-      query: 'weather',
-      location: 'San Francisco',
-    },
+  context: {
+    query: 'weather',
+    location: 'San Francisco',
   },
 });
 ```
@@ -68,7 +65,6 @@ export async function POST(req: Request) {
   const result = await streamText({
     model: openai('gpt-4o-mini'),
     prompt,
-    experimental_telemetry: { isEnabled: true },
   });
 
   return result.toDataStreamResponse();
@@ -132,13 +128,12 @@ async function main() {
           `Here is the tracking information for ${orderId}`,
       }),
     },
+    context: {
+      something: 'custom',
+      someOtherThing: 'other-value',
+    }
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'my-awesome-function',
-      metadata: {
-        something: 'custom',
-        someOtherThing: 'other-value',
-      },
     },
     maxSteps: 10,
   });

--- a/content/providers/05-observability/braintrust.mdx
+++ b/content/providers/05-observability/braintrust.mdx
@@ -131,7 +131,7 @@ async function main() {
     context: {
       something: 'custom',
       someOtherThing: 'other-value',
-    }
+    },
     experimental_telemetry: {
       functionId: 'my-awesome-function',
     },

--- a/content/providers/05-observability/confident-ai.mdx
+++ b/content/providers/05-observability/confident-ai.mdx
@@ -60,7 +60,6 @@ const { text } = await generateText({
   model: openai('gpt-4o'),
   prompt: 'What are LLMs?',
   experimental_telemetry: {
-    isEnabled: true,
     integrations: new OpenTelemetryIntegration({ tracer }),
   },
 });
@@ -80,9 +79,7 @@ const result = streamText({
   model: openai('gpt-4o'),
   prompt: 'Invent a new holiday and describe its traditions.',
   experimental_telemetry: {
-    isEnabled: true,
     integrations: new OpenTelemetryIntegration({ tracer }),
-
   },
 });
 
@@ -119,7 +116,6 @@ const result = await generateText({
   stopWhen: isStepCount(5),
   prompt: 'What is the weather in San Francisco?',
   experimental_telemetry: {
-    isEnabled: true,
     integrations: new OpenTelemetryIntegration({ tracer }),
   },
 });
@@ -147,7 +143,6 @@ const { object } = await generateObject({
   }),
   prompt: 'Generate a lasagna recipe.',
   experimental_telemetry: {
-    isEnabled: true,
     integrations: new OpenTelemetryIntegration({ tracer }),
   },
 });
@@ -190,9 +185,6 @@ registerTelemetryIntegration(new OpenTelemetryIntegration({ tracer }));
 const { text } = await generateText({
   model: openai('gpt-4o'),
   prompt: 'How do you make the best coffee?',
-  experimental_telemetry: {
-    isEnabled: true,
-  },
 });
 ```
 
@@ -217,9 +209,6 @@ registerTelemetryIntegration(new OpenTelemetryIntegration({ tracer }));
 const { text } = await generateText({
   model: openai('gpt-4o'),
   prompt: 'How do you make the best coffee?',
-  experimental_telemetry: {
-    isEnabled: true,
-  },
 });
 ```
 
@@ -259,9 +248,6 @@ registerTelemetryIntegration(new OpenTelemetryIntegration({ tracer }));
 const { text } = await generateText({
   model: openai('gpt-4o'),
   prompt: 'How do you make the best coffee?',
-  experimental_telemetry: {
-    isEnabled: true,
-  },
 });
 ```
 

--- a/content/providers/05-observability/laminar.mdx
+++ b/content/providers/05-observability/laminar.mdx
@@ -92,18 +92,15 @@ This is because Laminar depends on OpenTelemetry, which uses some Node.js-specif
 
 ### Tracing AI SDK calls
 
-Then, enable telemetry on your AI SDK calls:
+Once the integration is registered, telemetry is captured automatically on every AI SDK call:
 
-```javascript highlight="7"
+```javascript
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
   model: openai('gpt-4o-mini'),
   prompt: 'What is Laminar flow?',
-  experimental_telemetry: {
-    isEnabled: true,
-  },
 });
 ```
 
@@ -209,18 +206,15 @@ Read more in Laminar [docs](https://docs.lmnr.ai/tracing/introduction).
 
 ### Tracing AI SDK calls
 
-Then, enable telemetry on your AI SDK calls:
+Once the integration is registered, telemetry is captured automatically on every AI SDK call:
 
-```javascript highlight="7"
+```javascript
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
   model: openai('gpt-4o-mini'),
   prompt: 'What is Laminar flow?',
-  experimental_telemetry: {
-    isEnabled: true,
-  },
 });
 ```
 
@@ -269,7 +263,6 @@ const { text } = await generateText({
   model: openai('gpt-4.1-nano'),
   prompt: `Write a poem about Laminar flow.`,
   experimental_telemetry: {
-    isEnabled: true,
     functionId: 'poem-writer',
   },
 });
@@ -319,7 +312,6 @@ const { text } = await generateText({
   model: openai('gpt-4.1-nano'),
   prompt: `Write a poem about Laminar flow.`,
   experimental_telemetry: {
-    isEnabled: true,
     metadata: {
       'my-key': 'my-value',
       'another-key': 'another-value',
@@ -341,7 +333,6 @@ const { text } = await generateText({
   model: openai('gpt-4.1-nano'),
   prompt: `Write a poem about Laminar flow.`,
   experimental_telemetry: {
-    isEnabled: true,
     metadata: {
       tags: ['fallback-model', 'api-handler'],
     },
@@ -359,7 +350,6 @@ const { text } = await generateText({
   model: openai('gpt-4.1-nano'),
   prompt: `Write a poem about Laminar flow.`,
   experimental_telemetry: {
-    isEnabled: true,
     metadata: {
       sessionId: 'session-123',
       userId: 'user-123',

--- a/content/providers/05-observability/langfuse.mdx
+++ b/content/providers/05-observability/langfuse.mdx
@@ -17,13 +17,12 @@ description: Monitor, evaluate and debug your AI SDK application with Langfuse
 
 The AI SDK supports tracing via OpenTelemetry. With the `LangfuseSpanProcessor` you can collect these traces in Langfuse.
 
-Install `@ai-sdk/otel` and register the `OpenTelemetryIntegration` in your `instrumentation.ts` file to enable OpenTelemetry span collection, then enable telemetry on each request that you want to trace:
+Install `@ai-sdk/otel` and register the `OpenTelemetryIntegration` in your `instrumentation.ts` file. Once registered, telemetry is emitted automatically for every AI SDK call:
 
-```ts highlight="4"
+```ts
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Write a short story about a cat.',
-  experimental_telemetry: { isEnabled: true },
 });
 ```
 
@@ -131,7 +130,6 @@ async function main() {
     maxOutputTokens: 50,
     prompt: 'Invent a new holiday and describe its traditions.',
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'my-awesome-function',
       metadata: {
         something: 'custom',
@@ -182,7 +180,6 @@ for (let i = 0; i < 3; i++) {
     maxOutputTokens: 50,
     prompt: 'Invent a new holiday and describe its traditions.',
     experimental_telemetry: {
-      isEnabled: true,
       functionId: `holiday-tradition-${i}`,
       metadata: {
         langfuseTraceId: parentTraceId,
@@ -222,7 +219,6 @@ const result = await generateText({
   model: openai('gpt-4o'),
   prompt: fetchedPrompt.prompt,
   experimental_telemetry: {
-    isEnabled: true,
     metadata: {
       langfusePrompt: fetchedPrompt.toJSON(),
     },
@@ -236,12 +232,11 @@ The resulting generation will have the prompt linked to the trace in Langfuse. L
 
 All of the `metadata` fields are automatically captured by the exporter. You can also pass custom trace attributes to e.g. track users or sessions.
 
-```ts highlight="6-12"
+```ts highlight="5-11"
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Write a short story about a cat.',
   experimental_telemetry: {
-    isEnabled: true,
     functionId: 'my-awesome-function', // Trace name
     metadata: {
       langfuseTraceId: 'trace-123', // Langfuse trace

--- a/content/providers/05-observability/langwatch.mdx
+++ b/content/providers/05-observability/langwatch.mdx
@@ -122,7 +122,6 @@ const result = await generateText({
   prompt:
     'Explain why a chicken would make a terrible astronaut, be creative and humorous about it.',
   experimental_telemetry: {
-    isEnabled: true,
     // optional metadata
     metadata: {
       userId: 'myuser-123',

--- a/content/providers/05-observability/mlflow.mdx
+++ b/content/providers/05-observability/mlflow.mdx
@@ -67,9 +67,9 @@ export async function register() {
 }
 ```
 
-Then enable telemetry where you call the AI SDK:
+Once the integration is registered, telemetry is emitted automatically for your AI SDK calls:
 
-```ts filename="route.ts" highlight="8"
+```ts filename="route.ts"
 import { generateText } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
@@ -79,7 +79,6 @@ export async function POST(req: Request) {
   const { text } = await generateText({
     model: openai('gpt-5'),
     prompt,
-    experimental_telemetry: { isEnabled: true },
   });
 
   return new Response(JSON.stringify({ text }), {
@@ -122,11 +121,9 @@ sdk.start();
 init();
 registerTelemetryIntegration(new OpenTelemetryIntegration());
 
-// Make an AI SDK call with telemetry enabled
 const result = await generateText({
   model: openai('gpt-5'),
   prompt: 'What is MLflow?',
-  experimental_telemetry: { isEnabled: true },
 });
 
 console.log(result.text);
@@ -139,7 +136,7 @@ npx tsx main.ts
 
 ## Streaming
 
-Streaming is supported. As with `generateText`, set `experimental_telemetry.isEnabled` to `true`.
+Streaming is supported. Like `generateText`, traces are captured automatically once the integration is registered.
 
 ```ts
 import { streamText } from 'ai';
@@ -148,7 +145,6 @@ import { openai } from '@ai-sdk/openai';
 const stream = await streamText({
   model: openai('gpt-5'),
   prompt: 'Explain vector databases in one paragraph.',
-  experimental_telemetry: { isEnabled: true },
 });
 
 for await (const part of stream.textStream) {

--- a/content/providers/05-observability/patronus.mdx
+++ b/content/providers/05-observability/patronus.mdx
@@ -58,7 +58,7 @@ registerTelemetryIntegration(new OpenTelemetryIntegration());
 
 ### 2. Register the integration and enable telemetry
 
-After you've installed `@ai-sdk/otel` and added `registerTelemetryIntegration` to your `instrumentation.ts`, opt in with `experimental_telemetry`:
+Once you've installed `@ai-sdk/otel` and added `registerTelemetryIntegration` to your `instrumentation.ts`, telemetry is captured automatically. Pass `experimental_telemetry` to attach metadata:
 
 ```ts
 import { generateText } from 'ai';
@@ -68,7 +68,6 @@ const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Write a haiku about spring.',
   experimental_telemetry: {
-    isEnabled: true,
     functionId: 'spring-haiku', // span name
     metadata: {
       userId: 'user-123', // custom attrs surface in Patronus UI
@@ -96,7 +95,7 @@ export async function POST(req: Request) {
       const answer = await generateText({
         model: openai('gpt-4o'),
         prompt: body.prompt,
-        experimental_telemetry: { isEnabled: true, functionId: 'chat' },
+        experimental_telemetry: { functionId: 'chat' },
       });
 
       /* 2️⃣ run Patronus evaluation inside the same trace */

--- a/content/providers/05-observability/posthog.mdx
+++ b/content/providers/05-observability/posthog.mdx
@@ -53,7 +53,7 @@ export function register() {
 
 **Step 3.** Use the AI SDK with telemetry enabled in your route handlers or server actions
 
-```ts highlight="6-12"
+```ts highlight="6-11"
 import { generateText } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
@@ -61,7 +61,6 @@ const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Tell me a fun fact about hedgehogs.',
   experimental_telemetry: {
-    isEnabled: true,
     functionId: 'my-ai-function',
     metadata: {
       posthog_distinct_id: 'user_123', // optional: links events to a PostHog user
@@ -101,9 +100,9 @@ sdk.start();
 registerTelemetryIntegration(new OpenTelemetryIntegration());
 ```
 
-**Step 3.** Use the AI SDK with telemetry enabled
+**Step 3.** Use the AI SDK. Telemetry is captured automatically once the integration is registered:
 
-```ts highlight="6-13"
+```ts highlight="6-12"
 import { generateText } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
@@ -111,7 +110,6 @@ const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Tell me a fun fact about hedgehogs.',
   experimental_telemetry: {
-    isEnabled: true,
     functionId: 'my-ai-function',
     metadata: {
       posthog_distinct_id: 'user_123', // optional: links events to a PostHog user
@@ -137,12 +135,11 @@ The integration supports streaming functions like `streamText`. Each streamed ca
 
 Pass `posthog_distinct_id` in the `metadata` field to associate LLM events with a specific user in PostHog. If omitted, events are captured anonymously.
 
-```ts highlight="7"
+```ts highlight="6"
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Write a short story about a cat.',
   experimental_telemetry: {
-    isEnabled: true,
     metadata: {
       posthog_distinct_id: 'user_123',
     },
@@ -154,12 +151,11 @@ const result = await generateText({
 
 You can disable recording of inputs and outputs by setting `recordInputs` and `recordOutputs` to `false`:
 
-```ts highlight="6-7"
+```ts highlight="5-6"
 const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'Write a short story about a cat.',
   experimental_telemetry: {
-    isEnabled: true,
     recordInputs: false,
     recordOutputs: false,
   },

--- a/content/providers/05-observability/scorecard.mdx
+++ b/content/providers/05-observability/scorecard.mdx
@@ -38,7 +38,7 @@ export function register() {
 }
 ```
 
-You can then use the `experimental_telemetry` option to enable telemetry on supported AI SDK function calls:
+Once the integration is registered, telemetry is captured automatically for all AI SDK calls:
 
 ```typescript
 import { generateText } from 'ai';
@@ -47,7 +47,6 @@ import { openai } from '@ai-sdk/openai';
 const result = await generateText({
   model: openai('gpt-4o-mini'),
   prompt: 'Tell me a joke',
-  experimental_telemetry: { isEnabled: true },
 });
 ```
 

--- a/content/providers/05-observability/signoz.mdx
+++ b/content/providers/05-observability/signoz.mdx
@@ -84,20 +84,19 @@ The Vercel AI SDK uses [OpenTelemetry](https://signoz.io/blog/what-is-openteleme
 
 Check out more detailed information about Vercel AI SDK's telemetry options visit [here](https://ai-sdk.dev/docs/ai-sdk-core/telemetry#telemetry).
 
-With `@ai-sdk/otel` installed and `registerTelemetryIntegration` added to your `instrumentation.ts` (see Step 3 above), enable telemetry on your AI SDK calls:
+With `@ai-sdk/otel` installed and `registerTelemetryIntegration` added to your `instrumentation.ts` (see Step 3 above), telemetry is captured automatically on every AI SDK call:
 
 ```jsx
 const result = await generateText({
   model: openai('gpt-5-mini'),
   prompt: 'Write a short story about a cat.',
-  experimental_telemetry: { isEnabled: true },
 });
 ```
 
-When telemetry is enabled, you can also control whether you want to record the input values and the output values for the function. By default, both are enabled. You can disable them by setting the `recordInputs` and `recordOutputs` options to `false`.
+You can also control whether you want to record the input values and the output values for the function. By default, both are enabled. You can disable them by setting the `recordInputs` and `recordOutputs` options to `false`.
 
 ```jsx
-experimental_telemetry: { isEnabled: true, recordInputs: false, recordOutputs: false}
+experimental_telemetry: { recordInputs: false, recordOutputs: false }
 ```
 
 Disabling the recording of inputs and outputs can be useful for privacy, data transfer, and performance reasons. You might, for example, want to disable recording inputs if they contain sensitive information.
@@ -113,9 +112,8 @@ const result = await generateText({
   context: {
     something: 'custom',
     someOtherThing: 'other-value',
-  }
+  },
   experimental_telemetry: {
-    isEnabled: true,
     functionId: 'my-awesome-function',
   },
 });
@@ -139,9 +137,6 @@ registerTelemetryIntegration(
 const result = await generateText({
   model: openai('gpt-5-mini'),
   prompt: 'Write a short story about a cat.',
-  experimental_telemetry: {
-    isEnabled: true,
-  },
 });
 ```
 

--- a/content/providers/05-observability/traceloop.mdx
+++ b/content/providers/05-observability/traceloop.mdx
@@ -33,7 +33,7 @@ registerTelemetryIntegration(new OpenTelemetryIntegration());
 
 You can then use the `experimental_telemetry` option to enable telemetry on supported AI SDK function calls:
 
-```typescript highlight="7-13"
+```typescript highlight="7-12"
 import { generateText } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
@@ -41,7 +41,6 @@ const result = await generateText({
   model: openai('gpt-4o-mini'),
   prompt: 'What is 2 + 2?',
   experimental_telemetry: {
-    isEnabled: true,
     metadata: {
       query: 'weather',
       location: 'San Francisco',

--- a/content/providers/05-observability/weave.mdx
+++ b/content/providers/05-observability/weave.mdx
@@ -61,7 +61,6 @@ const result = await generateText({
   model: openai('gpt-4o-mini'),
   prompt: 'What is 2 + 2?',
   experimental_telemetry: {
-    isEnabled: true,
     metadata: {
       query: 'math',
       difficulty: 'easy',

--- a/examples/ai-e2e-next/agent/anthropic/web-fetch-agent.ts
+++ b/examples/ai-e2e-next/agent/anthropic/web-fetch-agent.ts
@@ -8,7 +8,6 @@ export const anthropicWebFetchAgent = new ToolLoopAgent({
   },
   reasoning: 'medium',
   experimental_telemetry: {
-    isEnabled: true,
     functionId: 'anthropic-web-fetch-agent',
   },
 });

--- a/examples/ai-functions/src/agent/openai/subagent.ts
+++ b/examples/ai-functions/src/agent/openai/subagent.ts
@@ -42,7 +42,6 @@ run(async () => {
     },
     stopWhen: isStepCount(3),
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'child-agent',
     },
   });
@@ -72,7 +71,6 @@ run(async () => {
     },
     stopWhen: isStepCount(3),
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'parent-agent',
     },
   });

--- a/examples/ai-functions/src/generate-text/anthropic/custom-provider-with-telemetry.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/custom-provider-with-telemetry.ts
@@ -24,7 +24,6 @@ run(async () => {
     model: myCustomProvider('claude-sonnet-4-20250514'),
     prompt: 'Say hello in 5 words',
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'anthropic-custom-provider-demo',
     },
   });

--- a/examples/ai-functions/src/generate-text/anthropic/nested-subagent-with-telemetry.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/nested-subagent-with-telemetry.ts
@@ -38,7 +38,6 @@ const createCityResearchAgent = (city: string) =>
             model: anthropic('claude-sonnet-4-5-20250929'),
             prompt: `Generate a realistic weather forecast for ${city} during ${season}. Include temperature in Celsius, humidity, wind speed, and a fun climate fact. Keep it to 2-3 sentences.`,
             experimental_telemetry: {
-              isEnabled: true,
               functionId: `forecast-lookup-${city.toLowerCase()}`,
             },
           });
@@ -47,7 +46,6 @@ const createCityResearchAgent = (city: string) =>
       },
     },
     experimental_telemetry: {
-      isEnabled: true,
       functionId: `weather-subagent-${city.toLowerCase()}`,
     },
   });
@@ -73,7 +71,6 @@ const weatherAgent = new ToolLoopAgent({
     },
   },
   experimental_telemetry: {
-    isEnabled: true,
     functionId: 'weather-comparison-agent',
   },
 });

--- a/examples/ai-functions/src/generate-text/anthropic/subagent-with-telemetry.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/subagent-with-telemetry.ts
@@ -34,7 +34,6 @@ const weatherAgent = new ToolLoopAgent({
           model: anthropic('claude-sonnet-4-5-20250929'),
           prompt: `You are a weather expert. Provide a brief weather report for ${city} including temperature, conditions, and a fun fact about the climate.`,
           experimental_telemetry: {
-            isEnabled: true,
             functionId: `weather-subagent-${city.toLowerCase()}`,
           },
         });
@@ -43,7 +42,6 @@ const weatherAgent = new ToolLoopAgent({
     },
   },
   experimental_telemetry: {
-    isEnabled: true,
     functionId: 'weather-comparison-agent',
   },
 });

--- a/examples/ai-functions/src/generate-text/anthropic/tool-schema-telemetry.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/tool-schema-telemetry.ts
@@ -41,7 +41,6 @@ run(async () => {
       },
     },
     experimental_telemetry: {
-      isEnabled: true,
       functionId: `cook-recipe`,
     },
   });

--- a/examples/ai-functions/src/generate-text/anthropic/with-langfuse-telemetry.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/with-langfuse-telemetry.ts
@@ -38,7 +38,6 @@ run(async () => {
     reasoning: 'medium',
     stopWhen: isStepCount(5),
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'anthropic-custom-provider-demo',
     },
   });

--- a/examples/ai-functions/src/generate-text/google/custom-provider-with-telemetry.ts
+++ b/examples/ai-functions/src/generate-text/google/custom-provider-with-telemetry.ts
@@ -24,7 +24,6 @@ run(async () => {
     model: myCustomProvider('gemini-2.5-flash'),
     prompt: 'Say hello in 5 words',
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'custom-provider-demo',
     },
   });

--- a/examples/ai-functions/src/stream-text/anthropic/subagent-with-telemetry.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/subagent-with-telemetry.ts
@@ -32,7 +32,6 @@ const weatherAgent = new ToolLoopAgent({
           model: anthropic('claude-sonnet-4-5-20250929'),
           prompt: `You are a weather expert. Provide a brief weather report for ${city} including temperature, conditions, and a fun fact about the climate.`,
           experimental_telemetry: {
-            isEnabled: true,
             functionId: `weather-subagent-${city.toLowerCase()}`,
           },
         });
@@ -41,7 +40,6 @@ const weatherAgent = new ToolLoopAgent({
     },
   },
   experimental_telemetry: {
-    isEnabled: true,
     functionId: 'weather-comparison-agent',
   },
 });

--- a/examples/ai-functions/src/telemetry/generate-text-output-object.ts
+++ b/examples/ai-functions/src/telemetry/generate-text-output-object.ts
@@ -34,7 +34,6 @@ run(async () => {
     }),
     prompt: 'Generate a lasagna recipe.',
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'my-awesome-function',
     },
   });

--- a/examples/ai-functions/src/telemetry/generate-text-tool-call.ts
+++ b/examples/ai-functions/src/telemetry/generate-text-tool-call.ts
@@ -37,7 +37,6 @@ run(async () => {
     prompt:
       'What is the weather in San Francisco and what attractions should I visit?',
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'my-awesome-function',
     },
   });

--- a/examples/ai-functions/src/telemetry/generate-text.ts
+++ b/examples/ai-functions/src/telemetry/generate-text.ts
@@ -20,7 +20,6 @@ run(async () => {
     maxOutputTokens: 50,
     prompt: 'Invent a new holiday and describe its traditions.',
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'my-awesome-function',
     },
     context: {

--- a/examples/ai-functions/src/telemetry/stream-text-output-object.ts
+++ b/examples/ai-functions/src/telemetry/stream-text-output-object.ts
@@ -38,7 +38,6 @@ run(async () => {
       someOtherThing: 'other-value',
     },
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'my-awesome-function',
     },
   });

--- a/examples/ai-functions/src/telemetry/stream-text.ts
+++ b/examples/ai-functions/src/telemetry/stream-text.ts
@@ -24,7 +24,6 @@ run(async () => {
       someOtherThing: 'other-value',
     },
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'my-awesome-function',
     },
   });

--- a/examples/next-openai-telemetry-sentry/app/api/text/route.ts
+++ b/examples/next-openai-telemetry-sentry/app/api/text/route.ts
@@ -12,7 +12,6 @@ export async function POST(req: Request) {
       example: 'value',
     },
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'example-function-id',
     },
   });

--- a/examples/next-openai-telemetry/app/api/text/route.ts
+++ b/examples/next-openai-telemetry/app/api/text/route.ts
@@ -12,7 +12,6 @@ export async function POST(req: Request) {
       example: 'value',
     },
     experimental_telemetry: {
-      isEnabled: true,
       functionId: 'example-function-id',
     },
   });

--- a/packages/devtools/examples/basic/index.ts
+++ b/packages/devtools/examples/basic/index.ts
@@ -17,7 +17,6 @@ const result = streamText({
   prompt: 'Whats the weather in SF and London in C?',
   tools,
   stopWhen: isStepCount(5),
-  experimental_telemetry: { isEnabled: true },
   providerOptions: {
     anthropic: {
       thinking: {


### PR DESCRIPTION
## Background

as a follow up to the PR https://github.com/vercel/ai/pull/14500, we had to make docs changes to show that `experimental_telemetry` doesn't need a `isEnabled: true` flag anymore (since it's enabled by default)

## Summary

remove the `isEnabled: true` flag wherever it's not needed anymore

## Manual Verification

verified by running existing telemetry examples

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)