### PR TITLE
chore(anthropic): remove unnecessary messages affix from Anthropic symbols and files

### DIFF
--- a/.changeset/light-suns-cross.md
+++ b/.changeset/light-suns-cross.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+"@ai-sdk/google-vertex": patch
+"@ai-sdk/anthropic": patch
+---
+
+chore(anthropic): remove unnecessary messages affix from Anthropic symbols and files

--- a/architecture/provider-abstraction.md
+++ b/architecture/provider-abstraction.md
@@ -37,7 +37,7 @@ Language models are used for text generation and structured generation workflows
 - **Model specification**
   - `LanguageModelV4` - [`packages/provider/src/language-model/v4/language-model-v4.ts`](packages/provider/src/language-model/v4/language-model-v4.ts)
 - **Provider implementations (examples)**
-  - [`OpenAIChatLanguageModel`](packages/openai/src/chat/openai-chat-language-model.ts), [`AnthropicMessagesLanguageModel`](packages/anthropic/src/anthropic-messages-language-model.ts)
+  - [`OpenAIChatLanguageModel`](packages/openai/src/chat/openai-chat-language-model.ts), [`AnthropicLanguageModel`](packages/anthropic/src/anthropic-language-model.ts)
 
 ```mermaid
 classDiagram

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -1,7 +1,7 @@
 import { createBedrockAnthropic } from './bedrock-anthropic-provider';
 import { NoSuchModelError } from '@ai-sdk/provider';
 import {
-  AnthropicMessagesLanguageModel,
+  AnthropicLanguageModel,
   anthropicTools,
 } from '@ai-sdk/anthropic/internal';
 import { vi, describe, beforeEach, it, expect } from 'vitest';
@@ -47,7 +47,7 @@ vi.mock('@ai-sdk/anthropic/internal', async () => {
   const originalModule = await vi.importActual('@ai-sdk/anthropic/internal');
   return {
     ...originalModule,
-    AnthropicMessagesLanguageModel: vi.fn(),
+    AnthropicLanguageModel: vi.fn(),
   };
 });
 
@@ -69,7 +69,7 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('anthropic.claude-3-5-sonnet-20241022-v2:0');
 
-    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
       'anthropic.claude-3-5-sonnet-20241022-v2:0',
       expect.objectContaining({
         baseURL: expect.stringContaining('bedrock-runtime'),
@@ -105,7 +105,7 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         baseURL: customBaseURL,
@@ -157,15 +157,16 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         headers: expect.any(Function),
       }),
     );
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     expect(config.headers).toEqual(expect.any(Function));
@@ -182,8 +183,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('anthropic.claude-3-sonnet-20240229-v1:0');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     const url = config.buildRequestUrl?.(
@@ -203,8 +205,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('anthropic.claude-3-sonnet-20240229-v1:0');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     const url = config.buildRequestUrl?.(
@@ -224,8 +227,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     const transformedBody = config.transformRequestBody?.(
@@ -253,8 +257,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     const transformedBody = config.transformRequestBody?.(
@@ -279,8 +284,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     const transformedBody = config.transformRequestBody?.(
@@ -310,8 +316,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     const transformedBody = config.transformRequestBody?.(
@@ -342,8 +349,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     const transformedBody = config.transformRequestBody?.(
@@ -375,8 +383,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     const transformedBody = config.transformRequestBody?.(
@@ -402,8 +411,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     const transformedBody = config.transformRequestBody?.(
@@ -430,8 +440,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     const transformedBody = config.transformRequestBody?.(
@@ -461,8 +472,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     expect(config.supportedUrls?.()).toEqual({});
@@ -497,8 +509,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     const transformedBody = config.transformRequestBody?.(
@@ -527,8 +540,9 @@ describe('bedrock-anthropic-provider', () => {
     });
     provider('us.anthropic.claude-3-5-sonnet-20240620-v1:0');
 
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     const url = config.buildRequestUrl?.(

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -14,7 +14,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import {
   anthropicTools,
-  AnthropicMessagesLanguageModel,
+  AnthropicLanguageModel,
 } from '@ai-sdk/anthropic/internal';
 import {
   BedrockCredentials,
@@ -249,7 +249,7 @@ export function createBedrockAnthropic(
   };
 
   const createChatModel = (modelId: BedrockAnthropicModelId) =>
-    new AnthropicMessagesLanguageModel(modelId, {
+    new AnthropicLanguageModel(modelId, {
       provider: 'bedrock.anthropic.messages',
       baseURL: getBaseURL(),
       headers: getHeaders,

--- a/packages/anthropic/src/__snapshots__/anthropic-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-language-model.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > agent skills > should expose container information as provider metadata 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > agent skills > should expose container information as provider metadata 1`] = `
 {
   "anthropic": {
     "container": {
@@ -36,7 +36,7 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > agent skills > should exp
 }
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > code execution 20250825 > should expose container information as provider metadata 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > code execution 20250825 > should expose container information as provider metadata 1`] = `
 {
   "anthropic": {
     "container": {
@@ -66,7 +66,7 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > code execution 20250825 >
 }
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > code execution 20250825 > should include code execution tool call and result in content 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > code execution 20250825 > should include code execution tool call and result in content 1`] = `
 [
   {
     "text": "I'll create a Python script to calculate Fibonacci numbers and then execute it to find the 10th Fibonacci number.",
@@ -135,7 +135,7 @@ The script uses an iterative approach to calculate Fibonacci numbers efficiently
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > code execution 20250825 > should include file id list in code execution tool generate call result. 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > code execution 20250825 > should include file id list in code execution tool generate call result. 1`] = `
 {
   "content": [
     {
@@ -652,7 +652,7 @@ Both files have been exported and are ready for download!",
 }
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > code execution 20260120 > should include code execution tool call and result in content 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > code execution 20260120 > should include code execution tool call and result in content 1`] = `
 [
   {
     "text": "I'll create a Python script to calculate Fibonacci numbers and then execute it to find the 10th Fibonacci number.",
@@ -721,7 +721,7 @@ The script uses an iterative approach to calculate Fibonacci numbers efficiently
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > mcp servers > should include mcp tool call and result in content 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > mcp servers > should include mcp tool call and result in content 1`] = `
 [
   {
     "dynamic": true,
@@ -765,7 +765,7 @@ As expected, it simply echoes back the exact message that was sent to it!",
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > memory 20250818 > should include memory tool call and result in content 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > memory 20250818 > should include memory tool call and result in content 1`] = `
 [
   {
     "input": "{"command":"view","path":"/memories"}",
@@ -776,7 +776,7 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > memory 20250818 > should 
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > programmatic tool calling > with fixture (multi-turn dice game) > should parse content with text, server_tool_use, tool_use with caller, and code_execution_tool_result 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > programmatic tool calling > with fixture (multi-turn dice game) > should parse content with text, server_tool_use, tool_use with caller, and code_execution_tool_result 1`] = `
 [
   {
     "text": "I'll help you simulate this dice game between two players! Let me run the game where both players roll dice each round until one player wins 3 rounds.",
@@ -907,7 +907,7 @@ The loaded die gave Player 1 a significant advantage, allowing them to win the g
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > tool search tool > bm25 variant > should include tool search tool call and result in content 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > tool search tool > bm25 variant > should include tool search tool call and result in content 1`] = `
 [
   {
     "text": "I'll search for a weather-related tool to help you get the current weather in San Francisco.",
@@ -952,7 +952,7 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > tool search tool > bm25 v
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > tool search tool > regex variant > should include tool search tool call and result in content 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > tool search tool > regex variant > should include tool search tool call and result in content 1`] = `
 [
   {
     "input": "{"pattern":"weather|SF|San Francisco|forecast|temperature|climate","limit":10}",
@@ -993,7 +993,7 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > tool search tool > regex 
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > web fetch tool > 20260209 text response > should include web fetch 20260209 tool call and result in content 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > web fetch tool > 20260209 text response > should include web fetch 20260209 tool call and result in content 1`] = `
 [
   {
     "input": "{"type":"programmatic-tool-call","code":"\\nimport json\\nresult = await web_fetch({\\"url\\": \\"https://example.com\\"})\\nparsed = json.loads(result) if isinstance(result, str) else result\\nif isinstance(parsed, list):\\n    print(parsed[0][\\"content\\"][:500])\\nelse:\\n    print(parsed)\\n"}",
@@ -1055,7 +1055,7 @@ This domain is for use in documentation examples without needing permission. Avo
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > web fetch tool > text response > should include web fetch tool call and result in content 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > web fetch tool > text response > should include web fetch tool call and result in content 1`] = `
 [
   {
     "text": "I'll fetch the Wikipedia page about Maglemosian culture to tell you what it's about.",
@@ -1153,7 +1153,7 @@ The page provides both historical context about this important prehistoric cultu
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > web fetch tool > text response without title > should include web fetch tool call and result in content 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > web fetch tool > text response without title > should include web fetch tool call and result in content 1`] = `
 [
   {
     "text": "I'll fetch the PDF from the URL you provided to see what it says about AI.",
@@ -1211,7 +1211,7 @@ However, due to copyright restrictions, I cannot reproduce the full text content
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > web fetch tool > unavailable error > should include web fetch tool call and result in content 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > web fetch tool > unavailable error > should include web fetch tool call and result in content 1`] = `
 [
   {
     "text": "I'll fetch the PDF document from the URL you provided to see what it says about AI.",
@@ -1241,7 +1241,7 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > web fetch tool > unavaila
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doGenerate > web search tool > with fixture > should include web search tool call and result in content 1`] = `
+exports[`AnthropicLanguageModel > doGenerate > web search tool > with fixture > should include web search tool call and result in content 1`] = `
 [
   {
     "input": "{"query":"tech news today September 26 2024"}",
@@ -1551,7 +1551,7 @@ For the most current breaking tech news today, I'd recommend checking major tech
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doStream > agent skills > should stream code execution tool results 1`] = `
+exports[`AnthropicLanguageModel > doStream > agent skills > should stream code execution tool results 1`] = `
 [
   {
     "type": "stream-start",
@@ -5285,7 +5285,7 @@ The presentation has",
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doStream > code execution 20250825 tool > should include file id list in code execution tool call result. 1`] = `
+exports[`AnthropicLanguageModel > doStream > code execution 20250825 tool > should include file id list in code execution tool call result. 1`] = `
 [
   {
     "type": "stream-start",
@@ -10359,7 +10359,7 @@ Error message: SyntaxError: Unexpected end of JSON input],
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doStream > code execution 20250825 tool > should stream code execution tool results 1`] = `
+exports[`AnthropicLanguageModel > doStream > code execution 20250825 tool > should stream code execution tool results 1`] = `
 [
   {
     "type": "stream-start",
@@ -11677,7 +11677,7 @@ The Fibonacci sequence starts with 0, ",
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doStream > code execution 20260120 tool > should stream code execution tool results without beta header 1`] = `
+exports[`AnthropicLanguageModel > doStream > code execution 20260120 tool > should stream code execution tool results without beta header 1`] = `
 [
   {
     "type": "stream-start",
@@ -12995,7 +12995,7 @@ The Fibonacci sequence starts with 0, ",
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doStream > json schema response format with output format (supported model) > should stream the text output 1`] = `
+exports[`AnthropicLanguageModel > doStream > json schema response format with output format (supported model) > should stream the text output 1`] = `
 [
   {
     "type": "stream-start",
@@ -13637,7 +13637,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > json schema response format
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doStream > mcp servers > should stream code execution tool results 1`] = `
+exports[`AnthropicLanguageModel > doStream > mcp servers > should stream code execution tool results 1`] = `
 [
   {
     "type": "stream-start",
@@ -13767,7 +13767,7 @@ It simply echoed back",
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doStream > programmatic tool calling > with fixture (multi-turn dice game) > should stream programmatic tool calling with multiple message_start/stop sequences 1`] = `
+exports[`AnthropicLanguageModel > doStream > programmatic tool calling > with fixture (multi-turn dice game) > should stream programmatic tool calling with multiple message_start/stop sequences 1`] = `
 [
   {
     "type": "stream-start",
@@ -16225,7 +16225,7 @@ The",
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doStream > tool search tool > bm25 variant > should stream tool search bm25 results 1`] = `
+exports[`AnthropicLanguageModel > doStream > tool search tool > bm25 variant > should stream tool search bm25 results 1`] = `
 [
   {
     "type": "stream-start",
@@ -16554,7 +16554,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > tool search tool > bm25 var
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doStream > tool search tool > regex variant > should stream tool search regex results 1`] = `
+exports[`AnthropicLanguageModel > doStream > tool search tool > regex variant > should stream tool search regex results 1`] = `
 [
   {
     "type": "stream-start",
@@ -16914,7 +16914,7 @@ The weather in",
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doStream > web fetch 20260209 tool > input provided in content_block_start > should stream web fetch 20260209 tool results 1`] = `
+exports[`AnthropicLanguageModel > doStream > web fetch 20260209 tool > input provided in content_block_start > should stream web fetch 20260209 tool results 1`] = `
 [
   {
     "type": "stream-start",
@@ -17248,7 +17248,7 @@ This domain is for use in documentation examples without needing permission. Avo
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doStream > web fetch tool > txt response > should stream web search tool results 1`] = `
+exports[`AnthropicLanguageModel > doStream > web fetch tool > txt response > should stream web search tool results 1`] = `
 [
   {
     "type": "stream-start",
@@ -17673,7 +17673,7 @@ The page also discusses",
 ]
 `;
 
-exports[`AnthropicMessagesLanguageModel > doStream > web search tool > should stream web search tool results 1`] = `
+exports[`AnthropicLanguageModel > doStream > web search tool > should stream web search tool results 1`] = `
 [
   {
     "type": "stream-start",

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -2,7 +2,7 @@ import { JSONSchema7 } from '@ai-sdk/provider';
 import { InferSchema, lazySchema, zodSchema } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
-export type AnthropicMessagesPrompt = {
+export type AnthropicPrompt = {
   system: Array<AnthropicTextContent> | undefined;
   messages: AnthropicMessage[];
 };
@@ -553,7 +553,7 @@ export type AnthropicResponseContextManagement = {
 
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-export const anthropicMessagesResponseSchema = lazySchema(() =>
+export const anthropicResponseSchema = lazySchema(() =>
   zodSchema(
     z.object({
       type: z.literal('message'),
@@ -893,7 +893,7 @@ export const anthropicMessagesResponseSchema = lazySchema(() =>
 
 // limited version of the schema, focused on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-export const anthropicMessagesChunkSchema = lazySchema(() =>
+export const anthropicChunkSchema = lazySchema(() =>
   zodSchema(
     z.discriminatedUnion('type', [
       z.object({
@@ -1342,7 +1342,7 @@ export type AnthropicReasoningMetadata = InferSchema<
 >;
 
 export type Citation = NonNullable<
-  (InferSchema<typeof anthropicMessagesResponseSchema>['content'][number] & {
+  (InferSchema<typeof anthropicResponseSchema>['content'][number] & {
     type: 'text';
   })['citations']
 >[number];

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -14,8 +14,8 @@ import {
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import fs from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AnthropicLanguageModelOptions } from './anthropic-messages-options';
-import { getModelCapabilities } from './anthropic-messages-language-model';
+import { AnthropicLanguageModelOptions } from './anthropic-options';
+import { getModelCapabilities } from './anthropic-language-model';
 import { anthropic, createAnthropic } from './anthropic-provider';
 
 vi.mock('./version', () => ({
@@ -32,7 +32,7 @@ const provider = createAnthropic({
 });
 const model = provider('claude-3-haiku-20240307');
 
-describe('AnthropicMessagesLanguageModel', () => {
+describe('AnthropicLanguageModel', () => {
   const server = createTestServer({
     'https://api.anthropic.com/v1/messages': {},
   });
@@ -9300,17 +9300,14 @@ describe('AnthropicMessagesLanguageModel', () => {
 
       prepareTransformJsonResponse();
 
-      const { AnthropicMessagesLanguageModel } =
-        await import('./anthropic-messages-language-model');
-      const model = new AnthropicMessagesLanguageModel(
-        'claude-3-haiku-20240307',
-        {
-          provider: 'test-provider',
-          baseURL: 'https://api.anthropic.com/v1',
-          headers: {},
-          transformRequestBody: transformFn,
-        },
-      );
+      const { AnthropicLanguageModel } =
+        await import('./anthropic-language-model');
+      const model = new AnthropicLanguageModel('claude-3-haiku-20240307', {
+        provider: 'test-provider',
+        baseURL: 'https://api.anthropic.com/v1',
+        headers: {},
+        transformRequestBody: transformFn,
+      });
 
       await model.doGenerate({
         prompt: TEST_PROMPT,
@@ -9342,17 +9339,14 @@ describe('AnthropicMessagesLanguageModel', () => {
 
       prepareTransformStreamResponse();
 
-      const { AnthropicMessagesLanguageModel } =
-        await import('./anthropic-messages-language-model');
-      const model = new AnthropicMessagesLanguageModel(
-        'claude-3-haiku-20240307',
-        {
-          provider: 'test-provider',
-          baseURL: 'https://api.anthropic.com/v1',
-          headers: {},
-          transformRequestBody: transformFn,
-        },
-      );
+      const { AnthropicLanguageModel } =
+        await import('./anthropic-language-model');
+      const model = new AnthropicLanguageModel('claude-3-haiku-20240307', {
+        provider: 'test-provider',
+        baseURL: 'https://api.anthropic.com/v1',
+        headers: {},
+        transformRequestBody: transformFn,
+      });
 
       const { stream } = await model.doStream({
         prompt: TEST_PROMPT,
@@ -9383,16 +9377,13 @@ describe('AnthropicMessagesLanguageModel', () => {
     it('should work without transformRequestBody', async () => {
       prepareTransformJsonResponse();
 
-      const { AnthropicMessagesLanguageModel } =
-        await import('./anthropic-messages-language-model');
-      const model = new AnthropicMessagesLanguageModel(
-        'claude-3-haiku-20240307',
-        {
-          provider: 'test-provider',
-          baseURL: 'https://api.anthropic.com/v1',
-          headers: {},
-        },
-      );
+      const { AnthropicLanguageModel } =
+        await import('./anthropic-language-model');
+      const model = new AnthropicLanguageModel('claude-3-haiku-20240307', {
+        provider: 'test-provider',
+        baseURL: 'https://api.anthropic.com/v1',
+        headers: {},
+      });
 
       await model.doGenerate({
         prompt: TEST_PROMPT,

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -40,24 +40,24 @@ import { anthropicFailedResponseHandler } from './anthropic-error';
 import { AnthropicMessageMetadata } from './anthropic-message-metadata';
 import {
   AnthropicContainer,
-  anthropicMessagesChunkSchema,
-  anthropicMessagesResponseSchema,
+  anthropicChunkSchema,
+  anthropicResponseSchema,
   AnthropicReasoningMetadata,
   AnthropicResponseContextManagement,
   AnthropicTool,
   Citation,
-} from './anthropic-messages-api';
+} from './anthropic-api';
 import {
-  AnthropicMessagesModelId,
+  AnthropicModelId,
   AnthropicLanguageModelOptions,
   anthropicLanguageModelOptions,
-} from './anthropic-messages-options';
+} from './anthropic-options';
 import { prepareTools } from './anthropic-prepare-tools';
 import {
-  AnthropicMessagesUsage,
-  convertAnthropicMessagesUsage,
-} from './convert-anthropic-messages-usage';
-import { convertToAnthropicMessagesPrompt } from './convert-to-anthropic-messages-prompt';
+  AnthropicUsage,
+  convertAnthropicUsage,
+} from './convert-anthropic-usage';
+import { convertToAnthropicPrompt } from './convert-to-anthropic-prompt';
 import { CacheControlValidator } from './get-cache-control';
 import { mapAnthropicStopReason } from './map-anthropic-stop-reason';
 
@@ -120,7 +120,7 @@ function createCitationSource(
   };
 }
 
-type AnthropicMessagesConfig = {
+type AnthropicLanguageModelConfig = {
   provider: string;
   baseURL: string;
   headers?: Resolvable<Record<string, string | undefined>>;
@@ -145,15 +145,15 @@ type AnthropicMessagesConfig = {
   supportsStrictTools?: boolean;
 };
 
-export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
+export class AnthropicLanguageModel implements LanguageModelV4 {
   readonly specificationVersion = 'v4';
 
-  readonly modelId: AnthropicMessagesModelId;
+  readonly modelId: AnthropicModelId;
 
-  private readonly config: AnthropicMessagesConfig;
+  private readonly config: AnthropicLanguageModelConfig;
   private readonly generateId: () => string;
 
-  static [WORKFLOW_SERIALIZE](model: AnthropicMessagesLanguageModel) {
+  static [WORKFLOW_SERIALIZE](model: AnthropicLanguageModel) {
     return serializeModelOptions({
       modelId: model.modelId,
       config: model.config,
@@ -161,16 +161,13 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
   }
 
   static [WORKFLOW_DESERIALIZE](options: {
-    modelId: AnthropicMessagesModelId;
-    config: AnthropicMessagesConfig;
+    modelId: AnthropicModelId;
+    config: AnthropicLanguageModelConfig;
   }) {
-    return new AnthropicMessagesLanguageModel(options.modelId, options.config);
+    return new AnthropicLanguageModel(options.modelId, options.config);
   }
 
-  constructor(
-    modelId: AnthropicMessagesModelId,
-    config: AnthropicMessagesConfig,
-  ) {
+  constructor(modelId: AnthropicModelId, config: AnthropicLanguageModelConfig) {
     this.modelId = modelId;
     this.config = config;
     this.generateId = config.generateId ?? generateId;
@@ -382,14 +379,13 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
       },
     });
 
-    const { prompt: messagesPrompt, betas } =
-      await convertToAnthropicMessagesPrompt({
-        prompt,
-        sendReasoning: anthropicOptions?.sendReasoning ?? true,
-        warnings,
-        cacheControlValidator,
-        toolNameMapping,
-      });
+    const { prompt: messagesPrompt, betas } = await convertToAnthropicPrompt({
+      prompt,
+      sendReasoning: anthropicOptions?.sendReasoning ?? true,
+      warnings,
+      cacheControlValidator,
+      toolNameMapping,
+    });
 
     /*
      * Map top-level `reasoning` to Anthropic thinking/effort when provider
@@ -900,7 +896,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
       body: this.transformRequestBody(args, betas),
       failedResponseHandler: anthropicFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
-        anthropicMessagesResponseSchema,
+        anthropicResponseSchema,
       ),
       abortSignal: options.abortSignal,
       fetch: this.config.fetch,
@@ -1291,7 +1287,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
         }),
         raw: response.stop_reason ?? undefined,
       },
-      usage: convertAnthropicMessagesUsage({ usage: response.usage }),
+      usage: convertAnthropicUsage({ usage: response.usage }),
       request: { body: args },
       response: {
         id: response.id ?? undefined,
@@ -1377,9 +1373,8 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
       headers: await this.getHeaders({ betas, headers: options.headers }),
       body: this.transformRequestBody(body, betas),
       failedResponseHandler: anthropicFailedResponseHandler,
-      successfulResponseHandler: createEventSourceResponseHandler(
-        anthropicMessagesChunkSchema,
-      ),
+      successfulResponseHandler:
+        createEventSourceResponseHandler(anthropicChunkSchema),
       abortSignal: options.abortSignal,
       fetch: this.config.fetch,
     });
@@ -1388,7 +1383,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
       unified: 'other',
       raw: undefined,
     };
-    const usage: AnthropicMessagesUsage = {
+    const usage: AnthropicUsage = {
       input_tokens: 0,
       output_tokens: 0,
       cache_creation_input_tokens: 0,
@@ -1448,7 +1443,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
 
     const transformedStream = response.pipeThrough(
       new TransformStream<
-        ParseResult<InferSchema<typeof anthropicMessagesChunkSchema>>,
+        ParseResult<InferSchema<typeof anthropicChunkSchema>>,
         LanguageModelV4StreamPart
       >({
         start(controller) {
@@ -2310,7 +2305,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV4 {
               controller.enqueue({
                 type: 'finish',
                 finishReason,
-                usage: convertAnthropicMessagesUsage({ usage, rawUsage }),
+                usage: convertAnthropicUsage({ usage, rawUsage }),
                 providerMetadata,
               });
               return;

--- a/packages/anthropic/src/anthropic-options.ts
+++ b/packages/anthropic/src/anthropic-options.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod/v4';
 
 // https://docs.claude.com/en/docs/about-claude/models/overview
-export type AnthropicMessagesModelId =
+export type AnthropicModelId =
   | 'claude-3-haiku-20240307'
   | 'claude-haiku-4-5-20251001'
   | 'claude-haiku-4-5'

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -5,10 +5,7 @@ import { webFetch_20260209OutputSchema } from './tool/web-fetch-20260209';
 import { webFetch_20250910OutputSchema } from './tool/web-fetch-20250910';
 import { webSearch_20260209OutputSchema } from './tool/web-search_20260209';
 import { webSearch_20250305OutputSchema } from './tool/web-search_20250305';
-import {
-  anthropicMessagesChunkSchema,
-  anthropicMessagesResponseSchema,
-} from './anthropic-messages-api';
+import { anthropicChunkSchema, anthropicResponseSchema } from './anthropic-api';
 
 describe('prepareTools', () => {
   it('should return undefined tools and tool_choice when tools are null', async () => {
@@ -1543,7 +1540,7 @@ describe('webSearch_20260209OutputSchema', () => {
   });
 });
 
-describe('anthropicMessagesResponseSchema - web_fetch_tool_result', () => {
+describe('anthropicResponseSchema - web_fetch_tool_result', () => {
   it('should accept PDF response with base64 source', async () => {
     const pdfResponse = {
       type: 'message',
@@ -1576,7 +1573,7 @@ describe('anthropicMessagesResponseSchema - web_fetch_tool_result', () => {
       },
     };
 
-    const schema = anthropicMessagesResponseSchema();
+    const schema = anthropicResponseSchema();
     const result = await schema.validate!(pdfResponse);
 
     expect(result.success).toBe(true);
@@ -1614,14 +1611,14 @@ describe('anthropicMessagesResponseSchema - web_fetch_tool_result', () => {
       },
     };
 
-    const schema = anthropicMessagesResponseSchema();
+    const schema = anthropicResponseSchema();
     const result = await schema.validate!(textResponse);
 
     expect(result.success).toBe(true);
   });
 });
 
-describe('anthropicMessagesChunkSchema - web_fetch_tool_result', () => {
+describe('anthropicChunkSchema - web_fetch_tool_result', () => {
   it('should accept base64 PDF source in streaming response', async () => {
     const pdfChunk = {
       type: 'content_block_start',
@@ -1646,7 +1643,7 @@ describe('anthropicMessagesChunkSchema - web_fetch_tool_result', () => {
       },
     };
 
-    const schema = anthropicMessagesChunkSchema();
+    const schema = anthropicChunkSchema();
     const result = await schema.validate!(pdfChunk);
 
     expect(result.success).toBe(true);
@@ -1676,7 +1673,7 @@ describe('anthropicMessagesChunkSchema - web_fetch_tool_result', () => {
       },
     };
 
-    const schema = anthropicMessagesChunkSchema();
+    const schema = anthropicChunkSchema();
     const result = await schema.validate!(pdfChunk);
 
     expect(result.success).toBe(true);

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -3,7 +3,7 @@ import {
   SharedV4Warning,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
-import { AnthropicTool, AnthropicToolChoice } from './anthropic-messages-api';
+import { AnthropicTool, AnthropicToolChoice } from './anthropic-api';
 import { CacheControlValidator } from './get-cache-control';
 import { textEditor_20250728ArgsSchema } from './tool/text-editor_20250728';
 import { webSearch_20260209ArgsSchema } from './tool/web-search_20260209';

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -15,8 +15,8 @@ import {
   withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
 import { AnthropicFiles } from './anthropic-files';
-import { AnthropicMessagesLanguageModel } from './anthropic-messages-language-model';
-import { AnthropicMessagesModelId } from './anthropic-messages-options';
+import { AnthropicLanguageModel } from './anthropic-language-model';
+import { AnthropicModelId } from './anthropic-options';
 import { anthropicTools } from './anthropic-tools';
 import { AnthropicSkills } from './skills/anthropic-skills';
 import { VERSION } from './version';
@@ -25,16 +25,16 @@ export interface AnthropicProvider extends ProviderV4 {
   /**
    * Creates a model for text generation.
    */
-  (modelId: AnthropicMessagesModelId): LanguageModelV4;
+  (modelId: AnthropicModelId): LanguageModelV4;
 
   /**
    * Creates a model for text generation.
    */
-  languageModel(modelId: AnthropicMessagesModelId): LanguageModelV4;
+  languageModel(modelId: AnthropicModelId): LanguageModelV4;
 
-  chat(modelId: AnthropicMessagesModelId): LanguageModelV4;
+  chat(modelId: AnthropicModelId): LanguageModelV4;
 
-  messages(modelId: AnthropicMessagesModelId): LanguageModelV4;
+  messages(modelId: AnthropicModelId): LanguageModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
@@ -141,8 +141,8 @@ export function createAnthropic(
     );
   };
 
-  const createChatModel = (modelId: AnthropicMessagesModelId) =>
-    new AnthropicMessagesLanguageModel(modelId, {
+  const createChatModel = (modelId: AnthropicModelId) =>
+    new AnthropicLanguageModel(modelId, {
       provider: providerName,
       baseURL,
       headers: getHeaders,
@@ -162,7 +162,7 @@ export function createAnthropic(
       fetch: options.fetch,
     });
 
-  const provider = function (modelId: AnthropicMessagesModelId) {
+  const provider = function (modelId: AnthropicModelId) {
     if (new.target) {
       throw new Error(
         'The Anthropic model function cannot be called with the new keyword.',

--- a/packages/anthropic/src/convert-anthropic-usage.test.ts
+++ b/packages/anthropic/src/convert-anthropic-usage.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import {
-  convertAnthropicMessagesUsage,
-  AnthropicMessagesUsage,
-} from './convert-anthropic-messages-usage';
+  convertAnthropicUsage,
+  AnthropicUsage,
+} from './convert-anthropic-usage';
 
-describe('convertAnthropicMessagesUsage', () => {
+describe('convertAnthropicUsage', () => {
   it('should use usage as raw when rawUsage is not provided', () => {
     const usage = {
       input_tokens: 10,
       output_tokens: 20,
     };
 
-    const result = convertAnthropicMessagesUsage({ usage });
+    const result = convertAnthropicUsage({ usage });
 
     expect(result.raw).toBe(usage);
   });
@@ -32,13 +32,13 @@ describe('convertAnthropicMessagesUsage', () => {
       },
     };
 
-    const result = convertAnthropicMessagesUsage({ usage, rawUsage });
+    const result = convertAnthropicUsage({ usage, rawUsage });
 
     expect(result.raw).toBe(rawUsage);
   });
 
   it('should compute token totals correctly with cache tokens', () => {
-    const result = convertAnthropicMessagesUsage({
+    const result = convertAnthropicUsage({
       usage: {
         input_tokens: 10,
         output_tokens: 20,
@@ -61,14 +61,14 @@ describe('convertAnthropicMessagesUsage', () => {
   });
 
   it('should handle null cache tokens', () => {
-    const usage: AnthropicMessagesUsage = {
+    const usage: AnthropicUsage = {
       input_tokens: 100,
       output_tokens: 50,
       cache_creation_input_tokens: null,
       cache_read_input_tokens: null,
     };
 
-    const result = convertAnthropicMessagesUsage({ usage });
+    const result = convertAnthropicUsage({ usage });
 
     expect(result.inputTokens.total).toBe(100);
     expect(result.inputTokens.cacheRead).toBe(0);
@@ -77,7 +77,7 @@ describe('convertAnthropicMessagesUsage', () => {
 
   describe('compaction usage with iterations', () => {
     it('should sum across all iterations when iterations array is present', () => {
-      const usage: AnthropicMessagesUsage = {
+      const usage: AnthropicUsage = {
         input_tokens: 45000,
         output_tokens: 1234,
         iterations: [
@@ -94,7 +94,7 @@ describe('convertAnthropicMessagesUsage', () => {
         ],
       };
 
-      const result = convertAnthropicMessagesUsage({ usage });
+      const result = convertAnthropicUsage({ usage });
 
       // Total should be sum of iterations, not top-level values
       expect(result.inputTokens.total).toBe(203000); // 180000 + 23000
@@ -104,7 +104,7 @@ describe('convertAnthropicMessagesUsage', () => {
     });
 
     it('should handle single iteration (message only, no compaction triggered)', () => {
-      const usage: AnthropicMessagesUsage = {
+      const usage: AnthropicUsage = {
         input_tokens: 5000,
         output_tokens: 500,
         iterations: [
@@ -116,14 +116,14 @@ describe('convertAnthropicMessagesUsage', () => {
         ],
       };
 
-      const result = convertAnthropicMessagesUsage({ usage });
+      const result = convertAnthropicUsage({ usage });
 
       expect(result.inputTokens.total).toBe(5000);
       expect(result.outputTokens.total).toBe(500);
     });
 
     it('should handle multiple compaction iterations (long-running task)', () => {
-      const usage: AnthropicMessagesUsage = {
+      const usage: AnthropicUsage = {
         input_tokens: 10000,
         output_tokens: 500,
         iterations: [
@@ -150,7 +150,7 @@ describe('convertAnthropicMessagesUsage', () => {
         ],
       };
 
-      const result = convertAnthropicMessagesUsage({ usage });
+      const result = convertAnthropicUsage({ usage });
 
       // Total = 200000 + 50000 + 180000 + 30000 = 460000 input
       // Total = 4000 + 2000 + 3500 + 1500 = 11000 output
@@ -159,7 +159,7 @@ describe('convertAnthropicMessagesUsage', () => {
     });
 
     it('should combine iterations with cache tokens', () => {
-      const usage: AnthropicMessagesUsage = {
+      const usage: AnthropicUsage = {
         input_tokens: 45000,
         output_tokens: 1234,
         cache_creation_input_tokens: 1000,
@@ -178,7 +178,7 @@ describe('convertAnthropicMessagesUsage', () => {
         ],
       };
 
-      const result = convertAnthropicMessagesUsage({ usage });
+      const result = convertAnthropicUsage({ usage });
 
       // Total input = sum of iterations + cache tokens
       // noCache = sum of iterations only
@@ -190,7 +190,7 @@ describe('convertAnthropicMessagesUsage', () => {
     });
 
     it('should use rawUsage as raw even when iterations are present', () => {
-      const usage: AnthropicMessagesUsage = {
+      const usage: AnthropicUsage = {
         input_tokens: 45000,
         output_tokens: 1234,
         iterations: [
@@ -212,7 +212,7 @@ describe('convertAnthropicMessagesUsage', () => {
         service_tier: 'standard',
       };
 
-      const result = convertAnthropicMessagesUsage({ usage, rawUsage });
+      const result = convertAnthropicUsage({ usage, rawUsage });
 
       expect(result.raw).toBe(rawUsage);
       expect(result.inputTokens.total).toBe(203000);
@@ -221,45 +221,45 @@ describe('convertAnthropicMessagesUsage', () => {
 
   describe('edge cases', () => {
     it('should use top-level values when iterations is null', () => {
-      const usage: AnthropicMessagesUsage = {
+      const usage: AnthropicUsage = {
         input_tokens: 100,
         output_tokens: 50,
         iterations: null,
       };
 
-      const result = convertAnthropicMessagesUsage({ usage });
+      const result = convertAnthropicUsage({ usage });
 
       expect(result.inputTokens.total).toBe(100);
       expect(result.outputTokens.total).toBe(50);
     });
 
     it('should use top-level values when iterations is undefined', () => {
-      const usage: AnthropicMessagesUsage = {
+      const usage: AnthropicUsage = {
         input_tokens: 100,
         output_tokens: 50,
       };
 
-      const result = convertAnthropicMessagesUsage({ usage });
+      const result = convertAnthropicUsage({ usage });
 
       expect(result.inputTokens.total).toBe(100);
       expect(result.outputTokens.total).toBe(50);
     });
 
     it('should use top-level values when iterations array is empty', () => {
-      const usage: AnthropicMessagesUsage = {
+      const usage: AnthropicUsage = {
         input_tokens: 100,
         output_tokens: 50,
         iterations: [],
       };
 
-      const result = convertAnthropicMessagesUsage({ usage });
+      const result = convertAnthropicUsage({ usage });
 
       expect(result.inputTokens.total).toBe(100);
       expect(result.outputTokens.total).toBe(50);
     });
 
     it('should handle zero tokens in iterations', () => {
-      const usage: AnthropicMessagesUsage = {
+      const usage: AnthropicUsage = {
         input_tokens: 0,
         output_tokens: 0,
         iterations: [
@@ -276,7 +276,7 @@ describe('convertAnthropicMessagesUsage', () => {
         ],
       };
 
-      const result = convertAnthropicMessagesUsage({ usage });
+      const result = convertAnthropicUsage({ usage });
 
       expect(result.inputTokens.total).toBe(0);
       expect(result.outputTokens.total).toBe(0);
@@ -285,7 +285,7 @@ describe('convertAnthropicMessagesUsage', () => {
 
   describe('real-world scenarios from documentation', () => {
     it('should match documentation example exactly', () => {
-      const usage: AnthropicMessagesUsage = {
+      const usage: AnthropicUsage = {
         input_tokens: 45000,
         output_tokens: 1234,
         iterations: [
@@ -302,7 +302,7 @@ describe('convertAnthropicMessagesUsage', () => {
         ],
       };
 
-      const result = convertAnthropicMessagesUsage({ usage });
+      const result = convertAnthropicUsage({ usage });
 
       const expectedTotalInput = 180000 + 23000; // 203000
       const expectedTotalOutput = 3500 + 1000; // 4500
@@ -317,13 +317,13 @@ describe('convertAnthropicMessagesUsage', () => {
     });
 
     it('should handle re-applying previous compaction block (no new compaction)', () => {
-      const usage: AnthropicMessagesUsage = {
+      const usage: AnthropicUsage = {
         input_tokens: 15000,
         output_tokens: 800,
         // No iterations - previous compaction block was re-applied
       };
 
-      const result = convertAnthropicMessagesUsage({ usage });
+      const result = convertAnthropicUsage({ usage });
 
       // Top-level values are accurate when no new compaction triggered
       expect(result.inputTokens.total).toBe(15000);

--- a/packages/anthropic/src/convert-anthropic-usage.ts
+++ b/packages/anthropic/src/convert-anthropic-usage.ts
@@ -11,7 +11,7 @@ export type AnthropicUsageIteration = {
   output_tokens: number;
 };
 
-export type AnthropicMessagesUsage = {
+export type AnthropicUsage = {
   input_tokens: number;
   output_tokens: number;
   cache_creation_input_tokens?: number | null;
@@ -25,11 +25,11 @@ export type AnthropicMessagesUsage = {
   iterations?: AnthropicUsageIteration[] | null;
 };
 
-export function convertAnthropicMessagesUsage({
+export function convertAnthropicUsage({
   usage,
   rawUsage,
 }: {
-  usage: AnthropicMessagesUsage;
+  usage: AnthropicUsage;
   rawUsage?: JSONObject;
 }): LanguageModelV4Usage {
   const cacheCreationTokens = usage.cache_creation_input_tokens ?? 0;

--- a/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { SharedV4Warning } from '@ai-sdk/provider';
 import { createToolNameMapping } from '@ai-sdk/provider-utils';
-import { convertToAnthropicMessagesPrompt } from './convert-to-anthropic-messages-prompt';
+import { convertToAnthropicPrompt } from './convert-to-anthropic-prompt';
 import { CacheControlValidator } from './get-cache-control';
 
 // Create a default identity tool name mapping for tests (no tools = no mapping)
@@ -12,7 +12,7 @@ const defaultToolNameMapping = createToolNameMapping({
 
 describe('system messages', () => {
   it('should convert a single system message into an anthropic system message', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [{ role: 'system', content: 'This is a system message' }],
       sendReasoning: true,
       warnings: [],
@@ -29,7 +29,7 @@ describe('system messages', () => {
   });
 
   it('should convert multiple system messages into an anthropic system message', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         { role: 'system', content: 'This is a system message' },
         { role: 'system', content: 'This is another system message' },
@@ -54,7 +54,7 @@ describe('system messages', () => {
 
 describe('user messages', () => {
   it('should add image parts for UInt8Array images', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -96,7 +96,7 @@ describe('user messages', () => {
   });
 
   it('should add image parts for URL images', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -137,7 +137,7 @@ describe('user messages', () => {
   });
 
   it('should treat URL strings in image file data as URLs, not base64)', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -178,7 +178,7 @@ describe('user messages', () => {
   });
 
   it('should treat URL strings in PDF file data as URLs, not base64)', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -219,7 +219,7 @@ describe('user messages', () => {
   });
 
   it('should add PDF file parts for base64 PDFs', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -261,7 +261,7 @@ describe('user messages', () => {
   });
 
   it('should add PDF file parts for URL PDFs', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -302,7 +302,7 @@ describe('user messages', () => {
   });
 
   it('should add text file parts for text/plain documents', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -350,7 +350,7 @@ describe('user messages', () => {
 
   it('should throw error for unsupported file types', async () => {
     await expect(
-      convertToAnthropicMessagesPrompt({
+      convertToAnthropicPrompt({
         prompt: [
           {
             role: 'user',
@@ -371,7 +371,7 @@ describe('user messages', () => {
   });
 
   it('should convert messages with image file parts using provider reference', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -413,7 +413,7 @@ describe('user messages', () => {
   });
 
   it('should convert messages with PDF file parts using provider reference', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -455,7 +455,7 @@ describe('user messages', () => {
   });
 
   it('should convert messages with text/plain file parts using provider reference', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -498,7 +498,7 @@ describe('user messages', () => {
 
   it('should throw when provider reference does not contain anthropic key', async () => {
     await expect(
-      convertToAnthropicMessagesPrompt({
+      convertToAnthropicPrompt({
         prompt: [
           {
             role: 'user',
@@ -523,7 +523,7 @@ describe('user messages', () => {
 
 describe('tool messages', () => {
   it('should convert a single tool result into an anthropic user message', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'tool',
@@ -567,7 +567,7 @@ describe('tool messages', () => {
   });
 
   it('should convert multiple tool results into an anthropic user message', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'tool',
@@ -623,7 +623,7 @@ describe('tool messages', () => {
   });
 
   it('should combine user and tool messages', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'tool',
@@ -672,7 +672,7 @@ describe('tool messages', () => {
   });
 
   it('should handle tool result with content parts', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'tool',
@@ -742,7 +742,7 @@ describe('tool messages', () => {
   });
 
   it('should handle tool result with PDF content', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'tool',
@@ -814,7 +814,7 @@ describe('tool messages', () => {
   });
 
   it('should handle tool result with custom tool-reference content for custom tool search', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'tool',
@@ -889,7 +889,7 @@ describe('tool messages', () => {
   });
 
   it('should handle tool result with url-based PDF content', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'tool',
@@ -950,7 +950,7 @@ describe('tool messages', () => {
   });
 
   it('should handle tool result with url-based image content', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'tool',
@@ -1013,7 +1013,7 @@ describe('tool messages', () => {
 
 describe('assistant messages', () => {
   it('should remove trailing whitespace from last assistant message when there is no further user message', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -1047,7 +1047,7 @@ describe('assistant messages', () => {
   });
 
   it('should remove trailing whitespace from last assistant message with multi-part content when there is no further user message', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -1087,7 +1087,7 @@ describe('assistant messages', () => {
   });
 
   it('should keep trailing whitespace from assistant message when there is a further user message', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -1129,7 +1129,7 @@ describe('assistant messages', () => {
   });
 
   it('should combine multiple sequential assistant messages into a single message', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         { role: 'user', content: [{ type: 'text', text: 'Hi!' }] },
         { role: 'assistant', content: [{ type: 'text', text: 'Hello' }] },
@@ -1161,7 +1161,7 @@ describe('assistant messages', () => {
 
   it('should convert assistant message reasoning parts with signature into thinking parts when sendReasoning is true', async () => {
     const warnings: SharedV4Warning[] = [];
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'assistant',
@@ -1214,7 +1214,7 @@ describe('assistant messages', () => {
 
   it('should ignore reasoning parts without signature into thinking parts when sendReasoning is true', async () => {
     const warnings: SharedV4Warning[] = [];
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'assistant',
@@ -1267,7 +1267,7 @@ describe('assistant messages', () => {
 
   it('should omit assistant message reasoning parts with signature when sendReasoning is false', async () => {
     const warnings: SharedV4Warning[] = [];
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'assistant',
@@ -1319,7 +1319,7 @@ describe('assistant messages', () => {
 
   it('should omit reasoning parts without signature when sendReasoning is false', async () => {
     const warnings: SharedV4Warning[] = [];
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'assistant',
@@ -1366,7 +1366,7 @@ describe('assistant messages', () => {
 
   it('should convert anthropic web_search tool call and result parts', async () => {
     const warnings: SharedV4Warning[] = [];
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'assistant',
@@ -1448,7 +1448,7 @@ describe('assistant messages', () => {
 
   it('should convert anthropic web_fetch tool call and result parts', async () => {
     const warnings: SharedV4Warning[] = [];
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'assistant',
@@ -1544,7 +1544,7 @@ describe('assistant messages', () => {
 
   it('should convert anthropic web_fetch tool call with error result', async () => {
     const warnings: SharedV4Warning[] = [];
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'assistant',
@@ -1616,7 +1616,7 @@ describe('assistant messages', () => {
 
   it('should convert anthropic web_fetch tool call with error result as object', async () => {
     const warnings: SharedV4Warning[] = [];
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'assistant',
@@ -1688,7 +1688,7 @@ describe('assistant messages', () => {
 
   it('should convert anthropic web_fetch tool call with error result as malformed string', async () => {
     const warnings: SharedV4Warning[] = [];
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'assistant',
@@ -1735,7 +1735,7 @@ describe('assistant messages', () => {
 
   it('should convert anthropic tool_search_tool_regex tool call and result parts', async () => {
     const warnings: SharedV4Warning[] = [];
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'assistant',
@@ -1817,7 +1817,7 @@ describe('assistant messages', () => {
   describe('code_execution 20250522', () => {
     it('should convert anthropic code_execution tool call and result parts', async () => {
       const warnings: SharedV4Warning[] = [];
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'assistant',
@@ -1894,7 +1894,7 @@ describe('assistant messages', () => {
 
     it('should pass back encrypted_code_execution_result for multi-turn (web_fetch_20260209/web_search_20260209)', async () => {
       const warnings: SharedV4Warning[] = [];
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'assistant',
@@ -1978,7 +1978,7 @@ describe('assistant messages', () => {
   describe('code_execution 20250825', () => {
     it('should convert anthropic code_execution tool call and result parts', async () => {
       const warnings: SharedV4Warning[] = [];
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'assistant',
@@ -2106,7 +2106,7 @@ describe('assistant messages', () => {
   describe('code_execution 20260120', () => {
     it('should convert anthropic code_execution tool call and result parts', async () => {
       const warnings: SharedV4Warning[] = [];
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'assistant',
@@ -2234,7 +2234,7 @@ describe('assistant messages', () => {
   describe('mcp tool use', () => {
     it('should convert anthropic mcp tool use parts', async () => {
       const warnings: SharedV4Warning[] = [];
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'assistant',
@@ -2328,7 +2328,7 @@ describe('assistant messages', () => {
 describe('cache control', () => {
   describe('system message', () => {
     it('should set cache_control on system message with message cache control', async () => {
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'system',
@@ -2361,7 +2361,7 @@ describe('cache control', () => {
 
   describe('user message', () => {
     it('should set cache_control on user message part with part cache control', async () => {
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'user',
@@ -2403,7 +2403,7 @@ describe('cache control', () => {
     });
 
     it('should set cache_control on last user message part with message cache control', async () => {
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'user',
@@ -2450,7 +2450,7 @@ describe('cache control', () => {
 
   describe('assistant message', () => {
     it('should set cache_control on assistant message text part with part cache control', async () => {
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           { role: 'user', content: [{ type: 'text', text: 'user-content' }] },
           {
@@ -2494,7 +2494,7 @@ describe('cache control', () => {
     });
 
     it('should set cache_control on assistant tool call part with part cache control', async () => {
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           { role: 'user', content: [{ type: 'text', text: 'user-content' }] },
           {
@@ -2542,7 +2542,7 @@ describe('cache control', () => {
     });
 
     it('should set cache_control on last assistant message part with message cache control', async () => {
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           { role: 'user', content: [{ type: 'text', text: 'user-content' }] },
           {
@@ -2591,7 +2591,7 @@ describe('cache control', () => {
 
   describe('tool message', () => {
     it('should set cache_control on tool result message part with part cache control', async () => {
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'tool',
@@ -2637,7 +2637,7 @@ describe('cache control', () => {
     });
 
     it('should set cache_control on last tool result message part with message cache control', async () => {
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'tool',
@@ -2700,7 +2700,7 @@ describe('cache control', () => {
     it('should reject cache_control on thinking blocks', async () => {
       const warnings: SharedV4Warning[] = [];
       const cacheControlValidator = new CacheControlValidator();
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'assistant',
@@ -2756,7 +2756,7 @@ describe('cache control', () => {
     it('should reject cache_control on redacted thinking blocks', async () => {
       const warnings: SharedV4Warning[] = [];
       const cacheControlValidator = new CacheControlValidator();
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'assistant',
@@ -2799,7 +2799,7 @@ describe('cache control', () => {
   it('should limit cache breakpoints to 4', async () => {
     const warnings: SharedV4Warning[] = [];
     const cacheControlValidator = new CacheControlValidator();
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'system',
@@ -2890,7 +2890,7 @@ describe('cache control', () => {
 
 describe('citations', () => {
   it('should not include citations by default', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -2938,7 +2938,7 @@ describe('citations', () => {
   });
 
   it('should include citations when enabled on file part', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -2994,7 +2994,7 @@ describe('citations', () => {
   });
 
   it('should include custom title and context when provided', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -3054,7 +3054,7 @@ describe('citations', () => {
   });
 
   it('should handle multiple documents with consistent citation settings', async () => {
-    const result = await convertToAnthropicMessagesPrompt({
+    const result = await convertToAnthropicPrompt({
       prompt: [
         {
           role: 'user',
@@ -3149,7 +3149,7 @@ describe('citations', () => {
 
   describe('message sequences', () => {
     it('should convert user-assistant-tool-assistant-user message sequence with multiple tool calls', async () => {
-      const result = await convertToAnthropicMessagesPrompt({
+      const result = await convertToAnthropicPrompt({
         prompt: [
           {
             role: 'user',

--- a/packages/anthropic/src/convert-to-anthropic-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.ts
@@ -18,13 +18,13 @@ import {
 } from '@ai-sdk/provider-utils';
 import {
   AnthropicAssistantMessage,
-  AnthropicMessagesPrompt,
+  AnthropicPrompt,
   anthropicReasoningMetadataSchema,
   AnthropicToolResultContent,
   AnthropicUserMessage,
   AnthropicWebFetchToolResultContent,
-} from './anthropic-messages-api';
-import { anthropicFilePartProviderOptions } from './anthropic-messages-options';
+} from './anthropic-api';
+import { anthropicFilePartProviderOptions } from './anthropic-options';
 import { CacheControlValidator } from './get-cache-control';
 import { codeExecution_20250522OutputSchema } from './tool/code-execution_20250522';
 import { codeExecution_20250825OutputSchema } from './tool/code-execution_20250825';
@@ -70,7 +70,7 @@ function getUrlString(data: LanguageModelV4DataContent): string {
   return data instanceof URL ? data.toString() : (data as string);
 }
 
-export async function convertToAnthropicMessagesPrompt({
+export async function convertToAnthropicPrompt({
   prompt,
   sendReasoning,
   warnings,
@@ -83,15 +83,15 @@ export async function convertToAnthropicMessagesPrompt({
   cacheControlValidator?: CacheControlValidator;
   toolNameMapping: ToolNameMapping;
 }): Promise<{
-  prompt: AnthropicMessagesPrompt;
+  prompt: AnthropicPrompt;
   betas: Set<string>;
 }> {
   const betas = new Set<string>();
   const blocks = groupIntoBlocks(prompt);
   const validator = cacheControlValidator || new CacheControlValidator();
 
-  let system: AnthropicMessagesPrompt['system'] = undefined;
-  const messages: AnthropicMessagesPrompt['messages'] = [];
+  let system: AnthropicPrompt['system'] = undefined;
+  const messages: AnthropicPrompt['messages'] = [];
 
   async function shouldEnableCitations(
     providerMetadata: SharedV4ProviderMetadata | undefined,

--- a/packages/anthropic/src/get-cache-control.ts
+++ b/packages/anthropic/src/get-cache-control.ts
@@ -1,5 +1,5 @@
 import { SharedV4Warning, SharedV4ProviderMetadata } from '@ai-sdk/provider';
-import { AnthropicCacheControl } from './anthropic-messages-api';
+import { AnthropicCacheControl } from './anthropic-api';
 
 // Anthropic allows a maximum of 4 cache breakpoints per request
 const MAX_CACHE_BREAKPOINTS = 4;

--- a/packages/anthropic/src/index.ts
+++ b/packages/anthropic/src/index.ts
@@ -6,7 +6,7 @@ export type {
   AnthropicLanguageModelOptions,
   /** @deprecated Use `AnthropicLanguageModelOptions` instead. */
   AnthropicLanguageModelOptions as AnthropicProviderOptions,
-} from './anthropic-messages-options';
+} from './anthropic-options';
 export type { AnthropicToolOptions } from './anthropic-prepare-tools';
 export { anthropic, createAnthropic } from './anthropic-provider';
 export type {

--- a/packages/anthropic/src/internal/index.ts
+++ b/packages/anthropic/src/internal/index.ts
@@ -1,7 +1,13 @@
 export {
-  AnthropicMessagesLanguageModel,
+  AnthropicLanguageModel,
+  /** @deprecated Use `AnthropicLanguageModel` instead. */
+  AnthropicLanguageModel as AnthropicMessagesLanguageModel,
   getModelCapabilities,
-} from '../anthropic-messages-language-model';
+} from '../anthropic-language-model';
 export { anthropicTools } from '../anthropic-tools';
-export type { AnthropicMessagesModelId } from '../anthropic-messages-options';
+export type {
+  AnthropicModelId,
+  /** @deprecated Use `AnthropicModelId` instead. */
+  AnthropicModelId as AnthropicMessagesModelId,
+} from '../anthropic-options';
 export { prepareTools } from '../anthropic-prepare-tools';

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-options.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-options.ts
@@ -1,5 +1,5 @@
 // https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude
-export type GoogleVertexAnthropicMessagesModelId =
+export type GoogleVertexAnthropicModelId =
   | 'claude-opus-4-7'
   | 'claude-opus-4-6'
   | 'claude-sonnet-4-6'

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -3,7 +3,7 @@ import {
   vertexAnthropicTools,
 } from './google-vertex-anthropic-provider';
 import { NoSuchModelError } from '@ai-sdk/provider';
-import { AnthropicMessagesLanguageModel } from '@ai-sdk/anthropic/internal';
+import { AnthropicLanguageModel } from '@ai-sdk/anthropic/internal';
 import { vi, describe, beforeEach, it, expect } from 'vitest';
 
 // Mock the imported modules
@@ -28,7 +28,7 @@ vi.mock('@ai-sdk/anthropic/internal', async () => {
   const originalModule = await vi.importActual('@ai-sdk/anthropic/internal');
   return {
     ...originalModule,
-    AnthropicMessagesLanguageModel: vi.fn(),
+    AnthropicLanguageModel: vi.fn(),
   };
 });
 
@@ -45,7 +45,7 @@ describe('google-vertex-anthropic-provider', () => {
     provider('test-model-id');
 
     // Assert that the model constructor was called with the correct arguments
-    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
       'test-model-id',
       expect.objectContaining({
         baseURL: expect.stringContaining(
@@ -78,7 +78,7 @@ describe('google-vertex-anthropic-provider', () => {
     provider('test-model-id');
 
     // Assert that the constructor was called with the correct baseURL
-    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
       expect.anything(), // modelId
       expect.objectContaining({
         baseURL: customBaseURL,
@@ -121,7 +121,7 @@ describe('google-vertex-anthropic-provider', () => {
     provider('test-model-id');
 
     // Assert that the model constructor was called with the correct headers
-    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
       expect.anything(), // modelId
       expect.objectContaining({
         headers: customHeaders,
@@ -147,7 +147,7 @@ describe('google-vertex-anthropic-provider', () => {
     provider('test-model-id');
 
     // Assert that the model constructor was called with supportedUrls function
-    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
       'test-model-id',
       expect.objectContaining({
         supportedUrls: expect.any(Function),
@@ -155,8 +155,9 @@ describe('google-vertex-anthropic-provider', () => {
     );
 
     // Get the actual config passed to the constructor
-    const constructorCall = vi.mocked(AnthropicMessagesLanguageModel).mock
-      .calls[vi.mocked(AnthropicMessagesLanguageModel).mock.calls.length - 1];
+    const constructorCall = vi.mocked(AnthropicLanguageModel).mock.calls[
+      vi.mocked(AnthropicLanguageModel).mock.calls.length - 1
+    ];
     const config = constructorCall[1];
 
     // Verify that supportedUrls returns empty object to force base64 conversion
@@ -170,7 +171,7 @@ describe('google-vertex-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
       'test-model-id',
       expect.objectContaining({
         baseURL:
@@ -187,7 +188,7 @@ describe('google-vertex-anthropic-provider', () => {
     });
     provider('test-model-id');
 
-    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
       'test-model-id',
       expect.objectContaining({
         baseURL:
@@ -206,9 +207,9 @@ describe('google-vertex-anthropic-provider', () => {
     // Create a model instance
     const model = provider('claude-3-5-sonnet-v2@20241022');
 
-    // Verify the model was created using AnthropicMessagesLanguageModel
+    // Verify the model was created using AnthropicLanguageModel
     // which already supports combining tools with structured outputs
-    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
       'claude-3-5-sonnet-v2@20241022',
       expect.objectContaining({
         provider: 'vertex.anthropic.messages',

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -13,7 +13,7 @@ import {
   anthropicTools,
   AnthropicLanguageModel,
 } from '@ai-sdk/anthropic/internal';
-import { GoogleVertexAnthropicMessagesModelId } from './google-vertex-anthropic-messages-options';
+import { GoogleVertexAnthropicModelId } from './google-vertex-anthropic-options';
 
 /**
  * Tools supported by Google Vertex Anthropic.
@@ -105,12 +105,12 @@ export interface GoogleVertexAnthropicProvider extends ProviderV4 {
   /**
    * Creates a model for text generation.
    */
-  (modelId: GoogleVertexAnthropicMessagesModelId): LanguageModelV4;
+  (modelId: GoogleVertexAnthropicModelId): LanguageModelV4;
 
   /**
    * Creates a model for text generation.
    */
-  languageModel(modelId: GoogleVertexAnthropicMessagesModelId): LanguageModelV4;
+  languageModel(modelId: GoogleVertexAnthropicModelId): LanguageModelV4;
 
   /**
    * Anthropic tools supported by Google Vertex.
@@ -179,7 +179,7 @@ export function createVertexAnthropic(
     );
   };
 
-  const createChatModel = (modelId: GoogleVertexAnthropicMessagesModelId) =>
+  const createChatModel = (modelId: GoogleVertexAnthropicModelId) =>
     new AnthropicLanguageModel(modelId, {
       provider: 'vertex.anthropic.messages',
       baseURL: getBaseURL(),
@@ -206,7 +206,7 @@ export function createVertexAnthropic(
       supportsStrictTools: false,
     });
 
-  const provider = function (modelId: GoogleVertexAnthropicMessagesModelId) {
+  const provider = function (modelId: GoogleVertexAnthropicModelId) {
     if (new.target) {
       throw new Error(
         'The Anthropic model function cannot be called with the new keyword.',

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -11,7 +11,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import {
   anthropicTools,
-  AnthropicMessagesLanguageModel,
+  AnthropicLanguageModel,
 } from '@ai-sdk/anthropic/internal';
 import { GoogleVertexAnthropicMessagesModelId } from './google-vertex-anthropic-messages-options';
 
@@ -180,7 +180,7 @@ export function createVertexAnthropic(
   };
 
   const createChatModel = (modelId: GoogleVertexAnthropicMessagesModelId) =>
-    new AnthropicMessagesLanguageModel(modelId, {
+    new AnthropicLanguageModel(modelId, {
       provider: 'vertex.anthropic.messages',
       baseURL: getBaseURL(),
       headers: options.headers ?? {},


### PR DESCRIPTION
## Background

The Anthropic provider had a redundant `messages` affix in several internal symbol and file names (e.g. `AnthropicMessagesLanguageModel`, `AnthropicMessagesModelId`, `anthropic-messages-language-model.ts`). While the Anthropic API uses `/messages` as its root, there is no other variant, so including it in the name is not helpful.

## Summary

- Rename files, types, and classes accordingly
- Maintain back compat for package-level exports by re-exporting as deprecated aliases under the old name

## Manual Verification

N/A

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
