### PR TITLE
fix(mcp): honor negotiated protocol version headers

### DIFF
--- a/.changeset/tall-apricots-rest.md
+++ b/.changeset/tall-apricots-rest.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+Fix MCP HTTP transports so they omit the `MCP-Protocol-Version` header before initialization negotiation completes, then reuse the server-negotiated version on subsequent requests.

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -13,7 +13,8 @@ import {
   Configuration,
   ElicitationRequestSchema,
 } from './types';
-import { JSONRPCRequest } from './json-rpc-message';
+import { JSONRPCMessage, JSONRPCRequest } from './json-rpc-message';
+import { MCPTransport } from './mcp-transport';
 import {
   beforeEach,
   afterEach,
@@ -922,6 +923,90 @@ describe('MCPClient', () => {
       expect(tools).toBeDefined();
       await client.close();
     }
+  });
+
+  it('should pass negotiated protocol version back to the transport', async () => {
+    const transport = Object.assign(
+      new MockMCPTransport({
+        initializeResult: {
+          protocolVersion: '2025-06-18',
+          serverInfo: {
+            name: 'mock-mcp-server',
+            version: '1.0.0',
+          },
+          capabilities: {
+            tools: {},
+          },
+        },
+      }),
+      {
+        setProtocolVersion: vi.fn(),
+      },
+    );
+
+    client = await createMCPClient({ transport });
+
+    expect(transport.setProtocolVersion).toHaveBeenCalledWith('2025-06-18');
+  });
+
+  it('should use the negotiated protocol version for the initialized notification', async () => {
+    const sentMessages: Array<{
+      message: JSONRPCMessage;
+      protocolVersion?: string;
+    }> = [];
+    let protocolVersion: string | undefined;
+
+    const transport: MCPTransport = {
+      onmessage: undefined,
+      onclose: undefined,
+      onerror: undefined,
+      async start() {},
+      async send(message) {
+        sentMessages.push({ message, protocolVersion });
+
+        if (
+          'method' in message &&
+          'id' in message &&
+          message.method === 'initialize'
+        ) {
+          this.onmessage?.({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              protocolVersion: '2025-06-18',
+              serverInfo: {
+                name: 'mock-mcp-server',
+                version: '1.0.0',
+              },
+              capabilities: {
+                tools: {},
+              },
+            },
+          });
+        }
+      },
+      async close() {},
+      setProtocolVersion(nextProtocolVersion) {
+        protocolVersion = nextProtocolVersion;
+      },
+    };
+
+    client = await createMCPClient({ transport });
+
+    expect(sentMessages).toMatchObject([
+      {
+        protocolVersion: undefined,
+        message: {
+          method: 'initialize',
+        },
+      },
+      {
+        protocolVersion: '2025-06-18',
+        message: {
+          method: 'notifications/initialized',
+        },
+      },
+    ]);
   });
 
   it('should expose serverInfo from initialization', async () => {

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -288,6 +288,7 @@ class DefaultMCPClient implements MCPClient {
         });
       }
 
+      this.transport.setProtocolVersion?.(result.protocolVersion);
       this.serverCapabilities = result.capabilities;
       this._serverInfo = result.serverInfo;
 

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -99,6 +99,36 @@ describe('HttpMCPTransport', () => {
     });
   });
 
