### PR TITLE
refactor: extract StreamingToolCallTracker to deduplicate streaming tool call handling

### DIFF
--- a/.changeset/refactor-streaming-tool-call-tracker.md
+++ b/.changeset/refactor-streaming-tool-call-tracker.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/deepseek': patch
+'@ai-sdk/alibaba': patch
+---
+
+Extract shared `StreamingToolCallTracker` class into `@ai-sdk/provider-utils` to deduplicate streaming tool call handling across OpenAI-compatible providers. Also adds missing `generateId()` fallback for `toolCallId` in Alibaba's `doGenerate` path and ensures all providers finalize unfinished tool calls during stream flush.

--- a/packages/alibaba/src/alibaba-chat-language-model.ts
+++ b/packages/alibaba/src/alibaba-chat-language-model.ts
@@ -4,7 +4,6 @@ import {
   prepareTools,
 } from '@ai-sdk/openai-compatible/internal';
 import {
-  InvalidResponseDataError,
   type LanguageModelV4,
   type LanguageModelV4CallOptions,
   type LanguageModelV4Content,
@@ -21,12 +20,12 @@ import {
   generateId,
   type InferSchema,
   isCustomReasoning,
-  isParsableJson,
   mapReasoningToProviderBudget,
   parseProviderOptions,
   postJsonToApi,
   type ParseResult,
   serializeModelOptions,
+  StreamingToolCallTracker,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
 } from '@ai-sdk/provider-utils';
@@ -222,7 +221,7 @@ export class AlibabaLanguageModel implements LanguageModelV4 {
       for (const toolCall of choice.message.tool_calls) {
         content.push({
           type: 'tool-call',
-          toolCallId: toolCall.id,
+          toolCallId: toolCall.id ?? generateId(),
           toolName: toolCall.function.name,
           input: toolCall.function.arguments!,
         });
@@ -281,13 +280,7 @@ export class AlibabaLanguageModel implements LanguageModelV4 {
     let activeText = false;
     let activeReasoningId: string | null = null;
 
-    // Track tool calls for accumulation across chunks
-    const toolCalls: Array<{
-      id: string;
-      type: 'function';
-      function: { name: string; arguments: string };
-      hasFinished: boolean;
-    }> = [];
+    const toolCallTracker = new StreamingToolCallTracker({ generateId });
 
     return {
       stream: response.pipeThrough(
@@ -400,106 +393,10 @@ export class AlibabaLanguageModel implements LanguageModelV4 {
               }
 
               for (const toolCallDelta of delta.tool_calls) {
-                const index = toolCallDelta.index ?? toolCalls.length;
-
-                // New tool call - first chunk with id and name
-                if (toolCalls[index] == null) {
-                  if (toolCallDelta.id == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'id' to be a string.`,
-                    });
-                  }
-
-                  if (toolCallDelta.function?.name == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'function.name' to be a string.`,
-                    });
-                  }
-
-                  controller.enqueue({
-                    type: 'tool-input-start',
-                    id: toolCallDelta.id,
-                    toolName: toolCallDelta.function.name,
-                  });
-
-                  toolCalls[index] = {
-                    id: toolCallDelta.id,
-                    type: 'function',
-                    function: {
-                      name: toolCallDelta.function.name,
-                      arguments: toolCallDelta.function.arguments ?? '',
-                    },
-                    hasFinished: false,
-                  };
-
-                  const toolCall = toolCalls[index];
-
-                  // Send initial delta if arguments started
-                  if (toolCall.function.arguments.length > 0) {
-                    controller.enqueue({
-                      type: 'tool-input-delta',
-                      id: toolCall.id,
-                      delta: toolCall.function.arguments,
-                    });
-                  }
-
-                  // Check if already complete (some providers send full tool call at once)
-                  if (isParsableJson(toolCall.function.arguments)) {
-                    controller.enqueue({
-                      type: 'tool-input-end',
-                      id: toolCall.id,
-                    });
-
-                    controller.enqueue({
-                      type: 'tool-call',
-                      toolCallId: toolCall.id,
-                      toolName: toolCall.function.name,
-                      input: toolCall.function.arguments,
-                    });
-
-                    toolCall.hasFinished = true;
-                  }
-
-                  continue;
-                }
-
-                // Existing tool call - accumulate arguments
-                const toolCall = toolCalls[index];
-
-                if (toolCall.hasFinished) {
-                  continue;
-                }
-
-                // Append arguments if not null (skip arguments: null chunks)
-                if (toolCallDelta.function?.arguments != null) {
-                  toolCall.function.arguments +=
-                    toolCallDelta.function.arguments;
-
-                  controller.enqueue({
-                    type: 'tool-input-delta',
-                    id: toolCall.id,
-                    delta: toolCallDelta.function.arguments,
-                  });
-                }
-
-                // Check if tool call is now complete
-                if (isParsableJson(toolCall.function.arguments)) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id,
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
-
-                  toolCall.hasFinished = true;
-                }
+                toolCallTracker.processDelta(
+                  toolCallDelta,
+                  controller.enqueue.bind(controller),
+                );
               }
             }
 
@@ -523,6 +420,8 @@ export class AlibabaLanguageModel implements LanguageModelV4 {
             if (activeText) {
               controller.enqueue({ type: 'text-end', id: '0' });
             }
+
+            toolCallTracker.flush(controller.enqueue.bind(controller));
 
             controller.enqueue({
               type: 'finish',

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.ts
@@ -1,6 +1,5 @@
 import {
   APICallError,
-  InvalidResponseDataError,
   LanguageModelV4,
   LanguageModelV4CallOptions,
   LanguageModelV4Content,
@@ -18,12 +17,12 @@ import {
   generateId,
   InferSchema,
   isCustomReasoning,
-  isParsableJson,
   parseProviderOptions,
   ParseResult,
   postJsonToApi,
   ResponseHandler,
   serializeModelOptions,
+  StreamingToolCallTracker,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
 } from '@ai-sdk/provider-utils';
@@ -265,15 +264,7 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
       fetch: this.config.fetch,
     });
 
-    const toolCalls: Array<{
-      id: string;
-      type: 'function';
-      function: {
-        name: string;
-        arguments: string;
-      };
-      hasFinished: boolean;
-    }> = [];
+    const toolCallTracker = new StreamingToolCallTracker({ generateId });
 
     let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
@@ -395,113 +386,10 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
               }
 
               for (const toolCallDelta of delta.tool_calls) {
-                const index = toolCallDelta.index;
-
-                if (toolCalls[index] == null) {
-                  if (toolCallDelta.id == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'id' to be a string.`,
-                    });
-                  }
-
-                  if (toolCallDelta.function?.name == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'function.name' to be a string.`,
-                    });
-                  }
-
-                  controller.enqueue({
-                    type: 'tool-input-start',
-                    id: toolCallDelta.id,
-                    toolName: toolCallDelta.function.name,
-                  });
-
-                  toolCalls[index] = {
-                    id: toolCallDelta.id,
-                    type: 'function',
-                    function: {
-                      name: toolCallDelta.function.name,
-                      arguments: toolCallDelta.function.arguments ?? '',
-                    },
-                    hasFinished: false,
-                  };
-
-                  const toolCall = toolCalls[index];
-
-                  if (
-                    toolCall.function?.name != null &&
-                    toolCall.function?.arguments != null
-                  ) {
-                    // send delta if the argument text has already started:
-                    if (toolCall.function.arguments.length > 0) {
-                      controller.enqueue({
-                        type: 'tool-input-delta',
-                        id: toolCall.id,
-                        delta: toolCall.function.arguments,
-                      });
-                    }
-
-                    // check if tool call is complete
-                    // (some providers send the full tool call in one chunk):
-                    if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
-
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                      });
-                      toolCall.hasFinished = true;
-                    }
-                  }
-
-                  continue;
-                }
-
-                // existing tool call, merge if not finished
-                const toolCall = toolCalls[index];
-
-                if (toolCall.hasFinished) {
-                  continue;
-                }
-
-                if (toolCallDelta.function?.arguments != null) {
-                  toolCall.function!.arguments +=
-                    toolCallDelta.function?.arguments ?? '';
-                }
-
-                // send delta
-                controller.enqueue({
-                  type: 'tool-input-delta',
-                  id: toolCall.id,
-                  delta: toolCallDelta.function.arguments ?? '',
-                });
-
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
-                  toolCall.hasFinished = true;
-                }
+                toolCallTracker.processDelta(
+                  toolCallDelta,
+                  controller.enqueue.bind(controller),
+                );
               }
             }
           },
