### PR TITLE
fix(mcp): add onNotification callback to createMCPClient

### DIFF
--- a/.changeset/mcp-onnotification-callback.md
+++ b/.changeset/mcp-onnotification-callback.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+added `onNotification` option to `createMCPClient` so server-initiated notifications (e.g. `notifications/message` log events) are forwarded to the caller instead of silently dropped

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -11,8 +11,9 @@ Creates a lightweight Model Context Protocol (MCP) client that connects to an MC
 - **Resources**: Methods to list, read, and discover resource templates from MCP servers
 - **Prompts**: Methods to list available prompts and retrieve prompt messages
 - **Elicitation**: Support for handling server requests for additional input during tool execution
+- **Notifications**: Optional callback to receive server-initiated notifications (e.g. log events via `notifications/message`)
 
-It currently does not support accepting notifications from an MCP server, and custom configuration of the client.
+It currently does not support custom configuration of the client.
 
 ## Import
 

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -138,6 +138,13 @@ It currently does not support accepting notifications from an MCP server, and cu
               description: 'Handler for uncaught errors',
             },
             {
+              name: 'onNotification',
+              type: '(notification: JSONRPCNotification) => void',
+              isOptional: true,
+              description:
+                'Handler for server-initiated notifications (e.g. notifications/message for server log events). When omitted, notifications are silently dropped.',
+            },
+            {
               name: 'capabilities',
               type: 'ClientCapabilities',
               isOptional: true,

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -1082,6 +1082,41 @@ describe('MCPClient', () => {
     expect(onUncaughtError).toHaveBeenCalled();
   });
 
+  it('should call onNotification when server sends a notification', async () => {
+    const onNotification = vi.fn();
+    const mockTransport = new MockMCPTransport();
+    createMockTransport.mockImplementation(() => mockTransport);
+    client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+      onNotification,
+    });
+
+    const notification = {
+      jsonrpc: '2.0' as const,
+      method: 'notifications/message',
+      params: { level: 'info', data: 'tool started' },
+    };
+    mockTransport.onmessage?.(notification);
+
+    expect(onNotification).toHaveBeenCalledWith(notification);
+  });
+
+  it('should not error when server sends a notification without onNotification', async () => {
+    const mockTransport = new MockMCPTransport();
+    createMockTransport.mockImplementation(() => mockTransport);
+    client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+    });
+
+    expect(() => {
+      mockTransport.onmessage?.({
+        jsonrpc: '2.0',
+        method: 'notifications/message',
+        params: { level: 'info', data: 'tool started' },
+      });
+    }).not.toThrow();
+  });
+
   it('should support custom transports', async () => {
     const mockTransport = new MockMCPTransport();
     client = await createMCPClient({

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -109,6 +109,11 @@ export interface MCPClientConfig {
    * NOTE: It is up to the client application to handle the requests properly. This parameter just helps surface the request from the server
    */
   capabilities?: ClientCapabilities;
+  /**
+   * Optional callback for server-initiated notifications (e.g. notifications/message for server logs).
+   * Called with the raw JSON-RPC notification message whenever the server sends one.
+   */
+  onNotification?: (notification: JSONRPCNotification) => void;
 }
 
 export async function createMCPClient(
@@ -193,13 +198,13 @@ export interface MCPClient {
  * This client is meant to be used to communicate with a single server. To communicate and fetch tools across multiple servers, it's recommended to create a new client instance per server.
  *
  * Not supported:
- * - Accepting notifications
  * - Session management (when passing a sessionId to an instance of the Streamable HTTP transport)
  * - Resumable SSE streams
  */
 class DefaultMCPClient implements MCPClient {
   private transport: MCPTransport;
   private onUncaughtError?: (error: unknown) => void;
+  private onNotification?: (notification: JSONRPCNotification) => void;
   private clientInfo: ClientConfiguration;
   private clientCapabilities: ClientCapabilities;
   private requestMessageId = 0;
@@ -219,9 +224,11 @@ class DefaultMCPClient implements MCPClient {
     name = 'ai-sdk-mcp-client',
     version = CLIENT_VERSION,
     onUncaughtError,
+    onNotification,
     capabilities,
   }: MCPClientConfig) {
     this.onUncaughtError = onUncaughtError;
+    this.onNotification = onNotification;
     this.clientCapabilities = capabilities ?? {};
 
     if (isCustomMcpTransport(transportConfig)) {
@@ -237,11 +244,7 @@ class DefaultMCPClient implements MCPClient {
         if ('id' in message) {
           this.onRequestMessage(message);
         } else {
-          this.onError(
-            new MCPClientError({
-              message: 'Unsupported message type',
-            }),
-          );
+          this.onNotification?.(message);
         }
         return;
       }


### PR DESCRIPTION
## Background

`DefaultMCPClient` takes full ownership of `transport.onmessage` in its constructor. Any `onmessage` handler set on the transport config is overwritten before the user's code can see it.

The transport's message router distinguishes three message types: responses (have no `method`), requests (have `method` + `id`), and notifications (have `method`, no `id`). Notifications — things like `notifications/message` from FastMCP's `log.info()` — were falling through to `onUncaughtError` with "Unsupported message type", or being silently dropped when `onUncaughtError` wasn't set.

## Summary

- Add `onNotification?: (notification: JSONRPCNotification) => void` to `MCPClientConfig`
- In the transport message router, call `this.onNotification?.(message)` when a notification arrives instead of routing to `onError`
- When `onNotification` is not set, notifications are quietly dropped (no error thrown)
- Document the new option in the `createMCPClient` reference page

## Test plan

- [x] `onNotification` is called when the server sends a notification
- [x] No error is thrown when a notification arrives and `onNotification` is not set
- [x] `pnpm test:node` in `packages/mcp` — 181 tests pass

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features — run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

Fixes #14693