### PR TITLE
fix(mcp): use negotiated protocol version in mcp-protocol-version header

### DIFF
--- a/.changeset/fix-mcp-protocol-version-downgrade.md
+++ b/.changeset/fix-mcp-protocol-version-downgrade.md
@@ -1,0 +1,9 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix(mcp): use negotiated protocol version in mcp-protocol-version header after initialization
+
+The `HttpMCPTransport` and `SseMCPTransport` always sent the client's `LATEST_PROTOCOL_VERSION` in the `mcp-protocol-version` header, even after the server negotiated a lower version during `initialize`. This caused post-initialization requests (like `notifications/initialized`) to be rejected with HTTP 400 by servers that only support older protocol versions (e.g. Figma Dev Mode MCP Server which supports up to `2025-06-18`).
+
+The transport now stores the negotiated `protocolVersion` from the server's initialize response and uses it in all subsequent request headers, falling back to `LATEST_PROTOCOL_VERSION` before initialization completes.

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -1949,4 +1949,36 @@ describe('MCPClient', () => {
       expect(tools['typed-titled-tool'].title).toBe('Typed Tool Title');
     });
   });
+
+  describe('protocol version negotiation', () => {
+    it('should set protocolVersion on transport after successful init', async () => {
+      const mockTransport = new MockMCPTransport();
+
+      client = await createMCPClient({
+        transport: mockTransport,
+      });
+
+      // The mock transport returns LATEST_PROTOCOL_VERSION by default
+      expect(mockTransport.protocolVersion).toBe(
+        (await import('./types')).LATEST_PROTOCOL_VERSION,
+      );
+    });
+
+    it('should set negotiated protocolVersion on transport when server downgrades', async () => {
+      const mockTransport = new MockMCPTransport({
+        initializeResult: {
+          protocolVersion: '2025-06-18',
+          serverInfo: { name: 'test-server', version: '1.0.0' },
+          capabilities: { tools: {} },
+        },
+      });
+
+      client = await createMCPClient({
+        transport: mockTransport,
+      });
+
+      expect(mockTransport.protocolVersion).toBe('2025-06-18');
+    });
+  });
+
 });

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -289,6 +289,7 @@ class DefaultMCPClient implements MCPClient {
       }
 
       this.serverCapabilities = result.capabilities;
+      this.transport.protocolVersion = result.protocolVersion;
       this._serverInfo = result.serverInfo;
 
       // Complete initialization handshake:

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -485,4 +485,62 @@ describe('HttpMCPTransport', () => {
       );
     });
   });
+
+  describe('protocol version downgrade', () => {
+    it('should use LATEST_PROTOCOL_VERSION by default', async () => {
+      await transport.start();
+
+      const message = {
+        jsonrpc: '2.0' as const,
+        method: 'initialize',
+        id: 1,
+        params: {},
+      };
+
+      await transport.send(message);
+
+      expect(server.calls[1].requestHeaders['mcp-protocol-version']).toBe(
+        LATEST_PROTOCOL_VERSION,
+      );
+    });
+
+    it('should use negotiated protocolVersion in headers after it is set', async () => {
+      const negotiatedVersion = '2025-06-18';
+
+      server.urls['http://localhost:4000/mcp'].response = {
+        type: 'json-value',
+        body: { jsonrpc: '2.0', id: 2, result: { ok: true } },
+        headers: { 'mcp-session-id': 'abc123' },
+      };
+
+      await transport.start();
+
+      // Simulate the client setting the negotiated version after initialize
+      transport.protocolVersion = negotiatedVersion;
+
+      const message = {
+        jsonrpc: '2.0' as const,
+        method: 'tools/list',
+        id: 2,
+        params: {},
+      };
+
+      const messagePromise = new Promise(resolve => {
+        transport.onmessage = msg => resolve(msg);
+      });
+
+      await transport.send(message);
+
+      await messagePromise;
+
+      // The POST for tools/list should use the negotiated version
+      const postCall = server.calls.find(
+        c => c.requestMethod === 'POST' && c.requestBody?.method === 'tools/list',
+      );
+      expect(postCall?.requestHeaders['mcp-protocol-version']).toBe(
+        negotiatedVersion,
+      );
+    });
+  });
+
 });

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -74,7 +74,7 @@ export class HttpMCPTransport implements MCPTransport {
     const headers: Record<string, string> = {
       ...this.headers,
       ...base,
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version': this.protocolVersion ?? LATEST_PROTOCOL_VERSION,
     };
 
     if (this.sessionId) {

--- a/packages/mcp/src/tool/mcp-sse-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.test.ts
@@ -452,4 +452,42 @@ describe('SseMCPTransport', () => {
       await transport.close();
     });
   });
