### PR TITLE
refactoring: rename tool execution events

### DIFF
--- a/.changeset/great-cups-serve.md
+++ b/.changeset/great-cups-serve.md
@@ -1,0 +1,8 @@
+---
+"@ai-sdk/provider-utils": patch
+"@ai-sdk/workflow": patch
+"@ai-sdk/otel": patch
+"ai": patch
+---
+
+refactoring: rename tool execution events

--- a/.changeset/workflow-agent-enrich-callbacks.md
+++ b/.changeset/workflow-agent-enrich-callbacks.md
@@ -3,7 +3,7 @@
 ---
 
 Enrich WorkflowAgent callback event shapes to align with ToolLoopAgent:
-- Add `stepNumber` to `onToolCallStart` and `onToolCallFinish`
+- Add `stepNumber` to `onToolExecutionStart` and `onToolExecutionEnd`
 - Add `steps` (previous step results) to `onStepStart`
-- Adopt discriminated union pattern (`success: true/false`) for `onToolCallFinish`
-- Add `durationMs` to `onToolCallFinish`
+- Adopt discriminated union pattern (`success: true/false`) for `onToolExecutionEnd`
+- Add `durationMs` to `onToolExecutionEnd`

--- a/.changeset/workflow-agent-enrich-callbacks.md
+++ b/.changeset/workflow-agent-enrich-callbacks.md
@@ -3,7 +3,7 @@
 ---
 
 Enrich WorkflowAgent callback event shapes to align with ToolLoopAgent:
-- Add `stepNumber` to `onToolExecutionStart` and `onToolExecutionEnd`
+- Add `stepNumber` to `onToolCallStart` and `onToolCallFinish`
 - Add `steps` (previous step results) to `onStepStart`