+  it('should clear negotiated protocol version between sessions', async () => {
+    server.urls['http://localhost:4000/mcp'].response = {
+      type: 'error',
+      status: 405,
+    };
+
+    await transport.start();
+
+    (
+      transport as unknown as {
+        setProtocolVersion(protocolVersion: string): void;
+        protocolVersion?: string;
+      }
+    ).setProtocolVersion('2025-06-18');
+
+    expect(
+      (transport as unknown as { protocolVersion?: string }).protocolVersion,
+    ).toBe('2025-06-18');
+
+    await transport.close();
+    expect(
+      (transport as unknown as { protocolVersion?: string }).protocolVersion,
+    ).toBeUndefined();
+
+    await transport.start();
+    expect(
+      (transport as unknown as { protocolVersion?: string }).protocolVersion,
+    ).toBeUndefined();
+  });
+
   it('should handle text/event-stream responses', async () => {
     transport = new HttpMCPTransport({ url: 'http://localhost:4000/stream' });
     const controller = new TestResponseController();

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -4,7 +4,6 @@ import {
 } from '@ai-sdk/test-server/with-vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HttpMCPTransport } from './mcp-http-transport';
-import { LATEST_PROTOCOL_VERSION } from './types';
 import { MCPClientError } from '../error/mcp-client-error';
 
 describe('HttpMCPTransport', () => {
@@ -45,8 +44,56 @@ describe('HttpMCPTransport', () => {
     expect(received).toEqual({ jsonrpc: '2.0', id: 1, result: { ok: true } });
 
     expect(server.calls[1].requestMethod).toBe('POST');
+    expect(server.calls[0].requestHeaders).toEqual({
+      accept: 'text/event-stream',
+    });
     expect(server.calls[1].requestHeaders).toEqual({
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      accept: 'application/json, text/event-stream',
+      'content-type': 'application/json',
+    });
+  });
+
+  it('should send negotiated protocol version on subsequent requests', async () => {
+    server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return { type: 'error', status: 405 };
+        case 1:
+          return {
+            type: 'json-value',
+            body: { jsonrpc: '2.0', id: 1, result: { ok: true } },
+          };
+        case 2:
+          return {
+            type: 'json-value',
+            body: { ok: true },
+          };
+        default:
+          return { type: 'empty', status: 200 };
+      }
+    };
+
+    await transport.start();
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'initialize',
+      id: 1,
+      params: {},
+    });
+
+    (
+      transport as unknown as {
+        setProtocolVersion(protocolVersion: string): void;
+      }
+    ).setProtocolVersion('2025-06-18');
+
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'notifications/initialized',
+    });
+
+    expect(server.calls[2].requestHeaders).toEqual({
+      'mcp-protocol-version': '2025-06-18',
       accept: 'application/json, text/event-stream',
       'content-type': 'application/json',
     });
