### PR TITLE
docs(ai): add @betterdb/agent-cache to community middleware

### DIFF
--- a/content/docs/03-ai-sdk-core/40-middleware.mdx
+++ b/content/docs/03-ai-sdk-core/40-middleware.mdx
@@ -266,6 +266,51 @@ const model = wrapLanguageModel({
 
 Find more examples at this [link](https://github.com/minpeter/ai-sdk-tool-call-middleware/tree/main/examples/core/src).
 
+### BetterDB Agent Cache
+
+The [BetterDB Agent Cache](https://github.com/BetterDB-inc/monitor/tree/main/packages/agent-cache) provides a multi-tier exact-match cache for AI agent workloads backed by Valkey or Redis. The Vercel AI SDK adapter (`createAgentCacheMiddleware`) wraps the LLM tier as language model middleware via `wrapLanguageModel`, caching non-streaming `generate()` responses. Works on vanilla Valkey 7+, Redis 6.2+, and managed equivalents (ElastiCache, Memorystore, MemoryDB) with no module requirements.
+
+```ts
+import { wrapLanguageModel, generateText } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+import Valkey from 'iovalkey';
+import { AgentCache } from '@betterdb/agent-cache';
+import { createAgentCacheMiddleware } from '@betterdb/agent-cache/ai';
+
+const client = new Valkey({ host: 'localhost', port: 6379 });
+
+const cache = new AgentCache({
+  client,
+  tierDefaults: { llm: { ttl: 3600 } },
+});
+
+const openai = createOpenAI({});
+
+const model = wrapLanguageModel({
+  model: openai.chat('gpt-4o-mini'),
+  middleware: createAgentCacheMiddleware({ cache }),
+});
+
+// First call - cache miss, model is invoked
+const result1 = await generateText({
+  model,
+  prompt: 'What is the capital of Bulgaria?',
+});
+
+// Second call - cache hit, response returned from Valkey
+const result2 = await generateText({
+  model,
+  prompt: 'What is the capital of Bulgaria?',
+});
+```
+
+<Note>
+  Streaming responses are not cached. The middleware only caches
+  non-streaming `generateText()` calls.
+</Note>
+
+Find the package on [npm](https://www.npmjs.com/package/@betterdb/agent-cache) and a full Vercel AI SDK example in the [repository](https://github.com/BetterDB-inc/monitor/tree/main/packages/agent-cache/examples/vercel-ai-sdk).
+
 ## Implementing Language Model Middleware
 
 <Note>


### PR DESCRIPTION
## Background

The Language Model Middleware docs page has a "Community Middleware" section with one existing entry (@ai-sdk tool/parser). This PR adds a second community middleware: @betterdb/agent-cache, which provides a packaged caching middleware as an alternative to the DIY approach documented in the Advanced Caching page.

## Summary

Added a `### BetterDB Agent Cache` entry inside the "Community Middleware" section of `content/docs/03-ai-sdk core/40-middleware.mdx`, after the existing `@ai-sdk-tool/parser` entry.

`createAgentCacheMiddleware` wraps the LLM tier of @betterdb/agent-cache as language model middleware via `wrapLanguageModel`, caching non-streaming `generateText()` responses in Valkey or Redis. Works on vanilla Valkey 7+ with no module requirements.

One file changed: `content/docs/03-ai-sdk-core/40-middleware.mdx`

- Package: https://www.npmjs.com/package/@betterdb/agent-cache
- Source: https://github.com/BetterDB-inc/monitor/tree/main/packages/agent-cache

## Manual Verification

This is a docs-only change. The new entry follows the same structure as the existing @ai-sdk-tool/parser community middleware entry (h3 heading, GitHub link, description, TypeScript code example, Note component, closing links).

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

The @betterdb/agent-cache package also provides adapters for LangChain (BaseCache) and LangGraph (BaseCheckpointSaver). Documentation PRs for those ecosystems are being tracked separately.

## Related Issues

N/A - this is a new community middleware documentation addition.