-- Adopt discriminated union pattern (`success: true/false`) for `onToolExecutionEnd`
-- Add `durationMs` to `onToolExecutionEnd`
+- Adopt discriminated union pattern (`success: true/false`) for `onToolCallFinish`
+- Add `durationMs` to `onToolCallFinish`

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -372,11 +372,11 @@ const result = await myAgent.generate({
     console.log(`Step ${stepNumber} starting`, { model: model.modelId });
   },
 
-  experimental_onToolCallStart({ toolCall }) {
+  experimental_onToolExecutionStart({ toolCall }) {
     console.log(`Tool call starting: ${toolCall.toolName}`);
   },
 
-  experimental_onToolCallFinish({ toolCall, durationMs, success }) {
+  experimental_onToolExecutionEnd({ toolCall, durationMs, success }) {
     console.log(`Tool call finished: ${toolCall.toolName} (${durationMs}ms)`, {
       success,
     });
@@ -404,8 +404,8 @@ The available lifecycle callbacks are:
 
 - **`experimental_onStart`**: Called once when the agent operation begins, before any LLM calls. Receives model info, prompt, settings, and `runtimeContext`.
 - **`experimental_onStepStart`**: Called before each step (LLM call). Receives the step number, model, messages being sent, tools, and prior steps.
-- **`experimental_onToolCallStart`**: Called right before a tool's `execute` function runs. Receives the tool call object with tool name, call ID, and input.
-- **`experimental_onToolCallFinish`**: Called right after a tool's `execute` function completes or errors. Receives the tool call, `durationMs`, and a `success` discriminator (`output` when successful, `error` when failed).
+- **`experimental_onToolExecutionStart`**: Called right before a tool's `execute` function runs. Receives the tool call object with tool name, call ID, and input.
+- **`experimental_onToolExecutionEnd`**: Called right after a tool's `execute` function completes or errors. Receives the tool call, `durationMs`, and a `success` discriminator (`output` when successful, `error` when failed).
 - **`onStepFinish`**: Called after each step finishes. Receives step results including usage, finish reason, and tool calls.
 - **`onFinish`**: Called when all steps are finished and the response is complete. Receives all step results, total usage, and `runtimeContext`.
 

--- a/content/docs/03-agents/07-workflow-agent.mdx
+++ b/content/docs/03-agents/07-workflow-agent.mdx
@@ -434,11 +434,11 @@ const agent = new WorkflowAgent({
     console.log(`Step ${stepNumber} starting`);
   },
 
-  experimental_onToolCallStart({ toolCall }) {
+  experimental_onToolExecutionStart({ toolCall }) {
     console.log(`Calling tool: ${toolCall.toolName}`);
   },
 
-  experimental_onToolCallFinish({ toolCall, result, error }) {
+  experimental_onToolExecutionEnd({ toolCall, result, error }) {
     console.log(`Tool finished: ${toolCall.toolName}`);
   },
 

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -135,11 +135,11 @@ const result = await generateText({
     console.log(`Step ${stepNumber} starting`, { model: model.modelId });
   },
 
-  experimental_onToolCallStart({ toolName, toolCallId, input }) {
+  experimental_onToolExecutionStart({ toolName, toolCallId, input }) {
     console.log(`Tool call starting: ${toolName}`, { toolCallId });
   },
 
-  experimental_onToolCallFinish({ toolName, durationMs, error }) {
+  experimental_onToolExecutionEnd({ toolName, durationMs, error }) {
     console.log(`Tool call finished: ${toolName} (${durationMs}ms)`, {
       success: !error,
     });
@@ -155,8 +155,8 @@ The available lifecycle callbacks are:
 
 - **`experimental_onStart`**: Called once when the `generateText` operation begins, before any LLM calls. Receives model info, prompt, settings, and `runtimeContext`.
 - **`experimental_onStepStart`**: Called before each step (LLM call). Receives the step number, model, prompt messages being sent, tools, and prior steps.
-- **`experimental_onToolCallStart`**: Called right before a tool's `execute` function runs. Receives the tool name, call ID, and input.
-- **`experimental_onToolCallFinish`**: Called right after a tool's `execute` function completes or errors. Receives the tool name, call ID, input, output (or undefined on error), error (or undefined on success), and `durationMs`.
+- **`experimental_onToolExecutionStart`**: Called right before a tool's `execute` function runs. Receives the tool name, call ID, and input.
+- **`experimental_onToolExecutionEnd`**: Called right after a tool's `execute` function completes or errors. Receives the tool name, call ID, input, output (or undefined on error), error (or undefined on success), and `durationMs`.
 - **`onStepFinish`**: Called after each step finishes. Now also includes `stepNumber` (zero-based index of the completed step).
 
 ## `streamText`
@@ -327,13 +327,13 @@ const result = streamText({
     console.log(`Step ${stepNumber} starting`, { model: model.modelId });
   },
 
-  experimental_onToolCallStart({ toolCall }) {
+  experimental_onToolExecutionStart({ toolCall }) {
     console.log(`Tool call starting: ${toolCall.toolName}`, {
       toolCallId: toolCall.toolCallId,
     });
   },
 
-  experimental_onToolCallFinish({ toolCall, durationMs, success, error }) {
+  experimental_onToolExecutionEnd({ toolCall, durationMs, success, error }) {
     console.log(`Tool call finished: ${toolCall.toolName} (${durationMs}ms)`, {
       success,
     });
@@ -349,8 +349,8 @@ The available lifecycle callbacks are:
 
 - **`experimental_onStart`**: Called once when the `streamText` operation begins, before any LLM calls. Receives model info, prompt, settings, and `runtimeContext`.
 - **`experimental_onStepStart`**: Called before each step (LLM call). Receives the step number, model, messages being sent, tools, and prior steps.
-- **`experimental_onToolCallStart`**: Called right before a tool's `execute` function runs. Receives the tool call object, messages, and the tool-specific context for that call.
-- **`experimental_onToolCallFinish`**: Called right after a tool's `execute` function completes or errors. Receives the tool call object, `durationMs`, and a discriminated union with `success`/`output` or `success`/`error`.
+- **`experimental_onToolExecutionStart`**: Called right before a tool's `execute` function runs. Receives the tool call object, messages, and the tool-specific context for that call.
+- **`experimental_onToolExecutionEnd`**: Called right after a tool's `execute` function completes or errors. Receives the tool call object, `durationMs`, and a discriminated union with `success`/`output` or `success`/`error`.
 - **`onStepFinish`**: Called after each step finishes. Receives the finish reason, usage, and other step details.
 
 ### `fullStream` property

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -367,7 +367,7 @@ const result = await generateText({
 
 ### Tool execution lifecycle callbacks
 
-You can use `experimental_onToolCallStart` and `experimental_onToolCallFinish` to observe tool execution.
+You can use `experimental_onToolExecutionStart` and `experimental_onToolExecutionEnd` to observe tool execution.
 These callbacks are called right before and after each tool's `execute` function, giving you
 visibility into tool execution timing, inputs, outputs, and errors:
 
@@ -376,10 +376,10 @@ import { generateText } from 'ai';
 
 const result = await generateText({
   // ... model, tools, prompt
-  experimental_onToolCallStart({ toolName, toolCallId, input }) {
+  experimental_onToolExecutionStart({ toolName, toolCallId, input }) {
     console.log(`Calling tool: ${toolName}`, { toolCallId, input });
   },
-  experimental_onToolCallFinish({
+  experimental_onToolExecutionEnd({
     toolName,
     toolCallId,
     output,

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -172,7 +172,7 @@ class MyIntegration implements TelemetryIntegration {
     );
   }
 
-  async onToolCallFinish(event) {
+  async onToolExecutionEnd(event) {
     if (event.success) {
       console.log(
         `Tool "${event.toolCall.toolName}" took ${event.durationMs}ms`,
@@ -209,13 +209,13 @@ export function myIntegration(): TelemetryIntegration {
         'Called when a step (LLM call) begins, before the provider is called.',
     },
     {
-      name: 'onToolCallStart',
-      type: '(event: OnToolCallStartEvent) => void | PromiseLike<void>',
+      name: 'onToolExecutionStart',
+      type: '(event: ToolExecutionStartEvent) => void | PromiseLike<void>',
       description: "Called when a tool's execute function is about to run.",
     },
     {
-      name: 'onToolCallFinish',
-      type: '(event: OnToolCallFinishEvent) => void | PromiseLike<void>',
+      name: 'onToolExecutionEnd',
+      type: '(event: ToolExecutionEndEvent) => void | PromiseLike<void>',
       description: "Called when a tool's execute function completes or errors.",
     },
     {

--- a/content/docs/03-ai-sdk-core/65-event-listeners.mdx
+++ b/content/docs/03-ai-sdk-core/65-event-listeners.mdx
@@ -44,13 +44,13 @@ const result = await generateText({
         'Called when a step (LLM call) begins, before the provider is called.',
     },
     {
-      name: 'experimental_onToolCallStart',
-      type: '(event: OnToolCallStartEvent) => void | Promise<void>',
+      name: 'experimental_onToolExecutionStart',
+      type: '(event: ToolExecutionStartEvent) => void | Promise<void>',
       description: "Called when a tool's execute function is about to run.",
     },
     {
-      name: 'experimental_onToolCallFinish',
-      type: '(event: OnToolCallFinishEvent) => void | Promise<void>',
+      name: 'experimental_onToolExecutionEnd',
+      type: '(event: ToolExecutionEndEvent) => void | Promise<void>',
       description: "Called when a tool's execute function completes or errors.",
     },
     {
@@ -379,7 +379,7 @@ const result = await generateText({
   ]}
 />
 
-#### `experimental_onToolCallStart`
+#### `experimental_onToolExecutionStart`
 
 Called before a tool's `execute` function runs.
 
@@ -388,7 +388,7 @@ const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'What is the weather?',
   tools: { getWeather },
-  experimental_onToolCallStart: event => {
+  experimental_onToolExecutionStart: event => {
     console.log('Tool:', event.toolCall.toolName);
     console.log('Input:', event.toolCall.input);
   },
@@ -466,7 +466,7 @@ const result = await generateText({
   ]}
 />
 
-#### `experimental_onToolCallFinish`
+#### `experimental_onToolExecutionEnd`
 
 Called after a tool's `execute` function completes or errors. Uses a discriminated union on the `success` field.
 
@@ -475,7 +475,7 @@ const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'What is the weather?',
   tools: { getWeather },
-  experimental_onToolCallFinish: event => {
+  experimental_onToolExecutionEnd: event => {
     console.log('Tool:', event.toolCall.toolName);
     console.log('Duration:', event.durationMs, 'ms');
 
@@ -1225,10 +1225,10 @@ const result = await generateText({
   model: openai('gpt-4o'),
   prompt: 'What is the weather?',
   tools: { getWeather },
-  experimental_onToolCallStart: event => {
+  experimental_onToolExecutionStart: event => {
     console.log(`Tool "${event.toolCall.toolName}" starting...`);
   },
-  experimental_onToolCallFinish: event => {
+  experimental_onToolExecutionEnd: event => {
     if (event.success) {
       console.log(
         `Tool "${event.toolCall.toolName}" completed in ${event.durationMs}ms`,

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -1182,14 +1182,14 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onToolCallStart',
-      type: '(event: OnToolCallStartEvent) => PromiseLike<void> | void',
+      name: 'experimental_onToolExecutionStart',
+      type: '(event: ToolExecutionStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
         "Callback that is called right before a tool's execute function runs. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).",
       properties: [
         {
-          type: 'OnToolCallStartEvent',
+          type: 'ToolExecutionStartEvent',
           parameters: [
             {
               name: 'stepNumber',
@@ -1237,14 +1237,14 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onToolCallFinish',
-      type: '(event: OnToolCallFinishEvent) => PromiseLike<void> | void',
+      name: 'experimental_onToolExecutionEnd',
+      type: '(event: ToolExecutionEndEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
         "Callback that is called right after a tool's execute function completes (or errors). Uses a discriminated union on the `success` field: when `success: true`, `output` contains the tool result; when `success: false`, `error` contains the error. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).",
       properties: [
         {
-          type: 'OnToolCallFinishEvent',
+          type: 'ToolExecutionEndEvent',
           parameters: [
             {
               name: 'stepNumber',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -2087,14 +2087,14 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onToolCallStart',
-      type: '(event: OnToolCallStartEvent) => PromiseLike<void> | void',
+      name: 'experimental_onToolExecutionStart',
+      type: '(event: ToolExecutionStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
         "Callback that is called right before a tool's execute function runs. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).",
       properties: [
         {
-          type: 'OnToolCallStartEvent',
+          type: 'ToolExecutionStartEvent',
           parameters: [
             {
               name: 'stepNumber',
@@ -2142,14 +2142,14 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onToolCallFinish',
-      type: '(event: OnToolCallFinishEvent) => PromiseLike<void> | void',
+      name: 'experimental_onToolExecutionEnd',
+      type: '(event: ToolExecutionEndEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
         "Callback that is called right after a tool's execute function completes (or errors). Uses a discriminated union on the `success` field: when `success: true`, `output` contains the tool result; when `success: false`, `error` contains the error. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).",
       properties: [
         {
-          type: 'OnToolCallFinishEvent',
+          type: 'ToolExecutionEndEvent',
           parameters: [
             {
               name: 'stepNumber',

--- a/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
@@ -76,11 +76,11 @@ export type AgentCallParameters<CALL_OPTIONS, TOOLS extends ToolSet = {}> = ([
     /**
      * Callback that is called before each tool execution begins.
      */
-    experimental_onToolCallStart?: ToolLoopAgentOnToolCallStartCallback<TOOLS>;
+    experimental_onToolExecutionStart?: ToolLoopAgentonToolExecutionStartCallback<TOOLS>;
     /**
      * Callback that is called after each tool execution completes.
      */
-    experimental_onToolCallFinish?: ToolLoopAgentOnToolCallFinishCallback<TOOLS>;
+    experimental_onToolExecutionEnd?: ToolLoopAgentonToolExecutionEndCallback<TOOLS>;
     /**
      * Callback that is called when each step (LLM call) is finished, including intermediate steps.
      */
@@ -164,8 +164,8 @@ Both `generate()` and `stream()` accept an `AgentCallParameters<CALL_OPTIONS, TO
 - `timeout` (optional): A timeout in milliseconds. Can be specified as a number or as an object with a `totalMs` property. The call will be aborted if it takes longer than the specified timeout. Can be used alongside `abortSignal`.
 - `experimental_onStart` (optional): Callback invoked when the agent operation begins, before any LLM calls. Experimental.
 - `experimental_onStepStart` (optional): Callback invoked when a step (LLM call) begins, before the provider is called. Experimental.
-- `experimental_onToolCallStart` (optional): Callback invoked right before a tool's execute function runs. Experimental.
-- `experimental_onToolCallFinish` (optional): Callback invoked right after a tool's execute function completes or errors. Experimental.
+- `experimental_onToolExecutionStart` (optional): Callback invoked right before a tool's execute function runs. Experimental.
+- `experimental_onToolExecutionEnd` (optional): Callback invoked right after a tool's execute function completes or errors. Experimental.
 - `onStepFinish` (optional): A callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage or logging.
 - `onFinish` (optional): A callback invoked when all steps are finished and the response is complete.
 

--- a/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
@@ -76,11 +76,11 @@ export type AgentCallParameters<CALL_OPTIONS, TOOLS extends ToolSet = {}> = ([
     /**
      * Callback that is called before each tool execution begins.
      */
-    experimental_onToolExecutionStart?: ToolLoopAgentonToolExecutionStartCallback<TOOLS>;
+    experimental_onToolExecutionStart?: OnToolExecutionStartCallback<TOOLS>;
     /**
      * Callback that is called after each tool execution completes.
      */
-    experimental_onToolExecutionEnd?: ToolLoopAgentonToolExecutionEndCallback<TOOLS>;
+    experimental_onToolExecutionEnd?: OnToolExecutionEndCallback<TOOLS>;
     /**
      * Callback that is called when each step (LLM call) is finished, including intermediate steps.
      */

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -376,7 +376,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
     },
     {
       name: 'experimental_onToolExecutionStart',
-      type: 'ToolLoopAgentonToolExecutionStartCallback',
+      type: 'OnToolExecutionStartCallback',
       isOptional: true,
       description:
         "Callback that is called right before a tool's execute function runs. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first). Experimental (can break in patch releases).",
@@ -431,7 +431,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
     },
     {
       name: 'experimental_onToolExecutionEnd',
-      type: 'ToolLoopAgentonToolExecutionEndCallback',
+      type: 'OnToolExecutionEndCallback',
       isOptional: true,
       description:
         "Callback that is called right after a tool's execute function completes (or errors). Uses a discriminated union on the `success` field: when `success: true`, `output` contains the tool result; when `success: false`, `error` contains the error. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first). Experimental (can break in patch releases).",
@@ -719,14 +719,14 @@ const result = await agent.generate({
     },
     {
       name: 'experimental_onToolExecutionStart',
-      type: 'ToolLoopAgentonToolExecutionStartCallback',
+      type: 'OnToolExecutionStartCallback',
       isOptional: true,
       description:
         "Callback that is called right before a tool's execute function runs. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",
     },
     {
       name: 'experimental_onToolExecutionEnd',
-      type: 'ToolLoopAgentonToolExecutionEndCallback',
+      type: 'OnToolExecutionEndCallback',
       isOptional: true,
       description:
         "Callback that is called right after a tool's execute function completes (or errors). If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",
@@ -822,14 +822,14 @@ for await (const chunk of stream.textStream) {
     },
     {
       name: 'experimental_onToolExecutionStart',
-      type: 'ToolLoopAgentonToolExecutionStartCallback',
+      type: 'OnToolExecutionStartCallback',
       isOptional: true,
       description:
         "Callback that is called right before a tool's execute function runs. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",
     },
     {
       name: 'experimental_onToolExecutionEnd',
-      type: 'ToolLoopAgentonToolExecutionEndCallback',
+      type: 'OnToolExecutionEndCallback',
       isOptional: true,
       description:
         "Callback that is called right after a tool's execute function completes (or errors). If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -375,14 +375,14 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onToolCallStart',
-      type: 'ToolLoopAgentOnToolCallStartCallback',
+      name: 'experimental_onToolExecutionStart',
+      type: 'ToolLoopAgentonToolExecutionStartCallback',
       isOptional: true,
       description:
         "Callback that is called right before a tool's execute function runs. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first). Experimental (can break in patch releases).",
       properties: [
         {
-          type: 'OnToolCallStartEvent',
+          type: 'ToolExecutionStartEvent',
           parameters: [
             {
               name: 'stepNumber',
@@ -430,14 +430,14 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onToolCallFinish',
-      type: 'ToolLoopAgentOnToolCallFinishCallback',
+      name: 'experimental_onToolExecutionEnd',
+      type: 'ToolLoopAgentonToolExecutionEndCallback',
       isOptional: true,
       description:
         "Callback that is called right after a tool's execute function completes (or errors). Uses a discriminated union on the `success` field: when `success: true`, `output` contains the tool result; when `success: false`, `error` contains the error. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first). Experimental (can break in patch releases).",
       properties: [
         {
-          type: 'OnToolCallFinishEvent',
+          type: 'ToolExecutionEndEvent',
           parameters: [
             {
               name: 'stepNumber',
@@ -718,15 +718,15 @@ const result = await agent.generate({
         'Callback that is called when a step (LLM call) begins, before the provider is called. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).',
     },
     {
-      name: 'experimental_onToolCallStart',
-      type: 'ToolLoopAgentOnToolCallStartCallback',
+      name: 'experimental_onToolExecutionStart',
+      type: 'ToolLoopAgentonToolExecutionStartCallback',
       isOptional: true,
       description:
         "Callback that is called right before a tool's execute function runs. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",
     },
     {
-      name: 'experimental_onToolCallFinish',
-      type: 'ToolLoopAgentOnToolCallFinishCallback',
+      name: 'experimental_onToolExecutionEnd',
+      type: 'ToolLoopAgentonToolExecutionEndCallback',
       isOptional: true,
       description:
         "Callback that is called right after a tool's execute function completes (or errors). If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",
@@ -821,15 +821,15 @@ for await (const chunk of stream.textStream) {
         'Callback that is called when a step (LLM call) begins, before the provider is called. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).',
     },
     {
-      name: 'experimental_onToolCallStart',
-      type: 'ToolLoopAgentOnToolCallStartCallback',
+      name: 'experimental_onToolExecutionStart',
+      type: 'ToolLoopAgentonToolExecutionStartCallback',
       isOptional: true,
       description:
         "Callback that is called right before a tool's execute function runs. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",
     },
     {
-      name: 'experimental_onToolCallFinish',
-      type: 'ToolLoopAgentOnToolCallFinishCallback',
+      name: 'experimental_onToolExecutionEnd',
+      type: 'ToolLoopAgentonToolExecutionEndCallback',
       isOptional: true,
       description:
         "Callback that is called right after a tool's execute function completes (or errors). If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).",

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -201,14 +201,14 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onToolCallStart',
-      type: 'WorkflowAgentOnToolCallStartCallback',
+      name: 'experimental_onToolExecutionStart',
+      type: 'WorkflowAgentonToolExecutionStartCallback',
       isOptional: true,
       description:
         "Callback called right before a tool's execute function runs. If also specified in `stream()`, both callbacks fire (constructor first). Experimental (can break in patch releases).",
       properties: [
         {
-          type: 'OnToolCallStartEvent',
+          type: 'ToolExecutionStartEvent',
           parameters: [
             {
               name: 'toolCall',
@@ -225,14 +225,14 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_onToolCallFinish',
-      type: 'WorkflowAgentOnToolCallFinishCallback',
+      name: 'experimental_onToolExecutionEnd',
+      type: 'WorkflowAgentonToolExecutionEndCallback',
       isOptional: true,
       description:
         "Callback called right after a tool's execute function completes or errors. Uses a discriminated union: check `success` to determine whether `output` or `error` is available. If also specified in `stream()`, both callbacks fire (constructor first). Experimental (can break in patch releases).",
       properties: [
         {
-          type: 'OnToolCallFinishEvent',
+          type: 'ToolExecutionEndEvent',
           parameters: [
             {
               name: 'toolCall',
@@ -506,18 +506,18 @@ const result = await agent.stream({
         'Per-call onStepStart callback. If also specified in the constructor, both fire (constructor first). Experimental.',
     },
     {
-      name: 'experimental_onToolCallStart',
-      type: 'WorkflowAgentOnToolCallStartCallback',
+      name: 'experimental_onToolExecutionStart',
+      type: 'WorkflowAgentonToolExecutionStartCallback',
       isOptional: true,
       description:
-        'Per-call onToolCallStart callback. If also specified in the constructor, both fire (constructor first). Experimental.',
+        'Per-call onToolExecutionStart callback. If also specified in the constructor, both fire (constructor first). Experimental.',
     },
     {
-      name: 'experimental_onToolCallFinish',
-      type: 'WorkflowAgentOnToolCallFinishCallback',
+      name: 'experimental_onToolExecutionEnd',
+      type: 'WorkflowAgentonToolExecutionEndCallback',
       isOptional: true,
       description:
-        'Per-call onToolCallFinish callback. If also specified in the constructor, both fire (constructor first). Experimental.',
+        'Per-call onToolExecutionEnd callback. If also specified in the constructor, both fire (constructor first). Experimental.',
     },
     {
       name: 'onStepFinish',

--- a/examples/ai-functions/src/generate-text/openai/listen-to-events.ts
+++ b/examples/ai-functions/src/generate-text/openai/listen-to-events.ts
@@ -31,13 +31,13 @@ async function main() {
       console.log('Step:', event.stepNumber);
       console.log('Message count:', event.messages.length);
     },
-    experimental_onToolCallStart: event => {
-      console.log('\n--- onToolCallStart ---');
+    experimental_onToolExecutionStart: event => {
+      console.log('\n--- onToolExecutionStart ---');
       console.log('Tool:', event.toolCall.toolName);
       console.log('Input:', JSON.stringify(event.toolCall.input));
     },
-    experimental_onToolCallFinish: event => {
-      console.log('\n--- onToolCallFinish ---');
+    experimental_onToolExecutionEnd: event => {
+      console.log('\n--- onToolExecutionEnd ---');
       console.log('Tool:', event.toolCall.toolName);
       console.log('Duration:', event.durationMs, 'ms');
       console.log('Success:', event.success);

--- a/examples/ai-functions/src/telemetry/generate-text-tool-call.ts
+++ b/examples/ai-functions/src/telemetry/generate-text-tool-call.ts
@@ -1,15 +1,12 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, tool, registerTelemetryIntegration } from 'ai';
-import {
-  OpenTelemetryIntegration,
-  GenAIOpenTelemetryIntegration,
-} from '@ai-sdk/otel';
+import { GenAIOpenTelemetryIntegration } from '@ai-sdk/otel';
+import { generateText, registerTelemetryIntegration, tool } from 'ai';
 import { z } from 'zod';
 import { weatherTool } from '../tools/weather-tool';
 
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node';
-import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { run } from '../lib/run';
 
 const sdk = new NodeSDK({

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -1,18 +1,19 @@
-import type { Arrayable } from '@ai-sdk/provider-utils';
+import type { Arrayable, Context, ToolSet } from '@ai-sdk/provider-utils';
 import { ModelMessage } from '@ai-sdk/provider-utils';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
 import { Output } from '../generate-text/output';
 import { StreamTextTransform } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';
-import type { Context, ToolSet } from '@ai-sdk/provider-utils';
+import {
+  OnToolExecutionEndCallback,
+  OnToolExecutionStartCallback,
+} from '../generate-text/tool-execution-events';
 import { TimeoutConfiguration } from '../prompt/request-options';
 import type {
   ToolLoopAgentOnFinishCallback,
   ToolLoopAgentOnStartCallback,
   ToolLoopAgentOnStepFinishCallback,
   ToolLoopAgentOnStepStartCallback,
-  ToolLoopAgentOnToolCallFinishCallback,
-  ToolLoopAgentOnToolCallStartCallback,
 } from './tool-loop-agent-settings';
 
 /**
@@ -83,12 +84,12 @@ export type AgentCallParameters<
     /**
      * Callback that is called before each tool execution begins.
      */
-    experimental_onToolCallStart?: ToolLoopAgentOnToolCallStartCallback<TOOLS>;
+    experimental_onToolExecutionStart?: OnToolExecutionStartCallback<TOOLS>;
 
     /**
      * Callback that is called after each tool execution completes.
      */
-    experimental_onToolCallFinish?: ToolLoopAgentOnToolCallFinishCallback<TOOLS>;
+    experimental_onToolExecutionEnd?: OnToolExecutionEndCallback<TOOLS>;
 
     /**
      * Callback that is called when each step (LLM call) is finished, including intermediate steps.

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -8,8 +8,6 @@ export {
   type ToolLoopAgentOnStartCallback,
   type ToolLoopAgentOnStepFinishCallback,
   type ToolLoopAgentOnStepStartCallback,
-  type ToolLoopAgentOnToolCallFinishCallback,
-  type ToolLoopAgentOnToolCallStartCallback,
   type ToolLoopAgentSettings,
 
   /**

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -1,6 +1,7 @@
 import type {
   Arrayable,
   Context,
+  IdGenerator,
   InferToolSetContext,
   ToolSet,
 } from '@ai-sdk/provider-utils';
@@ -200,6 +201,14 @@ export type ToolLoopAgentSettings<
     experimental_download?: DownloadFunction | undefined;
 
     /**
+     * Internal. For test use only. May change without notice.
+     */
+    _internal?: {
+      generateId?: IdGenerator;
+      generateCallId?: IdGenerator;
+    };
+
+    /**
      * The schema for the call options.
      */
     callOptionsSchema?: FlexibleSchema<CALL_OPTIONS>;
@@ -244,6 +253,7 @@ export type ToolLoopAgentSettings<
           | 'providerOptions'
           | 'experimental_download'
           | 'runtimeContext'
+          | '_internal'
         > & { toolsContext: InferToolSetContext<TOOLS> },
     ) => MaybePromiseLike<
       Pick<
@@ -272,6 +282,7 @@ export type ToolLoopAgentSettings<
         | 'providerOptions'
         | 'experimental_download'
         | 'runtimeContext'
+        | '_internal'
       > &
         Omit<Prompt, 'system'> & {
           toolsContext: InferToolSetContext<TOOLS>;

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -15,8 +15,6 @@ import type {
   OnStartEvent,
   OnStepFinishEvent,
   OnStepStartEvent,
-  OnToolCallFinishEvent,
-  OnToolCallStartEvent,
 } from '../generate-text/core-events';
 import { Output } from '../generate-text/output';
 import { PrepareStepFunction } from '../generate-text/prepare-step';
@@ -32,6 +30,10 @@ import { LanguageModel, ToolChoice } from '../types/language-model';
 import type { Callback } from '../util/callback';
 import { DownloadFunction } from '../util/download/download-function';
 import { AgentCallParameters } from './agent';
+import {
+  OnToolExecutionEndCallback,
+  OnToolExecutionStartCallback,
+} from '../generate-text/tool-execution-events';
 
 export type ToolLoopAgentOnStartCallback<
   TOOLS extends ToolSet = ToolSet,
@@ -44,14 +46,6 @@ export type ToolLoopAgentOnStepStartCallback<
   RUNTIME_CONTEXT extends Context = Context,
   OUTPUT extends Output = Output,
 > = Callback<OnStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
-
-export type ToolLoopAgentOnToolCallStartCallback<
-  TOOLS extends ToolSet = ToolSet,
-> = Callback<OnToolCallStartEvent<TOOLS>>;
-
-export type ToolLoopAgentOnToolCallFinishCallback<
-  TOOLS extends ToolSet = ToolSet,
-> = Callback<OnToolCallFinishEvent<TOOLS>>;
 
 export type ToolLoopAgentOnStepFinishCallback<
   TOOLS extends ToolSet = ToolSet,
@@ -164,14 +158,14 @@ export type ToolLoopAgentSettings<
     /**
      * Callback that is called before each tool execution begins.
      */
-    experimental_onToolCallStart?: ToolLoopAgentOnToolCallStartCallback<
+    experimental_onToolExecutionStart?: OnToolExecutionStartCallback<
       NoInfer<TOOLS>
     >;
 
     /**
      * Callback that is called after each tool execution completes.
      */
-    experimental_onToolCallFinish?: ToolLoopAgentOnToolCallFinishCallback<
+    experimental_onToolExecutionEnd?: OnToolExecutionEndCallback<
       NoInfer<TOOLS>
     >;
 

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -1947,15 +1947,29 @@ describe('ToolLoopAgent', () => {
 
         expect(event).toMatchInlineSnapshot(`
           {
-            "messagesLength": 1,
+            "callId": "call-1Dlj9xQ95LFvIezCKgG8sYYd",
+            "context": undefined,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "test",
+                "role": "user",
+              },
+            ],
             "modelId": "mock-model-id",
             "provider": "mock-provider",
             "stepNumber": 0,
-            "toolCallId": "call-1",
-            "toolCallInput": {
-              "value": "test",
+            "toolCall": {
+              "input": {
+                "value": "test",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "testTool",
+              "type": "tool-call",
             },
-            "toolCallName": "testTool",
           }
         `);
       });
@@ -2146,12 +2160,29 @@ describe('ToolLoopAgent', () => {
 
         expect(event).toMatchInlineSnapshot(`
           {
-            "messagesLength": 1,
-            "toolCallId": "call-1",
-            "toolCallInput": {
-              "value": "test",
+            "callId": "call-ElMGF84aHPF7sEA1MCdQspRH",
+            "context": undefined,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "test",
+                "role": "user",
+              },
+            ],
+            "modelId": "mock-model-id",
+            "provider": "mock-provider",
+            "stepNumber": 0,
+            "toolCall": {
+              "input": {
+                "value": "test",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "testTool",
+              "type": "tool-call",
             },
-            "toolCallName": "testTool",
           }
         `);
       });
@@ -2349,17 +2380,32 @@ describe('ToolLoopAgent', () => {
 
         expect(event).toMatchInlineSnapshot(`
           {
-            "messagesLength": 1,
+            "callId": "call-hyZ1s2879wfp2vBJsziBnpVm",
+            "context": undefined,
+            "durationMs": 0.009417000000041753,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "test",
+                "role": "user",
+              },
+            ],
             "modelId": "mock-model-id",
             "output": "hello-result",
             "provider": "mock-provider",
             "stepNumber": 0,
             "success": true,
-            "toolCallId": "call-1",
-            "toolCallInput": {
-              "value": "hello",
+            "toolCall": {
+              "input": {
+                "value": "hello",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "testTool",
+              "type": "tool-call",
             },
-            "toolCallName": "testTool",
           }
         `);
       });
@@ -2550,14 +2596,32 @@ describe('ToolLoopAgent', () => {
 
         expect(event).toMatchInlineSnapshot(`
           {
-            "messagesLength": 1,
+            "callId": "call-sqdyzfDyXWHGPU3hW9nRw3Fd",
+            "context": undefined,
+            "durationMs": 0.020040999999991982,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "test",
+                "role": "user",
+              },
+            ],
+            "modelId": "mock-model-id",
             "output": "hello-result",
+            "provider": "mock-provider",
+            "stepNumber": 0,
             "success": true,
-            "toolCallId": "call-1",
-            "toolCallInput": {
-              "value": "hello",
+            "toolCall": {
+              "input": {
+                "value": "hello",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "testTool",
+              "type": "tool-call",
             },
-            "toolCallName": "testTool",
           }
         `);
       });

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -1,6 +1,9 @@
 import { LanguageModelV4CallOptions } from '@ai-sdk/provider';
 import { tool } from '@ai-sdk/provider-utils';
-import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
+import {
+  convertArrayToReadableStream,
+  mockId,
+} from '@ai-sdk/provider-utils/test';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
@@ -15,7 +18,26 @@ import {
   ToolExecutionStartEvent,
 } from '../generate-text/tool-execution-events';
 
+// mock now function
+vi.mock('../util/now', () => ({
+  now: vi.fn(),
+}));
+import { now } from '../util/now';
+const mockNow = vi.mocked(now);
+
+const testSettings = {
+  _internal: {
+    generateId: mockId({ prefix: 'id' }),
+    generateCallId: mockId({ prefix: 'call' }),
+  },
+};
+
 describe('ToolLoopAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNow.mockReturnValue(0);
+  });
+
   describe('generate', () => {
     let doGenerateOptions: LanguageModelV4CallOptions | undefined;
     let mockModel: MockLanguageModelV4;
@@ -1936,6 +1958,7 @@ describe('ToolLoopAgent', () => {
                 `${value}-result`,
             }),
           },
+          ...testSettings,
         });
 
         await agent.generate({
@@ -1947,7 +1970,7 @@ describe('ToolLoopAgent', () => {
 
         expect(event).toMatchInlineSnapshot(`
           {
-            "callId": "call-yukj14m2O83KLVL68mxSKc8R",
+            "callId": "call-0",
             "context": undefined,
             "functionId": undefined,
             "messages": [
@@ -2147,6 +2170,7 @@ describe('ToolLoopAgent', () => {
                 `${value}-result`,
             }),
           },
+          ...testSettings,
         });
 
         const result = await agent.stream({
@@ -2160,7 +2184,7 @@ describe('ToolLoopAgent', () => {
 
         expect(event).toMatchInlineSnapshot(`
           {
-            "callId": "call-FeWmyBghKgZuSFB0erSrB2pe",
+            "callId": "call-1",
             "context": undefined,
             "functionId": undefined,
             "messages": [
@@ -2369,6 +2393,7 @@ describe('ToolLoopAgent', () => {
                 `${value}-result`,
             }),
           },
+          ...testSettings,
         });
 
         await agent.generate({
@@ -2380,9 +2405,9 @@ describe('ToolLoopAgent', () => {
 
         expect(event).toMatchInlineSnapshot(`
           {
-            "callId": "call-EHTFr7YZnap0EO9iZcjdRJyf",
+            "callId": "call-2",
             "context": undefined,
-            "durationMs": 0.008541999999977179,
+            "durationMs": 0,
             "functionId": undefined,
             "messages": [
               {
@@ -2583,6 +2608,7 @@ describe('ToolLoopAgent', () => {
                 `${value}-result`,
             }),
           },
+          ...testSettings,
         });
 
         const result = await agent.stream({
@@ -2596,9 +2622,9 @@ describe('ToolLoopAgent', () => {
 
         expect(event).toMatchInlineSnapshot(`
           {
-            "callId": "call-ErPhfs41PL269KvTUNXbqeKD",
+            "callId": "call-3",
             "context": undefined,
-            "durationMs": 0.014791999999999916,
+            "durationMs": 0,
             "functionId": undefined,
             "messages": [
               {

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -1787,7 +1787,7 @@ describe('ToolLoopAgent', () => {
     });
   });
 
-  describe('experimental_onToolCallStart', () => {
+  describe('experimental_onToolExecutionStart', () => {
     describe('generate', () => {
       const dummyResponseValues = {
         usage: {
@@ -1838,7 +1838,7 @@ describe('ToolLoopAgent', () => {
         });
       }
 
-      it('should call experimental_onToolCallStart from constructor', async () => {
+      it('should call experimental_onToolExecutionStart from constructor', async () => {
         const calls: string[] = [];
 
         const agent = new ToolLoopAgent({
@@ -1864,7 +1864,7 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
-      it('should call experimental_onToolCallStart from generate method', async () => {
+      it('should call experimental_onToolExecutionStart from generate method', async () => {
         const calls: string[] = [];
 
         const agent = new ToolLoopAgent({
@@ -2030,7 +2030,7 @@ describe('ToolLoopAgent', () => {
         });
       }
 
-      it('should call experimental_onToolCallStart from constructor', async () => {
+      it('should call experimental_onToolExecutionStart from constructor', async () => {
         const calls: string[] = [];
 
         const agent = new ToolLoopAgent({
@@ -2057,7 +2057,7 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
-      it('should call experimental_onToolCallStart from stream method', async () => {
+      it('should call experimental_onToolExecutionStart from stream method', async () => {
         const calls: string[] = [];
 
         const agent = new ToolLoopAgent({
@@ -2158,7 +2158,7 @@ describe('ToolLoopAgent', () => {
     });
   });
 
-  describe('experimental_onToolCallFinish', () => {
+  describe('experimental_onToolExecutionEnd', () => {
     describe('generate', () => {
       const dummyResponseValues = {
         usage: {
@@ -2240,7 +2240,7 @@ describe('ToolLoopAgent', () => {
         });
       }
 
-      it('should call experimental_onToolCallFinish from constructor', async () => {
+      it('should call experimental_onToolExecutionEnd from constructor', async () => {
         const calls: string[] = [];
 
         const agent = new ToolLoopAgent({
@@ -2266,7 +2266,7 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
-      it('should call experimental_onToolCallFinish from generate method', async () => {
+      it('should call experimental_onToolExecutionEnd from generate method', async () => {
         const calls: string[] = [];
 
         const agent = new ToolLoopAgent({
@@ -2434,7 +2434,7 @@ describe('ToolLoopAgent', () => {
         });
       }
 
-      it('should call experimental_onToolCallFinish from constructor', async () => {
+      it('should call experimental_onToolExecutionEnd from constructor', async () => {
         const calls: string[] = [];
 
         const agent = new ToolLoopAgent({
@@ -2461,7 +2461,7 @@ describe('ToolLoopAgent', () => {
         `);
       });
 
-      it('should call experimental_onToolCallFinish from stream method', async () => {
+      it('should call experimental_onToolExecutionEnd from stream method', async () => {
         const calls: string[] = [];
 
         const agent = new ToolLoopAgent({

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -1947,7 +1947,7 @@ describe('ToolLoopAgent', () => {
 
         expect(event).toMatchInlineSnapshot(`
           {
-            "callId": "call-1Dlj9xQ95LFvIezCKgG8sYYd",
+            "callId": "call-yukj14m2O83KLVL68mxSKc8R",
             "context": undefined,
             "functionId": undefined,
             "messages": [
@@ -2160,7 +2160,7 @@ describe('ToolLoopAgent', () => {
 
         expect(event).toMatchInlineSnapshot(`
           {
-            "callId": "call-ElMGF84aHPF7sEA1MCdQspRH",
+            "callId": "call-FeWmyBghKgZuSFB0erSrB2pe",
             "context": undefined,
             "functionId": undefined,
             "messages": [
@@ -2380,9 +2380,9 @@ describe('ToolLoopAgent', () => {
 
         expect(event).toMatchInlineSnapshot(`
           {
-            "callId": "call-hyZ1s2879wfp2vBJsziBnpVm",
+            "callId": "call-EHTFr7YZnap0EO9iZcjdRJyf",
             "context": undefined,
-            "durationMs": 0.009417000000041753,
+            "durationMs": 0.008541999999977179,
             "functionId": undefined,
             "messages": [
               {
@@ -2596,9 +2596,9 @@ describe('ToolLoopAgent', () => {
 
         expect(event).toMatchInlineSnapshot(`
           {
-            "callId": "call-sqdyzfDyXWHGPU3hW9nRw3Fd",
+            "callId": "call-ErPhfs41PL269KvTUNXbqeKD",
             "context": undefined,
-            "durationMs": 0.020040999999991982,
+            "durationMs": 0.014791999999999916,
             "functionId": undefined,
             "messages": [
               {

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -9,9 +9,11 @@ import type {
   ToolLoopAgentOnFinishCallback,
   ToolLoopAgentOnStartCallback,
   ToolLoopAgentOnStepStartCallback,
-  ToolLoopAgentOnToolCallFinishCallback,
-  ToolLoopAgentOnToolCallStartCallback,
 } from './tool-loop-agent-settings';
+import {
+  ToolExecutionEndEvent,
+  ToolExecutionStartEvent,
+} from '../generate-text/tool-execution-events';
 
 describe('ToolLoopAgent', () => {
   describe('generate', () => {
@@ -1848,7 +1850,7 @@ describe('ToolLoopAgent', () => {
                 `${value}-result`,
             }),
           },
-          experimental_onToolCallStart: async () => {
+          experimental_onToolExecutionStart: async () => {
             calls.push('constructor');
           },
         });
@@ -1878,7 +1880,7 @@ describe('ToolLoopAgent', () => {
 
         await agent.generate({
           prompt: 'test',
-          experimental_onToolCallStart: async () => {
+          experimental_onToolExecutionStart: async () => {
             calls.push('method');
           },
         });
@@ -1902,14 +1904,14 @@ describe('ToolLoopAgent', () => {
                 `${value}-result`,
             }),
           },
-          experimental_onToolCallStart: async () => {
+          experimental_onToolExecutionStart: async () => {
             calls.push('constructor');
           },
         });
 
         await agent.generate({
           prompt: 'test',
-          experimental_onToolCallStart: async () => {
+          experimental_onToolExecutionStart: async () => {
             calls.push('method');
           },
         });
@@ -1923,7 +1925,7 @@ describe('ToolLoopAgent', () => {
       });
 
       it('should pass correct event information', async () => {
-        let event!: Parameters<ToolLoopAgentOnToolCallStartCallback<any>>[0];
+        let event!: ToolExecutionStartEvent<any>;
 
         const agent = new ToolLoopAgent({
           model: createToolCallMockModel(),
@@ -1938,20 +1940,12 @@ describe('ToolLoopAgent', () => {
 
         await agent.generate({
           prompt: 'test',
-          experimental_onToolCallStart: async e => {
+          experimental_onToolExecutionStart: async e => {
             event = e;
           },
         });
 
-        expect({
-          stepNumber: event.stepNumber,
-          provider: event.provider,
-          modelId: event.modelId,
-          toolCallName: event.toolCall.toolName,
-          toolCallId: event.toolCall.toolCallId,
-          toolCallInput: event.toolCall.input,
-          messagesLength: event.messages.length,
-        }).toMatchInlineSnapshot(`
+        expect(event).toMatchInlineSnapshot(`
           {
             "messagesLength": 1,
             "modelId": "mock-model-id",
@@ -2048,7 +2042,7 @@ describe('ToolLoopAgent', () => {
                 `${value}-result`,
             }),
           },
-          experimental_onToolCallStart: async () => {
+          experimental_onToolExecutionStart: async () => {
             calls.push('constructor');
           },
         });
@@ -2079,7 +2073,7 @@ describe('ToolLoopAgent', () => {
 
         const result = await agent.stream({
           prompt: 'test',
-          experimental_onToolCallStart: async () => {
+          experimental_onToolExecutionStart: async () => {
             calls.push('method');
           },
         });
@@ -2105,14 +2099,14 @@ describe('ToolLoopAgent', () => {
                 `${value}-result`,
             }),
           },
-          experimental_onToolCallStart: async () => {
+          experimental_onToolExecutionStart: async () => {
             calls.push('constructor');
           },
         });
 
         const result = await agent.stream({
           prompt: 'test',
-          experimental_onToolCallStart: async () => {
+          experimental_onToolExecutionStart: async () => {
             calls.push('method');
           },
         });
@@ -2128,7 +2122,7 @@ describe('ToolLoopAgent', () => {
       });
 
       it('should pass correct event information', async () => {
-        let event!: Parameters<ToolLoopAgentOnToolCallStartCallback<any>>[0];
+        let event!: ToolExecutionStartEvent<any>;
 
         const agent = new ToolLoopAgent({
           model: createToolCallStreamMockModel(),
@@ -2143,19 +2137,14 @@ describe('ToolLoopAgent', () => {
 
         const result = await agent.stream({
           prompt: 'test',
-          experimental_onToolCallStart: async e => {
+          experimental_onToolExecutionStart: async e => {
             event = e;
           },
         });
 
         await result.consumeStream();
 
-        expect({
-          toolCallName: event.toolCall.toolName,
-          toolCallId: event.toolCall.toolCallId,
-          toolCallInput: event.toolCall.input,
-          messagesLength: event.messages.length,
-        }).toMatchInlineSnapshot(`
+        expect(event).toMatchInlineSnapshot(`
           {
             "messagesLength": 1,
             "toolCallId": "call-1",
@@ -2263,7 +2252,7 @@ describe('ToolLoopAgent', () => {
                 `${value}-result`,
             }),
           },
-          experimental_onToolCallFinish: async () => {
+          experimental_onToolExecutionEnd: async () => {
             calls.push('constructor');
           },
         });
@@ -2293,7 +2282,7 @@ describe('ToolLoopAgent', () => {
 
         await agent.generate({
           prompt: 'test',
-          experimental_onToolCallFinish: async () => {
+          experimental_onToolExecutionEnd: async () => {
             calls.push('method');
           },
         });
@@ -2317,14 +2306,14 @@ describe('ToolLoopAgent', () => {
                 `${value}-result`,
             }),
           },
-          experimental_onToolCallFinish: async () => {
+          experimental_onToolExecutionEnd: async () => {
             calls.push('constructor');
           },
         });
 
         await agent.generate({
           prompt: 'test',
-          experimental_onToolCallFinish: async () => {
+          experimental_onToolExecutionEnd: async () => {
             calls.push('method');
           },
         });
@@ -2338,7 +2327,7 @@ describe('ToolLoopAgent', () => {
       });
 
       it('should pass correct event information on success', async () => {
-        let event!: Parameters<ToolLoopAgentOnToolCallFinishCallback>[0];
+        let event!: ToolExecutionEndEvent<any>;
 
         const agent = new ToolLoopAgent({
           model: createToolCallMockModelWithInput('{ "value": "hello" }'),
@@ -2353,23 +2342,12 @@ describe('ToolLoopAgent', () => {
 
         await agent.generate({
           prompt: 'test',
-          experimental_onToolCallFinish: async e => {
+          experimental_onToolExecutionEnd: async e => {
             event = e;
           },
         });
 
-        expect(event.durationMs).toBeGreaterThanOrEqual(0);
-        expect({
-          stepNumber: event.stepNumber,
-          provider: event.provider,
-          modelId: event.modelId,
-          toolCallName: event.toolCall.toolName,
-          toolCallId: event.toolCall.toolCallId,
-          toolCallInput: event.toolCall.input,
-          success: event.success,
-          output: event.success ? event.output : undefined,
-          messagesLength: event.messages.length,
-        }).toMatchInlineSnapshot(`
+        expect(event).toMatchInlineSnapshot(`
           {
             "messagesLength": 1,
             "modelId": "mock-model-id",
@@ -2468,7 +2446,7 @@ describe('ToolLoopAgent', () => {
                 `${value}-result`,
             }),
           },
-          experimental_onToolCallFinish: async () => {
+          experimental_onToolExecutionEnd: async () => {
             calls.push('constructor');
           },
         });
@@ -2499,7 +2477,7 @@ describe('ToolLoopAgent', () => {
 
         const result = await agent.stream({
           prompt: 'test',
-          experimental_onToolCallFinish: async () => {
+          experimental_onToolExecutionEnd: async () => {
             calls.push('method');
           },
         });
@@ -2525,14 +2503,14 @@ describe('ToolLoopAgent', () => {
                 `${value}-result`,
             }),
           },
-          experimental_onToolCallFinish: async () => {
+          experimental_onToolExecutionEnd: async () => {
             calls.push('constructor');
           },
         });
 
         const result = await agent.stream({
           prompt: 'test',
-          experimental_onToolCallFinish: async () => {
+          experimental_onToolExecutionEnd: async () => {
             calls.push('method');
           },
         });
@@ -2548,7 +2526,7 @@ describe('ToolLoopAgent', () => {
       });
 
       it('should pass correct event information on success', async () => {
-        let event!: Parameters<ToolLoopAgentOnToolCallFinishCallback>[0];
+        let event!: ToolExecutionEndEvent<any>;
 
         const agent = new ToolLoopAgent({
           model: createToolCallStreamMockModel(),
@@ -2563,22 +2541,14 @@ describe('ToolLoopAgent', () => {
 
         const result = await agent.stream({
           prompt: 'test',
-          experimental_onToolCallFinish: async e => {
+          experimental_onToolExecutionEnd: async e => {
             event = e;
           },
         });
 
         await result.consumeStream();
 
-        expect(event.durationMs).toBeGreaterThanOrEqual(0);
-        expect({
-          toolCallName: event.toolCall.toolName,
-          toolCallId: event.toolCall.toolCallId,
-          toolCallInput: event.toolCall.input,
-          success: event.success,
-          output: event.success ? event.output : undefined,
-          messagesLength: event.messages.length,
-        }).toMatchInlineSnapshot(`
+        expect(event).toMatchInlineSnapshot(`
           {
             "messagesLength": 1,
             "output": "hello-result",
@@ -2950,11 +2920,11 @@ describe('ToolLoopAgent', () => {
               onStepStart: async () => {
                 events.push('onStepStart');
               },
-              onToolCallStart: async () => {
-                events.push('onToolCallStart');
+              onToolExecutionStart: async () => {
+                events.push('onToolExecutionStart');
               },
-              onToolCallFinish: async () => {
-                events.push('onToolCallFinish');
+              onToolExecutionEnd: async () => {
+                events.push('onToolExecutionEnd');
               },
               onStepFinish: async () => {
                 events.push('onStepFinish');
@@ -2971,8 +2941,8 @@ describe('ToolLoopAgent', () => {
         expect(events).toEqual([
           'onStart',
           'onStepStart',
-          'onToolCallStart',
-          'onToolCallFinish',
+          'onToolExecutionStart',
+          'onToolExecutionEnd',
           'onStepFinish',
           'onStepStart',
           'onStepFinish',
@@ -3182,11 +3152,11 @@ describe('ToolLoopAgent', () => {
               onStepStart: async () => {
                 events.push('onStepStart');
               },
-              onToolCallStart: async () => {
-                events.push('onToolCallStart');
+              onToolExecutionStart: async () => {
+                events.push('onToolExecutionStart');
               },
-              onToolCallFinish: async () => {
-                events.push('onToolCallFinish');
+              onToolExecutionEnd: async () => {
+                events.push('onToolExecutionEnd');
               },
               onStepFinish: async () => {
                 events.push('onStepFinish');
@@ -3204,8 +3174,8 @@ describe('ToolLoopAgent', () => {
         expect(events).toEqual([
           'onStart',
           'onStepStart',
-          'onToolCallStart',
-          'onToolCallFinish',
+          'onToolExecutionStart',
+          'onToolExecutionEnd',
           'onStepFinish',
           'onStepStart',
           'onStepFinish',

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -76,8 +76,8 @@ export class ToolLoopAgent<
       | 'instructions'
       | 'experimental_onStart'
       | 'experimental_onStepStart'
-      | 'experimental_onToolCallStart'
-      | 'experimental_onToolCallFinish'
+      | 'experimental_onToolExecutionStart'
+      | 'experimental_onToolExecutionEnd'
       | 'onStepFinish'
       | 'onFinish'
     > &

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -86,8 +86,8 @@ export class ToolLoopAgent<
     const {
       experimental_onStart: _settingsOnStart,
       experimental_onStepStart: _settingsOnStepStart,
-      experimental_onToolCallStart: _settingsOnToolCallStart,
-      experimental_onToolCallFinish: _settingsOnToolCallFinish,
+      experimental_onToolExecutionStart: _settingsOnToolExecutionStart,
+      experimental_onToolExecutionEnd: _settingsOnToolExecutionEnd,
       onStepFinish: _settingsOnStepFinish,
       onFinish: _settingsOnFinish,
       ...settingsWithoutCallbacks
@@ -140,8 +140,8 @@ export class ToolLoopAgent<
     timeout,
     experimental_onStart,
     experimental_onStepStart,
-    experimental_onToolCallStart,
-    experimental_onToolCallFinish,
+    experimental_onToolExecutionStart,
+    experimental_onToolExecutionEnd,
     onStepFinish,
     onFinish,
     ...options
@@ -165,13 +165,13 @@ export class ToolLoopAgent<
           | ToolLoopAgentOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
           | undefined,
       ),
-      experimental_onToolCallStart: mergeCallbacks(
-        this.settings.experimental_onToolCallStart,
-        experimental_onToolCallStart,
+      experimental_onToolExecutionStart: mergeCallbacks(
+        this.settings.experimental_onToolExecutionStart,
+        experimental_onToolExecutionStart,
       ),
-      experimental_onToolCallFinish: mergeCallbacks(
-        this.settings.experimental_onToolCallFinish,
-        experimental_onToolCallFinish,
+      experimental_onToolExecutionEnd: mergeCallbacks(
+        this.settings.experimental_onToolExecutionEnd,
+        experimental_onToolExecutionEnd,
       ),
       onStepFinish: mergeCallbacks(this.settings.onStepFinish, onStepFinish),
       onFinish: mergeCallbacks(this.settings.onFinish, onFinish),
@@ -192,8 +192,8 @@ export class ToolLoopAgent<
     experimental_transform,
     experimental_onStart,
     experimental_onStepStart,
-    experimental_onToolCallStart,
-    experimental_onToolCallFinish,
+    experimental_onToolExecutionStart,
+    experimental_onToolExecutionEnd,
     onStepFinish,
     onFinish,
     ...options
@@ -218,13 +218,13 @@ export class ToolLoopAgent<
           | ToolLoopAgentOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
           | undefined,
       ),
-      experimental_onToolCallStart: mergeCallbacks(
-        this.settings.experimental_onToolCallStart,
-        experimental_onToolCallStart,
+      experimental_onToolExecutionStart: mergeCallbacks(
+        this.settings.experimental_onToolExecutionStart,
+        experimental_onToolExecutionStart,
       ),
-      experimental_onToolCallFinish: mergeCallbacks(
-        this.settings.experimental_onToolCallFinish,
-        experimental_onToolCallFinish,
+      experimental_onToolExecutionEnd: mergeCallbacks(
+        this.settings.experimental_onToolExecutionEnd,
+        experimental_onToolExecutionEnd,
       ),
       onStepFinish: mergeCallbacks(this.settings.onStepFinish, onStepFinish),
       onFinish: mergeCallbacks(this.settings.onFinish, onFinish),

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -38,7 +38,7 @@ exports[`generateText > options.experimental_onStart > should send correct infor
 }
 `;
 
-exports[`generateText > options.experimental_onToolCallStart > should be called with correct tool name, id, and input 1`] = `
+exports[`generateText > options.experimental_onToolExecutionStart > should be called with correct tool name, id, and input 1`] = `
 {
   "callId": "test-telemetry-call-id",
   "context": undefined,

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -38,34 +38,6 @@ exports[`generateText > options.experimental_onStart > should send correct infor
 }
 `;
 
-exports[`generateText > options.experimental_onToolExecutionStart > should be called with correct tool name, id, and input 1`] = `
-{
-  "callId": "test-telemetry-call-id",
-  "context": undefined,
-  "functionId": undefined,
-  "messages": [
-    {
-      "content": "test-input",
-      "role": "user",
-    },
-  ],
-  "modelId": "mock-model-id",
-  "provider": "mock-provider",
-  "stepNumber": 0,
-  "toolCall": {
-    "input": {
-      "value": "test-arg",
-    },
-    "providerExecuted": undefined,
-    "providerMetadata": undefined,
-    "title": undefined,
-    "toolCallId": "call-1",
-    "toolName": "tool1",
-    "type": "tool-call",
-  },
-}
-`;
-
 exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callbacks > onFinish should send correct information 1`] = `
 {
   "callId": "test-telemetry-call-id",

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -38,34 +38,6 @@ exports[`streamText > options.experimental_onStart > should send correct informa
 }
 `;
 
-exports[`streamText > options.experimental_onToolExecutionStart > should be called with correct tool name, id, and input 1`] = `
-{
-  "callId": "test-telemetry-call-id",
-  "context": undefined,
-  "functionId": undefined,
-  "messages": [
-    {
-      "content": "test-input",
-      "role": "user",
-    },
-  ],
-  "modelId": "mock-model-id",
-  "provider": "mock-provider",
-  "stepNumber": 0,
-  "toolCall": {
-    "input": {
-      "value": "test-arg",
-    },
-    "providerExecuted": undefined,
-    "providerMetadata": undefined,
-    "title": undefined,
-    "toolCallId": "call-1",
-    "toolName": "tool1",
-    "type": "tool-call",
-  },
-}
-`;
-
 exports[`streamText > programmatic tool calling > 5 steps: code_execution triggers client tool across multiple turns (dice game fixture) > step inputs > should include all previous messages in step 5 prompt (final step) 1`] = `
 [
   {

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -38,7 +38,7 @@ exports[`streamText > options.experimental_onStart > should send correct informa
 }
 `;
 
-exports[`streamText > options.experimental_onToolCallStart > should be called with correct tool name, id, and input 1`] = `
+exports[`streamText > options.experimental_onToolExecutionStart > should be called with correct tool name, id, and input 1`] = `
 {
   "callId": "test-telemetry-call-id",
   "context": undefined,

--- a/packages/ai/src/generate-text/core-events.ts
+++ b/packages/ai/src/generate-text/core-events.ts
@@ -14,7 +14,6 @@ import type { Output } from './output';
 import type { StepResult } from './step-result';
 import type { StopCondition } from './stop-condition';
 import { TextStreamPart } from './stream-text-result';
-import type { TypedToolCall } from './tool-call';
 
 /**
  * Common model information used across callback events.
@@ -218,87 +217,6 @@ export interface OnStepStartEvent<
    */
   readonly toolsContext: InferToolSetContext<TOOLS>;
 }
-
-/**
- * Event passed to the `onToolCallStart` callback.
- *
- * Called when a tool execution begins, before the tool's `execute` function is invoked.
- */
-export interface OnToolCallStartEvent<TOOLS extends ToolSet = ToolSet> {
-  /** Unique identifier for this generation call, used to correlate events. */
-  readonly callId: string;
-
-  /** Zero-based index of the current step where this tool call occurs. */
-  readonly stepNumber: number | undefined;
-
-  /** The provider identifier (e.g., 'openai', 'anthropic'). */
-  readonly provider: string | undefined;
-
-  /** The specific model identifier (e.g., 'gpt-4o'). */
-  readonly modelId: string | undefined;
-
-  /** The full tool call object. */
-  readonly toolCall: TypedToolCall<TOOLS>;
-
-  /** The conversation messages available at tool execution time. */
-  readonly messages: Array<ModelMessage>;
-
-  /** Identifier from telemetry settings for grouping related operations. */
-  readonly functionId: string | undefined;
-
-  /** User-defined context object flowing through the generation. */
-  readonly context: InferToolSetContext<TOOLS>;
-}
-
-/**
- * Event passed to the `onToolCallFinish` callback.
- *
- * Called when a tool execution completes, either successfully or with an error.
- * Uses a discriminated union on the `success` field.
- */
-export type OnToolCallFinishEvent<TOOLS extends ToolSet = ToolSet> = {
-  /** Unique identifier for this generation call, used to correlate events. */
-  readonly callId: string;
-
-  /** Zero-based index of the current step where this tool call occurred. */
-  readonly stepNumber: number | undefined;
-
-  /** The provider identifier (e.g., 'openai', 'anthropic'). */
-  readonly provider: string | undefined;
-
-  /** The specific model identifier (e.g., 'gpt-4o'). */
-  readonly modelId: string | undefined;
-
-  /** The full tool call object. */
-  readonly toolCall: TypedToolCall<TOOLS>;
-
-  /** The conversation messages available at tool execution time. */
-  readonly messages: Array<ModelMessage>;
-
-  /** Execution time of the tool call in milliseconds. */
-  readonly durationMs: number;
-
-  /** Identifier from telemetry settings for grouping related operations. */
-  readonly functionId: string | undefined;
-
-  /** User-defined context object flowing through the generation. */
-  readonly context: InferToolSetContext<TOOLS>;
-} & (
-  | {
-      /** Indicates the tool call succeeded. */
-      readonly success: true;
-      /** The tool's return value. */
-      readonly output: unknown;
-      readonly error?: never;
-    }
-  | {
-      /** Indicates the tool call failed. */
-      readonly success: false;
-      readonly output?: never;
-      /** The error that occurred during tool execution. */
-      readonly error: unknown;
-    }
-);
 
 /**
  * Event passed to the `onChunk` callback.

--- a/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
@@ -244,8 +244,8 @@ describe('createExecuteToolsTransformation', () => {
     expect(toolExecuted).toBe(false);
   });
 
-  describe('onToolCallStart and onToolCallFinish callbacks', () => {
-    it('should call onToolCallStart before tool execution and onToolCallFinish after', async () => {
+  describe('onToolExecutionStart and onToolExecutionEnd callbacks', () => {
+    it('should call onToolExecutionStart before tool execution and onToolExecutionEnd after', async () => {
       const tools = {
         testTool: tool({
           inputSchema: z.object({ value: z.string() }),
@@ -347,7 +347,7 @@ describe('createExecuteToolsTransformation', () => {
       expect(finishEvents).toMatchInlineSnapshot();
     });
 
-    it('should call onToolCallFinish with success data', async () => {
+    it('should call onToolExecutionEnd with success data', async () => {
       const tools = {
         testTool: tool({
           inputSchema: z.object({ value: z.string() }),

--- a/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
@@ -9,6 +9,10 @@ import { z } from 'zod/v4';
 import { asLanguageModelUsage } from '../types/usage';
 import { createExecuteToolsTransformation } from './create-execute-tools-transformation';
 import { LanguageModelStreamPart } from './stream-language-model-call';
+import {
+  ToolExecutionEndEvent,
+  ToolExecutionStartEvent,
+} from './tool-execution-events';
 
 const finishChunk = {
   type: 'model-call-end' as const,
@@ -275,11 +279,11 @@ describe('createExecuteToolsTransformation', () => {
           timeout: undefined,
           abortSignal: undefined,
           toolsContext: {},
-          onToolCallStart: async () => {
-            callOrder.push('onToolCallStart');
+          onToolExecutionStart: async () => {
+            callOrder.push('onToolExecutionStart');
           },
-          onToolCallFinish: async () => {
-            callOrder.push('onToolCallFinish');
+          onToolExecutionEnd: async () => {
+            callOrder.push('onToolExecutionEnd');
           },
         }),
       );
@@ -287,9 +291,9 @@ describe('createExecuteToolsTransformation', () => {
       await convertReadableStreamToArray(transformedStream);
 
       expect(callOrder).toEqual([
-        'onToolCallStart',
+        'onToolExecutionStart',
         'execute',
-        'onToolCallFinish',
+        'onToolExecutionEnd',
       ]);
     });
 
@@ -301,8 +305,8 @@ describe('createExecuteToolsTransformation', () => {
         }),
       };
 
-      const startEvents: unknown[] = [];
-      const finishEvents: unknown[] = [];
+      const startEvents: ToolExecutionStartEvent<typeof tools>[] = [];
+      const finishEvents: ToolExecutionEndEvent<typeof tools>[] = [];
 
       const inputStream: ReadableStream<LanguageModelStreamPart<typeof tools>> =
         convertArrayToReadableStream([
@@ -328,43 +332,19 @@ describe('createExecuteToolsTransformation', () => {
           stepNumber: 2,
           provider: 'test-provider',
           modelId: 'test-model',
-          onToolCallStart: async event => {
-            startEvents.push({
-              stepNumber: event.stepNumber,
-              provider: event.provider,
-              modelId: event.modelId,
-              toolName: event.toolCall.toolName,
-            });
+          onToolExecutionStart: async event => {
+            startEvents.push(event);
           },
-          onToolCallFinish: async event => {
-            finishEvents.push({
-              stepNumber: event.stepNumber,
-              provider: event.provider,
-              modelId: event.modelId,
-              toolName: event.toolCall.toolName,
-            });
+          onToolExecutionEnd: async event => {
+            finishEvents.push(event);
           },
         }),
       );
 
       await convertReadableStreamToArray(transformedStream);
 
-      expect(startEvents).toEqual([
-        {
-          stepNumber: 2,
-          provider: 'test-provider',
-          modelId: 'test-model',
-          toolName: 'testTool',
-        },
-      ]);
-      expect(finishEvents).toEqual([
-        {
-          stepNumber: 2,
-          provider: 'test-provider',
-          modelId: 'test-model',
-          toolName: 'testTool',
-        },
-      ]);
+      expect(startEvents).toMatchInlineSnapshot();
+      expect(finishEvents).toMatchInlineSnapshot();
     });
 
     it('should call onToolCallFinish with success data', async () => {
@@ -375,7 +355,7 @@ describe('createExecuteToolsTransformation', () => {
         }),
       };
 
-      const finishEvents: unknown[] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<typeof tools>[] = [];
 
       const inputStream: ReadableStream<LanguageModelStreamPart<typeof tools>> =
         convertArrayToReadableStream([
@@ -398,27 +378,18 @@ describe('createExecuteToolsTransformation', () => {
           timeout: undefined,
           abortSignal: undefined,
           toolsContext: {},
-          onToolCallFinish: async event => {
-            finishEvents.push(event);
+          onToolExecutionEnd: async event => {
+            toolExecutionEndEvents.push(event);
           },
         }),
       );
 
       await convertReadableStreamToArray(transformedStream);
 
-      expect(finishEvents.length).toBe(1);
-      expect(finishEvents[0]).toMatchObject({
-        success: true,
-        output: 'abc-result',
-        toolCall: {
-          toolName: 'testTool',
-          toolCallId: 'call-1',
-        },
-      });
-      expect((finishEvents[0] as any).durationMs).toBeGreaterThanOrEqual(0);
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
     });
 
-    it('should call onToolCallFinish with error data when tool fails', async () => {
+    it('should call onToolExecutionEnd with error data when tool fails', async () => {
       const tools = {
         failingTool: tool({
           inputSchema: z.object({ value: z.string() }),
@@ -431,8 +402,7 @@ describe('createExecuteToolsTransformation', () => {
         }),
       };
 
-      const finishEvents: unknown[] = [];
-      const toolError = new Error('tool failed');
+      const toolExecutionEndEvents: ToolExecutionEndEvent<typeof tools>[] = [];
 
       const inputStream: ReadableStream<LanguageModelStreamPart<typeof tools>> =
         convertArrayToReadableStream([
@@ -455,23 +425,15 @@ describe('createExecuteToolsTransformation', () => {
           timeout: undefined,
           abortSignal: undefined,
           toolsContext: {},
-          onToolCallFinish: async event => {
-            finishEvents.push(event);
+          onToolExecutionEnd: async event => {
+            toolExecutionEndEvents.push(event);
           },
         }),
       );
 
       await convertReadableStreamToArray(transformedStream);
 
-      expect(finishEvents.length).toBe(1);
-      expect(finishEvents[0]).toMatchObject({
-        success: false,
-        error: toolError,
-        toolCall: {
-          toolName: 'failingTool',
-          toolCallId: 'call-1',
-        },
-      });
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
     });
 
     it('should not call callbacks for tools without execute', async () => {
@@ -481,8 +443,9 @@ describe('createExecuteToolsTransformation', () => {
         }),
       };
 
-      const startEvents: unknown[] = [];
-      const finishEvents: unknown[] = [];
+      const toolExecutionStartEvents: ToolExecutionStartEvent<typeof tools>[] =
+        [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<typeof tools>[] = [];
 
       const inputStream: ReadableStream<LanguageModelStreamPart<typeof tools>> =
         convertArrayToReadableStream([
@@ -505,19 +468,19 @@ describe('createExecuteToolsTransformation', () => {
           timeout: undefined,
           abortSignal: undefined,
           toolsContext: {},
-          onToolCallStart: async event => {
-            startEvents.push(event);
+          onToolExecutionStart: async event => {
+            toolExecutionStartEvents.push(event);
           },
-          onToolCallFinish: async event => {
-            finishEvents.push(event);
+          onToolExecutionEnd: async event => {
+            toolExecutionEndEvents.push(event);
           },
         }),
       );
 
       await convertReadableStreamToArray(transformedStream);
 
-      expect(startEvents.length).toBe(0);
-      expect(finishEvents.length).toBe(0);
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
     });
 
     it('should call callbacks for each tool in a multi-tool stream', async () => {
@@ -528,8 +491,9 @@ describe('createExecuteToolsTransformation', () => {
         }),
       };
 
-      const startEvents: unknown[] = [];
-      const finishEvents: unknown[] = [];
+      const toolExecutionStartEvents: ToolExecutionStartEvent<typeof tools>[] =
+        [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<typeof tools>[] = [];
 
       const inputStream: ReadableStream<LanguageModelStreamPart<typeof tools>> =
         convertArrayToReadableStream([
@@ -558,19 +522,19 @@ describe('createExecuteToolsTransformation', () => {
           timeout: undefined,
           abortSignal: undefined,
           toolsContext: {},
-          onToolCallStart: async event => {
-            startEvents.push(event.toolCall.toolCallId);
+          onToolExecutionStart: async event => {
+            toolExecutionStartEvents.push(event);
           },
-          onToolCallFinish: async event => {
-            finishEvents.push(event.toolCall.toolCallId);
+          onToolExecutionEnd: async event => {
+            toolExecutionEndEvents.push(event);
           },
         }),
       );
 
       await convertReadableStreamToArray(transformedStream);
 
-      expect(startEvents).toEqual(['call-1', 'call-2']);
-      expect(finishEvents).toEqual(['call-1', 'call-2']);
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
     });
 
     it('should not call callbacks for provider-executed tools', async () => {
@@ -581,8 +545,9 @@ describe('createExecuteToolsTransformation', () => {
         }),
       };
 
-      const startEvents: unknown[] = [];
-      const finishEvents: unknown[] = [];
+      const toolExecutionStartEvents: ToolExecutionStartEvent<typeof tools>[] =
+        [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<typeof tools>[] = [];
 
       const inputStream: ReadableStream<LanguageModelStreamPart<typeof tools>> =
         convertArrayToReadableStream([
@@ -614,19 +579,19 @@ describe('createExecuteToolsTransformation', () => {
           timeout: undefined,
           abortSignal: undefined,
           toolsContext: {},
-          onToolCallStart: async event => {
-            startEvents.push(event);
+          onToolExecutionStart: async event => {
+            toolExecutionStartEvents.push(event);
           },
-          onToolCallFinish: async event => {
-            finishEvents.push(event);
+          onToolExecutionEnd: async event => {
+            toolExecutionEndEvents.push(event);
           },
         }),
       );
 
       await convertReadableStreamToArray(transformedStream);
 
-      expect(startEvents.length).toBe(0);
-      expect(finishEvents.length).toBe(0);
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
     });
   });
 

--- a/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
@@ -343,8 +343,55 @@ describe('createExecuteToolsTransformation', () => {
 
       await convertReadableStreamToArray(transformedStream);
 
-      expect(startEvents).toMatchInlineSnapshot();
-      expect(finishEvents).toMatchInlineSnapshot();
+      expect(startEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": {
+              "value": "test",
+            },
+            "functionId": undefined,
+            "messages": [],
+            "modelId": "test-model",
+            "provider": "test-provider",
+            "stepNumber": 2,
+            "toolCall": {
+              "input": {
+                "value": "test",
+              },
+              "toolCallId": "call-1",
+              "toolName": "testTool",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
+      expect(finishEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": {
+              "value": "test",
+            },
+            "durationMs": 0.01783299999999599,
+            "functionId": undefined,
+            "messages": [],
+            "modelId": "test-model",
+            "output": "test-result",
+            "provider": "test-provider",
+            "stepNumber": 2,
+            "success": true,
+            "toolCall": {
+              "input": {
+                "value": "test",
+              },
+              "toolCallId": "call-1",
+              "toolName": "testTool",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
     });
 
     it('should call onToolExecutionEnd with success data', async () => {
@@ -386,7 +433,30 @@ describe('createExecuteToolsTransformation', () => {
 
       await convertReadableStreamToArray(transformedStream);
 
-      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "durationMs": 0.01979199999999537,
+            "functionId": undefined,
+            "messages": [],
+            "modelId": undefined,
+            "output": "abc-result",
+            "provider": undefined,
+            "stepNumber": undefined,
+            "success": true,
+            "toolCall": {
+              "input": {
+                "value": "abc",
+              },
+              "toolCallId": "call-1",
+              "toolName": "testTool",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
     });
 
     it('should call onToolExecutionEnd with error data when tool fails', async () => {
@@ -433,7 +503,30 @@ describe('createExecuteToolsTransformation', () => {
 
       await convertReadableStreamToArray(transformedStream);
 
-      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "durationMs": 0.02637499999997317,
+            "error": [Error: tool failed],
+            "functionId": undefined,
+            "messages": [],
+            "modelId": undefined,
+            "provider": undefined,
+            "stepNumber": undefined,
+            "success": false,
+            "toolCall": {
+              "input": {
+                "value": "test",
+              },
+              "toolCallId": "call-1",
+              "toolName": "failingTool",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
     });
 
     it('should not call callbacks for tools without execute', async () => {
@@ -479,8 +572,8 @@ describe('createExecuteToolsTransformation', () => {
 
       await convertReadableStreamToArray(transformedStream);
 
-      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
-      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot(`[]`);
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`[]`);
     });
 
     it('should call callbacks for each tool in a multi-tool stream', async () => {
@@ -533,8 +626,88 @@ describe('createExecuteToolsTransformation', () => {
 
       await convertReadableStreamToArray(transformedStream);
 
-      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
-      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "functionId": undefined,
+            "messages": [],
+            "modelId": undefined,
+            "provider": undefined,
+            "stepNumber": undefined,
+            "toolCall": {
+              "input": {
+                "value": "a",
+              },
+              "toolCallId": "call-1",
+              "toolName": "testTool",
+              "type": "tool-call",
+            },
+          },
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "functionId": undefined,
+            "messages": [],
+            "modelId": undefined,
+            "provider": undefined,
+            "stepNumber": undefined,
+            "toolCall": {
+              "input": {
+                "value": "b",
+              },
+              "toolCallId": "call-2",
+              "toolName": "testTool",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "durationMs": 0.017667000000017197,
+            "functionId": undefined,
+            "messages": [],
+            "modelId": undefined,
+            "output": "a-result",
+            "provider": undefined,
+            "stepNumber": undefined,
+            "success": true,
+            "toolCall": {
+              "input": {
+                "value": "a",
+              },
+              "toolCallId": "call-1",
+              "toolName": "testTool",
+              "type": "tool-call",
+            },
+          },
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "durationMs": 0.02208300000000918,
+            "functionId": undefined,
+            "messages": [],
+            "modelId": undefined,
+            "output": "b-result",
+            "provider": undefined,
+            "stepNumber": undefined,
+            "success": true,
+            "toolCall": {
+              "input": {
+                "value": "b",
+              },
+              "toolCallId": "call-2",
+              "toolName": "testTool",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
     });
 
     it('should not call callbacks for provider-executed tools', async () => {
@@ -590,8 +763,8 @@ describe('createExecuteToolsTransformation', () => {
 
       await convertReadableStreamToArray(transformedStream);
 
-      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
-      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot(`[]`);
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`[]`);
     });
   });
 

--- a/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
@@ -4,7 +4,7 @@ import {
   convertReadableStreamToArray,
   mockId,
 } from '@ai-sdk/provider-utils/test';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { asLanguageModelUsage } from '../types/usage';
 import { createExecuteToolsTransformation } from './create-execute-tools-transformation';
@@ -13,6 +13,13 @@ import {
   ToolExecutionEndEvent,
   ToolExecutionStartEvent,
 } from './tool-execution-events';
+
+// mock now function
+vi.mock('../util/now', () => ({
+  now: vi.fn(),
+}));
+import { now } from '../util/now';
+const mockNow = vi.mocked(now);
 
 const finishChunk = {
   type: 'model-call-end' as const,
@@ -34,6 +41,11 @@ const finishChunk = {
 };
 
 describe('createExecuteToolsTransformation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNow.mockReturnValue(0);
+  });
+
   it('should handle async tool execution', async () => {
     const tools = {
       syncTool: tool({
@@ -373,7 +385,7 @@ describe('createExecuteToolsTransformation', () => {
             "context": {
               "value": "test",
             },
-            "durationMs": 0.01783299999999599,
+            "durationMs": 0,
             "functionId": undefined,
             "messages": [],
             "modelId": "test-model",
@@ -438,7 +450,7 @@ describe('createExecuteToolsTransformation', () => {
           {
             "callId": "test-telemetry-call-id",
             "context": undefined,
-            "durationMs": 0.01979199999999537,
+            "durationMs": 0,
             "functionId": undefined,
             "messages": [],
             "modelId": undefined,
@@ -508,7 +520,7 @@ describe('createExecuteToolsTransformation', () => {
           {
             "callId": "test-telemetry-call-id",
             "context": undefined,
-            "durationMs": 0.02637499999997317,
+            "durationMs": 0,
             "error": [Error: tool failed],
             "functionId": undefined,
             "messages": [],
@@ -669,7 +681,7 @@ describe('createExecuteToolsTransformation', () => {
           {
             "callId": "test-telemetry-call-id",
             "context": undefined,
-            "durationMs": 0.017667000000017197,
+            "durationMs": 0,
             "functionId": undefined,
             "messages": [],
             "modelId": undefined,
@@ -689,7 +701,7 @@ describe('createExecuteToolsTransformation', () => {
           {
             "callId": "test-telemetry-call-id",
             "context": undefined,
-            "durationMs": 0.02208300000000918,
+            "durationMs": 0,
             "functionId": undefined,
             "messages": [],
             "modelId": undefined,

--- a/packages/ai/src/generate-text/create-execute-tools-transformation.ts
+++ b/packages/ai/src/generate-text/create-execute-tools-transformation.ts
@@ -1,4 +1,4 @@
-import type { ToolSet } from '@ai-sdk/provider-utils';
+import type { Arrayable, ToolSet } from '@ai-sdk/provider-utils';
 import {
   IdGenerator,
   InferToolSetContext,
@@ -10,11 +10,11 @@ import { TelemetryOptions } from '../telemetry/telemetry-options';
 import { executeToolCall } from './execute-tool-call';
 import { isToolApprovalNeeded } from './is-tool-approval-needed';
 import { LanguageModelStreamPart } from './stream-language-model-call';
-import {
-  StreamTextOnToolCallFinishCallback,
-  StreamTextOnToolCallStartCallback,
-} from './stream-text';
 import { TypedToolCall } from './tool-call';
+import {
+  OnToolExecutionEndCallback,
+  OnToolExecutionStartCallback,
+} from './tool-execution-events';
 import { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configuration';
 
 export function createExecuteToolsTransformation<TOOLS extends ToolSet>({
@@ -30,8 +30,8 @@ export function createExecuteToolsTransformation<TOOLS extends ToolSet>({
   stepNumber,
   provider,
   modelId,
-  onToolCallStart,
-  onToolCallFinish,
+  onToolExecutionStart,
+  onToolExecutionEnd,
   executeToolInTelemetryContext,
 }: {
   tools: TOOLS | undefined;
@@ -46,12 +46,8 @@ export function createExecuteToolsTransformation<TOOLS extends ToolSet>({
   stepNumber?: number;
   provider?: string;
   modelId?: string;
-  onToolCallStart?:
-    | StreamTextOnToolCallStartCallback<TOOLS>
-    | Array<StreamTextOnToolCallStartCallback<TOOLS> | undefined | null>;
-  onToolCallFinish?:
-    | StreamTextOnToolCallFinishCallback<TOOLS>
-    | Array<StreamTextOnToolCallFinishCallback<TOOLS> | undefined | null>;
+  onToolExecutionStart?: Arrayable<OnToolExecutionStartCallback<TOOLS>>;
+  onToolExecutionEnd?: Arrayable<OnToolExecutionEndCallback<TOOLS>>;
   executeToolInTelemetryContext?: TelemetryIntegration['executeTool'];
 }): TransformStream<
   LanguageModelStreamPart<TOOLS>,
@@ -132,8 +128,8 @@ export function createExecuteToolsTransformation<TOOLS extends ToolSet>({
                   stepNumber,
                   provider,
                   modelId,
-                  onToolCallStart,
-                  onToolCallFinish,
+                  onToolExecutionStart,
+                  onToolExecutionEnd,
                   executeToolInTelemetryContext,
                   onPreliminaryToolResult: result => {
                     controller.enqueue(result);

--- a/packages/ai/src/generate-text/execute-tool-call.test.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.test.ts
@@ -165,7 +165,7 @@ describe('executeToolCall', () => {
     });
   });
 
-  describe('onToolCallStart callback', () => {
+  describe('onToolExecutionStart callback', () => {
     it('should be called with correct data before execution', async () => {
       const toolExecutionStartEvents: ToolExecutionStartEvent<any>[] = [];
       const executionOrder: string[] = [];
@@ -193,7 +193,7 @@ describe('executeToolCall', () => {
         provider: 'test-provider',
         modelId: 'test-model',
         onToolExecutionStart: async event => {
-          executionOrder.push('onToolCallStart');
+          executionOrder.push('onToolExecutionStart');
           toolExecutionStartEvents.push(event);
         },
       });
@@ -227,7 +227,7 @@ describe('executeToolCall', () => {
           },
         ]
       `);
-      expect(executionOrder).toEqual(['onToolCallStart', 'execute']);
+      expect(executionOrder).toEqual(['onToolExecutionStart', 'execute']);
     });
 
     it('should not break execution when callback throws', async () => {
@@ -256,7 +256,7 @@ describe('executeToolCall', () => {
     });
   });
 
-  describe('onToolCallFinish callback', () => {
+  describe('onToolExecutionEnd callback', () => {
     it('should be called with success data when tool succeeds', async () => {
       const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
 
@@ -1012,7 +1012,7 @@ describe('executeToolCall', () => {
   });
 
   describe('array callbacks', () => {
-    it('should call all onToolCallStart listeners in an array', async () => {
+    it('should call all onToolExecutionStart listeners in an array', async () => {
       const calls: string[] = [];
 
       await executeToolCall({

--- a/packages/ai/src/generate-text/execute-tool-call.test.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.test.ts
@@ -2,10 +2,6 @@ import { tool } from '@ai-sdk/provider-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as z from 'zod/v4';
 import { executeToolCall } from './execute-tool-call';
-import {
-  GenerateTextOnToolCallFinishCallback,
-  GenerateTextOnToolCallStartCallback,
-} from './generate-text';
 import { TypedToolCall } from './tool-call';
 import { TypedToolResult } from './tool-result';
 
@@ -14,6 +10,10 @@ vi.mock('../util/now', () => ({
 }));
 
 import { now } from '../util/now';
+import {
+  ToolExecutionEndEvent,
+  ToolExecutionStartEvent,
+} from './tool-execution-events';
 
 const mockNow = vi.mocked(now);
 
@@ -167,9 +167,7 @@ describe('executeToolCall', () => {
 
   describe('onToolCallStart callback', () => {
     it('should be called with correct data before execution', async () => {
-      const startEvents: Parameters<
-        GenerateTextOnToolCallStartCallback<any>
-      >[0][] = [];
+      const toolExecutionStartEvents: ToolExecutionStartEvent<any>[] = [];
       const executionOrder: string[] = [];
 
       await executeToolCall({
@@ -194,13 +192,13 @@ describe('executeToolCall', () => {
         stepNumber: 2,
         provider: 'test-provider',
         modelId: 'test-model',
-        onToolCallStart: async event => {
+        onToolExecutionStart: async event => {
           executionOrder.push('onToolCallStart');
-          startEvents.push(event);
+          toolExecutionStartEvents.push(event);
         },
       });
 
-      expect(startEvents).toMatchInlineSnapshot(`
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot(`
         [
           {
             "callId": "test-telemetry-call-id",
@@ -246,7 +244,7 @@ describe('executeToolCall', () => {
         messages: [],
         abortSignal: undefined,
         toolsContext: {},
-        onToolCallStart: async () => {
+        onToolExecutionStart: async () => {
           throw new Error('callback error');
         },
       });
@@ -260,9 +258,7 @@ describe('executeToolCall', () => {
 
   describe('onToolCallFinish callback', () => {
     it('should be called with success data when tool succeeds', async () => {
-      const finishEvents: Parameters<
-        GenerateTextOnToolCallFinishCallback<any>
-      >[0][] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
 
       mockNow.mockReturnValueOnce(1000).mockReturnValueOnce(1050);
 
@@ -285,12 +281,12 @@ describe('executeToolCall', () => {
         stepNumber: 3,
         provider: 'test-provider',
         modelId: 'test-model',
-        onToolCallFinish: async event => {
-          finishEvents.push(event);
+        onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
       });
 
-      expect(finishEvents).toMatchInlineSnapshot(`
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
         [
           {
             "callId": "test-telemetry-call-id",
@@ -325,9 +321,7 @@ describe('executeToolCall', () => {
     });
 
     it('should be called with error data when tool fails', async () => {
-      const finishEvents: Parameters<
-        GenerateTextOnToolCallFinishCallback<any>
-      >[0][] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
       const toolError = new Error('execution failed');
 
       mockNow.mockReturnValueOnce(2000).mockReturnValueOnce(2100);
@@ -353,12 +347,12 @@ describe('executeToolCall', () => {
         stepNumber: 1,
         provider: 'provider-1',
         modelId: 'model-1',
-        onToolCallFinish: async event => {
-          finishEvents.push(event);
+        onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
       });
 
-      expect(finishEvents).toMatchInlineSnapshot(`
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
         [
           {
             "callId": "test-telemetry-call-id",
@@ -401,7 +395,7 @@ describe('executeToolCall', () => {
         messages: [],
         abortSignal: undefined,
         toolsContext: {},
-        onToolCallFinish: async () => {
+        onToolExecutionEnd: async () => {
           throw new Error('callback error');
         },
       });
@@ -430,7 +424,7 @@ describe('executeToolCall', () => {
         messages: [],
         abortSignal: undefined,
         toolsContext: {},
-        onToolCallFinish: async () => {
+        onToolExecutionEnd: async () => {
           throw new Error('callback error');
         },
       });
@@ -444,9 +438,7 @@ describe('executeToolCall', () => {
 
   describe('durationMs calculation', () => {
     it('should calculate correct duration on success', async () => {
-      const finishEvents: Parameters<
-        GenerateTextOnToolCallFinishCallback<any>
-      >[0][] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
 
       mockNow.mockReturnValueOnce(5000).mockReturnValueOnce(5250);
 
@@ -463,18 +455,16 @@ describe('executeToolCall', () => {
         messages: [],
         abortSignal: undefined,
         toolsContext: {},
-        onToolCallFinish: async event => {
-          finishEvents.push(event);
+        onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
       });
 
-      expect(finishEvents[0].durationMs).toBe(250);
+      expect(toolExecutionEndEvents[0].durationMs).toBe(250);
     });
 
     it('should calculate correct duration on error', async () => {
-      const finishEvents: Parameters<
-        GenerateTextOnToolCallFinishCallback<any>
-      >[0][] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
 
       mockNow.mockReturnValueOnce(1000).mockReturnValueOnce(1500);
 
@@ -493,12 +483,12 @@ describe('executeToolCall', () => {
         messages: [],
         abortSignal: undefined,
         toolsContext: {},
-        onToolCallFinish: async event => {
-          finishEvents.push(event);
+        onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
       });
 
-      expect(finishEvents[0].durationMs).toBe(500);
+      expect(toolExecutionEndEvents[0].durationMs).toBe(500);
     });
   });
 
@@ -600,10 +590,10 @@ describe('executeToolCall', () => {
         stepNumber: 2,
         provider: 'test-provider',
         modelId: 'test-model',
-        onToolCallStart: async event => {
+        onToolExecutionStart: async event => {
           startEvents.push(event);
         },
-        onToolCallFinish: async event => {
+        onToolExecutionEnd: async event => {
           finishEvents.push(event);
         },
       });
@@ -674,7 +664,7 @@ describe('executeToolCall', () => {
 
     it('should notify finish callback with error payload', async () => {
       const toolError = new Error('test error');
-      const finishEvents: any[] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
 
       await executeToolCall({
         toolCall: createToolCall(),
@@ -691,18 +681,12 @@ describe('executeToolCall', () => {
         messages: [],
         abortSignal: undefined,
         toolsContext: {},
-        onToolCallFinish: async event => {
-          finishEvents.push(event);
+        onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
       });
 
-      expect(finishEvents).toHaveLength(1);
-      expect(finishEvents[0]).toMatchObject({
-        callId: 'test-telemetry-call-id',
-        success: false,
-        error: toolError,
-      });
-      expect(finishEvents[0].durationMs).toEqual(expect.any(Number));
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
     });
 
     it('should execute the tool inside the executeToolInTelemetryContext wrapper when provided', async () => {
@@ -1044,7 +1028,7 @@ describe('executeToolCall', () => {
         messages: [],
         abortSignal: undefined,
         toolsContext: {},
-        onToolCallStart: [
+        onToolExecutionStart: [
           async () => {
             calls.push('first');
           },
@@ -1057,7 +1041,7 @@ describe('executeToolCall', () => {
       expect(calls).toEqual(['first', 'second']);
     });
 
-    it('should call all onToolCallFinish listeners in an array', async () => {
+    it('should call all onToolExecutionEnd listeners in an array', async () => {
       const calls: string[] = [];
 
       await executeToolCall({
@@ -1073,7 +1057,7 @@ describe('executeToolCall', () => {
         messages: [],
         abortSignal: undefined,
         toolsContext: {},
-        onToolCallFinish: [
+        onToolExecutionEnd: [
           async () => {
             calls.push('first');
           },
@@ -1084,41 +1068,6 @@ describe('executeToolCall', () => {
       });
 
       expect(calls).toEqual(['first', 'second']);
-    });
-
-    it('should skip undefined/null entries in callback arrays', async () => {
-      const calls: string[] = [];
-
-      await executeToolCall({
-        toolCall: createToolCall(),
-        tools: {
-          testTool: tool({
-            inputSchema: z.object({ value: z.string() }),
-            execute: async ({ value }) => `${value}-result`,
-          }),
-        },
-        telemetry: undefined,
-        callId: 'test-telemetry-call-id',
-        messages: [],
-        abortSignal: undefined,
-        toolsContext: {},
-        onToolCallStart: [
-          undefined,
-          async () => {
-            calls.push('start');
-          },
-          null,
-        ],
-        onToolCallFinish: [
-          null,
-          async () => {
-            calls.push('finish');
-          },
-          undefined,
-        ],
-      });
-
-      expect(calls).toEqual(['start', 'finish']);
     });
 
     it('should not break when one listener in the array throws', async () => {
@@ -1137,7 +1086,7 @@ describe('executeToolCall', () => {
         messages: [],
         abortSignal: undefined,
         toolsContext: {},
-        onToolCallStart: [
+        onToolExecutionStart: [
           async () => {
             throw new Error('listener error');
           },
@@ -1145,7 +1094,7 @@ describe('executeToolCall', () => {
             calls.push('second-start');
           },
         ],
-        onToolCallFinish: [
+        onToolExecutionEnd: [
           async () => {
             throw new Error('listener error');
           },

--- a/packages/ai/src/generate-text/execute-tool-call.test.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.test.ts
@@ -4,17 +4,16 @@ import * as z from 'zod/v4';
 import { executeToolCall } from './execute-tool-call';
 import { TypedToolCall } from './tool-call';
 import { TypedToolResult } from './tool-result';
-
-vi.mock('../util/now', () => ({
-  now: vi.fn(),
-}));
-
-import { now } from '../util/now';
 import {
   ToolExecutionEndEvent,
   ToolExecutionStartEvent,
 } from './tool-execution-events';
 
+// mock now function
+vi.mock('../util/now', () => ({
+  now: vi.fn(),
+}));
+import { now } from '../util/now';
 const mockNow = vi.mocked(now);
 
 describe('executeToolCall', () => {

--- a/packages/ai/src/generate-text/execute-tool-call.test.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.test.ts
@@ -686,7 +686,31 @@ describe('executeToolCall', () => {
         },
       });
 
-      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "durationMs": 0,
+            "error": [Error: test error],
+            "functionId": undefined,
+            "messages": [],
+            "modelId": undefined,
+            "provider": undefined,
+            "stepNumber": undefined,
+            "success": false,
+            "toolCall": {
+              "dynamic": false,
+              "input": {
+                "value": "test",
+              },
+              "toolCallId": "call-1",
+              "toolName": "testTool",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
     });
 
     it('should execute the tool inside the executeToolInTelemetryContext wrapper when provided', async () => {

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -30,10 +30,10 @@ import { TypedToolResult } from './tool-result';
  * Executes a single tool call and manages its lifecycle callbacks.
  *
  * This function handles the complete tool execution flow:
- * 1. Invokes `onToolCallStart` callback before execution
+ * 1. Invokes `onToolExecutionStart` callback before execution
  * 2. Executes the tool's `execute` function with proper context
  * 3. Handles streaming outputs via `onPreliminaryToolResult`
- * 4. Invokes `onToolCallFinish` callback with success or error result
+ * 4. Invokes `onToolExecutionEnd` callback with success or error result
  *
  * @returns The tool output (result or error), or undefined if the tool has no execute function.
  */

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -1,4 +1,5 @@
 import type {
+  Arrayable,
   InferToolContext,
   InferToolInput,
   InferToolSetContext,
@@ -16,12 +17,12 @@ import {
 import { TelemetryOptions } from '../telemetry/telemetry-options';
 import { notify } from '../util/notify';
 import { now } from '../util/now';
-import {
-  GenerateTextOnToolCallFinishCallback,
-  GenerateTextOnToolCallStartCallback,
-} from './generate-text';
 import { TypedToolCall } from './tool-call';
 import { TypedToolError } from './tool-error';
+import {
+  OnToolExecutionEndCallback,
+  OnToolExecutionStartCallback,
+} from './tool-execution-events';
 import { ToolOutput } from './tool-output';
 import { TypedToolResult } from './tool-result';
 
@@ -49,8 +50,8 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   provider,
   modelId,
   onPreliminaryToolResult,
-  onToolCallStart,
-  onToolCallFinish,
+  onToolExecutionStart,
+  onToolExecutionEnd,
   executeToolInTelemetryContext = async ({ execute }) => execute(),
 }: {
   toolCall: TypedToolCall<TOOLS>;
@@ -65,12 +66,8 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   provider?: string;
   modelId?: string;
   onPreliminaryToolResult?: (result: TypedToolResult<TOOLS>) => void;
-  onToolCallStart?:
-    | GenerateTextOnToolCallStartCallback<TOOLS>
-    | Array<GenerateTextOnToolCallStartCallback<TOOLS> | undefined | null>;
-  onToolCallFinish?:
-    | GenerateTextOnToolCallFinishCallback<TOOLS>
-    | Array<GenerateTextOnToolCallFinishCallback<TOOLS> | undefined | null>;
+  onToolExecutionStart?: Arrayable<OnToolExecutionStartCallback<TOOLS>>;
+  onToolExecutionEnd?: Arrayable<OnToolExecutionEndCallback<TOOLS>>;
   executeToolInTelemetryContext?: <T>(params: {
     callId: string;
     toolCallId: string;
@@ -101,7 +98,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
 
   let output: unknown;
 
-  await notify({ event: baseCallbackEvent, callbacks: onToolCallStart });
+  await notify({ event: baseCallbackEvent, callbacks: onToolExecutionStart });
 
   const toolTimeoutMs = getToolTimeoutMs<TOOLS>(timeout, toolName);
 
@@ -159,7 +156,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
         error,
         durationMs,
       },
-      callbacks: onToolCallFinish,
+      callbacks: onToolExecutionEnd,
     });
 
     return {
@@ -184,7 +181,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
       output,
       durationMs,
     },
-    callbacks: onToolCallFinish,
+    callbacks: onToolExecutionEnd,
   });
 
   return {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1626,7 +1626,35 @@ describe('generateText', () => {
         },
       });
 
-      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "test-input",
+                "role": "user",
+              },
+            ],
+            "modelId": "mock-model-id",
+            "provider": "mock-provider",
+            "stepNumber": 0,
+            "toolCall": {
+              "input": {
+                "value": "test-arg",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
     });
 
     it('should be called once per tool call in a multi-tool step', async () => {
@@ -1661,13 +1689,66 @@ describe('generateText', () => {
             execute: async ({ value }) => `${value}-result`,
           }),
         },
-        prompt: 'test-input',
         experimental_onToolExecutionStart: async event => {
           toolExecutionStartEvents.push(event);
         },
+        ...defaultSettings(),
       });
 
-      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "call-bIONpbEEcnMxkKBH3a9JuVlV",
+            "context": undefined,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "test-input",
+                "role": "user",
+              },
+            ],
+            "modelId": "mock-model-id",
+            "provider": "mock-provider",
+            "stepNumber": 0,
+            "toolCall": {
+              "input": {
+                "value": "a",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+          {
+            "callId": "call-bIONpbEEcnMxkKBH3a9JuVlV",
+            "context": undefined,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "test-input",
+                "role": "user",
+              },
+            ],
+            "modelId": "mock-model-id",
+            "provider": "mock-provider",
+            "stepNumber": 0,
+            "toolCall": {
+              "input": {
+                "value": "b",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-2",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
     });
 
     it('should be called before tool execution', async () => {
@@ -1772,7 +1853,7 @@ describe('generateText', () => {
         },
       });
 
-      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot(`[]`);
     });
 
     it('should pass context', async () => {
@@ -1868,13 +1949,44 @@ describe('generateText', () => {
             execute: async ({ value }) => `${value}-result`,
           }),
         },
-        prompt: 'test-input',
         experimental_onToolExecutionEnd: async event => {
           toolExecutionEndEvents.push(event);
         },
+        ...defaultSettings(),
       });
 
-      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "durationMs": 0,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "prompt",
+                "role": "user",
+              },
+            ],
+            "modelId": "mock-model-id",
+            "output": "test-arg-result",
+            "provider": "mock-provider",
+            "stepNumber": 0,
+            "success": true,
+            "toolCall": {
+              "input": {
+                "value": "test-arg",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
     });
 
     it('should be called with error data when tool execution fails', async () => {
@@ -1905,13 +2017,44 @@ describe('generateText', () => {
             },
           }),
         },
-        prompt: 'test-input',
         experimental_onToolExecutionEnd: async event => {
           toolExecutionEndEvents.push(event);
         },
+        ...defaultSettings(),
       });
 
-      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "durationMs": 0,
+            "error": [Error: tool execution failed],
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "prompt",
+                "role": "user",
+              },
+            ],
+            "modelId": "mock-model-id",
+            "provider": "mock-provider",
+            "stepNumber": 0,
+            "success": false,
+            "toolCall": {
+              "input": {
+                "value": "test",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
     });
 
     it('should have a positive durationMs', async () => {
@@ -2292,7 +2435,6 @@ describe('generateText', () => {
             execute: async ({ value }) => `${value}-result`,
           }),
         },
-        prompt: 'test-input',
         stopWhen: isStepCount(4),
         experimental_onToolExecutionStart: async event => {
           toolExecutionStartEvents.push(event);
@@ -2300,10 +2442,181 @@ describe('generateText', () => {
         experimental_onToolExecutionEnd: async event => {
           toolExecutionEndEvents.push(event);
         },
+        ...defaultSettings(),
       });
 
-      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
-      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "prompt",
+                "role": "user",
+              },
+            ],
+            "modelId": "mock-model-id",
+            "provider": "mock-provider",
+            "stepNumber": 0,
+            "toolCall": {
+              "input": {
+                "value": "step0",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "prompt",
+                "role": "user",
+              },
+              {
+                "content": [
+                  {
+                    "input": {
+                      "value": "step0",
+                    },
+                    "providerExecuted": undefined,
+                    "providerOptions": undefined,
+                    "toolCallId": "call-1",
+                    "toolName": "tool1",
+                    "type": "tool-call",
+                  },
+                ],
+                "role": "assistant",
+              },
+              {
+                "content": [
+                  {
+                    "output": {
+                      "type": "text",
+                      "value": "step0-result",
+                    },
+                    "toolCallId": "call-1",
+                    "toolName": "tool1",
+                    "type": "tool-result",
+                  },
+                ],
+                "role": "tool",
+              },
+            ],
+            "modelId": "mock-model-id",
+            "provider": "mock-provider",
+            "stepNumber": 1,
+            "toolCall": {
+              "input": {
+                "value": "step1",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-2",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "durationMs": 0,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "prompt",
+                "role": "user",
+              },
+            ],
+            "modelId": "mock-model-id",
+            "output": "step0-result",
+            "provider": "mock-provider",
+            "stepNumber": 0,
+            "success": true,
+            "toolCall": {
+              "input": {
+                "value": "step0",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "durationMs": 0,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "prompt",
+                "role": "user",
+              },
+              {
+                "content": [
+                  {
+                    "input": {
+                      "value": "step0",
+                    },
+                    "providerExecuted": undefined,
+                    "providerOptions": undefined,
+                    "toolCallId": "call-1",
+                    "toolName": "tool1",
+                    "type": "tool-call",
+                  },
+                ],
+                "role": "assistant",
+              },
+              {
+                "content": [
+                  {
+                    "output": {
+                      "type": "text",
+                      "value": "step0-result",
+                    },
+                    "toolCallId": "call-1",
+                    "toolName": "tool1",
+                    "type": "tool-result",
+                  },
+                ],
+                "role": "tool",
+              },
+            ],
+            "modelId": "mock-model-id",
+            "output": "step1-result",
+            "provider": "mock-provider",
+            "stepNumber": 1,
+            "success": true,
+            "toolCall": {
+              "input": {
+                "value": "step1",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-2",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
     });
   });
 
@@ -8889,7 +9202,16 @@ describe('generateText', () => {
         },
       });
 
-      expect(events).toMatchInlineSnapshot();
+      expect(events).toMatchInlineSnapshot(`
+        [
+          "onStart",
+          "onStepStart",
+          "onToolExecutionStart",
+          "onToolExecutionEnd",
+          "onStepFinish",
+          "onFinish",
+        ]
+      `);
     });
 
     it('should call globally registered integration listeners', async () => {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1,5 +1,4 @@
 import {
-  LanguageModelV4,
   LanguageModelV4CallOptions,
   LanguageModelV4FunctionTool,
   LanguageModelV4Prompt,
@@ -26,7 +25,7 @@ import {
   vitest,
 } from 'vitest';
 import { z } from 'zod/v4';
-import { Output } from '.';
+import { Output, ToolExecutionEndEvent, ToolExecutionStartEvent } from '.';
 import * as logWarningsModule from '../logger/log-warnings';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
 import {
@@ -35,12 +34,11 @@ import {
   GenerateTextOnStartCallback,
   GenerateTextOnStepFinishCallback,
   GenerateTextOnStepStartCallback,
-  GenerateTextOnToolCallStartCallback,
-  GenerateTextOnToolCallFinishCallback,
 } from './generate-text';
 import { GenerateTextResult } from './generate-text-result';
 import { StepResult } from './step-result';
 import { isLoopFinished, isStepCount } from './stop-condition';
+
 vi.mock('../version', () => {
   return {
     VERSION: '0.0.0-test',
@@ -1592,11 +1590,9 @@ describe('generateText', () => {
     });
   });
 
-  describe('options.experimental_onToolCallStart', () => {
+  describe('options.experimental_onToolExecutionStart', () => {
     it('should be called with correct tool name, id, and input', async () => {
-      const toolCallStartEvents: Parameters<
-        GenerateTextOnToolCallStartCallback<any>
-      >[0][] = [];
+      const toolExecutionStartEvents: ToolExecutionStartEvent<any>[] = [];
 
       await generateText({
         model: new MockLanguageModelV4({
@@ -1625,19 +1621,16 @@ describe('generateText', () => {
           generateId: () => 'test-call-id',
           generateCallId: () => 'test-telemetry-call-id',
         },
-        experimental_onToolCallStart: async event => {
-          toolCallStartEvents.push(event);
+        experimental_onToolExecutionStart: async event => {
+          toolExecutionStartEvents.push(event);
         },
       });
 
-      expect(toolCallStartEvents.length).toBe(1);
-      expect(toolCallStartEvents[0]).toMatchSnapshot();
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
     });
 
     it('should be called once per tool call in a multi-tool step', async () => {
-      const toolCallStartEvents: Parameters<
-        GenerateTextOnToolCallStartCallback<any>
-      >[0][] = [];
+      const toolExecutionStartEvents: ToolExecutionStartEvent<any>[] = [];
 
       await generateText({
         model: new MockLanguageModelV4({
@@ -1669,14 +1662,12 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallStart: async event => {
-          toolCallStartEvents.push(event);
+        experimental_onToolExecutionStart: async event => {
+          toolExecutionStartEvents.push(event);
         },
       });
 
-      expect(toolCallStartEvents.length).toBe(2);
-      expect(toolCallStartEvents[0].toolCall.toolCallId).toBe('call-1');
-      expect(toolCallStartEvents[1].toolCall.toolCallId).toBe('call-2');
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
     });
 
     it('should be called before tool execution', async () => {
@@ -1708,12 +1699,12 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallStart: async () => {
-          callOrder.push('onToolCallStart');
+        experimental_onToolExecutionStart: async () => {
+          callOrder.push('onToolExecutionStart');
         },
       });
 
-      expect(callOrder.indexOf('onToolCallStart')).toBeLessThan(
+      expect(callOrder.indexOf('onToolExecutionStart')).toBeLessThan(
         callOrder.indexOf('execute'),
       );
     });
@@ -1742,7 +1733,7 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallStart: async () => {
+        experimental_onToolExecutionStart: async () => {
           throw new Error('callback error');
         },
       });
@@ -1752,9 +1743,7 @@ describe('generateText', () => {
     });
 
     it('should not fire for tools without execute', async () => {
-      const toolCallStartEvents: Parameters<
-        GenerateTextOnToolCallStartCallback<any>
-      >[0][] = [];
+      const toolExecutionStartEvents: ToolExecutionStartEvent<any>[] = [];
 
       await generateText({
         model: new MockLanguageModelV4({
@@ -1778,18 +1767,16 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallStart: async event => {
-          toolCallStartEvents.push(event);
+        experimental_onToolExecutionStart: async event => {
+          toolExecutionStartEvents.push(event);
         },
       });
 
-      expect(toolCallStartEvents.length).toBe(0);
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
     });
 
     it('should pass context', async () => {
-      const toolCallStartEvents: Parameters<
-        GenerateTextOnToolCallStartCallback<any>
-      >[0][] = [];
+      const toolExecutionStartEvents: ToolExecutionStartEvent<any>[] = [];
 
       await generateText({
         model: new MockLanguageModelV4({
@@ -1815,13 +1802,13 @@ describe('generateText', () => {
           }),
         },
         toolsContext: { tool1: { context: 'test' } },
-        experimental_onToolCallStart: async event => {
-          toolCallStartEvents.push(event);
+        experimental_onToolExecutionStart: async event => {
+          toolExecutionStartEvents.push(event);
         },
         ...defaultSettings(),
       });
 
-      expect(toolCallStartEvents).toMatchInlineSnapshot(`
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot(`
         [
           {
             "callId": "test-telemetry-call-id",
@@ -1855,11 +1842,9 @@ describe('generateText', () => {
     });
   });
 
-  describe('options.experimental_onToolCallFinish', () => {
+  describe('options.experimental_onToolExecutionEnd', () => {
     it('should be called with correct data on success', async () => {
-      const toolCallFinishEvents: Parameters<
-        GenerateTextOnToolCallFinishCallback<any>
-      >[0][] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
 
       await generateText({
         model: new MockLanguageModelV4({
@@ -1884,26 +1869,16 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
       });
 
-      expect(toolCallFinishEvents.length).toBe(1);
-      expect(toolCallFinishEvents[0].toolCall.toolName).toBe('tool1');
-      expect(toolCallFinishEvents[0].toolCall.toolCallId).toBe('call-1');
-      expect(toolCallFinishEvents[0].toolCall.input).toEqual({
-        value: 'test-arg',
-      });
-      expect(toolCallFinishEvents[0].success).toBe(true);
-      expect(toolCallFinishEvents[0].output).toBe('test-arg-result');
-      expect(toolCallFinishEvents[0].durationMs).toBeGreaterThanOrEqual(0);
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
     });
 
     it('should be called with error data when tool execution fails', async () => {
-      const toolCallFinishEvents: Parameters<
-        GenerateTextOnToolCallFinishCallback<any>
-      >[0][] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
       const toolError = new Error('tool execution failed');
 
       await generateText({
@@ -1931,23 +1906,16 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
       });
 
-      expect(toolCallFinishEvents.length).toBe(1);
-      expect(toolCallFinishEvents[0].toolCall.toolName).toBe('tool1');
-      expect(toolCallFinishEvents[0].toolCall.toolCallId).toBe('call-1');
-      expect(toolCallFinishEvents[0].success).toBe(false);
-      expect(toolCallFinishEvents[0].error).toBe(toolError);
-      expect(toolCallFinishEvents[0].durationMs).toBeGreaterThanOrEqual(0);
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
     });
 
     it('should have a positive durationMs', async () => {
-      const toolCallFinishEvents: Parameters<
-        GenerateTextOnToolCallFinishCallback<any>
-      >[0][] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
 
       await generateText({
         model: new MockLanguageModelV4({
@@ -1972,13 +1940,13 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
       });
 
-      expect(toolCallFinishEvents[0].durationMs).toBeGreaterThanOrEqual(0);
-      expect(typeof toolCallFinishEvents[0].durationMs).toBe('number');
+      expect(toolExecutionEndEvents[0].durationMs).toBeGreaterThanOrEqual(0);
+      expect(typeof toolExecutionEndEvents[0].durationMs).toBe('number');
     });
 
     it('should not break generation when callback throws', async () => {
@@ -2005,7 +1973,7 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallFinish: async () => {
+        experimental_onToolExecutionEnd: async () => {
           throw new Error('callback error');
         },
       });
@@ -2015,9 +1983,7 @@ describe('generateText', () => {
     });
 
     it('should not fire for tools without execute', async () => {
-      const toolCallFinishEvents: Parameters<
-        GenerateTextOnToolCallFinishCallback<any>
-      >[0][] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
 
       await generateText({
         model: new MockLanguageModelV4({
@@ -2041,18 +2007,16 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
       });
 
-      expect(toolCallFinishEvents.length).toBe(0);
+      expect(toolExecutionEndEvents.length).toBe(0);
     });
 
     it('should pass context on success', async () => {
-      const toolCallFinishEvents: Parameters<
-        GenerateTextOnToolCallFinishCallback<any>
-      >[0][] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
 
       await generateText({
         model: new MockLanguageModelV4({
@@ -2078,13 +2042,13 @@ describe('generateText', () => {
           }),
         },
         toolsContext: { tool1: { context: 'test' } },
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
         ...defaultSettings(),
       });
 
-      expect(toolCallFinishEvents).toMatchInlineSnapshot(`
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
         [
           {
             "callId": "test-telemetry-call-id",
@@ -2121,9 +2085,7 @@ describe('generateText', () => {
     });
 
     it('should pass context on error', async () => {
-      const toolCallFinishEvents: Parameters<
-        GenerateTextOnToolCallFinishCallback<any>
-      >[0][] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
       const toolError = new Error('Tool execution failed');
 
       await generateText({
@@ -2152,13 +2114,13 @@ describe('generateText', () => {
           }),
         },
         toolsContext: { tool1: { context: 'test' } },
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
         ...defaultSettings(),
       });
 
-      expect(toolCallFinishEvents).toMatchInlineSnapshot(`
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
         [
           {
             "callId": "test-telemetry-call-id",
@@ -2195,7 +2157,7 @@ describe('generateText', () => {
     });
   });
 
-  describe('options.experimental_onToolCallStart and experimental_onToolCallFinish ordering', () => {
+  describe('options.experimental_onToolExecutionStart and experimental_onToolExecutionEnd ordering', () => {
     it('should call start before finish', async () => {
       const callOrder: string[] = [];
 
@@ -2222,15 +2184,15 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallStart: async () => {
-          callOrder.push('onToolCallStart');
+        experimental_onToolExecutionStart: async () => {
+          callOrder.push('onToolExecutionStart');
         },
-        experimental_onToolCallFinish: async () => {
-          callOrder.push('onToolCallFinish');
+        experimental_onToolExecutionEnd: async () => {
+          callOrder.push('onToolExecutionEnd');
         },
       });
 
-      expect(callOrder).toEqual(['onToolCallStart', 'onToolCallFinish']);
+      expect(callOrder).toEqual(['onToolExecutionStart', 'onToolExecutionEnd']);
     });
 
     it('should fire both tool call callbacks before onStepFinish', async () => {
@@ -2259,11 +2221,11 @@ describe('generateText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallStart: async () => {
-          callOrder.push('onToolCallStart');
+        experimental_onToolExecutionStart: async () => {
+          callOrder.push('onToolExecutionStart');
         },
-        experimental_onToolCallFinish: async () => {
-          callOrder.push('onToolCallFinish');
+        experimental_onToolExecutionEnd: async () => {
+          callOrder.push('onToolExecutionEnd');
         },
         onStepFinish: async () => {
           callOrder.push('onStepFinish');
@@ -2271,19 +2233,16 @@ describe('generateText', () => {
       });
 
       expect(callOrder).toEqual([
-        'onToolCallStart',
-        'onToolCallFinish',
+        'onToolExecutionStart',
+        'onToolExecutionEnd',
         'onStepFinish',
       ]);
     });
 
     it('should fire tool call callbacks for each tool in a multi-step loop', async () => {
-      const toolCallStartEvents: Parameters<
-        GenerateTextOnToolCallStartCallback<any>
-      >[0][] = [];
-      const toolCallFinishEvents: Parameters<
-        GenerateTextOnToolCallFinishCallback<any>
-      >[0][] = [];
+      const toolExecutionStartEvents: ToolExecutionStartEvent<any>[] = [];
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
+
       let responseCount = 0;
 
       await generateText({
@@ -2335,24 +2294,16 @@ describe('generateText', () => {
         },
         prompt: 'test-input',
         stopWhen: isStepCount(4),
-        experimental_onToolCallStart: async event => {
-          toolCallStartEvents.push(event);
+        experimental_onToolExecutionStart: async event => {
+          toolExecutionStartEvents.push(event);
         },
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
       });
 
-      expect(toolCallStartEvents.length).toBe(2);
-      expect(toolCallFinishEvents.length).toBe(2);
-
-      expect(toolCallStartEvents[0].toolCall.toolCallId).toBe('call-1');
-      expect(toolCallStartEvents[1].toolCall.toolCallId).toBe('call-2');
-
-      expect(toolCallFinishEvents[0].success).toBe(true);
-      expect(toolCallFinishEvents[0].output).toBe('step0-result');
-      expect(toolCallFinishEvents[1].success).toBe(true);
-      expect(toolCallFinishEvents[1].output).toBe('step1-result');
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
     });
   });
 
@@ -8922,11 +8873,11 @@ describe('generateText', () => {
             onStepStart: async () => {
               events.push('onStepStart');
             },
-            onToolCallStart: async () => {
-              events.push('onToolCallStart');
+            onToolExecutionStart: async () => {
+              events.push('onToolExecutionStart');
             },
-            onToolCallFinish: async () => {
-              events.push('onToolCallFinish');
+            onToolExecutionEnd: async () => {
+              events.push('onToolExecutionEnd');
             },
             onStepFinish: async () => {
               events.push('onStepFinish');
@@ -8938,14 +8889,7 @@ describe('generateText', () => {
         },
       });
 
-      expect(events).toEqual([
-        'onStart',
-        'onStepStart',
-        'onToolCallStart',
-        'onToolCallFinish',
-        'onStepFinish',
-        'onFinish',
-      ]);
+      expect(events).toMatchInlineSnapshot();
     });
 
     it('should call globally registered integration listeners', async () => {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1698,12 +1698,12 @@ describe('generateText', () => {
       expect(toolExecutionStartEvents).toMatchInlineSnapshot(`
         [
           {
-            "callId": "call-bIONpbEEcnMxkKBH3a9JuVlV",
+            "callId": "test-telemetry-call-id",
             "context": undefined,
             "functionId": undefined,
             "messages": [
               {
-                "content": "test-input",
+                "content": "prompt",
                 "role": "user",
               },
             ],
@@ -1723,12 +1723,12 @@ describe('generateText', () => {
             },
           },
           {
-            "callId": "call-bIONpbEEcnMxkKBH3a9JuVlV",
+            "callId": "test-telemetry-call-id",
             "context": undefined,
             "functionId": undefined,
             "messages": [
               {
-                "content": "test-input",
+                "content": "prompt",
                 "role": "user",
               },
             ],

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -64,8 +64,6 @@ import type {
   OnStartEvent,
   OnStepFinishEvent,
   OnStepStartEvent,
-  OnToolCallFinishEvent,
-  OnToolCallStartEvent,
 } from './core-events';
 import { executeToolCall } from './execute-tool-call';
 import { filterActiveTools } from './filter-active-tool';
@@ -93,6 +91,10 @@ import { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configurat
 import { ToolOutput } from './tool-output';
 import { TypedToolResult } from './tool-result';
 import { ToolsContextParameter } from './tools-context-parameter';
+import {
+  OnToolExecutionEndCallback,
+  OnToolExecutionStartCallback,
+} from './tool-execution-events';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -133,34 +135,6 @@ export type GenerateTextOnStepStartCallback<
   RUNTIME_CONTEXT extends Context = Context,
   OUTPUT extends Output = Output,
 > = Callback<OnStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
-
-/**
- * Callback that is set using the `experimental_onToolCallStart` option.
- *
- * Called when a tool execution begins, before the tool's `execute` function is invoked.
- * Use this for logging tool invocations, tracking tool usage, or pre-execution validation.
- *
- * @param event - The event object containing tool call information.
- */
-export type GenerateTextOnToolCallStartCallback<
-  TOOLS extends ToolSet = ToolSet,
-> = Callback<OnToolCallStartEvent<TOOLS>>;
-
-/**
- * Callback that is set using the `experimental_onToolCallFinish` option.
- *
- * Called when a tool execution completes, either successfully or with an error.
- * Use this for logging tool results, tracking execution time, or error handling.
- *
- * The event uses a discriminated union on the `success` field:
- * - When `success: true`: `output` contains the tool result, `error` is never present.
- * - When `success: false`: `error` contains the error, `output` is never present.
- *
- * @param event - The event object containing tool call result information.
- */
-export type GenerateTextOnToolCallFinishCallback<
-  TOOLS extends ToolSet = ToolSet,
-> = Callback<OnToolCallFinishEvent<TOOLS>>;
 
 /**
  * Callback that is set using the `onStepFinish` option.
@@ -278,8 +252,8 @@ export async function generateText<
   } = {},
   experimental_onStart: onStart,
   experimental_onStepStart: onStepStart,
-  experimental_onToolCallStart: onToolCallStart,
-  experimental_onToolCallFinish: onToolCallFinish,
+  experimental_onToolExecutionStart: onToolExecutionStart,
+  experimental_onToolExecutionEnd: onToolExecutionEnd,
   onStepFinish,
   onFinish,
   ...settings
@@ -388,14 +362,14 @@ export async function generateText<
     /**
      * Callback that is called right before a tool's execute function runs.
      */
-    experimental_onToolCallStart?: GenerateTextOnToolCallStartCallback<
+    experimental_onToolExecutionStart?: OnToolExecutionStartCallback<
       NoInfer<TOOLS>
     >;
 
     /**
      * Callback that is called right after a tool's execute function completes (or errors).
      */
-    experimental_onToolCallFinish?: GenerateTextOnToolCallFinishCallback<
+    experimental_onToolExecutionEnd?: OnToolExecutionEndCallback<
       NoInfer<TOOLS>
     >;
 
@@ -553,24 +527,24 @@ export async function generateText<
         stepNumber: 0,
         provider: model.provider,
         modelId: model.modelId,
-        onToolCallStart: event =>
+        onToolExecutionStart: event =>
           notify({
             event,
             callbacks: [
-              onToolCallStart,
-              unifiedTelemetry.onToolCallStart as
+              onToolExecutionStart,
+              unifiedTelemetry.onToolExecutionStart as
                 | undefined
-                | GenerateTextOnToolCallStartCallback<TOOLS>,
+                | OnToolExecutionStartCallback<TOOLS>,
             ],
           }),
-        onToolCallFinish: event =>
+        onToolExecutionEnd: event =>
           notify({
             event,
             callbacks: [
-              onToolCallFinish,
-              unifiedTelemetry.onToolCallFinish as
+              onToolExecutionEnd,
+              unifiedTelemetry.onToolExecutionEnd as
                 | undefined
-                | GenerateTextOnToolCallFinishCallback<TOOLS>,
+                | OnToolExecutionEndCallback<TOOLS>,
             ],
           }),
         executeToolInTelemetryContext: unifiedTelemetry.executeTool,
@@ -856,24 +830,24 @@ export async function generateText<
               stepNumber: steps.length,
               provider: stepModel.provider,
               modelId: stepModel.modelId,
-              onToolCallStart: event =>
+              onToolExecutionStart: event =>
                 notify({
                   event,
                   callbacks: [
-                    onToolCallStart,
-                    unifiedTelemetry.onToolCallStart as
+                    onToolExecutionStart,
+                    unifiedTelemetry.onToolExecutionStart as
                       | undefined
-                      | GenerateTextOnToolCallStartCallback<TOOLS>,
+                      | OnToolExecutionStartCallback<TOOLS>,
                   ],
                 }),
-              onToolCallFinish: event =>
+              onToolExecutionEnd: event =>
                 notify({
                   event,
                   callbacks: [
-                    onToolCallFinish,
-                    unifiedTelemetry.onToolCallFinish as
+                    onToolExecutionEnd,
+                    unifiedTelemetry.onToolExecutionEnd as
                       | undefined
-                      | GenerateTextOnToolCallFinishCallback<TOOLS>,
+                      | OnToolExecutionEndCallback<TOOLS>,
                   ],
                 }),
               executeToolInTelemetryContext: unifiedTelemetry.executeTool,
@@ -1092,8 +1066,8 @@ async function executeTools<TOOLS extends ToolSet>({
   stepNumber,
   provider,
   modelId,
-  onToolCallStart,
-  onToolCallFinish,
+  onToolExecutionStart,
+  onToolExecutionEnd,
   executeToolInTelemetryContext,
 }: {
   toolCalls: Array<TypedToolCall<TOOLS>>;
@@ -1107,8 +1081,8 @@ async function executeTools<TOOLS extends ToolSet>({
   stepNumber: number;
   provider: string;
   modelId: string;
-  onToolCallStart?: GenerateTextOnToolCallStartCallback<TOOLS>;
-  onToolCallFinish?: GenerateTextOnToolCallFinishCallback<TOOLS>;
+  onToolExecutionStart?: OnToolExecutionStartCallback<TOOLS>;
+  onToolExecutionEnd?: OnToolExecutionEndCallback<TOOLS>;
   executeToolInTelemetryContext?: TelemetryIntegration['executeTool'];
 }): Promise<Array<ToolOutput<TOOLS>>> {
   const toolOutputs = await Promise.all(
@@ -1125,8 +1099,8 @@ async function executeTools<TOOLS extends ToolSet>({
         stepNumber,
         provider,
         modelId,
-        onToolCallStart,
-        onToolCallFinish,
+        onToolExecutionStart,
+        onToolExecutionEnd,
         executeToolInTelemetryContext,
       }),
     ),

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -208,9 +208,9 @@ export type GenerateTextOnFinishCallback<
  * @param experimental_onStart - Callback invoked when generation begins, before any LLM calls.
  * @param experimental_onStepStart - Callback invoked when each step begins, before the provider is called.
  * Receives step number, messages (in ModelMessage format), tools, and runtimeContext.
- * @param experimental_onToolCallStart - Callback invoked before each tool execution begins.
+ * @param experimental_onToolExecutionStart - Callback invoked before each tool execution begins.
  * Receives tool name, call ID, input, and context.
- * @param experimental_onToolCallFinish - Callback invoked after each tool execution completes.
+ * @param experimental_onToolExecutionEnd - Callback invoked after each tool execution completes.
  * Uses a discriminated union: check `success` to determine if `output` or `error` is present.
  * @param onStepFinish - Callback that is called when each step (LLM call) is finished, including intermediate steps.
  * @param onFinish - Callback that is called when all steps are finished and the response is complete.

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -5,8 +5,6 @@ export type {
   OnStartEvent,
   OnStepFinishEvent,
   OnStepStartEvent,
-  OnToolCallFinishEvent,
-  OnToolCallStartEvent,
 } from './core-events';
 export { filterActiveTools as experimental_filterActiveTools } from './filter-active-tool';
 export {
@@ -15,8 +13,6 @@ export {
   type GenerateTextOnStartCallback,
   type GenerateTextOnStepFinishCallback,
   type GenerateTextOnStepStartCallback,
-  type GenerateTextOnToolCallFinishCallback,
-  type GenerateTextOnToolCallStartCallback,
 } from './generate-text';
 export type { GenerateTextResult } from './generate-text-result';
 export {
@@ -58,8 +54,6 @@ export {
   type StreamTextOnStartCallback,
   type StreamTextOnStepFinishCallback,
   type StreamTextOnStepStartCallback,
-  type StreamTextOnToolCallFinishCallback,
-  type StreamTextOnToolCallStartCallback,
   type StreamTextTransform,
 } from './stream-text';
 export type {
@@ -67,7 +61,6 @@ export type {
   TextStreamPart,
   UIMessageStreamOptions,
 } from './stream-text-result';
-export type { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configuration';
 export type { ToolApprovalRequestOutput } from './tool-approval-request-output';
 export type {
   DynamicToolCall,
@@ -80,6 +73,13 @@ export type {
   StaticToolError,
   TypedToolError,
 } from './tool-error';
+export type {
+  OnToolExecutionEndCallback,
+  OnToolExecutionStartCallback,
+  ToolExecutionEndEvent,
+  ToolExecutionStartEvent,
+} from './tool-execution-events';
+export type { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configuration';
 export type {
   StaticToolOutputDenied,
   TypedToolOutputDenied,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -10,6 +10,7 @@ import {
   SharedV4ProviderMetadata,
   SharedV4Warning,
 } from '@ai-sdk/provider';
+import type { ToolSet } from '@ai-sdk/provider-utils';
 import {
   delay,
   DelayedPromise,
@@ -54,11 +55,12 @@ import {
   StreamTextOnFinishCallback,
   StreamTextOnStartCallback,
   StreamTextOnStepStartCallback,
-  StreamTextOnToolCallFinishCallback,
-  StreamTextOnToolCallStartCallback,
 } from './stream-text';
 import { StreamTextResult, TextStreamPart } from './stream-text-result';
-import type { ToolSet } from '@ai-sdk/provider-utils';
+import {
+  OnToolExecutionEndCallback,
+  OnToolExecutionStartCallback,
+} from './tool-execution-events';
 
 const defaultSettings = () =>
   ({
@@ -6181,10 +6183,10 @@ describe('streamText', () => {
     });
   });
 
-  describe('options.experimental_onToolCallStart', () => {
+  describe('options.experimental_onToolExecutionStart', () => {
     it('should be called with correct tool name, id, and input', async () => {
-      const toolCallStartEvents: Parameters<
-        StreamTextOnToolCallStartCallback<any>
+      const toolExecutionStartEvents: Parameters<
+        OnToolExecutionStartCallback<any>
       >[0][] = [];
 
       const result = streamText({
@@ -6218,8 +6220,8 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallStart: async event => {
-          toolCallStartEvents.push(event);
+        experimental_onToolExecutionStart: async event => {
+          toolExecutionStartEvents.push(event);
         },
         onError: () => {},
         _internal: {
@@ -6230,13 +6232,12 @@ describe('streamText', () => {
 
       await result.consumeStream();
 
-      expect(toolCallStartEvents.length).toBe(1);
-      expect(toolCallStartEvents[0]).toMatchSnapshot();
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
     });
 
     it('should be called once per tool call in a multi-tool step', async () => {
-      const toolCallStartEvents: Parameters<
-        StreamTextOnToolCallStartCallback<any>
+      const toolExecutionStartEvents: Parameters<
+        OnToolExecutionStartCallback<any>
       >[0][] = [];
 
       const result = streamText({
@@ -6276,17 +6277,15 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallStart: async event => {
-          toolCallStartEvents.push(event);
+        experimental_onToolExecutionStart: async event => {
+          toolExecutionStartEvents.push(event);
         },
         onError: () => {},
       });
 
       await result.consumeStream();
 
-      expect(toolCallStartEvents.length).toBe(2);
-      expect(toolCallStartEvents[0].toolCall.toolCallId).toBe('call-1');
-      expect(toolCallStartEvents[1].toolCall.toolCallId).toBe('call-2');
+      expect(toolExecutionStartEvents.length).toMatchInlineSnapshot();
     });
 
     it('should be called before tool execution', async () => {
@@ -6326,7 +6325,7 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallStart: async () => {
+        experimental_onToolExecutionStart: async () => {
           callOrder.push('onToolCallStart');
         },
         onError: () => {},
@@ -6371,7 +6370,7 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallStart: async () => {
+        experimental_onToolExecutionStart: async () => {
           throw new Error('callback error');
         },
         onError: () => {},
@@ -6385,8 +6384,8 @@ describe('streamText', () => {
     });
 
     it('should not fire for tools without execute', async () => {
-      const toolCallStartEvents: Parameters<
-        StreamTextOnToolCallStartCallback<any>
+      const toolExecutionStartEvents: Parameters<
+        OnToolExecutionStartCallback<any>
       >[0][] = [];
 
       const result = streamText({
@@ -6419,20 +6418,20 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallStart: async event => {
-          toolCallStartEvents.push(event);
+        experimental_onToolExecutionStart: async event => {
+          toolExecutionStartEvents.push(event);
         },
         onError: () => {},
       });
 
       await result.consumeStream();
 
-      expect(toolCallStartEvents.length).toBe(0);
+      expect(toolExecutionStartEvents.length).toBe(0);
     });
 
     it('should pass context', async () => {
-      const toolCallStartEvents: Parameters<
-        StreamTextOnToolCallStartCallback<any>
+      const toolExecutionStartEvents: Parameters<
+        OnToolExecutionStartCallback<any>
       >[0][] = [];
 
       const result = streamText({
@@ -6467,15 +6466,15 @@ describe('streamText', () => {
           }),
         },
         toolsContext: { tool1: { context: 'test' } },
-        experimental_onToolCallStart: async event => {
-          toolCallStartEvents.push(event);
+        experimental_onToolExecutionStart: async event => {
+          toolExecutionStartEvents.push(event);
         },
         ...defaultSettings(),
       });
 
       await result.consumeStream();
 
-      expect(toolCallStartEvents).toMatchInlineSnapshot(`
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot(`
         [
           {
             "callId": "test-telemetry-call-id",
@@ -6509,10 +6508,10 @@ describe('streamText', () => {
     });
   });
 
-  describe('options.experimental_onToolCallFinish', () => {
+  describe('options.experimental_onToolExecutionEnd', () => {
     it('should be called with correct data on success', async () => {
-      const toolCallFinishEvents: Parameters<
-        StreamTextOnToolCallFinishCallback<any>
+      const toolExecutionEndEvents: Parameters<
+        OnToolExecutionEndCallback<any>
       >[0][] = [];
 
       const result = streamText({
@@ -6546,28 +6545,20 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
         onError: () => {},
       });
 
       await result.consumeStream();
 
-      expect(toolCallFinishEvents.length).toBe(1);
-      expect(toolCallFinishEvents[0].toolCall.toolName).toBe('tool1');
-      expect(toolCallFinishEvents[0].toolCall.toolCallId).toBe('call-1');
-      expect(toolCallFinishEvents[0].toolCall.input).toEqual({
-        value: 'test-arg',
-      });
-      expect(toolCallFinishEvents[0].success).toBe(true);
-      expect(toolCallFinishEvents[0].output).toBe('test-arg-result');
-      expect(toolCallFinishEvents[0].durationMs).toBeGreaterThanOrEqual(0);
+      expect(toolExecutionEndEvents.length).toMatchInlineSnapshot();
     });
 
     it('should be called with error data when tool execution fails', async () => {
-      const toolCallFinishEvents: Parameters<
-        StreamTextOnToolCallFinishCallback<any>
+      const toolExecutionEndEvents: Parameters<
+        OnToolExecutionEndCallback<any>
       >[0][] = [];
       const toolError = new Error('tool execution failed');
 
@@ -6604,25 +6595,25 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
         onError: () => {},
       });
 
       await result.consumeStream();
 
-      expect(toolCallFinishEvents.length).toBe(1);
-      expect(toolCallFinishEvents[0].toolCall.toolName).toBe('tool1');
-      expect(toolCallFinishEvents[0].toolCall.toolCallId).toBe('call-1');
-      expect(toolCallFinishEvents[0].success).toBe(false);
-      expect(toolCallFinishEvents[0].error).toBe(toolError);
-      expect(toolCallFinishEvents[0].durationMs).toBeGreaterThanOrEqual(0);
+      expect(toolExecutionEndEvents.length).toBe(1);
+      expect(toolExecutionEndEvents[0].toolCall.toolName).toBe('tool1');
+      expect(toolExecutionEndEvents[0].toolCall.toolCallId).toBe('call-1');
+      expect(toolExecutionEndEvents[0].success).toBe(false);
+      expect(toolExecutionEndEvents[0].error).toBe(toolError);
+      expect(toolExecutionEndEvents[0].durationMs).toBeGreaterThanOrEqual(0);
     });
 
     it('should have a positive durationMs', async () => {
-      const toolCallFinishEvents: Parameters<
-        StreamTextOnToolCallFinishCallback<any>
+      const toolExecutionEndEvents: Parameters<
+        OnToolExecutionEndCallback<any>
       >[0][] = [];
 
       const result = streamText({
@@ -6656,16 +6647,16 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
         onError: () => {},
       });
 
       await result.consumeStream();
 
-      expect(toolCallFinishEvents[0].durationMs).toBeGreaterThanOrEqual(0);
-      expect(typeof toolCallFinishEvents[0].durationMs).toBe('number');
+      expect(toolExecutionEndEvents[0].durationMs).toBeGreaterThanOrEqual(0);
+      expect(typeof toolExecutionEndEvents[0].durationMs).toBe('number');
     });
 
     it('should not break generation when callback throws', async () => {
@@ -6700,7 +6691,7 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallFinish: async () => {
+        experimental_onToolExecutionEnd: async () => {
           throw new Error('callback error');
         },
         onError: () => {},
@@ -6714,8 +6705,8 @@ describe('streamText', () => {
     });
 
     it('should not fire for tools without execute', async () => {
-      const toolCallFinishEvents: Parameters<
-        StreamTextOnToolCallFinishCallback<any>
+      const toolExecutionEndEvents: Parameters<
+        OnToolExecutionEndCallback<any>
       >[0][] = [];
 
       const result = streamText({
@@ -6748,20 +6739,20 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
         onError: () => {},
       });
 
       await result.consumeStream();
 
-      expect(toolCallFinishEvents.length).toBe(0);
+      expect(toolExecutionEndEvents.length).toBe(0);
     });
 
     it('should pass context on success', async () => {
-      const toolCallFinishEvents: Parameters<
-        StreamTextOnToolCallFinishCallback<any>
+      const toolExecutionEndEvents: Parameters<
+        OnToolExecutionEndCallback<any>
       >[0][] = [];
 
       const result = streamText({
@@ -6796,15 +6787,15 @@ describe('streamText', () => {
           }),
         },
         toolsContext: { tool1: { context: 'test' } },
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
         ...defaultSettings(),
       });
 
       await result.consumeStream();
 
-      expect(toolCallFinishEvents).toMatchInlineSnapshot(`
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
         [
           {
             "callId": "test-telemetry-call-id",
@@ -6841,8 +6832,8 @@ describe('streamText', () => {
     });
 
     it('should pass context on error', async () => {
-      const toolCallFinishEvents: Parameters<
-        StreamTextOnToolCallFinishCallback<any>
+      const toolExecutionEndEvents: Parameters<
+        OnToolExecutionEndCallback<any>
       >[0][] = [];
       const toolError = new Error('Tool execution failed');
 
@@ -6881,24 +6872,19 @@ describe('streamText', () => {
         },
         prompt: 'test-input',
         toolsContext: { tool1: { context: 'test' } },
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
         onError: () => {},
       });
 
       await result.consumeStream();
 
-      expect(toolCallFinishEvents.length).toBe(1);
-      expect(toolCallFinishEvents[0].success).toBe(false);
-      expect(toolCallFinishEvents[0].error).toBe(toolError);
-      expect(toolCallFinishEvents[0].context).toEqual({
-        context: 'test',
-      });
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
     });
   });
 
-  describe('options.experimental_onToolCallStart and experimental_onToolCallFinish ordering', () => {
+  describe('options.experimental_onToolExecutionStart and experimental_onToolExecutionEnd ordering', () => {
     it('should call start before finish', async () => {
       const callOrder: string[] = [];
 
@@ -6933,11 +6919,11 @@ describe('streamText', () => {
           }),
         },
         prompt: 'test-input',
-        experimental_onToolCallStart: async () => {
-          callOrder.push('onToolCallStart');
+        experimental_onToolExecutionStart: async () => {
+          callOrder.push('onToolExecutionStart');
         },
-        experimental_onToolCallFinish: async () => {
-          callOrder.push('onToolCallFinish');
+        experimental_onToolExecutionEnd: async () => {
+          callOrder.push('onToolExecutionEnd');
         },
         onError: () => {},
       });
@@ -6948,11 +6934,11 @@ describe('streamText', () => {
     });
 
     it('should fire tool call callbacks for each tool in a multi-step loop', async () => {
-      const toolCallStartEvents: Parameters<
-        StreamTextOnToolCallStartCallback<any>
+      const toolExecutionStartEvents: Parameters<
+        OnToolExecutionStartCallback<any>
       >[0][] = [];
-      const toolCallFinishEvents: Parameters<
-        StreamTextOnToolCallFinishCallback<any>
+      const toolExecutionEndEvents: Parameters<
+        OnToolExecutionEndCallback<any>
       >[0][] = [];
       let callCount = 0;
 
@@ -7035,27 +7021,19 @@ describe('streamText', () => {
         },
         prompt: 'test-input',
         stopWhen: isStepCount(4),
-        experimental_onToolCallStart: async event => {
-          toolCallStartEvents.push(event);
+        experimental_onToolExecutionStart: async event => {
+          toolExecutionStartEvents.push(event);
         },
-        experimental_onToolCallFinish: async event => {
-          toolCallFinishEvents.push(event);
+        experimental_onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
         },
         onError: () => {},
       });
 
       await result.consumeStream();
 
-      expect(toolCallStartEvents.length).toBe(2);
-      expect(toolCallFinishEvents.length).toBe(2);
-
-      expect(toolCallStartEvents[0].toolCall.toolCallId).toBe('call-1');
-      expect(toolCallStartEvents[1].toolCall.toolCallId).toBe('call-2');
-
-      expect(toolCallFinishEvents[0].success).toBe(true);
-      expect(toolCallFinishEvents[0].output).toBe('step0-result');
-      expect(toolCallFinishEvents[1].success).toBe(true);
-      expect(toolCallFinishEvents[1].output).toBe('step1-result');
+      expect(toolExecutionStartEvents.length).toMatchInlineSnapshot();
+      expect(toolExecutionEndEvents.length).toMatchInlineSnapshot();
     });
   });
 
@@ -23258,11 +23236,11 @@ describe('streamText', () => {
             onStepStart: async () => {
               events.push('onStepStart');
             },
-            onToolCallStart: async () => {
-              events.push('onToolCallStart');
+            onToolExecutionStart: async () => {
+              events.push('onToolExecutionStart');
             },
-            onToolCallFinish: async () => {
-              events.push('onToolCallFinish');
+            onToolExecutionEnd: async () => {
+              events.push('onToolExecutionEnd');
             },
             onStepFinish: async () => {
               events.push('onStepFinish');
@@ -23276,14 +23254,7 @@ describe('streamText', () => {
 
       await result.consumeStream();
 
-      expect(events).toEqual([
-        'onStart',
-        'onStepStart',
-        'onToolCallStart',
-        'onToolCallFinish',
-        'onStepFinish',
-        'onFinish',
-      ]);
+      expect(events).toMatchInlineSnapshot();
     });
 
     it('should call globally registered integration listeners', async () => {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -6326,14 +6326,14 @@ describe('streamText', () => {
         },
         prompt: 'test-input',
         experimental_onToolExecutionStart: async () => {
-          callOrder.push('onToolCallStart');
+          callOrder.push('onToolExecutionStart');
         },
         onError: () => {},
       });
 
       await result.consumeStream();
 
-      expect(callOrder.indexOf('onToolCallStart')).toBeLessThan(
+      expect(callOrder.indexOf('onToolExecutionStart')).toBeLessThan(
         callOrder.indexOf('execute'),
       );
     });
@@ -6930,7 +6930,7 @@ describe('streamText', () => {
 
       await result.consumeStream();
 
-      expect(callOrder).toEqual(['onToolCallStart', 'onToolCallFinish']);
+      expect(callOrder).toEqual(['onToolExecutionStart', 'onToolExecutionEnd']);
     });
 
     it('should fire tool call callbacks for each tool in a multi-step loop', async () => {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -6232,7 +6232,35 @@ describe('streamText', () => {
 
       await result.consumeStream();
 
-      expect(toolExecutionStartEvents).toMatchInlineSnapshot();
+      expect(toolExecutionStartEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": undefined,
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "test-input",
+                "role": "user",
+              },
+            ],
+            "modelId": "mock-model-id",
+            "provider": "mock-provider",
+            "stepNumber": 0,
+            "toolCall": {
+              "input": {
+                "value": "test-arg",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
     });
 
     it('should be called once per tool call in a multi-tool step', async () => {
@@ -6285,7 +6313,7 @@ describe('streamText', () => {
 
       await result.consumeStream();
 
-      expect(toolExecutionStartEvents.length).toMatchInlineSnapshot();
+      expect(toolExecutionStartEvents.length).toMatchInlineSnapshot(`2`);
     });
 
     it('should be called before tool execution', async () => {
@@ -6553,7 +6581,7 @@ describe('streamText', () => {
 
       await result.consumeStream();
 
-      expect(toolExecutionEndEvents.length).toMatchInlineSnapshot();
+      expect(toolExecutionEndEvents.length).toMatchInlineSnapshot(`1`);
     });
 
     it('should be called with error data when tool execution fails', async () => {
@@ -6870,17 +6898,49 @@ describe('streamText', () => {
             },
           }),
         },
-        prompt: 'test-input',
         toolsContext: { tool1: { context: 'test' } },
         experimental_onToolExecutionEnd: async event => {
           toolExecutionEndEvents.push(event);
         },
-        onError: () => {},
+        ...defaultSettings(),
       });
 
       await result.consumeStream();
 
-      expect(toolExecutionEndEvents).toMatchInlineSnapshot();
+      expect(toolExecutionEndEvents).toMatchInlineSnapshot(`
+        [
+          {
+            "callId": "test-telemetry-call-id",
+            "context": {
+              "context": "test",
+            },
+            "durationMs": 0,
+            "error": [Error: Tool execution failed],
+            "functionId": undefined,
+            "messages": [
+              {
+                "content": "prompt",
+                "role": "user",
+              },
+            ],
+            "modelId": "mock-model-id",
+            "provider": "mock-provider",
+            "stepNumber": 0,
+            "success": false,
+            "toolCall": {
+              "input": {
+                "value": "test",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "title": undefined,
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          },
+        ]
+      `);
     });
   });
 
@@ -7032,8 +7092,8 @@ describe('streamText', () => {
 
       await result.consumeStream();
 
-      expect(toolExecutionStartEvents.length).toMatchInlineSnapshot();
-      expect(toolExecutionEndEvents.length).toMatchInlineSnapshot();
+      expect(toolExecutionStartEvents.length).toMatchInlineSnapshot(`2`);
+      expect(toolExecutionEndEvents.length).toMatchInlineSnapshot(`2`);
     });
   });
 
@@ -23254,7 +23314,16 @@ describe('streamText', () => {
 
       await result.consumeStream();
 
-      expect(events).toMatchInlineSnapshot();
+      expect(events).toMatchInlineSnapshot(`
+        [
+          "onStart",
+          "onStepStart",
+          "onToolExecutionStart",
+          "onToolExecutionEnd",
+          "onStepFinish",
+          "onFinish",
+        ]
+      `);
     });
 
     it('should call globally registered integration listeners', async () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -14,6 +14,7 @@ import {
   asArray,
   createIdGenerator,
   DelayedPromise,
+  filterNullable,
   IdGenerator,
   isAbortError,
   ProviderOptions,
@@ -86,8 +87,6 @@ import type {
   OnStartEvent,
   OnStepFinishEvent,
   OnStepStartEvent,
-  OnToolCallFinishEvent,
-  OnToolCallStartEvent,
 } from './core-events';
 import { createExecuteToolsTransformation } from './create-execute-tools-transformation';
 import { executeToolCall } from './execute-tool-call';
@@ -125,6 +124,10 @@ import { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configurat
 import { ToolOutput } from './tool-output';
 import { StaticToolOutputDenied } from './tool-output-denied';
 import { ToolsContextParameter } from './tools-context-parameter';
+import {
+  OnToolExecutionEndCallback,
+  OnToolExecutionStartCallback,
+} from './tool-execution-events';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -244,13 +247,6 @@ export type StreamTextOnStepStartCallback<
   OUTPUT extends Output = Output,
 > = Callback<OnStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
 
-export type StreamTextOnToolCallStartCallback<TOOLS extends ToolSet = ToolSet> =
-  Callback<OnToolCallStartEvent<TOOLS>>;
-
-export type StreamTextOnToolCallFinishCallback<
-  TOOLS extends ToolSet = ToolSet,
-> = Callback<OnToolCallFinishEvent<TOOLS>>;
-
 /**
  * Generate a text and call tools for a given prompt using a language model.
  *
@@ -335,8 +331,8 @@ export function streamText<
   onStepFinish,
   experimental_onStart: onStart,
   experimental_onStepStart: onStepStart,
-  experimental_onToolCallStart: onToolCallStart,
-  experimental_onToolCallFinish: onToolCallFinish,
+  experimental_onToolExecutionStart: onToolExecutionStart,
+  experimental_onToolExecutionEnd: onToolExecutionEnd,
   runtimeContext = {} as RUNTIME_CONTEXT,
   toolsContext = {} as InferToolSetContext<TOOLS>,
   experimental_include: include,
@@ -511,14 +507,14 @@ export function streamText<
     /**
      * Callback that is called right before a tool's execute function runs.
      */
-    experimental_onToolCallStart?: StreamTextOnToolCallStartCallback<
+    experimental_onToolExecutionStart?: OnToolExecutionStartCallback<
       NoInfer<TOOLS>
     >;
 
     /**
      * Callback that is called right after a tool's execute function completes (or errors).
      */
-    experimental_onToolCallFinish?: StreamTextOnToolCallFinishCallback<
+    experimental_onToolExecutionEnd?: OnToolExecutionEndCallback<
       NoInfer<TOOLS>
     >;
 
@@ -595,8 +591,8 @@ export function streamText<
     onStepFinish,
     onStart,
     onStepStart,
-    onToolCallStart,
-    onToolCallFinish,
+    onToolExecutionStart,
+    onToolExecutionEnd,
     now,
     generateId,
     generateCallId,
@@ -782,8 +778,8 @@ class DefaultStreamTextResult<
     onStepFinish,
     onStart,
     onStepStart,
-    onToolCallStart,
-    onToolCallFinish,
+    onToolExecutionStart,
+    onToolExecutionEnd,
     runtimeContext,
     toolsContext,
     download,
@@ -858,8 +854,8 @@ class DefaultStreamTextResult<
           NoInfer<RUNTIME_CONTEXT>,
           NoInfer<OUTPUT>
         >;
-    onToolCallStart: undefined | StreamTextOnToolCallStartCallback<TOOLS>;
-    onToolCallFinish: undefined | StreamTextOnToolCallFinishCallback<TOOLS>;
+    onToolExecutionStart: undefined | OnToolExecutionStartCallback<TOOLS>;
+    onToolExecutionEnd: undefined | OnToolExecutionEndCallback<TOOLS>;
   }) {
     this.outputSpecification = output;
     this.includeRawChunks = includeRawChunks;
@@ -1424,16 +1420,18 @@ class DefaultStreamTextResult<
                 stepNumber: recordedSteps.length,
                 provider: model.provider,
                 modelId: model.modelId,
-                onToolCallStart: [
-                  onToolCallStart,
-                  unifiedTelemetry.onToolCallStart as
-                    | undefined
-                    | StreamTextOnToolCallStartCallback<TOOLS>,
-                ],
-                onToolCallFinish: [
-                  onToolCallFinish,
-                  unifiedTelemetry.onToolCallFinish,
-                ],
+                onToolExecutionStart: filterNullable(
+                  onToolExecutionStart,
+                  unifiedTelemetry.onToolExecutionStart as
+                    | OnToolExecutionStartCallback<TOOLS>
+                    | undefined,
+                ),
+                onToolExecutionEnd: filterNullable(
+                  onToolExecutionEnd,
+                  unifiedTelemetry.onToolExecutionEnd as
+                    | OnToolExecutionEndCallback<TOOLS>
+                    | undefined,
+                ),
                 executeToolInTelemetryContext: unifiedTelemetry.executeTool,
                 onPreliminaryToolResult: result => {
                   toolExecutionStepStreamController?.enqueue(result);
@@ -1668,16 +1666,18 @@ class DefaultStreamTextResult<
               stepNumber: recordedSteps.length,
               provider: stepModel.provider,
               modelId: stepModel.modelId,
-              onToolCallStart: [
-                onToolCallStart,
-                unifiedTelemetry.onToolCallStart as
-                  | undefined
-                  | StreamTextOnToolCallStartCallback<TOOLS>,
-              ],
-              onToolCallFinish: [
-                onToolCallFinish,
-                unifiedTelemetry.onToolCallFinish,
-              ],
+              onToolExecutionStart: filterNullable(
+                onToolExecutionStart,
+                unifiedTelemetry.onToolExecutionStart as
+                  | OnToolExecutionStartCallback<TOOLS>
+                  | undefined,
+              ),
+              onToolExecutionEnd: filterNullable(
+                onToolExecutionEnd,
+                unifiedTelemetry.onToolExecutionEnd as
+                  | OnToolExecutionEndCallback<TOOLS>
+                  | undefined,
+              ),
               executeToolInTelemetryContext: unifiedTelemetry.executeTool,
             }),
           );

--- a/packages/ai/src/generate-text/tool-execution-events.ts
+++ b/packages/ai/src/generate-text/tool-execution-events.ts
@@ -88,7 +88,7 @@ export type ToolExecutionEndEvent<TOOLS extends ToolSet = ToolSet> = {
 );
 
 /**
- * Callback that is set using the `experimental_onToolCallStart` option.
+ * Callback that is set using the `experimental_onToolExecutionStart` option.
  *
  * Called when a tool execution begins, before the tool's `execute` function is invoked.
  * Use this for logging tool invocations, tracking tool usage, or pre-execution validation.
@@ -99,7 +99,7 @@ export type OnToolExecutionStartCallback<TOOLS extends ToolSet = ToolSet> =
   Callback<ToolExecutionStartEvent<TOOLS>>;
 
 /**
- * Callback that is set using the `experimental_onToolCallFinish` option.
+ * Callback that is set using the `experimental_onToolExecutionEnd` option.
  *
  * Called when a tool execution completes, either successfully or with an error.
  * Use this for logging tool results, tracking execution time, or error handling.

--- a/packages/ai/src/generate-text/tool-execution-events.ts
+++ b/packages/ai/src/generate-text/tool-execution-events.ts
@@ -1,0 +1,114 @@
+import type {
+  InferToolSetContext,
+  ModelMessage,
+  ToolSet,
+} from '@ai-sdk/provider-utils';
+import type { TypedToolCall } from './tool-call';
+import { Callback } from '../util/callback';
+
+/**
+ * Event passed to the `onToolExecutionStart` callback.
+ *
+ * Called when a tool execution begins, before the tool's `execute` function is invoked.
+ */
+export interface ToolExecutionStartEvent<TOOLS extends ToolSet = ToolSet> {
+  /** Unique identifier for this generation call, used to correlate events. */
+  readonly callId: string;
+
+  /** Zero-based index of the current step where this tool call occurs. */
+  readonly stepNumber: number | undefined;
+
+  /** The provider identifier (e.g., 'openai', 'anthropic'). */
+  readonly provider: string | undefined;
+
+  /** The specific model identifier (e.g., 'gpt-4o'). */
+  readonly modelId: string | undefined;
+
+  /** The full tool call object. */
+  readonly toolCall: TypedToolCall<TOOLS>;
+
+  /** The conversation messages available at tool execution time. */
+  readonly messages: Array<ModelMessage>;
+
+  /** Identifier from telemetry settings for grouping related operations. */
+  readonly functionId: string | undefined;
+
+  /** User-defined context object flowing through the generation. */
+  readonly context: InferToolSetContext<TOOLS>;
+}
+
+/**
+ * Event passed to the `onToolExecutionEnd` callback.
+ *
+ * Called when a tool execution completes, either successfully or with an error.
+ * Uses a discriminated union on the `success` field.
+ */
+export type ToolExecutionEndEvent<TOOLS extends ToolSet = ToolSet> = {
+  /** Unique identifier for this generation call, used to correlate events. */
+  readonly callId: string;
+
+  /** Zero-based index of the current step where this tool call occurred. */
+  readonly stepNumber: number | undefined;
+
+  /** The provider identifier (e.g., 'openai', 'anthropic'). */
+  readonly provider: string | undefined;
+
+  /** The specific model identifier (e.g., 'gpt-4o'). */
+  readonly modelId: string | undefined;
+
+  /** The full tool call object. */
+  readonly toolCall: TypedToolCall<TOOLS>;
+
+  /** The conversation messages available at tool execution time. */
+  readonly messages: Array<ModelMessage>;
+
+  /** Execution time of the tool call in milliseconds. */
+  readonly durationMs: number;
+
+  /** Identifier from telemetry settings for grouping related operations. */
+  readonly functionId: string | undefined;
+
+  /** User-defined context object flowing through the generation. */
+  readonly context: InferToolSetContext<TOOLS>;
+} & (
+  | {
+      /** Indicates the tool call succeeded. */
+      readonly success: true;
+      /** The tool's return value. */
+      readonly output: unknown;
+      readonly error?: never;
+    }
+  | {
+      /** Indicates the tool call failed. */
+      readonly success: false;
+      readonly output?: never;
+      /** The error that occurred during tool execution. */
+      readonly error: unknown;
+    }
+);
+
+/**
+ * Callback that is set using the `experimental_onToolCallStart` option.
+ *
+ * Called when a tool execution begins, before the tool's `execute` function is invoked.
+ * Use this for logging tool invocations, tracking tool usage, or pre-execution validation.
+ *
+ * @param event - The event object containing tool call information.
+ */
+export type OnToolExecutionStartCallback<TOOLS extends ToolSet = ToolSet> =
+  Callback<ToolExecutionStartEvent<TOOLS>>;
+
+/**
+ * Callback that is set using the `experimental_onToolCallFinish` option.
+ *
+ * Called when a tool execution completes, either successfully or with an error.
+ * Use this for logging tool results, tracking execution time, or error handling.
+ *
+ * The event uses a discriminated union on the `success` field:
+ * - When `success: true`: `output` contains the tool result, `error` is never present.
+ * - When `success: false`: `error` contains the error, `output` is never present.
+ *
+ * @param event - The event object containing tool call result information.
+ */
+export type OnToolExecutionEndCallback<TOOLS extends ToolSet = ToolSet> =
+  Callback<ToolExecutionEndEvent<TOOLS>>;

--- a/packages/ai/src/generate-text/tool-execution-events.ts
+++ b/packages/ai/src/generate-text/tool-execution-events.ts
@@ -3,8 +3,8 @@ import type {
   ModelMessage,
   ToolSet,
 } from '@ai-sdk/provider-utils';
-import type { TypedToolCall } from './tool-call';
 import { Callback } from '../util/callback';
+import type { TypedToolCall } from './tool-call';
 
 /**
  * Event passed to the `onToolExecutionStart` callback.

--- a/packages/ai/src/telemetry/create-unified-telemetry.test.ts
+++ b/packages/ai/src/telemetry/create-unified-telemetry.test.ts
@@ -15,8 +15,8 @@ describe('createUnifiedTelemetry', () => {
 
     expect(telemetry.onStart).toBeDefined();
     expect(telemetry.onStepStart).toBeDefined();
-    expect(telemetry.onToolCallStart).toBeDefined();
-    expect(telemetry.onToolCallFinish).toBeDefined();
+    expect(telemetry.onToolExecutionStart).toBeDefined();
+    expect(telemetry.onToolExecutionEnd).toBeDefined();
     expect(telemetry.onChunk).toBeDefined();
     expect(telemetry.onStepFinish).toBeDefined();
     expect(telemetry.onObjectStepStart).toBeDefined();
@@ -60,7 +60,7 @@ describe('createUnifiedTelemetry', () => {
     });
 
     await expect(
-      telemetry.onToolCallStart!(dummyEvent),
+      telemetry.onToolExecutionStart!(dummyEvent),
     ).resolves.toBeUndefined();
     await expect(telemetry.onEmbedFinish!(dummyEvent)).resolves.toBeUndefined();
   });
@@ -123,8 +123,8 @@ describe('createUnifiedTelemetry', () => {
     const integration: TelemetryIntegration = {
       onStart: vi.fn(),
       onStepStart: vi.fn(),
-      onToolCallStart: vi.fn(),
-      onToolCallFinish: vi.fn(),
+      onToolExecutionStart: vi.fn(),
+      onToolExecutionEnd: vi.fn(),
       onChunk: vi.fn(),
       onStepFinish: vi.fn(),
       onObjectStepStart: vi.fn(),
@@ -141,8 +141,8 @@ describe('createUnifiedTelemetry', () => {
 
     await telemetry.onStart!(dummyEvent);
     await telemetry.onStepStart!(dummyEvent);
-    await telemetry.onToolCallStart!(dummyEvent);
-    await telemetry.onToolCallFinish!(dummyEvent);
+    await telemetry.onToolExecutionStart!(dummyEvent);
+    await telemetry.onToolExecutionEnd!(dummyEvent);
     await telemetry.onChunk!(dummyEvent);
     await telemetry.onStepFinish!(dummyEvent);
     await telemetry.onObjectStepStart!(dummyEvent);
@@ -156,8 +156,8 @@ describe('createUnifiedTelemetry', () => {
 
     expect(integration.onStart).toHaveBeenCalledOnce();
     expect(integration.onStepStart).toHaveBeenCalledOnce();
-    expect(integration.onToolCallStart).toHaveBeenCalledOnce();
-    expect(integration.onToolCallFinish).toHaveBeenCalledOnce();
+    expect(integration.onToolExecutionStart).toHaveBeenCalledOnce();
+    expect(integration.onToolExecutionEnd).toHaveBeenCalledOnce();
     expect(integration.onChunk).toHaveBeenCalledOnce();
     expect(integration.onStepFinish).toHaveBeenCalledOnce();
     expect(integration.onObjectStepStart).toHaveBeenCalledOnce();

--- a/packages/ai/src/telemetry/create-unified-telemetry.ts
+++ b/packages/ai/src/telemetry/create-unified-telemetry.ts
@@ -65,8 +65,8 @@ export function createUnifiedTelemetry({
   return {
     onStart: mergeTelemetryCallback('onStart'),
     onStepStart: mergeTelemetryCallback('onStepStart'),
-    onToolCallStart: mergeTelemetryCallback('onToolCallStart'),
-    onToolCallFinish: mergeTelemetryCallback('onToolCallFinish'),
+    onToolExecutionStart: mergeTelemetryCallback('onToolExecutionStart'),
+    onToolExecutionEnd: mergeTelemetryCallback('onToolExecutionEnd'),
     onChunk: mergeTelemetryCallback('onChunk'),
     onStepFinish: mergeTelemetryCallback('onStepFinish'),
     onObjectStepStart: mergeTelemetryCallback('onObjectStepStart'),

--- a/packages/ai/src/telemetry/telemetry-integration.ts
+++ b/packages/ai/src/telemetry/telemetry-integration.ts
@@ -17,9 +17,11 @@ import type {
   OnStartEvent,
   OnStepFinishEvent,
   OnStepStartEvent,
-  OnToolCallFinishEvent,
-  OnToolCallStartEvent,
 } from '../generate-text/core-events';
+import type {
+  ToolExecutionEndEvent,
+  ToolExecutionStartEvent,
+} from '../generate-text/tool-execution-events';
 import type {
   RerankFinishEvent,
   RerankOnFinishEvent,
@@ -59,7 +61,7 @@ export interface TelemetryIntegration {
    * Called when a tool execution begins, before the tool's `execute` function
    * is invoked. Use this to create tool-level spans or log tool invocations.
    */
-  onToolCallStart?: Callback<OnToolCallStartEvent>;
+  onToolExecutionStart?: Callback<ToolExecutionStartEvent>;
 
   /**
    * Called when a tool execution completes, either successfully or with an error.
@@ -68,7 +70,7 @@ export interface TelemetryIntegration {
    *
    * The event includes execution duration (`durationMs`) for performance tracking.
    */
-  onToolCallFinish?: Callback<OnToolCallFinishEvent>;
+  onToolExecutionEnd?: Callback<ToolExecutionEndEvent>;
 
   /**
    * Called for each chunk received during streaming.

--- a/packages/otel/src/gen-ai-open-telemetry-integration.test.ts
+++ b/packages/otel/src/gen-ai-open-telemetry-integration.test.ts
@@ -297,7 +297,7 @@ function makeToolCallStartEvent(overrides?: Record<string, unknown>) {
     context: {},
     toolsContext: {},
     ...overrides,
-  } as Parameters<NonNullable<TelemetryIntegration['onToolCallStart']>>[0];
+  } as Parameters<NonNullable<TelemetryIntegration['onToolExecutionStart']>>[0];
 }
 
 function makeToolCallFinishEvent(
@@ -329,13 +329,13 @@ function makeToolCallFinishEvent(
       ...base,
       success: true as const,
       output: { result: 'ok' },
-    } as Parameters<NonNullable<TelemetryIntegration['onToolCallFinish']>>[0];
+    } as Parameters<NonNullable<TelemetryIntegration['onToolExecutionEnd']>>[0];
   }
   return {
     ...base,
     success: false as const,
     error: new Error('tool failed'),
-  } as Parameters<NonNullable<TelemetryIntegration['onToolCallFinish']>>[0];
+  } as Parameters<NonNullable<TelemetryIntegration['onToolExecutionEnd']>>[0];
 }
 
 describe('GenAIOpenTelemetryIntegration', () => {
@@ -628,11 +628,11 @@ describe('GenAIOpenTelemetryIntegration', () => {
     });
   });
 
-  describe('onToolCallStart / onToolCallFinish', () => {
+  describe('onToolExecutionStart / onToolExecutionEnd', () => {
     it('creates an execute_tool span with correct attributes', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent());
-      integration.onToolCallStart!(makeToolCallStartEvent());
+      integration.onToolExecutionStart!(makeToolCallStartEvent());
 
       expect(tracer.spans).toHaveLength(3);
       expect(serializeSpan(tracer.spans[2], tracer)).toMatchInlineSnapshot(`
@@ -654,8 +654,8 @@ describe('GenAIOpenTelemetryIntegration', () => {
     it('sets gen_ai.tool.call.result on success', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent());
-      integration.onToolCallStart!(makeToolCallStartEvent());
-      integration.onToolCallFinish!(makeToolCallFinishEvent(true));
+      integration.onToolExecutionStart!(makeToolCallStartEvent());
+      integration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
 
       expect(serializeSpan(tracer.spans[2], tracer)).toMatchInlineSnapshot(`
         {
@@ -678,8 +678,8 @@ describe('GenAIOpenTelemetryIntegration', () => {
     it('records error on tool failure', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent());
-      integration.onToolCallStart!(makeToolCallStartEvent());
-      integration.onToolCallFinish!(makeToolCallFinishEvent(false));
+      integration.onToolExecutionStart!(makeToolCallStartEvent());
+      integration.onToolExecutionEnd!(makeToolCallFinishEvent(false));
 
       const toolSpan = tracer.spans[2];
       expect({
@@ -910,8 +910,8 @@ describe('GenAIOpenTelemetryIntegration', () => {
       integration.onStart!(makeOnStartEvent());
 
       integration.onStepStart!(makeStepStartEvent());
-      integration.onToolCallStart!(makeToolCallStartEvent());
-      integration.onToolCallFinish!(makeToolCallFinishEvent(true));
+      integration.onToolExecutionStart!(makeToolCallStartEvent());
+      integration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
       integration.onStepFinish!(
         makeStepFinishEvent({ finishReason: 'tool-calls' }),
       );
@@ -1005,8 +1005,8 @@ describe('GenAIOpenTelemetryIntegration', () => {
       integration.onStart!(makeOnStartEvent());
 
       integration.onStepStart!(makeStepStartEvent());
-      integration.onToolCallStart!(makeToolCallStartEvent());
-      integration.onToolCallFinish!(makeToolCallFinishEvent(true));
+      integration.onToolExecutionStart!(makeToolCallStartEvent());
+      integration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
       integration.onStepFinish!(
         makeStepFinishEvent({ finishReason: 'tool-calls' }),
       );
@@ -1101,8 +1101,8 @@ describe('GenAIOpenTelemetryIntegration', () => {
     it('does not use ai.* attribute prefix anywhere', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent());
-      integration.onToolCallStart!(makeToolCallStartEvent());
-      integration.onToolCallFinish!(makeToolCallFinishEvent(true));
+      integration.onToolExecutionStart!(makeToolCallStartEvent());
+      integration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
       integration.onStepFinish!(makeStepFinishEvent());
       integration.onFinish!(makeFinishEvent());
 

--- a/packages/otel/src/gen-ai-open-telemetry-integration.ts
+++ b/packages/otel/src/gen-ai-open-telemetry-integration.ts
@@ -25,8 +25,8 @@ import type {
   OnStartEvent,
   OnStepFinishEvent,
   OnStepStartEvent,
-  OnToolCallFinishEvent,
-  OnToolCallStartEvent,
+  ToolExecutionEndEvent,
+  ToolExecutionStartEvent,
   OutputInterface as Output,
   RerankFinishEvent,
   RerankOnFinishEvent,
@@ -540,7 +540,7 @@ export class GenAIOpenTelemetryIntegration implements TelemetryIntegration {
     state.stepContext = trace.setSpan(state.rootContext, state.stepSpan);
   }
 
-  onToolCallStart(event: OnToolCallStartEvent<ToolSet>): void {
+  onToolExecutionStart(event: ToolExecutionStartEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state?.stepContext) return;
 
@@ -571,7 +571,7 @@ export class GenAIOpenTelemetryIntegration implements TelemetryIntegration {
     });
   }
 
-  onToolCallFinish(event: OnToolCallFinishEvent<ToolSet>): void {
+  onToolExecutionEnd(event: ToolExecutionEndEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state) return;
 

--- a/packages/otel/src/open-telemetry-integration.test.ts
+++ b/packages/otel/src/open-telemetry-integration.test.ts
@@ -313,7 +313,7 @@ function makeToolCallStartEvent(overrides?: Record<string, unknown>) {
     context: {},
     toolsContext: {},
     ...overrides,
-  } as Parameters<NonNullable<TelemetryIntegration['onToolCallStart']>>[0];
+  } as Parameters<NonNullable<TelemetryIntegration['onToolExecutionStart']>>[0];
 }
 
 function makeToolCallFinishEvent(
@@ -345,13 +345,13 @@ function makeToolCallFinishEvent(
       ...base,
       success: true as const,
       output: { result: 'ok' },
-    } as Parameters<NonNullable<TelemetryIntegration['onToolCallFinish']>>[0];
+    } as Parameters<NonNullable<TelemetryIntegration['onToolExecutionEnd']>>[0];
   }
   return {
     ...base,
     success: false as const,
     error: new Error('tool failed'),
-  } as Parameters<NonNullable<TelemetryIntegration['onToolCallFinish']>>[0];
+  } as Parameters<NonNullable<TelemetryIntegration['onToolExecutionEnd']>>[0];
 }
 
 function makeChunkEvent(
@@ -504,11 +504,11 @@ describe('OpenTelemetryIntegration', () => {
     });
   });
 
-  describe('onToolCallStart', () => {
+  describe('onToolExecutionStart', () => {
     it('creates a tool span as child of step span', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
 
       expect(tracer.startSpan).toHaveBeenCalledTimes(3);
       expect(tracer.spans).toHaveLength(3);
@@ -518,7 +518,7 @@ describe('OpenTelemetryIntegration', () => {
     it('sets tool call attributes', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
 
       const attrs = getStartSpanAttributes(tracer, 2);
       expect(attrs['ai.toolCall.name']).toBe('myTool');
@@ -528,7 +528,7 @@ describe('OpenTelemetryIntegration', () => {
     it('sets tool call args as output attribute', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
 
       const attrs = getStartSpanAttributes(tracer, 2);
       expect(attrs['ai.toolCall.args']).toBe(JSON.stringify({ query: 'test' }));
@@ -536,7 +536,7 @@ describe('OpenTelemetryIntegration', () => {
 
     it('does not create tool span without prior step span', () => {
       otelIntegration.onStart!(makeOnStartEvent());
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
 
       expect(tracer.spans).toHaveLength(1);
     });
@@ -545,7 +545,7 @@ describe('OpenTelemetryIntegration', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
 
-      otelIntegration.onToolCallStart!(
+      otelIntegration.onToolExecutionStart!(
         makeToolCallStartEvent({
           toolCall: {
             toolCallId: 'tool-1',
@@ -554,7 +554,7 @@ describe('OpenTelemetryIntegration', () => {
           },
         }),
       );
-      otelIntegration.onToolCallStart!(
+      otelIntegration.onToolExecutionStart!(
         makeToolCallStartEvent({
           toolCall: {
             toolCallId: 'tool-2',
@@ -570,12 +570,12 @@ describe('OpenTelemetryIntegration', () => {
     });
   });
 
-  describe('onToolCallFinish', () => {
+  describe('onToolExecutionEnd', () => {
     it('ends the tool span on success', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
-      otelIntegration.onToolCallFinish!(makeToolCallFinishEvent(true));
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
 
       const toolSpan = tracer.spans[2];
       expect(toolSpan.ended).toBe(true);
@@ -584,8 +584,8 @@ describe('OpenTelemetryIntegration', () => {
     it('sets result attribute on successful tool call', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
-      otelIntegration.onToolCallFinish!(makeToolCallFinishEvent(true));
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
 
       const toolSpan = tracer.spans[2];
       expect(toolSpan.setAttributes).toHaveBeenCalled();
@@ -594,8 +594,8 @@ describe('OpenTelemetryIntegration', () => {
     it('records error on failed tool call', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
-      otelIntegration.onToolCallFinish!(makeToolCallFinishEvent(false));
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionEnd!(makeToolCallFinishEvent(false));
 
       const toolSpan = tracer.spans[2];
       expect(toolSpan.ended).toBe(true);
@@ -608,9 +608,9 @@ describe('OpenTelemetryIntegration', () => {
     it('does nothing for unknown tool call id', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
 
-      otelIntegration.onToolCallFinish!(
+      otelIntegration.onToolExecutionEnd!(
         makeToolCallFinishEvent(true, {
           toolCall: {
             toolCallId: 'unknown-tool',
@@ -627,10 +627,10 @@ describe('OpenTelemetryIntegration', () => {
     it('removes tool span from state after finishing', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
-      otelIntegration.onToolCallFinish!(makeToolCallFinishEvent(true));
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
 
-      otelIntegration.onToolCallFinish!(makeToolCallFinishEvent(true));
+      otelIntegration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
 
       expect(tracer.spans[2].end).toHaveBeenCalledTimes(1);
     });
@@ -1080,7 +1080,7 @@ describe('OpenTelemetryIntegration', () => {
     it('does not record tool call args when recordOutputs is false', () => {
       otelIntegration.onStart!(makeOnStartEvent({ recordOutputs: false }));
       otelIntegration.onStepStart!(makeStepStartEvent());
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
 
       const attrs = getStartSpanAttributes(tracer, 2);
       expect(attrs['ai.toolCall.args']).toBeUndefined();
@@ -1089,8 +1089,8 @@ describe('OpenTelemetryIntegration', () => {
     it('does not record tool call result when recordOutputs is false', () => {
       otelIntegration.onStart!(makeOnStartEvent({ recordOutputs: false }));
       otelIntegration.onStepStart!(makeStepStartEvent());
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
-      otelIntegration.onToolCallFinish!(makeToolCallFinishEvent(true));
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
 
       const toolSpan = tracer.spans[2];
       const setAttrsCalls = (toolSpan.setAttributes as ReturnType<typeof vi.fn>)
@@ -1107,8 +1107,8 @@ describe('OpenTelemetryIntegration', () => {
     it('creates correct span hierarchy for generateText with tool call', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
-      otelIntegration.onToolCallFinish!(makeToolCallFinishEvent(true));
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
       otelIntegration.onStepFinish!(makeStepFinishEvent());
       otelIntegration.onFinish!(makeFinishEvent());
 
@@ -1126,8 +1126,8 @@ describe('OpenTelemetryIntegration', () => {
       otelIntegration.onStart!(makeOnStartEvent());
 
       otelIntegration.onStepStart!(makeStepStartEvent({ stepNumber: 0 }));
-      otelIntegration.onToolCallStart!(makeToolCallStartEvent());
-      otelIntegration.onToolCallFinish!(makeToolCallFinishEvent(true));
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
+      otelIntegration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
       otelIntegration.onStepFinish!(makeStepFinishEvent({ stepNumber: 0 }));
 
       otelIntegration.onStepStart!(makeStepStartEvent({ stepNumber: 1 }));

--- a/packages/otel/src/open-telemetry-integration.ts
+++ b/packages/otel/src/open-telemetry-integration.ts
@@ -24,8 +24,8 @@ import type {
   OnStartEvent,
   OnStepFinishEvent,
   OnStepStartEvent,
-  OnToolCallFinishEvent,
-  OnToolCallStartEvent,
+  ToolExecutionEndEvent,
+  ToolExecutionStartEvent,
   OutputInterface as Output,
   RerankFinishEvent,
   RerankOnFinishEvent,
@@ -565,7 +565,7 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
     state.stepContext = trace.setSpan(state.rootContext, state.stepSpan);
   }
 
-  onToolCallStart(event: OnToolCallStartEvent<ToolSet>): void {
+  onToolExecutionStart(event: ToolExecutionStartEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state?.stepContext) return;
 
@@ -597,7 +597,7 @@ export class OpenTelemetryIntegration implements TelemetryIntegration {
     });
   }
 
-  onToolCallFinish(event: OnToolCallFinishEvent<ToolSet>): void {
+  onToolExecutionEnd(event: ToolExecutionEndEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state) return;
 

--- a/packages/provider-utils/src/filter-nullable.test.ts
+++ b/packages/provider-utils/src/filter-nullable.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterNullable } from './filter-nullable';
+
+describe('filterNullable', () => {
+  it('removes null and undefined values from a value list', () => {
+    expect(filterNullable(1, null, 2, undefined, 3)).toEqual([1, 2, 3]);
+  });
+
+  it('preserves other falsy values', () => {
+    expect(
+      filterNullable<number | boolean | string>(0, false, '', null, undefined),
+    ).toEqual([0, false, '']);
+  });
+});

--- a/packages/provider-utils/src/filter-nullable.ts
+++ b/packages/provider-utils/src/filter-nullable.ts
@@ -1,0 +1,11 @@
+/**
+ * Filters `null` and `undefined` values out of a list of values.
+ *
+ * @param values - The values to filter.
+ * @returns A new array containing only non-nullish values.
+ */
+export function filterNullable<T>(
+  ...values: Array<T | undefined | null>
+): Array<T> {
+  return values.filter((value): value is NonNullable<T> => value != null);
+}

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -14,6 +14,7 @@ export { downloadBlob } from './download-blob';
 export { DownloadError } from './download-error';
 export * from './extract-response-headers';
 export * from './fetch-function';
+export { filterNullable } from './filter-nullable';
 export { createIdGenerator, generateId, type IdGenerator } from './generate-id';
 export * from './get-error-message';
 export * from './get-from-api';

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -26,8 +26,8 @@ export {
   type ToolCallRepairFunction,
   type WorkflowAgentOnStartCallback,
   type WorkflowAgentOnStepStartCallback,
-  type WorkflowAgentonToolExecutionStartCallback,
-  type WorkflowAgentonToolExecutionEndCallback,
+  type WorkflowAgentOnToolExecutionStartCallback,
+  type WorkflowAgentOnToolExecutionEndCallback,
 } from './workflow-agent.js';
 
 export {

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -26,8 +26,8 @@ export {
   type ToolCallRepairFunction,
   type WorkflowAgentOnStartCallback,
   type WorkflowAgentOnStepStartCallback,
-  type WorkflowAgentOnToolCallStartCallback,
-  type WorkflowAgentOnToolCallFinishCallback,
+  type WorkflowAgentonToolExecutionStartCallback,
+  type WorkflowAgentonToolExecutionEndCallback,
 } from './workflow-agent.js';
 
 export {

--- a/packages/workflow/src/test/agent-e2e-workflows.ts
+++ b/packages/workflow/src/test/agent-e2e-workflows.ts
@@ -334,10 +334,10 @@ export async function agentOnStepStartE2e() {
 }
 
 // ============================================================================
-// GAP tests — experimental_onToolCallStart
+// GAP tests — experimental_onToolExecutionStart
 // ============================================================================
 
-export async function agentOnToolCallStartE2e() {
+export async function agentonToolExecutionStartE2e() {
   'use workflow';
   const calls: string[] = [];
   const agent = new WorkflowAgent({
@@ -356,14 +356,14 @@ export async function agentOnToolCallStartE2e() {
         execute: echoStep,
       },
     },
-    experimental_onToolCallStart: async () => {
+    experimental_onToolExecutionStart: async () => {
       calls.push('constructor');
     },
   } as any);
   await agent.stream({
     messages: [{ role: 'user', content: 'test' }],
     writable: getWritable(),
-    experimental_onToolCallStart: async () => {
+    experimental_onToolExecutionStart: async () => {
       calls.push('method');
     },
   } as any);
@@ -371,10 +371,10 @@ export async function agentOnToolCallStartE2e() {
 }
 
 // ============================================================================
-// GAP tests — experimental_onToolCallFinish
+// GAP tests — experimental_onToolExecutionEnd
 // ============================================================================
 
-export async function agentOnToolCallFinishE2e() {
+export async function agentonToolExecutionEndE2e() {
   'use workflow';
   const calls: string[] = [];
   let capturedEvent: any = null;
@@ -394,14 +394,14 @@ export async function agentOnToolCallFinishE2e() {
         execute: addNumbers,
       },
     },
-    experimental_onToolCallFinish: async () => {
+    experimental_onToolExecutionEnd: async () => {
       calls.push('constructor');
     },
   } as any);
   await agent.stream({
     messages: [{ role: 'user', content: 'test' }],
     writable: getWritable(),
-    experimental_onToolCallFinish: async (event: any) => {
+    experimental_onToolExecutionEnd: async (event: any) => {
       calls.push('method');
       capturedEvent = {
         toolName: event?.toolCall?.toolName,

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -935,9 +935,9 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
     });
   });
 
-  describe('experimental_onToolCallStart', () => {
+  describe('experimental_onToolExecutionStart', () => {
     describe('stream', () => {
-      it('should call experimental_onToolCallStart from constructor', async () => {
+      it('should call experimental_onToolExecutionStart from constructor', async () => {
         const calls: string[] = [];
 
         const agent = new WorkflowAgent({
@@ -949,7 +949,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
                 `${value}-result`,
             }),
           },
-          experimental_onToolCallStart: async () => {
+          experimental_onToolExecutionStart: async () => {
             calls.push('constructor');
           },
         });
@@ -967,7 +967,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         `);
       });
 
-      it('should call experimental_onToolCallStart from stream method', async () => {
+      it('should call experimental_onToolExecutionStart from stream method', async () => {
         const calls: string[] = [];
 
         const agent = new WorkflowAgent({
@@ -985,7 +985,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         await agent.stream({
           messages: [{ role: 'user' as const, content: 'test' }],
           writable,
-          experimental_onToolCallStart: async () => {
+          experimental_onToolExecutionStart: async () => {
             calls.push('method');
           },
         });
@@ -1009,7 +1009,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
                 `${value}-result`,
             }),
           },
-          experimental_onToolCallStart: async () => {
+          experimental_onToolExecutionStart: async () => {
             calls.push('constructor');
           },
         });
@@ -1018,7 +1018,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         await agent.stream({
           messages: [{ role: 'user' as const, content: 'test' }],
           writable,
-          experimental_onToolCallStart: async () => {
+          experimental_onToolExecutionStart: async () => {
             calls.push('method');
           },
         });
@@ -1049,7 +1049,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         await agent.stream({
           messages: [{ role: 'user' as const, content: 'test' }],
           writable,
-          experimental_onToolCallStart: async (e: any) => {
+          experimental_onToolExecutionStart: async (e: any) => {
             event = e;
           },
         });
@@ -1073,9 +1073,9 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
     });
   });
 
-  describe('experimental_onToolCallFinish', () => {
+  describe('experimental_onToolExecutionEnd', () => {
     describe('stream', () => {
-      it('should call experimental_onToolCallFinish from constructor', async () => {
+      it('should call experimental_onToolExecutionEnd from constructor', async () => {
         const calls: string[] = [];
 
         const agent = new WorkflowAgent({
@@ -1087,7 +1087,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
                 `${value}-result`,
             }),
           },
-          experimental_onToolCallFinish: async () => {
+          experimental_onToolExecutionEnd: async () => {
             calls.push('constructor');
           },
         });
@@ -1105,7 +1105,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         `);
       });
 
-      it('should call experimental_onToolCallFinish from stream method', async () => {
+      it('should call experimental_onToolExecutionEnd from stream method', async () => {
         const calls: string[] = [];
 
         const agent = new WorkflowAgent({
@@ -1123,7 +1123,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         await agent.stream({
           messages: [{ role: 'user' as const, content: 'test' }],
           writable,
-          experimental_onToolCallFinish: async () => {
+          experimental_onToolExecutionEnd: async () => {
             calls.push('method');
           },
         });
@@ -1147,7 +1147,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
                 `${value}-result`,
             }),
           },
-          experimental_onToolCallFinish: async () => {
+          experimental_onToolExecutionEnd: async () => {
             calls.push('constructor');
           },
         });
@@ -1156,7 +1156,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         await agent.stream({
           messages: [{ role: 'user' as const, content: 'test' }],
           writable,
-          experimental_onToolCallFinish: async () => {
+          experimental_onToolExecutionEnd: async () => {
             calls.push('method');
           },
         });
@@ -1187,7 +1187,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         await agent.stream({
           messages: [{ role: 'user' as const, content: 'test' }],
           writable,
-          experimental_onToolCallFinish: async (e: any) => {
+          experimental_onToolExecutionEnd: async (e: any) => {
             event = e;
           },
         });
@@ -1361,11 +1361,11 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
               onStepStart: async () => {
                 events.push('onStepStart');
               },
-              onToolCallStart: async () => {
-                events.push('onToolCallStart');
+              onToolExecutionStart: async () => {
+                events.push('onToolExecutionStart');
               },
-              onToolCallFinish: async () => {
-                events.push('onToolCallFinish');
+              onToolExecutionEnd: async () => {
+                events.push('onToolExecutionEnd');
               },
               onStepFinish: async () => {
                 events.push('onStepFinish');
@@ -1386,8 +1386,8 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         expect(events).toEqual([
           'onStart',
           'onStepStart',
-          'onToolCallStart',
-          'onToolCallFinish',
+          'onToolExecutionStart',
+          'onToolExecutionEnd',
           'onStepFinish',
           'onStepStart',
           'onStepFinish',

--- a/packages/workflow/src/workflow-agent-e2e.integration.test.ts
+++ b/packages/workflow/src/workflow-agent-e2e.integration.test.ts
@@ -18,8 +18,8 @@ import {
   agentOnStartE2e,
   agentOnStepFinishE2e,
   agentOnStepStartE2e,
-  agentOnToolCallFinishE2e,
-  agentOnToolCallStartE2e,
+  agentonToolExecutionEndE2e,
+  agentonToolExecutionStartE2e,
   agentPrepareCallE2e,
   agentRepairToolCallE2e,
   agentTimeoutE2e,
@@ -186,18 +186,18 @@ describe('WorkflowAgent integration', { timeout: 120_000 }, () => {
     });
   });
 
-  describe('experimental_onToolCallStart (GAP)', () => {
+  describe('experimental_onToolExecutionStart (GAP)', () => {
     it('completes but callbacks are not called (GAP)', async () => {
-      const run = await start(agentOnToolCallStartE2e, []);
+      const run = await start(agentonToolExecutionStartE2e, []);
       const rv = await run.returnValue;
       // GAP: when implemented, should be ['constructor', 'method']
       expect(rv.calls).toEqual([]);
     });
   });
 
-  describe('experimental_onToolCallFinish (GAP)', () => {
+  describe('experimental_onToolExecutionEnd (GAP)', () => {
     it('completes but callbacks are not called (GAP)', async () => {
-      const run = await start(agentOnToolCallFinishE2e, []);
+      const run = await start(agentonToolExecutionEndE2e, []);
       const rv = await run.returnValue;
       // GAP: when implemented, should be ['constructor', 'method']
       expect(rv.calls).toEqual([]);

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -2021,7 +2021,7 @@ describe('WorkflowAgent', () => {
       expect(onAbort).toHaveBeenCalledWith({ steps: [] });
     });
 
-    it('should pass stepNumber to onToolCallStart and use discriminated union in onToolCallFinish', async () => {
+    it('should pass stepNumber to onToolExecutionStart and use discriminated union in onToolExecutionEnd', async () => {
       const tools: ToolSet = {
         testTool: {
           description: 'A test tool',
@@ -2032,14 +2032,14 @@ describe('WorkflowAgent', () => {
 
       const mockModel = createMockModel();
 
-      const onToolCallStart = vi.fn();
-      const onToolCallFinish = vi.fn();
+      const onToolExecutionStart = vi.fn();
+      const onToolExecutionEnd = vi.fn();
 
       const agent = new WorkflowAgent({
         model: mockModel,
         tools,
-        experimental_onToolCallStart: onToolCallStart,
-        experimental_onToolCallFinish: onToolCallFinish,
+        experimental_onToolExecutionStart: onToolExecutionStart,
+        experimental_onToolExecutionEnd: onToolExecutionEnd,
       });
 
       const mockWritable = new WritableStream({
@@ -2079,8 +2079,8 @@ describe('WorkflowAgent', () => {
         writable: mockWritable,
       });
 
-      // Verify onToolCallStart includes stepNumber
-      expect(onToolCallStart).toHaveBeenCalledWith(
+      // Verify onToolExecutionStart includes stepNumber
+      expect(onToolExecutionStart).toHaveBeenCalledWith(
         expect.objectContaining({
           stepNumber: 0,
           toolCall: expect.objectContaining({
@@ -2090,8 +2090,8 @@ describe('WorkflowAgent', () => {
         }),
       );
 
-      // Verify onToolCallFinish uses discriminated union with success: true
-      expect(onToolCallFinish).toHaveBeenCalledWith(
+      // Verify onToolExecutionEnd uses discriminated union with success: true
+      expect(onToolExecutionEnd).toHaveBeenCalledWith(
         expect.objectContaining({
           stepNumber: 0,
           success: true,
@@ -2105,7 +2105,7 @@ describe('WorkflowAgent', () => {
       );
     });
 
-    it('should pass success: false in onToolCallFinish when tool errors', async () => {
+    it('should pass success: false in onToolExecutionEnd when tool errors', async () => {
       const tools: ToolSet = {
         failTool: {
           description: 'A tool that fails',
@@ -2118,12 +2118,12 @@ describe('WorkflowAgent', () => {
 
       const mockModel = createMockModel();
 
-      const onToolCallFinish = vi.fn();
+      const onToolExecutionEnd = vi.fn();
 
       const agent = new WorkflowAgent({
         model: mockModel,
         tools,
-        experimental_onToolCallFinish: onToolCallFinish,
+        experimental_onToolExecutionEnd: onToolExecutionEnd,
       });
 
       const mockWritable = new WritableStream({
@@ -2163,8 +2163,8 @@ describe('WorkflowAgent', () => {
         writable: mockWritable,
       });
 
-      // Verify onToolCallFinish uses discriminated union with success: false
-      expect(onToolCallFinish).toHaveBeenCalledWith(
+      // Verify onToolExecutionEnd uses discriminated union with success: false
+      expect(onToolExecutionEnd).toHaveBeenCalledWith(
         expect.objectContaining({
           stepNumber: 0,
           success: false,

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -7,10 +7,11 @@ import type {
   SharedV4ProviderOptions,
 } from '@ai-sdk/provider';
 import {
-  type Experimental_LanguageModelStreamPart as ModelCallStreamPart,
   type FinishReason,
+  LanguageModel,
   type LanguageModelResponseMetadata,
   type LanguageModelUsage,
+  type Experimental_LanguageModelStreamPart as ModelCallStreamPart,
   type ModelMessage,
   Output,
   type StepResult,
@@ -21,7 +22,6 @@ import {
   type ToolChoice,
   type ToolSet,
   type UIMessage,
-  LanguageModel,
   experimental_filterActiveTools as filterActiveTools,
 } from 'ai';
 import {
@@ -31,7 +31,6 @@ import {
   standardizePrompt,
 } from 'ai/internal';
 import { streamTextIterator } from './stream-text-iterator.js';
-import type { CompatibleLanguageModel } from './types.js';
 
 // Re-export for consumers
 export type { CompatibleLanguageModel } from './types.js';
@@ -491,12 +490,12 @@ export interface WorkflowAgentOptions<
   /**
    * Callback called before a tool's execute function runs.
    */
-  experimental_onToolExecutionStart?: WorkflowAgentonToolExecutionStartCallback;
+  experimental_onToolExecutionStart?: WorkflowAgentOnToolExecutionStartCallback;
 
   /**
    * Callback called after a tool execution completes.
    */
-  experimental_onToolExecutionEnd?: WorkflowAgentonToolExecutionEndCallback;
+  experimental_onToolExecutionEnd?: WorkflowAgentOnToolExecutionEndCallback;
 
   /**
    * Prepare the parameters for the stream call.
@@ -596,7 +595,7 @@ export type WorkflowAgentOnStepStartCallback<TTools extends ToolSet = ToolSet> =
 /**
  * Callback that is called before a tool's execute function runs.
  */
-export type WorkflowAgentonToolExecutionStartCallback = (event: {
+export type WorkflowAgentOnToolExecutionStartCallback = (event: {
   /** The tool call being executed */
   readonly toolCall: ToolCall;
   /** The current step number (0-based) */
@@ -608,7 +607,7 @@ export type WorkflowAgentonToolExecutionStartCallback = (event: {
  * Uses a discriminated union pattern: check `success` to determine
  * whether `output` or `error` is available.
  */
-export type WorkflowAgentonToolExecutionEndCallback = (
+export type WorkflowAgentOnToolExecutionEndCallback = (
   event:
     | {
         /** The tool call that was executed */
@@ -827,12 +826,12 @@ export type WorkflowAgentStreamOptions<
     /**
      * Callback called before a tool's execute function runs.
      */
-    experimental_onToolExecutionStart?: WorkflowAgentonToolExecutionStartCallback;
+    experimental_onToolExecutionStart?: WorkflowAgentOnToolExecutionStartCallback;
 
     /**
      * Callback called after a tool execution completes.
      */
-    experimental_onToolExecutionEnd?: WorkflowAgentonToolExecutionEndCallback;
+    experimental_onToolExecutionEnd?: WorkflowAgentOnToolExecutionEndCallback;
 
     /**
      * Callback function called before each step in the agent loop.
@@ -1013,8 +1012,8 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
   private constructorOnFinish?: WorkflowAgentOnFinishCallback<ToolSet>;
   private constructorOnStart?: WorkflowAgentOnStartCallback;
   private constructorOnStepStart?: WorkflowAgentOnStepStartCallback;
-  private constructoronToolExecutionStart?: WorkflowAgentonToolExecutionStartCallback;
-  private constructoronToolExecutionEnd?: WorkflowAgentonToolExecutionEndCallback;
+  private constructorOnToolExecutionStart?: WorkflowAgentOnToolExecutionStartCallback;
+  private constructorOnToolExecutionEnd?: WorkflowAgentOnToolExecutionEndCallback;
   private prepareCall?: PrepareCallCallback<TBaseTools>;
 
   constructor(options: WorkflowAgentOptions<TBaseTools>) {
@@ -1036,9 +1035,9 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
     this.constructorOnFinish = options.onFinish;
     this.constructorOnStart = options.experimental_onStart;
     this.constructorOnStepStart = options.experimental_onStepStart;
-    this.constructoronToolExecutionStart =
+    this.constructorOnToolExecutionStart =
       options.experimental_onToolExecutionStart;
-    this.constructoronToolExecutionEnd =
+    this.constructorOnToolExecutionEnd =
       options.experimental_onToolExecutionEnd;
     this.prepareCall = options.prepareCall;
 
@@ -1337,12 +1336,12 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       this.constructorOnStepStart,
       options.experimental_onStepStart,
     );
-    const mergedonToolExecutionStart = mergeCallbacks(
-      this.constructoronToolExecutionStart,
+    const mergedOnToolExecutionStart = mergeCallbacks(
+      this.constructorOnToolExecutionStart,
       options.experimental_onToolExecutionStart,
     );
-    const mergedonToolExecutionEnd = mergeCallbacks(
-      this.constructoronToolExecutionEnd,
+    const mergedOnToolExecutionEnd = mergeCallbacks(
+      this.constructorOnToolExecutionEnd,
       options.experimental_onToolExecutionEnd,
     );
 
@@ -1394,8 +1393,8 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
         input: toolCall.input,
       };
 
-      if (mergedonToolExecutionStart) {
-        await mergedonToolExecutionStart({
+      if (mergedOnToolExecutionStart) {
+        await mergedOnToolExecutionStart({
           toolCall: toolCallEvent,
           stepNumber: currentStepNumber,
         });
@@ -1407,8 +1406,8 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
         result = await executeTool(toolCall, tools, messages, context);
       } catch (err) {
         const durationMs = Date.now() - startTime;
-        if (mergedonToolExecutionEnd) {
-          await mergedonToolExecutionEnd({
+        if (mergedOnToolExecutionEnd) {
+          await mergedOnToolExecutionEnd({
             toolCall: toolCallEvent,
             stepNumber: currentStepNumber,
             durationMs,
@@ -1420,14 +1419,14 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       }
 
       const durationMs = Date.now() - startTime;
-      if (mergedonToolExecutionEnd) {
+      if (mergedOnToolExecutionEnd) {
         const isError =
           result.output &&
           'type' in result.output &&
           (result.output.type === 'error-text' ||
             result.output.type === 'error-json');
         if (isError) {
-          await mergedonToolExecutionEnd({
+          await mergedOnToolExecutionEnd({
             toolCall: toolCallEvent,
             stepNumber: currentStepNumber,
             durationMs,
@@ -1435,7 +1434,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
             error: 'value' in result.output ? result.output.value : undefined,
           });
         } else {
-          await mergedonToolExecutionEnd({
+          await mergedOnToolExecutionEnd({
             toolCall: toolCallEvent,
             stepNumber: currentStepNumber,
             durationMs,

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -491,12 +491,12 @@ export interface WorkflowAgentOptions<
   /**
    * Callback called before a tool's execute function runs.
    */
-  experimental_onToolCallStart?: WorkflowAgentOnToolCallStartCallback;
+  experimental_onToolExecutionStart?: WorkflowAgentonToolExecutionStartCallback;
 
   /**
    * Callback called after a tool execution completes.
    */
-  experimental_onToolCallFinish?: WorkflowAgentOnToolCallFinishCallback;
+  experimental_onToolExecutionEnd?: WorkflowAgentonToolExecutionEndCallback;
 
   /**
    * Prepare the parameters for the stream call.
@@ -596,7 +596,7 @@ export type WorkflowAgentOnStepStartCallback<TTools extends ToolSet = ToolSet> =
 /**
  * Callback that is called before a tool's execute function runs.
  */
-export type WorkflowAgentOnToolCallStartCallback = (event: {
+export type WorkflowAgentonToolExecutionStartCallback = (event: {
   /** The tool call being executed */
   readonly toolCall: ToolCall;
   /** The current step number (0-based) */
@@ -608,7 +608,7 @@ export type WorkflowAgentOnToolCallStartCallback = (event: {
  * Uses a discriminated union pattern: check `success` to determine
  * whether `output` or `error` is available.
  */
-export type WorkflowAgentOnToolCallFinishCallback = (
+export type WorkflowAgentonToolExecutionEndCallback = (
   event:
     | {
         /** The tool call that was executed */
@@ -827,12 +827,12 @@ export type WorkflowAgentStreamOptions<
     /**
      * Callback called before a tool's execute function runs.
      */
-    experimental_onToolCallStart?: WorkflowAgentOnToolCallStartCallback;
+    experimental_onToolExecutionStart?: WorkflowAgentonToolExecutionStartCallback;
 
     /**
      * Callback called after a tool execution completes.
      */
-    experimental_onToolCallFinish?: WorkflowAgentOnToolCallFinishCallback;
+    experimental_onToolExecutionEnd?: WorkflowAgentonToolExecutionEndCallback;
 
     /**
      * Callback function called before each step in the agent loop.
@@ -1013,8 +1013,8 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
   private constructorOnFinish?: WorkflowAgentOnFinishCallback<ToolSet>;
   private constructorOnStart?: WorkflowAgentOnStartCallback;
   private constructorOnStepStart?: WorkflowAgentOnStepStartCallback;
-  private constructorOnToolCallStart?: WorkflowAgentOnToolCallStartCallback;
-  private constructorOnToolCallFinish?: WorkflowAgentOnToolCallFinishCallback;
+  private constructoronToolExecutionStart?: WorkflowAgentonToolExecutionStartCallback;
+  private constructoronToolExecutionEnd?: WorkflowAgentonToolExecutionEndCallback;
   private prepareCall?: PrepareCallCallback<TBaseTools>;
 
   constructor(options: WorkflowAgentOptions<TBaseTools>) {
@@ -1036,8 +1036,10 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
     this.constructorOnFinish = options.onFinish;
     this.constructorOnStart = options.experimental_onStart;
     this.constructorOnStepStart = options.experimental_onStepStart;
-    this.constructorOnToolCallStart = options.experimental_onToolCallStart;
-    this.constructorOnToolCallFinish = options.experimental_onToolCallFinish;
+    this.constructoronToolExecutionStart =
+      options.experimental_onToolExecutionStart;
+    this.constructoronToolExecutionEnd =
+      options.experimental_onToolExecutionEnd;
     this.prepareCall = options.prepareCall;
 
     // Extract generation settings
@@ -1335,13 +1337,13 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       this.constructorOnStepStart,
       options.experimental_onStepStart,
     );
-    const mergedOnToolCallStart = mergeCallbacks(
-      this.constructorOnToolCallStart,
-      options.experimental_onToolCallStart,
+    const mergedonToolExecutionStart = mergeCallbacks(
+      this.constructoronToolExecutionStart,
+      options.experimental_onToolExecutionStart,
     );
-    const mergedOnToolCallFinish = mergeCallbacks(
-      this.constructorOnToolCallFinish,
-      options.experimental_onToolCallFinish,
+    const mergedonToolExecutionEnd = mergeCallbacks(
+      this.constructoronToolExecutionEnd,
+      options.experimental_onToolExecutionEnd,
     );
 
     // Determine effective tool choice
@@ -1377,7 +1379,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       });
     }
 
-    // Helper to wrap executeTool with onToolCallStart/onToolCallFinish callbacks
+    // Helper to wrap executeTool with onToolExecutionStart/onToolExecutionEnd callbacks
     const executeToolWithCallbacks = async (
       toolCall: { toolCallId: string; toolName: string; input: unknown },
       tools: ToolSet,
@@ -1392,8 +1394,8 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
         input: toolCall.input,
       };
 
-      if (mergedOnToolCallStart) {
-        await mergedOnToolCallStart({
+      if (mergedonToolExecutionStart) {
+        await mergedonToolExecutionStart({
           toolCall: toolCallEvent,
           stepNumber: currentStepNumber,
         });
@@ -1405,8 +1407,8 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
         result = await executeTool(toolCall, tools, messages, context);
       } catch (err) {
         const durationMs = Date.now() - startTime;
-        if (mergedOnToolCallFinish) {
-          await mergedOnToolCallFinish({
+        if (mergedonToolExecutionEnd) {
+          await mergedonToolExecutionEnd({
             toolCall: toolCallEvent,
             stepNumber: currentStepNumber,
             durationMs,
@@ -1418,14 +1420,14 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       }
 
       const durationMs = Date.now() - startTime;
-      if (mergedOnToolCallFinish) {
+      if (mergedonToolExecutionEnd) {
         const isError =
           result.output &&
           'type' in result.output &&
           (result.output.type === 'error-text' ||
             result.output.type === 'error-json');
         if (isError) {
-          await mergedOnToolCallFinish({
+          await mergedonToolExecutionEnd({
             toolCall: toolCallEvent,
             stepNumber: currentStepNumber,
             durationMs,
@@ -1433,7 +1435,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
             error: 'value' in result.output ? result.output.value : undefined,
           });
         } else {
-          await mergedOnToolCallFinish({
+          await mergedonToolExecutionEnd({
             toolCall: toolCallEvent,
             stepNumber: currentStepNumber,
             durationMs,


### PR DESCRIPTION
## Background

The tool event can be improved as follows:
- Align event names with start/end nomenclature. 
- Remove unnecessary `On` prefix from event.
- Change `Call` to `Execution` to emphasize that the event is about tool execution.

## Summary

* rename `OnToolCallStartEvent` to `ToolExecutionStartEvent`
* rename `OnToolCallFinishEvent` to `ToolExecutionEndEvent`
* extract `OnToolExecutionStartCallback` and replace StreamText/GenerateText/ToolLoopAgent variants
* extract `OnToolExecutionEndCallback` and replace StreamText/GenerateText/ToolLoopAgent variants
* rename `experimental_onToolCallStart` to `experimental_onToolExecutionStart`
* rename `experimental_onToolCallFinish` to `experimental_onToolExecutionEnd`
* introduce `filterNullable` helper function in provider utils
* add `_internal` to `ToolLoopAgentSettings` for testability