### PR TITLE
fix: more precise default message for tool execution denial

### DIFF
--- a/.changeset/nine-starfishes-relax.md
+++ b/.changeset/nine-starfishes-relax.md
@@ -1,0 +1,17 @@
+---
+"@ai-sdk/openai-compatible": patch
+"@ai-sdk/amazon-bedrock": patch
+"@ai-sdk/open-responses": patch
+"@ai-sdk/anthropic": patch
+"@ai-sdk/deepseek": patch
+"@ai-sdk/alibaba": patch
+"@ai-sdk/mistral": patch
+"@ai-sdk/cohere": patch
+"@ai-sdk/google": patch
+"@ai-sdk/openai": patch
+"@ai-sdk/groq": patch
+"@ai-sdk/xai": patch
+"ai": patch
+---
+
+fix: more precise default message for tool execution denial

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -316,7 +316,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                           type: 'error-text' as const,
                           value:
                             toolPart.approval.reason ??
-                            'Tool execution denied.',
+                            'Tool call execution denied.',
                         },
                         ...(toolPart.callProviderMetadata != null
                           ? { providerOptions: toolPart.callProviderMetadata }

--- a/packages/alibaba/src/convert-to-alibaba-chat-messages.ts
+++ b/packages/alibaba/src/convert-to-alibaba-chat-messages.ts
@@ -173,7 +173,7 @@ export function convertToAlibabaChatMessages({
               contentValue = output.value;
               break;
             case 'execution-denied':
-              contentValue = output.reason ?? 'Tool execution denied.';
+              contentValue = output.reason ?? 'Tool call execution denied.';
               break;
             case 'content':
             case 'json':

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -213,7 +213,7 @@ export async function convertToBedrockChatMessages(
                     break;
                   case 'execution-denied':
                     toolResultContent = [
-                      { text: output.reason ?? 'Tool execution denied.' },
+                      { text: output.reason ?? 'Tool call execution denied.' },
                     ];
                     break;
                   case 'json':

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -413,7 +413,8 @@ export async function convertToAnthropicMessagesPrompt({
                     contentValue = output.value;
                     break;
                   case 'execution-denied':
-                    contentValue = output.reason ?? 'Tool execution denied.';
+                    contentValue =
+                      output.reason ?? 'Tool call execution denied.';
                     break;
                   case 'json':
                   case 'error-json':

--- a/packages/cohere/src/convert-to-cohere-chat-prompt.ts
+++ b/packages/cohere/src/convert-to-cohere-chat-prompt.ts
@@ -133,7 +133,7 @@ export function convertToCohereChatPrompt(prompt: LanguageModelV4Prompt): {
                   contentValue = output.value;
                   break;
                 case 'execution-denied':
-                  contentValue = output.reason ?? 'Tool execution denied.';
+                  contentValue = output.reason ?? 'Tool call execution denied.';
                   break;
                 case 'content':
                 case 'json':

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -145,7 +145,7 @@ export function convertToDeepSeekChatMessages({
               contentValue = output.value;
               break;
             case 'execution-denied':
-              contentValue = output.reason ?? 'Tool execution denied.';
+              contentValue = output.reason ?? 'Tool call execution denied.';
               break;
             case 'content':
             case 'json':

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -478,7 +478,7 @@ export function convertToGoogleMessages(
                   name: part.toolName,
                   content:
                     output.type === 'execution-denied'
-                      ? (output.reason ?? 'Tool execution denied.')
+                      ? (output.reason ?? 'Tool call execution denied.')
                       : output.value,
                 },
               },

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -124,7 +124,7 @@ export function convertToGroqChatMessages(
               contentValue = output.value;
               break;
             case 'execution-denied':
-              contentValue = output.reason ?? 'Tool execution denied.';
+              contentValue = output.reason ?? 'Tool call execution denied.';
               break;
             case 'content':
             case 'json':

--- a/packages/mistral/src/convert-to-mistral-chat-messages.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.ts
@@ -140,7 +140,7 @@ export function convertToMistralChatMessages(
               contentValue = output.value;
               break;
             case 'execution-denied':
-              contentValue = output.reason ?? 'Tool execution denied.';
+              contentValue = output.reason ?? 'Tool call execution denied.';
               break;
             case 'content':
             case 'json':

--- a/packages/open-responses/src/responses/convert-to-open-responses-input.ts
+++ b/packages/open-responses/src/responses/convert-to-open-responses-input.ts
@@ -138,7 +138,7 @@ export async function convertToOpenResponsesInput({
                 contentValue = output.value;
                 break;
               case 'execution-denied':
-                contentValue = output.reason ?? 'Tool execution denied.';
+                contentValue = output.reason ?? 'Tool call execution denied.';
                 break;
               case 'json':
               case 'error-json':

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -233,7 +233,7 @@ export function convertToOpenAICompatibleChatMessages(
               contentValue = output.value;
               break;
             case 'execution-denied':
-              contentValue = output.reason ?? 'Tool execution denied.';
+              contentValue = output.reason ?? 'Tool call execution denied.';
               break;
             case 'content':
             case 'json':

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -211,7 +211,7 @@ export function convertToOpenAIChatMessages({
               contentValue = output.value;
               break;
             case 'execution-denied':
-              contentValue = output.reason ?? 'Tool execution denied.';
+              contentValue = output.reason ?? 'Tool call execution denied.';
               break;
             case 'content':
             case 'json':

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -2305,6 +2305,39 @@ describe('convertToOpenAIResponsesInput', () => {
       `);
     });
 
+    it('should convert execution-denied tool result to function_call_output', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_denied_123',
+                toolName: 'search',
+                output: {
+                  type: 'execution-denied',
+                  reason: 'User denied the tool execution',
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call_output',
+          call_id: 'call_denied_123',
+          output: 'User denied the tool execution',
+        },
+      ]);
+    });
+
     it('should convert single tool result part with multipart that contains text', async () => {
       const result = await convertToOpenAIResponsesInput({
         toolNameMapping: testToolNameMapping,
@@ -3113,6 +3146,127 @@ describe('convertToOpenAIResponsesInput', () => {
           ],
         }
       `);
+    });
+
+    it('should skip provider-executed execution-denied tool results in assistant messages', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'I need approval before running that tool.',
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'ws_denied_123',
+                toolName: 'web_search',
+                output: {
+                  type: 'execution-denied',
+                  reason: 'User denied the tool execution',
+                },
+              },
+              {
+                type: 'text',
+                text: 'The tool was not run.',
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: false,
+      });
+
+      expect(result).toEqual({
+        input: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'I need approval before running that tool.',
+              },
+            ],
+            id: undefined,
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'The tool was not run.',
+              },
+            ],
+            id: undefined,
+          },
+        ],
+        warnings: [],
+      });
+    });
+
+    it('should skip json-wrapped execution-denied tool results in assistant messages', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'I need approval before running that tool.',
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'ws_denied_json_123',
+                toolName: 'web_search',
+                output: {
+                  type: 'json',
+                  value: {
+                    type: 'execution-denied',
+                    reason: 'User denied the tool execution',
+                  },
+                },
+              },
+              {
+                type: 'text',
+                text: 'The tool was not run.',
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: false,
+      });
+
+      expect(result).toEqual({
+        input: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'I need approval before running that tool.',
+              },
+            ],
+            id: undefined,
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'The tool was not run.',
+              },
+            ],
+            id: undefined,
+          },
+        ],
+        warnings: [],
+      });
     });
 
     describe('local shell', () => {
@@ -4545,6 +4699,40 @@ describe('convertToOpenAIResponsesInput', () => {
           },
         ]
       `);
+    });
+
+    it('should convert execution-denied custom tool result to custom_tool_call_output', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_custom_denied_001',
+                toolName: 'write_sql',
+                output: {
+                  type: 'execution-denied',
+                  reason: 'User denied the tool execution',
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        customProviderToolNames,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'custom_tool_call_output',
+          call_id: 'call_custom_denied_001',
+          output: 'User denied the tool execution',
+        },
+      ]);
     });
 
     it('should convert custom tool result content output', async () => {

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -743,7 +743,7 @@ export async function convertToOpenAIResponsesInput({
                 outputValue = output.value;
                 break;
               case 'execution-denied':
-                outputValue = output.reason ?? 'Tool execution denied.';
+                outputValue = output.reason ?? 'Tool call execution denied.';
                 break;
               case 'json':
               case 'error-json':
@@ -806,7 +806,7 @@ export async function convertToOpenAIResponsesInput({
               contentValue = output.value;
               break;
             case 'execution-denied':
-              contentValue = output.reason ?? 'Tool execution denied.';
+              contentValue = output.reason ?? 'Tool call execution denied.';
               break;
             case 'json':
             case 'error-json':

--- a/packages/xai/src/convert-to-xai-chat-messages.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.ts
@@ -129,7 +129,7 @@ export function convertToXaiChatMessages(prompt: LanguageModelV4Prompt): {
               contentValue = output.value;
               break;
             case 'execution-denied':
-              contentValue = output.reason ?? 'Tool execution denied.';
+              contentValue = output.reason ?? 'Tool call execution denied.';
               break;
             case 'content':
             case 'json':


### PR DESCRIPTION
## Background

The default tool call denial message `Tool execution denied.` led to Open GPT 5 models rejecting further calls to the same tool with different inputs.

## Summary

Change the default message `Tool execution denied.` to the more precise `Tool call execution denied.`

## Related Issues
Discovered during #14643 