### PR TITLE
refactoring: rename toolNeedsApproval to toolApproval

### DIFF
--- a/.changeset/cyan-apes-drive.md
+++ b/.changeset/cyan-apes-drive.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+refactoring: rename toolNeedsApproval to toolApproval

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -78,7 +78,7 @@ const codeAgent = new ToolLoopAgent({
 ```
 
 You can also require approval before a tool executes. Use `needsApproval` on the
-tool itself for the default behavior, or set `toolNeedsApproval` on the
+tool itself for the default behavior, or set `toolApproval` on the
 `ToolLoopAgent` when approval should be configured per agent:
 
 ```ts
@@ -93,7 +93,7 @@ const agent = new ToolLoopAgent({
       execute: async ({ code }) => ({ output: code }),
     }),
   },
-  toolNeedsApproval: {
+  toolApproval: {
     runCode: true,
   },
 });

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -110,9 +110,9 @@ tool({
 By default, tools with an `execute` function run automatically as the model calls them. You can require approval before execution in two ways:
 
 - Set `needsApproval` on an individual tool to define its default approval behavior
-- Set `toolNeedsApproval` on `generateText` or `streamText` to configure approval for specific tools at call time
+- Set `toolApproval` on `generateText` or `streamText` to configure approval for specific tools at call time
 
-Use `needsApproval` when the tool should usually require approval wherever it is used. Use `toolNeedsApproval` when approval depends on the specific request or runtime context. If both are provided, `toolNeedsApproval` takes precedence.
+Use `needsApproval` when the tool should usually require approval wherever it is used. Use `toolApproval` when approval depends on the specific request or runtime context. If both are provided, `toolApproval` takes precedence.
 
 ### Tool-Level Approval with `needsApproval`
 
@@ -132,20 +132,20 @@ const runCommand = tool({
 });
 ```
 
-### Call-Level Approval with `toolNeedsApproval`
+### Call-Level Approval with `toolApproval`
 
 ```ts highlight="8-10"
 const result = await generateText({
   model: __MODEL__,
   tools: { runCommand },
-  toolNeedsApproval: {
+  toolApproval: {
     runCommand: true,
   },
   prompt: 'Remove the most recent file in the downloads folder',
 });
 ```
 
-`toolNeedsApproval` can also be a function per tool, which lets you decide dynamically based on the tool input and runtime options such as `toolCallId`, `messages`, and `context`.
+`toolApproval` can also be a function per tool, which lets you decide dynamically based on the tool input and runtime options such as `toolCallId`, `messages`, and `context`.
 
 This is useful for tools that perform sensitive operations like executing commands, processing payments, modifying data, and more potentially dangerous actions.
 
@@ -153,11 +153,11 @@ This is useful for tools that perform sensitive operations like executing comman
 
 When a tool requires approval, `generateText` and `streamText` don't pause execution. Instead, they complete and return `tool-approval-request` parts in the result content. This means the approval flow requires two calls to the model: the first returns the approval request, and the second (after receiving the approval response) either executes the tool or informs the model that approval was denied.
 
-The approval requirement can come from either tool-level `needsApproval` or call-level `toolNeedsApproval`.
+The approval requirement can come from either tool-level `needsApproval` or call-level `toolApproval`.
 
 Here's the complete flow:
 
-1. Call `generateText` or `streamText` with approval configured via `needsApproval` or `toolNeedsApproval`
+1. Call `generateText` or `streamText` with approval configured via `needsApproval` or `toolApproval`
 2. The model generates a tool call
 3. The call returns `tool-approval-request` parts in `result.content`
 4. Your app requests approval and collects the user's decision
@@ -224,7 +224,7 @@ Then call `generateText` or `streamText` again with the updated messages. If app
 
 <Note>
   Provider-executed tools are executed provider-side without considering the tool
-  approval setting. `needsApproval` and `toolNeedsApproval` only control tools
+  approval setting. `needsApproval` and `toolApproval` only control tools
   that the AI SDK executes locally.
 </Note>
 
@@ -248,7 +248,7 @@ const paymentTool = tool({
 
 In this example, only transactions over $1000 require approval. Smaller transactions execute automatically.
 
-You can use the same function shape in `toolNeedsApproval` when you want that decision to be defined at call time instead of on the tool itself.
+You can use the same function shape in `toolApproval` when you want that decision to be defined at call time instead of on the tool itself.
 
 ### Tool Execution Approval with useChat
 

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -540,7 +540,7 @@ To see `generateText` in action, check out [these examples](#examples).
         'Limits the tools that are available for the model to call without changing the tool call and result types in the result. All tools are active by default.',
     },
     {
-      name: 'toolNeedsApproval',
+      name: 'toolApproval',
       type: 'Record<TOOLNAME, boolean | ((input, options) => boolean | Promise<boolean>)>',
       isOptional: true,
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -584,7 +584,7 @@ To see `streamText` in action, check out [these examples](#examples).
         'The tools that are currently active. All tools are active by default.',
     },
     {
-      name: 'toolNeedsApproval',
+      name: 'toolApproval',
       type: 'Record<TOOLNAME, boolean | ((input, options) => boolean | Promise<boolean>)>',
       isOptional: true,
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -84,7 +84,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
         'Limits the subset of tools that are available in a specific call.',
     },
     {
-      name: 'toolNeedsApproval',
+      name: 'toolApproval',
       type: 'Record<string, boolean | ((input, options) => boolean | Promise<boolean>)>',
       isOptional: true,
       description:
@@ -992,7 +992,7 @@ const agent = new ToolLoopAgent({
       }),
     }),
   },
-  toolNeedsApproval: {
+  toolApproval: {
     weather: true,
   },
 });

--- a/examples/ai-functions/src/agent/openai/generate-tool-approval.ts
+++ b/examples/ai-functions/src/agent/openai/generate-tool-approval.ts
@@ -12,7 +12,7 @@ const agent = new ToolLoopAgent({
     'When a tool execution is not approved by the user, do not retry it.' +
     'Just say that the tool execution was not approved.',
   tools: { weather: weatherTool },
-  toolNeedsApproval: { weather: true },
+  toolApproval: { weather: true },
 });
 
 const terminal = readline.createInterface({

--- a/examples/ai-functions/src/generate-text/openai/tool-approval-user-defined.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-approval-user-defined.ts
@@ -47,7 +47,7 @@ run(async () => {
         'When a tool execution is not approved by the user, do not retry it.' +
         'Just say that the tool execution was not approved.',
       tools: { weather: weatherTool },
-      toolNeedsApproval: {
+      toolApproval: {
         weather: true,
       },
       messages,

--- a/examples/ai-functions/src/stream-text/openai/tool-approval-user-defined.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-approval-user-defined.ts
@@ -47,7 +47,7 @@ run(async () => {
         'When a tool execution is not approved by the user, do not retry it.' +
         'Just say that the tool execution was not approved.',
       tools: { weather: weatherTool },
-      toolNeedsApproval: {
+      toolApproval: {
         weather: true,
       },
       messages,

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -20,8 +20,12 @@ import type {
 import { Output } from '../generate-text/output';
 import { PrepareStepFunction } from '../generate-text/prepare-step';
 import { StopCondition } from '../generate-text/stop-condition';
+import { ToolApprovalConfiguration } from '../generate-text/tool-approval-configuration';
 import { ToolCallRepairFunction } from '../generate-text/tool-call-repair-function';
-import { ToolNeedsApprovalConfiguration } from '../generate-text/tool-needs-approval-configuration';
+import {
+  OnToolExecutionEndCallback,
+  OnToolExecutionStartCallback,
+} from '../generate-text/tool-execution-events';
 import { ToolsContextParameter } from '../generate-text/tools-context-parameter';
 import { LanguageModelCallOptions } from '../prompt/language-model-call-options';
 import { Prompt } from '../prompt/prompt';
@@ -31,10 +35,6 @@ import { LanguageModel, ToolChoice } from '../types/language-model';
 import type { Callback } from '../util/callback';
 import { DownloadFunction } from '../util/download/download-function';
 import { AgentCallParameters } from './agent';
-import {
-  OnToolExecutionEndCallback,
-  OnToolExecutionStartCallback,
-} from '../generate-text/tool-execution-events';
 
 export type ToolLoopAgentOnStartCallback<
   TOOLS extends ToolSet = ToolSet,
@@ -133,7 +133,7 @@ export type ToolLoopAgentSettings<
      *
      * This configuration takes precedence over tool-defined approval settings.
      */
-    toolNeedsApproval?: ToolNeedsApprovalConfiguration<NoInfer<TOOLS>>;
+    toolApproval?: ToolApprovalConfiguration<NoInfer<TOOLS>>;
 
     /**
      * Optional function that you can use to provide different settings for a step.
@@ -257,7 +257,7 @@ export type ToolLoopAgentSettings<
           | 'telemetry'
           | 'experimental_telemetry'
           | 'activeTools'
-          | 'toolNeedsApproval'
+          | 'toolApproval'
           | 'providerOptions'
           | 'experimental_download'
           | 'runtimeContext'
@@ -287,7 +287,7 @@ export type ToolLoopAgentSettings<
         | 'telemetry'
         | 'experimental_telemetry'
         | 'activeTools'
-        | 'toolNeedsApproval'
+        | 'toolApproval'
         | 'providerOptions'
         | 'experimental_download'
         | 'runtimeContext'

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import {
   Output,
   StreamTextOnFinishCallback,
-  ToolNeedsApprovalConfiguration,
+  ToolApprovalConfiguration,
 } from '../generate-text';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
 import { AsyncIterableStream } from '../util/async-iterable-stream';
@@ -91,7 +91,7 @@ describe('ToolLoopAgent', () => {
       expectTypeOf<typeof output>().toEqualTypeOf<{ value: string }>();
     });
 
-    it('should type toolNeedsApproval in settings and prepareCall', () => {
+    it('should type toolApproval in settings and prepareCall', () => {
       const tools = {
         testTool: tool({
           inputSchema: z.object({ value: z.string() }),
@@ -101,7 +101,7 @@ describe('ToolLoopAgent', () => {
       new ToolLoopAgent({
         model: new MockLanguageModelV4(),
         tools,
-        toolNeedsApproval: {
+        toolApproval: {
           testTool: (input, options) => {
             expectTypeOf(input).toEqualTypeOf<{ value: string }>();
             expectTypeOf(options.toolCallId).toEqualTypeOf<string>();
@@ -111,8 +111,8 @@ describe('ToolLoopAgent', () => {
           },
         },
         prepareCall: options => {
-          expectTypeOf(options.toolNeedsApproval).toEqualTypeOf<
-            ToolNeedsApprovalConfiguration<typeof tools> | undefined
+          expectTypeOf(options.toolApproval).toEqualTypeOf<
+            ToolApprovalConfiguration<typeof tools> | undefined
           >();
 
           return {

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -377,7 +377,7 @@ describe('ToolLoopAgent', () => {
         });
       });
 
-      it('should honor toolNeedsApproval in generate', async () => {
+      it('should honor toolApproval in generate', async () => {
         let modelCallCount = 0;
         const execute = vi.fn(async () => 'tool-result');
 
@@ -446,7 +446,7 @@ describe('ToolLoopAgent', () => {
               execute,
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             testTool: true,
           },
         });
@@ -657,7 +657,7 @@ describe('ToolLoopAgent', () => {
     `);
     });
 
