### PR TITLE
fix(xai, deepseek, groq, mistral): send null content for tool-only assistant messages

### DIFF
--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -123,7 +123,7 @@ export function convertToDeepSeekChatMessages({
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           reasoning_content: reasoning,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -102,7 +102,7 @@ export function convertToGroqChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           ...(reasoning.length > 0 ? { reasoning } : null),
           ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : null),
         });

--- a/packages/mistral/src/convert-to-mistral-chat-messages.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.ts
@@ -119,7 +119,7 @@ export function convertToMistralChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           prefix: isLastMessage ? true : undefined,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/xai/src/convert-to-xai-chat-messages.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.ts
@@ -108,7 +108,7 @@ export function convertToXaiChatMessages(prompt: LanguageModelV4Prompt): {
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 


### PR DESCRIPTION
## Summary

Fixes #14612

Follow-up to #13744. Applies the same `content: text || null` fix to the four remaining providers that still send `content: ""` for tool-only assistant messages.

## Problem

When an assistant message contains only `tool-call` parts (no text), the converters emit `content: ""`. Providers backed by AWS Bedrock reject this with:
```
ValidationException: messages: text content blocks must be non-empty
```

## Fix

```diff
- content: text,
+ content: text || null,
```

Applied to:
- `packages/xai/src/convert-to-xai-chat-messages.ts`
- `packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts`
- `packages/groq/src/convert-to-groq-chat-messages.ts`
- `packages/mistral/src/convert-to-mistral-chat-messages.ts`

Same pattern as the fix in #13744 for `@ai-sdk/openai` and `@ai-sdk/openai-compatible`.