### PR TITLE
docs(providers): add QuickSilver Pro to OpenAI-compatible providers

### DIFF
--- a/content/providers/02-openai-compatible-providers/50-quicksilverpro.mdx
+++ b/content/providers/02-openai-compatible-providers/50-quicksilverpro.mdx
@@ -1,0 +1,114 @@
+---
+title: QuickSilver Pro
+description: Use the QuickSilver Pro OpenAI-compatible API with the AI SDK.
+---
+
+# QuickSilver Pro Provider
+
+[QuickSilver Pro](https://quicksilverpro.io) is an OpenAI-compatible inference
+API for open-source large language models — DeepSeek V3, DeepSeek R1, and
+Qwen3.5-35B-A3B.
+
+## Setup
+
+The QuickSilver Pro provider is available via the `@ai-sdk/openai-compatible`
+module. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @ai-sdk/openai-compatible" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @ai-sdk/openai-compatible" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @ai-sdk/openai-compatible" dark />
+  </Tab>
+
+  <Tab>
+    <Snippet text="bun add @ai-sdk/openai-compatible" dark />
+  </Tab>
+</Tabs>
+
+### QuickSilver Pro Setup
+
+Get an API key from the [QuickSilver Pro dashboard](https://quicksilverpro.io/dashboard)
+and export it:
+
+```bash
+export QUICKSILVERPRO_API_KEY=sk-...
+```
+
+## Provider Instance
+
+To use QuickSilver Pro, create a custom provider instance with the
+`createOpenAICompatible` function from `@ai-sdk/openai-compatible`:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+
+const quicksilverpro = createOpenAICompatible({
+  name: 'quicksilverpro',
+  baseURL: 'https://api.quicksilverpro.io/v1',
+  apiKey: process.env.QUICKSILVERPRO_API_KEY,
+});
+```
+
+## Language Models
+
+You can interact with QuickSilver Pro language models using a provider
+instance. The first argument is the model id.
+
+```ts
+const model = quicksilverpro('deepseek-v3');
+```
+
+Supported model ids:
+
+- `deepseek-v3` — general-purpose chat, coding, structured JSON (131K context)
+- `deepseek-r1` — reasoning, math, logic (131K context)
+- `qwen3.5-35b` — long-context RAG and summarization (262K context, 3B active MoE)
+
+### Example
+
+You can use QuickSilver Pro language models to generate text with the
+`generateText` function:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText } from 'ai';
+
+const quicksilverpro = createOpenAICompatible({
+  name: 'quicksilverpro',
+  baseURL: 'https://api.quicksilverpro.io/v1',
+  apiKey: process.env.QUICKSILVERPRO_API_KEY,
+});
+
+const { text } = await generateText({
+  model: quicksilverpro('deepseek-v3'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+});
+```
+
+QuickSilver Pro language models can also generate text in a streaming fashion
+with the `streamText` function:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { streamText } from 'ai';
+
+const quicksilverpro = createOpenAICompatible({
+  name: 'quicksilverpro',
+  baseURL: 'https://api.quicksilverpro.io/v1',
+  apiKey: process.env.QUICKSILVERPRO_API_KEY,
+});
+
+const result = streamText({
+  model: quicksilverpro('deepseek-v3'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+});
+
+for await (const textPart of result.textStream) {
+  process.stdout.write(textPart);
+}
+```

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -15,6 +15,7 @@ We provide detailed documentation for the following OpenAI compatible providers:
 - [NIM](/providers/openai-compatible-providers/nim)
 - [Heroku](/providers/openai-compatible-providers/heroku)
 - [Clarifai](/providers/openai-compatible-providers/clarifai)
+- [QuickSilver Pro](/providers/openai-compatible-providers/quicksilverpro)
 
 The general setup and provider instance creation is the same for all of these providers.
 


### PR DESCRIPTION
## Summary

Adds a provider documentation page for [QuickSilver Pro](https://quicksilverpro.io) under `content/providers/02-openai-compatible-providers/`, following the same structure as the existing LM Studio / NIM / Heroku / Clarifai pages.

QuickSilver Pro is an OpenAI-compatible inference API for open-source LLMs — DeepSeek V3, DeepSeek R1, and Qwen3.5-35B-A3B. Users can already use it today via `@ai-sdk/openai-compatible`; this doc just makes the pattern discoverable for AI SDK users looking for cheaper open-model inference.

## Changes

- New file: `content/providers/02-openai-compatible-providers/50-quicksilverpro.mdx` — setup, provider instance, supported models, generate/stream examples.
- Updated: `content/providers/02-openai-compatible-providers/index.mdx` — added QuickSilver Pro to the list of documented OpenAI-compatible providers.

## Scope

Docs only. No code changes, no package changes, no new dependencies.

## Disclosure

I'm affiliated with QuickSilver Pro. Happy to trim, adjust tone, reorder, or drop sections if the content is more than you want — whatever fits the section's norm.