### PR TITLE
chore(examples): fix duplicated word in code-interpreter prompt

### DIFF
--- a/examples/ai-functions/src/stream-text/openai/code-interpreter-tool.ts
+++ b/examples/ai-functions/src/stream-text/openai/code-interpreter-tool.ts
@@ -9,7 +9,7 @@ run(async () => {
       code_interpreter: openai.tools.codeInterpreter(),
     },
     prompt:
-      'Simulate rolling two dice 10000 times and and return the sum all the results.',
+      'Simulate rolling two dice 10000 times and return the sum of all the results.',
   });
 
   for await (const chunk of result.fullStream) {


### PR DESCRIPTION
### Why

The OpenAI code-interpreter example prompt contains two small typos in a single sentence:

- `and and return` (duplicated "and")
- `the sum all the results` (missing "of")

These are user-facing strings in a runnable example — first-time readers tend to copy-paste example prompts verbatim, so small mistakes propagate. Also, the duplicated word makes the sentence ungrammatical and slightly changes the model's expected behavior (the LLM has to silently correct it before responding).

### What

Single-line change in `examples/ai-functions/src/stream-text/openai/code-interpreter-tool.ts`:

```diff
-      'Simulate rolling two dice 10000 times and and return the sum all the results.',
+      'Simulate rolling two dice 10000 times and return the sum of all the results.',
```

No logic, behavior, or API surface is touched. Examples are not released per `CONTRIBUTING.md`, so no changeset is needed.

1 file changed, 1 insertion(+), 1 deletion(-).

---
_Part of open-source blockchain work from [kcolbchain.com](https://kcolbchain.com) — maintained by [Abhishek Krishna](https://abhishekkrishna.com). PR opened via [kcolbchain contrib-bot](https://github.com/kcolbchain/kcolbchain.github.io/blob/master/deploy/contrib-bot/README.md)._