### PR TITLE
docs: mention `isLoopFinished()` stop condition in context of agent loops

### DIFF
--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,5 +1,0 @@
-{
-  "orgId": "team_nO2mCG4W8IxPIeKoSsqwAxxB",
-  "projectId": "prj_znSb9jeHIqTYz4YGRzm39sBneeSN",
-  "projectName": "ai-sdk-examples-next-pages"
-}

--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,0 +1,5 @@
+{
+  "orgId": "team_nO2mCG4W8IxPIeKoSsqwAxxB",
+  "projectId": "prj_znSb9jeHIqTYz4YGRzm39sBneeSN",
+  "projectName": "ai-sdk-examples-next-pages"
+}

--- a/content/docs/03-agents/07-workflow-agent.mdx
+++ b/content/docs/03-agents/07-workflow-agent.mdx
@@ -337,14 +337,18 @@ Because the workflow is durable, the approval request survives process restarts 
 Control how many steps the agent can take:
 
 ```ts
-import { isStepCount } from "ai";
+import { isLoopFinished, isStepCount } from "ai";
 
 const result = await agent.stream({
   messages,
   maxSteps: 10, // Maximum number of LLM calls
-  stopWhen: isStepCount(5), // Or use stop conditions from AI SDK
+  stopWhen: isLoopFinished(), // Let the agent run until all tool calls have completed
 });
 ```
+
+`isLoopFinished()` is useful when you want the agent to keep running until it has finished calling tools, but you should still pair it with `maxSteps` to avoid runaway loops. See https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/loop-finished#isloopfinished.
+
+You can also use other stop conditions from AI SDK helpers such as `isStepCount(5)`.
 
 By default, the agent loops until the model stops calling tools (no maximum).
 

--- a/content/docs/03-agents/07-workflow-agent.mdx
+++ b/content/docs/03-agents/07-workflow-agent.mdx
@@ -337,18 +337,28 @@ Because the workflow is durable, the approval request survives process restarts 
 Control how many steps the agent can take:
 
 ```ts
-import { isLoopFinished, isStepCount } from "ai";
+import { isStepCount } from "ai";
 
 const result = await agent.stream({
   messages,
   maxSteps: 10, // Maximum number of LLM calls
-  stopWhen: isLoopFinished(), // Let the agent run until all tool calls have completed
+  stopWhen: isStepCount(5), // Or use stop conditions from AI SDK
 });
 ```
 
-`isLoopFinished()` is useful when you want the agent to keep running until it has finished calling tools, but you should still pair it with `maxSteps` to avoid runaway loops. See https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/loop-finished#isloopfinished.
+If you want the agent to keep running until it has finished calling tools, you can also use `isLoopFinished()`:
 
-You can also use other stop conditions from AI SDK helpers such as `isStepCount(5)`.
+```ts
+import { isLoopFinished } from "ai";
+
+const result = await agent.stream({
+  messages,
+  maxSteps: 10,
+  stopWhen: isLoopFinished(),
+});
+```
+
+`isLoopFinished()` lets the agent run until all tool calls have completed, but you should still pair it with `maxSteps` to avoid runaway loops. See https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/loop-finished#isloopfinished.
 
 By default, the agent loops until the model stops calling tools (no maximum).
 

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -74,7 +74,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
       type: 'StopCondition | StopCondition[]',
       isOptional: true,
       description:
-        'Condition(s) for ending the agent loop. Default: isStepCount(20). Use `isLoopFinished()` to let the agent run until all tool calls have completed, but pair it with a maximum step limit to avoid runaway loops. See https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/loop-finished#isloopfinished.',
+        'Condition(s) for ending the agent loop. Default: isStepCount(20). Use `isLoopFinished()` to let the agent run until all tool calls have completed, but beware of potential runaway loops. See https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/loop-finished#isloopfinished.',
     },
     {
       name: 'activeTools',

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -74,7 +74,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
       type: 'StopCondition | StopCondition[]',
       isOptional: true,
       description:
-        'Condition(s) for ending the agent loop. Default: isStepCount(20).',
+        'Condition(s) for ending the agent loop. Default: isStepCount(20). Use `isLoopFinished()` to let the agent run until all tool calls have completed, but pair it with a maximum step limit to avoid runaway loops. See https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/loop-finished#isloopfinished.',
     },
     {
       name: 'activeTools',

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -88,7 +88,7 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
       name: 'stopWhen',
       type: 'StopCondition | StopCondition[]',
       isOptional: true,
-      description: 'Default stop condition for the agent loop. Per-stream values override this default.',
+      description: 'Default stop condition for the agent loop. Per-stream values override this default. Use `isLoopFinished()` to let the agent run until all tool calls have completed, but pair it with a maximum step limit to avoid runaway loops. See https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/loop-finished#isloopfinished.',
     },
     {
       name: 'activeTools',
@@ -409,7 +409,7 @@ const result = await agent.stream({
       name: 'stopWhen',
       type: 'StopCondition | StopCondition[]',
       isOptional: true,
-      description: 'Condition(s) for ending the agent loop.',
+      description: 'Condition(s) for ending the agent loop. Use `isLoopFinished()` to let the agent run until all tool calls have completed, but pair it with `maxSteps` to avoid runaway loops. See https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/loop-finished#isloopfinished.',
     },
     {
       name: 'maxSteps',

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -88,7 +88,7 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
       name: 'stopWhen',
       type: 'StopCondition | StopCondition[]',
       isOptional: true,
-      description: 'Default stop condition for the agent loop. Per-stream values override this default. Use `isLoopFinished()` to let the agent run until all tool calls have completed, but pair it with a maximum step limit to avoid runaway loops. See https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/loop-finished#isloopfinished.',
+      description: 'Default stop condition for the agent loop. Per-stream values override this default. Use `isLoopFinished()` to let the agent run until all tool calls have completed, but beware of potential runaway loops. See https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/loop-finished#isloopfinished.',
     },
     {
       name: 'activeTools',
@@ -409,7 +409,7 @@ const result = await agent.stream({
       name: 'stopWhen',
       type: 'StopCondition | StopCondition[]',
       isOptional: true,
-      description: 'Condition(s) for ending the agent loop. Use `isLoopFinished()` to let the agent run until all tool calls have completed, but pair it with `maxSteps` to avoid runaway loops. See https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/loop-finished#isloopfinished.',
+      description: 'Condition(s) for ending the agent loop. Use `isLoopFinished()` to let the agent run until all tool calls have completed, but beware of potential runaway loops. See https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/loop-finished#isloopfinished.',
     },
     {
       name: 'maxSteps',


### PR DESCRIPTION
## Summary

Add comprehensive documentation for the `isLoopFinished()` method to help users control agent loop termination conditions across the AI SDK documentation.

## Changes

**Documentation - Workflow Agent Guide (`content/docs/03-agents/07-workflow-agent.mdx`)**

- Document `isLoopFinished()` function for controlling agent loop execution
- Add examples demonstrating loop termination patterns

**Documentation - AI SDK Core Reference (`content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx`)**

- Update tool loop agent reference with `isLoopFinished()` documentation

**Documentation - AI SDK Workflow Reference (`content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx`)**

- Update workflow agent API reference with `isLoopFinished()` stop condition details

**Configuration (`.vercel/project.json`)**

- Add Vercel project configuration updates

---

[Chat](https://open-agents.dev/sessions/6zfWy_s9CePH7CHVpXxMg/chats/7MCAJzTKfkvRntyJ9DzGX) - Built with guidance from [Gregor Martynus](https://github.com/gr2m)