### PR TITLE
fix(gateway): add caching provider option

### DIFF
--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1482,6 +1482,48 @@ describe('GatewayLanguageModel', () => {
       });
     });
 
+    it('should pass caching option for doGenerate', async () => {
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Test response' },
+      });
+
+      await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          gateway: {
+            caching: 'auto',
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        gateway: { caching: 'auto' },
+      });
+    });
+
+    it('should pass caching option for doStream', async () => {
+      prepareStreamResponse({
+        content: ['Hello', ' world'],
+      });
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          gateway: {
+            caching: 'auto',
+          },
+        },
+      });
+
+      await convertReadableStreamToArray(stream);
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        gateway: { caching: 'auto' },
+      });
+    });
+
     it('should pass providerTimeouts for doGenerate', async () => {
       prepareJsonResponse({
         content: { type: 'text', text: 'Test response' },

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -26,6 +26,12 @@ const gatewayProviderOptions = lazySchema(() =>
        */
       sort: z.enum(['cost', 'ttft', 'tps']).optional(),
       /**
+       * Automatically apply cache markers for providers that require them.
+       *
+       * Example: `'auto'`
+       */
+      caching: z.literal('auto').optional(),
+      /**
        * The unique identifier for the end user on behalf of whom the request was made.
        *
        * Used for spend tracking and attribution purposes.


### PR DESCRIPTION
## Summary
- add `caching: 'auto'` to `GatewayProviderOptions`
- add request-body coverage for both `doGenerate` and `doStream`
- align the exported type with Vercel documentation for AI Gateway provider options

Closes #14595

## Verification
- ran `git diff --check`
- added regression tests covering the new option in both generate and stream paths

## Notes
- I did not run the package test suite locally because repo dependencies were not installed in this environment.
