### PR TITLE
fix(gateway): include caching in GatewayProviderOptions

### DIFF
--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1482,6 +1482,26 @@ describe('GatewayLanguageModel', () => {
       });
     });
 
+    it('should allow caching in provider options', async () => {
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Test response' },
+      });
+
+      await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          gateway: {
+            caching: 'auto',
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        gateway: { caching: 'auto' },
+      });
+    });
+
     it('should pass providerTimeouts for doGenerate', async () => {
       prepareJsonResponse({
         content: { type: 'text', text: 'Test response' },

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -6,6 +6,12 @@ const gatewayProviderOptions = lazySchema(() =>
   zodSchema(
     z.object({
       /**
+       * Controls prompt caching behavior for the selected provider/model.
+       *
+       * Example: `'auto'` enables provider-managed automatic caching when supported.
+       */
+      caching: z.enum(['auto']).optional(),
+      /**
        * Array of provider slugs that are the only ones allowed to be used.
        *
        * Example: `['azure', 'openai']` will only allow Azure and OpenAI to be used.


### PR DESCRIPTION
## Summary
- add the missing caching field to the gateway provider options schema
- cover the schema change with a gateway-language-model regression test
- align the exported TypeScript type with the documented automatic caching configuration

Closes #14595

## Verification
- pnpm vitest run packages/gateway/src/gateway-language-model.test.ts -t "allow caching in provider options" (not runnable here because vitest is not installed in the current workspace dependencies and this environment uses unsupported Node v25)