### PR TITLE
fix(google-vertex/anthropic): support eu/us multi-region endpoints

### DIFF
--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -196,6 +196,40 @@ describe('google-vertex-anthropic-provider', () => {
     );
   });
 
+  it('should use multi-region URL for eu location', () => {
+    const provider = createVertexAnthropic({
+      project: 'test-project',
+      location: 'eu',
+    });
+    provider('test-model-id');
+
+    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      expect.objectContaining({
+        baseURL:
+          'https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/publishers/anthropic/models',
+        provider: 'vertex.anthropic.messages',
+      }),
+    );
+  });
+
+  it('should use multi-region URL for us location', () => {
+    const provider = createVertexAnthropic({
+      project: 'test-project',
+      location: 'us',
+    });
+    provider('test-model-id');
+
+    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      expect.objectContaining({
+        baseURL:
+          'https://aiplatform.us.rep.googleapis.com/v1/projects/test-project/locations/us/publishers/anthropic/models',
+        provider: 'vertex.anthropic.messages',
+      }),
+    );
+  });
+
   it('should support combining tools with structured outputs (inherited from Anthropic)', () => {
     const provider = createVertexAnthropic({
       project: 'test-project',

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -173,9 +173,17 @@ export function createVertexAnthropic(
       environmentVariableName: 'GOOGLE_VERTEX_PROJECT',
     });
 
+    // Multi-region locations (e.g. 'us', 'eu') use a different hostname format:
+    // https://aiplatform.{location}.rep.googleapis.com/v1/...
+    // See: https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-partner-models#multi-region
+    const MULTI_REGION_LOCATIONS = new Set(['us', 'eu']);
+    const baseHost = MULTI_REGION_LOCATIONS.has(location ?? '')
+      ? `aiplatform.${location}.rep.googleapis.com`
+      : `${location === 'global' ? '' : location + '-'}aiplatform.googleapis.com`;
+
     return (
       withoutTrailingSlash(options.baseURL) ??
-      `https://${location === 'global' ? '' : location + '-'}aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`
+      `https://${baseHost}/v1/projects/${project}/locations/${location}/publishers/anthropic/models`
     );
   };
 


### PR DESCRIPTION
## Background

Fixes #14634

## Summary

Multi-region locations (`eu`, `us`) use a different hostname format than regular regional endpoints:

| Location type | Hostname format |
|---|---|
| Regular (e.g. `us-east5`) | `us-east5-aiplatform.googleapis.com` |
| Global | `aiplatform.googleapis.com` |
| Multi-region (`eu`, `us`) | `aiplatform.{location}.rep.googleapis.com` |

The current URL construction only handles the first two cases, producing incorrect hostnames like `eu-aiplatform.googleapis.com` for multi-region locations, which return 404s.

This PR detects multi-region locations and uses the correct `aiplatform.{location}.rep.googleapis.com` hostname format per [Google's documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-partner-models#multi-region).

## Changes

- `google-vertex-anthropic-provider.ts`: Added multi-region hostname detection for `eu` and `us` locations
- `google-vertex-anthropic-provider.test.ts`: Added test cases for both `eu` and `us` multi-region endpoints

## Verification

- Existing tests for `global` and regional locations (e.g. `us-east5`) remain unchanged
- Added dedicated tests verifying the correct URL format for `eu` and `us` multi-region locations