### PR TITLE
fix(ai): limit tool execution time duration to actual tool execution

### DIFF
--- a/.changeset/silver-jeans-pump.md
+++ b/.changeset/silver-jeans-pump.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): limit tool execution time duration to actual tool execution

--- a/packages/ai/src/generate-text/execute-tool-call.test.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.test.ts
@@ -742,6 +742,47 @@ describe('executeToolCall', () => {
       });
     });
 
+    it('should measure only the inner execute duration when wrapped in telemetry context', async () => {
+      const toolExecutionEndEvents: ToolExecutionEndEvent<any>[] = [];
+      const executeToolInTelemetryContext: <T>(params: {
+        callId: string;
+        toolCallId: string;
+        execute: () => PromiseLike<T>;
+      }) => Promise<T> = vi.fn(async ({ execute }) => {
+        now(); // simulate wrapper overhead before the tool runs
+        const result = await execute();
+        now(); // simulate wrapper overhead after the tool runs
+        return result;
+      });
+
+      mockNow
+        .mockReturnValueOnce(1000)
+        .mockReturnValueOnce(2000)
+        .mockReturnValueOnce(2300)
+        .mockReturnValueOnce(5000);
+
+      await executeToolCall({
+        toolCall: createToolCall({ toolCallId: 'my-call-id' }),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        telemetry: { isEnabled: true },
+        callId: 'test-telemetry-call-id',
+        messages: [],
+        abortSignal: undefined,
+        toolsContext: {},
+        executeToolInTelemetryContext,
+        onToolExecutionEnd: async event => {
+          toolExecutionEndEvents.push(event);
+        },
+      });
+
+      expect(toolExecutionEndEvents[0].durationMs).toBe(300);
+    });
+
     it('should execute the tool directly when executeToolInTelemetryContext is not provided', async () => {
       const result = await executeToolCall({
         toolCall: createToolCall({ toolCallId: 'my-call-id' }),

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -109,8 +109,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
         : AbortSignal.timeout(toolTimeoutMs)
       : abortSignal;
 
-  const startTime = now();
-
+  let durationMs = 0;
   try {
     // In order to correctly nest telemetry spans within tool calls spans, telemetry integrations need
     // to be able to execute the tool call in a telemetry-integration-specific context.
@@ -121,34 +120,37 @@ export async function executeToolCall<TOOLS extends ToolSet>({
       callId,
       toolCallId,
       execute: async () => {
-        const stream = executeTool({
-          tool,
-          input: input as InferToolInput<typeof tool>,
-          options: {
-            toolCallId,
-            messages,
-            abortSignal: toolAbortSignal,
-            context,
-          },
-        });
+        const startTime = now();
+        try {
+          const stream = executeTool({
+            tool,
+            input: input as InferToolInput<typeof tool>,
+            options: {
+              toolCallId,
+              messages,
+              abortSignal: toolAbortSignal,
+              context,
+            },
+          });
 
-        for await (const part of stream) {
-          if (part.type === 'preliminary') {
-            onPreliminaryToolResult?.({
-              ...toolCall,
-              type: 'tool-result',
-              output: part.output,
-              preliminary: true,
-            });
-          } else {
-            output = part.output;
+          for await (const part of stream) {
+            if (part.type === 'preliminary') {
+              onPreliminaryToolResult?.({
+                ...toolCall,
+                type: 'tool-result',
+                output: part.output,
+                preliminary: true,
+              });
+            } else {
+              output = part.output;
+            }
           }
+        } finally {
+          durationMs = now() - startTime;
         }
       },
     });
   } catch (error) {
-    const durationMs = now() - startTime;
-
     await notify({
       event: {
         ...baseCallbackEvent,
@@ -171,8 +173,6 @@ export async function executeToolCall<TOOLS extends ToolSet>({
         : {}),
     } as TypedToolError<TOOLS>;
   }
-
-  const durationMs = now() - startTime;
 
   await notify({
     event: {


### PR DESCRIPTION
## Background

The tool execution duration calculation included potential overhead from telemetry wrapper functions.

## Summary

Limit tool execution duration calculation to only cover tool execution.