### PR TITLE
feat(ai): allow multiple integrations to be registered at once

### DIFF
--- a/.changeset/flat-seals-press.md
+++ b/.changeset/flat-seals-press.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): allow multiple integrations to be registered at once

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -125,6 +125,19 @@ import { OpenTelemetryIntegration } from '@ai-sdk/otel';
 registerTelemetryIntegration(new OpenTelemetryIntegration());
 ```
 
+You can also register multiple integrations in a single call by passing them as additional arguments. They all receive the same lifecycle events:
+
+```ts
+import { registerTelemetryIntegration } from 'ai';
+import { OpenTelemetryIntegration } from '@ai-sdk/otel';
+import { DevToolsTelemetry } from '@ai-sdk/devtools';
+
+registerTelemetryIntegration(
+  new OpenTelemetryIntegration(),
+  DevToolsTelemetry(),
+);
+```
+
 ### Per-call integrations
 
 You can also pass one or more integrations to individual `generateText` or `streamText` calls. When per-call integrations are provided, they replace the globally registered integrations for that call:

--- a/examples/ai-functions/src/generate-text/anthropic/nested-subagent-with-telemetry.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/nested-subagent-with-telemetry.ts
@@ -10,8 +10,10 @@ import { NodeSDK } from '@opentelemetry/sdk-node';
 import { run } from '../../lib/run';
 import { z } from 'zod';
 
-registerTelemetryIntegration(DevToolsTelemetry());
-registerTelemetryIntegration(new OpenTelemetryIntegration());
+registerTelemetryIntegration(
+  new OpenTelemetryIntegration(),
+  DevToolsTelemetry(),
+);
 
 const sdk = new NodeSDK({
   spanProcessors: [new LangfuseSpanProcessor()],

--- a/examples/ai-functions/src/generate-text/anthropic/subagent-with-telemetry.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/subagent-with-telemetry.ts
@@ -10,8 +10,10 @@ import { NodeSDK } from '@opentelemetry/sdk-node';
 import { run } from '../../lib/run';
 import { z } from 'zod';
 
-registerTelemetryIntegration(DevToolsTelemetry());
-registerTelemetryIntegration(new OpenTelemetryIntegration());
+registerTelemetryIntegration(
+  new OpenTelemetryIntegration(),
+  DevToolsTelemetry(),
+);
 
 const sdk = new NodeSDK({
   spanProcessors: [new LangfuseSpanProcessor()],

--- a/examples/ai-functions/src/generate-text/anthropic/tool-schema-telemetry.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/tool-schema-telemetry.ts
@@ -10,8 +10,10 @@ import { LangfuseSpanProcessor } from '@langfuse/otel';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { run } from '../../lib/run';
 
-registerTelemetryIntegration(DevToolsTelemetry());
-registerTelemetryIntegration(new OpenTelemetryIntegration());
+registerTelemetryIntegration(
+  new OpenTelemetryIntegration(),
+  DevToolsTelemetry(),
+);
 
 const sdk = new NodeSDK({
   spanProcessors: [new LangfuseSpanProcessor()],

--- a/examples/ai-functions/src/stream-text/anthropic/subagent-with-telemetry.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/subagent-with-telemetry.ts
@@ -14,8 +14,10 @@ const sdk = new NodeSDK({
 });
 
 sdk.start();
-registerTelemetryIntegration(DevToolsTelemetry());
-registerTelemetryIntegration(new OpenTelemetryIntegration());
+registerTelemetryIntegration(
+  new OpenTelemetryIntegration(),
+  DevToolsTelemetry(),
+);
 
 const weatherAgent = new ToolLoopAgent({
   model: anthropic('claude-sonnet-4-5-20250929'),

--- a/packages/ai/src/telemetry/telemetry-integration-registry.test.ts
+++ b/packages/ai/src/telemetry/telemetry-integration-registry.test.ts
@@ -30,6 +30,26 @@ describe('registerTelemetryIntegration', () => {
       integration2,
     ]);
   });
+
+  it('adds multiple integrations passed in a single call', () => {
+    const integration1: TelemetryIntegration = { onStart: vi.fn() };
+    const integration2: TelemetryIntegration = { onFinish: vi.fn() };
+    const integration3: TelemetryIntegration = { onError: vi.fn() };
+
+    registerTelemetryIntegration(integration1, integration2, integration3);
+
+    expect(getGlobalTelemetryIntegrations()).toEqual([
+      integration1,
+      integration2,
+      integration3,
+    ]);
+  });
+
+  it('is a no-op when called with no integrations', () => {
+    registerTelemetryIntegration();
+
+    expect(getGlobalTelemetryIntegrations()).toEqual([]);
+  });
 });
 
 describe('getGlobalTelemetryIntegrations', () => {

--- a/packages/ai/src/telemetry/telemetry-integration-registry.ts
+++ b/packages/ai/src/telemetry/telemetry-integration-registry.ts
@@ -1,15 +1,15 @@
 import type { TelemetryIntegration } from './telemetry-integration';
 
 /**
- * Registers a telemetry integration globally.
+ * Registers one or more telemetry integrations globally.
  */
 export function registerTelemetryIntegration(
-  integration: TelemetryIntegration,
+  ...integrations: TelemetryIntegration[]
 ): void {
   if (!globalThis.AI_SDK_TELEMETRY_INTEGRATIONS) {
     globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = [];
   }
-  globalThis.AI_SDK_TELEMETRY_INTEGRATIONS.push(integration);
+  globalThis.AI_SDK_TELEMETRY_INTEGRATIONS.push(...integrations);
 }
 
 export function getGlobalTelemetryIntegrations(): TelemetryIntegration[] {


### PR DESCRIPTION
## Background

previously the `registerTelemetryIntegration` function only took single integrations and registered them globally. the dx was: 

```ts
registerTelemetryIntegration(DevToolsTelemetry());
registerTelemetryIntegration(new OpenTelemetryIntegration());
```

## Summary

converted the single-parameter function to use rest parameters, so it accepts multiple integrations

```ts
registerTelemetryIntegration(
  new OpenTelemetryIntegration(),
  DevToolsTelemetry(),
);
```

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)