### PR TITLE
fix(ai): download assistant file URLs during prompt conversion

### DIFF
--- a/.changeset/fresh-paths-resolve.md
+++ b/.changeset/fresh-paths-resolve.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): download assistant file URLs during prompt conversion

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -953,6 +953,90 @@ describe('convertToLanguageModelPrompt', () => {
     });
   });
 
+  describe('assistant message', () => {
+    it('should download file URLs for assistant file parts when the model does not support the URL', async () => {
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'file',
+                  data: 'https://example.com/document.pdf',
+                  mediaType: 'application/pdf',
+                  filename: 'document.pdf',
+                },
+              ],
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: createDefaultDownloadFunction(async ({ url }) => {
+          expect(url).toEqual(new URL('https://example.com/document.pdf'));
+          return {
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'application/pdf',
+          };
+        }),
+      });
+
+      expect(result).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'application/pdf',
+              filename: 'document.pdf',
+              data: new Uint8Array([0, 1, 2, 3]),
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should download file URLs for assistant reasoning-file parts when the model does not support the URL', async () => {
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          messages: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'reasoning-file',
+                  data: new URL('https://example.com/reasoning.pdf'),
+                  mediaType: 'application/pdf',
+                },
+              ],
+            },
+          ],
+        },
+        supportedUrls: {},
+        download: createDefaultDownloadFunction(async ({ url }) => {
+          expect(url).toEqual(new URL('https://example.com/reasoning.pdf'));
+          return {
+            data: new Uint8Array([4, 5, 6, 7]),
+            mediaType: 'application/pdf',
+          };
+        }),
+      });
+
+      expect(result).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning-file',
+              mediaType: 'application/pdf',
+              data: new Uint8Array([4, 5, 6, 7]),
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
   describe('tool message', () => {
     it('should combine 2 consecutive tool messages into a single tool message', async () => {
       const result = await convertToLanguageModelPrompt({

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -283,14 +283,24 @@ export function convertToLanguageModelMessage({
                     providerOptions,
                   };
                 }
-                const { data, mediaType } = convertToLanguageModelV4DataContent(
-                  part.data,
-                );
+                const { data: convertedData, mediaType: convertedMediaType } =
+                  convertToLanguageModelV4DataContent(part.data);
+                let data = convertedData;
+                let mediaType = convertedMediaType ?? part.mediaType;
+
+                if (data instanceof URL) {
+                  const downloadedFile = downloadedAssets[data.toString()];
+                  if (downloadedFile) {
+                    data = downloadedFile.data;
+                    mediaType ??= downloadedFile.mediaType;
+                  }
+                }
+
                 return {
                   type: 'file' as const,
                   data,
                   filename: part.filename,
-                  mediaType: mediaType ?? part.mediaType,
+                  mediaType,
                   providerOptions,
                 };
               }
@@ -302,13 +312,23 @@ export function convertToLanguageModelMessage({
                 };
               }
               case 'reasoning-file': {
-                const { data, mediaType } = convertToLanguageModelV4DataContent(
-                  part.data,
-                );
+                const { data: convertedData, mediaType: convertedMediaType } =
+                  convertToLanguageModelV4DataContent(part.data);
+                let data = convertedData;
+                let mediaType = convertedMediaType ?? part.mediaType;
+
+                if (data instanceof URL) {
+                  const downloadedFile = downloadedAssets[data.toString()];
+                  if (downloadedFile) {
+                    data = downloadedFile.data;
+                    mediaType ??= downloadedFile.mediaType;
+                  }
+                }
+
                 return {
                   type: 'reasoning-file' as const,
                   data,
-                  mediaType: mediaType ?? part.mediaType,
+                  mediaType,
                   providerOptions,
                 };
               }
@@ -402,7 +422,7 @@ export function convertToLanguageModelMessage({
 }
 
 /**
- * Downloads images and files from URLs in the messages.
+ * Downloads URL-backed assets in the messages.
  */
 async function downloadAssets(
   messages: ModelMessage[],
@@ -412,28 +432,43 @@ async function downloadAssets(
   Record<string, { mediaType: string | undefined; data: Uint8Array }>
 > {
   const plannedDownloads = messages
-    .filter(message => message.role === 'user')
-    .map(message => message.content)
-    .filter((content): content is Array<TextPart | ImagePart | FilePart> =>
-      Array.isArray(content),
-    )
-    .flat()
-    .filter(
-      (part): part is ImagePart | FilePart =>
-        part.type === 'image' || part.type === 'file',
-    )
-    .map(part => {
-      const mediaType =
-        part.mediaType ?? (part.type === 'image' ? 'image/*' : undefined);
+    .flatMap(message => {
+      if (message.role === 'user' && Array.isArray(message.content)) {
+        return message.content
+          .filter(
+            (part): part is ImagePart | FilePart =>
+              part.type === 'image' || part.type === 'file',
+          )
+          .map(part => ({
+            mediaType:
+              part.mediaType ?? (part.type === 'image' ? 'image/*' : undefined),
+            data: part.type === 'image' ? part.image : part.data,
+          }));
+      }
 
-      let data = part.type === 'image' ? part.image : part.data;
+      if (message.role === 'assistant' && Array.isArray(message.content)) {
+        return message.content
+          .filter(
+            (part): part is FilePart | ReasoningFilePart =>
+              part.type === 'file' || part.type === 'reasoning-file',
+          )
+          .map(part => ({
+            mediaType: part.mediaType,
+            data: part.data,
+          }));
+      }
+
+      return [];
+    })
+    .map(part => {
+      let data = part.data;
       if (typeof data === 'string') {
         try {
           data = new URL(data);
         } catch {}
       }
 
-      return { mediaType, data };
+      return { mediaType: part.mediaType, data };
     })
 
     .filter(


### PR DESCRIPTION
 ## Summary

  Fix prompt conversion so assistant-side file and reasoning-file URL assets are downloaded when the
  target model does not support direct URLs.

  Previously, downloadAssets() only planned downloads for user messages. That meant assistant message
  assets could remain as unsupported URLs and be forwarded to the provider on follow-up calls.

  ## Changes

  - include assistant file and reasoning-file parts in prompt asset download planning
  - consume downloaded assets when converting assistant file and reasoning-file parts
  - add regression tests for both assistant-side cases
  - add a patch changeset

  ## Verification

  - pnpm test:node -- src/prompt/convert-to-language-model-prompt.test.ts

  Passed: 62/62