### PR TITLE
fix(provider/google): include toolUsePromptTokenCount in input token usage

### DIFF
--- a/.changeset/google-tool-use-prompt-tokens.md
+++ b/.changeset/google-tool-use-prompt-tokens.md
@@ -1,0 +1,19 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(provider/google): include `toolUsePromptTokenCount` in input token usage
+
+Google Gemini reports tokens consumed by tool-use prompts (e.g. grounded
+Google Search, URL context) in a separate `toolUsePromptTokenCount` field
+in `usageMetadata`. These tokens are billed at the regular input rate but
+were previously dropped: they were not declared in `usageSchema` and the
+converter only summed `promptTokenCount` into `inputTokens.total`.
+
+The result was that grounded calls under-reported input tokens by the
+exact amount Google billed for the tool-use prompts (in one repro: 79
+of 401 total tokens, ~20%, were missing from `usage.inputTokens`).
+
+This change adds `toolUsePromptTokenCount` to the schema and includes it
+in `inputTokens.total` and `inputTokens.noCache`. Non-grounded calls are
+unaffected.

--- a/packages/google/src/convert-google-generative-ai-usage.test.ts
+++ b/packages/google/src/convert-google-generative-ai-usage.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { convertGoogleGenerativeAIUsage } from './convert-google-generative-ai-usage';
+
+describe('convertGoogleGenerativeAIUsage', () => {
+  it('returns undefined fields when usage is null', () => {
+    expect(convertGoogleGenerativeAIUsage(null)).toEqual({
+      inputTokens: {
+        total: undefined,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: undefined,
+        text: undefined,
+        reasoning: undefined,
+      },
+      raw: undefined,
+    });
+  });
+
+  it('maps prompt and candidate tokens for a basic call', () => {
+    const usage = convertGoogleGenerativeAIUsage({
+      promptTokenCount: 100,
+      candidatesTokenCount: 50,
+      totalTokenCount: 150,
+    });
+
+    expect(usage.inputTokens).toEqual({
+      total: 100,
+      noCache: 100,
+      cacheRead: 0,
+      cacheWrite: undefined,
+    });
+    expect(usage.outputTokens).toEqual({
+      total: 50,
+      text: 50,
+      reasoning: 0,
+    });
+  });
+
+  it('subtracts cached tokens from noCache while keeping total accurate', () => {
+    const usage = convertGoogleGenerativeAIUsage({
+      promptTokenCount: 100,
+      cachedContentTokenCount: 40,
+      candidatesTokenCount: 50,
+      totalTokenCount: 150,
+    });
+
+    expect(usage.inputTokens).toEqual({
+      total: 100,
+      noCache: 60,
+      cacheRead: 40,
+      cacheWrite: undefined,
+    });
+  });
+
+  it('reports thoughts (reasoning) tokens in output and total', () => {
+    const usage = convertGoogleGenerativeAIUsage({
+      promptTokenCount: 10,
+      candidatesTokenCount: 15,
+      thoughtsTokenCount: 8,
+      totalTokenCount: 33,
+    });
+
+    expect(usage.outputTokens).toEqual({
+      total: 23,
+      text: 15,
+      reasoning: 8,
+    });
+  });
+
+  it('includes toolUsePromptTokenCount in input tokens', () => {
+    // Realistic shape returned by Gemini for a grounded (Google Search) call.
+    // Without this, ~20% of the billed tokens silently disappear from the
+    // standard usage shape because they live only in totalTokenCount.
+    const usage = convertGoogleGenerativeAIUsage({
+      promptTokenCount: 70,
+      candidatesTokenCount: 53,
+      thoughtsTokenCount: 199,
+      toolUsePromptTokenCount: 79,
+      totalTokenCount: 401,
+    });
+
+    expect(usage.inputTokens).toEqual({
+      total: 149,
+      noCache: 149,
+      cacheRead: 0,
+      cacheWrite: undefined,
+    });
+    expect(usage.outputTokens).toEqual({
+      total: 252,
+      text: 53,
+      reasoning: 199,
+    });
+  });
+
+  it('combines cached content and tool-use prompt tokens correctly', () => {
+    const usage = convertGoogleGenerativeAIUsage({
+      promptTokenCount: 100,
+      cachedContentTokenCount: 30,
+      toolUsePromptTokenCount: 50,
+      candidatesTokenCount: 20,
+      totalTokenCount: 170,
+    });
+
+    expect(usage.inputTokens).toEqual({
+      total: 150,
+      noCache: 120,
+      cacheRead: 30,
+      cacheWrite: undefined,
+    });
+  });
+});

