### PR TITLE
chore: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ai-provider-api-changes.yml
+++ b/.github/workflows/ai-provider-api-changes.yml
@@ -9,14 +9,14 @@ jobs:
     name: 'Create Issue for Provider API Change'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8 }}
 
       - name: Create issues
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: POST /repos/{owner}/{repo}/issues
           owner: vercel

--- a/.github/workflows/assign-team-pull-request.yml
+++ b/.github/workflows/assign-team-pull-request.yml
@@ -14,7 +14,7 @@ jobs:
     # And only assign if pull request was created by a user, ignore bots
     if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type == 'User'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Assign pull request to author
         run: gh pr edit $PULL_REQUEST_URL --add-assignee $AUTHOR_LOGIN
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.11.0
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'pnpm'
@@ -40,15 +40,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.11.0
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'pnpm'
@@ -64,15 +64,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.11.0
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'pnpm'
@@ -88,15 +88,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.11.0
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'pnpm'
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload bundle size metafiles
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bundle-size-metafiles
           path: packages/ai/dist-bundle-check/*.json
@@ -128,15 +128,15 @@ jobs:
         node-version: [20, 22, 24]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.11.0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -183,15 +183,15 @@ jobs:
             max-load-time: 65
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.11.0
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -38,17 +38,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.11.0
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.repository_owner == 'vercel'
     steps:
       - name: Create access token for GitHub App
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
@@ -40,19 +40,19 @@ jobs:
           git config --global user.email '${{ steps.app-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.11.0
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event_name == 'pull_request_target'
     steps:
       - name: Create access token for GitHub App
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
@@ -32,7 +32,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -178,7 +178,7 @@ jobs:
     if: github.event_name == 'issues'
     steps:
       - name: Create access token for GitHub App
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
@@ -189,7 +189,7 @@ jobs:
           permission-issues: write
 
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/ultracite-on-automerge.yml
+++ b/.github/workflows/ultracite-on-automerge.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Create access token for GitHub App
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
@@ -68,17 +68,17 @@ jobs:
           fi
 
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ steps.pr-head.outputs.sha }}
           repository: ${{ steps.pr-head.outputs.repo_full_name }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -17,10 +17,10 @@ jobs:
   verify-changesets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
       - name: get all changed files from .changeset/*.md


### PR DESCRIPTION
## Summary

Updates all GitHub Actions used in CI/CD workflows to their latest major versions:

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4/v5 | **v6** |
| `actions/create-github-app-token` | v2 | **v3** |
| `actions/setup-node` | v4/v5 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `octokit/request-action` | v2.x | **v3** |
| `pnpm/action-setup` | v4 | **v5** |

### Breaking changes reviewed

- **checkout v6**: Credential persistence changes — no impact on our workflows
- **create-github-app-token v3**: Custom proxy handling removed (requires `NODE_USE_ENV_PROXY=1`) — not applicable (no proxy usage)
- **setup-node v6**: Automatic caching limited to npm by default — our workflows explicitly set `cache: 'pnpm'`, unaffected
- **upload-artifact v7**: Added direct upload support, ESM upgrade — standard upload usage unaffected
- **octokit/request-action v3**: Node 24 runner — no behavioral changes
- **pnpm/action-setup v5**: Node 24 runtime — no behavioral changes

## Test plan

- [ ] CI workflows pass on this PR
- [ ] Release workflow syntax is valid