### PR TITLE
fix(embed): tolerate missing warnings from v2 providers

### DIFF
--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -423,6 +423,21 @@ describe('result.warnings', () => {
     expect(result.warnings).toStrictEqual(expectedWarnings);
   });
 
+  it('should default warnings to an empty array when the provider omits them', async () => {
+    const result = await embedMany({
+      model: new MockEmbeddingModelV4({
+        maxEmbeddingsPerCall: null,
+        doEmbed: async () =>
+          ({
+            embeddings: dummyEmbeddings,
+          }) as any,
+      }),
+      values: testValues,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+  });
+
   it('should aggregate warnings from multiple calls', async () => {
     const warning1: Warning = {
       type: 'other',
@@ -459,6 +474,35 @@ describe('result.warnings', () => {
     });
 
     expect(result.warnings).toStrictEqual([warning1, warning2]);
+  });
+
+  it('should ignore undefined warnings from batched calls', async () => {
+    let callCount = 0;
+
+    const result = await embedMany({
+      model: new MockEmbeddingModelV4({
+        maxEmbeddingsPerCall: 2,
+        doEmbed: async () => {
+          switch (callCount++) {
+            case 0:
+              return {
+                embeddings: dummyEmbeddings.slice(0, 2),
+                warnings: undefined,
+              } as any;
+            case 1:
+              return {
+                embeddings: dummyEmbeddings.slice(2),
+                warnings: undefined,
+              } as any;
+            default:
+              throw new Error('Unexpected call');
+          }
+        },
+      }),
+      values: testValues,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
   });
 });
 

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -343,7 +343,9 @@ export async function embedMany({
 
       for (const result of results) {
         embeddings.push(...result.embeddings);
-        warnings.push(...result.warnings);
+        if (result.warnings) {
+          warnings.push(...result.warnings);
+        }
         responses.push(result.response);
         tokens += result.usage.tokens;
         if (result.providerMetadata) {

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -181,6 +181,20 @@ describe('result.warnings', () => {
 
     expect(result.warnings).toStrictEqual(expectedWarnings);
   });
+
+  it('should default warnings to an empty array when the provider omits them', async () => {
+    const result = await embed({
+      model: new MockEmbeddingModelV4({
+        doEmbed: async () =>
+          ({
+            embeddings: [dummyEmbedding],
+          }) as any,
+      }),
+      value: testValue,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+  });
 });
 
 describe('logWarnings', () => {
@@ -216,6 +230,25 @@ describe('logWarnings', () => {
     expect(logWarningsSpy).toHaveBeenCalledOnce();
     expect(logWarningsSpy).toHaveBeenCalledWith({
       warnings: expectedWarnings,
+      provider: 'mock-provider',
+      model: 'mock-model-id',
+    });
+  });
+
+  it('should call logWarnings with an empty array when warnings are omitted', async () => {
+    await embed({
+      model: new MockEmbeddingModelV4({
+        doEmbed: async () =>
+          ({
+            embeddings: [dummyEmbedding],
+          }) as any,
+      }),
+      value: testValue,
+    });
+
+    expect(logWarningsSpy).toHaveBeenCalledOnce();
+    expect(logWarningsSpy).toHaveBeenCalledWith({
+      warnings: [],
       provider: 'mock-provider',
       model: 'mock-model-id',
     });

--- a/packages/ai/src/logger/log-warnings.ts
+++ b/packages/ai/src/logger/log-warnings.ts
@@ -103,7 +103,7 @@ let hasLoggedBefore = false;
  */
 export const logWarnings: LogWarningsFunction = options => {
   // if the warnings array is empty, do nothing
-  if (options.warnings.length === 0) {
+  if (options.warnings == null || options.warnings.length === 0) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- guard logWarnings against undefined warning arrays
- avoid spreading undefined warnings in embedMany batch aggregation
- add regression tests for embed and embedMany when providers omit warnings entirely

Closes #14425

## Verification
- pnpm vitest run packages/ai/src/embed/embed.test.ts packages/ai/src/embed/embed-many.test.ts packages/ai/src/logger/log-warnings.test.ts (not runnable here because this workspace does not have vitest available in the current environment and uses unsupported Node v25)