### PR TITLE
fix: retain stack traces on async errors

### DIFF
--- a/.changeset/plenty-houses-swim.md
+++ b/.changeset/plenty-houses-swim.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/provider-utils": patch
+"ai": patch
+---
+
+fix: retain stack traces on async errors

--- a/examples/ai-functions/src/generate-text/mock/return-await-stack-trace.ts
+++ b/examples/ai-functions/src/generate-text/mock/return-await-stack-trace.ts
@@ -1,0 +1,172 @@
+import { generateText, LanguageModelMiddleware, wrapLanguageModel } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import { run } from '../../lib/run';
+
+function createFailingModel() {
+  return new MockLanguageModelV3({
+    doGenerate: async () => {
+      await Promise.resolve();
+
+      throw new Error('stack trace reproduction error');
+    },
+  });
+}
+
+async function plainLeaf() {
+  await Promise.resolve();
+
+  throw new Error('stack trace reproduction error');
+}
+
+async function plainWithoutAwait() {
+  return plainLeaf();
+}
+
+async function plainWithAwait() {
+  return await plainLeaf();
+}
+
+const wrapGenerateWithoutAwait: NonNullable<
+  LanguageModelMiddleware['wrapGenerate']
+> = async ({ doGenerate }) => doGenerate();
+
+const wrapGenerateWithAwait: NonNullable<
+  LanguageModelMiddleware['wrapGenerate']
+> = async ({ doGenerate }) => await doGenerate();
+
+function createWrappedModelWithoutAwait() {
+  const baseModel = createFailingModel();
+
+  async function wrappedDoGenerateWithoutAwait(
+    options: Parameters<MockLanguageModelV3['doGenerate']>[0],
+  ) {
+    return baseModel.doGenerate(options);
+  }
+
+  return new MockLanguageModelV3({
+    doGenerate: wrappedDoGenerateWithoutAwait,
+  });
+}
+
+function createWrappedModelWithAwait() {
+  const baseModel = createFailingModel();
+
+  async function wrappedDoGenerateWithAwait(
+    options: Parameters<MockLanguageModelV3['doGenerate']>[0],
+  ) {
+    return await baseModel.doGenerate(options);
+  }
+
+  return new MockLanguageModelV3({
+    doGenerate: wrappedDoGenerateWithAwait,
+  });
+}
+
+async function failingGenerateTextCall(
+  middleware: Pick<LanguageModelMiddleware, 'wrapGenerate'>,
+) {
+  return await generateText({
+    model: wrapLanguageModel({
+      model: createFailingModel(),
+      middleware,
+    }),
+    prompt: 'Trigger the mock provider error.',
+  });
+}
+
+async function sdkMiddlewareWithoutAwait() {
+  return await failingGenerateTextCall({
+    wrapGenerate: wrapGenerateWithoutAwait,
+  });
+}
+
+async function sdkMiddlewareWithAwait() {
+  return await failingGenerateTextCall({
+    wrapGenerate: wrapGenerateWithAwait,
+  });
+}
+
+async function sdkModelBoundaryWithoutAwait() {
+  return await generateText({
+    model: createWrappedModelWithoutAwait(),
+    prompt: 'Trigger the mock provider error.',
+  });
+}
+
+async function sdkModelBoundaryWithAwait() {
+  return await generateText({
+    model: createWrappedModelWithAwait(),
+    prompt: 'Trigger the mock provider error.',
+  });
+}
+
+async function runCase(
+  name: string,
+  fn: () => Promise<unknown>,
+  framesToCheck: string[],
+) {
+  try {
+    await fn();
+  } catch (error) {
+    const stack =
+      error instanceof Error ? (error.stack ?? error.message) : String(error);
+
+    console.log(`\n=== ${name} ===`);
+    console.log(
+      'Observed wrapper frames:',
+      framesToCheck
+        .map(
+          frame => `${frame}: ${stack.includes(frame) ? 'present' : 'missing'}`,
+        )
+        .join(', '),
+    );
+    console.log(stack);
+  }
+}
+
+run(async () => {
+  console.log(
+    [
+      'This example compares async wrappers that return a promise directly',
+      'with wrappers that use return await at the abstraction boundary.',
+      'It first shows the plain JavaScript behavior, then reproduces the',
+      'same missing-frame problem through generateText model and middleware wrappers.',
+    ].join(' '),
+  );
+
+  console.log('\nPlain async baseline:');
+  await runCase('plain async wrapper without return await', plainWithoutAwait, [
+    'plainWithoutAwait',
+  ]);
+
+  await runCase('plain async wrapper with return await', plainWithAwait, [
+    'plainWithAwait',
+  ]);
+
+  console.log(
+    '\nAI SDK reproduction: even the awaited wrappers below still disappear from the stack.',
+  );
+  await runCase(
+    'generateText model wrapper without return await',
+    sdkModelBoundaryWithoutAwait,
+    ['wrappedDoGenerateWithoutAwait'],
+  );
+
+  await runCase(
+    'generateText model wrapper with return await',
+    sdkModelBoundaryWithAwait,
+    ['wrappedDoGenerateWithAwait'],
+  );
+
+  await runCase(
+    'generateText middleware without return await',
+    sdkMiddlewareWithoutAwait,
+    ['wrapGenerateWithoutAwait'],
+  );
+
+  await runCase(
+    'generateText middleware with return await',
+    sdkMiddlewareWithAwait,
+    ['wrapGenerateWithAwait'],
+  );
+});

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -177,7 +177,7 @@ export class ToolLoopAgent<
       onFinish: mergeCallbacks(this.settings.onFinish, onFinish),
     };
 
