### PR TITLE
fix(ui): guard activeResponse access in makeRequest finally block (closes #11024)

### DIFF
--- a/.changeset/fix-active-response-state.md
+++ b/.changeset/fix-active-response-state.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ui): guard activeResponse access in makeRequest finally block to prevent "Cannot read properties of undefined (reading 'state')" error when calling sendMessage() after addToolOutput()

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -652,8 +652,9 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     let isDisconnect = false;
     let isError = false;
 
+    let activeResponse: ActiveResponse<UI_MESSAGE> | undefined;
     try {
-      const activeResponse = {
+      activeResponse = {
         state: createStreamingUIMessageState({
           lastMessage: this.state.snapshot(lastMessage),
           messageId: this.generateId(),
@@ -757,14 +758,16 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       this.setStatus({ status: 'error', error: err as Error });
     } finally {
       try {
-        this.onFinish?.({
-          message: this.activeResponse!.state.message,
-          messages: this.state.messages,
-          isAbort,
-          isDisconnect,
-          isError,
-          finishReason: this.activeResponse?.state.finishReason,
-        });
+        if (activeResponse) {
+          this.onFinish?.({
+            message: activeResponse.state.message,
+            messages: this.state.messages,
+            isAbort,
+            isDisconnect,
+            isError,
+            finishReason: activeResponse.state.finishReason,
+          });
+        }
       } catch (err) {
         console.error(err);
       }


### PR DESCRIPTION
## Fix: Guard activeResponse access in makeRequest finally block

### Problem
Calling `sendMessage()` after `addToolOutput()` causes:
```
TypeError: Cannot read properties of undefined (reading 'state')
    at Chat.makeRequest (chat.ts:688:41)
```

This happens because `activeResponse` was declared inside the `try` block but referenced in the `finally` block via `this.activeResponse!`, which could be cleared by concurrent calls or set to undefined before `onFinish` runs.

### Solution
1. Move `activeResponse` declaration before the `try` block so it is in scope in the `finally` block
2. Guard the `onFinish` call with `if (activeResponse)` check
3. Use the captured local variable instead of `this.activeResponse!` in the `finally` block

### Changes
- `packages/ai/src/ui/chat.ts`: Move `activeResponse` before `try`, add guard in `finally`

### Testing
All 26 chat tests pass.

Closes #11024