### PR TITLE
feat(gateway): add caching option to GatewayProviderOptions

### DIFF
--- a/.changeset/gateway-caching-option.md
+++ b/.changeset/gateway-caching-option.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+feat(gateway): add `caching` option to `GatewayProviderOptions` type, enabling automatic prompt caching across supported providers (Anthropic, MiniMax)

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -100,6 +100,15 @@ const gatewayProviderOptions = lazySchema(() =>
           byok: z.record(z.string(), z.number().int().min(1000)).optional(),
         })
         .optional(),
+      /**
+       * Enables automatic prompt caching across providers.
+       * When set to `'auto'`, AI Gateway applies the appropriate caching
+       * strategy based on the provider (e.g., adding `cache_control` breakpoints
+       * for Anthropic or MiniMax, which require explicit cache markers).
+       *
+       * Supported providers: Anthropic (direct, Vertex, Bedrock), MiniMax.
+       */
+      caching: z.enum(['auto']).optional(),
     }),
   ),
 );


### PR DESCRIPTION
Adds missing caching property to GatewayProviderOptions type.

Closes #14595