### PR TITLE
refactoring(ai): simplify mergeAbortSignals

### DIFF
--- a/.changeset/wet-dryers-do.md
+++ b/.changeset/wet-dryers-do.md
@@ -1,6 +1,5 @@
 ---
 "@ai-sdk/workflow": patch
-"@ai-sdk/otel": patch
 "ai": patch
 ---
 

--- a/.changeset/wet-dryers-do.md
+++ b/.changeset/wet-dryers-do.md
@@ -1,0 +1,8 @@
+---
+"@ai-sdk/provider-utils": patch
+"@ai-sdk/workflow": patch
+"@ai-sdk/otel": patch
+"ai": patch
+---
+
+refactoring(ai): simplify mergeAbortSignals

--- a/.changeset/wet-dryers-do.md
+++ b/.changeset/wet-dryers-do.md
@@ -1,5 +1,4 @@
 ---
-"@ai-sdk/provider-utils": patch
 "@ai-sdk/workflow": patch
 "@ai-sdk/otel": patch
 "ai": patch

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -14,6 +14,7 @@ import {
   TimeoutConfiguration,
 } from '../prompt/request-options';
 import { TelemetryOptions } from '../telemetry/telemetry-options';
+import { mergeAbortSignals } from '../util/merge-abort-signals';
 import { notify } from '../util/notify';
 import { now } from '../util/now';
 import {
@@ -104,13 +105,10 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   await notify({ event: baseCallbackEvent, callbacks: onToolCallStart });
 
   const toolTimeoutMs = getToolTimeoutMs<TOOLS>(timeout, toolName);
-
-  const toolAbortSignal =
-    toolTimeoutMs != null
-      ? abortSignal != null
-        ? AbortSignal.any([abortSignal, AbortSignal.timeout(toolTimeoutMs)])
-        : AbortSignal.timeout(toolTimeoutMs)
-      : abortSignal;
+  const toolAbortSignal = mergeAbortSignals(
+    abortSignal,
+    toolTimeoutMs != null ? AbortSignal.timeout(toolTimeoutMs) : undefined,
+  );
 
   const startTime = now();
 

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -105,10 +105,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   await notify({ event: baseCallbackEvent, callbacks: onToolCallStart });
 
   const toolTimeoutMs = getToolTimeoutMs<TOOLS>(timeout, toolName);
-  const toolAbortSignal = mergeAbortSignals(
-    abortSignal,
-    toolTimeoutMs != null ? AbortSignal.timeout(toolTimeoutMs) : undefined,
-  );
+  const toolAbortSignal = mergeAbortSignals(abortSignal, toolTimeoutMs);
 
   const startTime = now();
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -454,7 +454,7 @@ export async function generateText<
     stepTimeoutMs != null ? new AbortController() : undefined;
   const mergedAbortSignal = mergeAbortSignals(
     abortSignal,
-    totalTimeoutMs != null ? AbortSignal.timeout(totalTimeoutMs) : undefined,
+    totalTimeoutMs,
     stepAbortController?.signal,
   );
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -562,7 +562,7 @@ export function streamText<
     maxRetries,
     abortSignal: mergeAbortSignals(
       abortSignal,
-      totalTimeoutMs != null ? AbortSignal.timeout(totalTimeoutMs) : undefined,
+      totalTimeoutMs,
       stepAbortController?.signal,
       chunkAbortController?.signal,
     ),

--- a/packages/ai/src/util/merge-abort-signals.test.ts
+++ b/packages/ai/src/util/merge-abort-signals.test.ts
@@ -93,6 +93,32 @@ describe('mergeAbortSignals', () => {
     expect(merged).toBeUndefined();
   });
 
+  it('should create a timeout signal from numeric input', async () => {
+    const merged = mergeAbortSignals(10);
+
+    expect(merged).toBeInstanceOf(AbortSignal);
+    expect(merged!.aborted).toBe(false);
+
+    await new Promise<void>(resolve => {
+      merged!.addEventListener('abort', () => resolve(), { once: true });
+    });
+
+    expect(merged!.aborted).toBe(true);
+    expect(merged!.reason).toBeInstanceOf(DOMException);
+    expect((merged!.reason as DOMException).name).toBe('TimeoutError');
+  });
+
+  it('should preserve the first abort reason when mixing signals and timeouts', () => {
+    const controller = new AbortController();
+    const reason = new Error('manual abort reason');
+    const merged = mergeAbortSignals(controller.signal, 100);
+
+    controller.abort(reason);
+
+    expect(merged!.aborted).toBe(true);
+    expect(merged!.reason).toBe(reason);
+  });
+
   it('should filter out null and undefined signals', () => {
     const controller = new AbortController();
     const reason = new Error('abort reason');

--- a/packages/ai/src/util/merge-abort-signals.ts
+++ b/packages/ai/src/util/merge-abort-signals.ts
@@ -22,22 +22,5 @@ export function mergeAbortSignals(
     return validSignals[0];
   }
 
-  const controller = new AbortController();
-
-  for (const signal of validSignals) {
-    if (signal.aborted) {
-      controller.abort(signal.reason);
-      return controller.signal;
-    }
-
-    signal.addEventListener(
-      'abort',
-      () => {
-        controller.abort(signal.reason);
-      },
-      { once: true },
-    );
-  }
-
-  return controller.signal;
+  return AbortSignal.any(validSignals);
 }

--- a/packages/ai/src/util/merge-abort-signals.ts
+++ b/packages/ai/src/util/merge-abort-signals.ts
@@ -1,3 +1,5 @@
+import { filterNullable } from '@ai-sdk/provider-utils';
+
 /**
  * Merges multiple abort sources into a single `AbortSignal`.
  * The returned signal will abort when any input signal aborts or when any
@@ -11,12 +13,9 @@
 export function mergeAbortSignals(
   ...signals: (AbortSignal | null | undefined | number)[]
 ): AbortSignal | undefined {
-  // TODO use filterNullable
-  const validSignals = signals
-    .filter((signal): signal is AbortSignal => signal != null)
-    .map(signal =>
-      signal instanceof AbortSignal ? signal : AbortSignal.timeout(signal),
-    );
+  const validSignals = filterNullable(...signals).map(signal =>
+    signal instanceof AbortSignal ? signal : AbortSignal.timeout(signal),
+  );
 
   return validSignals.length === 0
     ? undefined

--- a/packages/ai/src/util/merge-abort-signals.ts
+++ b/packages/ai/src/util/merge-abort-signals.ts
@@ -1,19 +1,22 @@
 /**
- * Merges multiple AbortSignals into a single AbortSignal.
- * The returned signal will abort when any of the input signals abort,
- * with the same reason as the first signal to abort.
+ * Merges multiple abort sources into a single `AbortSignal`.
+ * The returned signal will abort when any input signal aborts or when any
+ * numeric timeout elapses, using the reason from the first source to abort.
  *
- * @param signals - The AbortSignals to merge. Null and undefined values are filtered out.
- * @returns An AbortSignal that aborts when any of the input signals abort,
- *          or undefined if no valid signals are provided.
+ * @param signals - Abort signals or timeout durations in milliseconds.
+ * `null` and `undefined` values are ignored.
+ * @returns An `AbortSignal` that aborts when any valid source aborts,
+ * or `undefined` if no valid sources are provided.
  */
 export function mergeAbortSignals(
-  ...signals: (AbortSignal | null | undefined)[]
+  ...signals: (AbortSignal | null | undefined | number)[]
 ): AbortSignal | undefined {
   // TODO use filterNullable
-  const validSignals = signals.filter(
-    (signal): signal is AbortSignal => signal != null,
-  );
+  const validSignals = signals
+    .filter((signal): signal is AbortSignal => signal != null)
+    .map(signal =>
+      signal instanceof AbortSignal ? signal : AbortSignal.timeout(signal),
+    );
 
   return validSignals.length === 0
     ? undefined

--- a/packages/ai/src/util/merge-abort-signals.ts
+++ b/packages/ai/src/util/merge-abort-signals.ts
@@ -15,13 +15,9 @@ export function mergeAbortSignals(
     (signal): signal is AbortSignal => signal != null,
   );
 
-  if (validSignals.length === 0) {
-    return undefined;
-  }
-
-  if (validSignals.length === 1) {
-    return validSignals[0];
-  }
-
-  return AbortSignal.any(validSignals);
+  return validSignals.length === 0
+    ? undefined
+    : validSignals.length === 1
+      ? validSignals[0]
+      : AbortSignal.any(validSignals);
 }

--- a/packages/ai/src/util/merge-abort-signals.ts
+++ b/packages/ai/src/util/merge-abort-signals.ts
@@ -10,6 +10,7 @@
 export function mergeAbortSignals(
   ...signals: (AbortSignal | null | undefined)[]
 ): AbortSignal | undefined {
+  // TODO use filterNullable
   const validSignals = signals.filter(
     (signal): signal is AbortSignal => signal != null,
   );

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1276,9 +1276,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
 
     const effectiveAbortSignal = mergeAbortSignals(
       options.abortSignal ?? effectiveGenerationSettings.abortSignal,
-      options.timeout != null
-        ? AbortSignal.timeout(options.timeout)
-        : undefined,
+      options.timeout,
     );
 
     // Merge generation settings: constructor defaults < prepareCall < stream options


### PR DESCRIPTION
## Background

Both the `mergeAbortSignals` implementation as well as the callers can be simplified.

## Summary

* allow timeout ms to be passed into `mergeAbortSignals`
* simplify `mergeAbortSignals` implementation with `filterNullable` and `AbortSignal.any`
* simplify callers
