### PR TITLE
feat(otel): add a step level span

### DIFF
--- a/.changeset/sour-otters-fetch.md
+++ b/.changeset/sour-otters-fetch.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/otel": patch
+---
+
+feat(otel): add a step level span

--- a/packages/otel/src/gen-ai-open-telemetry.test.ts
+++ b/packages/otel/src/gen-ai-open-telemetry.test.ts
@@ -412,12 +412,22 @@ describe('GenAIOpenTelemetry', () => {
   });
 
   describe('onStepStart', () => {
-    it('creates a chat span with correct attributes', () => {
+    it('creates agent_step and chat spans with correct attributes', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent());
 
-      expect(tracer.startSpan).toHaveBeenCalledTimes(2);
+      expect(tracer.startSpan).toHaveBeenCalledTimes(3);
       expect(serializeSpan(tracer.spans[1], tracer)).toMatchInlineSnapshot(`
+        {
+          "ended": false,
+          "initAttributes": {
+            "gen_ai.operation.name": "agent_step",
+          },
+          "name": "step 1",
+          "runtimeAttributes": {},
+        }
+      `);
+      expect(serializeSpan(tracer.spans[2], tracer)).toMatchInlineSnapshot(`
         {
           "ended": false,
           "initAttributes": {
@@ -446,7 +456,7 @@ describe('GenAIOpenTelemetry', () => {
         }),
       );
 
-      const attrs = getStartSpanAttributes(tracer, 1);
+      const attrs = getStartSpanAttributes(tracer, 2);
       expect(parseJsonAttributes(attrs, 'gen_ai.input.messages'))
         .toMatchInlineSnapshot(`
         {
@@ -472,7 +482,7 @@ describe('GenAIOpenTelemetry', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent({ stepTools: tools }));
 
-      const attrs = getStartSpanAttributes(tracer, 1);
+      const attrs = getStartSpanAttributes(tracer, 2);
       expect(parseJsonAttributes(attrs, 'gen_ai.tool.definitions'))
         .toMatchInlineSnapshot(`
         {
@@ -489,12 +499,12 @@ describe('GenAIOpenTelemetry', () => {
   });
 
   describe('onStepFinish', () => {
-    it('sets response attributes and token usage on step span', () => {
+    it('sets response attributes and token usage on the chat span', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent());
       integration.onStepFinish!(makeStepFinishEvent());
 
-      expect(serializeSpan(tracer.spans[1], tracer)).toMatchInlineSnapshot(`
+      expect(serializeSpan(tracer.spans[2], tracer)).toMatchInlineSnapshot(`
         {
           "ended": true,
           "initAttributes": {
@@ -524,8 +534,8 @@ describe('GenAIOpenTelemetry', () => {
       integration.onStepStart!(makeStepStartEvent());
       integration.onStepFinish!(makeStepFinishEvent());
 
-      const stepSpan = tracer.spans[1];
-      expect(parseJsonAttributes(stepSpan.attributes, 'gen_ai.output.messages'))
+      const chatSpan = tracer.spans[2];
+      expect(parseJsonAttributes(chatSpan.attributes, 'gen_ai.output.messages'))
         .toMatchInlineSnapshot(`
         {
           "gen_ai.output.messages": [
@@ -562,8 +572,8 @@ describe('GenAIOpenTelemetry', () => {
         }),
       );
 
-      const stepSpan = tracer.spans[1];
-      expect(parseJsonAttributes(stepSpan.attributes, 'gen_ai.output.messages'))
+      const chatSpan = tracer.spans[2];
+      expect(parseJsonAttributes(chatSpan.attributes, 'gen_ai.output.messages'))
         .toMatchInlineSnapshot(`
         {
           "gen_ai.output.messages": [
@@ -610,13 +620,13 @@ describe('GenAIOpenTelemetry', () => {
         }),
       );
 
-      const stepSpan = tracer.spans[1];
+      const chatSpan = tracer.spans[2];
       expect({
-        inputTokens: stepSpan.attributes['gen_ai.usage.input_tokens'],
-        outputTokens: stepSpan.attributes['gen_ai.usage.output_tokens'],
-        cacheRead: stepSpan.attributes['gen_ai.usage.cache_read.input_tokens'],
+        inputTokens: chatSpan.attributes['gen_ai.usage.input_tokens'],
+        outputTokens: chatSpan.attributes['gen_ai.usage.output_tokens'],
+        cacheRead: chatSpan.attributes['gen_ai.usage.cache_read.input_tokens'],
         cacheCreation:
-          stepSpan.attributes['gen_ai.usage.cache_creation.input_tokens'],
+          chatSpan.attributes['gen_ai.usage.cache_creation.input_tokens'],
       }).toMatchInlineSnapshot(`
         {
           "cacheCreation": 10,
@@ -634,8 +644,8 @@ describe('GenAIOpenTelemetry', () => {
       integration.onStepStart!(makeStepStartEvent());
       integration.onToolExecutionStart!(makeToolCallStartEvent());
 
-      expect(tracer.spans).toHaveLength(3);
-      expect(serializeSpan(tracer.spans[2], tracer)).toMatchInlineSnapshot(`
+      expect(tracer.spans).toHaveLength(4);
+      expect(serializeSpan(tracer.spans[3], tracer)).toMatchInlineSnapshot(`
         {
           "ended": false,
           "initAttributes": {
@@ -651,13 +661,22 @@ describe('GenAIOpenTelemetry', () => {
       `);
     });
 
+    it('parents chat and execute_tool spans under the same step span', () => {
+      integration.onStart!(makeOnStartEvent());
+      integration.onStepStart!(makeStepStartEvent());
+      integration.onToolExecutionStart!(makeToolCallStartEvent());
+
+      const mock = tracer.startSpan as ReturnType<typeof vi.fn>;
+      expect(mock.mock.calls[2][2]).toBe(mock.mock.calls[3][2]);
+    });
+
     it('sets gen_ai.tool.call.result on success', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent());
       integration.onToolExecutionStart!(makeToolCallStartEvent());
       integration.onToolExecutionEnd!(makeToolCallFinishEvent(true));
 
-      expect(serializeSpan(tracer.spans[2], tracer)).toMatchInlineSnapshot(`
+      expect(serializeSpan(tracer.spans[3], tracer)).toMatchInlineSnapshot(`
         {
           "ended": true,
           "initAttributes": {
@@ -681,7 +700,7 @@ describe('GenAIOpenTelemetry', () => {
       integration.onToolExecutionStart!(makeToolCallStartEvent());
       integration.onToolExecutionEnd!(makeToolCallFinishEvent(false));
 
-      const toolSpan = tracer.spans[2];
+      const toolSpan = tracer.spans[3];
       expect({
         status: toolSpan.status,
         ended: toolSpan.ended,
@@ -844,8 +863,8 @@ describe('GenAIOpenTelemetry', () => {
         },
       });
 
-      const stepSpan = tracer.spans[1];
-      expect(stepSpan.events).toMatchInlineSnapshot(`[]`);
+      const chatSpan = tracer.spans[2];
+      expect(chatSpan.events).toMatchInlineSnapshot(`[]`);
     });
 
     it('does not emit events for stream finish', () => {
@@ -861,13 +880,13 @@ describe('GenAIOpenTelemetry', () => {
         },
       });
 
-      const stepSpan = tracer.spans[1];
-      expect(stepSpan.events).toMatchInlineSnapshot(`[]`);
+      const chatSpan = tracer.spans[2];
+      expect(chatSpan.events).toMatchInlineSnapshot(`[]`);
     });
   });
 
   describe('onError', () => {
-    it('records error on root and step spans', () => {
+    it('records error on root, step, and chat spans', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent());
 
@@ -887,6 +906,14 @@ describe('GenAIOpenTelemetry', () => {
           {
             "ended": true,
             "name": "invoke_agent gpt-4",
+            "status": {
+              "code": 2,
+              "message": "something went wrong",
+            },
+          },
+          {
+            "ended": true,
+            "name": "step 1",
             "status": {
               "code": 2,
               "message": "something went wrong",
@@ -934,11 +961,19 @@ describe('GenAIOpenTelemetry', () => {
           },
           {
             "ended": true,
+            "name": "step 1",
+          },
+          {
+            "ended": true,
             "name": "chat gpt-4",
           },
           {
             "ended": true,
             "name": "execute_tool myTool",
+          },
+          {
+            "ended": true,
+            "name": "step 2",
           },
           {
             "ended": true,
@@ -975,6 +1010,14 @@ describe('GenAIOpenTelemetry', () => {
               "gen_ai.usage.input_tokens": 10,
               "gen_ai.usage.output_tokens": 20,
             },
+          },
+          {
+            "ended": true,
+            "initAttributes": {
+              "gen_ai.operation.name": "agent_step",
+            },
+            "name": "step 1",
+            "runtimeAttributes": {},
           },
           {
             "ended": true,
@@ -1041,6 +1084,14 @@ describe('GenAIOpenTelemetry', () => {
           {
             "ended": true,
             "initAttributes": {
+              "gen_ai.operation.name": "agent_step",
+            },
+            "name": "step 1",
+            "runtimeAttributes": {},
+          },
+          {
+            "ended": true,
+            "initAttributes": {
               "gen_ai.operation.name": "chat",
               "gen_ai.provider.name": "openai",
               "gen_ai.request.max_tokens": 100,
@@ -1072,6 +1123,14 @@ describe('GenAIOpenTelemetry', () => {
             "runtimeAttributes": {
               "gen_ai.tool.call.result": "{"result":"ok"}",
             },
+          },
+          {
+            "ended": true,
+            "initAttributes": {
+              "gen_ai.operation.name": "agent_step",
+            },
+            "name": "step 2",
+            "runtimeAttributes": {},
           },
           {
             "ended": true,

--- a/packages/otel/src/gen-ai-open-telemetry.ts
+++ b/packages/otel/src/gen-ai-open-telemetry.ts
@@ -132,6 +132,8 @@ interface CallState {
   rootContext: OpenTelemetryContext | undefined;
   stepSpan: Span | undefined;
   stepContext: OpenTelemetryContext | undefined;
+  inferenceSpan: Span | undefined;
+  inferenceContext: OpenTelemetryContext | undefined;
   embedSpans: Map<string, { span: Span; context: OpenTelemetryContext }>;
   rerankSpan: { span: Span; context: OpenTelemetryContext } | undefined;
   toolSpans: Map<string, { span: Span; context: OpenTelemetryContext }>;
@@ -281,6 +283,8 @@ export class GenAIOpenTelemetry implements Telemetry {
       rootContext,
       stepSpan: undefined,
       stepContext: undefined,
+      inferenceSpan: undefined,
+      inferenceContext: undefined,
       embedSpans: new Map(),
       rerankSpan: undefined,
       toolSpans: new Map(),
@@ -358,6 +362,8 @@ export class GenAIOpenTelemetry implements Telemetry {
       rootContext,
       stepSpan: undefined,
       stepContext: undefined,
+      inferenceSpan: undefined,
+      inferenceContext: undefined,
       embedSpans: new Map(),
       rerankSpan: undefined,
       toolSpans: new Map(),
@@ -403,22 +409,25 @@ export class GenAIOpenTelemetry implements Telemetry {
     });
 
     const spanName = `chat ${event.modelId}`;
-    state.stepSpan = this.tracer.startSpan(
+    state.inferenceSpan = this.tracer.startSpan(
       spanName,
       { attributes, kind: SpanKind.CLIENT },
       state.rootContext,
     );
-    state.stepContext = trace.setSpan(state.rootContext, state.stepSpan);
+    state.inferenceContext = trace.setSpan(
+      state.rootContext,
+      state.inferenceSpan,
+    );
   }
 
   /** @deprecated */
   onObjectStepFinish(event: ObjectOnStepFinishEvent): void {
     const state = this.getCallState(event.callId);
-    if (!state?.stepSpan) return;
+    if (!state?.inferenceSpan) return;
 
     const { telemetry } = state;
 
-    state.stepSpan.setAttributes(
+    state.inferenceSpan.setAttributes(
       selectAttributes(telemetry, {
         'gen_ai.response.finish_reasons': [event.finishReason],
         'gen_ai.response.id': event.response.id,
@@ -443,9 +452,9 @@ export class GenAIOpenTelemetry implements Telemetry {
       }),
     );
 
-    state.stepSpan.end();
-    state.stepSpan = undefined;
-    state.stepContext = undefined;
+    state.inferenceSpan.end();
+    state.inferenceSpan = undefined;
+    state.inferenceContext = undefined;
   }
 
   private onEmbedOperationStart(event: EmbedOnStartEvent): void {
@@ -482,6 +491,8 @@ export class GenAIOpenTelemetry implements Telemetry {
       rootContext,
       stepSpan: undefined,
       stepContext: undefined,
+      inferenceSpan: undefined,
+      inferenceContext: undefined,
       embedSpans: new Map(),
       rerankSpan: undefined,
       toolSpans: new Map(),
@@ -497,8 +508,18 @@ export class GenAIOpenTelemetry implements Telemetry {
 
     const { telemetry } = state;
     const providerName = mapProviderName(event.provider);
+    const stepAttributes = selectAttributes(telemetry, {
+      'gen_ai.operation.name': 'agent_step',
+    });
 
-    const attributes = selectAttributes(telemetry, {
+    state.stepSpan = this.tracer.startSpan(
+      `step ${event.stepNumber + 1}`,
+      { attributes: stepAttributes, kind: SpanKind.INTERNAL },
+      state.rootContext,
+    );
+    state.stepContext = trace.setSpan(state.rootContext, state.stepSpan);
+
+    const inferenceAttributes = selectAttributes(telemetry, {
       'gen_ai.operation.name': 'chat',
       'gen_ai.provider.name': providerName,
       'gen_ai.request.model': event.modelId,
@@ -531,13 +552,15 @@ export class GenAIOpenTelemetry implements Telemetry {
       },
     });
 
-    const spanName = `chat ${event.modelId}`;
-    state.stepSpan = this.tracer.startSpan(
-      spanName,
-      { attributes, kind: SpanKind.CLIENT },
-      state.rootContext,
+    state.inferenceSpan = this.tracer.startSpan(
+      `chat ${event.modelId}`,
+      { attributes: inferenceAttributes, kind: SpanKind.CLIENT },
+      state.stepContext,
     );
-    state.stepContext = trace.setSpan(state.rootContext, state.stepSpan);
+    state.inferenceContext = trace.setSpan(
+      state.stepContext,
+      state.inferenceSpan,
+    );
   }
 
   onToolExecutionStart(event: ToolExecutionStartEvent<ToolSet>): void {
@@ -603,11 +626,11 @@ export class GenAIOpenTelemetry implements Telemetry {
 
   onStepFinish(event: OnStepFinishEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
-    if (!state?.stepSpan) return;
+    if (!state?.stepSpan || !state.inferenceSpan) return;
 
     const { telemetry } = state;
 
-    state.stepSpan.setAttributes(
+    state.inferenceSpan.setAttributes(
       selectAttributes(telemetry, {
         'gen_ai.response.finish_reasons': [event.finishReason],
         'gen_ai.response.id': event.response.id,
@@ -633,6 +656,10 @@ export class GenAIOpenTelemetry implements Telemetry {
         },
       }),
     );
+
+    state.inferenceSpan.end();
+    state.inferenceSpan = undefined;
+    state.inferenceContext = undefined;
 
     state.stepSpan.end();
     state.stepSpan = undefined;
@@ -835,6 +862,8 @@ export class GenAIOpenTelemetry implements Telemetry {
       rootContext,
       stepSpan: undefined,
       stepContext: undefined,
+      inferenceSpan: undefined,
+      inferenceContext: undefined,
       embedSpans: new Map(),
       rerankSpan: undefined,
       toolSpans: new Map(),
@@ -899,9 +928,24 @@ export class GenAIOpenTelemetry implements Telemetry {
 
     const actualError = event.error ?? error;
 
+    for (const { span: toolSpan } of state.toolSpans.values()) {
+      recordSpanError(toolSpan, actualError);
+      toolSpan.end();
+    }
+    state.toolSpans.clear();
+
+    if (state.inferenceSpan) {
+      recordSpanError(state.inferenceSpan, actualError);
+      state.inferenceSpan.end();
+      state.inferenceSpan = undefined;
+      state.inferenceContext = undefined;
+    }
+
     if (state.stepSpan) {
       recordSpanError(state.stepSpan, actualError);
       state.stepSpan.end();
+      state.stepSpan = undefined;
+      state.stepContext = undefined;
     }
 
     for (const { span: embedSpan } of state.embedSpans.values()) {


### PR DESCRIPTION
## Background

the telemetry spans needed more visibility on the steps that were running + needed to be aligned with genAI semantic conventions.

## Summary

`GenAIOpenTelemetry` now creates an explicit agent_step span for each generateText / streamText step, with both chat and execute_tool parented under that step span

## Manual Verification

ran the example `examples/ai-functions/src/generate-text/anthropic/subagent-with-telemetry.ts` before and after the change

### Before

<img width="474" height="349" alt="image" src="https://github.com/user-attachments/assets/c886c674-78a6-42de-8d3b-355142bfc6ab" />

### After

<img width="941" height="990" alt="image" src="https://github.com/user-attachments/assets/a10b91fd-dc40-46cf-8b24-80556ae5c1e2" />

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

the duration of the `chat` span might need new events so that the model call's duration can be calculated accurately