### PR TITLE
fix: make input-streaming input optional for exactOptionalPropertyTypes compat

### DIFF
--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -282,7 +282,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
 } & (
   | {
       state: 'input-streaming';
-      input: DeepPartial<asUITool<TOOL>['input']> | undefined;
+      input?: DeepPartial<asUITool<TOOL>['input']> | undefined;
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;
@@ -394,7 +394,7 @@ export type DynamicToolUIPart = {
 } & (
   | {
       state: 'input-streaming';
-      input: unknown | undefined;
+      input?: unknown | undefined;
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;


### PR DESCRIPTION
## Summary

Under `exactOptionalPropertyTypes: true`, `input: T | undefined` (required key, value may be undefined) is **not** assignable from `input?: T` (optional key). This breaks consumers whose type pipelines (tRPC, Zod `z.infer`, JSON utility types) produce optional properties when working with `UIMessage`, `UIToolInvocation`, or `DynamicToolUIPart` containing `input-streaming` state parts.

## Changes

Changed both `UIToolInvocation` and `DynamicToolUIPart` `input-streaming` variants from:
```ts
input: T | undefined;  // required key
```
to:
```ts
input?: T | undefined;  // optional key
```

This aligns the type declarations with the runtime validator in `validate-ui-messages.ts`, which already treats `input` as optional for `input-streaming` states (`z.unknown().optional()`).

## Why this is correct

- The runtime validator already accepts missing `input` for `input-streaming` — the types should match
- During input streaming, `input` starts absent and accumulates incrementally, so `input?` is semantically correct
- Backward compatible: existing code that provides `input` explicitly still type-checks

Closes #14703