### PR TITLE
feat(ai): expose inputMessages and partialText in onAbort callback

### DIFF
--- a/.changeset/expose-abort-usage.md
+++ b/.changeset/expose-abort-usage.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): expose usage metrics in onAbort callback

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1799,6 +1799,18 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'Array<StepResult>',
               description: 'Details for all previously finished steps.',
             },
+            {
+              name: 'usage',
+              type: 'LanguageModelUsage | undefined',
+              description:
+                'Token usage for the current (aborted) step. undefined if the provider had not yet sent usage data before the abort.',
+            },
+            {
+              name: 'totalUsage',
+              type: 'LanguageModelUsage | undefined',
+              description:
+                'Aggregated token usage across all completed steps plus the current step. undefined if no usage data was received before the abort.',
+            },
           ],
         },
       ],

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -17009,6 +17009,8 @@ describe('streamText', () => {
           [
             {
               "steps": [],
+              "totalUsage": undefined,
+              "usage": undefined,
             },
           ]
         `);
@@ -17325,6 +17327,23 @@ describe('streamText', () => {
                   "warnings": [],
                 },
               ],
+              "totalUsage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
+              "usage": undefined,
             },
           ]
         `);
@@ -17558,6 +17577,39 @@ describe('streamText', () => {
           [
             {
               "steps": [],
+              "totalUsage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokenDetails": {
+                  "cacheReadTokens": undefined,
+                  "cacheWriteTokens": undefined,
+                  "noCacheTokens": 3,
+                },
+                "inputTokens": 3,
+                "outputTokenDetails": {
+                  "reasoningTokens": undefined,
+                  "textTokens": 10,
+                },
+                "outputTokens": 10,
+                "raw": undefined,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
           ]
         `);
@@ -17592,6 +17644,302 @@ describe('streamText', () => {
               },
             ]
           `);
+      });
+    });
+
+    describe('onAbort usage data', () => {
+      it('should have undefined usage and totalUsage when abort fires before provider sends usage', async () => {
+        const abortController = new AbortController();
+        let pullCalls = 0;
+        const onAbortCalls: Array<any> = [];
+
+        const result = streamText({
+          abortSignal: abortController.signal,
+          onAbort: event => {
+            onAbortCalls.push(event);
+          },
+          model: new MockLanguageModelV4({
+            doStream: async () => ({
+              stream: new ReadableStream({
+                pull(controller) {
+                  switch (pullCalls++) {
+                    case 0:
+                      controller.enqueue({
+                        type: 'stream-start',
+                        warnings: [],
+                      });
+                      break;
+                    case 1:
+                      controller.enqueue({ type: 'text-start', id: '1' });
+                      break;
+                    case 2:
+                      controller.enqueue({
+                        type: 'text-delta',
+                        id: '1',
+                        delta: 'Hello',
+                      });
+                      break;
+                    case 3:
+                      // abort WITHOUT sending a finish/usage chunk
+                      abortController.abort();
+                      controller.error(
+                        new DOMException(
+                          'The user aborted a request.',
+                          'AbortError',
+                        ),
+                      );
+                      break;
+                  }
+                },
+              }),
+            }),
+          }),
+          prompt: 'test-input',
+        });
+
+        await result.consumeStream();
+
+        expect(onAbortCalls[0].usage).toMatchInlineSnapshot(`undefined`);
+        expect(onAbortCalls[0].totalUsage).toMatchInlineSnapshot(`undefined`);
+      });
+
+      it('should have real usage and totalUsage when provider sent usage before abort', async () => {
+        const abortController = new AbortController();
+        let pullCalls = 0;
+        const onAbortCalls: Array<any> = [];
+
+        const result = streamText({
+          abortSignal: abortController.signal,
+          onAbort: event => {
+            onAbortCalls.push(event);
+          },
+          model: new MockLanguageModelV4({
+            doStream: async () => ({
+              stream: new ReadableStream({
+                pull(controller) {
+                  switch (pullCalls++) {
+                    case 0:
+                      controller.enqueue({
+                        type: 'stream-start',
+                        warnings: [],
+                      });
+                      break;
+                    case 1:
+                      controller.enqueue({ type: 'text-start', id: '1' });
+                      break;
+                    case 2:
+                      controller.enqueue({
+                        type: 'text-delta',
+                        id: '1',
+                        delta: 'Hello',
+                      });
+                      break;
+                    case 3:
+                      // send finish (with real usage) BEFORE abort fires
+                      controller.enqueue({
+                        type: 'finish',
+                        finishReason: { unified: 'stop', raw: 'stop' },
+                        usage: testUsage,
+                      });
+                      break;
+                    case 4:
+                      // now abort — usage was already recorded
+                      abortController.abort();
+                      controller.error(
+                        new DOMException(
+                          'The user aborted a request.',
+                          'AbortError',
+                        ),
+                      );
+                      break;
+                  }
+                },
+              }),
+            }),
+          }),
+          prompt: 'test-input',
+        });
+
+        await result.consumeStream();
+
+        expect(onAbortCalls[0].usage).toMatchInlineSnapshot(`
+          {
+            "cachedInputTokens": undefined,
+            "inputTokenDetails": {
+              "cacheReadTokens": undefined,
+              "cacheWriteTokens": undefined,
+              "noCacheTokens": 3,
+            },
+            "inputTokens": 3,
+            "outputTokenDetails": {
+              "reasoningTokens": undefined,
+              "textTokens": 10,
+            },
+            "outputTokens": 10,
+            "raw": undefined,
+            "reasoningTokens": undefined,
+            "totalTokens": 13,
+          }
+        `);
+        expect(onAbortCalls[0].totalUsage).toMatchInlineSnapshot(`
+          {
+            "cachedInputTokens": undefined,
+            "inputTokenDetails": {
+              "cacheReadTokens": undefined,
+              "cacheWriteTokens": undefined,
+              "noCacheTokens": 3,
+            },
+            "inputTokens": 3,
+            "outputTokenDetails": {
+              "reasoningTokens": undefined,
+              "textTokens": 10,
+            },
+            "outputTokens": 10,
+            "reasoningTokens": undefined,
+            "totalTokens": 13,
+          }
+        `);
+      });
+
+      it('should aggregate usage across steps on multi-step abort', async () => {
+        const abortController = new AbortController();
+        let pullCalls = 0;
+        let streamCalls = 0;
+        const onAbortCalls: Array<any> = [];
+
+        const result = streamText({
+          abortSignal: abortController.signal,
+          onAbort: event => {
+            onAbortCalls.push(event);
+          },
+          model: new MockLanguageModelV4({
+            doStream: async () => ({
+              stream: new ReadableStream({
+                start() {
+                  streamCalls++;
+                  pullCalls = 0;
+                },
+                pull(controller) {
+                  if (streamCalls === 1) {
+                    // step 1: completes naturally with usage
+                    switch (pullCalls++) {
+                      case 0:
+                        controller.enqueue({
+                          type: 'stream-start',
+                          warnings: [],
+                        });
+                        break;
+                      case 1:
+                        controller.enqueue({
+                          type: 'tool-call',
+                          toolCallId: 'call-1',
+                          toolName: 'tool1',
+                          input: `{ "value": "value" }`,
+                        });
+                        break;
+                      case 2:
+                        controller.enqueue({
+                          type: 'finish',
+                          finishReason: {
+                            unified: 'tool-calls',
+                            raw: undefined,
+                          },
+                          usage: testUsage,
+                        });
+                        controller.close();
+                        break;
+                    }
+                  } else {
+                    // step 2: sends usage then aborts
+                    switch (pullCalls++) {
+                      case 0:
+                        controller.enqueue({
+                          type: 'stream-start',
+                          warnings: [],
+                        });
+                        break;
+                      case 1:
+                        controller.enqueue({ type: 'text-start', id: '1' });
+                        break;
+                      case 2:
+                        controller.enqueue({
+                          type: 'text-delta',
+                          id: '1',
+                          delta: 'Hello',
+                        });
+                        break;
+                      case 3:
+                        // step 2 sends usage before abort
+                        controller.enqueue({
+                          type: 'finish',
+                          finishReason: { unified: 'stop', raw: 'stop' },
+                          usage: testUsage2,
+                        });
+                        break;
+                      case 4:
+                        abortController.abort();
+                        controller.error(
+                          new DOMException(
+                            'The user aborted a request.',
+                            'AbortError',
+                          ),
+                        );
+                        break;
+                    }
+                  }
+                },
+              }),
+            }),
+          }),
+          tools: {
+            tool1: {
+              inputSchema: z.object({ value: z.string() }),
+              execute: async () => 'result1',
+            },
+          },
+          stopWhen: isStepCount(3),
+          ...defaultSettings(),
+        });
+
+        await result.consumeStream();
+
+        expect(onAbortCalls[0].usage).toMatchInlineSnapshot(`
+          {
+            "cachedInputTokens": 0,
+            "inputTokenDetails": {
+              "cacheReadTokens": 0,
+              "cacheWriteTokens": 0,
+              "noCacheTokens": 3,
+            },
+            "inputTokens": 3,
+            "outputTokenDetails": {
+              "reasoningTokens": 10,
+              "textTokens": 10,
+            },
+            "outputTokens": 10,
+            "raw": undefined,
+            "reasoningTokens": 10,
+            "totalTokens": 13,
+          }
+        `);
+        expect(onAbortCalls[0].totalUsage).toMatchInlineSnapshot(`
+          {
+            "cachedInputTokens": 0,
+            "inputTokenDetails": {
+              "cacheReadTokens": 0,
+              "cacheWriteTokens": 0,
+              "noCacheTokens": 6,
+            },
+            "inputTokens": 6,
+            "outputTokenDetails": {
+              "reasoningTokens": 10,
+              "textTokens": 20,
+            },
+            "outputTokens": 20,
+            "reasoningTokens": 10,
+            "totalTokens": 26,
+          }
+        `);
       });
     });
   });

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -202,6 +202,16 @@ export type StreamTextOnAbortCallback<
    * Details for all previously finished steps.
    */
   readonly steps: StepResult<TOOLS, CONTEXT>[];
