### PR TITLE
fix: remove _internal.now

### DIFF
--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -16,11 +16,11 @@ import {
 import { ServerResponse } from 'http';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
+import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { LanguageModelCallOptions } from '../prompt/language-model-call-options';
 import { prepareLanguageModelCallOptions } from '../prompt/prepare-language-model-call-options';
-import { RequestOptions } from '../prompt/request-options';
-import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { Prompt } from '../prompt/prompt';
+import { RequestOptions } from '../prompt/request-options';
 import { standardizePrompt } from '../prompt/standardize-prompt';
 import { wrapGatewayError } from '../prompt/wrap-gateway-error';
 import { createUnifiedTelemetry } from '../telemetry/create-unified-telemetry';
@@ -49,18 +49,18 @@ import type { Callback } from '../util/callback';
 import { createStitchableStream } from '../util/create-stitchable-stream';
 import { DownloadFunction } from '../util/download/download-function';
 import { notify } from '../util/notify';
-import { now as originalNow } from '../util/now';
+import { now } from '../util/now';
 import { prepareRetries } from '../util/prepare-retries';
+import { getOutputStrategy, OutputStrategy } from './output-strategy';
+import { parseAndValidateObjectResultWithRepair } from './parse-and-validate-object-result';
+import { RepairTextFunction } from './repair-text';
+import { ObjectStreamPart, StreamObjectResult } from './stream-object-result';
 import type {
   ObjectOnFinishEvent,
   ObjectOnStartEvent,
   ObjectOnStepFinishEvent,
   ObjectOnStepStartEvent,
 } from './structured-output-events';
-import { getOutputStrategy, OutputStrategy } from './output-strategy';
-import { parseAndValidateObjectResultWithRepair } from './parse-and-validate-object-result';
-import { RepairTextFunction } from './repair-text';
-import { ObjectStreamPart, StreamObjectResult } from './stream-object-result';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
 
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
@@ -285,7 +285,6 @@ export function streamObject<
       _internal?: {
         generateId?: () => string;
         currentDate?: () => Date;
-        now?: () => number;
       };
     },
 ): StreamObjectResult<
@@ -324,7 +323,6 @@ export function streamObject<
     _internal: {
       generateId = originalGenerateId,
       currentDate = () => new Date(),
-      now = originalNow,
     } = {},
     ...settings
   } = options;
@@ -375,7 +373,6 @@ export function streamObject<
     download,
     generateId,
     currentDate,
-    now,
   });
 }
 
@@ -427,7 +424,6 @@ class DefaultStreamObjectResult<
     download,
     generateId,
     currentDate,
-    now,
   }: {
     model: LanguageModel;
     telemetry: TelemetryOptions | undefined;
@@ -451,7 +447,6 @@ class DefaultStreamObjectResult<
     download: DownloadFunction | undefined;
     generateId: () => string;
     currentDate: () => Date;
-    now: () => number;
   }) {
     const model = resolveLanguageModel(modelArg);
 

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -8392,7 +8392,6 @@ describe('streamText', () => {
           },
           stopWhen: isStepCount(3),
           _internal: {
-            now: mockValues(0, 100, 500, 600, 1000),
             generateId: mockId({ prefix: 'id' }),
             generateCallId: () => 'test-telemetry-call-id',
           },
@@ -10409,7 +10408,6 @@ describe('streamText', () => {
           },
           stopWhen: isStepCount(3),
           _internal: {
-            now: mockValues(0, 100, 500, 600, 1000),
             generateId: mockId({ prefix: 'id' }),
             generateCallId: () => 'test-telemetry-call-id',
           },
@@ -11572,7 +11570,6 @@ describe('streamText', () => {
             },
           ],
           _internal: {
-            now: mockValues(0, 100, 500, 600, 1000),
             generateId: () => 'test-call-id',
             generateCallId: () => 'test-telemetry-call-id',
           },
@@ -13542,9 +13539,6 @@ describe('streamText', () => {
         },
         toolChoice: 'required',
         prompt: 'test-input',
-        _internal: {
-          now: mockValues(0, 100, 500),
-        },
       });
 
       await result.consumeStream();
@@ -13757,9 +13751,6 @@ describe('streamText', () => {
         },
         toolChoice: 'required',
         prompt: 'test-input',
-        _internal: {
-          now: mockValues(0, 100, 500),
-        },
       });
 
       expect(

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -78,7 +78,7 @@ import { DownloadFunction } from '../util/download/download-function';
 import { mergeAbortSignals } from '../util/merge-abort-signals';
 import { mergeObjects } from '../util/merge-objects';
 import { notify } from '../util/notify';
-import { now as originalNow } from '../util/now';
+import { now } from '../util/now';
 import { prepareRetries } from '../util/prepare-retries';
 import { collectToolApprovals } from './collect-tool-approvals';
 import { ContentPart } from './content-part';
@@ -120,14 +120,14 @@ import {
 import { toResponseMessages } from './to-response-messages';
 import { TypedToolCall } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair-function';
-import { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configuration';
-import { ToolOutput } from './tool-output';
-import { StaticToolOutputDenied } from './tool-output-denied';
-import { ToolsContextParameter } from './tools-context-parameter';
 import {
   OnToolExecutionEndCallback,
   OnToolExecutionStartCallback,
 } from './tool-execution-events';
+import { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configuration';
+import { ToolOutput } from './tool-output';
+import { StaticToolOutputDenied } from './tool-output-denied';
+import { ToolsContextParameter } from './tools-context-parameter';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -336,7 +336,6 @@ export function streamText<
   toolsContext = {} as InferToolSetContext<TOOLS>,
   experimental_include: include,
   _internal: {
-    now = originalNow,
     generateId = originalGenerateId,
     generateCallId = originalGenerateCallId,
   } = {},
@@ -530,7 +529,6 @@ export function streamText<
      * Internal. For test use only. May change without notice.
      */
     _internal?: {
-      now?: () => number;
       generateId?: IdGenerator;
       generateCallId?: IdGenerator;
     };
@@ -585,7 +583,6 @@ export function streamText<
     onStepStart,
     onToolExecutionStart,
     onToolExecutionEnd,
-    now,
     generateId,
     generateCallId,
     download,
@@ -758,7 +755,6 @@ class DefaultStreamTextResult<
     providerOptions,
     prepareStep,
     includeRawChunks,
-    now,
     generateId,
     generateCallId,
     timeout,
@@ -807,7 +803,6 @@ class DefaultStreamTextResult<
       | PrepareStepFunction<NoInfer<TOOLS>, NoInfer<RUNTIME_CONTEXT>>
       | undefined;
     includeRawChunks: boolean;
-    now: () => number;
     generateId: () => string;
     generateCallId: () => string;
     timeout: TimeoutConfiguration<TOOLS> | undefined;


### PR DESCRIPTION
## Background

The `now()` function can be mocked directly with vitest. Inject `now` via `_internal` is no longer needed.

## Summary

Remove `_internal.now` on `streamText` and `streamObject`. Remove dead test code.
