### PR TITLE
chore(provider/google): update available models

### DIFF
--- a/.changeset/add-google-deep-research-models.md
+++ b/.changeset/add-google-deep-research-models.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+chore(provider/google): update available models

--- a/packages/google/src/google-options.ts
+++ b/packages/google/src/google-options.ts
@@ -32,6 +32,8 @@ export type GoogleModelId =
   | 'gemini-flash-latest'
   | 'gemini-flash-lite-latest'
   | 'deep-research-pro-preview-12-2025'
+  | 'deep-research-max-preview-04-2026'
+  | 'deep-research-preview-04-2026'
   | 'nano-banana-pro-preview'
   | 'aqa'
   // Experimental models


### PR DESCRIPTION
## Background

Routine model list maintenance for the Google provider:
- Add new `deep-research-max-preview-04-2026` model
- Add new `deep-research-preview-04-2026` model

Gateway doesn't support these, so no changes to the Gateway model lists are needed.

## Manual Verification

N/A

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Fixes #14670