### PR TITLE
fix(amazon-bedrock): do not replay unsigned reasoning content in multi-turn messages

### DIFF
--- a/.changeset/fix-unsigned-reasoning-leak.md
+++ b/.changeset/fix-unsigned-reasoning-leak.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(amazon-bedrock): do not replay unsigned reasoning content in multi-turn messages
+
+Reasoning parts without a `signature` or `redactedData` (e.g. from OpenAI models with extended thinking on Bedrock) are no longer replayed as `reasoningContent` blocks in multi-turn conversations. Replaying unsigned reasoning caused models to leak raw `<reasoning>` tags into the visible text response. Signed reasoning (Anthropic) and redacted reasoning are unaffected.

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -721,7 +721,7 @@ describe('assistant messages', () => {
     `);
   });
 
-  it('should trim trailing whitespace from reasoning content without signature when it is the last part', async () => {
+  it('should drop reasoning content without signature or redactedData', async () => {
     const result = await convertToBedrockChatMessages([
       {
         role: 'user',
@@ -732,8 +732,9 @@ describe('assistant messages', () => {
         content: [
           {
             type: 'reasoning',
-            text: 'This is my reasoning with trailing space    ',
+            text: 'This is unsigned reasoning that should be dropped',
           },
+          { type: 'text', text: 'The answer is 42.' },
         ],
       },
     ]);
@@ -752,11 +753,7 @@ describe('assistant messages', () => {
           {
             "content": [
               {
-                "reasoningContent": {
-                  "reasoningText": {
-                    "text": "This is my reasoning with trailing space",
-                  },
-                },
+                "text": "The answer is 42.",
               },
             ],
             "role": "assistant",
@@ -767,23 +764,46 @@ describe('assistant messages', () => {
     `);
   });
 
-  it('should only trim last reasoning part when multiple reasoning parts have trailing spaces', async () => {
+  it('should drop unsigned reasoning in multi-turn tool use and keep other content', async () => {
     const result = await convertToBedrockChatMessages([
       {
         role: 'user',
-        content: [{ type: 'text', text: 'Explain your reasoning' }],
+        content: [{ type: 'text', text: 'What is the weather?' }],
       },
       {
         role: 'assistant',
         content: [
           {
             type: 'reasoning',
-            text: 'First reasoning with trailing space    ',
+            text: 'Let me check the weather API.',
           },
           {
-            type: 'reasoning',
-            text: 'Second reasoning with trailing space    ',
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'getWeather',
+            input: { city: 'SF' },
           },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'getWeather',
+            output: { type: 'text', value: 'Sunny, 72F' },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'The weather is sunny.',
+          },
+          { type: 'text', text: 'It is sunny and 72F in SF.' },
         ],
       },
     ]);
@@ -794,7 +814,7 @@ describe('assistant messages', () => {
           {
             "content": [
               {
-                "text": "Explain your reasoning",
+                "text": "What is the weather?",
               },
             ],
             "role": "user",
@@ -802,18 +822,36 @@ describe('assistant messages', () => {
           {
             "content": [
               {
-                "reasoningContent": {
-                  "reasoningText": {
-                    "text": "First reasoning with trailing space    ",
+                "toolUse": {
+                  "input": {
+                    "city": "SF",
                   },
+                  "name": "getWeather",
+                  "toolUseId": "call-1",
                 },
               },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
               {
-                "reasoningContent": {
-                  "reasoningText": {
-                    "text": "Second reasoning with trailing space",
-                  },
+                "toolResult": {
+                  "content": [
+                    {
+                      "text": "Sunny, 72F",
+                    },
+                  ],
+                  "toolUseId": "call-1",
                 },
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "text": "It is sunny and 72F in SF.",
               },
             ],
             "role": "assistant",

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -316,22 +316,6 @@ export async function convertToBedrockChatMessages(
                       },
                     },
                   });
-                } else {
-                  // trim the last text part if it's the last message in the block
-                  // because Bedrock does not allow trailing whitespace
-                  // in pre-filled assistant responses
-                  bedrockContent.push({
-                    reasoningContent: {
-                      reasoningText: {
-                        text: trimIfLast(
-                          isLastBlock,
-                          isLastMessage,
-                          isLastContentPart,
-                          part.text,
-                        ),
-                      },
-                    },
-                  });
                 }
 
                 break;


### PR DESCRIPTION
PR #13972 fixed a bug where `trimIfLast()` invalidated Anthropic reasoning signatures by trimming trailing whitespace. During that refactoring, the code structure in `convert-to-bedrock-chat-messages.ts` changed from:

```ts
if (reasoningMetadata != null) {
  if (reasoningMetadata.signature != null) { /* replay with trim */ }
  else if (reasoningMetadata.redactedData != null) { /* replay redacted */ }
}
// unsigned reasoning → silently dropped (no else branch)
```

to:

```ts
if (reasoningMetadata?.signature != null) { /* replay without trim  */ }
else if (reasoningMetadata?.redactedData != null) { /* replay redacted */ }
else { /* replay unsigned reasoning as reasoningContent ← NEW catch-all */ }
```

The outer `if (reasoningMetadata != null)` guard was removed and replaced with optional chaining. This inadvertently introduced an `else` catch-all that **replays unsigned reasoning** (reasoning parts with no `providerMetadata`) as `reasoningContent` blocks — a case that was previously silently dropped.

The PR #13972 commit message states: *"reasoning blocks without a signature still get trimmed as before"*, but Anthropic models always include a signature. The only case reaching the `else` branch is unsigned reasoning from non-Anthropic models (e.g., OpenAI extended thinking on Bedrock), which should not be replayed.

## Summary

- Remove the `else` catch-all branch in the `reasoning` case of `convertToBedrockChatMessages`
- Reasoning parts without `signature` or `redactedData` are now silently dropped (restoring pre-#13972 behavior for this specific case)
- Signed reasoning (Anthropic) and redacted reasoning remain completely unaffected
- Add comment explaining why unsigned reasoning is intentionally not replayed
- Update tests to verify unsigned reasoning is dropped rather than replayed

### Why the `else` branch is unnecessary

- **Anthropic** always includes a cryptographic `signature` → handled by the `if` branch
- **Anthropic redacted reasoning** always has `redactedData` → handled by the `else if` branch
- **Non-Anthropic models** (OpenAI) produce unsigned reasoning that should not be replayed — replaying it causes the model to leak raw `<reasoning>` tags into the visible text response

## Manual Verification

Tested against real Bedrock models with a multi-turn agent + tool-use scenario (non-streaming `generateText`):

| Model | Without fix | With fix |
|---|---|---|
| `openai.gpt-oss-120b-1:0` | Leaks `<reasoning>` tags (33-100% of runs) | No leak |
| `us.anthropic.claude-sonnet-4-20250514-v1:0` | OK (reasoning with signature) | OK |
| `moonshotai.kimi-k2.5` | OK (no reasoning blocks) |  OK |
| `amazon.nova-pro-v1:0` | OK (no reasoning blocks) | OK |

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

- Fixes #14720
- Caused by #13972 (backported in #13979)
- Related: #14175 (empty text blocks with reasoning — same code area)
