### PR TITLE
docs: document cancellation on Vercel for tools and streams

### DIFF
--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -727,6 +727,54 @@ const result = await generateText({
 });
 ```
 
+#### Cancellation on Vercel
+
+When you deploy tools to Vercel and opt into [request cancellation](https://vercel.com/docs/functions/functions-api-reference#cancel-requests) with `"supportsCancellation": true` in `vercel.json`, cancellation is cooperative: your tool keeps running until it observes the signal and returns.
+
+Two things to know:
+
+- **`abortSignal.aborted` only flips once the client disconnects.** In practice this means polling it at the top of each iteration of a loop works, but only between `await` points. If your tool has large async gaps (e.g. batched parallel work), listen to the `abort` event directly rather than only polling `.aborted`.
+- **Cleanup work that runs after the response closes must be wrapped in `waitUntil`.** Once your tool returns and the response stream closes, the function is eligible to be reaped. Any persistence you trigger from an `abort` listener (or in a `finally` block after the response closes) is only guaranteed to complete if it is attached to `waitUntil`.
+
+<Note>
+  This behavior is the same as for any Vercel Function. See the [Vercel cancel
+  requests docs](https://vercel.com/docs/functions/functions-api-reference#cancel-requests)
+  for the full contract.
+</Note>
+
+```ts highlight="2,14-18,23"
+import { tool } from 'ai';
+import { waitUntil } from '@vercel/functions';
+import { z } from 'zod';
+
+export const processBatch = tool({
+  description: 'Process a batch of items and persist progress',
+  inputSchema: z.object({ items: z.array(z.string()) }),
+  execute: async ({ items }, { abortSignal }) => {
+    const completed: string[] = [];
+
+    // Persist partial progress if the request is cancelled. `waitUntil` keeps
+    // the async work alive after the response stream closes so it is not lost
+    // when the function is reaped.
+    const onAbort = () => waitUntil(saveProgress([...completed]));
+    abortSignal?.addEventListener('abort', onAbort, { once: true });
+
+    try {
+      for (const item of items) {
+        if (abortSignal?.aborted) break;
+        await processItem(item);
+        completed.push(item);
+      }
+      return { completed: completed.length, cancelled: abortSignal?.aborted };
+    } finally {
+      abortSignal?.removeEventListener('abort', onAbort);
+    }
+  },
+});
+```
+
+For stream-level cleanup (saving partial steps, logging aborts across a whole generation), use `onAbort` on `streamText`. See [Stopping Streams](/docs/advanced/stopping-streams#handling-stream-abort-cleanup).
+
 ### Runtime Context
 
 You can pass in arbitrary runtime context from `generateText` or `streamText` via the `runtimeContext` setting.

--- a/content/docs/06-advanced/02-stopping-streams.mdx
+++ b/content/docs/06-advanced/02-stopping-streams.mdx
@@ -177,6 +177,45 @@ export async function POST(req: Request) {
 
 The `consumeStream` function is necessary for proper abort handling in UI message streams. It ensures that the stream is properly consumed even when aborted, preventing potential memory leaks or hanging connections.
 
+## Cancellation on Vercel
+
+When your route is deployed to Vercel and opts into [request cancellation](https://vercel.com/docs/functions/functions-api-reference#cancel-requests) (`"supportsCancellation": true` in `vercel.json`), a few properties of the cancellation contract are worth knowing when you use `onAbort`, `abortSignal` in tools, or read the `abort` stream part:
+
+- **`req.signal` fires when the client disconnects.** The AI SDK forwards this signal to the model provider and to your tools. Your handler keeps running after the signal fires; it is not killed mid-instruction.
+- **The response stream closes as soon as the signal fires.** Anything you log or write to the stream after that point will not reach the client.
+- **Work that must complete after the stream closes needs `waitUntil`.** Once the response stream closes, the function becomes eligible to be reaped. Callbacks like `onAbort` and `onFinish` run in-process, so either do your persistence inline before returning, or wrap it with `waitUntil` to guarantee completion.
+
+<Note type="warning">
+  The Vercel docs state this directly: "anything that must be completed in the
+  event of request cancellation should be put in a `waitUntil` or `after`
+  promise. If you don't, there is no guarantee that code will be executed after
+  the request is cancelled."
+</Note>
+
+```tsx highlight="2-3,12-16"
+import { consumeStream, streamText } from 'ai';
+import { waitUntil } from '@vercel/functions';
+__PROVIDER_IMPORT__;
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = streamText({
+    model: __MODEL__,
+    messages,
+    abortSignal: req.signal,
+    onAbort: ({ steps }) => {
+      // Use waitUntil so the save survives the response stream closing.
+      waitUntil(savePartialConversation(steps));
+    },
+  });
+
+  return result.toUIMessageStreamResponse({ consumeSseStream: consumeStream });
+}
+```
+
+For tool-level cleanup (persisting progress inside a long-running tool `execute`), see [Cancellation on Vercel](/docs/ai-sdk-core/tools-and-tool-calling#cancellation-on-vercel) in the Tools guide.
+
 ## AI SDK RSC
 
 <Note type="warning">

--- a/content/docs/06-advanced/10-vercel-deployment-guide.mdx
+++ b/content/docs/06-advanced/10-vercel-deployment-guide.mdx
@@ -95,6 +95,52 @@ export const maxDuration = 30;
 
 You can increase the max duration to 60 seconds on the Hobby Tier. For other tiers, [see the documentation](https://vercel.com/docs/functions/runtimes#max-duration) for limits.
 
+### Request Cancellation
+
+When a user hits "Stop" on a chat, closes the browser tab, or an HTTP client aborts the request, the browser closes the connection. On Vercel, you can opt into surfacing this as an `AbortSignal` on the server by adding [`supportsCancellation`](https://vercel.com/docs/functions/functions-api-reference#cancel-requests) to your function config:
+
+```json filename="vercel.json"
+{
+  "functions": {
+    "app/**/api/**/route.ts": {
+      "supportsCancellation": true,
+      "maxDuration": 300
+    }
+  }
+}
+```
+
+With this enabled:
+
+- `req.signal` fires when the client disconnects.
+- Forwarding `req.signal` to `streamText` / `generateText` cancels the in-flight request to the model provider.
+- Tools receive the same signal in their `execute` options and can use it to stop their own work.
+
+Cancellation is cooperative. The function keeps running after the signal fires, but the response stream is already closed, so anything you write or log after that point does not reach the client. Work that must complete after the stream closes — persistence, analytics, logging — needs to be wrapped in [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package#waituntil) from `@vercel/functions`:
+
+```ts highlight="2,11-14"
+import { streamText } from 'ai';
+import { waitUntil } from '@vercel/functions';
+__PROVIDER_IMPORT__;
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = streamText({
+    model: __MODEL__,
+    messages,
+    abortSignal: req.signal,
+    onAbort: ({ steps }) => {
+      waitUntil(saveSteps(steps));
+    },
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+For the end-to-end pattern (including tool-level cleanup and `onFinish` with `isAborted`), see [Stopping Streams](/docs/advanced/stopping-streams) and [Cancellation on Vercel](/docs/ai-sdk-core/tools-and-tool-calling#cancellation-on-vercel) in the Tools guide.
+
 ## Security Considerations
 
 Given the high cost of calling an LLM, it's important to have measures in place that can protect your application from abuse.


### PR DESCRIPTION
Adds clear guidance on Vercel’s supportsCancellation in the three places developers are most likely to check. It explains that cancellation is cooperative, the response stream ends when the client disconnects, and any work that must run after the response (like partial saves, analytics, or logging) needs to be wrapped in waitUntil from `@vercel/functions`. It includes examples for using a signal listener + waitUntil inside a tool’s execute, using onAbort + waitUntil with streamText, and a brief summary in the Vercel deployment guide. All sections link to each other so readers can easily follow the topic from anywhere.


