### PR TITLE
refactor(ai/core): align token terminology with AI SDK glossary

### DIFF
--- a/.changeset/fix-terminology-token-names.md
+++ b/.changeset/fix-terminology-token-names.md
@@ -1,0 +1,13 @@
+---
+"ai": patch
+---
+
+fix(ai): remove dead-code fallback with stale token field names in streamObject
+
+The `flush` handler in `stream-object.ts` contained an unreachable fallback object
+`usage ?? { promptTokens, completionTokens, totalTokens }`. The `usage` variable is
+always initialized to `createNullLanguageModelUsage()` before the stream starts, so
+the nullish-coalescing branch could never execute. The fallback also used the old
+`promptTokens`/`completionTokens` field names that no longer exist on `LanguageModelUsage`
+(which uses `inputTokens`/`outputTokens` per the AI SDK glossary). The dead code is
+removed and `finalUsage` is now assigned directly from `usage`.

--- a/content/cookbook/20-rsc/92-stream-ui-record-token-usage.mdx
+++ b/content/cookbook/20-rsc/92-stream-ui-record-token-usage.mdx
@@ -130,10 +130,10 @@ export async function continueConversation(
       },
     },
     onFinish: ({ usage }) => {
-      const { promptTokens, completionTokens, totalTokens } = usage;
+      const { inputTokens, outputTokens, totalTokens } = usage;
       // your own logic, e.g. for saving the chat history or recording usage
-      console.log('Prompt tokens:', promptTokens);
-      console.log('Completion tokens:', completionTokens);
+      console.log('Input tokens:', inputTokens);
+      console.log('Output tokens:', outputTokens);
       console.log('Total tokens:', totalTokens);
     },
   });

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -557,9 +557,18 @@ const stopWordTransform =
             finishReason: 'stop',
             rawFinishReason: 'stop',
             usage: {
-              completionTokens: NaN,
-              promptTokens: NaN,
+              inputTokens: NaN,
+              outputTokens: NaN,
               totalTokens: NaN,
+              inputTokenDetails: {
+                noCacheTokens: undefined,
+                cacheReadTokens: undefined,
+                cacheWriteTokens: undefined,
+              },
+              outputTokenDetails: {
+                textTokens: undefined,
+                reasoningTokens: undefined,
+              },
             },
             response: {
               id: 'response-id',
@@ -575,9 +584,18 @@ const stopWordTransform =
             finishReason: 'stop',
             rawFinishReason: 'stop',
             totalUsage: {
-              completionTokens: NaN,
-              promptTokens: NaN,
+              inputTokens: NaN,
+              outputTokens: NaN,
               totalTokens: NaN,
+              inputTokenDetails: {
+                noCacheTokens: undefined,
+                cacheReadTokens: undefined,
+                cacheWriteTokens: undefined,
+              },
+              outputTokenDetails: {
+                textTokens: undefined,
+                reasoningTokens: undefined,
+              },
             },
           });
 

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -462,7 +462,7 @@ This is the legacy format. Consider migrating to the `GenAIOpenTelemetry` for be
   - `ai.response.toolCalls`: the tool calls that were made as part of the generation (stringified JSON)
   - `ai.response.msToFirstChunk`: the time it took to receive the first chunk in milliseconds
   - `ai.response.msToFinish`: the time it took to receive the finish part of the LLM stream in milliseconds
