### PR TITLE
docs(providers): add QuickSilver Pro to OpenAI-compatible providers

### DIFF
--- a/content/providers/02-openai-compatible-providers/50-quicksilverpro.mdx
+++ b/content/providers/02-openai-compatible-providers/50-quicksilverpro.mdx
@@ -1,0 +1,124 @@
+---
+title: QuickSilver Pro
+description: Use the QuickSilver Pro OpenAI-compatible API with the AI SDK.
+---
+
+# QuickSilver Pro Provider
+
+[QuickSilver Pro](https://quicksilverpro.io/?ref=VRC7K2M9) provides an OpenAI-compatible API for popular open-source models — DeepSeek V3, DeepSeek R1, and Qwen 3.5 35B A3B. New accounts receive a starter credit on email signup, so you can try the AI SDK integration without a credit card.
+
+## Setup
+
+The QuickSilver Pro provider is available via the `@ai-sdk/openai-compatible` module as it is compatible with the OpenAI API. You can install it with
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+  <Tab>
+    <Snippet text="pnpm add @ai-sdk/openai-compatible" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @ai-sdk/openai-compatible" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @ai-sdk/openai-compatible" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="bun add @ai-sdk/openai-compatible" dark />
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+To use QuickSilver Pro, create an `@ai-sdk/openai-compatible` provider instance pointing at the QSP endpoint:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+
+const quicksilverpro = createOpenAICompatible({
+  name: 'quicksilverpro',
+  baseURL: 'https://api.quicksilverpro.io/v1',
+  apiKey: process.env.QSP_API_KEY,
+});
+```
+
+You can obtain an API key by signing up at [quicksilverpro.io](https://quicksilverpro.io/?ref=VRC7K2M9) and then storing it as `QSP_API_KEY` in your environment.
+
+## Language Models
+
+Use a QSP provider instance to create language models. The first argument is the model id, e.g. `deepseek-v3`.
+
+```ts
+const model = quicksilverpro('deepseek-v3');
+```
+
+The following chat models are currently served:
+
+- `deepseek-v3` — general-purpose, strong at code and conversational tasks
+- `deepseek-r1` — reasoning / chain-of-thought; returns `<think>...</think>` traces
+- `qwen3.5-35b` — Qwen 3.5 35B A3B; strong at long-context and Chinese-language tasks
+
+### Example — `generateText`
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText } from 'ai';
+
+const quicksilverpro = createOpenAICompatible({
+  name: 'quicksilverpro',
+  baseURL: 'https://api.quicksilverpro.io/v1',
+  apiKey: process.env.QSP_API_KEY,
+});
+
+const { text } = await generateText({
+  model: quicksilverpro('deepseek-v3'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+});
+
+console.log(text);
+```
+
+### Example — streaming with `streamText`
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { streamText } from 'ai';
+
+const quicksilverpro = createOpenAICompatible({
+  name: 'quicksilverpro',
+  baseURL: 'https://api.quicksilverpro.io/v1',
+  apiKey: process.env.QSP_API_KEY,
+});
+
+const result = streamText({
+  model: quicksilverpro('deepseek-r1'),
+  prompt: 'Explain the halting problem in three sentences.',
+});
+
+for await (const chunk of result.textStream) {
+  process.stdout.write(chunk);
+}
+```
+
+### Reasoning traces (DeepSeek R1)
+
+`deepseek-r1` emits chain-of-thought reasoning inside `<think>...</think>` tags within the completion text. The AI SDK surfaces this through the standard content channel — parse or strip the wrapper in your application if you want to present only the final answer to users.
+
+### Including model ids for auto-completion
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+
+type QuickSilverProChatModelIds =
+  | 'deepseek-v3'
+  | 'deepseek-r1'
+  | 'qwen3.5-35b'
+  | (string & {});
+
+const quicksilverpro = createOpenAICompatible<QuickSilverProChatModelIds>({
+  name: 'quicksilverpro',
+  baseURL: 'https://api.quicksilverpro.io/v1',
+  apiKey: process.env.QSP_API_KEY,
+});
+
+// Subsequent calls auto-complete the known model ids while still allowing free-form strings.
+const model = quicksilverpro('deepseek-v3');
+```

--- a/content/providers/02-openai-compatible-providers/50-quicksilverpro.mdx
+++ b/content/providers/02-openai-compatible-providers/50-quicksilverpro.mdx
@@ -89,7 +89,7 @@ const quicksilverpro = createOpenAICompatible({
 });
 
 const result = streamText({
-  model: quicksilverpro('deepseek-r1'),
+  model: quicksilverpro('deepseek-v3'),
   prompt: 'Explain the halting problem in three sentences.',
 });
 
@@ -98,9 +98,32 @@ for await (const chunk of result.textStream) {
 }
 ```
 
-### Reasoning traces (DeepSeek R1)
+### Reasoning Models
 
-`deepseek-r1` emits chain-of-thought reasoning inside `<think>...</think>` tags within the completion text. The AI SDK surfaces this through the standard content channel — parse or strip the wrapper in your application if you want to present only the final answer to users.
+QuickSilver Pro exposes the chain-of-thought of `deepseek-r1` in the generated text using the `<think>` tag. Use the `extractReasoningMiddleware` helper to pull the reasoning out and expose it as a separate `reasoning` property on the result:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { wrapLanguageModel, extractReasoningMiddleware, generateText } from 'ai';
+
+const quicksilverpro = createOpenAICompatible({
+  name: 'quicksilverpro',
+  baseURL: 'https://api.quicksilverpro.io/v1',
+  apiKey: process.env.QSP_API_KEY,
+});
+
+const enhancedModel = wrapLanguageModel({
+  model: quicksilverpro('deepseek-r1'),
+  middleware: extractReasoningMiddleware({ tagName: 'think' }),
+});
+
+const { text, reasoningText } = await generateText({
+  model: enhancedModel,
+  prompt: 'Explain the halting problem in three sentences.',
+});
+```
+
+The wrapped model is a drop-in replacement — you can use it with `generateText`, `streamText`, or any other AI SDK function the base provider supports.
 
 ### Including model ids for auto-completion
 

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -15,6 +15,7 @@ We provide detailed documentation for the following OpenAI compatible providers:
 - [NIM](/providers/openai-compatible-providers/nim)
 - [Heroku](/providers/openai-compatible-providers/heroku)
 - [Clarifai](/providers/openai-compatible-providers/clarifai)
+- [QuickSilver Pro](/providers/openai-compatible-providers/quicksilverpro)
 
 The general setup and provider instance creation is the same for all of these providers.
 


### PR DESCRIPTION
## What

Adds **QuickSilver Pro** to the OpenAI-compatible providers section of the AI SDK docs. Two file changes:

- `content/providers/02-openai-compatible-providers/50-quicksilverpro.mdx` (new) — provider page following the LM Studio / NIM / Heroku / Clarifai template
- `content/providers/02-openai-compatible-providers/index.mdx` — one-line addition to the "detailed documentation" list

Structure mirrors the existing OpenAI-compatible entries exactly: Setup (install `@ai-sdk/openai-compatible`), Provider Instance, Language Models, examples with `generateText` + `streamText`, and typed model-id autocompletion. No code changes to any SDK package.

## Why

[QuickSilver Pro](https://quicksilverpro.io/?ref=VRC7K2M9) exposes DeepSeek V3, DeepSeek R1, and Qwen 3.5 35B A3B behind the OpenAI-compatible Chat Completions API. AI SDK users searching for OSS-model providers that work out of the box with `@ai-sdk/openai-compatible` don't currently have a listed option for these specific models — the closest is Heroku (different use case, requires CLI provisioning) or a custom provider. This page gives them a copy-paste-to-code path.

## Testing

- Built the docs site locally with `pnpm dev` — the page renders correctly under `/providers/openai-compatible-providers/quicksilverpro` and the new entry appears in the parent `index.mdx` list
- Verified the baseURL (`https://api.quicksilverpro.io/v1`) responds with a standard OpenAI-compatible 401 on invalid auth and a 200 on `GET /v1/models` with a valid API key (so `createOpenAICompatible` auto-detection just works)
- `generateText` + `streamText` examples executed end-to-end against the live endpoint during drafting

## Disclosure

I work on QuickSilver Pro. The page links to `https://quicksilverpro.io/?ref=VRC7K2M9`, where the `?ref=` URL param is a channel-attribution tag (no user-side kickback or cost difference — it helps us measure which docs sources drive signups). Happy to strip the `?ref=` parameter if the maintainers prefer clean URLs; flagging proactively.

## Checklist

- [x] New file follows the directory's numbering convention (`50-` slots after `45-clarifai.mdx`/`45-heroku.mdx`)
- [x] Frontmatter format matches sibling files (`title` + `description`)
- [x] Follows existing conventions (Tabs block, Snippet components, code-fence highlights)
- [x] No new SDK code, no new deps
- [x] Atomic — one logical change (single provider listing)
