### PR TITLE
fix(ai): remove deprecated experimental_prepareStep

### DIFF
--- a/.changeset/fair-birds-cheer.md
+++ b/.changeset/fair-birds-cheer.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+Remove the deprecated `experimental_prepareStep` option from `generateText`.
+
+Use `prepareStep` instead.

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -281,6 +281,38 @@ const result = await generateText({
 });
 ```
 
+### Core: Remove Deprecated `experimental_prepareStep` Option
+
+The deprecated `experimental_prepareStep` option has been removed in AI SDK 7. Replace all remaining usages with `prepareStep`.
+
+This option was deprecated in AI SDK 5, so if you already migrated to `prepareStep`, no changes are needed. Otherwise, update `generateText` calls:
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  tools: { weather },
+  experimental_prepareStep: ({ stepNumber }) => {
+    console.log('Preparing step', stepNumber);
+    return {
+      activeTools: ['weather'],
+    };
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  tools: { weather },
+  prepareStep: ({ stepNumber }) => {
+    console.log('Preparing step', stepNumber);
+    return {
+      activeTools: ['weather'],
+    };
+  },
+});
+```
+
 ### Tools: Remove Deprecated `ToolCallOptions` Type
 
 The deprecated `ToolCallOptions` type has been removed in AI SDK 7. Replace all remaining usages with `ToolExecutionOptions`.

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -265,8 +265,7 @@ export async function generateText<
   experimental_telemetry: telemetry,
   providerOptions,
   activeTools,
-  experimental_prepareStep,
-  prepareStep = experimental_prepareStep,
+  prepareStep,
   experimental_repairToolCall: repairToolCall,
   experimental_download: download,
   runtimeContext = {} as RUNTIME_CONTEXT,
@@ -356,14 +355,6 @@ export async function generateText<
      * By default, files are downloaded if the model does not support the URL for the given media type.
      */
     experimental_download?: DownloadFunction | undefined;
-
-    /**
-     * @deprecated Use `prepareStep` instead.
-     */
-    experimental_prepareStep?: PrepareStepFunction<
-      NoInfer<TOOLS>,
-      RUNTIME_CONTEXT
-    >;
 
     /**
      * Optional function that you can use to provide different settings for a step.


### PR DESCRIPTION
## Background

`experimental_prepareStep` was deprecated in AI SDK 5

## Summary

Remove `experimental_prepareStep` option from `generateText`.