### PR TITLE
fix(provider-utils): include type 'object' in default asSchema JSON schema

### DIFF
--- a/.changeset/fix-asschema-default-object-type.md
+++ b/.changeset/fix-asschema-default-object-type.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+fix(provider-utils): include `type: "object"` in the default JSON schema returned by `asSchema(null | undefined)`
+
+The default schema returned when no `inputSchema` is provided on a tool previously omitted the `type` field. OpenAI's API was lenient and accepted it, but stricter OpenAI-compatible providers (e.g. GitHub Copilot's `/chat/completions` endpoint) reject the schema with errors like `schema must be a JSON Schema of 'type: "object"', got 'type: "None"'`. Adding `type: "object"` to the default makes the schema spec-conformant and unblocks tool use against strict providers.

--- a/packages/provider-utils/src/schema.test.ts
+++ b/packages/provider-utils/src/schema.test.ts
@@ -500,3 +500,25 @@ describe('StandardSchema (StandardJSONSchemaV1)', () => {
     });
   });
 });
+
+describe('asSchema default', () => {
+  it('should return a JSON Schema object with type "object" when schema is undefined', async () => {
+    const schema = asSchema(undefined);
+
+    expect(await schema.jsonSchema).toStrictEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    });
+  });
+
+  it('should return a JSON Schema object with type "object" when schema is null', async () => {
+    const schema = asSchema(null as any);
+
+    expect(await schema.jsonSchema).toStrictEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    });
+  });
+});

--- a/packages/provider-utils/src/schema.ts
+++ b/packages/provider-utils/src/schema.ts
@@ -133,7 +133,11 @@ export function asSchema<OBJECT>(
   schema: FlexibleSchema<OBJECT> | undefined,
 ): Schema<OBJECT> {
   return schema == null
-    ? jsonSchema({ properties: {}, additionalProperties: false })
+    ? jsonSchema({
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      })
     : isSchema(schema)
       ? schema
       : '~standard' in schema


### PR DESCRIPTION
## Summary

Fixes the GPT-via-GitHub-Copilot arm of #14568.

When `asSchema` is called with `null`/`undefined` it returns a default JSON schema for use as tool `parameters`. That default previously omitted the `type` field:

```ts
// before
jsonSchema({ properties: {}, additionalProperties: false });
```

OpenAI's own `/chat/completions` is lenient and accepts this, but stricter OpenAI-compatible endpoints — notably GitHub Copilot's `/chat/completions` — reject it with errors like:

```
400: Invalid schema for function 'read_file': schema must be a JSON Schema
of 'type: "object"', got 'type: "None"'.
```

("None" is the server's stringification of the missing type.) This hits users of `@ai-sdk/openai-compatible` any time a tool reaches `prepareTools` in `packages/ai` without an `inputSchema` — `await asSchema(tool.inputSchema).jsonSchema` falls back to the default, which then gets sent as `parameters` to the provider.

The fix adds `type: 'object'` to the default, making it spec-conformant JSON Schema and unblocking tool calls against strict providers.

```ts
// after
jsonSchema({
  type: 'object',
  properties: {},
  additionalProperties: false,
});
```

### Scope

This addresses the GPT arm of #14568 (`schema must be a JSON Schema of 'type: "object"'`). The Claude arm (`NoOutputGeneratedError` when streaming back through Copilot) is a separate response-parsing issue and is not touched by this PR.

## Changes

- `packages/provider-utils/src/schema.ts` — add `type: 'object'` to the default schema in `asSchema`.
- `packages/provider-utils/src/schema.test.ts` — regression tests for `asSchema(undefined)` and `asSchema(null)`.
- `.changeset/fix-asschema-default-object-type.md` — patch changeset for `@ai-sdk/provider-utils`.

## Test plan

- [x] New unit tests in `schema.test.ts` cover both `null` and `undefined` inputs; assert the returned `jsonSchema` includes `type: 'object'`.
- [x] Full `packages/provider-utils` test suite passes (512 tests).
- [x] Full `packages/ai` test suite passes (2436 tests, no snapshot regressions, 0 type errors).
- [x] `packages/openai-compatible` prepare-tools + chat-language-model test suites pass (102 tests).
- [x] `oxlint` reports 0 warnings / 0 errors on the edited files.
- [ ] Manual repro against GitHub Copilot API — unable to run locally without a Copilot token; the existing `@ai-sdk/openai-compatible` tests that use `inputSchema: {}` (no type) would previously send schemas without `type` to the provider; they now send a schema with `type: 'object'` when the input schema is omitted entirely at the `ai` layer.

## Related

- Fixes (partially): #14568
