### PR TITLE
feat(provider/openai): add gpt-image-2 model support

### DIFF
--- a/.changeset/young-months-cheer.md
+++ b/.changeset/young-months-cheer.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/gateway": patch
+"@ai-sdk/openai": patch
+---
+
+feat(provider/openai): add gpt-image-2 model support

--- a/examples/ai-functions/src/generate-image/openai/gpt-image-2.ts
+++ b/examples/ai-functions/src/generate-image/openai/gpt-image-2.ts
@@ -1,0 +1,13 @@
+import { openai } from '@ai-sdk/openai';
+import { generateImage } from 'ai';
+import { presentImages } from '../../lib/present-image';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { image } = await generateImage({
+    model: openai.image('gpt-image-2'),
+    prompt: 'The new york times home page for april 21 2026',
+  });
+
+  await presentImages([image]);
+});

--- a/packages/gateway/src/gateway-image-model-settings.ts
+++ b/packages/gateway/src/gateway-image-model-settings.ts
@@ -18,6 +18,7 @@ export type GatewayImageModelId =
   | 'openai/gpt-image-1'
   | 'openai/gpt-image-1-mini'
   | 'openai/gpt-image-1.5'
+  | 'openai/gpt-image-2'
   | 'prodia/flux-fast-schnell'
   | 'recraft/recraft-v2'
   | 'recraft/recraft-v3'

--- a/packages/openai/src/image/openai-image-model.test.ts
+++ b/packages/openai/src/image/openai-image-model.test.ts
@@ -260,6 +260,33 @@ describe('doGenerate', () => {
     expect(requestBody).not.toHaveProperty('response_format');
   });
 
+  it('should not include response_format for gpt-image-2', async () => {
+    prepareJsonFixtureResponse('openai-image');
+
+    const gptImageModel = provider.image('gpt-image-2');
+    await gptImageModel.doGenerate({
+      prompt,
+      files: undefined,
+      mask: undefined,
+      n: 1,
+      size: '1024x1024',
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {},
+    });
+
+    const requestBody =
+      await server.calls[server.calls.length - 1].requestBodyJson;
+    expect(requestBody).toStrictEqual({
+      model: 'gpt-image-2',
+      prompt,
+      n: 1,
+      size: '1024x1024',
+    });
+
+    expect(requestBody).not.toHaveProperty('response_format');
+  });
+
   it('should not include response_format for chatgpt-image-latest', async () => {
     prepareJsonFixtureResponse('openai-image');
 

--- a/packages/openai/src/image/openai-image-options.ts
+++ b/packages/openai/src/image/openai-image-options.ts
@@ -4,6 +4,7 @@ export type OpenAIImageModelId =
   | 'gpt-image-1'
   | 'gpt-image-1-mini'
   | 'gpt-image-1.5'
+  | 'gpt-image-2'
   | 'chatgpt-image-latest'
   | (string & {});
 
@@ -14,6 +15,7 @@ export const modelMaxImagesPerCall: Record<OpenAIImageModelId, number> = {
   'gpt-image-1': 10,
   'gpt-image-1-mini': 10,
   'gpt-image-1.5': 10,
+  'gpt-image-2': 10,
   'chatgpt-image-latest': 10,
 };
 
@@ -22,6 +24,7 @@ const defaultResponseFormatPrefixes = [
   'gpt-image-1-mini',
   'gpt-image-1.5',
   'gpt-image-1',
+  'gpt-image-2',
 ];
 
 export function hasDefaultResponseFormat(modelId: string): boolean {


### PR DESCRIPTION
## Summary

- Adds `gpt-image-2` to the `OpenAIImageModelId` type union, `modelMaxImagesPerCall` (10, matching `gpt-image-1.5`), and the `defaultResponseFormatPrefixes` list so the provider does **not** send `response_format: 'b64_json'` to OpenAI — which the model rejects with `400 Unknown parameter: 'response_format'`.
- Adds `openai/gpt-image-2` to `GatewayImageModelId`.
- Adds a regression test mirroring the existing `gpt-image-1` / `chatgpt-image-latest` cases to assert no `response_format` is sent.
- Adds an `examples/ai-functions` entry for the new model.