-  - `ai.response.avgCompletionTokensPerSecond`: the average number of completion tokens per second
+  - `ai.response.avgOutputTokensPerSecond`: the average number of output tokens per second
   - `ai.response.finishReason`: the reason why the generation finished
 
 - `ai.toolCall` (span): a tool call that is made as part of the streamText call. See [Legacy tool call spans](#legacy-tool-call-spans) for more details.
@@ -543,8 +543,8 @@ Many spans that use LLMs (`ai.generateText`, `ai.generateText.doGenerate`, `ai.s
 - `ai.settings.maxRetries`: the maximum number of retries that were set
 - `ai.telemetry.functionId`: the functionId that was set through `telemetry.functionId`
 - `ai.settings.runtimeContext.*`: the runtime context that was passed in through the `runtimeContext` option
-- `ai.usage.completionTokens`: the number of completion tokens that were used
-- `ai.usage.promptTokens`: the number of prompt tokens that were used
+- `ai.usage.outputTokens`: the number of output tokens that were used
+- `ai.usage.inputTokens`: the number of input tokens that were used
 
 ##### Call LLM span information
 
@@ -567,8 +567,8 @@ Spans that correspond to individual LLM calls (`ai.generateText.doGenerate`, `ai
   - `gen_ai.response.finish_reasons`: the finish reasons that were returned by the provider
   - `gen_ai.response.model`: the model that was used to generate the response. This can be different from the model that was requested if the provider supports aliases.
   - `gen_ai.response.id`: the id of the response. Uses the ID from the provider when available.
-  - `gen_ai.usage.input_tokens`: the number of prompt tokens that were used
-  - `gen_ai.usage.output_tokens`: the number of completion tokens that were used
+  - `gen_ai.usage.input_tokens`: the number of input tokens that were used
+  - `gen_ai.usage.output_tokens`: the number of output tokens that were used
 
 ##### Basic embedding span information
 

--- a/packages/ai/src/generate-object/stream-object.test.ts
+++ b/packages/ai/src/generate-object/stream-object.test.ts
@@ -727,6 +727,59 @@ describe('streamObject', () => {
 
         expect(result!).toMatchSnapshot();
       });
+
+      it('should call onFinish with usage using inputTokens/outputTokens fields', async () => {
+        let result: Parameters<
+          Required<Parameters<typeof streamObject>[0]>['onFinish']
+        >[0];
+
+        const { partialObjectStream } = streamObject({
+          model: new MockLanguageModelV4({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: '1' },
+                {
+                  type: 'text-delta',
+                  id: '1',
+                  delta: '{ "content": "Hello, world!" }',
+                },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+          onFinish: async event => {
+            result = event as unknown as typeof result;
+          },
+          _internal: {
+            generateId: () => 'test-id',
+          },
+        });
+
+        await convertAsyncIterableToArray(partialObjectStream);
+
+        // verify usage uses new inputTokens/outputTokens terminology, not the
+        // deprecated promptTokens/completionTokens
+        expect(result!.usage).toMatchObject({
+          inputTokens: 3,
+          outputTokens: 10,
+          totalTokens: 13,
+        });
+        expect(result!.usage).not.toHaveProperty('promptTokens');
+        expect(result!.usage).not.toHaveProperty('completionTokens');
+      });
     });
 
     describe('options.headers', () => {

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -760,11 +760,7 @@ class DefaultStreamObjectResult<
 
             async flush(controller) {
               try {
-                const finalUsage = usage ?? {
-                  promptTokens: NaN,
-                  completionTokens: NaN,
-                  totalTokens: NaN,
-                };
+                const finalUsage = usage;
 
                 await notify({
                   event: {


### PR DESCRIPTION
## Background

The AI SDK's ubiquitous language glossary (issue #14234) specifies that "completion tokens" and "prompt tokens" are aliases to avoid — the canonical terms are **Output Tokens** and **Input Tokens**. The OTel integration already emits the correct attribute names, but several docs and one source file still used the old names.

## Summary

**`packages/ai/src/generate-object/stream-object.ts`**

Removed unreachable dead-code fallback `usage ?? { promptTokens: NaN, completionTokens: NaN, totalTokens: NaN }`. The `usage` variable is always initialized to `createNullLanguageModelUsage()` before stream processing starts, so the nullish-coalescing branch could never execute. The stale field names also no longer exist on `LanguageModelUsage`.

**`content/docs/03-ai-sdk-core/60-telemetry.mdx`**

Corrected four stale attribute names to match what the SDK actually emits:
- `ai.usage.promptTokens` -> `ai.usage.inputTokens`
- `ai.usage.completionTokens` -> `ai.usage.outputTokens`
- `ai.response.avgCompletionTokensPerSecond` -> `ai.response.avgOutputTokensPerSecond`
- Updated `gen_ai.usage.*` description text to drop "prompt/completion" language

**`content/docs/03-ai-sdk-core/05-generating-text.mdx`**

Updated a custom stream transformer example that was constructing `finish-step` and `finish` events with old field names. Updated to the current `LanguageModelUsage` shape (`inputTokens`/`outputTokens` with required `inputTokenDetails`/`outputTokenDetails`).

**`content/cookbook/20-rsc/92-stream-ui-record-token-usage.mdx`**

Updated a `streamUI` example that was destructuring `{ promptTokens, completionTokens }` from `usage`. Updated to `{ inputTokens, outputTokens }`.

**`packages/ai/src/generate-object/stream-object.test.ts`**

Added a test that processes a full stream through `streamObject` and asserts the `onFinish` callback receives a `usage` object with `inputTokens` and `outputTokens` fields, and explicitly asserts that `promptTokens` and `completionTokens` are not present. All 2399 existing tests continue to pass alongside the new one (2400 total).

## Manual Verification

Verified via automated tests that exercise the full stream processing pipeline:

- Stream completes normally with a `finish` chunk -> `onFinish` receives `usage` with `inputTokens` and `outputTokens` fields
- `promptTokens` and `completionTokens` are explicitly absent from the `usage` object
- All 2400 tests pass (2399 existing + 1 new)

## Checklist

1. Tests have been added / updated
2. Documentation has been added / updated
3. A patch changeset has been added (run `pnpm changeset` in the project root)
4. Self-review completed

## Related Issues

Relates to #14234