@@ -515,22 +403,7 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
               controller.enqueue({ type: 'text-end', id: 'txt-0' });
             }
 
-            // go through all tool calls and send the ones that are not finished
-            for (const toolCall of toolCalls.filter(
-              toolCall => !toolCall.hasFinished,
-            )) {
-              controller.enqueue({
-                type: 'tool-input-end',
-                id: toolCall.id,
-              });
-
-              controller.enqueue({
-                type: 'tool-call',
-                toolCallId: toolCall.id ?? generateId(),
-                toolName: toolCall.function.name,
-                input: toolCall.function.arguments,
-              });
-            }
+            toolCallTracker.flush(controller.enqueue.bind(controller));
 
             controller.enqueue({
               type: 'finish',

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -1,5 +1,4 @@
 import {
-  InvalidResponseDataError,
   LanguageModelV4,
   LanguageModelV4CallOptions,
   LanguageModelV4Content,
@@ -13,12 +12,12 @@ import {
 import {
   FetchFunction,
   ParseResult,
+  StreamingToolCallTracker,
   combineHeaders,
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
   isCustomReasoning,
-  isParsableJson,
   mapReasoningToProviderEffort,
   parseProviderOptions,
   postJsonToApi,
@@ -284,15 +283,10 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
       fetch: this.config.fetch,
     });
 
-    const toolCalls: Array<{
-      id: string;
-      type: 'function';
-      function: {
-        name: string;
-        arguments: string;
-      };
-      hasFinished: boolean;
-    }> = [];
+    const toolCallTracker = new StreamingToolCallTracker({
+      generateId,
+      typeValidation: 'required',
+    });
 
     let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
@@ -436,120 +430,10 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
               }
 
               for (const toolCallDelta of delta.tool_calls) {
-                const index = toolCallDelta.index;
-
-                if (toolCalls[index] == null) {
-                  if (toolCallDelta.type !== 'function') {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'function' type.`,
-                    });
-                  }
-
-                  if (toolCallDelta.id == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'id' to be a string.`,
-                    });
-                  }
-
-                  if (toolCallDelta.function?.name == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'function.name' to be a string.`,
-                    });
-                  }
-
-                  controller.enqueue({
-                    type: 'tool-input-start',
-                    id: toolCallDelta.id,
-                    toolName: toolCallDelta.function.name,
-                  });
-
-                  toolCalls[index] = {
-                    id: toolCallDelta.id,
-                    type: 'function',
-                    function: {
-                      name: toolCallDelta.function.name,
-                      arguments: toolCallDelta.function.arguments ?? '',
-                    },
-                    hasFinished: false,
-                  };
-
-                  const toolCall = toolCalls[index];
-
-                  if (
-                    toolCall.function?.name != null &&
-                    toolCall.function?.arguments != null
-                  ) {
-                    // send delta if the argument text has already started:
-                    if (toolCall.function.arguments.length > 0) {
-                      controller.enqueue({
-                        type: 'tool-input-delta',
-                        id: toolCall.id,
-                        delta: toolCall.function.arguments,
-                      });
-                    }
-
-                    // check if tool call is complete
-                    // (some providers send the full tool call in one chunk):
-                    if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
-
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                      });
-                      toolCall.hasFinished = true;
-                    }
-                  }
-
-                  continue;
-                }
-
-                // existing tool call, merge if not finished
-                const toolCall = toolCalls[index];
-
-                if (toolCall.hasFinished) {
-                  continue;
-                }
-
-                if (toolCallDelta.function?.arguments != null) {
-                  toolCall.function!.arguments +=
-                    toolCallDelta.function?.arguments ?? '';
-                }
-
-                // send delta
-                controller.enqueue({
-                  type: 'tool-input-delta',
-                  id: toolCall.id,
-                  delta: toolCallDelta.function.arguments ?? '',
-                });
-
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
-                  toolCall.hasFinished = true;
-                }
+                toolCallTracker.processDelta(
+                  toolCallDelta,
+                  controller.enqueue.bind(controller),
+                );
               }
             }
           },
@@ -562,6 +446,8 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
             if (isActiveText) {
               controller.enqueue({ type: 'text-end', id: 'txt-0' });
             }
+
+            toolCallTracker.flush(controller.enqueue.bind(controller));
 
             controller.enqueue({
               type: 'finish',

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -1,6 +1,5 @@
 import {
   APICallError,
-  InvalidResponseDataError,
   LanguageModelV4,
   LanguageModelV4CallOptions,
   LanguageModelV4Content,
@@ -19,12 +18,12 @@ import {
   FetchFunction,
   generateId,
   isCustomReasoning,
-  isParsableJson,
   parseProviderOptions,
   ParseResult,
   postJsonToApi,
   ResponseHandler,
   serializeModelOptions,
+  StreamingToolCallTracker,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
 } from '@ai-sdk/provider-utils';
@@ -430,16 +429,17 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
       fetch: this.config.fetch,
     });
 
-    const toolCalls: Array<{
-      id: string;
-      type: 'function';
-      function: {
-        name: string;
-        arguments: string;
-      };
-      hasFinished: boolean;
-      thoughtSignature?: string;
-    }> = [];
+    const providerOptionsName = metadataKey;
+    const toolCallTracker = new StreamingToolCallTracker({
+      generateId,
+      extractMetadata: delta => {
+        const sig = (delta as any).extra_content?.google?.thought_signature;
+        return sig
+          ? { [providerOptionsName]: { thoughtSignature: sig } }
+          : undefined;
+      },
+      buildToolCallProviderMetadata: metadata => metadata,
+    });
 
     let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
@@ -448,7 +448,6 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
     let usage: z.infer<typeof openaiCompatibleTokenUsageSchema> | undefined =
       undefined;
     let isFirstChunk = true;
-    const providerOptionsName = metadataKey;
     let isActiveReasoning = false;
     let isActiveText = false;
 
@@ -570,134 +569,10 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
               }
 
               for (const toolCallDelta of delta.tool_calls) {
-                const index = toolCallDelta.index ?? toolCalls.length;
-
-                if (toolCalls[index] == null) {
-                  if (toolCallDelta.id == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'id' to be a string.`,
-                    });
-                  }
-
-                  if (toolCallDelta.function?.name == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'function.name' to be a string.`,
-                    });
-                  }
-
-                  controller.enqueue({
-                    type: 'tool-input-start',
-                    id: toolCallDelta.id,
-                    toolName: toolCallDelta.function.name,
-                  });
-
-                  toolCalls[index] = {
-                    id: toolCallDelta.id,
-                    type: 'function',
-                    function: {
-                      name: toolCallDelta.function.name,
-                      arguments: toolCallDelta.function.arguments ?? '',
-                    },
-                    hasFinished: false,
-                    thoughtSignature:
-                      toolCallDelta.extra_content?.google?.thought_signature ??
-                      undefined,
-                  };
-
-                  const toolCall = toolCalls[index];
-
-                  if (
-                    toolCall.function?.name != null &&
-                    toolCall.function?.arguments != null
-                  ) {
-                    // send delta if the argument text has already started:
-                    if (toolCall.function.arguments.length > 0) {
-                      controller.enqueue({
-                        type: 'tool-input-delta',
-                        id: toolCall.id,
-                        delta: toolCall.function.arguments,
-                      });
-                    }
-
-                    // check if tool call is complete
-                    // (some providers send the full tool call in one chunk):
-                    if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
-
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                        ...(toolCall.thoughtSignature
-                          ? {
-                              providerMetadata: {
-                                [providerOptionsName]: {
-                                  thoughtSignature: toolCall.thoughtSignature,
-                                },
-                              },
-                            }
-                          : {}),
-                      });
-                      toolCall.hasFinished = true;
-                    }
-                  }
-
-                  continue;
-                }
-
-                // existing tool call, merge if not finished
-                const toolCall = toolCalls[index];
-
-                if (toolCall.hasFinished) {
-                  continue;
-                }
-
-                if (toolCallDelta.function?.arguments != null) {
-                  toolCall.function!.arguments +=
-                    toolCallDelta.function?.arguments ?? '';
-                }
-
-                // send delta
-                controller.enqueue({
-                  type: 'tool-input-delta',
-                  id: toolCall.id,
-                  delta: toolCallDelta.function.arguments ?? '',
-                });
-
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                    ...(toolCall.thoughtSignature
-                      ? {
-                          providerMetadata: {
-                            [providerOptionsName]: {
-                              thoughtSignature: toolCall.thoughtSignature,
-                            },
-                          },
-                        }
-                      : {}),
-                  });
-                  toolCall.hasFinished = true;
-                }
+                toolCallTracker.processDelta(
+                  toolCallDelta,
+                  controller.enqueue.bind(controller),
+                );
               }
             }
           },
@@ -711,31 +586,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
               controller.enqueue({ type: 'text-end', id: 'txt-0' });
             }
 
-            // go through all tool calls and send the ones that are not finished
-            for (const toolCall of toolCalls.filter(
-              toolCall => !toolCall.hasFinished,
-            )) {
-              controller.enqueue({
-                type: 'tool-input-end',
-                id: toolCall.id,
-              });
-
-              controller.enqueue({
-                type: 'tool-call',
-                toolCallId: toolCall.id ?? generateId(),
-                toolName: toolCall.function.name,
-                input: toolCall.function.arguments,
-                ...(toolCall.thoughtSignature
-                  ? {
-                      providerMetadata: {
-                        [providerOptionsName]: {
-                          thoughtSignature: toolCall.thoughtSignature,
-                        },
-                      },
-                    }
-                  : {}),
-              });
-            }
+            toolCallTracker.flush(controller.enqueue.bind(controller));
 
             const providerMetadata: SharedV4ProviderMetadata = {
               [providerOptionsName]: {},

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -1,5 +1,4 @@
 import {
-  InvalidResponseDataError,
   LanguageModelV4,
   LanguageModelV4CallOptions,
   LanguageModelV4Content,
@@ -13,12 +12,12 @@ import {
 import {
   FetchFunction,
   ParseResult,
+  StreamingToolCallTracker,
   combineHeaders,
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
   isCustomReasoning,
-  isParsableJson,
   parseProviderOptions,
   postJsonToApi,
   serializeModelOptions,
@@ -453,15 +452,10 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
       fetch: this.config.fetch,
     });
 
-    const toolCalls: Array<{
-      id: string;
-      type: 'function';
-      function: {
-        name: string;
-        arguments: string;
-      };
-      hasFinished: boolean;
-    }> = [];
+    const toolCallTracker = new StreamingToolCallTracker({
+      generateId,
+      typeValidation: 'if-present',
+    });
 
     let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
@@ -571,124 +565,10 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
 
             if (delta.tool_calls != null) {
               for (const toolCallDelta of delta.tool_calls) {
-                const index = toolCallDelta.index;
-
-                // Tool call start. OpenAI returns all information except the arguments in the first chunk.
-                if (toolCalls[index] == null) {
-                  if (
-                    toolCallDelta.type != null &&
-                    toolCallDelta.type !== 'function'
-                  ) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'function' type.`,
-                    });
-                  }
-
-                  if (toolCallDelta.id == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'id' to be a string.`,
-                    });
-                  }
-
-                  if (toolCallDelta.function?.name == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'function.name' to be a string.`,
-                    });
-                  }
-
-                  controller.enqueue({
-                    type: 'tool-input-start',
-                    id: toolCallDelta.id,
-                    toolName: toolCallDelta.function.name,
-                  });
-
-                  toolCalls[index] = {
-                    id: toolCallDelta.id,
-                    type: 'function',
-                    function: {
-                      name: toolCallDelta.function.name,
-                      arguments: toolCallDelta.function.arguments ?? '',
-                    },
-                    hasFinished: false,
-                  };
-
-                  const toolCall = toolCalls[index];
-
-                  if (
-                    toolCall.function?.name != null &&
-                    toolCall.function?.arguments != null
-                  ) {
-                    // send delta if the argument text has already started:
-                    if (toolCall.function.arguments.length > 0) {
-                      controller.enqueue({
-                        type: 'tool-input-delta',
-                        id: toolCall.id,
-                        delta: toolCall.function.arguments,
-                      });
-                    }
-
-                    // check if tool call is complete
-                    // (some providers send the full tool call in one chunk):
-                    if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
-
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                      });
-                      toolCall.hasFinished = true;
-                    }
-                  }
-
-                  continue;
-                }
-
-                // existing tool call, merge if not finished
-                const toolCall = toolCalls[index];
-
-                if (toolCall.hasFinished) {
-                  continue;
-                }
-
-                if (toolCallDelta.function?.arguments != null) {
-                  toolCall.function!.arguments +=
-                    toolCallDelta.function?.arguments ?? '';
-                }
-
-                // send delta
-                controller.enqueue({
-                  type: 'tool-input-delta',
-                  id: toolCall.id,
-                  delta: toolCallDelta.function.arguments ?? '',
-                });
-
-                // check if tool call is complete
-                if (
-                  toolCall.function?.name != null &&
-                  toolCall.function?.arguments != null &&
-                  isParsableJson(toolCall.function.arguments)
-                ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
-                  toolCall.hasFinished = true;
-                }
+                toolCallTracker.processDelta(
+                  toolCallDelta,
+                  controller.enqueue.bind(controller),
+                );
               }
             }
 