--- a/packages/google/src/convert-google-generative-ai-usage.ts
+++ b/packages/google/src/convert-google-generative-ai-usage.ts
@@ -11,6 +11,7 @@ export type GoogleGenerativeAIUsageMetadata = {
   totalTokenCount?: number | null;
   cachedContentTokenCount?: number | null;
   thoughtsTokenCount?: number | null;
+  toolUsePromptTokenCount?: number | null;
   trafficType?: string | null;
   promptTokensDetails?: GoogleGenerativeAITokenDetail[] | null;
   candidatesTokensDetails?: GoogleGenerativeAITokenDetail[] | null;
@@ -40,11 +41,18 @@ export function convertGoogleGenerativeAIUsage(
   const candidatesTokens = usage.candidatesTokenCount ?? 0;
   const cachedContentTokens = usage.cachedContentTokenCount ?? 0;
   const thoughtsTokens = usage.thoughtsTokenCount ?? 0;
+  // Tokens consumed by tool-use prompts (e.g. grounded search, URL context).
+  // Google bills these at the regular input rate but reports them as a
+  // separate field. Including them in `inputTokens.total` ensures consumers
+  // that compute cost from the standard usage shape match Google's billing.
+  // See https://ai.google.dev/api/generate-content#UsageMetadata.
+  const toolUsePromptTokens = usage.toolUsePromptTokenCount ?? 0;
+  const totalInputTokens = promptTokens + toolUsePromptTokens;
 
   return {
     inputTokens: {
-      total: promptTokens,
-      noCache: promptTokens - cachedContentTokens,
+      total: totalInputTokens,
+      noCache: totalInputTokens - cachedContentTokens,
       cacheRead: cachedContentTokens,
       cacheWrite: undefined,
     },

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -1391,6 +1391,10 @@ const usageSchema = z.object({
   promptTokenCount: z.number().nullish(),
   candidatesTokenCount: z.number().nullish(),
   totalTokenCount: z.number().nullish(),
+  // Tokens used by tool-use prompts (e.g. grounded search, URL context).
+  // Google bills this at the regular input rate; see
+  // https://ai.google.dev/api/generate-content#UsageMetadata.
+  toolUsePromptTokenCount: z.number().nullish(),
   // https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#TrafficType
   trafficType: z.string().nullish(),
   // https://ai.google.dev/api/generate-content#Modality


### PR DESCRIPTION
## Background

When you call Gemini with a tool that runs a tool-use prompt — most commonly grounded `google_search` or `url_context` — the model's `usageMetadata` reports those tokens in a separate field, `toolUsePromptTokenCount`, on top of `promptTokenCount`. Both are billed at the regular input rate. Google's docs: <https://ai.google.dev/api/generate-content#UsageMetadata>.

Today the `@ai-sdk/google` provider drops this field on the floor:

1. `usageSchema` in `google-generative-ai-language-model.ts` doesn't declare `toolUsePromptTokenCount`, so zod strips it from the parsed response.
2. `convertGoogleGenerativeAIUsage` only sums `promptTokenCount` into `inputTokens.total`.

## Impact

For a grounded call this means the standard `usage.inputTokens.total` is silently lower than what Google actually bills. We hit this in production: a grounded Gemini 2.5 Flash call returned

```jsonc
"usageMetadata": {
  "promptTokenCount":         70,
  "candidatesTokenCount":     53,
  "thoughtsTokenCount":      199,
  "toolUsePromptTokenCount":  79,   // ← billed, but invisible to consumers
  "totalTokenCount":         401
}
```

The AI SDK surfaced `inputTokens.total = 70`, leaving 79 tokens (~20% of the call's billable input) unaccounted for. Anyone computing cost from the standard `LanguageModelV4Usage` shape silently undercounts.

## Fix

- Declare `toolUsePromptTokenCount` on `usageSchema` so zod stops stripping it.
- Add the field to `GoogleGenerativeAIUsageMetadata`.
- Sum `toolUsePromptTokenCount` into `inputTokens.total` and `inputTokens.noCache` in `convertGoogleGenerativeAIUsage`. Cached read tokens already cap `noCache` correctly.
- For non-grounded calls the value is missing/zero and the math collapses to the existing behavior — no behavior change.

## Tests

Added a focused `convert-google-generative-ai-usage.test.ts` covering:
- null usage (unchanged behavior)
- basic prompt + candidate mapping
- cached content interaction with `noCache`
- thoughts (reasoning) tokens
- `toolUsePromptTokenCount` in input total (new)
- combined cached + tool-use prompt tokens (new)

`pnpm test:node` in `packages/google` passes all 400 tests (was 394).

The existing inline-snapshot test that asserts on `usage` (`should support includeThoughts with google generative ai provider`) does not include `toolUsePromptTokenCount` in its fixture, so its snapshot is unchanged.

## Notes

- Patch changeset added per `CONTRIBUTING.md`.
- The schema and converter are the only two places `toolUsePromptTokenCount` needs to flow through. The `LanguageModelV4Usage` type has no dedicated tool-use slot, so summing into `inputTokens.total` is the most spec-aligned destination — that's where Google bills it, and that's what consumers price against.
- Happy to also surface a per-field `toolUsePrompt` count on `LanguageModelV4Usage.inputTokens` (or via `raw`) in a follow-up if maintainers want callers to be able to break it out.

Made with [Cursor](https://cursor.com)