### PR TITLE
fix(provider-utils): defer tool-input-start when function.name arrives in later delta

### DIFF
--- a/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
@@ -242,21 +242,138 @@ describe('StreamingToolCallTracker', () => {
       ).toThrow("Expected 'id' to be a string.");
     });
 
-    it('should throw when function.name is missing', () => {
+    it('should defer tool-input-start when function.name arrives in a later delta', () => {
       const tracker = new StreamingToolCallTracker();
-      const { enqueue } = createCollector();
+      const { parts, enqueue } = createCollector();
 
-      expect(() =>
-        tracker.processDelta(
-          {
-            index: 0,
-            id: 'call_1',
-            type: 'function',
-            function: {},
-          },
-          enqueue,
-        ),
-      ).toThrow("Expected 'function.name' to be a string.");
+      // First delta: id and empty arguments, but no name
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_123',
+          type: 'function',
+          function: { arguments: '' },
+        },
+        enqueue,
+      );
+
+      // No events emitted yet (name is pending)
+      expect(parts).toEqual([]);
+
+      parts.length = 0;
+
+      // Second delta: name arrives with first argument fragment
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_123',
+          type: 'function',
+          function: { name: 'bash', arguments: '{' },
+        },
+        enqueue,
+      );
+
+      expect(parts).toEqual([
+        { type: 'tool-input-start', id: 'call_123', toolName: 'bash' },
+        { type: 'tool-input-delta', id: 'call_123', delta: '{' },
+      ]);
+
+      parts.length = 0;
+
+      // Third delta: more arguments
+      tracker.processDelta(
+        {
+          index: 0,
+          function: { arguments: '"command": "ls -la"}' },
+        },
+        enqueue,
+      );
+
+      expect(parts).toEqual([
+        {
+          type: 'tool-input-delta',
+          id: 'call_123',
+          delta: '"command": "ls -la"}',
+        },
+        { type: 'tool-input-end', id: 'call_123' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_123',
+          toolName: 'bash',
+          input: '{"command": "ls -la"}',
+        },
+      ]);
+    });
+
+    it('should buffer arguments before name arrives and replay them', () => {
+      const tracker = new StreamingToolCallTracker();
+      const { parts, enqueue } = createCollector();
+
+      // First delta: id with some arguments but no name
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { arguments: '{"ke' },
+        },
+        enqueue,
+      );
+
+      expect(parts).toEqual([]);
+
+      parts.length = 0;
+
+      // Second delta: name arrives
+      tracker.processDelta(
+        {
+          index: 0,
+          function: { name: 'my_tool', arguments: 'y": "val"}' },
+        },
+        enqueue,
+      );
+
+      // Should emit start + combined buffered+new arguments
+      expect(parts).toEqual([
+        { type: 'tool-input-start', id: 'call_1', toolName: 'my_tool' },
+        {
+          type: 'tool-input-delta',
+          id: 'call_1',
+          delta: '{"key": "val"}',
+        },
+        { type: 'tool-input-end', id: 'call_1' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'my_tool',
+          input: '{"key": "val"}',
+        },
+      ]);
+    });
+
+    it('should not emit events for tool calls that never receive a name', () => {
+      const tracker = new StreamingToolCallTracker();
+      const { parts, enqueue } = createCollector();
+
+      // Delta without name
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { arguments: '{"key": "val"}' },
+        },
+        enqueue,
+      );
+
+      expect(parts).toEqual([]);
+
+      parts.length = 0;
+
+      // Flush should skip unstarted tool calls
+      tracker.flush(enqueue);
+
+      expect(parts).toEqual([]);
     });
   });
 

--- a/packages/provider-utils/src/streaming-tool-call-tracker.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.ts
@@ -59,6 +59,8 @@ interface TrackedToolCall {
   type: 'function';
   function: { name: string; arguments: string };
   hasFinished: boolean;
+  /** True once `tool-input-start` has been emitted (i.e. name is known). */
+  hasStarted: boolean;
   metadata?: SharedV4ProviderMetadata;
 }
 