@@ -710,6 +590,8 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
             if (isActiveText) {
               controller.enqueue({ type: 'text-end', id: '0' });
             }
+
+            toolCallTracker.flush(controller.enqueue.bind(controller));
 
             controller.enqueue({
               type: 'finish',

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -63,6 +63,11 @@ export {
   type ValidationResult,
 } from './schema';
 export { serializeModelOptions } from './serialize-model-options';
+export {
+  StreamingToolCallTracker,
+  type StreamingToolCallDelta,
+  type StreamingToolCallTrackerOptions,
+} from './streaming-tool-call-tracker';
 export { stripFileExtension } from './strip-file-extension';
 export * from './uint8-utils';
 export { validateDownloadUrl } from './validate-download-url';

--- a/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
@@ -1,0 +1,536 @@
+import { LanguageModelV4StreamPart } from '@ai-sdk/provider';
+import { describe, expect, it, vi } from 'vitest';
+import { StreamingToolCallTracker } from './streaming-tool-call-tracker';
+
+function createCollector() {
+  const parts: LanguageModelV4StreamPart[] = [];
+  const enqueue = (part: LanguageModelV4StreamPart) => parts.push(part);
+  return { parts, enqueue };
+}
+
+describe('StreamingToolCallTracker', () => {
+  describe('processDelta', () => {
+    it('should handle a single tool call accumulated across multiple deltas', () => {
+      const tracker = new StreamingToolCallTracker();
+      const { parts, enqueue } = createCollector();
+
+      // First delta: new tool call with id and name
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'get_weather', arguments: '{"ci' },
+        },
+        enqueue,
+      );
+
+      expect(parts).toEqual([
+        { type: 'tool-input-start', id: 'call_1', toolName: 'get_weather' },
+        { type: 'tool-input-delta', id: 'call_1', delta: '{"ci' },
+      ]);
+
+      parts.length = 0;
+
+      // Second delta: more arguments
+      tracker.processDelta(
+        {
+          index: 0,
+          function: { arguments: 'ty": "San' },
+        },
+        enqueue,
+      );
+
+      expect(parts).toEqual([
+        {
+          type: 'tool-input-delta',
+          id: 'call_1',
+          delta: 'ty": "San',
+        },
+      ]);
+
+      parts.length = 0;
+
+      // Third delta: completes the JSON
+      tracker.processDelta(
+        {
+          index: 0,
+          function: { arguments: ' Francisco"}' },
+        },
+        enqueue,
+      );
+
+      expect(parts).toEqual([
+        {
+          type: 'tool-input-delta',
+          id: 'call_1',
+          delta: ' Francisco"}',
+        },
+        { type: 'tool-input-end', id: 'call_1' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'get_weather',
+          input: '{"city": "San Francisco"}',
+        },
+      ]);
+    });
+
+    it('should handle a full tool call in a single chunk', () => {
+      const tracker = new StreamingToolCallTracker();
+      const { parts, enqueue } = createCollector();
+
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            arguments: '{"city": "London"}',
+          },
+        },
+        enqueue,
+      );
+
+      expect(parts).toEqual([
+        { type: 'tool-input-start', id: 'call_1', toolName: 'get_weather' },
+        {
+          type: 'tool-input-delta',
+          id: 'call_1',
+          delta: '{"city": "London"}',
+        },
+        { type: 'tool-input-end', id: 'call_1' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'get_weather',
+          input: '{"city": "London"}',
+        },
+      ]);
+    });
+
+    it('should handle multiple concurrent tool calls', () => {
+      const tracker = new StreamingToolCallTracker();
+      const { parts, enqueue } = createCollector();
+
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'get_weather', arguments: '' },
+        },
+        enqueue,
+      );
+
+      tracker.processDelta(
+        {
+          index: 1,
+          id: 'call_2',
+          type: 'function',
+          function: { name: 'get_time', arguments: '' },
+        },
+        enqueue,
+      );
+
+      expect(parts).toEqual([
+        { type: 'tool-input-start', id: 'call_1', toolName: 'get_weather' },
+        { type: 'tool-input-start', id: 'call_2', toolName: 'get_time' },
+      ]);
+    });
+
+    it('should skip deltas for already-finished tool calls', () => {
+      const tracker = new StreamingToolCallTracker();
+      const { parts, enqueue } = createCollector();
+
+      // Complete tool call in one chunk
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'fn', arguments: '{}' },
+        },
+        enqueue,
+      );
+
+      parts.length = 0;
+
+      // Late delta for the same tool call
+      tracker.processDelta(
+        {
+          index: 0,
+          function: { arguments: 'extra' },
+        },
+        enqueue,
+      );
+
+      expect(parts).toEqual([]);
+    });
+
+    it('should skip delta emission when arguments are null', () => {
+      const tracker = new StreamingToolCallTracker();
+      const { parts, enqueue } = createCollector();
+
+      // Create tool call
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'fn', arguments: '' },
+        },
+        enqueue,
+      );
+
+      parts.length = 0;
+
+      // Delta with null arguments
+      tracker.processDelta(
+        {
+          index: 0,
+          function: { arguments: null },
+        },
+        enqueue,
+      );
+
+      expect(parts).toEqual([]);
+    });
+
+    it('should use index fallback when index is not provided', () => {
+      const tracker = new StreamingToolCallTracker();
+      const { parts, enqueue } = createCollector();
+
+      tracker.processDelta(
+        {
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'fn1', arguments: '{}' },
+        },
+        enqueue,
+      );
+
+      tracker.processDelta(
+        {
+          id: 'call_2',
+          type: 'function',
+          function: { name: 'fn2', arguments: '{}' },
+        },
+        enqueue,
+      );
+
+      expect(parts.filter(p => p.type === 'tool-input-start')).toEqual([
+        { type: 'tool-input-start', id: 'call_1', toolName: 'fn1' },
+        { type: 'tool-input-start', id: 'call_2', toolName: 'fn2' },
+      ]);
+    });
+
+    it('should throw when id is missing', () => {
+      const tracker = new StreamingToolCallTracker();
+      const { enqueue } = createCollector();
+
+      expect(() =>
+        tracker.processDelta(
+          {
+            index: 0,
+            type: 'function',
+            function: { name: 'fn' },
+          },
+          enqueue,
+        ),
+      ).toThrow("Expected 'id' to be a string.");
+    });
+
+    it('should throw when function.name is missing', () => {
+      const tracker = new StreamingToolCallTracker();
+      const { enqueue } = createCollector();
+
+      expect(() =>
+        tracker.processDelta(
+          {
+            index: 0,
+            id: 'call_1',
+            type: 'function',
+            function: {},
+          },
+          enqueue,
+        ),
+      ).toThrow("Expected 'function.name' to be a string.");
+    });
+  });
+
+  describe('typeValidation', () => {
+    it('should not validate type with typeValidation: none', () => {
+      const tracker = new StreamingToolCallTracker({
+        typeValidation: 'none',
+      });
+      const { enqueue } = createCollector();
+
+      // Should not throw even with a non-function type
+      expect(() =>
+        tracker.processDelta(
+          {
+            index: 0,
+            id: 'call_1',
+            type: 'custom',
+            function: { name: 'fn', arguments: '' },
+          },
+          enqueue,
+        ),
+      ).not.toThrow();
+    });
+
+    it('should validate type when present with typeValidation: if-present', () => {
+      const tracker = new StreamingToolCallTracker({
+        typeValidation: 'if-present',
+      });
+      const { enqueue } = createCollector();
+
+      // Should throw for non-function type
+      expect(() =>
+        tracker.processDelta(
+          {
+            index: 0,
+            id: 'call_1',
+            type: 'custom',
+            function: { name: 'fn', arguments: '' },
+          },
+          enqueue,
+        ),
+      ).toThrow("Expected 'function' type.");
+
+      // Should not throw when type is null
+      expect(() =>
+        tracker.processDelta(
+          {
+            index: 0,
+            id: 'call_1',
+            function: { name: 'fn', arguments: '' },
+          },
+          enqueue,
+        ),
+      ).not.toThrow();
+    });
+
+    it('should require function type with typeValidation: required', () => {
+      const tracker = new StreamingToolCallTracker({
+        typeValidation: 'required',
+      });
+      const { enqueue } = createCollector();
+
+      // Should throw when type is null/undefined
+      expect(() =>
+        tracker.processDelta(
+          {
+            index: 0,
+            id: 'call_1',
+            function: { name: 'fn', arguments: '' },
+          },
+          enqueue,
+        ),
+      ).toThrow("Expected 'function' type.");
+
+      // Should not throw for 'function' type
+      expect(() =>
+        tracker.processDelta(
+          {
+            index: 0,
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'fn', arguments: '' },
+          },
+          enqueue,
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe('flush', () => {
+    it('should finalize unfinished tool calls on flush', () => {
+      const tracker = new StreamingToolCallTracker();
+      const { parts, enqueue } = createCollector();
+
+      // Start a tool call but don't complete it
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'fn', arguments: '{"key": "val' },
+        },
+        enqueue,
+      );
+
+      parts.length = 0;
+
+      // Flush should finalize
+      tracker.flush(enqueue);
+
+      expect(parts).toEqual([
+        { type: 'tool-input-end', id: 'call_1' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'fn',
+          input: '{"key": "val',
+        },
+      ]);
+    });
+
+    it('should not re-finalize already finished tool calls', () => {
+      const tracker = new StreamingToolCallTracker();
+      const { parts, enqueue } = createCollector();
+
+      // Complete tool call in one chunk
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'fn', arguments: '{}' },
+        },
+        enqueue,
+      );
+
+      parts.length = 0;
+
+      tracker.flush(enqueue);
+
+      // No events should be emitted since tool call was already finished
+      expect(parts).toEqual([]);
+    });
+  });
+
+  describe('metadata', () => {
+    it('should extract and include provider metadata in tool-call events', () => {
+      const tracker = new StreamingToolCallTracker({
+        extractMetadata: delta => {
+          const sig = (delta as any).extra_content?.google?.thought_signature;
+          return sig ? { thoughtSignature: sig } : undefined;
+        },
+        buildToolCallProviderMetadata: metadata => {
+          if (metadata?.thoughtSignature) {
+            return { google: { thoughtSignature: metadata.thoughtSignature } };
+          }
+          return undefined;
+        },
+      });
+      const { parts, enqueue } = createCollector();
+
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'fn', arguments: '{}' },
+          extra_content: { google: { thought_signature: 'sig123' } },
+        } as any,
+        enqueue,
+      );
+
+      const toolCallEvent = parts.find(p => p.type === 'tool-call');
+      expect(toolCallEvent).toEqual({
+        type: 'tool-call',
+        toolCallId: 'call_1',
+        toolName: 'fn',
+        input: '{}',
+        providerMetadata: {
+          google: { thoughtSignature: 'sig123' },
+        },
+      });
+    });
+
+    it('should include provider metadata for unfinished tool calls finalized in flush', () => {
+      const tracker = new StreamingToolCallTracker({
+        extractMetadata: () => ({ custom: { key: 'value' } }),
+        buildToolCallProviderMetadata: metadata => {
+          return metadata ? { provider: metadata } : undefined;
+        },
+      });
+      const { parts, enqueue } = createCollector();
+
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'fn', arguments: '{"incomplete' },
+        },
+        enqueue,
+      );
+
+      parts.length = 0;
+
+      tracker.flush(enqueue);
+
+      const toolCallEvent = parts.find(p => p.type === 'tool-call');
+      expect(toolCallEvent).toEqual({
+        type: 'tool-call',
+        toolCallId: 'call_1',
+        toolName: 'fn',
+        input: '{"incomplete',
+        providerMetadata: { provider: { custom: { key: 'value' } } },
+      });
+    });
+
+    it('should not include providerMetadata when buildToolCallProviderMetadata returns undefined', () => {
+      const tracker = new StreamingToolCallTracker({
+        extractMetadata: () => undefined,
+        buildToolCallProviderMetadata: () => undefined,
+      });
+      const { parts, enqueue } = createCollector();
+
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'fn', arguments: '{}' },
+        },
+        enqueue,
+      );
+
+      const toolCallEvent = parts.find(p => p.type === 'tool-call');
+      expect(toolCallEvent).toEqual({
+        type: 'tool-call',
+        toolCallId: 'call_1',
+        toolName: 'fn',
+        input: '{}',
+      });
+      expect(toolCallEvent).not.toHaveProperty('providerMetadata');
+    });
+  });
+
+  describe('generateId', () => {
+    it('should use custom generateId for tool call IDs when id is missing in fallback', () => {
+      const mockGenerateId = vi.fn(() => 'custom-id');
+      const tracker = new StreamingToolCallTracker({
+        generateId: mockGenerateId,
+      });
+      const { parts, enqueue } = createCollector();
+
+      // Start a tool call
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'fn', arguments: '{"key": "val' },
+        },
+        enqueue,
+      );
+
+      parts.length = 0;
+
+      // Flush to finalize
+      tracker.flush(enqueue);
+
+      // The toolCallId should use the original id since it's present
+      const toolCallEvent = parts.find(p => p.type === 'tool-call');
+      expect(toolCallEvent).toMatchObject({
+        toolCallId: 'call_1',
+      });
+    });
+  });
+});

