### PR TITLE
fix(ai): remove deprecated experimental_output option

### DIFF
--- a/.changeset/remove-experimental-output.md
+++ b/.changeset/remove-experimental-output.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+remove the deprecated `experimental_output` alias and document the `output` migration for AI SDK 7

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -2402,7 +2402,7 @@ To see `generateText` in action, check out [these examples](#examples).
       name: 'output',
       type: 'Output',
       isOptional: true,
-      description: 'Experimental setting for generating structured outputs.',
+      description: 'The generated structured output. It uses the `output` specification.',
     },
     {
       name: 'steps',

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -259,6 +259,38 @@ Potential breaking issues:
 - If at least one tool declares `contextSchema`, `toolsContext` becomes required and only includes the tools that actually declare contextual data.
 - If you were relying on every tool callback seeing the same full runtime object, move shared step data to `runtimeContext`, or explicitly provide the needed per-tool data in each tool's `toolsContext` entry.
 
+### Structured Outputs: Remove Deprecated `experimental_output` Option and Result
+
+The deprecated `experimental_output` option has been removed in AI SDK 7. Replace all remaining usages with `output`.
+
+The deprecated `generateText()` result property `experimental_output` has also been removed. Read `result.output` instead.
+
+This name was deprecated in AI SDK 6, so if you already migrated to `output`, no changes are needed. Otherwise, update both the call options and any result access:
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  experimental_output: Output.object({
+    schema: recipeSchema,
+  }),
+  prompt: 'Generate a recipe.',
+});
+
+console.log(result.experimental_output);
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  output: Output.object({
+    schema: recipeSchema,
+  }),
+  prompt: 'Generate a recipe.',
+});
+
+console.log(result.output);
+```
+
 ### Tools: Remove Deprecated `experimental_activeTools` Option
 
 The deprecated `experimental_activeTools` option has been removed in AI SDK 7. Replace all remaining usages with `activeTools`.

--- a/packages/ai/src/generate-text/generate-text-result.ts
+++ b/packages/ai/src/generate-text/generate-text-result.ts
@@ -157,13 +157,6 @@ export interface GenerateTextResult<
   /**
    * The generated structured output. It uses the `output` specification.
    *
-   * @deprecated Use `output` instead.
-   */
-  readonly experimental_output: InferCompleteOutput<OUTPUT>;
-
-  /**
-   * The generated structured output. It uses the `output` specification.
-   *
    */
   readonly output: InferCompleteOutput<OUTPUT>;
 }

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -260,8 +260,7 @@ export async function generateText<
   timeout,
   headers,
   stopWhen = isStepCount(1),
-  experimental_output,
-  output = experimental_output,
+  output,
   toolNeedsApproval,
   experimental_telemetry: telemetry,
   providerOptions,
@@ -333,13 +332,6 @@ export async function generateText<
      * Optional specification for parsing structured outputs from the LLM response.
      */
     output?: OUTPUT;
-
-    /**
-     * Optional specification for parsing structured outputs from the LLM response.
-     *
-     * @deprecated Use `output` instead.
-     */
-    experimental_output?: OUTPUT;
 
     /**
      * Optional tool approval configuration.
@@ -1234,10 +1226,6 @@ class DefaultGenerateTextResult<
 
   get usage() {
     return this.finalStep.usage;
-  }
-
-  get experimental_output() {
-    return this.output;
   }
 
   get output() {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -315,8 +315,7 @@ export function streamText<
   timeout,
   headers,
   stopWhen = isStepCount(1),
-  experimental_output,
-  output = experimental_output,
+  output,
   toolNeedsApproval,
   experimental_telemetry: telemetry,
   prepareStep,
@@ -396,13 +395,6 @@ export function streamText<
      * Optional specification for parsing structured outputs from the LLM response.
      */
     output?: OUTPUT;
-
-    /**
-     * Optional specification for parsing structured outputs from the LLM response.
-     *
-     * @deprecated Use `output` instead.
-     */
-    experimental_output?: OUTPUT;
 
     /**
      * Optional tool approval configuration.


### PR DESCRIPTION
## Background

`experimental_output` was deprecated in AI SDK 6.

## Summary

Remove `experimental_output` option for `generateText`.