### PR TITLE
fix(provider/amazon-bedrock): merge custom reasoning config properties when top-level reasoning parameter is set

### DIFF
--- a/.changeset/empty-toys-burn.md
+++ b/.changeset/empty-toys-burn.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(provider/amazon-bedrock): merge custom reasoning config properties when top-level reasoning parameter is set

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/anthropic-reasoning-partial-config.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/anthropic-reasoning-partial-config.ts
@@ -1,0 +1,32 @@
+import {
+  bedrock,
+  type AmazonBedrockLanguageModelOptions,
+} from '@ai-sdk/amazon-bedrock';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: bedrock('us.anthropic.claude-opus-4-7'),
+    prompt:
+      'Solve this step by step: if f(x) = x^3 - 6x^2 + 11x - 6, find all roots and prove they are correct.',
+    reasoning: 'high',
+    providerOptions: {
+      bedrock: {
+        /*
+         * Partial reasoningConfig: `type` and `maxReasoningEffort` are derived
+         * from the top-level `reasoning` parameter. Only `display` is provided
+         * here and merged on top of the derived fields.
+         */
+        reasoningConfig: { display: 'summarized' },
+      } satisfies AmazonBedrockLanguageModelOptions,
+    },
+  });
+
+  console.log('Reasoning:');
+  console.log(result.reasoning);
+  console.log();
+
+  console.log('Text:');
+  console.log(result.text);
+});

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-reasoning-partial-config.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-reasoning-partial-config.ts
@@ -1,0 +1,35 @@
+import {
+  bedrock,
+  type AmazonBedrockLanguageModelOptions,
+} from '@ai-sdk/amazon-bedrock';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: bedrock('us.anthropic.claude-opus-4-7'),
+    prompt:
+      'Solve this step by step: if f(x) = x^3 - 6x^2 + 11x - 6, find all roots and prove they are correct.',
+    reasoning: 'high',
+    providerOptions: {
+      bedrock: {
+        /*
+         * Partial reasoningConfig: `type` and `maxReasoningEffort` are derived
+         * from the top-level `reasoning` parameter. Only `display` is provided
+         * here and merged on top of the derived fields.
+         */
+        reasoningConfig: { display: 'summarized' },
+      } satisfies AmazonBedrockLanguageModelOptions,
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'reasoning-delta') {
+      process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
+    } else if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+
+  console.log();
+});

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -5835,7 +5835,7 @@ describe('doGenerate', () => {
       ).toBe('high');
     });
 
