### PR TITLE
feat(provider/deepseek): add DeepSeek V4 Pro and V4 Flash model IDs

### DIFF
--- a/.changeset/add-deepseek-v4-models.md
+++ b/.changeset/add-deepseek-v4-models.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/deepseek': patch
+---
+
+Add DeepSeek V4 Flash and V4 Pro to known model IDs for improved autocomplete support.

--- a/packages/deepseek/src/chat/deepseek-chat-options.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-options.ts
@@ -4,6 +4,8 @@ import { z } from 'zod/v4';
 export type DeepSeekChatModelId =
   | 'deepseek-chat'
   | 'deepseek-reasoner'
+  | 'deepseek-v4-flash'
+  | 'deepseek-v4-pro'
   | (string & {});
 
 export const deepseekLanguageModelOptions = z.object({


### PR DESCRIPTION
## Summary

Add deepseek-v4-flash and deepseek-v4-pro to the DeepSeekChatModelId type union in the @ai-sdk/deepseek package.

### What Changed

- **packages/deepseek/src/chat/deepseek-chat-options.ts**: Added two new model IDs to the union type

### Why

DeepSeek has released its V4 model series:
- **deepseek-v4-flash**: 284B params, 1M context, optimized for speed and cost
- **deepseek-v4-pro**: 1.6T params, 1M context, optimized for complex reasoning

Both support thinking mode, tool calls, and JSON output. The legacy \deepseek-chat\ and \deepseek-reasoner\ names are being deprecated (mapping to V4 Flash modes).

Adding these IDs improves autocomplete/IntelliSense for users adopting the new models.

### Source

https://api-docs.deepseek.com/quick_start/pricing

### AI Disclosure

This PR was authored with AI assistance.