--- a/packages/provider-utils/src/streaming-tool-call-tracker.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.ts
@@ -1,0 +1,243 @@
+import {
+  InvalidResponseDataError,
+  LanguageModelV4StreamPart,
+  SharedV4ProviderMetadata,
+} from '@ai-sdk/provider';
+import { generateId as defaultGenerateId } from './generate-id';
+import { isParsableJson } from './parse-json';
+
+/**
+ * Minimal interface for a streaming tool call delta from an OpenAI-compatible API.
+ */
+export interface StreamingToolCallDelta {
+  index?: number | null;
+  id?: string | null;
+  type?: string | null;
+  function?: {
+    name?: string | null;
+    arguments?: string | null;
+  } | null;
+}
+
+export interface StreamingToolCallTrackerOptions {
+  /**
+   * ID generator function for tool call IDs.
+   * Defaults to the standard generateId.
+   */
+  generateId?: () => string;
+
+  /**
+   * How to validate the `type` field on new tool call deltas.
+   * - `'none'`: no validation (default)
+   * - `'if-present'`: throw if type is present and not `'function'`
+   * - `'required'`: throw if type is not exactly `'function'`
+   */
+  typeValidation?: 'none' | 'if-present' | 'required';
+
+  /**
+   * Extract provider-specific metadata from a tool call delta.
+   * Called once when a new tool call is detected.
+   * The returned metadata is stored on the tool call and passed to
+   * `buildToolCallProviderMetadata` when the tool call is finalized.
+   */
+  extractMetadata?: (
+    delta: StreamingToolCallDelta,
+  ) => SharedV4ProviderMetadata | undefined;
+
+  /**
+   * Build the `providerMetadata` object for a `tool-call` event.
+   * Receives the metadata previously extracted via `extractMetadata`.
+   * If `undefined` is returned, no `providerMetadata` is included in the event.
+   */
+  buildToolCallProviderMetadata?: (
+    metadata: SharedV4ProviderMetadata | undefined,
+  ) => SharedV4ProviderMetadata | undefined;
+}
+
+interface TrackedToolCall {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+  hasFinished: boolean;
+  metadata?: SharedV4ProviderMetadata;
+}
+
+/**
+ * Tracks streaming tool call state across multiple deltas from an
+ * OpenAI-compatible chat completion stream. Handles argument accumulation,
+ * emits tool-input-start/delta/end and tool-call events, and finalizes
+ * unfinished tool calls on flush.
+ *
+ * Used by openai, openai-compatible, groq, deepseek, and alibaba providers.
+ */
+export class StreamingToolCallTracker {
+  private toolCalls: TrackedToolCall[] = [];
+  private readonly _generateId: () => string;
+  private readonly typeValidation: 'none' | 'if-present' | 'required';
+  private readonly extractMetadata?: (
+    delta: StreamingToolCallDelta,
+  ) => SharedV4ProviderMetadata | undefined;
+  private readonly buildToolCallProviderMetadata?: (
+    metadata: SharedV4ProviderMetadata | undefined,
+  ) => SharedV4ProviderMetadata | undefined;
+
+  constructor(options: StreamingToolCallTrackerOptions = {}) {
+    this._generateId = options.generateId ?? defaultGenerateId;
+    this.typeValidation = options.typeValidation ?? 'none';
+    this.extractMetadata = options.extractMetadata;
+    this.buildToolCallProviderMetadata = options.buildToolCallProviderMetadata;
+  }
+
+  /**
+   * Process a tool call delta from a streaming response chunk.
+   * Emits tool-input-start, tool-input-delta, tool-input-end, and tool-call
+   * events as appropriate.
+   */
+  processDelta(
+    toolCallDelta: StreamingToolCallDelta,
+    enqueue: (part: LanguageModelV4StreamPart) => void,
+  ): void {
+    const index = toolCallDelta.index ?? this.toolCalls.length;
+
+    if (this.toolCalls[index] == null) {
+      this.processNewToolCall(index, toolCallDelta, enqueue);
+    } else {
+      this.processExistingToolCall(index, toolCallDelta, enqueue);
+    }
+  }
+
+  /**
+   * Finalize any unfinished tool calls. Should be called during the stream's
+   * flush handler to ensure all tool calls are properly completed.
+   */
+  flush(enqueue: (part: LanguageModelV4StreamPart) => void): void {
+    for (const toolCall of this.toolCalls) {
+      if (!toolCall.hasFinished) {
+        this.finishToolCall(toolCall, enqueue);
+      }
+    }
+  }
+
+  private processNewToolCall(
+    index: number,
+    toolCallDelta: StreamingToolCallDelta,
+    enqueue: (part: LanguageModelV4StreamPart) => void,
+  ): void {
+    if (this.typeValidation === 'required') {
+      if (toolCallDelta.type !== 'function') {
+        throw new InvalidResponseDataError({
+          data: toolCallDelta,
+          message: `Expected 'function' type.`,
+        });
+      }
+    } else if (this.typeValidation === 'if-present') {
+      if (toolCallDelta.type != null && toolCallDelta.type !== 'function') {
+        throw new InvalidResponseDataError({
+          data: toolCallDelta,
+          message: `Expected 'function' type.`,
+        });
+      }
+    }
+
+    if (toolCallDelta.id == null) {
+      throw new InvalidResponseDataError({
+        data: toolCallDelta,
+        message: `Expected 'id' to be a string.`,
+      });
+    }
+
+    if (toolCallDelta.function?.name == null) {
+      throw new InvalidResponseDataError({
+        data: toolCallDelta,
+        message: `Expected 'function.name' to be a string.`,
+      });
+    }
+
+    enqueue({
+      type: 'tool-input-start',
+      id: toolCallDelta.id,
+      toolName: toolCallDelta.function.name,
+    });
+
+    const metadata = this.extractMetadata?.(toolCallDelta);
+
+    this.toolCalls[index] = {
+      id: toolCallDelta.id,
+      type: 'function',
+      function: {
+        name: toolCallDelta.function.name,
+        arguments: toolCallDelta.function.arguments ?? '',
+      },
+      hasFinished: false,
+      metadata,
+    };
+
+    const toolCall = this.toolCalls[index];
+
+    // Emit initial delta if arguments already present
+    if (toolCall.function.arguments.length > 0) {
+      enqueue({
+        type: 'tool-input-delta',
+        id: toolCall.id,
+        delta: toolCall.function.arguments,
+      });
+    }
+
+    // Check if tool call is complete
+    // (some providers send the full tool call in one chunk)
+    if (isParsableJson(toolCall.function.arguments)) {
+      this.finishToolCall(toolCall, enqueue);
+    }
+  }
+
+  private processExistingToolCall(
+    index: number,
+    toolCallDelta: StreamingToolCallDelta,
+    enqueue: (part: LanguageModelV4StreamPart) => void,
+  ): void {
+    const toolCall = this.toolCalls[index];
+
+    if (toolCall.hasFinished) {
+      return;
+    }
+
+    if (toolCallDelta.function?.arguments != null) {
+      toolCall.function.arguments += toolCallDelta.function.arguments;
+
+      enqueue({
+        type: 'tool-input-delta',
+        id: toolCall.id,
+        delta: toolCallDelta.function.arguments,
+      });
+    }
+
+    // Check if tool call is complete
+    if (isParsableJson(toolCall.function.arguments)) {
+      this.finishToolCall(toolCall, enqueue);
+    }
+  }
+
+  private finishToolCall(
+    toolCall: TrackedToolCall,
+    enqueue: (part: LanguageModelV4StreamPart) => void,
+  ): void {
+    enqueue({
+      type: 'tool-input-end',
+      id: toolCall.id,
+    });
+
+    const providerMetadata = this.buildToolCallProviderMetadata?.(
+      toolCall.metadata,
+    );
+
+    enqueue({
+      type: 'tool-call',
+      toolCallId: toolCall.id ?? this._generateId(),
+      toolName: toolCall.function.name,
+      input: toolCall.function.arguments,
+      ...(providerMetadata ? { providerMetadata } : {}),
+    });
+
+    toolCall.hasFinished = true;
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts shared streaming tool call state management into a reusable `StreamingToolCallTracker` class in `@ai-sdk/provider-utils`
- Removes ~660 lines of duplicated code across 5 OpenAI-compatible providers (openai, openai-compatible, groq, deepseek, alibaba)
- Fixes missing `generateId()` fallback for `toolCallId` in the Alibaba provider's `doGenerate` path
- Ensures all providers finalize unfinished tool calls during stream flush (previously only openai-compatible and deepseek did this)

Recreates #13141 against the current main branch.

## Background

All 5 OpenAI-compatible providers had nearly identical ~80-line tool call tracking logic (accumulating arguments across deltas, emitting start/delta/end/call events). This PR extracts that into a shared class.

The `StreamingToolCallTracker` class:
- Tracks tool call state across streaming deltas (start detection, argument accumulation)
- Finalizes tool calls both inline (via `isParsableJson`) and in `flush()` as a safety net
- Supports provider-specific metadata (e.g., Google's `thoughtSignature` via openai-compatible)
- Supports configurable type validation (`none`, `if-present`, `required`)
- Has comprehensive test coverage (17 test cases)

## Verification

- [x] All provider-utils tests pass (505 tests)
- [x] All openai tests pass (673 tests)
- [x] All openai-compatible tests pass (224 tests)
- [x] All groq tests pass (90 tests)
- [x] All deepseek tests pass (27 tests)
- [x] All alibaba tests pass (82 tests)

## Test plan

- [ ] CI passes for all affected packages
- [ ] Verify streaming tool calls still work correctly end-to-end
- [ ] Verify provider-specific metadata (e.g., Google thoughtSignature) passes through correctly