### PR TITLE
docs(reference): mention isLoopFinished() in ToolLoopAgent and WorkflowAgent

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -74,7 +74,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
       type: 'StopCondition | StopCondition[]',
       isOptional: true,
       description:
-        'Condition(s) for ending the agent loop. Default: isStepCount(20).',
+        'Condition(s) for ending the agent loop. Default: isStepCount(20). Use [`isLoopFinished()`](/docs/reference/ai-sdk-core/loop-finished#isloopfinished) to let the agent run until all tools have been called. **Caution:** Without a step limit, runaway loops could incur significant costs.',
     },
     {
       name: 'activeTools',

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -88,7 +88,7 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
       name: 'stopWhen',
       type: 'StopCondition | StopCondition[]',
       isOptional: true,
-      description: 'Default stop condition for the agent loop. Per-stream values override this default.',
+      description: 'Default stop condition for the agent loop. Per-stream values override this default. Use [`isLoopFinished()`](/docs/reference/ai-sdk-core/loop-finished#isloopfinished) to let the agent run until all tools have been called. **Caution:** Without a step limit, runaway loops could incur significant costs.',
     },
     {
       name: 'activeTools',
@@ -409,7 +409,7 @@ const result = await agent.stream({
       name: 'stopWhen',
       type: 'StopCondition | StopCondition[]',
       isOptional: true,
-      description: 'Condition(s) for ending the agent loop.',
+      description: 'Condition(s) for ending the agent loop. Use [`isLoopFinished()`](/docs/reference/ai-sdk-core/loop-finished#isloopfinished) to let the agent run until all tools have been called. **Caution:** Without a step limit, runaway loops could incur significant costs.',
     },
     {
       name: 'maxSteps',


### PR DESCRIPTION
[@Gregor Martynus](https://vercel.slack.com/team/U08RQH8ETMY) suggested adding `isLoopFinished()` to the agent reference docs so users can discover it more easily.

### What changed

- Added `isLoopFinished()` mention to `stopWhen` parameter in ToolLoopAgent constructor docs
- Added `isLoopFinished()` mention to `stopWhen` parameter in WorkflowAgent constructor and `stream()` method docs
- Included runaway loops disclaimer in each description
- Linked to the full reference page at `/docs/reference/ai-sdk-core/loop-finished#isloopfinished`