-    it('should let providerOptions.bedrock.reasoningConfig take precedence over top-level reasoning', async () => {
+    it('should let explicit reasoningConfig fields win over derived reasoning values', async () => {
       prepareJsonFixtureResponse('bedrock-text');
 
       await model.doGenerate({
@@ -5856,6 +5856,94 @@ describe('doGenerate', () => {
         type: 'enabled',
         budget_tokens: 5000,
       });
+    });
+
+    it('should merge top-level reasoning with partial reasoningConfig for newer Anthropic models', async () => {
+      server.urls[newerAnthropicGenerateUrl].response = simpleResponse;
+
+      await newerAnthropicModel.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'high',
+        providerOptions: {
+          bedrock: {
+            reasoningConfig: { display: 'summarized' },
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.additionalModelRequestFields?.thinking).toEqual({
+        type: 'adaptive',
+        display: 'summarized',
+      });
+      expect(
+        requestBody.additionalModelRequestFields?.output_config?.effort,
+      ).toBe('high');
+    });
+
+    it('should honor reasoning "none" even when partial reasoningConfig is provided', async () => {
+      server.urls[newerAnthropicGenerateUrl].response = simpleResponse;
+
+      await newerAnthropicModel.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'none',
+        providerOptions: {
+          bedrock: {
+            reasoningConfig: { display: 'summarized' },
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(
+        requestBody.additionalModelRequestFields?.thinking,
+      ).toBeUndefined();
+      expect(
+        requestBody.additionalModelRequestFields?.output_config,
+      ).toBeUndefined();
+    });
+
+    it('should let user-specified type win while still deriving maxReasoningEffort from reasoning', async () => {
+      server.urls[newerAnthropicGenerateUrl].response = simpleResponse;
+
+      await newerAnthropicModel.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'high',
+        providerOptions: {
+          bedrock: {
+            reasoningConfig: { type: 'enabled', budgetTokens: 3000 },
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.additionalModelRequestFields?.thinking).toEqual({
+        type: 'enabled',
+        budget_tokens: 3000,
+      });
+      expect(
+        requestBody.additionalModelRequestFields?.output_config?.effort,
+      ).toBe('high');
+    });
+
+    it('should let user-specified maxReasoningEffort win over derived for non-Anthropic models', async () => {
+      server.urls[novaGenerateUrl].response = simpleResponse;
+
+      await novaModel.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'high',
+        providerOptions: {
+          bedrock: {
+            reasoningConfig: { maxReasoningEffort: 'low' },
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(
+        requestBody.additionalModelRequestFields?.reasoningConfig
+          ?.maxReasoningEffort,
+      ).toBe('low');
     });
 
     it('should strip temperature, topP, topK for Anthropic models when reasoning enables thinking', async () => {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -1209,7 +1209,7 @@ function resolveBedrockReasoningConfig({
   isAnthropicModel: boolean;
   modelId: string;
 }): AmazonBedrockLanguageModelOptions {
-  if (!isCustomReasoning(reasoning) || bedrockOptions.reasoningConfig != null) {
+  if (!isCustomReasoning(reasoning)) {
     return bedrockOptions;
   }
 
@@ -1229,6 +1229,7 @@ function resolveBedrockReasoningConfig({
       result.reasoningConfig = {
         type: 'adaptive',
         maxReasoningEffort: effort,
+        ...bedrockOptions.reasoningConfig,
       };
     } else {
       const budgetTokens = mapReasoningToProviderBudget({
@@ -1241,6 +1242,7 @@ function resolveBedrockReasoningConfig({
         result.reasoningConfig = {
           type: 'enabled',
           budgetTokens,
+          ...bedrockOptions.reasoningConfig,
         };
       }
     }
@@ -1250,7 +1252,21 @@ function resolveBedrockReasoningConfig({
       effortMap: bedrockReasoningEffortMap,
       warnings,
     });
-    result.reasoningConfig = { maxReasoningEffort: effort };
+    result.reasoningConfig = {
+      maxReasoningEffort: effort,
+      ...bedrockOptions.reasoningConfig,
+    };
+  }
+
+  /*
+   * Mirror anthropic-messages-language-model.ts: when the merged type ends up
+   * 'disabled' (user override combined with a non-none reasoning), strip
+   * derived effort/budget so downstream does not emit output_config.effort
+   * alongside disabled thinking.
+   */
+  if (result.reasoningConfig?.type === 'disabled') {
+    delete result.reasoningConfig.maxReasoningEffort;
+    delete result.reasoningConfig.budgetTokens;
   }
 
   return result;


### PR DESCRIPTION
## Background

When a user set the top-level `reasoning` parameter alongside a partial `providerOptions.bedrock.reasoningConfig`, the provider was ignoring the custom config entirely and using only the values derived from `reasoning`. This made it impossible to set or override individual fields (e.g. `display`, `budgetTokens`) while still benefiting from the automatic effort/budget mapping.

## Summary

- `resolveBedrockReasoningConfig` now spreads `bedrockOptions.reasoningConfig` on top of the derived fields, so explicit user values win while anything omitted is still derived from the top-level `reasoning` parameter.
- When the merged result ends up with `type: 'disabled'`, derived `maxReasoningEffort`/`budgetTokens` are stripped to avoid emitting conflicting API fields — mirroring the same guard in `anthropic-messages-language-model`.

## Manual Verification

Run the new examples added in this PR.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
