### PR TITLE
fix(anthropic): remove cacheCreationInputTokens from providerMetadata

### DIFF
--- a/.changeset/giant-months-retire.md
+++ b/.changeset/giant-months-retire.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/google-vertex": major
+"@ai-sdk/anthropic": major
+---
+
+fix(anthropic): remove cacheCreationInputTokens from providerMetadata

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -453,3 +453,36 @@ const mcpClient = await createMCPClient({
 ```
 
 If the MCP server you use does not issue redirects, no changes are needed — the new default is more secure.
+
+## Anthropic Provider
+
+### `providerMetadata.anthropic.cacheCreationInputTokens` Removed
+
+The Anthropic-specific `cacheCreationInputTokens` field on `providerMetadata.anthropic` has been removed from the responses of `generateText` and `streamText` (as well as the `@ai-sdk/google-vertex/anthropic` sub-provider). This duplicated information that is already available on the standard, provider-agnostic `usage` object.
+
+Use `result.usage.inputTokenDetails.cacheWriteTokens` to read the number of tokens written to the cache, and `result.usage.inputTokenDetails.cacheReadTokens` to read the number of tokens served from the cache:
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: anthropic('claude-sonnet-4-5'),
+  messages: [
+    /* ... messages with cacheControl ... */
+  ],
+});
+
+console.log(result.providerMetadata?.anthropic?.cacheCreationInputTokens);
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: anthropic('claude-sonnet-4-5'),
+  messages: [
+    /* ... messages with cacheControl ... */
+  ],
+});
+
+console.log(result.usage.inputTokenDetails.cacheWriteTokens);
+console.log(result.usage.inputTokenDetails.cacheReadTokens);
+```
+
+If you need the raw Anthropic-shaped usage payload (including `cache_creation_input_tokens`, `cache_read_input_tokens`, `cache_creation`, `service_tier`, etc.), it is still available unchanged at `result.providerMetadata?.anthropic?.usage`.

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -482,7 +482,6 @@ const result = await generateText({
 });
 
 console.log(result.usage.inputTokenDetails.cacheWriteTokens);
-console.log(result.usage.inputTokenDetails.cacheReadTokens);
 ```
 
 If you need the raw Anthropic-shaped usage payload (including `cache_creation_input_tokens`, `cache_read_input_tokens`, `cache_creation`, `service_tier`, etc.), it is still available unchanged at `result.providerMetadata?.anthropic?.usage`.

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -584,13 +584,12 @@ For more details, see [Anthropic's Context Management documentation](https://doc
 In the messages and message parts, you can use the `providerOptions` property to set cache control breakpoints.
 You need to set the `anthropic` property in the `providerOptions` object to `{ cacheControl: { type: 'ephemeral' } }` to set a cache control breakpoint.
 
-The cache creation input tokens are then returned in the `providerMetadata` object
-for `generateText`, again under the `anthropic` property.
-When you use `streamText`, the response contains a promise
-that resolves to the metadata. Alternatively you can receive it in the
-`onFinish` callback.
+Cache read and cache write (creation) token counts are returned on the standard
+`usage` object for both `generateText` and `streamText`. You can access them at
+`result.usage.inputTokenDetails.cacheReadTokens` and
+`result.usage.inputTokenDetails.cacheWriteTokens`.
 
-```ts highlight="8,18-20,29-30"
+```ts highlight="8,18-20,29-32"
 import { anthropic } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 
@@ -617,8 +616,11 @@ const result = await generateText({
 });
 
 console.log(result.text);
-console.log(result.providerMetadata?.anthropic);
-// e.g. { cacheCreationInputTokens: 2118 }
+console.log('Cache read tokens:', result.usage.inputTokenDetails.cacheReadTokens);
+console.log(
+  'Cache write tokens:',
+  result.usage.inputTokenDetails.cacheWriteTokens,
+);
 ```
 
 You can also use cache control on system messages by providing multiple system messages at the head of your messages array:

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1538,13 +1538,12 @@ on how to integrate reasoning into your chatbot.
 In the messages and message parts, you can use the `providerOptions` property to set cache control breakpoints.
 You need to set the `anthropic` property in the `providerOptions` object to `{ cacheControl: { type: 'ephemeral' } }` to set a cache control breakpoint.
 
-The cache creation input tokens are then returned in the `providerMetadata` object
-for `generateText`, again under the `anthropic` property.
-When you use `streamText`, the response contains a promise
-that resolves to the metadata. Alternatively you can receive it in the
-`onFinish` callback.
+Cache read and cache write (creation) token counts are returned on the standard
+`usage` object for both `generateText` and `streamText`. You can access them at
+`result.usage.inputTokenDetails.cacheReadTokens` and
+`result.usage.inputTokenDetails.cacheWriteTokens`.
 
-```ts highlight="8,18-20,29-30"
+```ts highlight="8,18-20,29-32"
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
 import { generateText } from 'ai';
 
@@ -1571,8 +1570,11 @@ const result = await generateText({
 });
 
 console.log(result.text);
-console.log(result.providerMetadata?.anthropic);
-// e.g. { cacheCreationInputTokens: 2118, cacheReadInputTokens: 0 }
+console.log('Cache read tokens:', result.usage.inputTokenDetails.cacheReadTokens);
+console.log(
+  'Cache write tokens:',
+  result.usage.inputTokenDetails.cacheWriteTokens,
+);
 ```
 
 You can also use cache control on system messages by providing multiple system messages at the head of your messages array:

--- a/examples/ai-functions/src/generate-text/anthropic/cache-control.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/cache-control.ts
@@ -10,7 +10,7 @@ const errorMessage = fs.readFileSync('data/error-message.txt', 'utf8');
 
 run(async () => {
   const result = await generateText({
-    model: anthropic('claude-3-5-sonnet-20240620'),
+    model: anthropic('claude-sonnet-4-5'),
     messages: [
       {
         role: 'user',
@@ -40,9 +40,12 @@ run(async () => {
   console.log(result.text);
   console.log();
 
-  console.log('Cache read tokens:', result.usage.cachedInputTokens);
+  console.log(
+    'Cache read tokens:',
+    result.usage.inputTokenDetails.cacheReadTokens,
+  );
   console.log(
     'Cache write tokens:',
-    result.providerMetadata?.anthropic?.cacheCreationInputTokens,
+    result.usage.inputTokenDetails.cacheWriteTokens,
   );
 });

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-cache-control.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-cache-control.ts
@@ -36,6 +36,13 @@ run(async () => {
   });
 
   console.log(result.text);
-  console.log(result.providerMetadata?.anthropic);
-  // e.g. { cacheCreationInputTokens: 2118, cacheReadInputTokens: 0 }
+  console.log();
+  console.log(
+    'Cache read tokens:',
+    result.usage.inputTokenDetails.cacheReadTokens,
+  );
+  console.log(
+    'Cache write tokens:',
+    result.usage.inputTokenDetails.cacheWriteTokens,
+  );
 });

--- a/examples/ai-functions/src/stream-text/anthropic/cache-control.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/cache-control.ts
@@ -46,7 +46,9 @@ run(async () => {
     process.stdout.write(textPart);
   }
 
-  console.log('=== providerMetadata Promise ===');
-  console.log((await result.providerMetadata)?.anthropic);
-  // e.g. { cacheCreationInputTokens: 2118, cacheReadInputTokens: 0 }
+  const usage = await result.usage;
+  console.log();
+  console.log('=== usage ===');
+  console.log('Cache read tokens:', usage.inputTokenDetails.cacheReadTokens);
+  console.log('Cache write tokens:', usage.inputTokenDetails.cacheWriteTokens);
 });

--- a/examples/ai-functions/src/stream-text/google/vertex-anthropic-cache-control.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-anthropic-cache-control.ts
@@ -44,7 +44,9 @@ run(async () => {
     process.stdout.write(textPart);
   }
 
-  console.log('=== providerMetadata Promise ===');
-  console.log((await result.providerMetadata)?.anthropic);
-  // e.g. { cacheCreationInputTokens: 2118, cacheReadInputTokens: 0 }
+  const usage = await result.usage;
+  console.log();
+  console.log('=== usage ===');
+  console.log('Cache read tokens:', usage.inputTokenDetails.cacheReadTokens);
+  console.log('Cache write tokens:', usage.inputTokenDetails.cacheWriteTokens);
 });

--- a/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`AnthropicMessagesLanguageModel > doGenerate > agent skills > should expose container information as provider metadata 1`] = `
 {
   "anthropic": {
-    "cacheCreationInputTokens": 0,
     "container": {
       "expiresAt": "2025-10-20T11:48:47.798310Z",
       "id": "container_011CUJKA7aVjWm5XJL9ozHGS",
@@ -40,7 +39,6 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > agent skills > should exp
 exports[`AnthropicMessagesLanguageModel > doGenerate > code execution 20250825 > should expose container information as provider metadata 1`] = `
 {
   "anthropic": {
-    "cacheCreationInputTokens": 0,
     "container": {
       "expiresAt": "2025-10-14T10:28:40.590791Z",
       "id": "container_011CU6rVteVhydYXRyNs6G1M",
@@ -291,7 +289,6 @@ Both files have been exported and are ready for download!",
   },
   "providerMetadata": {
     "anthropic": {
-      "cacheCreationInputTokens": 0,
       "container": {
         "expiresAt": "2025-10-20T15:10:44.950231Z",
         "id": "container_011CUJar2mdkMcv7daEVAQw2",
@@ -5224,7 +5221,6 @@ The presentation has",
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": {
           "expiresAt": "2025-10-20T12:27:25.107823Z",
           "id": "container_011CUJNGs88jcQ8KEiZguEUo",
@@ -10300,7 +10296,6 @@ Both",
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": {
           "expiresAt": "2025-10-20T15:14:00.777587Z",
           "id": "container_011CUJb5Pk4kFWskBpuCjwXj",
@@ -11624,7 +11619,6 @@ The Fibonacci sequence starts with 0, ",
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": {
           "expiresAt": "2025-10-14T10:02:00.044495Z",
           "id": "container_011CU6pTr2hLT47seQ5Xs4yj",
@@ -12943,7 +12937,6 @@ The Fibonacci sequence starts with 0, ",
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": {
           "expiresAt": "2025-10-14T10:02:00.044495Z",
           "id": "container_011CU6pTr2hLT47seQ5Xs4yj",
@@ -13598,7 +13591,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > json schema response format
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": null,
         "contextManagement": null,
         "iterations": null,
@@ -13721,7 +13713,6 @@ It simply echoed back",
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": null,
         "contextManagement": null,
         "iterations": null,
@@ -14623,7 +14614,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": {
           "expiresAt": "2025-12-20T05:33:35.789626Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -14717,7 +14707,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:37.969567Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -14797,7 +14786,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:39.648288Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -14877,7 +14865,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:41.431511Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -14957,7 +14944,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:43.145757Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -15037,7 +15023,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:44.839216Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -15117,7 +15102,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:46.531362Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -15197,7 +15181,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:48.294455Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -15277,7 +15260,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:49.977349Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -15357,7 +15339,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:51.565949Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -15437,7 +15418,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:53.308898Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -15517,7 +15497,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:55.035858Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -15597,7 +15576,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:56.857745Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -15677,7 +15655,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling >
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": null,
         "container": {
           "expiresAt": "2025-12-20T05:33:58.450677Z",
           "id": "container_011CWHPPTDTn1XufeRB9uHeH",
@@ -16196,7 +16173,6 @@ The",
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": null,
         "contextManagement": null,
         "iterations": null,
@@ -16420,7 +16396,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > tool search tool > bm25 var
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": null,
         "contextManagement": null,
         "iterations": null,
@@ -16533,7 +16508,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > tool search tool > bm25 var
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": null,
         "contextManagement": null,
         "iterations": null,
@@ -16753,7 +16727,6 @@ exports[`AnthropicMessagesLanguageModel > doStream > tool search tool > regex va
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": null,
         "contextManagement": null,
         "iterations": null,
@@ -16895,7 +16868,6 @@ The weather in",
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": null,
         "contextManagement": null,
         "iterations": null,
@@ -17216,7 +17188,6 @@ This domain is for use in documentation examples without needing permission. Avo
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": {
           "expiresAt": "2026-03-03T19:38:14.861782Z",
           "id": "container_011CYgdezfe66pcmCprMd28x",
@@ -17648,7 +17619,6 @@ The page also discusses",
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": null,
         "contextManagement": null,
         "iterations": null,
@@ -18591,7 +18561,6 @@ The main tech story today appears to be Apple's significant",
     },
     "providerMetadata": {
       "anthropic": {
-        "cacheCreationInputTokens": 0,
         "container": null,
         "contextManagement": null,
         "iterations": null,

--- a/packages/anthropic/src/anthropic-message-metadata.ts
+++ b/packages/anthropic/src/anthropic-message-metadata.ts
@@ -21,9 +21,6 @@ export interface AnthropicUsageIteration {
 
 export interface AnthropicMessageMetadata {
   usage: JSONObject;
-  // TODO remove cacheCreationInputTokens in AI SDK 6
-  // (use value in usage object instead)
-  cacheCreationInputTokens: number | null;
   stopSequence: string | null;
 
   /**

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -1378,7 +1378,6 @@ describe('AnthropicMessagesLanguageModel', () => {
       expect(result.providerMetadata).toMatchInlineSnapshot(`
         {
           "anthropic": {
-            "cacheCreationInputTokens": null,
             "container": null,
             "contextManagement": null,
             "iterations": null,
@@ -1839,7 +1838,6 @@ describe('AnthropicMessagesLanguageModel', () => {
           },
           "providerMetadata": {
             "anthropic": {
-              "cacheCreationInputTokens": 10,
               "container": null,
               "contextManagement": null,
               "iterations": null,
@@ -2003,7 +2001,6 @@ describe('AnthropicMessagesLanguageModel', () => {
           },
           "providerMetadata": {
             "anthropic": {
-              "cacheCreationInputTokens": 10,
               "container": null,
               "contextManagement": null,
               "iterations": null,
@@ -5699,7 +5696,6 @@ describe('AnthropicMessagesLanguageModel', () => {
               },
               "providerMetadata": {
                 "anthropic": {
-                  "cacheCreationInputTokens": 0,
                   "container": null,
                   "contextManagement": null,
                   "iterations": null,
@@ -5855,7 +5851,6 @@ describe('AnthropicMessagesLanguageModel', () => {
               },
               "providerMetadata": {
                 "anthropic": {
-                  "cacheCreationInputTokens": 0,
                   "container": null,
                   "contextManagement": null,
                   "iterations": null,
@@ -6057,7 +6052,6 @@ describe('AnthropicMessagesLanguageModel', () => {
                 },
                 "providerMetadata": {
                   "anthropic": {
-                    "cacheCreationInputTokens": 0,
                     "container": null,
                     "contextManagement": null,
                     "iterations": null,
@@ -6267,7 +6261,6 @@ describe('AnthropicMessagesLanguageModel', () => {
             },
             "providerMetadata": {
               "anthropic": {
-                "cacheCreationInputTokens": null,
                 "container": null,
                 "contextManagement": null,
                 "iterations": null,
@@ -6407,7 +6400,6 @@ describe('AnthropicMessagesLanguageModel', () => {
             },
             "providerMetadata": {
               "anthropic": {
-                "cacheCreationInputTokens": null,
                 "container": null,
                 "contextManagement": null,
                 "iterations": null,
@@ -6504,7 +6496,6 @@ describe('AnthropicMessagesLanguageModel', () => {
             },
             "providerMetadata": {
               "anthropic": {
-                "cacheCreationInputTokens": null,
                 "container": null,
                 "contextManagement": null,
                 "iterations": null,
@@ -6587,7 +6578,6 @@ describe('AnthropicMessagesLanguageModel', () => {
             },
             "providerMetadata": {
               "anthropic": {
-                "cacheCreationInputTokens": null,
                 "container": null,
                 "contextManagement": null,
                 "iterations": null,
@@ -7083,7 +7073,6 @@ describe('AnthropicMessagesLanguageModel', () => {
             },
             "providerMetadata": {
               "anthropic": {
-                "cacheCreationInputTokens": null,
                 "container": null,
                 "contextManagement": null,
                 "iterations": null,
@@ -7458,7 +7447,6 @@ describe('AnthropicMessagesLanguageModel', () => {
             },
             "providerMetadata": {
               "anthropic": {
-                "cacheCreationInputTokens": 10,
                 "container": null,
                 "contextManagement": null,
                 "iterations": null,
@@ -7550,7 +7538,6 @@ describe('AnthropicMessagesLanguageModel', () => {
             },
             "providerMetadata": {
               "anthropic": {
-                "cacheCreationInputTokens": 10,
                 "container": null,
                 "contextManagement": null,
                 "iterations": null,
@@ -7648,7 +7635,6 @@ describe('AnthropicMessagesLanguageModel', () => {
             },
             "providerMetadata": {
               "anthropic": {
-                "cacheCreationInputTokens": 10,
                 "container": null,
                 "contextManagement": null,
                 "iterations": null,
@@ -7766,7 +7752,6 @@ describe('AnthropicMessagesLanguageModel', () => {
               },
               "providerMetadata": {
                 "anthropic": {
-                  "cacheCreationInputTokens": null,
                   "container": null,
                   "contextManagement": null,
                   "iterations": null,
@@ -7830,7 +7815,6 @@ describe('AnthropicMessagesLanguageModel', () => {
               },
               "providerMetadata": {
                 "anthropic": {
-                  "cacheCreationInputTokens": null,
                   "container": null,
                   "contextManagement": null,
                   "iterations": null,
@@ -8081,7 +8065,6 @@ describe('AnthropicMessagesLanguageModel', () => {
               },
               "providerMetadata": {
                 "anthropic": {
-                  "cacheCreationInputTokens": null,
                   "container": null,
                   "contextManagement": null,
                   "iterations": null,
@@ -8289,7 +8272,6 @@ describe('AnthropicMessagesLanguageModel', () => {
                 },
                 "providerMetadata": {
                   "anthropic": {
-                    "cacheCreationInputTokens": null,
                     "container": null,
                     "contextManagement": null,
                     "iterations": null,
@@ -8396,7 +8378,6 @@ describe('AnthropicMessagesLanguageModel', () => {
                 },
                 "providerMetadata": {
                   "anthropic": {
-                    "cacheCreationInputTokens": 0,
                     "container": null,
                     "contextManagement": null,
                     "iterations": null,

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -1303,8 +1303,6 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
       providerMetadata: (() => {
         const anthropicMetadata = {
           usage: response.usage as JSONObject,
-          cacheCreationInputTokens:
-            response.usage.cache_creation_input_tokens ?? null,
           stopSequence: response.stop_sequence ?? null,
 
           iterations: response.usage.iterations
@@ -1425,7 +1423,6 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
       | AnthropicMessageMetadata['contextManagement']
       | null = null;
     let rawUsage: JSONObject | undefined = undefined;
-    let cacheCreationInputTokens: number | null = null;
     let stopSequence: string | null = null;
     let container: AnthropicMessageMetadata['container'] | null = null;
     let isJsonResponseFromTool = false;
@@ -2145,9 +2142,6 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
                 ...(value.message.usage as JSONObject),
               };
 
-              cacheCreationInputTokens =
-                value.message.usage.cache_creation_input_tokens ?? null;
-
               if (value.message.container != null) {
                 container = {
                   expiresAt: value.message.container.expires_at,
@@ -2245,8 +2239,6 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
               if (value.usage.cache_creation_input_tokens != null) {
                 usage.cache_creation_input_tokens =
                   value.usage.cache_creation_input_tokens;
-                cacheCreationInputTokens =
-                  value.usage.cache_creation_input_tokens;
               }
               if (value.usage.iterations != null) {
                 usage.iterations = value.usage.iterations;
@@ -2292,7 +2284,6 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
             case 'message_stop': {
               const anthropicMetadata = {
                 usage: (rawUsage as JSONObject) ?? null,
-                cacheCreationInputTokens,
                 stopSequence,
                 iterations: usage.iterations
                   ? usage.iterations.map(iter => ({

--- a/packages/google-vertex/README.md
+++ b/packages/google-vertex/README.md
@@ -136,7 +136,6 @@ async function main() {
 
   console.log(result.text);
   console.log(result.providerMetadata?.anthropic);
-  // e.g. { cacheCreationInputTokens: 2118, cacheReadInputTokens: 0 }
 }
 
 main().catch(console.error);


### PR DESCRIPTION
## Background

created as a follow up for the comment https://github.com/vercel/ai/issues/14482#issuecomment-4263403429 + there was also a TODO comment that i came across while resolving that issue.

< Breaking Change >

## Summary

- remove the `cacheCreationInputTokens` option from `providerMetadata.anthropic`

users can access the same information via 
```ts
const result = await generateText({ /* ... */ });

result.usage.inputTokenDetails.cacheWriteTokens;
```
or
```ts
const result = await generateText({ /* ... */ });

result.providerMetadata.anthropic.usage.cache_creation_input_tokens
```

## Manual Verification

verified by running the example `examples/ai-functions/src/stream-text/anthropic/cache-control.ts`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)