### PR TITLE
fix(provider): send content:null for tool-only messages

### DIFF
--- a/.changeset/fix-tool-only-content-null.md
+++ b/.changeset/fix-tool-only-content-null.md
@@ -1,0 +1,8 @@
+---
+"@ai-sdk/xai": patch
+"@ai-sdk/deepseek": patch
+"@ai-sdk/groq": patch
+"@ai-sdk/mistral": patch
+---
+
+fix(provider): send `content: null` instead of `content: ""` for tool-only assistant messages

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -123,7 +123,7 @@ export function convertToDeepSeekChatMessages({
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           reasoning_content: reasoning,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -102,7 +102,7 @@ export function convertToGroqChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           ...(reasoning.length > 0 ? { reasoning } : null),
           ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : null),
         });

--- a/packages/mistral/src/convert-to-mistral-chat-messages.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.ts
@@ -119,7 +119,7 @@ export function convertToMistralChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           prefix: isLastMessage ? true : undefined,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/xai/src/convert-to-xai-chat-messages.test.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.test.ts
@@ -213,7 +213,7 @@ describe('convertToXaiChatMessages', () => {
     expect(messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call_123',
@@ -258,7 +258,7 @@ describe('convertToXaiChatMessages', () => {
     expect(messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call_123',

--- a/packages/xai/src/convert-to-xai-chat-messages.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.ts
@@ -108,7 +108,7 @@ export function convertToXaiChatMessages(prompt: LanguageModelV4Prompt): {
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text || null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 


### PR DESCRIPTION
Fixes tool-only assistant messages emitting content:"" instead of content:null across xai/deepseek/groq/mistral providers.

Closes #14612