### PR TITLE
fix: upgrade eventsource-parser to 3.0.8

### DIFF
--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -46,7 +46,7 @@
     "@ai-sdk/provider": "workspace:*",
     "@standard-schema/spec": "^1.1.0",
     "@workflow/serde": "4.1.0",
-    "eventsource-parser": "^3.0.6"
+    "eventsource-parser": "^3.0.8"
   },
   "devDependencies": {
     "@types/node": "20.17.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2748,8 +2748,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       eventsource-parser:
-        specifier: ^3.0.6
-        version: 3.0.6
+        specifier: ^3.0.8
+        version: 3.0.8
     devDependencies:
       '@types/node':
         specifier: 20.17.24
@@ -13477,6 +13477,10 @@ packages:
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.5:
@@ -25381,7 +25385,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
       hono: 4.12.3
@@ -33072,13 +33076,15 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
+  eventsource-parser@3.0.8: {}
+
   eventsource@3.0.5:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
 
   execa@5.1.1:
     dependencies:


### PR DESCRIPTION
## Background

The `eventsource-parser` performance was significantly increased in https://github.com/rexxars/eventsource-parser/pull/27

## Summary

Bump `eventsource-parser` dependency to `^3.0.8`.