### PR TITLE
fix(provider/google): strip $ref and $defs from tool response content

### DIFF
--- a/.changeset/fix-google-sanitize-ref-in-function-response.md
+++ b/.changeset/fix-google-sanitize-ref-in-function-response.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(provider/google): strip $ref and $defs from tool response content to prevent Gemini 400 errors
+
+Stripping $ref and $defs unconditionally means that a tool response containing a literal field named $ref or $defs (e.g., a MongoDB DBRef-shaped object) will also have that field removed; this is an accepted tradeoff since resolving $ref/$defs inline is impractical for the recursive schemas z.lazy() produces.

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -658,6 +658,277 @@ describe('tool messages', () => {
     });
   });
 
+  it('should strip $ref and $defs from function response content to avoid Gemini 400 errors', async () => {
+    const result = convertToGoogleMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolName: 'get_schema',
+            toolCallId: 'testCallId',
+            output: {
+              type: 'json',
+              value: {
+                tools: [
+                  {
+                    name: 'find_records',
+                    inputSchema: {
+                      type: 'object',
+                      properties: {
+                        filter: { $ref: '#/$defs/__schema0' },
+                      },
+                      $defs: {
+                        __schema0: {
+                          type: 'object',
+                          properties: { field: { type: 'string' } },
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      systemInstruction: undefined,
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'testCallId',
+                name: 'get_schema',
+                response: {
+                  name: 'get_schema',
+                  content: {
+                    tools: [
+                      {
+                        name: 'find_records',
+                        inputSchema: {
+                          type: 'object',
+                          properties: {
+                            filter: {},
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should pass through null property values unchanged', async () => {
+    const result = convertToGoogleMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolName: 'test_tool',
+            toolCallId: 'testCallId',
+            output: {
+              type: 'json',
+              value: {
+                status: 'success',
+                data: null,
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      systemInstruction: undefined,
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'testCallId',
+                name: 'test_tool',
+                response: {
+                  name: 'test_tool',
+                  content: {
+                    status: 'success',
+                    data: null,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should pass through non-plain objects like Date unchanged', async () => {
+    const eventDate = new Date('2026-01-01T00:00:00Z');
+    const result = convertToGoogleMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolName: 'test_tool',
+            toolCallId: 'testCallId',
+            output: {
+              type: 'json',
+              value: {
+                status: 'success',
+                occurredAt: eventDate,
+              },
+            } as any,
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      systemInstruction: undefined,
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'testCallId',
+                name: 'test_tool',
+                response: {
+                  name: 'test_tool',
+                  content: {
+                    status: 'success',
+                    occurredAt: eventDate,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should strip $ref key at top level', async () => {
+    const result = convertToGoogleMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolName: 'test_tool',
+            toolCallId: 'testCallId',
+            output: {
+              type: 'json',
+              value: {
+                $ref: '#/definitions/something',
+                result: 'value',
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      systemInstruction: undefined,
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'testCallId',
+                name: 'test_tool',
+                response: {
+                  name: 'test_tool',
+                  content: {
+                    result: 'value',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should strip $ref from nested objects in arrays', async () => {
+    const result = convertToGoogleMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolName: 'test_tool',
+            toolCallId: 'testCallId',
+            output: {
+              type: 'json',
+              value: {
+                items: [
+                  {
+                    id: 1,
+                    $ref: '#/schema',
+                    data: 'keep this',
+                  },
+                  {
+                    id: 2,
+                    data: 'also keep',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      systemInstruction: undefined,
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'testCallId',
+                name: 'test_tool',
+                response: {
+                  name: 'test_tool',
+                  content: {
+                    items: [
+                      {
+                        id: 1,
+                        data: 'keep this',
+                      },
+                      {
+                        id: 2,
+                        data: 'also keep',
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('should convert tool result content with image-data into functionResponse parts', async () => {
     const result = convertToGoogleMessages([
       {

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -190,6 +190,24 @@ function appendLegacyToolResultParts(
   }
 }
 
+/* Recursively strips $ref and $defs keys from plain objects/arrays before sending as functionResponse.response.content — Gemini's proto parser treats $ref string values as references to declared function names and returns a 400 INVALID_ARGUMENT when they don't match, which happens when a tool result contains a JSON Schema (e.g. from z.toJSONSchema() with z.lazy()); non-plain values (Date, Map, Set, class instances, etc.) are left untouched rather than being silently flattened by Object.entries/fromEntries. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function sanitizeFunctionResponseContent(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeFunctionResponseContent);
+  if (!isPlainObject(value)) return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (key === '$ref' || key === '$defs') continue;
+    out[key] = sanitizeFunctionResponseContent(val);
+  }
+  return out;
+}
+
 export function convertToGoogleMessages(
   prompt: LanguageModelV4Prompt,
   options?: {
@@ -592,7 +610,7 @@ export function convertToGoogleMessages(
                   content:
                     output.type === 'execution-denied'
                       ? (output.reason ?? 'Tool call execution denied.')
-                      : output.value,
+                      : sanitizeFunctionResponseContent(output.value),
                 },
               },
             });


### PR DESCRIPTION
Closes #14369

## Background

The Google/Gemini provider forwards tool-result values verbatim as `functionResponse.response.content`. When a tool returns a value containing JSON Schema (for example from `z.toJSONSchema()` with `z.lazy()`), that value can include `$ref`/`$defs` keys. Gemini's proto parser treats `$ref` string values as references to declared function names, and returns `400 INVALID_ARGUMENT` when they don't match a declared function.

## Summary

Adds `sanitizeFunctionResponseContent()`, guarded by an `isPlainObject()` check, which recursively strips `$ref` and `$defs` keys from plain objects and arrays before the value is sent to Gemini. Non-plain values (`Date`, `Map`, `Set`, class instances) pass through untouched instead of being flattened, and tool responses without schema-shaped data are unaffected.

## Manual Verification

Reproduced the original 400 error against live Gemini with a tool returning `z.toJSONSchema()` output, applied the fix, and confirmed the same call succeeds.

## Checklist

- [x] All commits are signed
- [x] Tests have been added / updated
- [x] A patch changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues

Closes #14369
