### PR TITLE
refactor(workflow): use `experimental_filterActiveTools` from `ai`

### DIFF
--- a/.changeset/workflow-use-filter-active-tools.md
+++ b/.changeset/workflow-use-filter-active-tools.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+refactor: replace duplicate `filterTools`/`filterToolSet` with shared `experimental_filterActiveTools` from `ai`

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -3,14 +3,15 @@ import type {
   LanguageModelV4Prompt,
   LanguageModelV4ToolResultPart,
 } from '@ai-sdk/provider';
-import type {
-  Experimental_LanguageModelStreamPart as ModelCallStreamPart,
-  LanguageModel,
-  ModelMessage,
-  StepResult,
-  ToolCallRepairFunction,
-  ToolChoice,
-  ToolSet,
+import {
+  type Experimental_LanguageModelStreamPart as ModelCallStreamPart,
+  type LanguageModel,
+  type ModelMessage,
+  type StepResult,
+  type ToolCallRepairFunction,
+  type ToolChoice,
+  type ToolSet,
+  experimental_filterActiveTools as filterActiveTools,
 } from 'ai';
 import {
   doStreamStep,
@@ -239,7 +240,10 @@ export async function* streamTextIterator({
       // Filter tools if activeTools is specified
       const effectiveTools =
         currentActiveTools && currentActiveTools.length > 0
-          ? filterToolSet(tools, currentActiveTools)
+          ? (filterActiveTools({
+              tools,
+              activeTools: currentActiveTools,
+            }) ?? tools)
           : tools;
 
       // Serialize tools before crossing the step boundary — zod schemas
@@ -381,19 +385,6 @@ export async function* streamTextIterator({
   }
 
   return conversationPrompt;
-}
-
-/**
- * Filter a tool set to only include the specified active tools.
- */
-function filterToolSet(tools: ToolSet, activeTools: string[]): ToolSet {
-  const filtered: ToolSet = {};
-  for (const toolName of activeTools) {
-    if (toolName in tools) {
-      filtered[toolName] = tools[toolName];
-    }
-  }
-  return filtered;
 }
 
 /**

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -22,6 +22,7 @@ import {
   type ToolSet,
   type UIMessage,
   LanguageModel,
+  experimental_filterActiveTools as filterActiveTools,
 } from 'ai';
 import {
   convertToLanguageModelPrompt,
@@ -1353,7 +1354,10 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
     const effectiveActiveTools = options.activeTools ?? this.activeTools;
     const effectiveTools =
       effectiveActiveTools && effectiveActiveTools.length > 0
-        ? filterTools(this.tools, effectiveActiveTools as string[])
+        ? (filterActiveTools({
+            tools: this.tools,
+            activeTools: effectiveActiveTools as string[],
+          }) ?? this.tools)
         : this.tools;
 
     // Initialize context
@@ -1970,19 +1974,6 @@ function aggregateUsage(steps: StepResult<any, any>[]): LanguageModelUsage {
     outputTokens,
     totalTokens: inputTokens + outputTokens,
   } as LanguageModelUsage;
-}
-
-function filterTools<TTools extends ToolSet>(
-  tools: TTools,
-  activeTools: string[],
-): ToolSet {
-  const filtered: ToolSet = {};
-  for (const toolName of activeTools) {
-    if (toolName in tools) {
-      filtered[toolName] = tools[toolName];
-    }
-  }
-  return filtered;
 }
 
 // Matches AI SDK's getErrorMessage from @ai-sdk/provider-utils


### PR DESCRIPTION
## Summary

- Replace two duplicate local `filterTools`/`filterToolSet` implementations in `workflow-agent.ts` and `stream-text-iterator.ts` with the shared `experimental_filterActiveTools` utility from ai core
- Removes ~18 lines of duplicated code

Recreated from #13958 (which targeted the old `durable-agent` package, now renamed to `workflow`).