@@ -318,7 +365,6 @@ describe('HttpMCPTransport', () => {
     await transport.send(message);
 
     expect(server.calls[0].requestHeaders).toEqual({
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
       accept: 'text/event-stream',
       ...customHeaders,
     });
@@ -326,7 +372,6 @@ describe('HttpMCPTransport', () => {
 
     expect(server.calls[1].requestHeaders).toEqual({
       'content-type': 'application/json',
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
       accept: 'application/json, text/event-stream',
       ...customHeaders,
     });

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -129,6 +129,88 @@ describe('HttpMCPTransport', () => {
     ).toBeUndefined();
   });
 
+  it('should reset inbound SSE state and ignore stale reconnection timers between sessions', async () => {
+    vi.useFakeTimers();
+
+    let getCallCount = 0;
+    const fetchFn = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const method = init?.method ?? 'GET';
+
+        if (method === 'GET') {
+          getCallCount += 1;
+          if (getCallCount === 1) {
+            throw new Error('connection lost');
+          }
+
+          return new Response(null, {
+            status: 405,
+            statusText: 'Method Not Allowed',
+          });
+        }
+
+        return new Response(null, { status: 200 });
+      },
+    );
+
+    transport = new HttpMCPTransport({
+      url: 'http://localhost:4000/mcp',
+      fetch: fetchFn,
+    });
+    transport.onerror = () => {};
+
+    try {
+      await transport.start();
+
+      await vi.waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      (
+        transport as unknown as {
+          lastInboundEventId?: string;
+          inboundReconnectAttempts: number;
+        }
+      ).lastInboundEventId = 'event-123';
+
+      await transport.close();
+
+      expect(
+        (
+          transport as unknown as {
+            lastInboundEventId?: string;
+          }
+        ).lastInboundEventId,
+      ).toBeUndefined();
+      expect(
+        (
+          transport as unknown as {
+            inboundReconnectAttempts: number;
+          }
+        ).inboundReconnectAttempts,
+      ).toBe(0);
+
+      await transport.start();
+
+      await vi.waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+
+      expect(fetchFn.mock.calls[1]?.[1]?.headers).toMatchObject({
+        accept: 'text/event-stream',
+      });
+      expect(fetchFn.mock.calls[1]?.[1]?.headers).not.toHaveProperty(
+        'last-event-id',
+      );
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('should handle text/event-stream responses', async () => {
     transport = new HttpMCPTransport({ url: 'http://localhost:4000/stream' });
     const controller = new TestResponseController();

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -14,7 +14,6 @@ import {
   UnauthorizedError,
   auth,
 } from './oauth';
-import { LATEST_PROTOCOL_VERSION } from './types';
 
 /**
  * HTTP MCP transport implementing the Streamable HTTP style.
@@ -27,6 +26,7 @@ export class HttpMCPTransport implements MCPTransport {
   private url: URL;
   private abortController?: AbortController;
   private headers?: Record<string, string>;
+  private protocolVersion?: string;
   private authProvider?: OAuthClientProvider;
   private resourceMetadataUrl?: URL;
   private sessionId?: string;
@@ -74,8 +74,11 @@ export class HttpMCPTransport implements MCPTransport {
     const headers: Record<string, string> = {
       ...this.headers,
       ...base,
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
     };
+
+    if (this.protocolVersion) {
+      headers['mcp-protocol-version'] = this.protocolVersion;
+    }
 
     if (this.sessionId) {
       headers['mcp-session-id'] = this.sessionId;
@@ -93,6 +96,10 @@ export class HttpMCPTransport implements MCPTransport {
       `ai-sdk/${VERSION}`,
       getRuntimeEnvironmentUserAgent(),
     );
+  }
+
+  setProtocolVersion(protocolVersion: string): void {
+    this.protocolVersion = protocolVersion;
   }
 
   async start(): Promise<void> {

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -109,6 +109,8 @@ export class HttpMCPTransport implements MCPTransport {
           'MCP HTTP Transport Error: Transport already started. Note: client.connect() calls start() automatically.',
       });
     }
+
+    this.protocolVersion = undefined;
     this.abortController = new AbortController();
 
     void this.openInboundSse();
@@ -132,7 +134,12 @@ export class HttpMCPTransport implements MCPTransport {
       }
     } catch {}
 
+    this.protocolVersion = undefined;
     this.abortController?.abort();
+    this.abortController = undefined;
+    this.sessionId = undefined;
+    this.resourceMetadataUrl = undefined;
+    this.inboundSseConnection = undefined;
     this.onclose?.();
   }
 

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -164,6 +164,7 @@ export class HttpMCPTransport implements MCPTransport {
           try {
             const result = await auth(this.authProvider, {
               serverUrl: this.url,
+              protocolVersion: this.protocolVersion,
               resourceMetadataUrl: this.resourceMetadataUrl,
               fetchFn: this.fetchFn,
             });
@@ -344,6 +345,7 @@ export class HttpMCPTransport implements MCPTransport {
         try {
           const result = await auth(this.authProvider, {
             serverUrl: this.url,
+            protocolVersion: this.protocolVersion,
             resourceMetadataUrl: this.resourceMetadataUrl,
             fetchFn: this.fetchFn,
           });

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -37,6 +37,7 @@ export class HttpMCPTransport implements MCPTransport {
   // Inbound SSE resumption and reconnection state
   private lastInboundEventId?: string;
   private inboundReconnectAttempts = 0;
+  private inboundSseSessionId = 0;
   private readonly reconnectionOptions = {
     initialReconnectionDelay: 1000,
     maxReconnectionDelay: 30000,
@@ -102,6 +103,26 @@ export class HttpMCPTransport implements MCPTransport {
     this.protocolVersion = protocolVersion;
   }
 
+  private resetInboundSseState(): void {
+    this.lastInboundEventId = undefined;
+    this.inboundReconnectAttempts = 0;
+    this.inboundSseConnection = undefined;
+  }
+
+  private startInboundSseSession(): number {
+    this.inboundSseSessionId += 1;
+    this.resetInboundSseState();
+    return this.inboundSseSessionId;
+  }
+
+  private isActiveInboundSseSession(sessionId: number): boolean {
+    return (
+      this.inboundSseSessionId === sessionId &&
+      this.abortController != null &&
+      !this.abortController.signal.aborted
+    );
+  }
+
   async start(): Promise<void> {
     if (this.abortController) {
       throw new MCPClientError({
@@ -112,11 +133,13 @@ export class HttpMCPTransport implements MCPTransport {
 
     this.protocolVersion = undefined;
     this.abortController = new AbortController();
+    const inboundSseSessionId = this.startInboundSseSession();
 
-    void this.openInboundSse();
+    void this.openInboundSse(false, undefined, inboundSseSessionId);
   }
 
   async close(): Promise<void> {
+    this.inboundSseSessionId += 1;
     this.inboundSseConnection?.close();
     try {
       if (
@@ -139,7 +162,7 @@ export class HttpMCPTransport implements MCPTransport {
     this.abortController = undefined;
     this.sessionId = undefined;
     this.resourceMetadataUrl = undefined;
-    this.inboundSseConnection = undefined;
+    this.resetInboundSseState();
     this.onclose?.();
   }
 
@@ -191,7 +214,11 @@ export class HttpMCPTransport implements MCPTransport {
           // If inbound SSE was not available earlier (e.g. 405 before init), try again now
           // Do not await to avoid blocking send()
           if (!this.inboundSseConnection) {
-            void this.openInboundSse();
+            void this.openInboundSse(
+              false,
+              undefined,
+              this.inboundSseSessionId,
+            );
           }
           return;
         }
@@ -315,10 +342,14 @@ export class HttpMCPTransport implements MCPTransport {
     }
 
     const delay = this.getNextReconnectionDelay(this.inboundReconnectAttempts);
+    const inboundSseSessionId = this.inboundSseSessionId;
+    const resumeToken = this.lastInboundEventId;
     this.inboundReconnectAttempts += 1;
     setTimeout(async () => {
-      if (this.abortController?.signal.aborted) return;
-      await this.openInboundSse(false, this.lastInboundEventId);
+      if (!this.isActiveInboundSseSession(inboundSseSessionId)) {
+        return;
+      }
+      await this.openInboundSse(false, resumeToken, inboundSseSessionId);
     }, delay);
   }
 
@@ -326,11 +357,19 @@ export class HttpMCPTransport implements MCPTransport {
   private async openInboundSse(
     triedAuth: boolean = false,
     resumeToken?: string,
+    inboundSseSessionId: number = this.inboundSseSessionId,
   ): Promise<void> {
+    if (!this.isActiveInboundSseSession(inboundSseSessionId)) {
+      return;
+    }
+
     try {
       const headers = await this.commonHeaders({
         Accept: 'text/event-stream',
       });
+      if (!this.isActiveInboundSseSession(inboundSseSessionId)) {
+        return;
+      }
       if (resumeToken) {
         headers['last-event-id'] = resumeToken;
       }
@@ -341,6 +380,9 @@ export class HttpMCPTransport implements MCPTransport {
         signal: this.abortController?.signal,
         redirect: this.redirectMode,
       });
+      if (!this.isActiveInboundSseSession(inboundSseSessionId)) {
+        return;
+      }
 
       const sessionId = response.headers.get('mcp-session-id');
       if (sessionId) {
@@ -365,7 +407,7 @@ export class HttpMCPTransport implements MCPTransport {
           this.onerror?.(error);
           return;
         }
-        return this.openInboundSse(true, resumeToken);
+        return this.openInboundSse(true, resumeToken, inboundSseSessionId);
       }
 
       if (response.status === 405) {

--- a/packages/mcp/src/tool/mcp-sse-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.test.ts
@@ -5,7 +5,6 @@ import {
 import { MCPClientError } from '../error/mcp-client-error';
 import { SseMCPTransport } from './mcp-sse-transport';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { LATEST_PROTOCOL_VERSION } from './types';
 
 describe('SseMCPTransport', () => {
   const server = createTestServer({
@@ -52,9 +51,41 @@ describe('SseMCPTransport', () => {
     expect(server.calls[0].requestMethod).toBe('GET');
     expect(server.calls[0].requestUrl).toBe('http://localhost:3000/sse');
     expect(server.calls[0].requestHeaders).toEqual({
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
       accept: 'text/event-stream',
     });
+  });
+
+  it('should send negotiated protocol version on subsequent POST requests', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['http://localhost:3000/sse'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    const connectPromise = transport.start();
+    controller.write(
+      'event: endpoint\ndata: http://localhost:3000/messages\n\n',
+    );
+    await connectPromise;
+
+    (
+      transport as unknown as {
+        setProtocolVersion(protocolVersion: string): void;
+      }
+    ).setProtocolVersion('2025-06-18');
+
+    await transport.send({
+      jsonrpc: '2.0' as const,
+      method: 'notifications/initialized',
+    });
+
+    expect(server.calls[1].requestHeaders).toEqual({
+      'content-type': 'application/json',
+      'mcp-protocol-version': '2025-06-18',
+    });
+
+    await transport.close();
   });
 
   it('should throw if server returns non-200 status', async () => {
@@ -268,7 +299,6 @@ describe('SseMCPTransport', () => {
 
     // Verify SSE connection headers
     expect(server.calls[0].requestHeaders).toEqual({
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
       accept: 'text/event-stream',
       ...customHeaders,
     });
@@ -277,7 +307,6 @@ describe('SseMCPTransport', () => {
     // Verify POST request headers
     expect(server.calls[1].requestHeaders).toEqual({
       'content-type': 'application/json',
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
       ...customHeaders,
     });
     expect(server.calls[1].requestUserAgent).toContain('ai-sdk/');

--- a/packages/mcp/src/tool/mcp-sse-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.test.ts
@@ -88,6 +88,47 @@ describe('SseMCPTransport', () => {
     await transport.close();
   });
 
+  it('should clear negotiated protocol version between sessions', async () => {
+    const firstController = new TestResponseController();
+
+    server.urls['http://localhost:3000/sse'].response = ({ callNumber }) => {
+      switch (callNumber) {
+        case 0:
+          return {
+            type: 'controlled-stream',
+            controller: firstController,
+          };
+        default:
+          return {
+            type: 'json-value',
+            body: { ok: true },
+          };
+      }
+    };
+
+    const firstConnectPromise = transport.start();
+    firstController.write(
+      'event: endpoint\ndata: http://localhost:3000/messages\n\n',
+    );
+    await firstConnectPromise;
+
+    (
+      transport as unknown as {
+        setProtocolVersion(protocolVersion: string): void;
+        protocolVersion?: string;
+      }
+    ).setProtocolVersion('2025-06-18');
+
+    expect(
+      (transport as unknown as { protocolVersion?: string }).protocolVersion,
+    ).toBe('2025-06-18');
+
+    await transport.close();
+    expect(
+      (transport as unknown as { protocolVersion?: string }).protocolVersion,
+    ).toBeUndefined();
+  });
+
   it('should throw if server returns non-200 status', async () => {
     server.urls['http://localhost:3000/sse'].response = {
       type: 'error',

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -108,6 +108,7 @@ export class SseMCPTransport implements MCPTransport {
             try {
               const result = await auth(this.authProvider, {
                 serverUrl: this.url,
+                protocolVersion: this.protocolVersion,
                 resourceMetadataUrl: this.resourceMetadataUrl,
                 fetchFn: this.fetchFn,
               });
@@ -255,6 +256,7 @@ export class SseMCPTransport implements MCPTransport {
           try {
             const result = await auth(this.authProvider, {
               serverUrl: this.url,
+              protocolVersion: this.protocolVersion,
               resourceMetadataUrl: this.resourceMetadataUrl,
               fetchFn: this.fetchFn,
             });

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -14,7 +14,6 @@ import {
   UnauthorizedError,
   auth,
 } from './oauth';
-import { LATEST_PROTOCOL_VERSION } from './types';
 
 export class SseMCPTransport implements MCPTransport {
   private endpoint?: URL;
@@ -25,6 +24,7 @@ export class SseMCPTransport implements MCPTransport {
     close: () => void;
   };
   private headers?: Record<string, string>;
+  private protocolVersion?: string;
   private authProvider?: OAuthClientProvider;
   private resourceMetadataUrl?: URL;
   private redirectMode: RequestRedirect;
@@ -60,8 +60,11 @@ export class SseMCPTransport implements MCPTransport {
     const headers: Record<string, string> = {
       ...this.headers,
       ...base,
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
     };
+
+    if (this.protocolVersion) {
+      headers['mcp-protocol-version'] = this.protocolVersion;
+    }
 
     if (this.authProvider) {
       const tokens = await this.authProvider.tokens();
@@ -75,6 +78,10 @@ export class SseMCPTransport implements MCPTransport {
       `ai-sdk/${VERSION}`,
       getRuntimeEnvironmentUserAgent(),
     );
+  }
+
+  setProtocolVersion(protocolVersion: string): void {
+    this.protocolVersion = protocolVersion;
   }
 
   async start(): Promise<void> {

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -90,6 +90,7 @@ export class SseMCPTransport implements MCPTransport {
         return resolve();
       }
 
+      this.protocolVersion = undefined;
       this.abortController = new AbortController();
 
       const establishConnection = async (triedAuth: boolean = false) => {
@@ -222,8 +223,13 @@ export class SseMCPTransport implements MCPTransport {
 
   async close(): Promise<void> {
     this.connected = false;
+    this.protocolVersion = undefined;
     this.sseConnection?.close();
     this.abortController?.abort();
+    this.abortController = undefined;
+    this.endpoint = undefined;
+    this.resourceMetadataUrl = undefined;
+    this.sseConnection = undefined;
     this.onclose?.();
   }
 

--- a/packages/mcp/src/tool/mcp-transport.ts
+++ b/packages/mcp/src/tool/mcp-transport.ts
@@ -27,6 +27,12 @@ export interface MCPTransport {
   close(): Promise<void>;
 
   /**
+   * Update the protocol version header used for HTTP-based follow-up requests
+   * after initialization negotiation completes.
+   */
+  setProtocolVersion?(protocolVersion: string): void;
+
+  /**
    * Event handler for transport closure
    */
   onclose?: () => void;

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -1577,6 +1577,62 @@ describe('auth function', () => {
     );
   });
 
+  it('uses the negotiated protocol version for OAuth metadata discovery', async () => {
+    mockFetch.mockImplementation((url, options) => {
+      const urlString = url.toString();
+
+      if (urlString.includes('/.well-known/oauth-protected-resource')) {
+        expect(options?.headers).toEqual({
+          'MCP-Protocol-Version': '2025-06-18',
+        });
+
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            resource: 'https://api.example.com/mcp-server',
+            authorization_servers: ['https://auth.example.com'],
+          }),
+        });
+      }
+
+      if (urlString.includes('/.well-known/oauth-authorization-server')) {
+        expect(options?.headers).toEqual({
+          'MCP-Protocol-Version': '2025-06-18',
+        });
+
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            issuer: 'https://auth.example.com',
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+          }),
+        });
+      }
+
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    (mockProvider.clientInformation as Mock).mockResolvedValue({
+      client_id: 'test-client',
+      client_secret: 'test-secret',
+    });
+    (mockProvider.tokens as Mock).mockResolvedValue(undefined);
+    (mockProvider.saveCodeVerifier as Mock).mockResolvedValue(undefined);
+    (mockProvider.redirectToAuthorization as Mock).mockResolvedValue(undefined);
+
+    const result = await auth(mockProvider, {
+      serverUrl: 'https://api.example.com/mcp-server',
+      protocolVersion: '2025-06-18',
+    });
+
+    expect(result).toBe('REDIRECT');
+  });
+
   it('includes resource in token exchange when authorization code is provided', async () => {
     // Mock successful metadata discovery and token exchange - need protected resource metadata
     mockFetch.mockImplementation(url => {

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -835,6 +835,7 @@ export async function auth(
     authorizationCode?: string;
     callbackState?: string;
     scope?: string;
+    protocolVersion?: string;
     resourceMetadataUrl?: URL;
     fetchFn?: FetchFunction;
   },
@@ -895,6 +896,7 @@ async function authInternal(
     authorizationCode,
     callbackState,
     scope,
+    protocolVersion,
     resourceMetadataUrl,
     fetchFn,
   }: {
@@ -902,6 +904,7 @@ async function authInternal(
     authorizationCode?: string;
     callbackState?: string;
     scope?: string;
+    protocolVersion?: string;
     resourceMetadataUrl?: URL;
     fetchFn?: FetchFunction;
   },
@@ -911,7 +914,7 @@ async function authInternal(
   try {
     resourceMetadata = await discoverOAuthProtectedResourceMetadata(
       serverUrl,
-      { resourceMetadataUrl },
+      { protocolVersion, resourceMetadataUrl },
       fetchFn,
     );
     if (
@@ -940,6 +943,7 @@ async function authInternal(
     authorizationServerUrl,
     {
       fetchFn,
+      protocolVersion,
     },
   );
 


### PR DESCRIPTION
## Background

`@ai-sdk/mcp` was sending `MCP-Protocol-Version` headers before initialization negotiation completed, and then continued to use the latest client version instead of the server-negotiated version on follow-up HTTP requests. This broke MCP servers that only accept older protocol versions until negotiation finishes.

Fixes #14413.

## Summary

- add an optional `setProtocolVersion()` hook to the MCP transport interface for negotiated HTTP header state
- update the built-in HTTP and SSE transports to omit `MCP-Protocol-Version` until negotiation completes
- apply the negotiated protocol version in `createMCPClient()` before sending `notifications/initialized`
- add regression tests for both transports and the client handshake ordering
- add a patch changeset for `@ai-sdk/mcp`

## Manual Verification

Not applicable as a user-facing manual flow. This is an internal transport-handshake fix, so verification was done with focused end-to-end transport/client regression coverage and package-level checks.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

- Fixes #14413