+
+  describe('protocol version downgrade', () => {
+    it('should use negotiated protocolVersion in POST headers after it is set', async () => {
+      const controller = new TestResponseController();
+
+      server.urls['http://localhost:3000/sse'].response = {
+        type: 'controlled-stream',
+        controller,
+        headers: { 'content-type': 'text/event-stream' },
+      };
+
+      const connectPromise = transport.start();
+      controller.write(
+        'event: endpoint\ndata: http://localhost:3000/messages\n\n',
+      );
+      await connectPromise;
+
+      // Simulate protocol version negotiation
+      transport.protocolVersion = '2025-06-18';
+
+      await transport.send({
+        jsonrpc: '2.0' as const,
+        method: 'tools/list',
+        params: {},
+        id: '1',
+      });
+
+      const postCall = server.calls.find(
+        c => c.requestMethod === 'POST',
+      );
+      expect(postCall?.requestHeaders['mcp-protocol-version']).toBe(
+        '2025-06-18',
+      );
+
+      await transport.close();
+    });
+  });
+
 });

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -60,7 +60,7 @@ export class SseMCPTransport implements MCPTransport {
     const headers: Record<string, string> = {
       ...this.headers,
       ...base,
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version': this.protocolVersion ?? LATEST_PROTOCOL_VERSION,
     };
 
     if (this.authProvider) {

--- a/packages/mcp/src/tool/mcp-transport.ts
+++ b/packages/mcp/src/tool/mcp-transport.ts
@@ -40,6 +40,14 @@ export interface MCPTransport {
    * Event handler for received messages
    */
   onmessage?: (message: JSONRPCMessage) => void;
+
+  /**
+   * The protocol version negotiated during initialization.
+   * Set by the client after a successful initialize handshake so that
+   * subsequent requests use the server-agreed version in the
+   * mcp-protocol-version header instead of the client's latest version.
+   */
+  protocolVersion?: string;
 }
 
 export type MCPTransportConfig = {


### PR DESCRIPTION
## Summary

Fixes #14413

- After `initialize`, the server may negotiate a lower protocol version than `LATEST_PROTOCOL_VERSION`. Both `HttpMCPTransport` and `SseMCPTransport` were hardcoding `LATEST_PROTOCOL_VERSION` in the `mcp-protocol-version` header for every request, violating the MCP spec and causing HTTP 400 from servers that only support older versions (e.g. Figma Dev Mode MCP Server, which supports up to `2025-06-18`).
- Adds a `protocolVersion` property to the `MCPTransport` interface. The client sets it after a successful `initialize` response, and both transports now use it (falling back to `LATEST_PROTOCOL_VERSION` before init completes).

## Changes

- `mcp-transport.ts`: Added optional `protocolVersion` property to `MCPTransport` interface
- `mcp-http-transport.ts`: `commonHeaders()` uses `this.protocolVersion ?? LATEST_PROTOCOL_VERSION`
- `mcp-sse-transport.ts`: Same change as HTTP transport
- `mcp-client.ts`: Sets `this.transport.protocolVersion = result.protocolVersion` after successful init

## Test plan

- [ ] New tests in `mcp-http-transport.test.ts` verify the header defaults to `LATEST_PROTOCOL_VERSION` and switches to the negotiated version after `protocolVersion` is set
- [ ] New test in `mcp-sse-transport.test.ts` verifies POST headers use the negotiated version
- [ ] New tests in `mcp-client.test.ts` verify the client sets `protocolVersion` on the transport for both default and downgraded scenarios
- [ ] Existing tests continue to pass (no breaking changes -- the property is optional and defaults to current behavior)