### PR TITLE
fix(workflow): remove obsolete `maxSteps` parameter

### DIFF
--- a/.changeset/remove-maxsteps-workflow-agent.md
+++ b/.changeset/remove-maxsteps-workflow-agent.md
@@ -1,5 +1,5 @@
 ---
-"@ai-sdk/workflow": minor
+"@ai-sdk/workflow": patch
 ---
 
 Remove `maxSteps` option from `WorkflowAgent`. Use `stopWhen` with stop conditions like `isStepCount()` instead.

--- a/.changeset/remove-maxsteps-workflow-agent.md
+++ b/.changeset/remove-maxsteps-workflow-agent.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/workflow": minor
+---
+
+Remove `maxSteps` option from `WorkflowAgent`. Use `stopWhen` with stop conditions like `isStepCount()` instead.

--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,5 +1,0 @@
-{
-  "orgId": "team_nO2mCG4W8IxPIeKoSsqwAxxB",
-  "projectId": "prj_znSb9jeHIqTYz4YGRzm39sBneeSN",
-  "projectName": "ai-sdk-examples-next-pages"
-}

--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,0 +1,5 @@
+{
+  "orgId": "team_nO2mCG4W8IxPIeKoSsqwAxxB",
+  "projectId": "prj_znSb9jeHIqTYz4YGRzm39sBneeSN",
+  "projectName": "ai-sdk-examples-next-pages"
+}

--- a/content/cookbook/00-guides/21-llama-3_1.mdx
+++ b/content/cookbook/00-guides/21-llama-3_1.mdx
@@ -158,12 +158,12 @@ Agents use LLMs to choose the next step in a problem-solving process. They can r
 
 ### Implementing Agents with the AI SDK
 
-The AI SDK supports agent implementation through the `maxSteps` parameter. This allows the model to make multiple decisions and tool calls in a single interaction.
+The AI SDK supports agent implementation through the `stopWhen` parameter and built-in stop conditions. This allows the model to make multiple decisions and tool calls in a single interaction.
 
 Here's an example of an agent that solves math problems:
 
 ```tsx
-import { generateText, tool } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { deepinfra } from '@ai-sdk/deepinfra';
 import * as mathjs from 'mathjs';
 import { z } from 'zod';
@@ -183,7 +183,7 @@ const { text: answer } = await generateText({
       execute: async ({ expression }) => mathjs.evaluate(expression),
     }),
   },
-  maxSteps: 5,
+  stopWhen: isStepCount(5),
 });
 ```
 

