### PR TITLE
fix: correct audio/mp4 detection to check ftyp at byte offset 4

### DIFF
--- a/packages/provider-utils/src/detect-media-type.test.ts
+++ b/packages/provider-utils/src/detect-media-type.test.ts
@@ -543,21 +543,46 @@ describe('detectMediaType signature matching', () => {
   });
 
   describe('MP4', () => {
-    it('should detect MP4 from bytes', () => {
-      const mp4Bytes = new Uint8Array([0x66, 0x74, 0x79, 0x70]);
+    it('should detect MP4/M4A from bytes with ftyp at offset 4', () => {
+      // Real M4A header: 4-byte box length + "ftyp" + "M4A "
+      const m4aBytes = new Uint8Array([
+        0x00, 0x00, 0x00, 0x1c, // box length (28)
+        0x66, 0x74, 0x79, 0x70, // ftyp
+        0x4d, 0x34, 0x41, 0x20, // M4A
+        0x00, 0x00, 0x02, 0x00, // minor version
+      ]);
       expect(
         detectMediaType({
-          data: mp4Bytes,
+          data: m4aBytes,
           topLevelType: 'audio',
         }),
       ).toBe('audio/mp4');
     });
 
-    it('should detect MP4 from base64', () => {
-      const mp4Base64 = 'ZnR5cA'; // Base64 string starting with MP4 signature
+    it('should detect MP4/M4A from base64 with ftyp at offset 4', () => {
+      const m4aBytes = new Uint8Array([
+        0x00, 0x00, 0x00, 0x1c,
+        0x66, 0x74, 0x79, 0x70,
+        0x4d, 0x34, 0x41, 0x20,
+      ]);
       expect(
         detectMediaType({
-          data: mp4Base64,
+          data: convertUint8ArrayToBase64(m4aBytes),
+          topLevelType: 'audio',
+        }),
+      ).toBe('audio/mp4');
+    });
+
+    it('should detect MP4 with isom brand from bytes', () => {
+      // MP4 with isom brand (common from ffmpeg)
+      const mp4Bytes = new Uint8Array([
+        0x00, 0x00, 0x00, 0x20, // box length (32)
+        0x66, 0x74, 0x79, 0x70, // ftyp
+        0x69, 0x73, 0x6f, 0x6d, // isom
+      ]);
+      expect(
+        detectMediaType({
+          data: mp4Bytes,
           topLevelType: 'audio',
         }),
       ).toBe('audio/mp4');

--- a/packages/provider-utils/src/detect-media-type.ts
+++ b/packages/provider-utils/src/detect-media-type.ts
@@ -119,7 +119,16 @@ const audioMediaTypeSignatures = [
   },
   {
     mediaType: 'audio/mp4' as const,
-    bytesPrefix: [0x66, 0x74, 0x79, 0x70],
+    bytesPrefix: [
+      null,
+      null,
+      null,
+      null,
+      0x66,
+      0x74,
+      0x79,
+      0x70, // ftyp at offset 4 (after 4-byte box-length header)
+    ],
   },
   {
     mediaType: 'audio/webm',


### PR DESCRIPTION
## Summary

`experimental_transcribe()` silently misidentifies m4a/mp4 audio files as `audio/wav`, causing HTTP 400 rejections from providers like OpenAI.

Closes #14721

## Root Cause

The `audio/mp4` signature in `audioMediaTypeSignatures` checks for the `ftyp` atom at byte offset 0:

```
bytesPrefix: [0x66, 0x74, 0x79, 0x70]  // ftyp at offset 0
```

But ISO base media files (m4a, mp4) always start with a 4-byte box-length header before `ftyp`:

```
bytes 0..7:  00 00 00 1c  66 74 79 70
             ^^^^^^^^^^^  ^^^^^^^^^^^
             box length   ftyp (at offset 4)
```

The `video/mp4` signature already handles this correctly with null wildcards for the box-length prefix.

## Changes

- **`detect-media-type.ts`**: Changed `audio/mp4` bytesPrefix to `[null, null, null, null, 0x66, 0x74, 0x79, 0x70]`, matching the existing `video/mp4` pattern
- **`detect-media-type.test.ts`**: Updated MP4 tests to use real file headers (M4A with `0x1c` box length, isom brand) instead of bare `ftyp` bytes

## Testing

Tests use the exact byte sequence from the issue reproduction (`00 00 00 1c 66 74 79 70 4d 34 41 20`).