### PR TITLE
fix(ai): store raw invalid tool input as structured error object

### DIFF
--- a/.changeset/fix-parse-tool-call-invalid-input.md
+++ b/.changeset/fix-parse-tool-call-invalid-input.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): store raw invalid tool input as structured object instead of string

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -395,7 +395,7 @@ describe('parseToolCall', () => {
           "dynamic": true,
           "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_JSONParseError: JSON parsing failed: Text: invalid json.
         Error message: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON],
-          "input": "invalid json",
+          "input": { "rawInvalidInput": "invalid json" },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -395,7 +395,9 @@ describe('parseToolCall', () => {
           "dynamic": true,
           "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_JSONParseError: JSON parsing failed: Text: invalid json.
         Error message: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON],
-          "input": { "rawInvalidInput": "invalid json" },
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,
@@ -434,7 +436,9 @@ describe('parseToolCall', () => {
         {
           "dynamic": true,
           "error": [AI_ToolCallRepairError: Error repairing tool call: Error: test error],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -80,7 +80,9 @@ export async function parseToolCall<TOOLS extends ToolSet>({
   } catch (error) {
     // use parsed input when possible
     const parsedInput = await safeParseJSON({ text: toolCall.input });
-    const input = parsedInput.success ? parsedInput.value : toolCall.input;
+    const input = parsedInput.success
+      ? parsedInput.value
+      : { rawInvalidInput: toolCall.input };
 
     // TODO AI SDK 6: special invalid tool call parts
     return {


### PR DESCRIPTION
Fixes invalid JSON input being stored as raw string instead of structured error object.

Closes #14442