### PR TITLE
fix(workflow): Preserve invalid tool call errors in workflow UI streams

### DIFF
--- a/.changeset/rare-birds-deny.md
+++ b/.changeset/rare-birds-deny.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/workflow": patch
+---
+
+fix (workflow): preserve invalid tool calls as errors instead of emitting synthetic success results

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -639,6 +639,112 @@ describe('WorkflowAgent', () => {
 
       consoleWarnSpy.mockRestore();
     });
+
+    it('should keep invalid tool calls on the error path without executing them', async () => {
+      const execute = vi.fn(async () => 'should-not-run');
+      const tools: ToolSet = {
+        testTool: {
+          description: 'A test tool',
+          inputSchema: z.object({ city: z.string() }),
+          execute,
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: mockModel,
+        tools,
+      });
+
+      const writes: any[] = [];
+      const mockWritable = new WritableStream({
+        write: chunk => {
+          writes.push(chunk);
+        },
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const invalidError = new Error('Invalid input for tool testTool');
+      const mockMessages: LanguageModelV4Prompt = [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ];
+      const finalMessages: LanguageModelV4Prompt = [
+        ...mockMessages,
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'done',
+            },
+          ],
+        },
+      ];
+      const mockIterator = {
+        next: vi
+          .fn()
+          .mockResolvedValueOnce({
+            done: false,
+            value: {
+              toolCalls: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'invalid-call-id',
+                  toolName: 'testTool',
+                  input: { cities: 'San Francisco' },
+                  invalid: true,
+                  error: invalidError,
+                } satisfies ParsedToolCall,
+              ],
+              messages: mockMessages,
+            },
+          })
+          .mockResolvedValueOnce({
+            done: true,
+            value: finalMessages,
+          }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      const result = await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: mockWritable,
+      });
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(mockIterator.next).toHaveBeenCalledTimes(2);
+      expect(mockIterator.next.mock.calls[1][0]).toMatchInlineSnapshot(`
+        [
+          {
+            "output": {
+              "type": "error-text",
+              "value": "Invalid input for tool testTool",
+            },
+            "toolCallId": "invalid-call-id",
+            "toolName": "testTool",
+            "type": "tool-result",
+          },
+        ]
+      `);
+      expect(writes).toEqual([
+        { type: 'finish-step' },
+        { type: 'start-step' },
+        { type: 'finish' },
+      ]);
+      expect(result.toolCalls).toMatchObject([
+        {
+          type: 'tool-call',
+          toolCallId: 'invalid-call-id',
+          toolName: 'testTool',
+          input: { cities: 'San Francisco' },
+        },
+      ]);
+      expect(result.toolResults).toHaveLength(0);
+    });
   });
 
   describe('client-side tools (tools without execute)', () => {

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1542,11 +1542,16 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
 
         // Only execute tools if there are tool calls
         if (toolCalls.length > 0) {
+          const invalidToolCalls = toolCalls.filter(tc => tc.invalid === true);
+          const validToolCalls = toolCalls.filter(tc => tc.invalid !== true);
+
           // Separate provider-executed tool calls from client-executed ones
-          const nonProviderToolCalls = toolCalls.filter(
+          const nonProviderToolCalls = validToolCalls.filter(
             tc => !tc.providerExecuted,
           );
-          const providerToolCalls = toolCalls.filter(tc => tc.providerExecuted);
+          const providerToolCalls = validToolCalls.filter(
+            tc => tc.providerExecuted,
+          );
 
           // Check which tools need approval (can be async)
           const approvalNeeded = await Promise.all(
@@ -1610,7 +1615,15 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
                 ),
               );
 
-            const resolvedResults = [...executableResults, ...providerResults];
+            const continuationInvalidResults = invalidToolCalls.map(
+              createInvalidToolResult,
+            );
+            const resolvedResults = [
+              ...executableResults,
+              ...providerResults,
+              ...continuationInvalidResults,
+            ];
+            const executedResults = [...executableResults, ...providerResults];
 
             const allToolCalls: ToolCall[] = toolCalls.map(tc => ({
               type: 'tool-call' as const,
@@ -1619,7 +1632,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
               input: tc.input,
             }));
 
-            const allToolResults: ToolResult[] = resolvedResults.map(r => ({
+            const allToolResults: ToolResult[] = executedResults.map(r => ({
               type: 'tool-result' as const,
               toolCallId: r.toolCallId,
               toolName: r.toolName,
@@ -1707,25 +1720,32 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
             providerToolCalls.map(toolCall =>
               resolveProviderToolResult(toolCall, providerExecutedToolResults),
             );
+          const continuationInvalidToolResults = invalidToolCalls.map(
+            createInvalidToolResult,
+          );
 
-          // Combine results in the original order
-          const toolResults = toolCalls.map(tc => {
+          // Combine executable/provider results in the original order,
+          // while preserving invalid tool calls as error results for the
+          // next model step without emitting them as synthetic UI success.
+          const continuationToolResults = toolCalls.flatMap(tc => {
+            const invalidResult = continuationInvalidToolResults.find(
+              r => r.toolCallId === tc.toolCallId,
+            );
+            if (invalidResult) return [invalidResult];
             const clientResult = clientToolResults.find(
               r => r.toolCallId === tc.toolCallId,
             );
-            if (clientResult) return clientResult;
+            if (clientResult) return [clientResult];
             const providerResult = providerToolResults.find(
               r => r.toolCallId === tc.toolCallId,
             );
-            if (providerResult) return providerResult;
-            // This should never happen, but return empty result as fallback
-            return {
-              type: 'tool-result' as const,
-              toolCallId: tc.toolCallId,
-              toolName: tc.toolName,
-              output: { type: 'text' as const, value: '' },
-            };
+            if (providerResult) return [providerResult];
+            return [];
           });
+          const executedToolResults = continuationToolResults.filter(
+            result =>
+              !invalidToolCalls.some(tc => tc.toolCallId === result.toolCallId),
+          );
 
           // Write tool results and step boundaries to the stream so the
           // UI can transition tool parts to output-available state and
@@ -1733,7 +1753,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
           if (options.writable) {
             await writeToolResultsWithStepBoundary(
               options.writable,
-              toolResults.map(r => ({
+              executedToolResults.map(r => ({
                 toolCallId: r.toolCallId,
                 toolName: r.toolName,
                 input: toolCalls.find(tc => tc.toolCallId === r.toolCallId)
@@ -1750,7 +1770,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
             toolName: tc.toolName,
             input: tc.input,
           }));
-          lastStepToolResults = toolResults.map(r => ({
+          lastStepToolResults = executedToolResults.map(r => ({
             type: 'tool-result' as const,
             toolCallId: r.toolCallId,
             toolName: r.toolName,
@@ -1758,7 +1778,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
             output: 'value' in r.output ? r.output.value : undefined,
           }));
 
-          result = await iterator.next(toolResults);
+          result = await iterator.next(continuationToolResults);
         } else {
           // Final step with no tool calls - reset tracking
           lastStepToolCalls = [];
@@ -2057,6 +2077,22 @@ function resolveProviderToolResult(
             type: 'json' as const,
             value: result as JSONValue,
           },
+  };
+}
+
+function createInvalidToolResult(toolCall: {
+  toolCallId: string;
+  toolName: string;
+  error?: unknown;
+}): LanguageModelV4ToolResultPart {
+  return {
+    type: 'tool-result' as const,
+    toolCallId: toolCall.toolCallId,
+    toolName: toolCall.toolName,
+    output: {
+      type: 'error-text' as const,
+      value: getErrorMessage(toolCall.error),
+    },
   };
 }
 


### PR DESCRIPTION
# Preserve invalid tool call errors in workflow UI streams

WorkflowAgent currently assumes every tool call must end with a workflow-generated tool result. That breaks the invalid-input path from AI SDK core: an invalid call already emits `tool-input-error` and `tool-output-error`, but workflow later synthesizes a fallback result and writes it back as `tool-output-available`. The UI reducer treats that as the final state and overwrites the original error.

This change teaches WorkflowAgent to keep invalid tool calls out of workflow-side execution and success-style result synthesis. Valid executable and provider-executed calls still flow through the existing loop, but invalid calls are carried forward only as `error-text` continuation results for the next model step. That preserves model-side recovery behavior without emitting a synthetic `tool-result` chunk that would mutate the UI into an `output-available` state. The final workflow result now reports `toolResults` only for tools that actually executed.

The test coverage adds a regression around this lifecycle. It verifies that an invalid call is not executed, that workflow does not emit a synthetic `tool-result` write for it, that the iterator still receives the error continuation result, and that the package returns no executed tool result for the invalid call.

## Testing

- `pnpm --filter @ai-sdk/workflow test:node`
- `pnpm --filter @ai-sdk/workflow type-check`
