### PR TITLE
feat(ai): rename the core-event types

### DIFF
--- a/.changeset/tender-pianos-yell.md
+++ b/.changeset/tender-pianos-yell.md
@@ -1,0 +1,8 @@
+---
+"@ai-sdk/devtools": patch
+"@ai-sdk/workflow": patch
+"@ai-sdk/otel": patch
+"ai": patch
+---
+
+feat(ai): rename the core-event types

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -211,13 +211,13 @@ export function myIntegration(): Telemetry {
   content={[
     {
       name: 'onStart',
-      type: '(event: OnStartEvent) => void | PromiseLike<void>',
+      type: '(event: GenerateTextStartEvent) => void | PromiseLike<void>',
       description:
         'Called when the generation operation begins, before any LLM calls.',
     },
     {
       name: 'onStepStart',
-      type: '(event: OnStepStartEvent) => void | PromiseLike<void>',
+      type: '(event: GenerateTextStepStartEvent) => void | PromiseLike<void>',
       description:
         'Called when a step (LLM call) begins, before the provider is called.',
     },
@@ -233,12 +233,12 @@ export function myIntegration(): Telemetry {
     },
     {
       name: 'onStepFinish',
-      type: '(event: OnStepFinishEvent) => void | PromiseLike<void>',
+      type: '(event: GenerateTextStepEndEvent) => void | PromiseLike<void>',
       description: 'Called when a step (LLM call) completes.',
     },
     {
       name: 'onFinish',
-      type: '(event: OnFinishEvent) => void | PromiseLike<void>',
+      type: '(event: GenerateTextEndEvent) => void | PromiseLike<void>',
       description:
         'Called when the entire generation completes (all steps finished).',
     },

--- a/content/docs/03-ai-sdk-core/65-event-listeners.mdx
+++ b/content/docs/03-ai-sdk-core/65-event-listeners.mdx
@@ -34,12 +34,12 @@ const result = await generateText({
   content={[
     {
       name: 'experimental_onStart',
-      type: '(event: OnStartEvent) => void | Promise<void>',
+      type: '(event: GenerateTextStartEvent) => void | Promise<void>',
       description: 'Called when generation begins, before any LLM calls.',
     },
     {
       name: 'experimental_onStepStart',
-      type: '(event: OnStepStartEvent) => void | Promise<void>',
+      type: '(event: GenerateTextStepStartEvent) => void | Promise<void>',
       description:
         'Called when a step (LLM call) begins, before the provider is called.',
     },
@@ -55,12 +55,12 @@ const result = await generateText({
     },
     {
       name: 'onStepFinish',
-      type: '(event: OnStepFinishEvent) => void | Promise<void>',
+      type: '(event: GenerateTextStepEndEvent) => void | Promise<void>',
       description: 'Called when a step (LLM call) completes.',
     },
     {
       name: 'onFinish',
-      type: '(event: OnFinishEvent) => void | Promise<void>',
+      type: '(event: GenerateTextEndEvent) => void | Promise<void>',
       description:
         'Called when the entire generation completes (all steps finished).',
     },
@@ -73,13 +73,13 @@ const result = await generateText({
   content={[
     {
       name: 'experimental_onStart',
-      type: '(event: EmbedOnStartEvent) => void | Promise<void>',
+      type: '(event: EmbedStartEvent) => void | Promise<void>',
       description:
         'Called when the embedding operation begins, before the embedding model is called.',
     },
     {
       name: 'experimental_onFinish',
-      type: '(event: EmbedOnFinishEvent) => void | Promise<void>',
+      type: '(event: EmbedEndEvent) => void | Promise<void>',
       description:
         'Called when the embedding operation completes, after the embedding model returns.',
     },
@@ -92,13 +92,13 @@ const result = await generateText({
   content={[
     {
       name: 'experimental_onStart',
-      type: '(event: RerankOnStartEvent) => void | Promise<void>',
+      type: '(event: RerankStartEvent) => void | Promise<void>',
       description:
         'Called when the reranking operation begins, before the reranking model is called.',
     },
     {
       name: 'experimental_onFinish',
-      type: '(event: RerankOnFinishEvent) => void | Promise<void>',
+      type: '(event: RerankEndEvent) => void | Promise<void>',
       description:
         'Called when the reranking operation completes, after the reranking model returns.',
     },

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -916,13 +916,13 @@ To see `generateText` in action, check out [these examples](#examples).
     },
     {
       name: 'experimental_onStart',
-      type: '(event: OnStartEvent) => PromiseLike<void> | void',
+      type: '(event: GenerateTextStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
         'Callback that is called when the generateText operation begins, before any LLM calls are made. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
       properties: [
         {
-          type: 'OnStartEvent',
+          type: 'GenerateTextStartEvent',
           parameters: [
             {
               name: 'model',
@@ -1063,13 +1063,13 @@ To see `generateText` in action, check out [these examples](#examples).
     },
     {
       name: 'experimental_onStepStart',
-      type: '(event: OnStepStartEvent) => PromiseLike<void> | void',
+      type: '(event: GenerateTextStepStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
         'Callback that is called when a step (LLM call) begins, before the provider is called. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
       properties: [
         {
-          type: 'OnStepStartEvent',
+          type: 'GenerateTextStepStartEvent',
           parameters: [
             {
               name: 'stepNumber',
@@ -1571,7 +1571,7 @@ To see `generateText` in action, check out [these examples](#examples).
         'Callback that is called when the entire generation completes (all steps finished). The event includes the final step result properties along with aggregated data from all steps.',
       properties: [
         {
-          type: 'OnFinishEvent',
+          type: 'GenerateTextEndEvent',
           parameters: [
             {
               name: 'stepNumber',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1823,13 +1823,13 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'experimental_onStart',
-      type: '(event: OnStartEvent) => PromiseLike<void> | void',
+      type: '(event: GenerateTextStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
         'Callback that is called when the streamText operation begins, before any LLM calls are made. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
       properties: [
         {
-          type: 'OnStartEvent',
+          type: 'GenerateTextStartEvent',
           parameters: [
             {
               name: 'model',
@@ -1970,13 +1970,13 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'experimental_onStepStart',
-      type: '(event: OnStepStartEvent) => PromiseLike<void> | void',
+      type: '(event: GenerateTextStepStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
         'Callback that is called when a step (LLM call) begins, before the provider is called. Errors thrown in this callback are silently caught and do not break the generation flow. Experimental (can break in patch releases).',
       properties: [
         {
-          type: 'OnStepStartEvent',
+          type: 'GenerateTextStepStartEvent',
           parameters: [
             {
               name: 'stepNumber',

--- a/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
@@ -117,13 +117,13 @@ const { embedding } = await embed({
     },
     {
       name: 'experimental_onStart',
-      type: '(event: EmbedOnStartEvent) => PromiseLike<void> | void',
+      type: '(event: EmbedStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
         'Callback that is called when the embed operation begins, before the embedding model is called. Errors thrown in this callback are silently caught and do not break the embedding flow. Experimental (can break in patch releases).',
       properties: [
         {
-          type: 'EmbedOnStartEvent',
+          type: 'EmbedStartEvent',
           parameters: [
             {
               name: 'callId',
@@ -171,13 +171,13 @@ const { embedding } = await embed({
     },
     {
       name: 'experimental_onFinish',
-      type: '(event: EmbedOnFinishEvent) => PromiseLike<void> | void',
+      type: '(event: EmbedEndEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
         'Callback that is called when the embed operation completes, after the embedding model returns. Errors thrown in this callback are silently caught and do not break the embedding flow. Experimental (can break in patch releases).',
       properties: [
         {
-          type: 'EmbedOnFinishEvent',
+          type: 'EmbedEndEvent',
           parameters: [
             {
               name: 'callId',

--- a/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
@@ -129,13 +129,13 @@ const { embeddings } = await embedMany({
     },
     {
       name: 'experimental_onStart',
-      type: '(event: EmbedOnStartEvent) => PromiseLike<void> | void',
+      type: '(event: EmbedStartEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
         'Callback that is called when the embedMany operation begins, before the embedding model is called. Errors thrown in this callback are silently caught and do not break the embedding flow. Experimental (can break in patch releases).',
       properties: [
         {
-          type: 'EmbedOnStartEvent',
+          type: 'EmbedStartEvent',
           parameters: [
             {
               name: 'callId',
@@ -184,13 +184,13 @@ const { embeddings } = await embedMany({
     },
     {
       name: 'experimental_onFinish',
-      type: '(event: EmbedOnFinishEvent) => PromiseLike<void> | void',
+      type: '(event: EmbedEndEvent) => PromiseLike<void> | void',
       isOptional: true,
       description:
         'Callback that is called when the embedMany operation completes, after all embedding model calls return. Errors thrown in this callback are silently caught and do not break the embedding flow. Experimental (can break in patch releases).',
       properties: [
         {
-          type: 'EmbedOnFinishEvent',
+          type: 'EmbedEndEvent',
           parameters: [
             {
               name: 'callId',

--- a/content/docs/07-reference/01-ai-sdk-core/06-rerank.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-rerank.mdx
@@ -131,14 +131,14 @@ const { ranking } = await rerank({
     },
     {
       name: 'experimental_onStart',
-      type: '(event: RerankOnStartEvent) => void | Promise<void>',
+      type: '(event: RerankStartEvent) => void | Promise<void>',
       isOptional: true,
       description:
         'Called when the rerank operation begins, before the reranking model is called.',
     },
     {
       name: 'experimental_onFinish',
-      type: '(event: RerankOnFinishEvent) => void | Promise<void>',
+      type: '(event: RerankEndEvent) => void | Promise<void>',
       isOptional: true,
       description:
         'Called when the rerank operation completes, after the reranking model returns.',

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -119,7 +119,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
         'Callback that is called when the agent operation begins, before any LLM calls are made. Useful for logging, analytics, or initializing state. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first). Experimental (can break in patch releases).',
       properties: [
         {
-          type: 'OnStartEvent',
+          type: 'GenerateTextStartEvent',
           parameters: [
             {
               name: 'model',
@@ -264,7 +264,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
         'Callback that is called when a step (LLM call) begins, before the provider is called. Each step represents a single LLM invocation. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first). Experimental (can break in patch releases).',
       properties: [
         {
-          type: 'OnStepStartEvent',
+          type: 'GenerateTextStepStartEvent',
           parameters: [
             {
               name: 'stepNumber',

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -150,7 +150,7 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
         'Callback called when the agent starts streaming, before any LLM calls. Receives the model and messages. If also specified in `stream()`, both callbacks fire (constructor first). Experimental (can break in patch releases).',
       properties: [
         {
-          type: 'OnStartEvent',
+          type: 'GenerateTextStartEvent',
           parameters: [
             {
               name: 'model',
@@ -174,7 +174,7 @@ To see `WorkflowAgent` in action, check out [these examples](#examples).
         'Callback called before each step (LLM call) begins. Receives step number, model, and messages. If also specified in `stream()`, both callbacks fire (constructor first). Experimental (can break in patch releases).',
       properties: [
         {
-          type: 'OnStepStartEvent',
+          type: 'GenerateTextStepStartEvent',
           parameters: [
             {
               name: 'stepNumber',

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -12,10 +12,10 @@ import {
   SystemModelMessage,
 } from '@ai-sdk/provider-utils';
 import type {
-  OnFinishEvent,
-  OnStartEvent,
-  OnStepFinishEvent,
-  OnStepStartEvent,
+  GenerateTextEndEvent,
+  GenerateTextStartEvent,
+  GenerateTextStepEndEvent,
+  GenerateTextStepStartEvent,
 } from '../generate-text/core-events';
 import { Output } from '../generate-text/output';
 import { PrepareStepFunction } from '../generate-text/prepare-step';
@@ -40,23 +40,23 @@ export type ToolLoopAgentOnStartCallback<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
   OUTPUT extends Output = Output,
-> = Callback<OnStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
+> = Callback<GenerateTextStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
 
 export type ToolLoopAgentOnStepStartCallback<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
   OUTPUT extends Output = Output,
-> = Callback<OnStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
+> = Callback<GenerateTextStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
 
 export type ToolLoopAgentOnStepFinishCallback<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
-> = Callback<OnStepFinishEvent<TOOLS, RUNTIME_CONTEXT>>;
+> = Callback<GenerateTextStepEndEvent<TOOLS, RUNTIME_CONTEXT>>;
 
 export type ToolLoopAgentOnFinishCallback<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
-> = Callback<OnFinishEvent<TOOLS, RUNTIME_CONTEXT>>;
+> = Callback<GenerateTextEndEvent<TOOLS, RUNTIME_CONTEXT>>;
 
 /**
  * Configuration options for an agent.

--- a/packages/ai/src/embed/embed-events.ts
+++ b/packages/ai/src/embed/embed-events.ts
@@ -80,7 +80,7 @@ export interface EmbedOnFinishEvent {
  * For `embed`, there is one call. For `embedMany`, there may be multiple
  * calls when values are chunked.
  */
-export interface EmbedStartEvent {
+export interface EmbeddingModelCallStartEvent {
   /** Unique identifier for this embed call, used to correlate events. */
   readonly callId: string;
 
@@ -105,7 +105,7 @@ export interface EmbedStartEvent {
  *
  * Contains the embeddings, usage, and any warnings from the model response.
  */
-export interface EmbedFinishEvent {
+export interface EmbeddingModelCallEndEvent {
   /** Unique identifier for this embed call, used to correlate events. */
   readonly callId: string;
 
@@ -130,3 +130,9 @@ export interface EmbedFinishEvent {
   /** Token usage for this model call. */
   readonly usage: EmbeddingModelUsage;
 }
+
+/** @deprecated Use `EmbeddingModelCallStartEvent` instead. */
+export type EmbedStartEvent = EmbeddingModelCallStartEvent;
+
+/** @deprecated Use `EmbeddingModelCallEndEvent` instead. */
+export type EmbedFinishEvent = EmbeddingModelCallEndEvent;

--- a/packages/ai/src/embed/embed-events.ts
+++ b/packages/ai/src/embed/embed-events.ts
@@ -8,7 +8,7 @@ import type { Warning } from '../types/warning';
  *
  * Called when the operation begins, before the embedding model is called.
  */
-export interface EmbedOnStartEvent {
+export interface EmbedStartEvent {
   /** Unique identifier for this embed call, used to correlate events. */
   readonly callId: string;
 
@@ -39,7 +39,7 @@ export interface EmbedOnStartEvent {
  *
  * Called when the operation completes, after the embedding model returns.
  */
-export interface EmbedOnFinishEvent {
+export interface EmbedEndEvent {
   /** Unique identifier for this embed call, used to correlate events. */
   readonly callId: string;
 
@@ -130,9 +130,3 @@ export interface EmbeddingModelCallEndEvent {
   /** Token usage for this model call. */
   readonly usage: EmbeddingModelUsage;
 }
-
-/** @deprecated Use `EmbeddingModelCallStartEvent` instead. */
-export type EmbedStartEvent = EmbeddingModelCallStartEvent;
-
-/** @deprecated Use `EmbeddingModelCallEndEvent` instead. */
-export type EmbedFinishEvent = EmbeddingModelCallEndEvent;

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -14,7 +14,7 @@ import { MockEmbeddingModelV4 } from '../test/mock-embedding-model-v4';
 import { Embedding, EmbeddingModelUsage, Warning } from '../types';
 import { createResolvablePromise } from '../util/create-resolvable-promise';
 import { embedMany } from './embed-many';
-import type { EmbedOnStartEvent, EmbedOnFinishEvent } from './embed-events';
+import type { EmbedStartEvent, EmbedEndEvent } from './embed-events';
 
 vi.mock('../version', () => {
   return {
@@ -546,7 +546,7 @@ describe('logWarnings', () => {
 
 describe('options.experimental_onStart', () => {
   it('should send correct event information', async () => {
-    let startEvent!: EmbedOnStartEvent;
+    let startEvent!: EmbedStartEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -569,7 +569,7 @@ describe('options.experimental_onStart', () => {
   });
 
   it('should include telemetry fields', async () => {
-    let startEvent!: EmbedOnStartEvent;
+    let startEvent!: EmbedStartEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -595,7 +595,7 @@ describe('options.experimental_onStart', () => {
   });
 
   it('should accept deprecated experimental_telemetry as an alias for telemetry', async () => {
-    let startEvent!: EmbedOnStartEvent;
+    let startEvent!: EmbedStartEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -621,7 +621,7 @@ describe('options.experimental_onStart', () => {
   });
 
   it('should include model information', async () => {
-    let startEvent!: EmbedOnStartEvent;
+    let startEvent!: EmbedStartEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -675,7 +675,7 @@ describe('options.experimental_onStart', () => {
   });
 
   it('should include providerOptions and headers', async () => {
-    let startEvent!: EmbedOnStartEvent;
+    let startEvent!: EmbedStartEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -702,7 +702,7 @@ describe('options.experimental_onStart', () => {
 
 describe('options.experimental_onFinish', () => {
   it('should send correct event information (single call path)', async () => {
-    let finishEvent!: EmbedOnFinishEvent;
+    let finishEvent!: EmbedEndEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -725,7 +725,7 @@ describe('options.experimental_onFinish', () => {
   });
 
   it('should send correct event information (chunked path)', async () => {
-    let finishEvent!: EmbedOnFinishEvent;
+    let finishEvent!: EmbedEndEvent;
     let callCount = 0;
 
     await embedMany({
@@ -770,7 +770,7 @@ describe('options.experimental_onFinish', () => {
   });
 
   it('should include embeddings and usage in event', async () => {
-    let finishEvent!: EmbedOnFinishEvent;
+    let finishEvent!: EmbedEndEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -789,7 +789,7 @@ describe('options.experimental_onFinish', () => {
   });
 
   it('should include model information', async () => {
-    let finishEvent!: EmbedOnFinishEvent;
+    let finishEvent!: EmbedEndEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -808,7 +808,7 @@ describe('options.experimental_onFinish', () => {
   });
 
   it('should include responses data', async () => {
-    let finishEvent!: EmbedOnFinishEvent;
+    let finishEvent!: EmbedEndEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({
@@ -870,8 +870,8 @@ describe('options.experimental_onFinish', () => {
 
 describe('options.experimental_onStart and experimental_onFinish together', () => {
   it('should have consistent callId across both events', async () => {
-    let startEvent!: EmbedOnStartEvent;
-    let finishEvent!: EmbedOnFinishEvent;
+    let startEvent!: EmbedStartEvent;
+    let finishEvent!: EmbedEndEvent;
 
     await embedMany({
       model: new MockEmbeddingModelV4({

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -13,7 +13,7 @@ import type { Callback } from '../util/callback';
 import { notify } from '../util/notify';
 import { prepareRetries } from '../util/prepare-retries';
 import { splitArray } from '../util/split-array';
-import type { EmbedOnFinishEvent, EmbedOnStartEvent } from './embed-events';
+import type { EmbedEndEvent, EmbedStartEvent } from './embed-events';
 import { EmbedManyResult } from './embed-many-result';
 import { VERSION } from '../version';
 
@@ -118,13 +118,13 @@ export async function embedMany({
    * Callback that is called when the embedMany operation begins,
    * before the embedding model is called.
    */
-  experimental_onStart?: Callback<EmbedOnStartEvent>;
+  experimental_onStart?: Callback<EmbedStartEvent>;
 
   /**
    * Callback that is called when the embedMany operation completes,
    * after all embedding model calls return.
    */
-  experimental_onFinish?: Callback<EmbedOnFinishEvent>;
+  experimental_onFinish?: Callback<EmbedEndEvent>;
 
   /**
    * Internal. For test use only. May change without notice.

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -5,7 +5,7 @@ import * as logWarningsModule from '../logger/log-warnings';
 import { MockEmbeddingModelV4 } from '../test/mock-embedding-model-v4';
 import { Embedding, EmbeddingModelUsage, Warning } from '../types';
 import { embed } from './embed';
-import type { EmbedOnStartEvent, EmbedOnFinishEvent } from './embed-events';
+import type { EmbedStartEvent, EmbedEndEvent } from './embed-events';
 
 const dummyEmbedding = [0.1, 0.2, 0.3];
 const testValue = 'sunny day at the beach';
@@ -224,7 +224,7 @@ describe('logWarnings', () => {
 
 describe('options.experimental_onStart', () => {
   it('should send correct event information', async () => {
-    let startEvent!: EmbedOnStartEvent;
+    let startEvent!: EmbedStartEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
@@ -246,7 +246,7 @@ describe('options.experimental_onStart', () => {
   });
 
   it('should include telemetry fields', async () => {
-    let startEvent!: EmbedOnStartEvent;
+    let startEvent!: EmbedStartEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
@@ -271,7 +271,7 @@ describe('options.experimental_onStart', () => {
   });
 
   it('should accept deprecated experimental_telemetry as an alias for telemetry', async () => {
-    let startEvent!: EmbedOnStartEvent;
+    let startEvent!: EmbedStartEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
@@ -296,7 +296,7 @@ describe('options.experimental_onStart', () => {
   });
 
   it('should include model information', async () => {
-    let startEvent!: EmbedOnStartEvent;
+    let startEvent!: EmbedStartEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
@@ -347,7 +347,7 @@ describe('options.experimental_onStart', () => {
   });
 
   it('should include providerOptions and headers', async () => {
-    let startEvent!: EmbedOnStartEvent;
+    let startEvent!: EmbedStartEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
@@ -373,7 +373,7 @@ describe('options.experimental_onStart', () => {
 
 describe('options.experimental_onFinish', () => {
   it('should send correct event information', async () => {
-    let finishEvent!: EmbedOnFinishEvent;
+    let finishEvent!: EmbedEndEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
@@ -395,7 +395,7 @@ describe('options.experimental_onFinish', () => {
   });
 
   it('should include embedding and usage in event', async () => {
-    let finishEvent!: EmbedOnFinishEvent;
+    let finishEvent!: EmbedEndEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
@@ -413,7 +413,7 @@ describe('options.experimental_onFinish', () => {
   });
 
   it('should include model information', async () => {
-    let finishEvent!: EmbedOnFinishEvent;
+    let finishEvent!: EmbedEndEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
@@ -431,7 +431,7 @@ describe('options.experimental_onFinish', () => {
   });
 
   it('should include warnings and providerMetadata', async () => {
-    let finishEvent!: EmbedOnFinishEvent;
+    let finishEvent!: EmbedEndEvent;
     const expectedWarnings: Warning[] = [
       { type: 'other', message: 'test warning' },
     ];
@@ -461,7 +461,7 @@ describe('options.experimental_onFinish', () => {
   });
 
   it('should include response data', async () => {
-    let finishEvent!: EmbedOnFinishEvent;
+    let finishEvent!: EmbedEndEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({
@@ -518,8 +518,8 @@ describe('options.experimental_onFinish', () => {
 
 describe('options.experimental_onStart and experimental_onFinish together', () => {
   it('should have consistent callId across both events', async () => {
-    let startEvent!: EmbedOnStartEvent;
-    let finishEvent!: EmbedOnFinishEvent;
+    let startEvent!: EmbedStartEvent;
+    let finishEvent!: EmbedEndEvent;
 
     await embed({
       model: new MockEmbeddingModelV4({

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -12,7 +12,7 @@ import type { Callback } from '../util/callback';
 import { notify } from '../util/notify';
 import { prepareRetries } from '../util/prepare-retries';
 import { VERSION } from '../version';
-import type { EmbedOnFinishEvent, EmbedOnStartEvent } from './embed-events';
+import type { EmbedEndEvent, EmbedStartEvent } from './embed-events';
 import { EmbedResult } from './embed-result';
 
 const originalGenerateCallId = createIdGenerator({
@@ -102,13 +102,13 @@ export async function embed({
    * Callback that is called when the embed operation begins,
    * before the embedding model is called.
    */
-  experimental_onStart?: Callback<EmbedOnStartEvent>;
+  experimental_onStart?: Callback<EmbedStartEvent>;
 
   /**
    * Callback that is called when the embed operation completes,
    * after the embedding model returns.
    */
-  experimental_onFinish?: Callback<EmbedOnFinishEvent>;
+  experimental_onFinish?: Callback<EmbedEndEvent>;
 
   /**
    * Internal. For test use only. May change without notice.

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -35,10 +35,10 @@ import { getOutputStrategy } from './output-strategy';
 import { parseAndValidateObjectResultWithRepair } from './parse-and-validate-object-result';
 import { RepairTextFunction } from './repair-text';
 import type {
-  ObjectOnFinishEvent,
-  ObjectOnStartEvent,
-  ObjectOnStepFinishEvent,
-  ObjectOnStepStartEvent,
+  GenerateObjectEndEvent,
+  GenerateObjectStartEvent,
+  GenerateObjectStepEndEvent,
+  GenerateObjectStepStartEvent,
 } from './structured-output-events';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
 
@@ -197,25 +197,25 @@ export async function generateObject<
        * Callback that is called when the generateObject operation begins,
        * before the LLM call is made.
        */
-      experimental_onStart?: Callback<ObjectOnStartEvent>;
+      experimental_onStart?: Callback<GenerateObjectStartEvent>;
 
       /**
        * Callback that is called when the model call (step) begins,
        * before the provider is called.
        */
-      experimental_onStepStart?: Callback<ObjectOnStepStartEvent>;
+      experimental_onStepStart?: Callback<GenerateObjectStepStartEvent>;
 
       /**
        * Callback that is called when the model call (step) completes,
        * with the raw result before JSON parsing.
        */
-      onStepFinish?: Callback<ObjectOnStepFinishEvent>;
+      onStepFinish?: Callback<GenerateObjectStepEndEvent>;
 
       /**
        * Callback that is called when the entire operation completes
        * with the final parsed and validated object.
        */
-      onFinish?: Callback<ObjectOnFinishEvent<RESULT>>;
+      onFinish?: Callback<GenerateObjectEndEvent<RESULT>>;
 
       /**
        * Internal. For test use only. May change without notice.
@@ -396,7 +396,7 @@ export async function generateObject<
       model: model.modelId,
     });
 
-    const stepFinishEvent: ObjectOnStepFinishEvent = {
+    const stepFinishEvent: GenerateObjectStepEndEvent = {
       callId,
       stepNumber: 0 as const,
       provider: model.provider,

--- a/packages/ai/src/generate-object/index.ts
+++ b/packages/ai/src/generate-object/index.ts
@@ -1,9 +1,9 @@
 export { generateObject } from './generate-object';
 export type {
-  ObjectOnFinishEvent,
-  ObjectOnStartEvent,
-  ObjectOnStepFinishEvent,
-  ObjectOnStepStartEvent,
+  GenerateObjectEndEvent,
+  GenerateObjectStartEvent,
+  GenerateObjectStepEndEvent,
+  GenerateObjectStepStartEvent,
 } from './structured-output-events';
 export type { RepairTextFunction } from './repair-text';
 export type { GenerateObjectResult } from './generate-object-result';

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -52,10 +52,10 @@ import { notify } from '../util/notify';
 import { now as originalNow } from '../util/now';
 import { prepareRetries } from '../util/prepare-retries';
 import type {
-  ObjectOnFinishEvent,
-  ObjectOnStartEvent,
-  ObjectOnStepFinishEvent,
-  ObjectOnStepStartEvent,
+  GenerateObjectEndEvent,
+  GenerateObjectStartEvent,
+  GenerateObjectStepEndEvent,
+  GenerateObjectStepStartEvent,
 } from './structured-output-events';
 import { getOutputStrategy, OutputStrategy } from './output-strategy';
 import { parseAndValidateObjectResultWithRepair } from './parse-and-validate-object-result';
@@ -259,19 +259,19 @@ export function streamObject<
        * Callback that is called when the streamObject operation begins,
        * before the LLM call is made.
        */
-      experimental_onStart?: Callback<ObjectOnStartEvent>;
+      experimental_onStart?: Callback<GenerateObjectStartEvent>;
 
       /**
        * Callback that is called when the model call (step) begins,
        * before the provider is called.
        */
-      experimental_onStepStart?: Callback<ObjectOnStepStartEvent>;
+      experimental_onStepStart?: Callback<GenerateObjectStepStartEvent>;
 
       /**
        * Callback that is called when the model streaming step completes,
        * with the raw accumulated text before final schema validation.
        */
-      onStepFinish?: Callback<ObjectOnStepFinishEvent>;
+      onStepFinish?: Callback<GenerateObjectStepEndEvent>;
 
       /**
        * Callback that is invoked when an error occurs during streaming.
@@ -283,7 +283,7 @@ export function streamObject<
       /**
        * Callback that is called when the LLM response and the final object validation are finished.
        */
-      onFinish?: Callback<ObjectOnFinishEvent<RESULT>>;
+      onFinish?: Callback<GenerateObjectEndEvent<RESULT>>;
 
       /**
        * Internal. For test use only. May change without notice.
@@ -450,11 +450,11 @@ class DefaultStreamObjectResult<
     schemaDescription: string | undefined;
     providerOptions: ProviderOptions | undefined;
     repairText: RepairTextFunction | undefined;
-    onStart: Callback<ObjectOnStartEvent> | undefined;
-    onStepStart: Callback<ObjectOnStepStartEvent> | undefined;
-    onStepFinish: Callback<ObjectOnStepFinishEvent> | undefined;
+    onStart: Callback<GenerateObjectStartEvent> | undefined;
+    onStepStart: Callback<GenerateObjectStepStartEvent> | undefined;
+    onStepFinish: Callback<GenerateObjectStepEndEvent> | undefined;
     onError: StreamObjectOnErrorCallback;
-    onFinish: Callback<ObjectOnFinishEvent<RESULT>> | undefined;
+    onFinish: Callback<GenerateObjectEndEvent<RESULT>> | undefined;
     download: DownloadFunction | undefined;
     generateId: () => string;
     currentDate: () => Date;

--- a/packages/ai/src/generate-object/structured-output-events.ts
+++ b/packages/ai/src/generate-object/structured-output-events.ts
@@ -21,7 +21,7 @@ import type { LanguageModelUsage } from '../types/usage';
  *
  * @deprecated
  */
-export interface ObjectOnStartEvent {
+export type GenerateObjectStartEvent = {
   /** Unique identifier for this generation call, used to correlate events. */
   readonly callId: string;
 
@@ -81,7 +81,7 @@ export interface ObjectOnStartEvent {
 
   /** Optional description of the schema. */
   readonly schemaDescription: string | undefined;
-}
+};
 
 /**
  * Event passed to the `experimental_onStepStart` callback of
@@ -92,7 +92,7 @@ export interface ObjectOnStartEvent {
  *
  * @deprecated
  */
-export interface ObjectOnStepStartEvent {
+export type GenerateObjectStepStartEvent = {
   /** Unique identifier for this generation call, used to correlate events. */
   readonly callId: string;
 
@@ -113,7 +113,7 @@ export interface ObjectOnStepStartEvent {
 
   /** The prompt messages in provider format (for telemetry). */
   readonly promptMessages?: LanguageModelV4Prompt;
-}
+};
 
 /**
  * Event passed to the `onStepFinish` callback of
@@ -124,7 +124,7 @@ export interface ObjectOnStepStartEvent {
  *
  * @deprecated
  */
-export interface ObjectOnStepFinishEvent {
+export type GenerateObjectStepEndEvent = {
   /** Unique identifier for this generation call, used to correlate events. */
   readonly callId: string;
 
@@ -165,7 +165,7 @@ export interface ObjectOnStepFinishEvent {
 
   /** Milliseconds from the start of the stream to the first chunk (streaming only). */
   readonly msToFirstChunk: number | undefined;
-}
+};
 
 /**
  * Event passed to the `onFinish` callback of
@@ -177,7 +177,7 @@ export interface ObjectOnStepFinishEvent {
  *
  * @deprecated
  */
-export interface ObjectOnFinishEvent<RESULT> {
+export type GenerateObjectEndEvent<RESULT> = {
   /** Unique identifier for this generation call, used to correlate events. */
   readonly callId: string;
 
@@ -216,4 +216,4 @@ export interface ObjectOnFinishEvent<RESULT> {
 
   /** Additional provider-specific metadata. */
   readonly providerMetadata: ProviderMetadata | undefined;
-}
+};

--- a/packages/ai/src/generate-text/core-events.ts
+++ b/packages/ai/src/generate-text/core-events.ts
@@ -30,7 +30,7 @@ export interface CallbackModelInfo {
  *
  * Called when the generation operation begins, before any LLM calls.
  */
-export interface OnStartEvent<
+export interface GenerateTextStartEvent<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
   OUTPUT extends Output = Output,
@@ -126,7 +126,7 @@ export interface OnStartEvent<
  * Called when a step (LLM call) begins, before the provider is called.
  * Each step represents a single LLM invocation.
  */
-export interface OnStepStartEvent<
+export interface GenerateTextStepStartEvent<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
   OUTPUT extends Output = Output,
@@ -195,7 +195,7 @@ export interface OnStepStartEvent<
  * The chunk is either a content part (text-delta, tool-call, etc.) or
  * a stream lifecycle marker (`ai.stream.firstChunk` / `ai.stream.finish`).
  */
-export interface OnChunkEvent<TOOLS extends ToolSet = ToolSet> {
+export interface ChunkEvent<TOOLS extends ToolSet = ToolSet> {
   readonly chunk:
     | TextStreamPart<TOOLS>
     | {
@@ -212,7 +212,7 @@ export interface OnChunkEvent<TOOLS extends ToolSet = ToolSet> {
  * Called when a step (LLM call) completes.
  * Includes the StepResult for that step along with the call identifier.
  */
-export type OnStepFinishEvent<
+export type GenerateTextStepEndEvent<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
 > = StepResult<TOOLS, RUNTIME_CONTEXT>;
@@ -223,7 +223,7 @@ export type OnStepFinishEvent<
  * Called when the entire generation completes (all steps finished).
  * Includes the final step's result along with aggregated data from all steps.
  */
-export type OnFinishEvent<
+export type GenerateTextEndEvent<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
 > = StepResult<TOOLS, RUNTIME_CONTEXT> & {
@@ -233,3 +233,15 @@ export type OnFinishEvent<
   /** Aggregated token usage across all steps. */
   readonly totalUsage: LanguageModelUsage;
 };
+
+/** @deprecated Use `GenerateTextStepEndEvent` instead. */
+export type OnStepFinishEvent<
+  TOOLS extends ToolSet = ToolSet,
+  RUNTIME_CONTEXT extends Context = Context,
+> = GenerateTextStepEndEvent<TOOLS, RUNTIME_CONTEXT>;
+
+/** @deprecated Use `GenerateTextEndEvent` instead. */
+export type OnFinishEvent<
+  TOOLS extends ToolSet = ToolSet,
+  RUNTIME_CONTEXT extends Context = Context,
+> = GenerateTextEndEvent<TOOLS, RUNTIME_CONTEXT>;

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -60,10 +60,10 @@ import { VERSION } from '../version';
 import { collectToolApprovals } from './collect-tool-approvals';
 import { ContentPart } from './content-part';
 import type {
-  OnFinishEvent,
-  OnStartEvent,
-  OnStepFinishEvent,
-  OnStepStartEvent,
+  GenerateTextEndEvent,
+  GenerateTextStartEvent,
+  GenerateTextStepEndEvent,
+  GenerateTextStepStartEvent,
 } from './core-events';
 import { executeToolCall } from './execute-tool-call';
 import { filterActiveTools } from './filter-active-tool';
@@ -120,7 +120,7 @@ export type GenerateTextOnStartCallback<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
   OUTPUT extends Output = Output,
-> = Callback<OnStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
+> = Callback<GenerateTextStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
 
 /**
  * Callback that is set using the `experimental_onStepStart` option.
@@ -135,7 +135,7 @@ export type GenerateTextOnStepStartCallback<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
   OUTPUT extends Output = Output,
-> = Callback<OnStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
+> = Callback<GenerateTextStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
 
 /**
  * Callback that is set using the `onStepFinish` option.
@@ -148,7 +148,7 @@ export type GenerateTextOnStepStartCallback<
 export type GenerateTextOnStepFinishCallback<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
-> = Callback<OnStepFinishEvent<TOOLS, RUNTIME_CONTEXT>>;
+> = Callback<GenerateTextStepEndEvent<TOOLS, RUNTIME_CONTEXT>>;
 
 /**
  * Callback that is set using the `onFinish` option.
@@ -162,7 +162,7 @@ export type GenerateTextOnStepFinishCallback<
 export type GenerateTextOnFinishCallback<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
-> = Callback<OnFinishEvent<TOOLS, RUNTIME_CONTEXT>>;
+> = Callback<GenerateTextEndEvent<TOOLS, RUNTIME_CONTEXT>>;
 
 /**
  * Generate a text and call tools for a given prompt using a language model.

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -1,10 +1,12 @@
 export type { ContentPart } from './content-part';
 export type {
-  OnChunkEvent,
+  ChunkEvent,
+  GenerateTextEndEvent,
+  GenerateTextStartEvent,
+  GenerateTextStepEndEvent,
+  GenerateTextStepStartEvent,
   OnFinishEvent,
-  OnStartEvent,
   OnStepFinishEvent,
-  OnStepStartEvent,
 } from './core-events';
 export { filterActiveTools as experimental_filterActiveTools } from './filter-active-tool';
 export {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -84,10 +84,10 @@ import { prepareRetries } from '../util/prepare-retries';
 import { collectToolApprovals } from './collect-tool-approvals';
 import { ContentPart } from './content-part';
 import type {
-  OnFinishEvent,
-  OnStartEvent,
-  OnStepFinishEvent,
-  OnStepStartEvent,
+  GenerateTextEndEvent,
+  GenerateTextStartEvent,
+  GenerateTextStepEndEvent,
+  GenerateTextStepStartEvent,
 } from './core-events';
 import { createExecuteToolsTransformation } from './create-execute-tools-transformation';
 import { executeToolCall } from './execute-tool-call';
@@ -168,7 +168,7 @@ export type StreamTextOnErrorCallback = Callback<{
 export type StreamTextOnStepFinishCallback<
   TOOLS extends ToolSet,
   RUNTIME_CONTEXT extends Context,
-> = Callback<OnStepFinishEvent<TOOLS, RUNTIME_CONTEXT>>;
+> = Callback<GenerateTextStepEndEvent<TOOLS, RUNTIME_CONTEXT>>;
 
 /**
  * Callback that is set using the `onChunk` option.
@@ -201,7 +201,7 @@ export type StreamTextOnChunkCallback<TOOLS extends ToolSet> = (event: {
 export type StreamTextOnFinishCallback<
   TOOLS extends ToolSet,
   RUNTIME_CONTEXT extends Context,
-> = Callback<OnFinishEvent<TOOLS, RUNTIME_CONTEXT>>;
+> = Callback<GenerateTextEndEvent<TOOLS, RUNTIME_CONTEXT>>;
 
 /**
  * Callback that is set using the `onAbort` option.
@@ -231,7 +231,7 @@ export type StreamTextOnStartCallback<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
   OUTPUT extends Output = Output,
-> = Callback<OnStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
+> = Callback<GenerateTextStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
 
 /**
  * Callback that is set using the `experimental_onStepStart` option.
@@ -246,7 +246,7 @@ export type StreamTextOnStepStartCallback<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
   OUTPUT extends Output = Output,
-> = Callback<OnStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
+> = Callback<GenerateTextStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
 
 /**
  * Generate a text and call tools for a given prompt using a language model.

--- a/packages/ai/src/rerank/index.ts
+++ b/packages/ai/src/rerank/index.ts
@@ -3,6 +3,8 @@ export type { RerankResult } from './rerank-result';
 export type {
   RerankOnStartEvent,
   RerankOnFinishEvent,
+  RerankingModelCallStartEvent,
+  RerankingModelCallEndEvent,
   RerankStartEvent,
   RerankFinishEvent,
 } from './rerank-events';

--- a/packages/ai/src/rerank/index.ts
+++ b/packages/ai/src/rerank/index.ts
@@ -1,10 +1,8 @@
 export { rerank } from './rerank';
 export type { RerankResult } from './rerank-result';
 export type {
-  RerankOnStartEvent,
-  RerankOnFinishEvent,
+  RerankStartEvent,
+  RerankEndEvent,
   RerankingModelCallStartEvent,
   RerankingModelCallEndEvent,
-  RerankStartEvent,
-  RerankFinishEvent,
 } from './rerank-events';

--- a/packages/ai/src/rerank/rerank-events.ts
+++ b/packages/ai/src/rerank/rerank-events.ts
@@ -8,7 +8,7 @@ import type { Warning } from '../types/warning';
  *
  * Called when the operation begins, before the reranking model is called.
  */
-export interface RerankOnStartEvent {
+export interface RerankStartEvent {
   /** Unique identifier for this rerank call, used to correlate events. */
   readonly callId: string;
 
@@ -43,7 +43,7 @@ export interface RerankOnStartEvent {
  *
  * Called when the operation completes, after the reranking model returns.
  */
-export interface RerankOnFinishEvent {
+export interface RerankEndEvent {
   /** Unique identifier for this rerank call, used to correlate events. */
   readonly callId: string;
 
@@ -138,9 +138,3 @@ export interface RerankingModelCallEndEvent {
   /** The ranking results from the model. */
   readonly ranking: Array<{ index: number; relevanceScore: number }>;
 }
-
-/** @deprecated Use `RerankingModelCallStartEvent` instead. */
-export type RerankStartEvent = RerankingModelCallStartEvent;
-
-/** @deprecated Use `RerankingModelCallEndEvent` instead. */
-export type RerankFinishEvent = RerankingModelCallEndEvent;

--- a/packages/ai/src/rerank/rerank-events.ts
+++ b/packages/ai/src/rerank/rerank-events.ts
@@ -88,7 +88,7 @@ export interface RerankOnFinishEvent {
 /**
  * Event fired when an individual reranking model call (inner doRerank) begins.
  */
-export interface RerankStartEvent {
+export interface RerankingModelCallStartEvent {
   /** Unique identifier for this rerank call, used to correlate events. */
   readonly callId: string;
 
@@ -119,7 +119,7 @@ export interface RerankStartEvent {
  *
  * Contains the ranking results from the model response.
  */
-export interface RerankFinishEvent {
+export interface RerankingModelCallEndEvent {
   /** Unique identifier for this rerank call, used to correlate events. */
   readonly callId: string;
 
@@ -138,3 +138,9 @@ export interface RerankFinishEvent {
   /** The ranking results from the model. */
   readonly ranking: Array<{ index: number; relevanceScore: number }>;
 }
+
+/** @deprecated Use `RerankingModelCallStartEvent` instead. */
+export type RerankStartEvent = RerankingModelCallStartEvent;
+
+/** @deprecated Use `RerankingModelCallEndEvent` instead. */
+export type RerankFinishEvent = RerankingModelCallEndEvent;

--- a/packages/ai/src/rerank/rerank.test.ts
+++ b/packages/ai/src/rerank/rerank.test.ts
@@ -2,7 +2,7 @@ import { RerankingModelV4CallOptions } from '@ai-sdk/provider';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MockRerankingModelV4 } from '../test/mock-reranking-model-v4';
 import { rerank } from './rerank';
-import type { RerankOnStartEvent, RerankOnFinishEvent } from './rerank-events';
+import type { RerankStartEvent, RerankEndEvent } from './rerank-events';
 import { RerankResult } from './rerank-result';
 describe('rerank', () => {
   describe('rerank with string documents', () => {
@@ -363,7 +363,7 @@ describe('rerank', () => {
     });
 
     it('should send correct event information', async () => {
-      let startEvent!: RerankOnStartEvent;
+      let startEvent!: RerankStartEvent;
 
       await rerank({
         model: mockModel,
@@ -389,7 +389,7 @@ describe('rerank', () => {
     });
 
     it('should include telemetry fields', async () => {
-      let startEvent!: RerankOnStartEvent;
+      let startEvent!: RerankStartEvent;
 
       await rerank({
         model: mockModel,
@@ -417,7 +417,7 @@ describe('rerank', () => {
     });
 
     it('should accept deprecated experimental_telemetry as an alias for telemetry', async () => {
-      let startEvent!: RerankOnStartEvent;
+      let startEvent!: RerankStartEvent;
 
       await rerank({
         model: mockModel,
@@ -445,7 +445,7 @@ describe('rerank', () => {
     });
 
     it('should include model information', async () => {
-      let startEvent!: RerankOnStartEvent;
+      let startEvent!: RerankStartEvent;
 
       await rerank({
         model: mockModel,
@@ -506,7 +506,7 @@ describe('rerank', () => {
     });
 
     it('should include providerOptions, headers, documents, and query', async () => {
-      let startEvent!: RerankOnStartEvent;
+      let startEvent!: RerankStartEvent;
 
       await rerank({
         model: mockModel,
@@ -561,7 +561,7 @@ describe('rerank', () => {
     });
 
     it('should send correct event information', async () => {
-      let finishEvent!: RerankOnFinishEvent;
+      let finishEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -587,7 +587,7 @@ describe('rerank', () => {
     });
 
     it('should include ranking and documents in event', async () => {
-      let finishEvent!: RerankOnFinishEvent;
+      let finishEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -628,7 +628,7 @@ describe('rerank', () => {
     });
 
     it('should include model information', async () => {
-      let finishEvent!: RerankOnFinishEvent;
+      let finishEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -649,7 +649,7 @@ describe('rerank', () => {
     });
 
     it('should include warnings and providerMetadata', async () => {
-      let finishEvent!: RerankOnFinishEvent;
+      let finishEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -673,7 +673,7 @@ describe('rerank', () => {
     });
 
     it('should include response data', async () => {
-      let finishEvent!: RerankOnFinishEvent;
+      let finishEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -754,8 +754,8 @@ describe('rerank', () => {
     });
 
     it('should have consistent callId across both events', async () => {
-      let startEvent!: RerankOnStartEvent;
-      let finishEvent!: RerankOnFinishEvent;
+      let startEvent!: RerankStartEvent;
+      let finishEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,
@@ -830,8 +830,8 @@ describe('rerank', () => {
     });
 
     it('should fire callbacks for empty documents', async () => {
-      let startEvent!: RerankOnStartEvent;
-      let finishEvent!: RerankOnFinishEvent;
+      let startEvent!: RerankStartEvent;
+      let finishEvent!: RerankEndEvent;
 
       await rerank({
         model: mockModel,

--- a/packages/ai/src/rerank/rerank.ts
+++ b/packages/ai/src/rerank/rerank.ts
@@ -8,7 +8,7 @@ import { TelemetryOptions } from '../telemetry/telemetry-options';
 import { RerankingModel } from '../types';
 import type { Callback } from '../util/callback';
 import { notify } from '../util/notify';
-import type { RerankOnFinishEvent, RerankOnStartEvent } from './rerank-events';
+import type { RerankEndEvent, RerankStartEvent } from './rerank-events';
 import { RerankResult } from './rerank-result';
 
 const originalGenerateCallId = createIdGenerator({
@@ -108,13 +108,13 @@ export async function rerank<VALUE extends JSONObject | string>({
    * Callback that is called when the rerank operation begins,
    * before the reranking model is called.
    */
-  experimental_onStart?: Callback<RerankOnStartEvent>;
+  experimental_onStart?: Callback<RerankStartEvent>;
 
   /**
    * Callback that is called when the rerank operation completes,
    * after the reranking model returns.
    */
-  experimental_onFinish?: Callback<RerankOnFinishEvent>;
+  experimental_onFinish?: Callback<RerankEndEvent>;
 
   /**
    * Internal. For test use only. May change without notice.

--- a/packages/ai/src/telemetry/telemetry.ts
+++ b/packages/ai/src/telemetry/telemetry.ts
@@ -1,9 +1,9 @@
 import type { ToolSet } from '@ai-sdk/provider-utils';
 import type {
-  EmbedFinishEvent,
   EmbedOnFinishEvent,
   EmbedOnStartEvent,
-  EmbedStartEvent,
+  EmbeddingModelCallEndEvent,
+  EmbeddingModelCallStartEvent,
 } from '../embed/embed-events';
 import type {
   ObjectOnFinishEvent,
@@ -12,21 +12,21 @@ import type {
   ObjectOnStepStartEvent,
 } from '../generate-object/structured-output-events';
 import type {
-  OnChunkEvent,
-  OnFinishEvent,
-  OnStartEvent,
-  OnStepFinishEvent,
-  OnStepStartEvent,
+  ChunkEvent,
+  GenerateTextEndEvent,
+  GenerateTextStartEvent,
+  GenerateTextStepEndEvent,
+  GenerateTextStepStartEvent,
 } from '../generate-text/core-events';
 import type {
   ToolExecutionEndEvent,
   ToolExecutionStartEvent,
 } from '../generate-text/tool-execution-events';
 import type {
-  RerankFinishEvent,
   RerankOnFinishEvent,
   RerankOnStartEvent,
-  RerankStartEvent,
+  RerankingModelCallEndEvent,
+  RerankingModelCallStartEvent,
 } from '../rerank/rerank-events';
 import type { Callback } from '../util/callback';
 import { TelemetryOptions } from '../telemetry/telemetry-options';
@@ -35,30 +35,30 @@ export type InferTelemetryEvent<EVENT> = EVENT &
   Omit<TelemetryOptions, 'integrations' | 'isEnabled'>;
 
 type OperationStartEvent =
-  | OnStartEvent
+  | GenerateTextStartEvent
   | ObjectOnStartEvent
   | EmbedOnStartEvent
   | RerankOnStartEvent;
 
 type OperationFinishEvent =
-  | OnFinishEvent<ToolSet>
+  | GenerateTextEndEvent<ToolSet>
   | ObjectOnFinishEvent<unknown>
   | EmbedOnFinishEvent
   | RerankOnFinishEvent;
 
 export interface TelemetryDispatcher {
   onStart?: Callback<OperationStartEvent>;
-  onStepStart?: Callback<OnStepStartEvent>;
+  onStepStart?: Callback<GenerateTextStepStartEvent>;
   onToolExecutionStart?: Callback<ToolExecutionStartEvent>;
   onToolExecutionEnd?: Callback<ToolExecutionEndEvent>;
-  onChunk?: Callback<OnChunkEvent>;
-  onStepFinish?: Callback<OnStepFinishEvent>;
+  onChunk?: Callback<ChunkEvent>;
+  onStepFinish?: Callback<GenerateTextStepEndEvent>;
   onObjectStepStart?: Callback<ObjectOnStepStartEvent>;
   onObjectStepFinish?: Callback<ObjectOnStepFinishEvent>;
-  onEmbedStart?: Callback<EmbedStartEvent>;
-  onEmbedFinish?: Callback<EmbedFinishEvent>;
-  onRerankStart?: Callback<RerankStartEvent>;
-  onRerankFinish?: Callback<RerankFinishEvent>;
+  onEmbedStart?: Callback<EmbeddingModelCallStartEvent>;
+  onEmbedFinish?: Callback<EmbeddingModelCallEndEvent>;
+  onRerankStart?: Callback<RerankingModelCallStartEvent>;
+  onRerankFinish?: Callback<RerankingModelCallEndEvent>;
   onFinish?: Callback<OperationFinishEvent>;
   onError?: Callback<unknown>;
   executeTool?: Telemetry['executeTool'];
@@ -87,7 +87,7 @@ export interface Telemetry {
    * The event includes the step number, accumulated previous step results,
    * and the messages that will be sent to the model.
    */
-  onStepStart?: Callback<InferTelemetryEvent<OnStepStartEvent>>;
+  onStepStart?: Callback<InferTelemetryEvent<GenerateTextStepStartEvent>>;
 
   /**
    * Called when a tool execution begins, before the tool's `execute` function
@@ -108,7 +108,7 @@ export interface Telemetry {
    * Called for each chunk received during streaming.
    * Only relevant for `streamText` — not called during `generateText`.
    */
-  onChunk?: Callback<OnChunkEvent>;
+  onChunk?: Callback<ChunkEvent>;
 
   /**
    * Called when an individual step (single LLM invocation) completes.
@@ -116,7 +116,7 @@ export interface Telemetry {
    * and results, usage statistics, finish reason, and optional request/response
    * bodies.
    */
-  onStepFinish?: Callback<InferTelemetryEvent<OnStepFinishEvent>>;
+  onStepFinish?: Callback<InferTelemetryEvent<GenerateTextStepEndEvent>>;
 
   /**
    * Called when an object generation step (single LLM invocation) begins.
@@ -139,25 +139,25 @@ export interface Telemetry {
    * For `embed`, there is one call. For `embedMany`, there may be multiple
    * calls when values are chunked.
    */
-  onEmbedStart?: Callback<InferTelemetryEvent<EmbedStartEvent>>;
+  onEmbedStart?: Callback<InferTelemetryEvent<EmbeddingModelCallStartEvent>>;
 
   /**
    * Called when an individual embedding model call (doEmbed) completes.
    * Contains the embeddings, usage, and any warnings from the model response.
    */
-  onEmbedFinish?: Callback<InferTelemetryEvent<EmbedFinishEvent>>;
+  onEmbedFinish?: Callback<InferTelemetryEvent<EmbeddingModelCallEndEvent>>;
 
   /**
    * Called when an individual reranking model call (doRerank) begins.
    * There is one call per `rerank` invocation.
    */
-  onRerankStart?: Callback<InferTelemetryEvent<RerankStartEvent>>;
+  onRerankStart?: Callback<InferTelemetryEvent<RerankingModelCallStartEvent>>;
 
   /**
    * Called when an individual reranking model call (doRerank) completes.
    * Contains the ranking results from the model response.
    */
-  onRerankFinish?: Callback<InferTelemetryEvent<RerankFinishEvent>>;
+  onRerankFinish?: Callback<InferTelemetryEvent<RerankingModelCallEndEvent>>;
 
   /**
    * Called when an operation completes. Fired for text generation

--- a/packages/ai/src/telemetry/telemetry.ts
+++ b/packages/ai/src/telemetry/telemetry.ts
@@ -6,10 +6,10 @@ import type {
   EmbeddingModelCallStartEvent,
 } from '../embed/embed-events';
 import type {
-  ObjectOnFinishEvent,
-  ObjectOnStartEvent,
-  ObjectOnStepFinishEvent,
-  ObjectOnStepStartEvent,
+  GenerateObjectEndEvent,
+  GenerateObjectStartEvent,
+  GenerateObjectStepEndEvent,
+  GenerateObjectStepStartEvent,
 } from '../generate-object/structured-output-events';
 import type {
   ChunkEvent,
@@ -36,13 +36,13 @@ export type InferTelemetryEvent<EVENT> = EVENT &
 
 type OperationStartEvent =
   | GenerateTextStartEvent
-  | ObjectOnStartEvent
+  | GenerateObjectStartEvent
   | EmbedStartEvent
   | RerankStartEvent;
 
 type OperationFinishEvent =
   | GenerateTextEndEvent<ToolSet>
-  | ObjectOnFinishEvent<unknown>
+  | GenerateObjectEndEvent<unknown>
   | EmbedEndEvent
   | RerankEndEvent;
 
@@ -53,8 +53,8 @@ export interface TelemetryDispatcher {
   onToolExecutionEnd?: Callback<ToolExecutionEndEvent>;
   onChunk?: Callback<ChunkEvent>;
   onStepFinish?: Callback<GenerateTextStepEndEvent>;
-  onObjectStepStart?: Callback<ObjectOnStepStartEvent>;
-  onObjectStepFinish?: Callback<ObjectOnStepFinishEvent>;
+  onObjectStepStart?: Callback<GenerateObjectStepStartEvent>;
+  onObjectStepFinish?: Callback<GenerateObjectStepEndEvent>;
   onEmbedStart?: Callback<EmbeddingModelCallStartEvent>;
   onEmbedFinish?: Callback<EmbeddingModelCallEndEvent>;
   onRerankStart?: Callback<RerankingModelCallStartEvent>;
@@ -124,7 +124,9 @@ export interface Telemetry {
    *
    * @deprecated
    */
-  onObjectStepStart?: Callback<InferTelemetryEvent<ObjectOnStepStartEvent>>;
+  onObjectStepStart?: Callback<
+    InferTelemetryEvent<GenerateObjectStepStartEvent>
+  >;
 
   /**
    * Called when an object generation step (single LLM invocation) completes,
@@ -132,7 +134,9 @@ export interface Telemetry {
    *
    * @deprecated
    */
-  onObjectStepFinish?: Callback<InferTelemetryEvent<ObjectOnStepFinishEvent>>;
+  onObjectStepFinish?: Callback<
+    InferTelemetryEvent<GenerateObjectStepEndEvent>
+  >;
 
   /**
    * Called when an individual embedding model call (doEmbed) begins.

--- a/packages/ai/src/telemetry/telemetry.ts
+++ b/packages/ai/src/telemetry/telemetry.ts
@@ -1,7 +1,7 @@
 import type { ToolSet } from '@ai-sdk/provider-utils';
 import type {
-  EmbedOnFinishEvent,
-  EmbedOnStartEvent,
+  EmbedEndEvent,
+  EmbedStartEvent,
   EmbeddingModelCallEndEvent,
   EmbeddingModelCallStartEvent,
 } from '../embed/embed-events';
@@ -23,8 +23,8 @@ import type {
   ToolExecutionStartEvent,
 } from '../generate-text/tool-execution-events';
 import type {
-  RerankOnFinishEvent,
-  RerankOnStartEvent,
+  RerankEndEvent,
+  RerankStartEvent,
   RerankingModelCallEndEvent,
   RerankingModelCallStartEvent,
 } from '../rerank/rerank-events';
@@ -37,14 +37,14 @@ export type InferTelemetryEvent<EVENT> = EVENT &
 type OperationStartEvent =
   | GenerateTextStartEvent
   | ObjectOnStartEvent
-  | EmbedOnStartEvent
-  | RerankOnStartEvent;
+  | EmbedStartEvent
+  | RerankStartEvent;
 
 type OperationFinishEvent =
   | GenerateTextEndEvent<ToolSet>
   | ObjectOnFinishEvent<unknown>
-  | EmbedOnFinishEvent
-  | RerankOnFinishEvent;
+  | EmbedEndEvent
+  | RerankEndEvent;
 
 export interface TelemetryDispatcher {
   onStart?: Callback<OperationStartEvent>;

--- a/packages/devtools/src/integration.ts
+++ b/packages/devtools/src/integration.ts
@@ -3,9 +3,9 @@ import type {
   GenerateTextStepStartEvent,
   GenerateTextStepEndEvent,
   ChunkEvent,
-  ObjectOnStartEvent,
-  ObjectOnStepStartEvent,
-  ObjectOnStepFinishEvent,
+  GenerateObjectStartEvent,
+  GenerateObjectStepStartEvent,
+  GenerateObjectStepEndEvent,
   Telemetry,
   ToolSet,
 } from 'ai';
@@ -201,7 +201,7 @@ export function DevToolsTelemetry(): Telemetry {
 
       const startEvent = event as (
         | GenerateTextStartEvent<ToolSet>
-        | ObjectOnStartEvent
+        | GenerateObjectStartEvent
       ) & {
         functionId?: string | undefined;
       };
@@ -272,7 +272,7 @@ export function DevToolsTelemetry(): Telemetry {
     },
 
     onObjectStepStart: async event => {
-      const stepStartEvent = event as ObjectOnStepStartEvent & {
+      const stepStartEvent = event as GenerateObjectStepStartEvent & {
         promptMessages?: unknown[];
       };
 
@@ -412,7 +412,7 @@ export function DevToolsTelemetry(): Telemetry {
     },
 
     onObjectStepFinish: async event => {
-      const stepResult = event as ObjectOnStepFinishEvent;
+      const stepResult = event as GenerateObjectStepEndEvent;
 
       const state = callStates.get(stepResult.callId);
       if (!state) return;

--- a/packages/devtools/src/integration.ts
+++ b/packages/devtools/src/integration.ts
@@ -1,8 +1,8 @@
 import type {
-  OnStartEvent,
-  OnStepStartEvent,
-  OnStepFinishEvent,
-  OnChunkEvent,
+  GenerateTextStartEvent,
+  GenerateTextStepStartEvent,
+  GenerateTextStepEndEvent,
+  ChunkEvent,
   ObjectOnStartEvent,
   ObjectOnStepStartEvent,
   ObjectOnStepFinishEvent,
@@ -200,7 +200,7 @@ export function DevToolsTelemetry(): Telemetry {
       }
 
       const startEvent = event as (
-        | OnStartEvent<ToolSet>
+        | GenerateTextStartEvent<ToolSet>
         | ObjectOnStartEvent
       ) & {
         functionId?: string | undefined;
@@ -218,7 +218,7 @@ export function DevToolsTelemetry(): Telemetry {
     },
 
     onStepStart: async event => {
-      const stepStartEvent = event as OnStepStartEvent<ToolSet> & {
+      const stepStartEvent = event as GenerateTextStepStartEvent<ToolSet> & {
         promptMessages?: unknown[];
       };
 
@@ -316,7 +316,7 @@ export function DevToolsTelemetry(): Telemetry {
     },
 
     onChunk: async event => {
-      const { chunk } = event as OnChunkEvent;
+      const { chunk } = event as ChunkEvent;
 
       if (chunk.type === 'raw') {
         const rawValue = (chunk as { rawValue: unknown }).rawValue;
@@ -364,7 +364,7 @@ export function DevToolsTelemetry(): Telemetry {
     },
 
     onStepFinish: async event => {
-      const stepResult = event as OnStepFinishEvent<ToolSet>;
+      const stepResult = event as GenerateTextStepEndEvent<ToolSet>;
 
       const state = callStates.get(stepResult.callId);
       if (!state) return;

--- a/packages/otel/src/gen-ai-open-telemetry.ts
+++ b/packages/otel/src/gen-ai-open-telemetry.ts
@@ -13,8 +13,8 @@ import {
 } from '@opentelemetry/api';
 import type {
   EmbeddingModelCallEndEvent,
-  EmbedOnFinishEvent,
-  EmbedOnStartEvent,
+  EmbedEndEvent,
+  EmbedStartEvent,
   EmbeddingModelCallStartEvent,
   ObjectOnFinishEvent,
   ObjectOnStartEvent,
@@ -29,8 +29,8 @@ import type {
   ToolExecutionStartEvent,
   OutputInterface as Output,
   RerankingModelCallEndEvent,
-  RerankOnFinishEvent,
-  RerankOnStartEvent,
+  RerankEndEvent,
+  RerankStartEvent,
   RerankingModelCallStartEvent,
   InferTelemetryEvent,
   Telemetry,
@@ -186,22 +186,20 @@ export class GenAIOpenTelemetry implements Telemetry {
     event:
       | InferTelemetryEvent<GenerateTextStartEvent>
       | InferTelemetryEvent<ObjectOnStartEvent>
-      | InferTelemetryEvent<EmbedOnStartEvent>
-      | InferTelemetryEvent<RerankOnStartEvent>,
+      | InferTelemetryEvent<EmbedStartEvent>
+      | InferTelemetryEvent<RerankStartEvent>,
   ): void {
     if (
       event.operationId === 'ai.embed' ||
       event.operationId === 'ai.embedMany'
     ) {
-      this.onEmbedOperationStart(
-        event as InferTelemetryEvent<EmbedOnStartEvent>,
-      );
+      this.onEmbedOperationStart(event as InferTelemetryEvent<EmbedStartEvent>);
       return;
     }
 
     if (event.operationId === 'ai.rerank') {
       this.onRerankOperationStart(
-        event as InferTelemetryEvent<RerankOnStartEvent>,
+        event as InferTelemetryEvent<RerankStartEvent>,
       );
       return;
     }
@@ -465,7 +463,7 @@ export class GenAIOpenTelemetry implements Telemetry {
   }
 
   private onEmbedOperationStart(
-    event: InferTelemetryEvent<EmbedOnStartEvent>,
+    event: InferTelemetryEvent<EmbedStartEvent>,
   ): void {
     const telemetry: TelemetryOptions = {
       recordInputs: event.recordInputs,
@@ -678,8 +676,8 @@ export class GenAIOpenTelemetry implements Telemetry {
     event:
       | GenerateTextEndEvent<ToolSet>
       | ObjectOnFinishEvent<unknown>
-      | EmbedOnFinishEvent
-      | RerankOnFinishEvent,
+      | EmbedEndEvent
+      | RerankEndEvent,
   ): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
@@ -688,12 +686,12 @@ export class GenAIOpenTelemetry implements Telemetry {
       state.operationId === 'ai.embed' ||
       state.operationId === 'ai.embedMany'
     ) {
-      this.onEmbedOperationFinish(event as EmbedOnFinishEvent);
+      this.onEmbedOperationFinish(event as EmbedEndEvent);
       return;
     }
 
     if (state.operationId === 'ai.rerank') {
-      this.onRerankOperationFinish(event as RerankOnFinishEvent);
+      this.onRerankOperationFinish(event as RerankEndEvent);
       return;
     }
 
@@ -773,7 +771,7 @@ export class GenAIOpenTelemetry implements Telemetry {
     this.cleanupCallState(event.callId);
   }
 
-  private onEmbedOperationFinish(event: EmbedOnFinishEvent): void {
+  private onEmbedOperationFinish(event: EmbedEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 
@@ -837,7 +835,7 @@ export class GenAIOpenTelemetry implements Telemetry {
   }
 
   private onRerankOperationStart(
-    event: InferTelemetryEvent<RerankOnStartEvent>,
+    event: InferTelemetryEvent<RerankStartEvent>,
   ): void {
     const telemetry: TelemetryOptions = {
       recordInputs: event.recordInputs,
@@ -882,7 +880,7 @@ export class GenAIOpenTelemetry implements Telemetry {
     });
   }
 
-  private onRerankOperationFinish(event: RerankOnFinishEvent): void {
+  private onRerankOperationFinish(event: RerankEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 

--- a/packages/otel/src/gen-ai-open-telemetry.ts
+++ b/packages/otel/src/gen-ai-open-telemetry.ts
@@ -12,26 +12,26 @@ import {
   Tracer,
 } from '@opentelemetry/api';
 import type {
-  EmbedFinishEvent,
+  EmbeddingModelCallEndEvent,
   EmbedOnFinishEvent,
   EmbedOnStartEvent,
-  EmbedStartEvent,
+  EmbeddingModelCallStartEvent,
   ObjectOnFinishEvent,
   ObjectOnStartEvent,
   ObjectOnStepFinishEvent,
   ObjectOnStepStartEvent,
-  OnChunkEvent,
-  OnFinishEvent,
-  OnStartEvent,
-  OnStepFinishEvent,
-  OnStepStartEvent,
+  ChunkEvent,
+  GenerateTextEndEvent,
+  GenerateTextStartEvent,
+  GenerateTextStepEndEvent,
+  GenerateTextStepStartEvent,
   ToolExecutionEndEvent,
   ToolExecutionStartEvent,
   OutputInterface as Output,
-  RerankFinishEvent,
+  RerankingModelCallEndEvent,
   RerankOnFinishEvent,
   RerankOnStartEvent,
-  RerankStartEvent,
+  RerankingModelCallStartEvent,
   InferTelemetryEvent,
   Telemetry,
   TelemetryOptions,
@@ -120,7 +120,7 @@ interface OtelStepStartEvent<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends AISDKContext = AISDKContext,
   OUTPUT extends Output = Output,
-> extends OnStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
+> extends GenerateTextStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
   readonly promptMessages?: LanguageModelV4Prompt;
   readonly stepTools?: ReadonlyArray<Record<string, unknown>>;
   readonly stepToolChoice?: unknown;
@@ -184,7 +184,7 @@ export class GenAIOpenTelemetry implements Telemetry {
 
   onStart(
     event:
-      | InferTelemetryEvent<OnStartEvent>
+      | InferTelemetryEvent<GenerateTextStartEvent>
       | InferTelemetryEvent<ObjectOnStartEvent>
       | InferTelemetryEvent<EmbedOnStartEvent>
       | InferTelemetryEvent<RerankOnStartEvent>,
@@ -216,10 +216,12 @@ export class GenAIOpenTelemetry implements Telemetry {
       return;
     }
 
-    this.onGenerateStart(event as InferTelemetryEvent<OnStartEvent>);
+    this.onGenerateStart(event as InferTelemetryEvent<GenerateTextStartEvent>);
   }
 
-  private onGenerateStart(event: InferTelemetryEvent<OnStartEvent>): void {
+  private onGenerateStart(
+    event: InferTelemetryEvent<GenerateTextStartEvent>,
+  ): void {
     const telemetry: TelemetryOptions = {
       recordInputs: event.recordInputs,
       recordOutputs: event.recordOutputs,
@@ -630,7 +632,7 @@ export class GenAIOpenTelemetry implements Telemetry {
     state.toolSpans.delete(event.toolCall.toolCallId);
   }
 
-  onStepFinish(event: OnStepFinishEvent<ToolSet>): void {
+  onStepFinish(event: GenerateTextStepEndEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state?.stepSpan || !state.inferenceSpan) return;
 
@@ -674,7 +676,7 @@ export class GenAIOpenTelemetry implements Telemetry {
 
   onFinish(
     event:
-      | OnFinishEvent<ToolSet>
+      | GenerateTextEndEvent<ToolSet>
       | ObjectOnFinishEvent<unknown>
       | EmbedOnFinishEvent
       | RerankOnFinishEvent,
@@ -703,10 +705,10 @@ export class GenAIOpenTelemetry implements Telemetry {
       return;
     }
 
-    this.onGenerateFinish(event as OnFinishEvent<ToolSet>);
+    this.onGenerateFinish(event as GenerateTextEndEvent<ToolSet>);
   }
 
-  private onGenerateFinish(event: OnFinishEvent<ToolSet>): void {
+  private onGenerateFinish(event: GenerateTextEndEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 
@@ -787,7 +789,7 @@ export class GenAIOpenTelemetry implements Telemetry {
     this.cleanupCallState(event.callId);
   }
 
-  onEmbedStart(event: EmbedStartEvent): void {
+  onEmbedStart(event: EmbeddingModelCallStartEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan || !state.rootContext) return;
 
@@ -814,7 +816,7 @@ export class GenAIOpenTelemetry implements Telemetry {
     });
   }
 
-  onEmbedFinish(event: EmbedFinishEvent): void {
+  onEmbedFinish(event: EmbeddingModelCallEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state) return;
 
@@ -888,7 +890,7 @@ export class GenAIOpenTelemetry implements Telemetry {
     this.cleanupCallState(event.callId);
   }
 
-  onRerankStart(event: RerankStartEvent): void {
+  onRerankStart(event: RerankingModelCallStartEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan || !state.rootContext) return;
 
@@ -912,7 +914,7 @@ export class GenAIOpenTelemetry implements Telemetry {
     state.rerankSpan = { span: rerankSpan, context: rerankContext };
   }
 
-  onRerankFinish(event: RerankFinishEvent): void {
+  onRerankFinish(event: RerankingModelCallEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rerankSpan) return;
 
@@ -922,7 +924,7 @@ export class GenAIOpenTelemetry implements Telemetry {
     state.rerankSpan = undefined;
   }
 
-  onChunk(_event: OnChunkEvent<ToolSet>): void {
+  onChunk(_event: ChunkEvent<ToolSet>): void {
     // No-op: streaming chunk events are not part of the GenAI SemConv.
   }
 

--- a/packages/otel/src/gen-ai-open-telemetry.ts
+++ b/packages/otel/src/gen-ai-open-telemetry.ts
@@ -16,10 +16,10 @@ import type {
   EmbedEndEvent,
   EmbedStartEvent,
   EmbeddingModelCallStartEvent,
-  ObjectOnFinishEvent,
-  ObjectOnStartEvent,
-  ObjectOnStepFinishEvent,
-  ObjectOnStepStartEvent,
+  GenerateObjectEndEvent,
+  GenerateObjectStartEvent,
+  GenerateObjectStepEndEvent,
+  GenerateObjectStepStartEvent,
   ChunkEvent,
   GenerateTextEndEvent,
   GenerateTextStartEvent,
@@ -185,7 +185,7 @@ export class GenAIOpenTelemetry implements Telemetry {
   onStart(
     event:
       | InferTelemetryEvent<GenerateTextStartEvent>
-      | InferTelemetryEvent<ObjectOnStartEvent>
+      | InferTelemetryEvent<GenerateObjectStartEvent>
       | InferTelemetryEvent<EmbedStartEvent>
       | InferTelemetryEvent<RerankStartEvent>,
   ): void {
@@ -209,7 +209,7 @@ export class GenAIOpenTelemetry implements Telemetry {
       event.operationId === 'ai.streamObject'
     ) {
       this.onObjectOperationStart(
-        event as InferTelemetryEvent<ObjectOnStartEvent>,
+        event as InferTelemetryEvent<GenerateObjectStartEvent>,
       );
       return;
     }
@@ -299,7 +299,7 @@ export class GenAIOpenTelemetry implements Telemetry {
   }
 
   private onObjectOperationStart(
-    event: InferTelemetryEvent<ObjectOnStartEvent>,
+    event: InferTelemetryEvent<GenerateObjectStartEvent>,
   ): void {
     const telemetry: TelemetryOptions = {
       recordInputs: event.recordInputs,
@@ -379,7 +379,7 @@ export class GenAIOpenTelemetry implements Telemetry {
   }
 
   /** @deprecated */
-  onObjectStepStart(event: ObjectOnStepStartEvent): void {
+  onObjectStepStart(event: GenerateObjectStepStartEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan || !state.rootContext) return;
 
@@ -426,7 +426,7 @@ export class GenAIOpenTelemetry implements Telemetry {
   }
 
   /** @deprecated */
-  onObjectStepFinish(event: ObjectOnStepFinishEvent): void {
+  onObjectStepFinish(event: GenerateObjectStepEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.inferenceSpan) return;
 
@@ -675,7 +675,7 @@ export class GenAIOpenTelemetry implements Telemetry {
   onFinish(
     event:
       | GenerateTextEndEvent<ToolSet>
-      | ObjectOnFinishEvent<unknown>
+      | GenerateObjectEndEvent<unknown>
       | EmbedEndEvent
       | RerankEndEvent,
   ): void {
@@ -699,7 +699,7 @@ export class GenAIOpenTelemetry implements Telemetry {
       state.operationId === 'ai.generateObject' ||
       state.operationId === 'ai.streamObject'
     ) {
-      this.onObjectOperationFinish(event as ObjectOnFinishEvent<unknown>);
+      this.onObjectOperationFinish(event as GenerateObjectEndEvent<unknown>);
       return;
     }
 
@@ -741,7 +741,9 @@ export class GenAIOpenTelemetry implements Telemetry {
     this.cleanupCallState(event.callId);
   }
 
-  private onObjectOperationFinish(event: ObjectOnFinishEvent<unknown>): void {
+  private onObjectOperationFinish(
+    event: GenerateObjectEndEvent<unknown>,
+  ): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -12,8 +12,8 @@ import {
 } from '@opentelemetry/api';
 import type {
   EmbeddingModelCallEndEvent,
-  EmbedOnFinishEvent,
-  EmbedOnStartEvent,
+  EmbedEndEvent,
+  EmbedStartEvent,
   EmbeddingModelCallStartEvent,
   ObjectOnFinishEvent,
   ObjectOnStartEvent,
@@ -28,8 +28,8 @@ import type {
   ToolExecutionStartEvent,
   OutputInterface as Output,
   RerankingModelCallEndEvent,
-  RerankOnFinishEvent,
-  RerankOnStartEvent,
+  RerankEndEvent,
+  RerankStartEvent,
   RerankingModelCallStartEvent,
   InferTelemetryEvent,
   Telemetry,
@@ -179,22 +179,20 @@ export class OpenTelemetry implements Telemetry {
     event:
       | InferTelemetryEvent<GenerateTextStartEvent>
       | InferTelemetryEvent<ObjectOnStartEvent>
-      | InferTelemetryEvent<EmbedOnStartEvent>
-      | InferTelemetryEvent<RerankOnStartEvent>,
+      | InferTelemetryEvent<EmbedStartEvent>
+      | InferTelemetryEvent<RerankStartEvent>,
   ): void {
     if (
       event.operationId === 'ai.embed' ||
       event.operationId === 'ai.embedMany'
     ) {
-      this.onEmbedOperationStart(
-        event as InferTelemetryEvent<EmbedOnStartEvent>,
-      );
+      this.onEmbedOperationStart(event as InferTelemetryEvent<EmbedStartEvent>);
       return;
     }
 
     if (event.operationId === 'ai.rerank') {
       this.onRerankOperationStart(
-        event as InferTelemetryEvent<RerankOnStartEvent>,
+        event as InferTelemetryEvent<RerankStartEvent>,
       );
       return;
     }
@@ -449,7 +447,7 @@ export class OpenTelemetry implements Telemetry {
   }
 
   private onEmbedOperationStart(
-    event: InferTelemetryEvent<EmbedOnStartEvent>,
+    event: InferTelemetryEvent<EmbedStartEvent>,
   ): void {
     const telemetry: TelemetryOptions = {
       recordInputs: event.recordInputs,
@@ -720,8 +718,8 @@ export class OpenTelemetry implements Telemetry {
     event:
       | GenerateTextEndEvent<ToolSet>
       | ObjectOnFinishEvent<unknown>
-      | EmbedOnFinishEvent
-      | RerankOnFinishEvent,
+      | EmbedEndEvent
+      | RerankEndEvent,
   ): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
@@ -730,12 +728,12 @@ export class OpenTelemetry implements Telemetry {
       state.operationId === 'ai.embed' ||
       state.operationId === 'ai.embedMany'
     ) {
-      this.onEmbedOperationFinish(event as EmbedOnFinishEvent);
+      this.onEmbedOperationFinish(event as EmbedEndEvent);
       return;
     }
 
     if (state.operationId === 'ai.rerank') {
-      this.onRerankOperationFinish(event as RerankOnFinishEvent);
+      this.onRerankOperationFinish(event as RerankEndEvent);
       return;
     }
 
@@ -850,7 +848,7 @@ export class OpenTelemetry implements Telemetry {
     this.cleanupCallState(event.callId);
   }
 
-  private onEmbedOperationFinish(event: EmbedOnFinishEvent): void {
+  private onEmbedOperationFinish(event: EmbedEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 
@@ -934,7 +932,7 @@ export class OpenTelemetry implements Telemetry {
   }
 
   private onRerankOperationStart(
-    event: InferTelemetryEvent<RerankOnStartEvent>,
+    event: InferTelemetryEvent<RerankStartEvent>,
   ): void {
     const telemetry: TelemetryOptions = {
       recordInputs: event.recordInputs,
@@ -982,7 +980,7 @@ export class OpenTelemetry implements Telemetry {
     });
   }
 
-  private onRerankOperationFinish(event: RerankOnFinishEvent): void {
+  private onRerankOperationFinish(event: RerankEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -11,26 +11,26 @@ import {
   Tracer,
 } from '@opentelemetry/api';
 import type {
-  EmbedFinishEvent,
+  EmbeddingModelCallEndEvent,
   EmbedOnFinishEvent,
   EmbedOnStartEvent,
-  EmbedStartEvent,
+  EmbeddingModelCallStartEvent,
   ObjectOnFinishEvent,
   ObjectOnStartEvent,
   ObjectOnStepFinishEvent,
   ObjectOnStepStartEvent,
-  OnChunkEvent,
-  OnFinishEvent,
-  OnStartEvent,
-  OnStepFinishEvent,
-  OnStepStartEvent,
+  ChunkEvent,
+  GenerateTextEndEvent,
+  GenerateTextStartEvent,
+  GenerateTextStepEndEvent,
+  GenerateTextStepStartEvent,
   ToolExecutionEndEvent,
   ToolExecutionStartEvent,
   OutputInterface as Output,
-  RerankFinishEvent,
+  RerankingModelCallEndEvent,
   RerankOnFinishEvent,
   RerankOnStartEvent,
-  RerankStartEvent,
+  RerankingModelCallStartEvent,
   InferTelemetryEvent,
   Telemetry,
   TelemetryOptions,
@@ -113,7 +113,7 @@ interface OtelStepStartEvent<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends AISDKContext = AISDKContext,
   OUTPUT extends Output = Output,
-> extends OnStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
+> extends GenerateTextStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
   readonly promptMessages?: LanguageModelV4Prompt;
   readonly stepTools?: ReadonlyArray<Record<string, unknown>>;
   readonly stepToolChoice?: unknown;
@@ -177,7 +177,7 @@ export class OpenTelemetry implements Telemetry {
 
   onStart(
     event:
-      | InferTelemetryEvent<OnStartEvent>
+      | InferTelemetryEvent<GenerateTextStartEvent>
       | InferTelemetryEvent<ObjectOnStartEvent>
       | InferTelemetryEvent<EmbedOnStartEvent>
       | InferTelemetryEvent<RerankOnStartEvent>,
@@ -209,10 +209,12 @@ export class OpenTelemetry implements Telemetry {
       return;
     }
 
-    this.onGenerateStart(event as InferTelemetryEvent<OnStartEvent>);
+    this.onGenerateStart(event as InferTelemetryEvent<GenerateTextStartEvent>);
   }
 
-  private onGenerateStart(event: InferTelemetryEvent<OnStartEvent>): void {
+  private onGenerateStart(
+    event: InferTelemetryEvent<GenerateTextStartEvent>,
+  ): void {
     const telemetry: TelemetryOptions = {
       recordInputs: event.recordInputs,
       recordOutputs: event.recordOutputs,
@@ -633,7 +635,7 @@ export class OpenTelemetry implements Telemetry {
     state.toolSpans.delete(event.toolCall.toolCallId);
   }
 
-  onStepFinish(event: OnStepFinishEvent<ToolSet>): void {
+  onStepFinish(event: GenerateTextStepEndEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state?.stepSpan) return;
 
@@ -716,7 +718,7 @@ export class OpenTelemetry implements Telemetry {
 
   onFinish(
     event:
-      | OnFinishEvent<ToolSet>
+      | GenerateTextEndEvent<ToolSet>
       | ObjectOnFinishEvent<unknown>
       | EmbedOnFinishEvent
       | RerankOnFinishEvent,
@@ -745,10 +747,10 @@ export class OpenTelemetry implements Telemetry {
       return;
     }
 
-    this.onGenerateFinish(event as OnFinishEvent<ToolSet>);
+    this.onGenerateFinish(event as GenerateTextEndEvent<ToolSet>);
   }
 
-  private onGenerateFinish(event: OnFinishEvent<ToolSet>): void {
+  private onGenerateFinish(event: GenerateTextEndEvent<ToolSet>): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 
@@ -877,7 +879,7 @@ export class OpenTelemetry implements Telemetry {
     this.cleanupCallState(event.callId);
   }
 
-  onEmbedStart(event: EmbedStartEvent): void {
+  onEmbedStart(event: EmbeddingModelCallStartEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan || !state.rootContext) return;
 
@@ -907,7 +909,7 @@ export class OpenTelemetry implements Telemetry {
     });
   }
 
-  onEmbedFinish(event: EmbedFinishEvent): void {
+  onEmbedFinish(event: EmbeddingModelCallEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state) return;
 
@@ -988,7 +990,7 @@ export class OpenTelemetry implements Telemetry {
     this.cleanupCallState(event.callId);
   }
 
-  onRerankStart(event: RerankStartEvent): void {
+  onRerankStart(event: RerankingModelCallStartEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan || !state.rootContext) return;
 
@@ -1015,7 +1017,7 @@ export class OpenTelemetry implements Telemetry {
     state.rerankSpan = { span: rerankSpan, context: rerankContext };
   }
 
-  onRerankFinish(event: RerankFinishEvent): void {
+  onRerankFinish(event: RerankingModelCallEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rerankSpan) return;
 
@@ -1035,7 +1037,7 @@ export class OpenTelemetry implements Telemetry {
     state.rerankSpan = undefined;
   }
 
-  onChunk(event: OnChunkEvent<ToolSet>): void {
+  onChunk(event: ChunkEvent<ToolSet>): void {
     const chunk = event.chunk as {
       type: string;
       callId?: unknown;

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -15,10 +15,10 @@ import type {
   EmbedEndEvent,
   EmbedStartEvent,
   EmbeddingModelCallStartEvent,
-  ObjectOnFinishEvent,
-  ObjectOnStartEvent,
-  ObjectOnStepFinishEvent,
-  ObjectOnStepStartEvent,
+  GenerateObjectEndEvent,
+  GenerateObjectStartEvent,
+  GenerateObjectStepEndEvent,
+  GenerateObjectStepStartEvent,
   ChunkEvent,
   GenerateTextEndEvent,
   GenerateTextStartEvent,
@@ -178,7 +178,7 @@ export class OpenTelemetry implements Telemetry {
   onStart(
     event:
       | InferTelemetryEvent<GenerateTextStartEvent>
-      | InferTelemetryEvent<ObjectOnStartEvent>
+      | InferTelemetryEvent<GenerateObjectStartEvent>
       | InferTelemetryEvent<EmbedStartEvent>
       | InferTelemetryEvent<RerankStartEvent>,
   ): void {
@@ -202,7 +202,7 @@ export class OpenTelemetry implements Telemetry {
       event.operationId === 'ai.streamObject'
     ) {
       this.onObjectOperationStart(
-        event as InferTelemetryEvent<ObjectOnStartEvent>,
+        event as InferTelemetryEvent<GenerateObjectStartEvent>,
       );
       return;
     }
@@ -275,7 +275,7 @@ export class OpenTelemetry implements Telemetry {
   }
 
   private onObjectOperationStart(
-    event: InferTelemetryEvent<ObjectOnStartEvent>,
+    event: InferTelemetryEvent<GenerateObjectStartEvent>,
   ): void {
     const telemetry: TelemetryOptions = {
       recordInputs: event.recordInputs,
@@ -342,7 +342,7 @@ export class OpenTelemetry implements Telemetry {
   }
 
   /** @deprecated */
-  onObjectStepStart(event: ObjectOnStepStartEvent): void {
+  onObjectStepStart(event: GenerateObjectStepStartEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan || !state.rootContext) return;
 
@@ -393,7 +393,7 @@ export class OpenTelemetry implements Telemetry {
   }
 
   /** @deprecated */
-  onObjectStepFinish(event: ObjectOnStepFinishEvent): void {
+  onObjectStepFinish(event: GenerateObjectStepEndEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.stepSpan) return;
 
@@ -717,7 +717,7 @@ export class OpenTelemetry implements Telemetry {
   onFinish(
     event:
       | GenerateTextEndEvent<ToolSet>
-      | ObjectOnFinishEvent<unknown>
+      | GenerateObjectEndEvent<unknown>
       | EmbedEndEvent
       | RerankEndEvent,
   ): void {
@@ -741,7 +741,7 @@ export class OpenTelemetry implements Telemetry {
       state.operationId === 'ai.generateObject' ||
       state.operationId === 'ai.streamObject'
     ) {
-      this.onObjectOperationFinish(event as ObjectOnFinishEvent<unknown>);
+      this.onObjectOperationFinish(event as GenerateObjectEndEvent<unknown>);
       return;
     }
 
@@ -819,7 +819,9 @@ export class OpenTelemetry implements Telemetry {
     this.cleanupCallState(event.callId);
   }
 
-  private onObjectOperationFinish(event: ObjectOnFinishEvent<unknown>): void {
+  private onObjectOperationFinish(
+    event: GenerateObjectEndEvent<unknown>,
+  ): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan) return;
 

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -546,7 +546,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
 
       // GAP: WorkflowAgent's onStart event doesn't include system, temperature,
       // maxOutputTokens, experimental_context, or resolved model yet.
-      // These fields need to be added to match ToolLoopAgent's OnStartEvent.
+      // These fields need to be added to match ToolLoopAgent's GenerateTextStartEvent.
       it('should pass correct event information', async () => {
         let startEvent!: any;
 
@@ -725,7 +725,7 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
 
       // GAP: WorkflowAgent's onStepStart event doesn't include system,
       // experimental_context, or resolved model yet.
-      // These fields need to be added to match ToolLoopAgent's OnStepStartEvent.
+      // These fields need to be added to match ToolLoopAgent's GenerateTextStepStartEvent.
       it('should pass correct event information', async () => {
         let stepStartEvent!: any;
 


### PR DESCRIPTION
## Background

we had to rename the event names to align with a proper nomenclature across the codebase

## Summary

Generate Text events
- OnStartEvent -> GenerateTextStartEvent
- OnStepStartEvent -> GenerateTextStepStartEvent
- OnChunkEvent -> ChunkEvent
- OnStepFinishEvent -> GenerateTextStepEndEvent
- OnFinishEvent -> GenerateTextEndEvent

Rerank Events
- RerankOnStartEvent -> RerankStartEvent
- RerankOnFinishEvent -> RerankEndEvent
- RerankStartEvent -> RerankingModelCallStartEvent
- RerankFinishEvent -> RerankingModelCallEndEvent

Embed Events
- EmbedOnStartEvent -> EmbedStartEvent
- EmbedOnFinishEvent -> EmbedEndEvent
- EmbedStartEvent -> EmbeddingModelCallStartEvent
- EmbedFinishEvent -> EmbeddingModelCallEndEvent

## Manual Verification

na

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)