### PR TITLE
fix(google): omit includeServerSideToolInvocations from Vertex tool_config

### DIFF
--- a/.changeset/fix-vertex-include-server-side-tool-invocations.md
+++ b/.changeset/fix-vertex-include-server-side-tool-invocations.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(google): omit includeServerSideToolInvocations from tool_config on Vertex provider

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -172,6 +172,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
       tools,
       toolChoice,
       modelId: this.modelId,
+      isVertexProvider,
     });
 
     const resolvedThinking = resolveThinkingConfig({

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -852,3 +852,59 @@ it('should use AUTO mode when no tools have strict: true', () => {
     functionCallingConfig: { mode: 'AUTO' },
   });
 });
+
+it('should not include includeServerSideToolInvocations for Vertex provider on Gemini 3', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'testFunction',
+        description: 'A test function',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      {
+        type: 'provider',
+        id: 'google.google_search',
+        name: 'google_search',
+        args: {},
+      },
+    ],
+    modelId: 'gemini-3-flash-preview',
+    isVertexProvider: true,
+  });
+
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'VALIDATED' },
+  });
+  expect(result.toolConfig).not.toHaveProperty(
+    'includeServerSideToolInvocations',
+  );
+  expect(result.toolWarnings).toEqual([]);
+});
+
+it('should include includeServerSideToolInvocations for non-Vertex provider on Gemini 3', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'testFunction',
+        description: 'A test function',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      {
+        type: 'provider',
+        id: 'google.google_search',
+        name: 'google_search',
+        args: {},
+      },
+    ],
+    modelId: 'gemini-3-flash-preview',
+    isVertexProvider: false,
+  });
+
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'VALIDATED' },
+    includeServerSideToolInvocations: true,
+  });
+  expect(result.toolWarnings).toEqual([]);
+});

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -10,10 +10,12 @@ export function prepareTools({
   tools,
   toolChoice,
   modelId,
+  isVertexProvider = false,
 }: {
   tools: LanguageModelV4CallOptions['tools'];
   toolChoice?: LanguageModelV4CallOptions['toolChoice'];
   modelId: GoogleGenerativeAIModelId;
+  isVertexProvider?: boolean;
 }): {
   tools:
     | Array<
@@ -202,10 +204,10 @@ export function prepareTools({
           mode: 'VALIDATED' | 'ANY' | 'NONE';
           allowedFunctionNames?: string[];
         };
-        includeServerSideToolInvocations: true;
+        includeServerSideToolInvocations?: true;
       } = {
         functionCallingConfig: { mode: 'VALIDATED' },
-        includeServerSideToolInvocations: true,
+        ...(!isVertexProvider && { includeServerSideToolInvocations: true }),
       };
 
       if (toolChoice != null) {


### PR DESCRIPTION
## Summary

- Vertex AI rejects the `includeServerSideToolInvocations` field in `tool_config` for Gemini 3.x models with function tools, returning a 400 `INVALID_ARGUMENT` error
- Add an `isVertexProvider` parameter to `prepareTools` (defaults to `false`) and only include `includeServerSideToolInvocations: true` when the provider is not Vertex
- The language model already computes `isVertexProvider` and now passes it through to `prepareTools`

## Test plan

- [x] Added test: `should not include includeServerSideToolInvocations for Vertex provider on Gemini 3`
- [x] Added test: `should include includeServerSideToolInvocations for non-Vertex provider on Gemini 3`
- [x] Existing tests continue to pass (197 tests passing)

Fixes #14655