### PR TITLE
fix(provider/gateway): add missing caching property to GatewayProviderOptions

### DIFF
--- a/.changeset/fix-gateway-caching-type.md
+++ b/.changeset/fix-gateway-caching-type.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+fix(provider/gateway): add missing `caching` property to GatewayProviderOptions type

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -851,6 +851,14 @@ The following gateway provider options are available:
 
   For full details, see [Provider Timeouts](https://vercel.com/docs/ai-gateway/models-and-providers/provider-timeouts).
 
+- **caching** _'auto'_
+
+  Automatic prompt caching strategy. When set to `'auto'`, AI Gateway handles caching automatically based on the provider. For providers that require explicit cache markers (Anthropic, MiniMax), AI Gateway adds a `cache_control` breakpoint at the end of static content. For providers with implicit caching (OpenAI, Google, DeepSeek), no modification is needed.
+
+  When not set, requests pass through without modification.
+
+  For full details, see [Automatic Caching](https://vercel.com/docs/ai-gateway/models-and-providers/automatic-caching).
+
 You can combine these options to have fine-grained control over routing and tracking:
 
 ```ts

--- a/examples/ai-functions/src/stream-text/gateway/auto-caching.ts
+++ b/examples/ai-functions/src/stream-text/gateway/auto-caching.ts
@@ -1,0 +1,26 @@
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: 'anthropic/claude-sonnet-4.6',
+    system:
+      'You are a helpful assistant with access to a large knowledge base. ' +
+      'Answer questions concisely and accurately.',
+    prompt: 'What is the capital of France?',
+    providerOptions: {
+      gateway: {
+        caching: 'auto',
+      } satisfies GatewayProviderOptions,
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/packages/gateway/src/gateway-provider-options.test-d.ts
+++ b/packages/gateway/src/gateway-provider-options.test-d.ts
@@ -1,0 +1,27 @@
+import { describe, it } from 'vitest';
+import type { GatewayProviderOptions } from './index';
+
+describe('GatewayProviderOptions', () => {
+  it('should accept caching: auto', () => {
+    const options = {
+      caching: 'auto',
+    } satisfies GatewayProviderOptions;
+
+    options;
+  });
+
+  it('should make caching optional', () => {
+    const options = {} satisfies GatewayProviderOptions;
+
+    options;
+  });
+
+  it('should reject unknown caching values', () => {
+    const options = {
+      // @ts-expect-error 'manual' is not a valid caching value
+      caching: 'manual',
+    } satisfies GatewayProviderOptions;
+
+    options;
+  });
+});

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -100,6 +100,19 @@ const gatewayProviderOptions = lazySchema(() =>
           byok: z.record(z.string(), z.number().int().min(1000)).optional(),
         })
         .optional(),
+      /**
+       * Automatic prompt caching strategy.
+       *
+       * - `'auto'`: Let AI Gateway handle caching automatically. For providers that
+       *   require explicit cache markers (Anthropic, MiniMax), AI Gateway adds a
+       *   `cache_control` breakpoint at the end of static content. For providers
+       *   with implicit caching (OpenAI, Google, DeepSeek), no modification is needed.
+       *
+       * When not set, requests pass through without modification.
+       *
+       * See https://vercel.com/docs/ai-gateway/models-and-providers/automatic-caching
+       */
+      caching: z.literal('auto').optional(),
     }),
   ),
 );


### PR DESCRIPTION
## Background

`GatewayProviderOptions` was missing the `caching` field, so TypeScript raises an error when users set `caching: 'auto'` per the [automatic caching docs](https://vercel.com/docs/ai-gateway/models-and-providers/automatic-caching).

## Summary

- Add `caching: z.literal('auto').optional()` to the `gatewayProviderOptions` schema
- Document `caching` in the Gateway Provider Options reference section of `content/providers/01-ai-sdk-providers/00-ai-gateway.mdx`
- Add `examples/ai-functions/src/stream-text/gateway/auto-caching.ts`
- Add `packages/gateway/src/gateway-provider-options.test-d.ts` with type tests for the new field

## Manual Verification

Run the new example:
```
cd examples/ai-functions
pnpm tsx src/stream-text/gateway/auto-caching.ts
```

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

Fixes #14595