-    it('should honor toolNeedsApproval in stream', async () => {
+    it('should honor toolApproval in stream', async () => {
       let modelCallCount = 0;
       const execute = vi.fn(async () => 'tool-result');
 
@@ -747,7 +747,7 @@ describe('ToolLoopAgent', () => {
             execute,
           }),
         },
-        toolNeedsApproval: {
+        toolApproval: {
           testTool: true,
         },
       });

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -22,7 +22,7 @@ import {
  * The loop continues until:
  * - A finish reasoning other than tool-calls is returned, or
  * - A tool that is invoked does not have an execute function, or
- * - A tool call needs approval via `toolNeedsApproval` or tool-level `needsApproval`, or
+ * - A tool call needs approval via `toolApproval` or tool-level `needsApproval`, or
  * - A stop condition is met (default stop condition is isStepCount(20))
  */
 export class ToolLoopAgent<

--- a/packages/ai/src/generate-text/create-execute-tools-transformation.ts
+++ b/packages/ai/src/generate-text/create-execute-tools-transformation.ts
@@ -10,12 +10,12 @@ import { TelemetryOptions } from '../telemetry/telemetry-options';
 import { executeToolCall } from './execute-tool-call';
 import { isToolApprovalNeeded } from './is-tool-approval-needed';
 import { LanguageModelStreamPart } from './stream-language-model-call';
+import { ToolApprovalConfiguration } from './tool-approval-configuration';
 import { TypedToolCall } from './tool-call';
 import {
   OnToolExecutionEndCallback,
   OnToolExecutionStartCallback,
 } from './tool-execution-events';
-import { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configuration';
 
 export function createExecuteToolsTransformation<TOOLS extends ToolSet>({
   tools,
@@ -25,7 +25,7 @@ export function createExecuteToolsTransformation<TOOLS extends ToolSet>({
   abortSignal,
   timeout,
   toolsContext,
-  toolNeedsApproval,
+  toolApproval,
   generateId,
   stepNumber,
   provider,
@@ -41,7 +41,7 @@ export function createExecuteToolsTransformation<TOOLS extends ToolSet>({
   abortSignal: AbortSignal | undefined;
   timeout?: TimeoutConfiguration<TOOLS>;
   toolsContext: InferToolSetContext<TOOLS>;
-  toolNeedsApproval?: ToolNeedsApprovalConfiguration<TOOLS>;
+  toolApproval?: ToolApprovalConfiguration<TOOLS>;
   generateId: IdGenerator;
   stepNumber?: number;
   provider?: string;
@@ -88,7 +88,7 @@ export function createExecuteToolsTransformation<TOOLS extends ToolSet>({
             await isToolApprovalNeeded({
               tools,
               toolCall: chunk,
-              toolNeedsApproval,
+              toolApproval,
               messages,
               toolsContext,
             })

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -7562,7 +7562,7 @@ describe('generateText', () => {
               execute: async () => 'result1',
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             tool1: true,
           },
           stopWhen: isStepCount(3),
@@ -7783,7 +7783,7 @@ describe('generateText', () => {
               execute: input => `result for ${input.value}`,
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             tool1: (input, options) => {
               needsApprovalCalls.push({ input, options });
               return input.value === 'value-needs-approval';
@@ -7979,7 +7979,7 @@ describe('generateText', () => {
               execute: executeFunction,
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             tool1: true,
           },
           stopWhen: isStepCount(3),
@@ -8147,7 +8147,7 @@ describe('generateText', () => {
               },
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             tool1: true,
           },
           stopWhen: isStepCount(3),
@@ -8263,7 +8263,7 @@ describe('generateText', () => {
               execute: executeFunction,
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             tool1: true,
           },
           stopWhen: isStepCount(3),
@@ -8424,7 +8424,7 @@ describe('generateText', () => {
               execute: executeFunction,
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             tool1: true,
           },
           stopWhen: isStepCount(3),

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -83,18 +83,18 @@ import {
   StopCondition,
 } from './stop-condition';
 import { toResponseMessages } from './to-response-messages';
+import { ToolApprovalConfiguration } from './tool-approval-configuration';
 import { ToolApprovalRequestOutput } from './tool-approval-request-output';
 import { TypedToolCall } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair-function';
 import { TypedToolError } from './tool-error';
-import { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configuration';
-import { ToolOutput } from './tool-output';
-import { TypedToolResult } from './tool-result';
-import { ToolsContextParameter } from './tools-context-parameter';
 import {
   OnToolExecutionEndCallback,
   OnToolExecutionStartCallback,
 } from './tool-execution-events';
+import { ToolOutput } from './tool-output';
+import { TypedToolResult } from './tool-result';
+import { ToolsContextParameter } from './tools-context-parameter';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -235,7 +235,7 @@ export async function generateText<
   headers,
   stopWhen = isStepCount(1),
   output,
-  toolNeedsApproval,
+  toolApproval,
   experimental_telemetry,
   telemetry = experimental_telemetry,
   providerOptions,
@@ -320,7 +320,7 @@ export async function generateText<
      *
      * This configuration takes precedence over tool-defined approval settings.
      */
-    toolNeedsApproval?: ToolNeedsApprovalConfiguration<TOOLS>;
+    toolApproval?: ToolApprovalConfiguration<TOOLS>;
 
     /**
      * Custom download function to use for URLs.
@@ -774,7 +774,7 @@ export async function generateText<
           if (
             await isToolApprovalNeeded({
               tools,
-              toolNeedsApproval,
+              toolApproval,
               toolCall,
               messages: stepInputMessages,
               toolsContext,

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -61,6 +61,7 @@ export type {
   TextStreamPart,
   UIMessageStreamOptions,
 } from './stream-text-result';
+export type { ToolApprovalConfiguration } from './tool-approval-configuration';
 export type { ToolApprovalRequestOutput } from './tool-approval-request-output';
 export type {
   DynamicToolCall,
@@ -79,7 +80,6 @@ export type {
   ToolExecutionEndEvent,
   ToolExecutionStartEvent,
 } from './tool-execution-events';
-export type { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configuration';
 export type {
   StaticToolOutputDenied,
   TypedToolOutputDenied,

--- a/packages/ai/src/generate-text/is-tool-approval-needed.test.ts
+++ b/packages/ai/src/generate-text/is-tool-approval-needed.test.ts
@@ -14,7 +14,7 @@ describe('isToolApprovalNeeded', () => {
           inputSchema: z.object({ city: z.string() }),
         }),
       },
-      toolNeedsApproval: undefined,
+      toolApproval: undefined,
       toolCall: {
         type: 'tool-call',
         toolCallId: 'call-1',
@@ -30,17 +30,17 @@ describe('isToolApprovalNeeded', () => {
   });
 
   it('uses user-defined approval before tool-defined approval', async () => {
-    const toolNeedsApproval = vi.fn(() => false);
+    const toolApproval = vi.fn(() => false);
     const userDefinedNeedsApproval = vi.fn(() => true);
 
     const result = await isToolApprovalNeeded({
       tools: {
         weather: tool({
           inputSchema: z.object({ city: z.string() }),
-          needsApproval: toolNeedsApproval,
+          needsApproval: toolApproval,
         }),
       },
-      toolNeedsApproval: {
+      toolApproval: {
         weather: userDefinedNeedsApproval,
       },
       toolCall: {
@@ -56,7 +56,7 @@ describe('isToolApprovalNeeded', () => {
 
     expect(result).toBe(true);
     expect(userDefinedNeedsApproval).toHaveBeenCalledTimes(1);
-    expect(toolNeedsApproval).not.toHaveBeenCalled();
+    expect(toolApproval).not.toHaveBeenCalled();
   });
 
   it('passes tool input and options to a user-defined approval callback', async () => {
@@ -68,7 +68,7 @@ describe('isToolApprovalNeeded', () => {
           inputSchema: z.object({ city: z.string() }),
         }),
       },
-      toolNeedsApproval: {
+      toolApproval: {
         weather: userDefinedNeedsApproval,
       },
       toolCall: {
@@ -92,16 +92,16 @@ describe('isToolApprovalNeeded', () => {
   });
 
   it('uses tool-defined approval when no user-defined approval is configured', async () => {
-    const toolNeedsApproval = vi.fn(() => true);
+    const toolApproval = vi.fn(() => true);
 
     const result = await isToolApprovalNeeded({
       tools: {
         weather: tool({
           inputSchema: z.object({ city: z.string() }),
-          needsApproval: toolNeedsApproval,
+          needsApproval: toolApproval,
         }),
       },
-      toolNeedsApproval: undefined,
+      toolApproval: undefined,
       toolCall: {
         type: 'tool-call',
         toolCallId: 'call-1',
@@ -114,7 +114,7 @@ describe('isToolApprovalNeeded', () => {
     });
 
     expect(result).toBe(true);
-    expect(toolNeedsApproval).toHaveBeenCalledWith(
+    expect(toolApproval).toHaveBeenCalledWith(
       { city: 'Berlin' },
       {
         toolCallId: 'call-1',
@@ -135,7 +135,7 @@ describe('isToolApprovalNeeded', () => {
             needsApproval: vi.fn(() => true),
           }),
         },
-        toolNeedsApproval: {
+        toolApproval: {
           weather: userDefinedNeedsApproval,
         },
         toolCall: {

--- a/packages/ai/src/generate-text/is-tool-approval-needed.ts
+++ b/packages/ai/src/generate-text/is-tool-approval-needed.ts
@@ -4,9 +4,9 @@ import {
   ModelMessage,
   ToolSet,
 } from '@ai-sdk/provider-utils';
-import { validateToolContext } from './validate-tool-context';
-import { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configuration';
+import { ToolApprovalConfiguration } from './tool-approval-configuration';
 import { TypedToolCall } from './tool-call';
+import { validateToolContext } from './validate-tool-context';
 
 /**
  * Resolves whether a tool call requires approval by checking user-supplied and tool-defined
@@ -16,7 +16,7 @@ import { TypedToolCall } from './tool-call';
 export async function isToolApprovalNeeded<TOOLS extends ToolSet>({
   tools,
   toolCall,
-  toolNeedsApproval,
+  toolApproval,
   messages,
   toolsContext,
 }: {
@@ -27,7 +27,7 @@ export async function isToolApprovalNeeded<TOOLS extends ToolSet>({
    *
    * This configuration takes precedence over tool-defined approval settings.
    */
-  toolNeedsApproval: ToolNeedsApprovalConfiguration<TOOLS> | undefined;
+  toolApproval: ToolApprovalConfiguration<TOOLS> | undefined;
 
   toolCall: TypedToolCall<TOOLS>; // assuming tool call is valid
   messages: ModelMessage[];
@@ -50,7 +50,7 @@ export async function isToolApprovalNeeded<TOOLS extends ToolSet>({
   const input = toolCall.input as InferToolInput<TOOLS[keyof TOOLS]>;
 
   // user-defined tool approval
-  const userDefinedToolNeedsApproval = toolNeedsApproval?.[toolName];
+  const userDefinedToolNeedsApproval = toolApproval?.[toolName];
   if (userDefinedToolNeedsApproval != null) {
     return typeof userDefinedToolNeedsApproval === 'boolean'
       ? userDefinedToolNeedsApproval

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -20945,7 +20945,7 @@ describe('streamText', () => {
               execute: async () => 'result1',
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             tool1: true,
           },
         });
@@ -21175,7 +21175,7 @@ describe('streamText', () => {
               execute: input => `result for ${input.value}`,
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             tool1: (input, options) => {
               needsApprovalCalls.push({ input, options });
               return input.value === 'value-needs-approval';
@@ -21540,7 +21540,7 @@ describe('streamText', () => {
               execute: executeFunction,
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             tool1: true,
           },
           stopWhen: isStepCount(3),
@@ -21846,7 +21846,7 @@ describe('streamText', () => {
               },
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             tool1: true,
           },
           stopWhen: isStepCount(3),
@@ -21972,7 +21972,7 @@ describe('streamText', () => {
               },
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             tool1: true,
           },
           stopWhen: isStepCount(3),
@@ -22303,7 +22303,7 @@ describe('streamText', () => {
               execute: executeFunction,
             }),
           },
-          toolNeedsApproval: {
+          toolApproval: {
             tool1: true,
           },
           stopWhen: isStepCount(3),

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -118,16 +118,16 @@ import {
   UIMessageStreamOptions,
 } from './stream-text-result';
 import { toResponseMessages } from './to-response-messages';
+import { ToolApprovalConfiguration } from './tool-approval-configuration';
 import { TypedToolCall } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair-function';
-import { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configuration';
-import { ToolOutput } from './tool-output';
-import { StaticToolOutputDenied } from './tool-output-denied';
-import { ToolsContextParameter } from './tools-context-parameter';
 import {
   OnToolExecutionEndCallback,
   OnToolExecutionStartCallback,
 } from './tool-execution-events';
+import { ToolOutput } from './tool-output';
+import { StaticToolOutputDenied } from './tool-output-denied';
+import { ToolsContextParameter } from './tools-context-parameter';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -312,7 +312,7 @@ export function streamText<
   headers,
   stopWhen = isStepCount(1),
   output,
-  toolNeedsApproval,
+  toolApproval,
   experimental_telemetry,
   telemetry = experimental_telemetry,
   prepareStep,
@@ -405,7 +405,7 @@ export function streamText<
      *
      * This configuration takes precedence over tool-defined approval settings.
      */
-    toolNeedsApproval?: ToolNeedsApprovalConfiguration<TOOLS>;
+    toolApproval?: ToolApprovalConfiguration<TOOLS>;
 
     /**
      * Optional function that you can use to provide different settings for a step.
@@ -578,7 +578,7 @@ export function streamText<
     repairToolCall,
     stopConditions: asArray(stopWhen),
     output,
-    toolNeedsApproval,
+    toolApproval,
     providerOptions,
     prepareStep,
     includeRawChunks,
@@ -762,7 +762,7 @@ class DefaultStreamTextResult<
     repairToolCall,
     stopConditions,
     output,
-    toolNeedsApproval,
+    toolApproval,
     providerOptions,
     prepareStep,
     includeRawChunks,
@@ -809,7 +809,7 @@ class DefaultStreamTextResult<
       StopCondition<NoInfer<TOOLS>, NoInfer<RUNTIME_CONTEXT>>
     >;
     output: OUTPUT | undefined;
-    toolNeedsApproval: ToolNeedsApprovalConfiguration<TOOLS> | undefined;
+    toolApproval: ToolApprovalConfiguration<TOOLS> | undefined;
     providerOptions: ProviderOptions | undefined;
     prepareStep:
       | PrepareStepFunction<NoInfer<TOOLS>, NoInfer<RUNTIME_CONTEXT>>
@@ -1661,7 +1661,7 @@ class DefaultStreamTextResult<
               abortSignal,
               timeout,
               toolsContext,
-              toolNeedsApproval,
+              toolApproval,
               generateId,
               stepNumber: recordedSteps.length,
               provider: stepModel.provider,

--- a/packages/ai/src/generate-text/tool-approval-configuration.test-d.ts
+++ b/packages/ai/src/generate-text/tool-approval-configuration.test-d.ts
@@ -1,9 +1,9 @@
 import { ModelMessage, tool } from '@ai-sdk/provider-utils';
 import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
-import type { ToolNeedsApprovalConfiguration } from './tool-needs-approval-configuration';
+import type { ToolApprovalConfiguration } from './tool-approval-configuration';
 
-describe('ToolNeedsApprovalConfiguration', () => {
+describe('ToolApprovalConfiguration', () => {
   const tools = {
     weather: tool({
       inputSchema: z.object({
@@ -21,7 +21,7 @@ describe('ToolNeedsApprovalConfiguration', () => {
   };
 
   it('allows booleans and infers tool-specific approval callback types', () => {
-    const config: ToolNeedsApprovalConfiguration<typeof tools> = {
+    const config: ToolApprovalConfiguration<typeof tools> = {
       weather: (input, { context, toolCallId, messages }) => {
         expectTypeOf(input).toEqualTypeOf<{ location: string }>();
         expectTypeOf(context).toEqualTypeOf<{ weatherApiKey: string }>();
@@ -34,12 +34,12 @@ describe('ToolNeedsApprovalConfiguration', () => {
     };
 
     expectTypeOf(config).toEqualTypeOf<
-      ToolNeedsApprovalConfiguration<typeof tools>
+      ToolApprovalConfiguration<typeof tools>
     >();
   });
 
   it('keeps each tool approval callback specific to that tool', () => {
-    const config: ToolNeedsApprovalConfiguration<typeof tools> = {
+    const config: ToolApprovalConfiguration<typeof tools> = {
       calculator: (input, options) => {
         expectTypeOf(input).toEqualTypeOf<{ expression: string }>();
         expectTypeOf(options.context).toEqualTypeOf<never>();
@@ -49,41 +49,41 @@ describe('ToolNeedsApprovalConfiguration', () => {
     };
 
     expectTypeOf(config).toEqualTypeOf<
-      ToolNeedsApprovalConfiguration<typeof tools>
+      ToolApprovalConfiguration<typeof tools>
     >();
   });
 
   describe('negative cases', () => {
     it('rejects approval configuration for unknown tool keys', () => {
-      const config: ToolNeedsApprovalConfiguration<typeof tools> = {
+      const config: ToolApprovalConfiguration<typeof tools> = {
         // @ts-expect-error tool approval only accepts keys from the provided tool set
         search: true,
       };
 
       expectTypeOf(config).toEqualTypeOf<
-        ToolNeedsApprovalConfiguration<typeof tools>
+        ToolApprovalConfiguration<typeof tools>
       >();
     });
 
     it('rejects callbacks with the wrong input type for a tool', () => {
-      const config: ToolNeedsApprovalConfiguration<typeof tools> = {
+      const config: ToolApprovalConfiguration<typeof tools> = {
         // @ts-expect-error weather approval callbacks must receive the weather tool input
         weather: (input: { expression: string }) => input.expression.length > 0,
       };
 
       expectTypeOf(config).toEqualTypeOf<
-        ToolNeedsApprovalConfiguration<typeof tools>
+        ToolApprovalConfiguration<typeof tools>
       >();
     });
 
     it('rejects callbacks with the wrong return type', () => {
-      const config: ToolNeedsApprovalConfiguration<typeof tools> = {
+      const config: ToolApprovalConfiguration<typeof tools> = {
         // @ts-expect-error approval callbacks must return a boolean or promise-like boolean
         calculator: () => 'approved',
       };
 
       expectTypeOf(config).toEqualTypeOf<
-        ToolNeedsApprovalConfiguration<typeof tools>
+        ToolApprovalConfiguration<typeof tools>
       >();
     });
   });

--- a/packages/ai/src/generate-text/tool-approval-configuration.ts
+++ b/packages/ai/src/generate-text/tool-approval-configuration.ts
@@ -11,7 +11,7 @@ import {
  * Each tool can be assigned either a boolean or a function that decides at
  * runtime whether approval is needed.
  */
-export type ToolNeedsApprovalConfiguration<TOOLS extends ToolSet> = {
+export type ToolApprovalConfiguration<TOOLS extends ToolSet> = {
   [key in keyof TOOLS]?:
     | boolean
     | ToolNeedsApprovalFunction<


### PR DESCRIPTION
# Background

We want to enhance the tool approval function to allow for automatic accept or reject without user interaction. The name `toolApproval` is shorter and much better aligned with that desired API.

## Summary

* rename `toolNeedsApproval` to `toolApproval`
* rename `ToolNeedsApprovalConfiguration` to `ToolApprovalConfiguration`

## Future Work

* change tool approval function outputs to "not-applicable", "approved", "rejected", "user-approval"

## Related Issues

Builds on #14480