+  /**
+   * Token usage for the current (aborted) step.
+   * undefined if the provider had not yet sent usage data before the abort.
+   */
+  readonly usage?: LanguageModelUsage;
+  /**
+   * Aggregated token usage across all completed steps plus the current step.
+   * undefined if no usage data was received before the abort.
+   */
+  readonly totalUsage?: LanguageModelUsage;
 }) => PromiseLike<void> | void;
 
 /**
@@ -878,6 +888,8 @@ class DefaultStreamTextResult<
     let recordedFinishReason: FinishReason | undefined = undefined;
     let recordedRawFinishReason: string | undefined = undefined;
     let recordedTotalUsage: LanguageModelUsage | undefined = undefined;
+    let currentStepUsage: LanguageModelUsage | undefined = undefined;
+    let completedStepsUsage: LanguageModelUsage | undefined = undefined;
     let recordedRequest: LanguageModelRequestMetadata = {};
     let recordedWarnings: Array<CallWarning> = [];
     const recordedSteps: StepResult<TOOLS, CONTEXT>[] = [];
@@ -1221,7 +1233,18 @@ class DefaultStreamTextResult<
       async pull(controller) {
         // abort handling:
         function abort() {
-          onAbort?.({ steps: recordedSteps });
+          const totalUsage =
+            currentStepUsage != null || completedStepsUsage != null
+              ? addLanguageModelUsage(
+                  completedStepsUsage ?? createNullLanguageModelUsage(),
+                  currentStepUsage ?? createNullLanguageModelUsage(),
+                )
+              : undefined;
+          onAbort?.({
+            steps: recordedSteps,
+            usage: currentStepUsage,
+            totalUsage,
+          });
           controller.enqueue({
             type: 'abort',
             // The `reason` is usually of type DOMException, but it can also be of any type,
@@ -1828,6 +1851,7 @@ class DefaultStreamTextResult<
                       // Note: tool executions might not be finished yet when the finish event is emitted.
                       // store usage and finish reason for promises and onFinish callback:
                       stepUsage = chunk.usage;
+                      currentStepUsage = chunk.usage;
                       stepFinishReason = chunk.finishReason;
                       stepRawFinishReason = chunk.rawFinishReason;
                       stepProviderMetadata = chunk.providerMetadata;
@@ -1902,6 +1926,10 @@ class DefaultStreamTextResult<
                   });
 
                   const combinedUsage = addLanguageModelUsage(usage, stepUsage);
+
+                  // track cumulative usage of completed steps for the onAbort callback:
+                  completedStepsUsage = combinedUsage;
+                  currentStepUsage = undefined;
 
                   // wait for the step to be fully processed by the event processor
                   // to ensure that the recorded steps are complete:

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -452,6 +452,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
       raw: undefined,
     };
     let usage: OpenAIChatUsage | undefined = undefined;
+    let finishSent = false;
     let metadataExtracted = false;
     let isActiveText = false;
 
@@ -688,6 +689,18 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
                 });
               }
             }
+
+            // Emit finish chunk early when usage data arrives so it is available
+            // if the stream is aborted before it closes naturally.
+            if (value.usage != null && !finishSent) {
+              controller.enqueue({
+                type: 'finish',
+                finishReason,
+                usage: convertOpenAIChatUsage(usage!),
+                ...(providerMetadata != null ? { providerMetadata } : {}),
+              });
+              finishSent = true;
+            }
           },
 
           flush(controller) {
@@ -695,12 +708,15 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
               controller.enqueue({ type: 'text-end', id: '0' });
             }
 
-            controller.enqueue({
-              type: 'finish',
-              finishReason,
-              usage: convertOpenAIChatUsage(usage),
-              ...(providerMetadata != null ? { providerMetadata } : {}),
-            });
+            if (!finishSent) {
+              controller.enqueue({
+                type: 'finish',
+                finishReason,
+                usage: convertOpenAIChatUsage(usage),
+                ...(providerMetadata != null ? { providerMetadata } : {}),
+              });
+              finishSent = true;
+            }
           },
         }),
       ),


### PR DESCRIPTION
 ## Background  

When a `streamText` call is aborted — via `AbortSignal`, the user stopping generation, or a dropped connection — the `onAbort` callback fires but receives **no usage data**. `onFinish` never fires on abort at all. This makes it impossible to track token consumption for billing or quota purposes when streams don't complete naturally.
                                                                                                                                                              
## Summary                                                                                                                                               
                                                                                                                                                              
  **`packages/ai/src/generate-text/stream-text.ts`**                                                                                                    
  - Added `usage?: LanguageModelUsage` and `totalUsage?: LanguageModelUsage` to `StreamTextOnAbortCallback`
  - Added `inputMessages: ModelMessage[]` — the full message list passed to the model for the aborted step (initial messages + completed prior step tool
  call/result pairs)                                                     
  - Added `partialText?: string` — the text actively being streamed at abort time; `undefined` if no text was generated; resets at each step boundary
  - Introduced `currentStepUsage`, `completedStepsUsage`, `currentStepInputMessages`, and `pullLevelTextContent` as outer-scope tracking variables            
  - Wired all fields into the existing `abort()` function — if the provider had not yet sent usage data before the abort, `usage` is `undefined` (honest, no  
  estimation)                                                                                                                                                 
                                                                                                                                                              
  **`packages/openai/src/chat/openai-chat-language-model.ts`**                                                                                                
  - OpenAI's finish chunk (which carries real usage) was only emitted in `flush()`, which never runs on abort                                                 
  - Now emits the finish chunk as soon as usage data arrives in the stream `transform()`, with a `finishSent` guard to prevent double-emission in `flush()`   
                                                                                                                                                              
  **`content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx`**                                         U                                               
  - Documented `usage`, `totalUsage`, `inputMessages`, and `partialText` fields in the `onAbort` callback parameters
                                                                                                                                                              
  **`content/docs/03-ai-sdk-core/50-error-handling.mdx`**                                                                                                     
  - Updated `onAbort` section to describe all four new fields                                                                                                 
                                                                                                                                                              
 ## Usage                                                                                                                                                    

  ```typescript                                                                                                                                               
  onAbort({ totalUsage, usage, inputMessages, partialText }) {                                      
    const completedTokens = totalUsage?.totalTokens ?? 0;                                                                                                     

    // Use real usage if provider sent it, otherwise estimate with your own tokenizer:
    const abortedStepTokens = usage?.totalTokens                         
      ?? (countTokens(inputMessages) + countTokens(partialText ?? ''));                                                                                       
                                                                                                                                                              
    trackUsage(completedTokens + abortedStepTokens);                                                                                                          
  }                                                                                                                                                           
  ```  
    
  ## Manual Verification                                                                                                                                         
   
   Verified via automated tests that exercise the full stream processing pipeline:                                                                             

  1. Abort fires before any usage chunk → usage and totalUsage are undefined
  2. Abort fires after the provider sent a usage chunk → usage and totalUsage contain the real token counts
  3. Multi-step stream, abort in step 2 → totalUsage correctly sums step 1 and step 2 usage
  4. Abort before first chunk → inputMessages contains the step's input, partialText is undefined                                                             
  5. Abort mid-text → partialText contains the streamed text up to abort 
  6. Multi-step abort → inputMessages includes tool call/result pairs from prior steps                                                                        
                                                                                                                                                              
  All 2200+ existing tests continue to pass.                                                                                                                  
                                                                                                                                                              
  ## Checklist                                                                                                                                                   
                                                                                                                                                              
  - Tests have been added / updated (for bug fixes / features)                                                                                                
  - Documentation has been added / updated (for bug fixes / features)                
  - A patch changeset for relevant packages has been added (for bug fixes / features - run pnpm changeset in the project root)
  - I have reviewed this pull request (self-review)                      

  Related Issues                                                                                                                                              
   
  Fixes #7628                                                                                                                                                 
  Fixes #7805                                                                                                                                             