### PR TITLE
fix(google-vertex): omit unsupported mixed-tool config field

### DIFF
--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -5863,6 +5863,65 @@ describe('doStream', () => {
     ).toBeUndefined();
   });
 
+  it('should not send includeServerSideToolInvocations for Vertex mixed tool requests', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: { parts: [{ text: 'Hello' }], role: 'model' },
+            finishReason: 'STOP',
+            safetyRatings: SAFETY_RATINGS,
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 1,
+          candidatesTokenCount: 1,
+          totalTokenCount: 2,
+        },
+      },
+    };
+
+    const vertexModel = new GoogleLanguageModel('gemini-3-flash-preview', {
+      provider: 'google.vertex.chat',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      headers: { 'x-goog-api-key': 'test-api-key' },
+      generateId: () => 'test-id',
+    });
+
+    await vertexModel.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+        {
+          type: 'provider',
+          id: 'google.google_search',
+          name: 'google_search',
+          args: {},
+        },
+      ],
+    });
+
+    expect((await server.calls[0].requestBodyJson).toolConfig)
+      .toMatchInlineSnapshot(`
+      {
+        "functionCallingConfig": {
+          "mode": "VALIDATED",
+        },
+      }
+    `);
+  });
+
   it('should not send streamFunctionCallArguments for Vertex provider doGenerate (unary API)', async () => {
     server.urls[TEST_URL_GEMINI_PRO].response = {
       type: 'json-value',

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -207,15 +207,23 @@ export class GoogleLanguageModel implements LanguageModelV4 {
         ? (googleOptions?.streamFunctionCallArguments ?? false)
         : undefined;
 
+    const sanitizedGoogleToolConfig =
+      isVertexProvider && googleToolConfig?.includeServerSideToolInvocations
+        ? (({
+            includeServerSideToolInvocations: _ignored,
+            ...toolConfig
+          }) => toolConfig)(googleToolConfig)
+        : googleToolConfig;
+
     const toolConfig =
-      googleToolConfig ||
+      sanitizedGoogleToolConfig ||
       streamFunctionCallArguments ||
       googleOptions?.retrievalConfig
         ? {
-            ...googleToolConfig,
+            ...sanitizedGoogleToolConfig,
             ...(streamFunctionCallArguments && {
               functionCallingConfig: {
-                ...googleToolConfig?.functionCallingConfig,
+                ...sanitizedGoogleToolConfig?.functionCallingConfig,
                 streamFunctionCallArguments: true as const,
               },
             }),


### PR DESCRIPTION
## Summary
- omit `toolConfig.includeServerSideToolInvocations` when the shared Google model is running under the Vertex provider
- keep combined Gemini 3 function/provider tools working by preserving the validated function-calling config
- add a regression test covering mixed tool requests for `google.vertex.chat`

## Testing
- not run locally: `pnpm test:node -- google-language-model.test.ts` in `packages/google` (this clone does not have `node_modules` bootstrapped, so `vitest` is unavailable)
