### PR TITLE
fix: guard against undefined warnings from EmbeddingModelV2 providers

### DIFF
--- a/.changeset/fix-embed-undefined-warnings.md
+++ b/.changeset/fix-embed-undefined-warnings.md
@@ -1,0 +1,7 @@
+---
+'ai': patch
+---
+
+fix: guard against undefined warnings from EmbeddingModelV2 providers in embed/embedMany
+
+`EmbeddingModelV2` providers (e.g. `@ai-sdk/google-vertex@3.x`) do not include `warnings` in their `doEmbed` return type, causing `embed()` and `embedMany()` to crash at runtime. This adds null-safety by defaulting `modelResponse.warnings` to `[]` and adding guards in `logWarnings` and the `embedMany` chunked aggregation path.

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -919,6 +919,53 @@ describe('options.experimental_onStart and experimental_onFinish together', () =
   });
 });
 
+
+describe('result.warnings with undefined warnings from provider', () => {
+  it('should default to empty array when provider returns undefined warnings (single call path)', async () => {
+    const result = await embedMany({
+      model: new MockEmbeddingModelV4({
+        maxEmbeddingsPerCall: null,
+        doEmbed: async () => ({
+          embeddings: dummyEmbeddings,
+          // no warnings property, simulating EmbeddingModelV2 provider
+        }),
+      }),
+      values: testValues,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it('should handle undefined warnings in chunked path', async () => {
+    let callCount = 0;
+
+    const result = await embedMany({
+      model: new MockEmbeddingModelV4({
+        maxEmbeddingsPerCall: 2,
+        doEmbed: async () => {
+          switch (callCount++) {
+            case 0:
+              return {
+                embeddings: dummyEmbeddings.slice(0, 2),
+                // no warnings property
+              };
+            case 1:
+              return {
+                embeddings: dummyEmbeddings.slice(2),
+                // no warnings property
+              };
+            default:
+              throw new Error('Unexpected call');
+          }
+        },
+      }),
+      values: testValues,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+  });
+});
+
 function mockEmbed(
   expectedValues: Array<string>,
   embeddings: Array<Embedding>,

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -219,7 +219,7 @@ export async function embedMany({
           return {
             embeddings,
             usage,
-            warnings: modelResponse.warnings,
+            warnings: modelResponse.warnings ?? [],
             providerMetadata: modelResponse.providerMetadata,
             response: modelResponse.response,
           };
@@ -331,7 +331,7 @@ export async function embedMany({
             return {
               embeddings: chunkEmbeddings,
               usage,
-              warnings: modelResponse.warnings,
+              warnings: modelResponse.warnings ?? [],
               providerMetadata: modelResponse.providerMetadata,
               response: modelResponse.response,
             };
@@ -341,7 +341,9 @@ export async function embedMany({
 
       for (const result of results) {
         embeddings.push(...result.embeddings);
-        warnings.push(...result.warnings);
+        if (result.warnings) {
+          warnings.push(...result.warnings);
+        }
         responses.push(result.response);
         tokens += result.usage.tokens;
         if (result.providerMetadata) {

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -564,6 +564,23 @@ describe('options.experimental_onStart and experimental_onFinish together', () =
   });
 });
 
+
+describe('result.warnings with undefined warnings from provider', () => {
+  it('should default to empty array when provider returns undefined warnings', async () => {
+    const result = await embed({
+      model: new MockEmbeddingModelV4({
+        doEmbed: async () => ({
+          embeddings: [dummyEmbedding],
+          // no warnings property, simulating EmbeddingModelV2 provider
+        }),
+      }),
+      value: testValue,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+  });
+});
+
 function mockEmbed(
   expectedValues: Array<string>,
   embeddings: Array<Embedding>,

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -197,7 +197,7 @@ export async function embed({
         return {
           embedding,
           usage,
-          warnings: modelResponse.warnings,
+          warnings: modelResponse.warnings ?? [],
           providerMetadata: modelResponse.providerMetadata,
           response: modelResponse.response,
         };

--- a/packages/ai/src/logger/log-warnings.test.ts
+++ b/packages/ai/src/logger/log-warnings.test.ts
@@ -357,4 +357,16 @@ describe('logWarnings', () => {
       expect(mockConsoleWarn).not.toHaveBeenCalled();
     });
   });
+  describe('when warnings is undefined', () => {
+    it('should not throw and should not log', () => {
+      logWarnings({
+        warnings: undefined as any,
+        provider: 'test-provider',
+        model: 'test-model',
+      });
+
+      expect(mockConsoleWarn).not.toHaveBeenCalled();
+      expect(mockConsoleInfo).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/ai/src/logger/log-warnings.ts
+++ b/packages/ai/src/logger/log-warnings.ts
@@ -100,8 +100,8 @@ let hasLoggedBefore = false;
  * @param options.model - The model id used for the call.
  */
 export const logWarnings: LogWarningsFunction = options => {
-  // if the warnings array is empty, do nothing
-  if (options.warnings.length === 0) {
+  // if the warnings array is empty or undefined, do nothing
+  if (!options.warnings || options.warnings.length === 0) {
     return;
   }
 


### PR DESCRIPTION
## Summary

Fixes #14425

`embed()` and `embedMany()` crash at runtime when used with `EmbeddingModelV2` providers (e.g. `@ai-sdk/google-vertex@3.x`) because `doEmbed` does not return a `warnings` property but the SDK assumes it is always present and iterable.

### Changes

- **`embed.ts` / `embed-many.ts`**: Default `modelResponse.warnings` to `[]` via nullish coalescing (`?? []`) at the source where the value is destructured from the model response
- **`log-warnings.ts`**: Add null guard (`!options.warnings ||`) before accessing `.length` so `logWarnings` handles undefined gracefully
- **`embed-many.ts` (chunked path)**: Wrap `warnings.push(...result.warnings)` in a null check to prevent "is not iterable" error

### Errors fixed

**`embed()`** -- `logWarnings` at `log-warnings.ts`:
```
TypeError: Cannot read properties of undefined (reading 'length')
```

**`embedMany()`** -- spreading `result.warnings`:
```
TypeError: result.warnings is not iterable
```

## Test plan

- Added test in `log-warnings.test.ts`: calling `logWarnings` with `undefined` warnings does not throw
- Added test in `embed.test.ts`: `embed()` with a provider that omits `warnings` returns `[]` 
- Added tests in `embed-many.test.ts`: `embedMany()` with undefined warnings works for both single-call and chunked paths