### PR TITLE
feat(ai): remove unnecessary data from events

### DIFF
--- a/.changeset/spotty-hats-sniff.md
+++ b/.changeset/spotty-hats-sniff.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/otel": patch
+"ai": patch
+---
+
+feat(ai): remove unnecessary data from events

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -1973,15 +1973,6 @@ describe('ToolLoopAgent', () => {
             "callId": "call-0",
             "context": undefined,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "test",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "toolCall": {
               "input": {
                 "value": "test",
@@ -2187,15 +2178,6 @@ describe('ToolLoopAgent', () => {
             "callId": "call-1",
             "context": undefined,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "test",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "toolCall": {
               "input": {
                 "value": "test",
@@ -2409,16 +2391,7 @@ describe('ToolLoopAgent', () => {
             "context": undefined,
             "durationMs": 0,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "test",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
             "output": "hello-result",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "success": true,
             "toolCall": {
               "input": {
@@ -2626,16 +2599,7 @@ describe('ToolLoopAgent', () => {
             "context": undefined,
             "durationMs": 0,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "test",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
             "output": "hello-result",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "success": true,
             "toolCall": {
               "input": {

--- a/packages/ai/src/generate-text/core-events.ts
+++ b/packages/ai/src/generate-text/core-events.ts
@@ -186,21 +186,6 @@ export interface OnStepStartEvent<
   /** Additional provider-specific options for this step. */
   readonly providerOptions: ProviderOptions | undefined;
 
-  /**
-   * Timeout configuration for the generation.
-   * Can be a number (milliseconds) or an object with totalMs, stepMs, chunkMs, toolMs, and per-tool overrides via tools.
-   */
-  readonly timeout: TimeoutConfiguration<TOOLS> | undefined;
-
-  /** Additional HTTP headers sent with the request. */
-  readonly headers: Record<string, string | undefined> | undefined;
-
-  /**
-   * Condition(s) for stopping the generation.
-   * When the condition is an array, any of the conditions can be met to stop.
-   */
-  readonly stopWhen: Arrayable<StopCondition<TOOLS, RUNTIME_CONTEXT>>;
-
   /** The output specification for structured outputs, if configured. */
   readonly output: OUTPUT | undefined;
 

--- a/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
@@ -361,10 +361,6 @@ describe('createExecuteToolsTransformation', () => {
               "value": "test",
             },
             "functionId": undefined,
-            "messages": [],
-            "modelId": "test-model",
-            "provider": "test-provider",
-            "stepNumber": 2,
             "toolCall": {
               "input": {
                 "value": "test",
@@ -385,11 +381,7 @@ describe('createExecuteToolsTransformation', () => {
             },
             "durationMs": 0,
             "functionId": undefined,
-            "messages": [],
-            "modelId": "test-model",
             "output": "test-result",
-            "provider": "test-provider",
-            "stepNumber": 2,
             "success": true,
             "toolCall": {
               "input": {
@@ -450,11 +442,7 @@ describe('createExecuteToolsTransformation', () => {
             "context": undefined,
             "durationMs": 0,
             "functionId": undefined,
-            "messages": [],
-            "modelId": undefined,
             "output": "abc-result",
-            "provider": undefined,
-            "stepNumber": undefined,
             "success": true,
             "toolCall": {
               "input": {
@@ -521,10 +509,6 @@ describe('createExecuteToolsTransformation', () => {
             "durationMs": 0,
             "error": [Error: tool failed],
             "functionId": undefined,
-            "messages": [],
-            "modelId": undefined,
-            "provider": undefined,
-            "stepNumber": undefined,
             "success": false,
             "toolCall": {
               "input": {
@@ -642,10 +626,6 @@ describe('createExecuteToolsTransformation', () => {
             "callId": "test-telemetry-call-id",
             "context": undefined,
             "functionId": undefined,
-            "messages": [],
-            "modelId": undefined,
-            "provider": undefined,
-            "stepNumber": undefined,
             "toolCall": {
               "input": {
                 "value": "a",
@@ -659,10 +639,6 @@ describe('createExecuteToolsTransformation', () => {
             "callId": "test-telemetry-call-id",
             "context": undefined,
             "functionId": undefined,
-            "messages": [],
-            "modelId": undefined,
-            "provider": undefined,
-            "stepNumber": undefined,
             "toolCall": {
               "input": {
                 "value": "b",
@@ -681,11 +657,7 @@ describe('createExecuteToolsTransformation', () => {
             "context": undefined,
             "durationMs": 0,
             "functionId": undefined,
-            "messages": [],
-            "modelId": undefined,
             "output": "a-result",
-            "provider": undefined,
-            "stepNumber": undefined,
             "success": true,
             "toolCall": {
               "input": {
@@ -701,11 +673,7 @@ describe('createExecuteToolsTransformation', () => {
             "context": undefined,
             "durationMs": 0,
             "functionId": undefined,
-            "messages": [],
-            "modelId": undefined,
             "output": "b-result",
-            "provider": undefined,
-            "stepNumber": undefined,
             "success": true,
             "toolCall": {
               "input": {

--- a/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
@@ -342,9 +342,6 @@ describe('createExecuteToolsTransformation', () => {
           timeout: undefined,
           abortSignal: undefined,
           toolsContext: { testTool: { value: 'test' } },
-          stepNumber: 2,
-          provider: 'test-provider',
-          modelId: 'test-model',
           onToolExecutionStart: async event => {
             startEvents.push(event);
           },

--- a/packages/ai/src/generate-text/create-execute-tools-transformation.ts
+++ b/packages/ai/src/generate-text/create-execute-tools-transformation.ts
@@ -27,9 +27,6 @@ export function createExecuteToolsTransformation<TOOLS extends ToolSet>({
   toolsContext,
   toolApproval,
   generateId,
-  stepNumber,
-  provider,
-  modelId,
   onToolExecutionStart,
   onToolExecutionEnd,
   executeToolInTelemetryContext,
@@ -43,9 +40,6 @@ export function createExecuteToolsTransformation<TOOLS extends ToolSet>({
   toolsContext: InferToolSetContext<TOOLS>;
   toolApproval?: ToolApprovalConfiguration<TOOLS>;
   generateId: IdGenerator;
-  stepNumber?: number;
-  provider?: string;
-  modelId?: string;
   onToolExecutionStart?: Arrayable<OnToolExecutionStartCallback<TOOLS>>;
   onToolExecutionEnd?: Arrayable<OnToolExecutionEndCallback<TOOLS>>;
   executeToolInTelemetryContext?: Telemetry['executeTool'];
@@ -125,9 +119,6 @@ export function createExecuteToolsTransformation<TOOLS extends ToolSet>({
                   abortSignal,
                   timeout,
                   toolsContext,
-                  stepNumber,
-                  provider,
-                  modelId,
                   onToolExecutionStart,
                   onToolExecutionEnd,
                   executeToolInTelemetryContext,

--- a/packages/ai/src/generate-text/execute-tool-call.test.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.test.ts
@@ -221,9 +221,6 @@ describe('executeToolCall', () => {
         messages: [{ role: 'user', content: 'test message' }],
         abortSignal: undefined,
         toolsContext: { testTool: { key1: 'value1' } },
-        stepNumber: 2,
-        provider: 'test-provider',
-        modelId: 'test-model',
         onToolExecutionStart: async event => {
           executionOrder.push('onToolExecutionStart');
           toolExecutionStartEvents.push(event);
@@ -238,15 +235,6 @@ describe('executeToolCall', () => {
               "key1": "value1",
             },
             "functionId": "test-function",
-            "messages": [
-              {
-                "content": "test message",
-                "role": "user",
-              },
-            ],
-            "modelId": "test-model",
-            "provider": "test-provider",
-            "stepNumber": 2,
             "toolCall": {
               "dynamic": false,
               "input": {
@@ -310,9 +298,6 @@ describe('executeToolCall', () => {
         messages: [{ role: 'user', content: 'test message' }],
         abortSignal: undefined,
         toolsContext: { testTool: { key1: 'value1' } },
-        stepNumber: 3,
-        provider: 'test-provider',
-        modelId: 'test-model',
         onToolExecutionEnd: async event => {
           toolExecutionEndEvents.push(event);
         },
@@ -327,16 +312,7 @@ describe('executeToolCall', () => {
             },
             "durationMs": 50,
             "functionId": "test-function",
-            "messages": [
-              {
-                "content": "test message",
-                "role": "user",
-              },
-            ],
-            "modelId": "test-model",
             "output": "test-result",
-            "provider": "test-provider",
-            "stepNumber": 3,
             "success": true,
             "toolCall": {
               "dynamic": false,
@@ -376,9 +352,6 @@ describe('executeToolCall', () => {
         messages: [],
         abortSignal: undefined,
         toolsContext: { testTool: { key1: 'value1' } },
-        stepNumber: 1,
-        provider: 'provider-1',
-        modelId: 'model-1',
         onToolExecutionEnd: async event => {
           toolExecutionEndEvents.push(event);
         },
@@ -393,11 +366,6 @@ describe('executeToolCall', () => {
             },
             "durationMs": 100,
             "error": [Error: execution failed],
-            "functionId": "test-function",
-            "messages": [],
-            "modelId": "model-1",
-            "provider": "provider-1",
-            "stepNumber": 1,
             "success": false,
             "toolCall": {
               "dynamic": false,
@@ -619,9 +587,6 @@ describe('executeToolCall', () => {
         messages: [{ role: 'user', content: 'hello' }],
         abortSignal: undefined,
         toolsContext: { testTool: { key1: 'value1' } },
-        stepNumber: 2,
-        provider: 'test-provider',
-        modelId: 'test-model',
         onToolExecutionStart: async event => {
           startEvents.push(event);
         },
@@ -637,16 +602,6 @@ describe('executeToolCall', () => {
             "context": {
               "key1": "value1",
             },
-            "functionId": "test-function",
-            "messages": [
-              {
-                "content": "hello",
-                "role": "user",
-              },
-            ],
-            "modelId": "test-model",
-            "provider": "test-provider",
-            "stepNumber": 2,
             "toolCall": {
               "dynamic": false,
               "input": {
@@ -668,17 +623,7 @@ describe('executeToolCall', () => {
               "key1": "value1",
             },
             "durationMs": 0,
-            "functionId": "test-function",
-            "messages": [
-              {
-                "content": "hello",
-                "role": "user",
-              },
-            ],
-            "modelId": "test-model",
             "output": "test-result",
-            "provider": "test-provider",
-            "stepNumber": 2,
             "success": true,
             "toolCall": {
               "dynamic": false,

--- a/packages/ai/src/generate-text/execute-tool-call.test.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.test.ts
@@ -366,6 +366,7 @@ describe('executeToolCall', () => {
             },
             "durationMs": 100,
             "error": [Error: execution failed],
+            "functionId": "test-function",
             "success": false,
             "toolCall": {
               "dynamic": false,
@@ -602,6 +603,7 @@ describe('executeToolCall', () => {
             "context": {
               "key1": "value1",
             },
+            "functionId": "test-function",
             "toolCall": {
               "dynamic": false,
               "input": {
@@ -623,6 +625,7 @@ describe('executeToolCall', () => {
               "key1": "value1",
             },
             "durationMs": 0,
+            "functionId": "test-function",
             "output": "test-result",
             "success": true,
             "toolCall": {
@@ -671,10 +674,6 @@ describe('executeToolCall', () => {
             "durationMs": 0,
             "error": [Error: test error],
             "functionId": undefined,
-            "messages": [],
-            "modelId": undefined,
-            "provider": undefined,
-            "stepNumber": undefined,
             "success": false,
             "toolCall": {
               "dynamic": false,

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -47,9 +47,6 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   messages,
   abortSignal,
   timeout,
-  stepNumber,
-  provider,
-  modelId,
   onPreliminaryToolResult,
   onToolExecutionStart,
   onToolExecutionEnd,
@@ -63,9 +60,6 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   abortSignal: AbortSignal | undefined;
   toolsContext: InferToolSetContext<TOOLS>;
   timeout?: TimeoutConfiguration<TOOLS>;
-  stepNumber?: number;
-  provider?: string;
-  modelId?: string;
   onPreliminaryToolResult?: (result: TypedToolResult<TOOLS>) => void;
   onToolExecutionStart?: Arrayable<OnToolExecutionStartCallback<TOOLS>>;
   onToolExecutionEnd?: Arrayable<OnToolExecutionEndCallback<TOOLS>>;
@@ -90,11 +84,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
 
   const baseCallbackEvent = {
     callId,
-    stepNumber,
-    provider,
-    modelId,
     toolCall,
-    messages,
     functionId: telemetry?.functionId,
     context, // TODO rename to toolContext
   };

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1658,15 +1658,6 @@ describe('generateText', () => {
             "callId": "test-telemetry-call-id",
             "context": undefined,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "test-input",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "toolCall": {
               "input": {
                 "value": "test-arg",
@@ -1727,15 +1718,6 @@ describe('generateText', () => {
             "callId": "test-telemetry-call-id",
             "context": undefined,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "toolCall": {
               "input": {
                 "value": "a",
@@ -1752,15 +1734,6 @@ describe('generateText', () => {
             "callId": "test-telemetry-call-id",
             "context": undefined,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "toolCall": {
               "input": {
                 "value": "b",
@@ -1923,15 +1896,6 @@ describe('generateText', () => {
               "context": "test",
             },
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "toolCall": {
               "input": {
                 "value": "test",
@@ -1988,16 +1952,7 @@ describe('generateText', () => {
             "context": undefined,
             "durationMs": 0,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
             "output": "test-arg-result",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "success": true,
             "toolCall": {
               "input": {
@@ -2057,15 +2012,6 @@ describe('generateText', () => {
             "durationMs": 0,
             "error": [Error: tool execution failed],
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "success": false,
             "toolCall": {
               "input": {
@@ -2226,16 +2172,7 @@ describe('generateText', () => {
             },
             "durationMs": 0,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
             "output": "test-result",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "success": true,
             "toolCall": {
               "input": {
@@ -2299,15 +2236,6 @@ describe('generateText', () => {
             "durationMs": 0,
             "error": [Error: Tool execution failed],
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "success": false,
             "toolCall": {
               "input": {
@@ -2477,15 +2405,6 @@ describe('generateText', () => {
             "callId": "test-telemetry-call-id",
             "context": undefined,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "toolCall": {
               "input": {
                 "value": "step0",
@@ -2502,44 +2421,6 @@ describe('generateText', () => {
             "callId": "test-telemetry-call-id",
             "context": undefined,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-              {
-                "content": [
-                  {
-                    "input": {
-                      "value": "step0",
-                    },
-                    "providerExecuted": undefined,
-                    "providerOptions": undefined,
-                    "toolCallId": "call-1",
-                    "toolName": "tool1",
-                    "type": "tool-call",
-                  },
-                ],
-                "role": "assistant",
-              },
-              {
-                "content": [
-                  {
-                    "output": {
-                      "type": "text",
-                      "value": "step0-result",
-                    },
-                    "toolCallId": "call-1",
-                    "toolName": "tool1",
-                    "type": "tool-result",
-                  },
-                ],
-                "role": "tool",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 1,
             "toolCall": {
               "input": {
                 "value": "step1",
@@ -2561,16 +2442,7 @@ describe('generateText', () => {
             "context": undefined,
             "durationMs": 0,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
             "output": "step0-result",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "success": true,
             "toolCall": {
               "input": {
@@ -2589,45 +2461,7 @@ describe('generateText', () => {
             "context": undefined,
             "durationMs": 0,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-              {
-                "content": [
-                  {
-                    "input": {
-                      "value": "step0",
-                    },
-                    "providerExecuted": undefined,
-                    "providerOptions": undefined,
-                    "toolCallId": "call-1",
-                    "toolName": "tool1",
-                    "type": "tool-call",
-                  },
-                ],
-                "role": "assistant",
-              },
-              {
-                "content": [
-                  {
-                    "output": {
-                      "type": "text",
-                      "value": "step0-result",
-                    },
-                    "toolCallId": "call-1",
-                    "toolName": "tool1",
-                    "type": "tool-result",
-                  },
-                ],
-                "role": "tool",
-              },
-            ],
-            "modelId": "mock-model-id",
             "output": "step1-result",
-            "provider": "mock-provider",
-            "stepNumber": 1,
             "success": true,
             "toolCall": {
               "input": {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -524,9 +524,6 @@ export async function generateText<
         abortSignal: mergedAbortSignal,
         timeout,
         toolsContext,
-        stepNumber: 0,
-        provider: model.provider,
-        modelId: model.modelId,
         onToolExecutionStart: event =>
           notify({
             event,
@@ -683,11 +680,8 @@ export async function generateText<
             activeTools: prepareStepResult?.activeTools ?? activeTools,
             steps: [...steps],
             providerOptions: stepProviderOptions,
-            timeout,
-            headers,
-            stopWhen,
-            output,
             functionId: telemetry?.functionId,
+            output,
             runtimeContext,
             promptMessages,
             stepTools,
@@ -827,9 +821,6 @@ export async function generateText<
               abortSignal: mergedAbortSignal,
               timeout,
               toolsContext,
-              stepNumber: steps.length,
-              provider: stepModel.provider,
-              modelId: stepModel.modelId,
               onToolExecutionStart: event =>
                 notify({
                   event,
@@ -1063,9 +1054,6 @@ async function executeTools<TOOLS extends ToolSet>({
   abortSignal,
   timeout,
   toolsContext,
-  stepNumber,
-  provider,
-  modelId,
   onToolExecutionStart,
   onToolExecutionEnd,
   executeToolInTelemetryContext,
@@ -1078,9 +1066,6 @@ async function executeTools<TOOLS extends ToolSet>({
   abortSignal: AbortSignal | undefined;
   timeout?: TimeoutConfiguration<TOOLS>;
   toolsContext: InferToolSetContext<TOOLS>;
-  stepNumber: number;
-  provider: string;
-  modelId: string;
   onToolExecutionStart?: OnToolExecutionStartCallback<TOOLS>;
   onToolExecutionEnd?: OnToolExecutionEndCallback<TOOLS>;
   executeToolInTelemetryContext?: Telemetry['executeTool'];
@@ -1097,9 +1082,6 @@ async function executeTools<TOOLS extends ToolSet>({
           abortSignal,
           timeout,
           toolsContext,
-          stepNumber,
-          provider,
-          modelId,
           onToolExecutionStart,
           onToolExecutionEnd,
           executeToolInTelemetryContext,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -6260,15 +6260,6 @@ describe('streamText', () => {
             "callId": "test-telemetry-call-id",
             "context": undefined,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "test-input",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "toolCall": {
               "input": {
                 "value": "test-arg",
@@ -6532,15 +6523,6 @@ describe('streamText', () => {
               "context": "test",
             },
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "toolCall": {
               "input": {
                 "value": "test",
@@ -6854,16 +6836,7 @@ describe('streamText', () => {
             },
             "durationMs": 0,
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
             "output": "test-result",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "success": true,
             "toolCall": {
               "input": {
@@ -6939,15 +6912,6 @@ describe('streamText', () => {
             "durationMs": 0,
             "error": [Error: Tool execution failed],
             "functionId": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
-            "modelId": "mock-model-id",
-            "provider": "mock-provider",
-            "stepNumber": 0,
             "success": false,
             "toolCall": {
               "input": {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1417,9 +1417,6 @@ class DefaultStreamTextResult<
                 abortSignal,
                 timeout,
                 toolsContext,
-                stepNumber: recordedSteps.length,
-                provider: model.provider,
-                modelId: model.modelId,
                 onToolExecutionStart: filterNullable(
                   onToolExecutionStart,
                   unifiedTelemetry.onToolExecutionStart as
@@ -1617,13 +1614,10 @@ class DefaultStreamTextResult<
                     activeTools: prepareStepResult?.activeTools ?? activeTools,
                     steps: [...recordedSteps],
                     providerOptions: stepProviderOptions,
-                    timeout,
-                    headers,
-                    stopWhen,
-                    output,
                     ...callbackTelemetryProps,
                     runtimeContext,
                     toolsContext,
+                    output,
                     promptMessages,
                     stepTools,
                     stepToolChoice,
@@ -1663,9 +1657,6 @@ class DefaultStreamTextResult<
               toolsContext,
               toolApproval,
               generateId,
-              stepNumber: recordedSteps.length,
-              provider: stepModel.provider,
-              modelId: stepModel.modelId,
               onToolExecutionStart: filterNullable(
                 onToolExecutionStart,
                 unifiedTelemetry.onToolExecutionStart as

--- a/packages/ai/src/generate-text/tool-execution-events.ts
+++ b/packages/ai/src/generate-text/tool-execution-events.ts
@@ -1,8 +1,4 @@
-import type {
-  InferToolSetContext,
-  ModelMessage,
-  ToolSet,
-} from '@ai-sdk/provider-utils';
+import type { InferToolSetContext, ToolSet } from '@ai-sdk/provider-utils';
 import { Callback } from '../util/callback';
 import type { TypedToolCall } from './tool-call';
 
@@ -15,20 +11,8 @@ export interface ToolExecutionStartEvent<TOOLS extends ToolSet = ToolSet> {
   /** Unique identifier for this generation call, used to correlate events. */
   readonly callId: string;
 
-  /** Zero-based index of the current step where this tool call occurs. */
-  readonly stepNumber: number | undefined;
-
-  /** The provider identifier (e.g., 'openai', 'anthropic'). */
-  readonly provider: string | undefined;
-
-  /** The specific model identifier (e.g., 'gpt-4o'). */
-  readonly modelId: string | undefined;
-
   /** The full tool call object. */
   readonly toolCall: TypedToolCall<TOOLS>;
-
-  /** The conversation messages available at tool execution time. */
-  readonly messages: Array<ModelMessage>;
 
   /** Identifier from telemetry settings for grouping related operations. */
   readonly functionId: string | undefined;
@@ -47,20 +31,8 @@ export type ToolExecutionEndEvent<TOOLS extends ToolSet = ToolSet> = {
   /** Unique identifier for this generation call, used to correlate events. */
   readonly callId: string;
 
-  /** Zero-based index of the current step where this tool call occurred. */
-  readonly stepNumber: number | undefined;
-
-  /** The provider identifier (e.g., 'openai', 'anthropic'). */
-  readonly provider: string | undefined;
-
-  /** The specific model identifier (e.g., 'gpt-4o'). */
-  readonly modelId: string | undefined;
-
   /** The full tool call object. */
   readonly toolCall: TypedToolCall<TOOLS>;
-
-  /** The conversation messages available at tool execution time. */
-  readonly messages: Array<ModelMessage>;
 
   /** Execution time of the tool call in milliseconds. */
   readonly durationMs: number;

--- a/packages/otel/src/gen-ai-open-telemetry.test.ts
+++ b/packages/otel/src/gen-ai-open-telemetry.test.ts
@@ -188,12 +188,9 @@ function makeStepStartEvent(overrides?: Record<string, unknown>) {
     activeTools: undefined,
     steps: [],
     providerOptions: undefined,
-    timeout: undefined,
-    headers: undefined,
-    stopWhen: undefined,
-    output: undefined,
     abortSignal: undefined,
     include: undefined,
+    output: undefined,
     functionId: undefined,
     runtimeContext: {},
     toolsContext: {},
@@ -282,16 +279,12 @@ function makeFinishEvent(overrides?: Record<string, unknown>) {
 function makeToolCallStartEvent(overrides?: Record<string, unknown>) {
   return {
     callId,
-    stepNumber: 0,
-    provider: model.provider,
-    modelId: model.modelId,
     toolCall: {
       type: 'tool-call' as const,
       toolCallId: 'tool-call-1',
       toolName: 'myTool',
       input: { query: 'test' },
     },
-    messages: [],
     abortSignal: undefined,
     functionId: undefined,
     context: {},
@@ -306,16 +299,12 @@ function makeToolCallFinishEvent(
 ) {
   const base = {
     callId,
-    stepNumber: 0,
-    provider: model.provider,
-    modelId: model.modelId,
     toolCall: {
       type: 'tool-call' as const,
       toolCallId: 'tool-call-1',
       toolName: 'myTool',
       input: { query: 'test' },
     },
-    messages: [],
     abortSignal: undefined,
     durationMs: 42,
     functionId: undefined,

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -204,11 +204,8 @@ function makeStepStartEvent(overrides?: Record<string, unknown>) {
     activeTools: undefined,
     steps: [],
     providerOptions: undefined,
-    timeout: undefined,
-    headers: undefined,
-    stopWhen: undefined,
-    output: undefined,
     abortSignal: undefined,
+    output: undefined,
     include: undefined,
     functionId: undefined,
     runtimeContext: {},
@@ -298,16 +295,12 @@ function makeFinishEvent(overrides?: Record<string, unknown>) {
 function makeToolCallStartEvent(overrides?: Record<string, unknown>) {
   return {
     callId,
-    stepNumber: 0,
-    provider: model.provider,
-    modelId: model.modelId,
     toolCall: {
       type: 'tool-call' as const,
       toolCallId: 'tool-call-1',
       toolName: 'myTool',
       input: { query: 'test' },
     },
-    messages: [],
     abortSignal: undefined,
     functionId: undefined,
     context: {},
@@ -322,16 +315,12 @@ function makeToolCallFinishEvent(
 ) {
   const base = {
     callId,
-    stepNumber: 0,
-    provider: model.provider,
-    modelId: model.modelId,
     toolCall: {
       type: 'tool-call' as const,
       toolCallId: 'tool-call-1',
       toolName: 'myTool',
       input: { query: 'test' },
     },
-    messages: [],
     abortSignal: undefined,
     durationMs: 42,
     functionId: undefined,


### PR DESCRIPTION
## Background

there was unnecessary data being passed through the core lifecycle events that could be stripped away. 

## Summary

- from tool execution event - step number, messages, provider, modelId were removed
- from step start event - timeout, headers and stopWhen data was removed

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)