@@ -112,7 +114,7 @@ export class StreamingToolCallTracker {
    */
   flush(enqueue: (part: LanguageModelV4StreamPart) => void): void {
     for (const toolCall of this.toolCalls) {
-      if (!toolCall.hasFinished) {
+      if (!toolCall.hasFinished && toolCall.hasStarted) {
         this.finishToolCall(toolCall, enqueue);
       }
     }
@@ -146,36 +148,31 @@ export class StreamingToolCallTracker {
       });
     }
 
-    if (toolCallDelta.function?.name == null) {
-      throw new InvalidResponseDataError({
-        data: toolCallDelta,
-        message: `Expected 'function.name' to be a string.`,
-      });
-    }
-
-    enqueue({
-      type: 'tool-input-start',
-      id: toolCallDelta.id,
-      toolName: toolCallDelta.function.name,
-    });
-
     const metadata = this.extractMetadata?.(toolCallDelta);
+    const name = toolCallDelta.function?.name ?? '';
+    const hasName = name.length > 0;
 
     this.toolCalls[index] = {
       id: toolCallDelta.id,
       type: 'function',
       function: {
-        name: toolCallDelta.function.name,
-        arguments: toolCallDelta.function.arguments ?? '',
+        name,
+        arguments: toolCallDelta.function?.arguments ?? '',
       },
       hasFinished: false,
+      hasStarted: false,
       metadata,
     };
 
     const toolCall = this.toolCalls[index];
 
-    // Emit initial delta if arguments already present
-    if (toolCall.function.arguments.length > 0) {
+    // If name is available, emit tool-input-start immediately
+    if (hasName) {
+      this.startToolCall(toolCall, enqueue);
+    }
+
+    // Emit initial delta if arguments already present and started
+    if (toolCall.hasStarted && toolCall.function.arguments.length > 0) {
       enqueue({
         type: 'tool-input-delta',
         id: toolCall.id,
@@ -185,7 +182,7 @@ export class StreamingToolCallTracker {
 
     // Check if tool call is complete
     // (some providers send the full tool call in one chunk)
-    if (isParsableJson(toolCall.function.arguments)) {
+    if (toolCall.hasStarted && isParsableJson(toolCall.function.arguments)) {
       this.finishToolCall(toolCall, enqueue);
     }
   }
@@ -201,20 +198,56 @@ export class StreamingToolCallTracker {
       return;
     }
 
-    if (toolCallDelta.function?.arguments != null) {
+    // If name arrives in a later delta, start the tool call now
+    if (
+      !toolCall.hasStarted &&
+      toolCallDelta.function?.name != null &&
+      toolCallDelta.function.name.length > 0
+    ) {
+      toolCall.function.name = toolCallDelta.function.name;
+      this.startToolCall(toolCall, enqueue);
+
+      // Replay any buffered arguments as a single delta
+      const buffered =
+        toolCall.function.arguments +
+        (toolCallDelta.function.arguments ?? '');
+      toolCall.function.arguments = buffered;
+
+      if (buffered.length > 0) {
+        enqueue({
+          type: 'tool-input-delta',
+          id: toolCall.id,
+          delta: buffered,
+        });
+      }
+    } else if (toolCallDelta.function?.arguments != null) {
       toolCall.function.arguments += toolCallDelta.function.arguments;
 
-      enqueue({
-        type: 'tool-input-delta',
-        id: toolCall.id,
-        delta: toolCallDelta.function.arguments,
-      });
+      if (toolCall.hasStarted) {
+        enqueue({
+          type: 'tool-input-delta',
+          id: toolCall.id,
+          delta: toolCallDelta.function.arguments,
+        });
+      }
     }
 
     // Check if tool call is complete
-    if (isParsableJson(toolCall.function.arguments)) {
+    if (toolCall.hasStarted && isParsableJson(toolCall.function.arguments)) {
       this.finishToolCall(toolCall, enqueue);
     }
+  }
+
+  private startToolCall(
+    toolCall: TrackedToolCall,
+    enqueue: (part: LanguageModelV4StreamPart) => void,
+  ): void {
+    enqueue({
+      type: 'tool-input-start',
+      id: toolCall.id,
+      toolName: toolCall.function.name,
+    });
+    toolCall.hasStarted = true;
   }
 
   private finishToolCall(


### PR DESCRIPTION
## Summary

Fixes #14722

Some OpenAI-compatible providers send the first `tool_calls` delta with an `id` and `function.arguments` but **without** `function.name`, then provide `function.name` in a subsequent delta. The `StreamingToolCallTracker` previously threw `AI_InvalidResponseDataError` on the first delta because it required `function.name` to be present immediately.

## Changes

**`packages/provider-utils/src/streaming-tool-call-tracker.ts`**
- When a new tool call delta arrives without `function.name`, create a pending tracked entry and buffer arguments instead of throwing
- Defer `tool-input-start` emission until `function.name` is received in a later delta
- When name arrives, emit `tool-input-start` followed by a single `tool-input-delta` with all buffered arguments
- Skip tool calls that never receive a name during `flush()` — no broken events emitted
- Add `hasStarted` flag to `TrackedToolCall` to track whether `tool-input-start` has been emitted

**`packages/provider-utils/src/streaming-tool-call-tracker.test.ts`**
- Add test: deferred name across multiple deltas (reproduces the exact chunk pattern from #14722)
- Add test: buffered arguments replayed when name arrives
- Add test: tool calls without name are silently skipped on flush
- Remove test that expected throwing on missing `function.name` (now handled gracefully)

## Reproduction

The chunk ordering from the issue:
```
delta: {tool_calls: [{index:0, id:"call_123", type:"function", function:{arguments:""}}]}     // no name
delta: {tool_calls: [{index:0, id:"call_123", type:"function", function:{name:"bash", arguments:"{"}}]}  // name arrives
delta: {tool_calls: [{index:0, function:{arguments:"\"command\""}}]}
...
```

Previously threw: `AI_InvalidResponseDataError: Expected 'function.name' to be a string.`
Now: accumulates correctly and emits a valid tool call.

## Related

- Similar prior fix for empty arguments: #6687
- Downstream report: https://github.com/anomalyco/opencode/issues/6649