### PR TITLE
fix(xai): strip additionalProperties from tool schemas for xAI compatibility

### DIFF
--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -263,7 +263,6 @@ describe('XaiChatLanguageModel', () => {
                 "name": "test-tool",
                 "parameters": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
-                  "additionalProperties": false,
                   "properties": {
                     "value": {
                       "type": "string",

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -36,7 +36,7 @@ import {
   type XaiChatModelId,
 } from './xai-chat-options';
 import { xaiFailedResponseHandler } from './xai-error';
-import { prepareTools } from './xai-prepare-tools';
+import { prepareTools, removeAdditionalProperties } from './xai-prepare-tools';
 
 type XaiChatConfig = {
   provider: string;
@@ -182,7 +182,7 @@ export class XaiChatLanguageModel implements LanguageModelV4 {
                 type: 'json_schema',
                 json_schema: {
                   name: responseFormat.name ?? 'response',
-                  schema: responseFormat.schema,
+                  schema: removeAdditionalProperties(responseFormat.schema),
                   strict: true,
                 },
               }

--- a/packages/xai/src/xai-prepare-tools.test.ts
+++ b/packages/xai/src/xai-prepare-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { prepareTools } from './xai-prepare-tools';
+import { prepareTools, removeAdditionalProperties } from './xai-prepare-tools';
 
 describe('prepareTools', () => {
   it('should return undefined tools and toolChoice when tools are undefined', () => {
@@ -352,6 +352,77 @@ describe('prepareTools', () => {
           ],
         }
       `);
+    });
+  });
+});
+
+describe('removeAdditionalProperties', () => {
+  it('should remove additionalProperties from top-level object schema', () => {
+    const result = removeAdditionalProperties({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+      additionalProperties: false,
+    });
+    expect(result).toEqual({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    });
+  });
+
+  it('should remove additionalProperties from nested object schemas', () => {
+    const result = removeAdditionalProperties({
+      type: 'object',
+      properties: {
+        address: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+          additionalProperties: false,
+        },
+      },
+      additionalProperties: false,
+    });
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        address: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+        },
+      },
+    });
+  });
+
+  it('should handle schemas without additionalProperties', () => {
+    const schema = {
+      type: 'object' as const,
+      properties: { name: { type: 'string' as const } },
+    };
+    const result = removeAdditionalProperties(schema);
+    expect(result).toEqual(schema);
+  });
+
+  it('should strip additionalProperties from tool parameters in prepareTools', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'test',
+          description: 'test',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+          },
+        },
+      ],
+    });
+    expect(result.tools![0].function.parameters).toEqual({
+      type: 'object',
+      properties: { value: { type: 'string' } },
+      required: ['value'],
     });
   });
 });

--- a/packages/xai/src/xai-prepare-tools.ts
+++ b/packages/xai/src/xai-prepare-tools.ts
@@ -1,4 +1,5 @@
 import {
+  JSONSchema7,
   UnsupportedFunctionalityError,
   type LanguageModelV4CallOptions,
   type SharedV4Warning,
@@ -58,7 +59,7 @@ export function prepareTools({
         function: {
           name: tool.name,
           description: tool.description,
-          parameters: tool.inputSchema,
+          parameters: removeAdditionalProperties(tool.inputSchema as JSONSchema7),
           ...(tool.strict != null ? { strict: tool.strict } : {}),
         },
       });
@@ -95,4 +96,70 @@ export function prepareTools({
       });
     }
   }
+}
+
+/**
+ * xAI rejects schemas containing `additionalProperties: false` because it
+ * treats `false` as an unsupported boolean property schema.  The AI SDK's
+ * `addAdditionalPropertiesToJsonSchema` adds this field globally, so we
+ * strip it here before sending to xAI.
+ *
+ * @see https://docs.x.ai/docs/guides/structured-outputs
+ */
+export function removeAdditionalProperties(schema: JSONSchema7): JSONSchema7 {
+  if (schema == null || typeof schema !== 'object') {
+    return schema;
+  }
+
+  const result = { ...schema };
+
+  if ('additionalProperties' in result) {
+    delete result.additionalProperties;
+  }
+
+  if (result.properties != null) {
+    result.properties = Object.fromEntries(
+      Object.entries(result.properties).map(([key, value]) => [
+        key,
+        typeof value === 'object' && value !== null
+          ? removeAdditionalProperties(value as JSONSchema7)
+          : value,
+      ]),
+    );
+  }
+
+  if (result.items != null) {
+    result.items = Array.isArray(result.items)
+      ? result.items.map(item =>
+          typeof item === 'object' && item !== null
+            ? removeAdditionalProperties(item as JSONSchema7)
+            : item,
+        )
+      : typeof result.items === 'object' && result.items !== null
+        ? removeAdditionalProperties(result.items as JSONSchema7)
+        : result.items;
+  }
+
+  for (const keyword of ['anyOf', 'allOf', 'oneOf'] as const) {
+    if (result[keyword] != null) {
+      result[keyword] = (result[keyword] as JSONSchema7[]).map(s =>
+        typeof s === 'object' && s !== null
+          ? removeAdditionalProperties(s as JSONSchema7)
+          : s,
+      );
+    }
+  }
+
+  if (result.definitions != null) {
+    result.definitions = Object.fromEntries(
+      Object.entries(result.definitions).map(([key, value]) => [
+        key,
+        typeof value === 'object' && value !== null
+          ? removeAdditionalProperties(value as JSONSchema7)
+          : value,
+      ]),
+    );
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Summary

Fixes #14678

xAI's validator rejects `additionalProperties: false` in tool schemas, treating `false` as an unsupported boolean property schema. The AI SDK's `addAdditionalPropertiesToJsonSchema` in `@ai-sdk/provider-utils` adds this field globally for all providers, which breaks xAI/Grok tool calling with:

```
[xAI] Invalid request content: Schema validation failed: [standard_violation]
/properties/properties/additionalProperties: property schema 'false' is not supported
```

## Changes

Added a `removeAdditionalProperties` helper in the xAI provider (`packages/xai/src/xai-prepare-tools.ts`) that recursively strips `additionalProperties` from schemas before sending to the xAI API. Applied to:
- Tool parameter schemas in `prepareTools()`
- Response format schemas in `xai-chat-language-model.ts`

This is a provider-level fix that doesn't affect other providers. xAI defaults `additionalProperties` to `false` already, so removing it is semantically equivalent.

## Testing

- Added unit tests for `removeAdditionalProperties` (top-level, nested, no-op cases)
- Added integration test verifying `prepareTools` strips the field from tool parameters
- Updated inline snapshot in `xai-chat-language-model.test.ts` to reflect the change

Note: Unable to run the full test suite locally (pnpm install OOMs on this machine), relying on CI for full validation.