### PR TITLE
fix(ai): guard undefined warnings in EmbeddingModelV2 doEmbed

### DIFF
--- a/.changeset/fix-embed-warnings-null.md
+++ b/.changeset/fix-embed-warnings-null.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): guard undefined warnings in EmbeddingModelV2 doEmbed return

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -460,6 +460,21 @@ describe('result.warnings', () => {
 
     expect(result.warnings).toStrictEqual([warning1, warning2]);
   });
+
+  it('should handle undefined warnings from provider (embedding model v2)', async () => {
+    const result = await embedMany({
+      model: new MockEmbeddingModelV4({
+        maxEmbeddingsPerCall: 2,
+        doEmbed: async () => ({
+          // Simulate EmbeddingModelV2 provider that returns undefined warnings
+          embeddings: dummyEmbeddings.slice(0, 2),
+        }),
+      }),
+      values: testValues.slice(0, 2),
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+  });
 });
 
 describe('logWarnings', () => {

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -343,7 +343,7 @@ export async function embedMany({
 
       for (const result of results) {
         embeddings.push(...result.embeddings);
-        warnings.push(...result.warnings);
+        warnings.push(...(result.warnings ?? []));
         responses.push(result.response);
         tokens += result.usage.tokens;
         if (result.providerMetadata) {

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -181,6 +181,20 @@ describe('result.warnings', () => {
 
     expect(result.warnings).toStrictEqual(expectedWarnings);
   });
+
+  it('should handle undefined warnings from provider (embedding model v2)', async () => {
+    const result = await embed({
+      model: new MockEmbeddingModelV4({
+        doEmbed: async () => ({
+          // Simulate EmbeddingModelV2 provider that returns undefined warnings
+          embeddings: [dummyEmbedding],
+        }),
+      }),
+      value: testValue,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+  });
 });
 
 describe('logWarnings', () => {

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -201,7 +201,7 @@ export async function embed({
         return {
           embedding,
           usage,
-          warnings: modelResponse.warnings,
+          warnings: modelResponse.warnings ?? [],
           providerMetadata: modelResponse.providerMetadata,
           response: modelResponse.response,
         };

--- a/packages/ai/src/logger/log-warnings.ts
+++ b/packages/ai/src/logger/log-warnings.ts
@@ -102,8 +102,8 @@ let hasLoggedBefore = false;
  * @param options.model - The model id used for the call, if scoped to a specific provider.
  */
 export const logWarnings: LogWarningsFunction = options => {
-  // if the warnings array is empty, do nothing
-  if (options.warnings.length === 0) {
+  // if the warnings array is empty or undefined, do nothing
+  if (!options.warnings || options.warnings.length === 0) {
     return;
   }
 


### PR DESCRIPTION
Fixes EmbeddingModelV2 protocol missing warnings field in doEmbed return type, causing undefined access.

Closes #14425