### PR TITLE
feat(ai): concurrent event notification

### DIFF
--- a/.changeset/pink-geese-hug.md
+++ b/.changeset/pink-geese-hug.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): concurrent event notification

--- a/packages/ai/src/util/notify.test.ts
+++ b/packages/ai/src/util/notify.test.ts
@@ -75,26 +75,46 @@ describe('notify', () => {
       `);
     });
 
-    it('should await async callbacks sequentially', async () => {
+    it('should run async callbacks in parallel and await all of them', async () => {
       const calls: string[] = [];
+      let resolveSlowCallback!: () => void;
 
-      await notify({
+      const notifyPromise = notify({
         event: 'test',
         callbacks: [
           async () => {
-            await new Promise(resolve => setTimeout(resolve, 5));
-            calls.push('slow');
+            calls.push('slow start');
+            await new Promise<void>(resolve => {
+              resolveSlowCallback = () => {
+                calls.push('slow end');
+                resolve();
+              };
+            });
           },
           () => {
-            calls.push('fast');
+            calls.push('fast start');
+            calls.push('fast end');
           },
         ],
       });
 
       expect(calls).toMatchInlineSnapshot(`
         [
-          "slow",
-          "fast",
+          "slow start",
+          "fast start",
+          "fast end",
+        ]
+      `);
+
+      resolveSlowCallback();
+      await notifyPromise;
+
+      expect(calls).toMatchInlineSnapshot(`
+        [
+          "slow start",
+          "fast start",
+          "fast end",
+          "slow end",
         ]
       `);
     });

--- a/packages/ai/src/util/notify.ts
+++ b/packages/ai/src/util/notify.ts
@@ -2,16 +2,18 @@ import { Arrayable, asArray } from '@ai-sdk/provider-utils';
 import type { Callback } from './callback';
 
 /**
- * Notifies all provided callbacks with the given event.
+ * Notifies all provided callbacks with the given event in parallel.
  * Errors in callbacks do not break the generation flow.
  */
 export async function notify<EVENT>(options: {
   event: EVENT;
   callbacks?: Arrayable<Callback<EVENT> | undefined | null>;
 }): Promise<void> {
-  for (const callback of asArray(options.callbacks)) {
-    try {
-      await callback?.(options.event);
-    } catch {}
-  }
+  await Promise.all(
+    asArray(options.callbacks).map(async callback => {
+      try {
+        await callback?.(options.event);
+      } catch {}
+    }),
+  );
 }


### PR DESCRIPTION
## Background

`notify` was invoking callbacks sequentially, waiting for each callback to finish. This can be less efficient when e.g. network calls are involved.

## Summary

Change `notify` to invoke callbacks concurrently.