--- a/content/cookbook/05-node/90-dynamic-prompt-caching.mdx
+++ b/content/cookbook/05-node/90-dynamic-prompt-caching.mdx
@@ -106,11 +106,11 @@ export function addCacheControlToMessages({
 
 ## Using the Utility
 
-Integrate the utility into your agent using the `prepareStep` callback with `generateText` and `maxSteps`:
+Integrate the utility into your agent using the `prepareStep` callback with `generateText` and `stopWhen`:
 
 ```ts
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, tool } from 'ai';
+import { generateText, tool, isStepCount } from 'ai';
 import { z } from 'zod';
 import { addCacheControlToMessages } from './add-cache-control-to-messages';
 
@@ -118,7 +118,7 @@ async function main() {
   const result = await generateText({
     model: anthropic('claude-sonnet-4-5'),
     prompt: 'Help me analyze this codebase and suggest improvements.',
-    maxSteps: 10,
+    stopWhen: isStepCount(10),
     tools: {
       // your tools here
       analyzeFile: tool({

--- a/content/docs/03-agents/07-workflow-agent.mdx
+++ b/content/docs/03-agents/07-workflow-agent.mdx
@@ -341,8 +341,7 @@ import { isStepCount } from "ai";
 
 const result = await agent.stream({
   messages,
-  maxSteps: 10, // Maximum number of LLM calls
-  stopWhen: isStepCount(5), // Or use stop conditions from AI SDK
+  stopWhen: isStepCount(10), // Stop after 10 LLM calls
 });
 ```
 

--- a/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
+++ b/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
@@ -165,7 +165,7 @@ With AI SDK UI, `useChat` comes with built-in support for parallel tool calls. Y
 
 In AI SDK RSC, `streamUI` does not support multi-step tool calls. You will have to use a combination of `streamText`, `createStreamableUI` and `createStreamableValue`.
 
-With AI SDK UI, `useChat` comes with built-in support for multi-step tool calls. You can set `maxSteps` in the `streamText` function to define the number of steps the language model can make in a single call. The `useChat` hook will then handle the multi-step tool calls for you automatically.
+With AI SDK UI, `useChat` comes with built-in support for multi-step tool calls. You can set `stopWhen` in the `streamText` function to define when the model should stop making tool calls. The `useChat` hook will then handle the multi-step tool calls for you automatically.
 
 ### Generative User Interfaces
 
@@ -349,12 +349,13 @@ After switching to AI SDK UI, these messages are synced by initializing the `use
 'use client';
 
 import { useChat } from '@ai-sdk/react';
+import { isStepCount } from 'ai';
 
 export function ListFlights({ chatId, flights }) {
   const { append } = useChat({
     id: chatId,
     body: { id: chatId },
-    maxSteps: 5,
+    stopWhen: isStepCount(5),
   });
 
   return (

--- a/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
+++ b/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
@@ -349,13 +349,11 @@ After switching to AI SDK UI, these messages are synced by initializing the `use
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { isStepCount } from 'ai';
 
 export function ListFlights({ chatId, flights }) {
   const { append } = useChat({
     id: chatId,
     body: { id: chatId },
-    stopWhen: isStepCount(5),
   });
 
   return (

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -411,12 +411,7 @@ const result = await agent.stream({
       isOptional: true,
       description: 'Condition(s) for ending the agent loop.',
     },
-    {
-      name: 'maxSteps',
-      type: 'number',
-      isOptional: true,
-      description: 'Maximum number of sequential LLM calls (steps). By default, the agent loops until completion.',
-    },
+
     {
       name: 'toolChoice',
       type: 'ToolChoice',

--- a/content/providers/03-community-providers/26-mcp-sampling.mdx
+++ b/content/providers/03-community-providers/26-mcp-sampling.mdx
@@ -326,7 +326,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { createMCPSamplingProvider } from '@mcpc-tech/mcp-sampling-ai-provider';
-import { generateText } from 'ai';
+import { generateText, isStepCount } from 'ai';
 import { z } from 'zod';
 
 const server = new Server(
@@ -376,7 +376,7 @@ server.setRequestHandler(CallToolRequestSchema, async request => {
       prompt:
         request.params.arguments?.question ||
         'What is the weather in San Francisco?',
-      maxSteps: 5,
+      stopWhen: isStepCount(5),
     });
 
     return { content: [{ type: 'text', text: result.text }] };

--- a/content/providers/03-community-providers/35-react-native-apple.mdx
+++ b/content/providers/03-community-providers/35-react-native-apple.mdx
@@ -160,7 +160,7 @@ const result = await generateText({
 
 <Note>
   Since tools are executed by Apple Intelligence rather than the AI SDK,
-  multi-step features like `maxSteps`, `onStepStart`, and `onStepFinish` are not
+  multi-step features like `stopWhen`, `onStepStart`, and `onStepFinish` are not
   supported.
 </Note>
 

--- a/content/providers/05-observability/braintrust.mdx
+++ b/content/providers/05-observability/braintrust.mdx
@@ -91,7 +91,7 @@ Then, set up the OpenTelemetry SDK:
 
 ```typescript
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { registerTelemetryIntegration, generateText, tool } from 'ai';
+import { registerTelemetryIntegration, generateText, tool, isStepCount } from 'ai';
 import { OpenTelemetryIntegration } from '@ai-sdk/otel';
 import { openai } from '@ai-sdk/openai';
 import { z } from 'zod';
@@ -140,7 +140,7 @@ async function main() {
         someOtherThing: 'other-value',
       },
     },
-    maxSteps: 10,
+    stopWhen: isStepCount(10),
   });
 
   await sdk.shutdown();

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -55,7 +55,6 @@ export async function* streamTextIterator({
   writable,
   model,
   stopConditions,
-  maxSteps,
   onStepFinish,
   onStepStart,
   onError,
@@ -73,7 +72,6 @@ export async function* streamTextIterator({
   writable?: WritableStream<ModelCallStreamPart<ToolSet>>;
   model: LanguageModel;
   stopConditions?: ModelStopCondition[] | ModelStopCondition;
-  maxSteps?: number;
   onStepFinish?: WorkflowAgentOnStepFinishCallback<any>;
   onStepStart?: WorkflowAgentOnStepStartCallback;
   onError?: WorkflowAgentOnErrorCallback;
@@ -104,16 +102,7 @@ export async function* streamTextIterator({
   let lastStep: StepResult<any, any> | undefined;
   let lastStepWasToolCalls = false;
 
-  // Default maxSteps to Infinity to preserve backwards compatibility
-  // (agent loops until completion unless explicitly limited)
-  const effectiveMaxSteps = maxSteps ?? Infinity;
-
   while (!done) {
-    // Check if we've exceeded the maximum number of steps
-    if (stepNumber >= effectiveMaxSteps) {
-      break;
-    }
-
     // Check for abort signal
     if (currentGenerationSettings.abortSignal?.aborted) {
       break;

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -1524,42 +1524,6 @@ describe('WorkflowAgent', () => {
     });
   });
 
-  describe('maxSteps', () => {
-    it('should pass maxSteps to streamTextIterator', async () => {
-      const mockModel = createMockModel();
-
-      const agent = new WorkflowAgent({
-        model: mockModel,
-        tools: {},
-      });
-
-      const mockWritable = new WritableStream({
-        write: vi.fn(),
-        close: vi.fn(),
-      });
-
-      const { streamTextIterator } = await import('./stream-text-iterator.js');
-      const mockIterator = {
-        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
-      };
-      vi.mocked(streamTextIterator).mockReturnValue(
-        mockIterator as unknown as MockIterator,
-      );
-
-      await agent.stream({
-        messages: [{ role: 'user', content: 'test' }],
-        writable: mockWritable,
-        maxSteps: 5,
-      });
-
-      expect(streamTextIterator).toHaveBeenCalledWith(
-        expect.objectContaining({
-          maxSteps: 5,
-        }),
-      );
-    });
-  });
-
   describe('toolChoice', () => {
     it('should pass toolChoice from constructor to streamTextIterator', async () => {
       const mockModel = createMockModel();

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -715,13 +715,6 @@ export type WorkflowAgentStreamOptions<
       | Array<StopCondition<NoInfer<ToolSet>, any>>;
 
     /**
-     * Maximum number of sequential LLM calls (steps), e.g. when you use tool calls.
-     * A maximum number can be set to prevent infinite loops in the case of misconfigured tools.
-     * By default, it's unlimited (the agent loops until completion).
-     */
-    maxSteps?: number;
-
-    /**
      * The tool choice strategy. Default: 'auto'.
      * Overrides the toolChoice from the constructor if provided.
      */
@@ -1471,7 +1464,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       writable: options.writable,
       prompt: modelPrompt,
       stopConditions: options.stopWhen ?? this.stopWhen,
-      maxSteps: options.maxSteps,
+
       onStepFinish: mergedOnStepFinish,
       onStepStart: mergedOnStepStart,
       onError: options.onError,


### PR DESCRIPTION
## Summary

Remove the maxSteps parameter from the workflow agent to simplify the API and reduce unnecessary complexity in step limiting.

## Changes

**Workflow Agent (`packages/workflow/src/workflow-agent.ts`)**

- Remove maxSteps parameter and associated logic

**Tests (`packages/workflow/src/workflow-agent.test.ts`)**

- Remove test cases for maxSteps parameter behavior

**Stream Iterator (`packages/workflow/src/stream-text-iterator.ts`)**

- Remove maxSteps-related functionality

---

[Chat](https://open-agents-jel94gmlv.preview.open-agents.dev/sessions/hRioeUabCtHHGRbEuM6ld/chats/yYSIJVXbWfo587Cjou0H5) - Built with guidance from [Gregor Martynus](https://github.com/gr2m)