-    return generate({
+    return await generate({
       ...preparedCall,
       ...callbackArgs,
     } as unknown as Parameters<typeof generate>[0]);
@@ -230,7 +230,7 @@ export class ToolLoopAgent<
       onFinish: mergeCallbacks(this.settings.onFinish, onFinish),
     };
 
-    return stream({
+    return await stream({
       ...preparedCall,
       ...callbackArgs,
     } as unknown as Parameters<typeof stream>[0]);

--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -168,23 +168,24 @@ export async function generateImage({
   });
 
   const results = await Promise.all(
-    callImageCounts.map(async callImageCount =>
-      retry(() => {
-        const { prompt, files, mask } = normalizePrompt(promptArg);
+    callImageCounts.map(
+      async callImageCount =>
+        await retry(() => {
+          const { prompt, files, mask } = normalizePrompt(promptArg);
 
-        return model.doGenerate({
-          prompt,
-          files,
-          mask,
-          n: callImageCount,
-          abortSignal,
-          headers: headersWithUserAgent,
-          size,
-          aspectRatio,
-          seed,
-          providerOptions: providerOptions ?? {},
-        });
-      }),
+          return model.doGenerate({
+            prompt,
+            files,
+            mask,
+            n: callImageCount,
+            abortSignal,
+            headers: headersWithUserAgent,
+            size,
+            aspectRatio,
+            seed,
+            providerOptions: providerOptions ?? {},
+          });
+        }),
     ),
   );
 

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -52,7 +52,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   onPreliminaryToolResult,
   onToolExecutionStart,
   onToolExecutionEnd,
-  executeToolInTelemetryContext = async ({ execute }) => execute(),
+  executeToolInTelemetryContext = async ({ execute }) => await execute(),
 }: {
   toolCall: TypedToolCall<TOOLS>;
   tools: TOOLS | undefined;

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1086,23 +1086,24 @@ async function executeTools<TOOLS extends ToolSet>({
   executeToolInTelemetryContext?: TelemetryIntegration['executeTool'];
 }): Promise<Array<ToolOutput<TOOLS>>> {
   const toolOutputs = await Promise.all(
-    toolCalls.map(async toolCall =>
-      executeToolCall({
-        toolCall,
-        tools,
-        telemetry,
-        callId,
-        messages,
-        abortSignal,
-        timeout,
-        toolsContext,
-        stepNumber,
-        provider,
-        modelId,
-        onToolExecutionStart,
-        onToolExecutionEnd,
-        executeToolInTelemetryContext,
-      }),
+    toolCalls.map(
+      async toolCall =>
+        await executeToolCall({
+          toolCall,
+          tools,
+          telemetry,
+          callId,
+          messages,
+          abortSignal,
+          timeout,
+          toolsContext,
+          stepNumber,
+          provider,
+          modelId,
+          onToolExecutionStart,
+          onToolExecutionEnd,
+          executeToolInTelemetryContext,
+        }),
     ),
   );
 

--- a/packages/ai/src/generate-video/generate-video.ts
+++ b/packages/ai/src/generate-video/generate-video.ts
@@ -180,22 +180,23 @@ export async function experimental_generateVideo({
   });
 
   const results = await Promise.all(
-    callVideoCounts.map(async callVideoCount =>
-      retry(() =>
-        model.doGenerate({
-          prompt,
-          n: callVideoCount,
-          aspectRatio,
-          resolution,
-          duration,
-          fps,
-          seed,
-          image,
-          providerOptions: providerOptions ?? {},
-          headers: headersWithUserAgent,
-          abortSignal,
-        } satisfies Experimental_VideoModelV4CallOptions),
-      ),
+    callVideoCounts.map(
+      async callVideoCount =>
+        await retry(() =>
+          model.doGenerate({
+            prompt,
+            n: callVideoCount,
+            aspectRatio,
+            resolution,
+            duration,
+            fps,
+            seed,
+            image,
+            providerOptions: providerOptions ?? {},
+            headers: headersWithUserAgent,
+            abortSignal,
+          } satisfies Experimental_VideoModelV4CallOptions),
+        ),
     ),
   );
 

--- a/packages/ai/src/middleware/wrap-embedding-model.ts
+++ b/packages/ai/src/middleware/wrap-embedding-model.ts
@@ -77,14 +77,14 @@ const doWrap = ({
       params: EmbeddingModelV4CallOptions,
     ): Promise<EmbeddingModelV4Result> {
       const transformedParams = await doTransform({ params });
-      const doEmbed = async () => model.doEmbed(transformedParams);
+      const doEmbed = async () => await model.doEmbed(transformedParams);
       return wrapEmbed
-        ? wrapEmbed({
+        ? await wrapEmbed({
             doEmbed,
             params: transformedParams,
             model,
           })
-        : doEmbed();
+        : await doEmbed();
     },
   };
 };

--- a/packages/ai/src/middleware/wrap-image-model.ts
+++ b/packages/ai/src/middleware/wrap-image-model.ts
@@ -80,14 +80,14 @@ const doWrap = ({
       params: ImageModelV4CallOptions,
     ): Promise<ImageModelV4Result> {
       const transformedParams = await doTransform({ params });
-      const doGenerate = async () => model.doGenerate(transformedParams);
+      const doGenerate = async () => await model.doGenerate(transformedParams);
       return wrapGenerate
-        ? wrapGenerate({
+        ? await wrapGenerate({
             doGenerate,
             params: transformedParams,
             model,
           })
-        : doGenerate();
+        : await doGenerate();
     },
   };
 };

--- a/packages/ai/src/middleware/wrap-language-model.ts
+++ b/packages/ai/src/middleware/wrap-language-model.ts
@@ -82,27 +82,32 @@ const doWrap = ({
       params: LanguageModelV4CallOptions,
     ): Promise<LanguageModelV4GenerateResult> {
       const transformedParams = await doTransform({ params, type: 'generate' });
-      const doGenerate = async () => model.doGenerate(transformedParams);
-      const doStream = async () => model.doStream(transformedParams);
+      const doGenerate = async () => await model.doGenerate(transformedParams);
+      const doStream = async () => await model.doStream(transformedParams);
       return wrapGenerate
-        ? wrapGenerate({
+        ? await wrapGenerate({
             doGenerate,
             doStream,
             params: transformedParams,
             model,
           })
-        : doGenerate();
+        : await doGenerate();
     },
 
     async doStream(
       params: LanguageModelV4CallOptions,
     ): Promise<LanguageModelV4StreamResult> {
       const transformedParams = await doTransform({ params, type: 'stream' });
-      const doGenerate = async () => model.doGenerate(transformedParams);
-      const doStream = async () => model.doStream(transformedParams);
+      const doGenerate = async () => await model.doGenerate(transformedParams);
+      const doStream = async () => await model.doStream(transformedParams);
       return wrapStream
-        ? wrapStream({ doGenerate, doStream, params: transformedParams, model })
-        : doStream();
+        ? await wrapStream({
+            doGenerate,
+            doStream,
+            params: transformedParams,
+            model,
+          })
+        : await doStream();
     },
   };
 };

--- a/packages/ai/src/telemetry/create-unified-telemetry.ts
+++ b/packages/ai/src/telemetry/create-unified-telemetry.ts
@@ -93,7 +93,7 @@ export function createUnifiedTelemetry({
               execute = () =>
                 executeWrapper({ ...args, execute: innerExecute });
             }
-            return execute();
+            return await execute();
           }
         : undefined,
   };

--- a/packages/ai/src/test/mock-language-model-v2.ts
+++ b/packages/ai/src/test/mock-language-model-v2.ts
@@ -42,7 +42,7 @@ export class MockLanguageModelV2 implements LanguageModelV2 {
       this.doGenerateCalls.push(options);
 
       if (typeof doGenerate === 'function') {
-        return doGenerate(options);
+        return await doGenerate(options);
       } else if (Array.isArray(doGenerate)) {
         return doGenerate[this.doGenerateCalls.length];
       } else {
@@ -53,7 +53,7 @@ export class MockLanguageModelV2 implements LanguageModelV2 {
       this.doStreamCalls.push(options);
 
       if (typeof doStream === 'function') {
-        return doStream(options);
+        return await doStream(options);
       } else if (Array.isArray(doStream)) {
         return doStream[this.doStreamCalls.length];
       } else {
@@ -63,7 +63,7 @@ export class MockLanguageModelV2 implements LanguageModelV2 {
     this._supportedUrls =
       typeof supportedUrls === 'function'
         ? supportedUrls
-        : async () => supportedUrls;
+        : async () => await supportedUrls;
   }
 
   get supportedUrls() {

--- a/packages/ai/src/test/mock-language-model-v3.ts
+++ b/packages/ai/src/test/mock-language-model-v3.ts
@@ -47,7 +47,7 @@ export class MockLanguageModelV3 implements LanguageModelV3 {
       this.doGenerateCalls.push(options);
 
       if (typeof doGenerate === 'function') {
-        return doGenerate(options);
+        return await doGenerate(options);
       } else if (Array.isArray(doGenerate)) {
         return doGenerate[this.doGenerateCalls.length];
       } else {
@@ -58,7 +58,7 @@ export class MockLanguageModelV3 implements LanguageModelV3 {
       this.doStreamCalls.push(options);
 
       if (typeof doStream === 'function') {
-        return doStream(options);
+        return await doStream(options);
       } else if (Array.isArray(doStream)) {
         return doStream[this.doStreamCalls.length];
       } else {
@@ -68,7 +68,7 @@ export class MockLanguageModelV3 implements LanguageModelV3 {
     this._supportedUrls =
       typeof supportedUrls === 'function'
         ? supportedUrls
-        : async () => supportedUrls;
+        : async () => await supportedUrls;
   }
 
   get supportedUrls() {

--- a/packages/ai/src/test/mock-language-model-v4.ts
+++ b/packages/ai/src/test/mock-language-model-v4.ts
@@ -47,7 +47,7 @@ export class MockLanguageModelV4 implements LanguageModelV4 {
       this.doGenerateCalls.push(options);
 
       if (typeof doGenerate === 'function') {
-        return doGenerate(options);
+        return await doGenerate(options);
       } else if (Array.isArray(doGenerate)) {
         return doGenerate[this.doGenerateCalls.length];
       } else {
@@ -58,7 +58,7 @@ export class MockLanguageModelV4 implements LanguageModelV4 {
       this.doStreamCalls.push(options);
 
       if (typeof doStream === 'function') {
-        return doStream(options);
+        return await doStream(options);
       } else if (Array.isArray(doStream)) {
         return doStream[this.doStreamCalls.length];
       } else {
@@ -68,7 +68,7 @@ export class MockLanguageModelV4 implements LanguageModelV4 {
     this._supportedUrls =
       typeof supportedUrls === 'function'
         ? supportedUrls
-        : async () => supportedUrls;
+        : async () => await supportedUrls;
   }
 
   get supportedUrls() {

--- a/packages/ai/src/util/create-stitchable-stream.ts
+++ b/packages/ai/src/util/create-stitchable-stream.ts
@@ -38,7 +38,7 @@ export function createStitchableStream<T>(): {
     if (innerStreamReaders.length === 0) {
       waitForNewStream = createResolvablePromise<void>();
       await waitForNewStream.promise;
-      return processPull();
+      return await processPull();
     }
 
     try {

--- a/packages/ai/src/util/download/download-function.ts
+++ b/packages/ai/src/util/download/download-function.ts
@@ -40,6 +40,6 @@ export const createDefaultDownloadFunction =
       requestedDownloads.map(async requestedDownload =>
         requestedDownload.isUrlSupportedByModel
           ? null
-          : download(requestedDownload),
+          : await download(requestedDownload),
       ),
     );

--- a/packages/ai/src/util/retry-with-exponential-backoff.ts
+++ b/packages/ai/src/util/retry-with-exponential-backoff.ts
@@ -70,7 +70,7 @@ export const retryWithExponentialBackoffRespectingRetryHeaders =
     abortSignal?: AbortSignal;
   } = {}): RetryFunction =>
   async <OUTPUT>(f: () => PromiseLike<OUTPUT>) =>
-    _retryWithExponentialBackoff(f, {
+    await _retryWithExponentialBackoff(f, {
       maxRetries,
       delayInMs: initialDelayInMs,
       backoffFactor,
@@ -129,7 +129,7 @@ async function _retryWithExponentialBackoff<OUTPUT>(
         { abortSignal },
       );
 
-      return _retryWithExponentialBackoff(
+      return await _retryWithExponentialBackoff(
         f,
         {
           maxRetries,

--- a/packages/provider-utils/src/parse-json.ts
+++ b/packages/provider-utils/src/parse-json.ts
@@ -43,7 +43,7 @@ export async function parseJSON<T>({
       return value;
     }
 
-    return validateTypes<T>({ value, schema });
+    return await validateTypes<T>({ value, schema });
   } catch (error) {
     if (
       JSONParseError.isInstance(error) ||

--- a/packages/provider-utils/src/post-to-api.ts
+++ b/packages/provider-utils/src/post-to-api.ts
@@ -28,7 +28,7 @@ export const postJsonToApi = async <T>({
   abortSignal?: AbortSignal;
   fetch?: FetchFunction;
 }) =>
-  postToApi({
+  await postToApi({
     url,
     headers: {
       'Content-Type': 'application/json',
@@ -61,7 +61,7 @@ export const postFormDataToApi = async <T>({
   abortSignal?: AbortSignal;
   fetch?: FetchFunction;
 }) =>
-  postToApi({
+  await postToApi({
     url,
     headers,
     body: {

--- a/packages/provider-utils/src/test/convert-response-stream-to-array.ts
+++ b/packages/provider-utils/src/test/convert-response-stream-to-array.ts
@@ -3,7 +3,7 @@ import { convertReadableStreamToArray } from './convert-readable-stream-to-array
 export async function convertResponseStreamToArray(
   response: Response,
 ): Promise<string[]> {
-  return convertReadableStreamToArray(
+  return await convertReadableStreamToArray(
     response.body!.pipeThrough(new TextDecoderStream()),
   );
 }


### PR DESCRIPTION
## Background

Missing `await` statements on `async` functions lead to stack traces dropping frames when errors occur on V8 (see #13838 ).

## Summary
Add `await` statements to the identified async functions that were missing an await statement.

## Limitations

Unit tests would be runtime-specific and brittle and were therefore avoided. There is currently no automatic test coverage.

## Manual Verification

- [x] run `examples/ai-functions/src/generate-text/mock/return-await-stack-trace.ts` before/after and ensure the problem exists and the fix works

## Related Issues

Fixes #13838