### PR TITLE
refactoring: remove real-time delays in unit tests

### DIFF
--- a/.changeset/loud-chefs-kick.md
+++ b/.changeset/loud-chefs-kick.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/provider-utils": patch
+"ai": patch
+---
+
+refactoring: remove real-time delays in unit tests

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "5.8.3",
     "ultracite": "7.3.2",
     "update-ts-references": "^3.6.0",
-    "vitest": "4.1.0"
+    "vitest": "4.1.5"
   },
   "engines": {
     "node": "^18.0.0 || ^20.0.0 || ^22.0.0 || ^24.0.0"

--- a/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
@@ -4,7 +4,7 @@ import {
   convertReadableStreamToArray,
   mockId,
 } from '@ai-sdk/provider-utils/test';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { TypeValidationError } from '../error';
 import { asLanguageModelUsage } from '../types/usage';
@@ -43,8 +43,13 @@ const finishChunk = {
 
 describe('createExecuteToolsTransformation', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
     mockNow.mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should handle async tool execution', async () => {
@@ -1110,7 +1115,9 @@ describe('createExecuteToolsTransformation', () => {
         }),
       );
 
-      const result = await convertReadableStreamToArray(transformedStream);
+      const resultPromise = convertReadableStreamToArray(transformedStream);
+      await vi.advanceTimersByTimeAsync(10);
+      const result = await resultPromise;
 
       expect(result).toMatchInlineSnapshot(`
         [

--- a/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
@@ -1075,7 +1075,7 @@ describe('createExecuteToolsTransformation', () => {
         failingTool: tool({
           inputSchema: z.object({ value: z.string() }),
           execute: async ({ value }) => {
-            await delay(10); // TODO find elegant way to test setTimeout
+            await delay(10);
             if (value === 'test') {
               throw toolError;
             }

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -4032,7 +4032,7 @@ describe('streamText', () => {
                 delta: ' world',
               });
 
-              await new Promise(resolve => setTimeout(resolve, 10));
+              await delay(10);
 
               if (!abortSignal?.aborted) {
                 controller.enqueue({

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream-response.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream-response.test.ts
@@ -1,9 +1,10 @@
+import { delay } from '@ai-sdk/provider-utils';
 import {
   convertArrayToReadableStream,
   convertReadableStreamToArray,
 } from '@ai-sdk/provider-utils/test';
+import { describe, expect, it, vi } from 'vitest';
 import { createUIMessageStreamResponse } from './create-ui-message-stream-response';
-import { describe, it, expect, vi } from 'vitest';
 
 describe('createUIMessageStreamResponse', () => {
   it('should create a Response with correct headers and encoded stream', async () => {
@@ -120,7 +121,7 @@ describe('createUIMessageStreamResponse', () => {
     `);
 
     // Wait for consumeSseStream to complete
-    await new Promise(resolve => setTimeout(resolve, 0));
+    await delay(0);
 
     // Verify consumeSseStream received the same data
     expect(consumedData).toMatchInlineSnapshot(`

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream-response.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream-response.test.ts
@@ -1,12 +1,19 @@
-import { delay } from '@ai-sdk/provider-utils';
 import {
   convertArrayToReadableStream,
   convertReadableStreamToArray,
 } from '@ai-sdk/provider-utils/test';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createUIMessageStreamResponse } from './create-ui-message-stream-response';
 
 describe('createUIMessageStreamResponse', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should create a Response with correct headers and encoded stream', async () => {
     const response = createUIMessageStreamResponse({
       status: 200,
@@ -121,7 +128,7 @@ describe('createUIMessageStreamResponse', () => {
     `);
 
     // Wait for consumeSseStream to complete
-    await delay(0);
+    await vi.advanceTimersByTimeAsync(0);
 
     // Verify consumeSseStream received the same data
     expect(consumedData).toMatchInlineSnapshot(`

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
@@ -1,6 +1,6 @@
-import { delay, DelayedPromise } from '@ai-sdk/provider-utils';
+import { DelayedPromise } from '@ai-sdk/provider-utils';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UIMessage } from '../ui/ui-messages';
 import { consumeStream } from '../util/consume-stream';
 import { createUIMessageStream } from './create-ui-message-stream';
@@ -8,6 +8,14 @@ import { UIMessageChunk } from './ui-message-chunks';
 import { UIMessageStreamWriter } from './ui-message-stream-writer';
 
 describe('createUIMessageStream', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should send data stream part and close the stream', async () => {
     const stream = createUIMessageStream({
       execute: ({ writer }) => {
@@ -352,7 +360,7 @@ describe('createUIMessageStream', () => {
     // close controller1
     controller1!.close();
 
-    await delay(); // relinquish control
+    await vi.advanceTimersByTimeAsync(0); // relinquish control
 
     // it should still be able to write to controller2
     controller2!.enqueue({ type: 'text-delta', id: '2', delta: '2a' });

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -1,17 +1,16 @@
+import { mockId } from '@ai-sdk/provider-utils/test';
 import {
   createTestServer,
   TestResponseController,
 } from '@ai-sdk/test-server/with-vitest';
-import { mockId } from '@ai-sdk/provider-utils/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
 import { createResolvablePromise } from '../util/create-resolvable-promise';
 import { AbstractChat, ChatInit, ChatState, ChatStatus } from './chat';
-import { UIMessage } from './ui-messages';
-import { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
 import { DefaultChatTransport } from './default-chat-transport';
-import { lastAssistantMessageIsCompleteWithToolCalls } from './last-assistant-message-is-complete-with-tool-calls';
-import { describe, it, expect, beforeEach } from 'vitest';
-import { delay } from '@ai-sdk/provider-utils';
 import { lastAssistantMessageIsCompleteWithApprovalResponses } from './last-assistant-message-is-complete-with-approval-responses';
+import { lastAssistantMessageIsCompleteWithToolCalls } from './last-assistant-message-is-complete-with-tool-calls';
+import { UIMessage } from './ui-messages';
 
 class TestChatState<
   UI_MESSAGE extends UIMessage,
@@ -71,6 +70,14 @@ const server = createTestServer({
 });
 
 describe('Chat', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe('send a simple message', () => {
     let chat: TestChat;
     let letOnFinishArgs: any[] = [];
@@ -476,7 +483,7 @@ describe('Chat', () => {
 
       // wait until the stream is consumed before sending the error
       while ((chat.messages[1]?.parts[1] as any)?.text !== 'Hello') {
-        await delay();
+        await vi.advanceTimersByTimeAsync(0);
       }
 
       controller.error(new TypeError('fetch failed'));
@@ -708,7 +715,7 @@ describe('Chat', () => {
 
       // wait until the stream is consumed before sending the error
       while ((chat.messages[1]?.parts[1] as any)?.text !== 'Hello') {
-        await delay();
+        await vi.advanceTimersByTimeAsync(0);
       }
 
       await chat.stop();

--- a/packages/ai/src/util/notify.test.ts
+++ b/packages/ai/src/util/notify.test.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Callback } from './callback';
 import { notify } from './notify';
 import { delay } from '@ai-sdk/provider-utils';
 
 describe('notify', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe('callback invocation', () => {
     it('should call a single callback with the event', async () => {
       const calls: string[] = [];
@@ -58,13 +66,16 @@ describe('notify', () => {
     it('should await async callbacks before continuing', async () => {
       const calls: string[] = [];
 
-      await notify({
+      const notifyPromise = notify({
         event: 'test',
         callbacks: async () => {
           await delay(1);
           calls.push('async done');
         },
       });
+
+      await vi.advanceTimersByTimeAsync(1);
+      await notifyPromise;
 
       calls.push('after notify');
 

--- a/packages/ai/src/util/notify.test.ts
+++ b/packages/ai/src/util/notify.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Callback } from './callback';
 import { notify } from './notify';
+import { delay } from '@ai-sdk/provider-utils';
 
 describe('notify', () => {
   describe('callback invocation', () => {

--- a/packages/ai/src/util/notify.test.ts
+++ b/packages/ai/src/util/notify.test.ts
@@ -60,7 +60,7 @@ describe('notify', () => {
       await notify({
         event: 'test',
         callbacks: async () => {
-          await new Promise(resolve => setTimeout(resolve, 1));
+          await delay(1);
           calls.push('async done');
         },
       });

--- a/packages/ai/src/util/write-to-server-response.test.ts
+++ b/packages/ai/src/util/write-to-server-response.test.ts
@@ -3,6 +3,7 @@ import { ServerResponse } from 'node:http';
 import { describe, it, expect } from 'vitest';
 import { writeToServerResponse } from './write-to-server-response';
 import { createMockServerResponse } from '../test/mock-server-response';
+import { delay } from '@ai-sdk/provider-utils';
 
 describe('writeToServerResponse', () => {
   it('should write data to ServerResponse', async () => {
@@ -65,12 +66,12 @@ describe('writeToServerResponse', () => {
     });
 
     // Wait for first chunk to be written
-    await new Promise(resolve => setTimeout(resolve, 10));
+    await delay(10);
     expect(mockResponse.writeCallCount).toBe(1);
 
     // Enqueue second chunk - it should trigger write which returns false (backpressure)
     readyToEnqueue!(new TextEncoder().encode('chunk2'));
-    await new Promise(resolve => setTimeout(resolve, 5));
+    await delay(5);
 
     // Second chunk write should have been called but returned false
     expect(mockResponse.writeCallCount).toBe(2);
@@ -78,14 +79,14 @@ describe('writeToServerResponse', () => {
 
     // Enqueue third chunk - it should NOT trigger write yet (still waiting for drain from chunk 2)
     readyToEnqueue!(new TextEncoder().encode('chunk3'));
-    await new Promise(resolve => setTimeout(resolve, 5));
+    await delay(5);
 
     // Third chunk shouldn't be written yet (waiting for drain)
     expect(mockResponse.writeCallCount).toBe(2);
 
     // Simulate drain to allow third write
     mockResponse.simulateDrain();
-    await new Promise(resolve => setTimeout(resolve, 10));
+    await delay(10);
     expect(mockResponse.writeCallCount).toBe(3);
 
     // Close the stream

--- a/packages/ai/src/util/write-to-server-response.test.ts
+++ b/packages/ai/src/util/write-to-server-response.test.ts
@@ -1,9 +1,8 @@
 import { EventEmitter } from 'node:events';
 import { ServerResponse } from 'node:http';
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { writeToServerResponse } from './write-to-server-response';
 import { createMockServerResponse } from '../test/mock-server-response';
-import { delay } from '@ai-sdk/provider-utils';
 
 describe('writeToServerResponse', () => {
   it('should write data to ServerResponse', async () => {
@@ -33,70 +32,82 @@ describe('writeToServerResponse', () => {
     expect(mockResponse.ended).toBe(true);
   });
 
-  it('should respect backpressure and wait for drain event', async () => {
-    const mockResponse = createBackpressureMockResponse();
-    let drainEventCount = 0;
-    let readyToEnqueue: ((value: unknown) => void) | null = null;
-
-    // Track drain events
-    mockResponse.on('drain', () => {
-      drainEventCount++;
+  describe('backpressure handling', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
     });
 
-    // Create stream that provides chunks on-demand (async)
-    const stream = new ReadableStream({
-      start(controller) {
-        // First chunk available immediately
-        controller.enqueue(new TextEncoder().encode('chunk1'));
-        // Set up callback for additional chunks
-        readyToEnqueue = value => {
-          if (value === null) {
-            controller.close();
-          } else {
-            controller.enqueue(value as Uint8Array);
-          }
-        };
-      },
+    afterEach(() => {
+      vi.useRealTimers();
     });
 
-    writeToServerResponse({
-      response: mockResponse,
-      status: 200,
-      stream,
+    it('should respect backpressure and wait for drain event', async () => {
+      const mockResponse = createBackpressureMockResponse();
+      let drainEventCount = 0;
+      let readyToEnqueue: ((value: unknown) => void) | null = null;
+
+      // Track drain events
+      mockResponse.on('drain', () => {
+        drainEventCount++;
+      });
+
+      // Create stream that provides chunks on-demand (async)
+      const stream = new ReadableStream({
+        start(controller) {
+          // First chunk available immediately
+          controller.enqueue(new TextEncoder().encode('chunk1'));
+          // Set up callback for additional chunks
+          readyToEnqueue = value => {
+            if (value === null) {
+              controller.close();
+            } else {
+              controller.enqueue(value as Uint8Array);
+            }
+          };
+        },
+      });
+
+      writeToServerResponse({
+        response: mockResponse,
+        status: 200,
+        stream,
+      });
+
+      // Wait for first chunk to be written
+      await vi.advanceTimersByTimeAsync(10);
+      expect(mockResponse.writeCallCount).toBe(1);
+
+      // Enqueue second chunk - it should trigger write which returns false (backpressure)
+      readyToEnqueue!(new TextEncoder().encode('chunk2'));
+      await vi.advanceTimersByTimeAsync(5);
+
+      // Second chunk write should have been called but returned false
+      expect(mockResponse.writeCallCount).toBe(2);
+      expect(mockResponse.writtenChunks.length).toBe(2);
+
+      // Enqueue third chunk - it should NOT trigger write yet (still waiting for drain from chunk 2)
+      readyToEnqueue!(new TextEncoder().encode('chunk3'));
+      await vi.advanceTimersByTimeAsync(5);
+
+      // Third chunk shouldn't be written yet (waiting for drain)
+      expect(mockResponse.writeCallCount).toBe(2);
+
+      // Simulate drain to allow third write
+      mockResponse.simulateDrain();
+      await vi.advanceTimersByTimeAsync(10);
+      expect(mockResponse.writeCallCount).toBe(3);
+
+      // Close the stream
+      readyToEnqueue!(null);
+      await vi.runAllTimersAsync();
+
+      expect(mockResponse.ended).toBe(true);
+
+      // Verify that drain was called (indicating backpressure was respected)
+      expect(drainEventCount).toBeGreaterThanOrEqual(1);
+      // Verify all chunks were eventually written
+      expect(mockResponse.writtenChunks).toHaveLength(3);
     });
-
-    // Wait for first chunk to be written
-    await delay(10);
-    expect(mockResponse.writeCallCount).toBe(1);
-
-    // Enqueue second chunk - it should trigger write which returns false (backpressure)
-    readyToEnqueue!(new TextEncoder().encode('chunk2'));
-    await delay(5);
-
-    // Second chunk write should have been called but returned false
-    expect(mockResponse.writeCallCount).toBe(2);
-    expect(mockResponse.writtenChunks.length).toBe(2);
-
-    // Enqueue third chunk - it should NOT trigger write yet (still waiting for drain from chunk 2)
-    readyToEnqueue!(new TextEncoder().encode('chunk3'));
-    await delay(5);
-
-    // Third chunk shouldn't be written yet (waiting for drain)
-    expect(mockResponse.writeCallCount).toBe(2);
-
-    // Simulate drain to allow third write
-    mockResponse.simulateDrain();
-    await delay(10);
-    expect(mockResponse.writeCallCount).toBe(3);
-
-    // Close the stream
-    readyToEnqueue!(null);
-    await mockResponse.waitForEnd();
-
-    // Verify that drain was called (indicating backpressure was respected)
-    expect(drainEventCount).toBeGreaterThanOrEqual(1);
-    // Verify all chunks were eventually written
-    expect(mockResponse.writtenChunks).toHaveLength(3);
   });
 
   it('should set headers correctly when statusText is undefined', async () => {

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -44,7 +44,7 @@
     "jsdom": "^24.0.0",
     "tsup": "^7.2.0",
     "typescript": "5.8.3",
-    "vitest": "^4.1.0",
+    "vitest": "^4.1.5",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -39,7 +39,7 @@
     "tsup": "^8",
     "tsx": "4.19.2",
     "typescript": "5.8.3",
-    "vitest": "2.1.4"
+    "vitest": "^4.1.5"
   },
   "bin": {
     "codemod": "./dist/bin/codemod.js"

--- a/packages/codemod/vitest.config.ts
+++ b/packages/codemod/vitest.config.ts
@@ -3,5 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
+    // Codemod tests do CPU-heavy TypeScript syntax validation and can exceed
+    // Vitest's default 5s timeout on saturated CI runners, especially in the
+    // Node 24 matrix where the root test job runs many packages concurrently.
+    maxWorkers: process.env.CI ? 2 : undefined,
+    testTimeout: process.env.CI ? 15_000 : 5_000,
   },
 });

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -63,7 +63,7 @@
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17",
     "tsup": "^8",
-    "vitest": "^3.2.1",
+    "vitest": "^4.1.5",
     "tsx": "^4.19.2",
     "tw-animate-css": "^1.4.0",
     "typescript": "5.8.3",

--- a/packages/devtools/src/integration.test.ts
+++ b/packages/devtools/src/integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Telemetry } from 'ai';
 import { DevToolsTelemetry } from './integration.js';
 
@@ -82,6 +82,10 @@ describe('DevToolsTelemetry', () => {
         randomUUID: () => '00000000-0000-0000-0000-000000000000',
       }),
     );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   function createIntegration(): TestIntegration {

--- a/packages/devtools/src/viewer/client/components/shared-components.tsx
+++ b/packages/devtools/src/viewer/client/components/shared-components.tsx
@@ -72,7 +72,7 @@ export function JsonBlock({
       </button>
       <pre
         className={`font-mono ${sizeClasses[size]} text-muted-foreground whitespace-pre-wrap wrap-break-words bg-background rounded p-2 ${
-          compact ? 'max-h-20 overflow-hidden' : ''
+          compact ? 'overflow-hidden max-h-20' : ''
         }`}
       >
         {displayString}
@@ -108,16 +108,16 @@ export function RawDataSection({
         <ChevronRight
           className={`size-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
         />
-        <span className="font-medium uppercase tracking-wider">
+        <span className="font-medium tracking-wider uppercase">
           Request / Response
         </span>
       </button>
 
       {expanded && (
-        <div className="px-4 pb-4 grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-4 px-4 pb-4">
           {rawRequest && (
             <div className="flex flex-col">
-              <div className="h-7 flex items-end mb-2">
+              <div className="flex items-end mb-2 h-7">
                 <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
                   Request
                 </span>
@@ -129,7 +129,7 @@ export function RawDataSection({
           )}
           {(rawResponse || rawChunks) && (
             <div className="flex flex-col">
-              <div className="h-7 flex items-end justify-between mb-2">
+              <div className="flex justify-between items-end mb-2 h-7">
                 <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
                   {isStream ? 'Stream' : 'Response'}
                 </span>
@@ -182,8 +182,8 @@ export function UsageDetails({ usage }: { usage: ParsedUsage }) {
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-2 gap-4">
-        <div className="rounded-lg border border-border bg-card p-4">
-          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-2">
+        <div className="p-4 rounded-lg border border-border bg-card">
+          <div className="mb-2 text-xs font-medium tracking-wider uppercase text-muted-foreground">
             Input Tokens
           </div>
           <div className="text-2xl font-semibold">{inputBreakdown.total}</div>
@@ -212,8 +212,8 @@ export function UsageDetails({ usage }: { usage: ParsedUsage }) {
           )}
         </div>
 
-        <div className="rounded-lg border border-border bg-card p-4">
-          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-2">
+        <div className="p-4 rounded-lg border border-border bg-card">
+          <div className="mb-2 text-xs font-medium tracking-wider uppercase text-muted-foreground">
             Output Tokens
           </div>
           <div className="text-2xl font-semibold">{outputBreakdown.total}</div>
@@ -239,7 +239,7 @@ export function UsageDetails({ usage }: { usage: ParsedUsage }) {
 
       {usage?.raw != null && (
         <div>
-          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-2">
+          <div className="mb-2 text-xs font-medium tracking-wider uppercase text-muted-foreground">
             Raw Provider Usage
           </div>
           <JsonBlock data={usage.raw} size="sm" />
@@ -247,7 +247,7 @@ export function UsageDetails({ usage }: { usage: ParsedUsage }) {
       )}
 
       <div>
-        <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-2">
+        <div className="mb-2 text-xs font-medium tracking-wider uppercase text-muted-foreground">
           Full Usage Object
         </div>
         <JsonBlock data={usage} size="sm" />
@@ -283,33 +283,33 @@ export function TokenBreakdownTooltip({
   }
 
   return (
-    <div className="text-xs space-y-2">
+    <div className="space-y-2 text-xs">
       <div>
-        <div className="font-medium mb-1">Input: {input.total}</div>
+        <div className="mb-1 font-medium">Input: {input.total}</div>
         {input.cacheRead !== undefined && (
-          <div className="text-muted-foreground ml-2">
+          <div className="ml-2 text-muted-foreground">
             Cache read: {input.cacheRead}
           </div>
         )}
         {input.cacheWrite !== undefined && (
-          <div className="text-muted-foreground ml-2">
+          <div className="ml-2 text-muted-foreground">
             Cache write: {input.cacheWrite}
           </div>
         )}
       </div>
       <div>
-        <div className="font-medium mb-1">Output: {output.total}</div>
+        <div className="mb-1 font-medium">Output: {output.total}</div>
         {output.text !== undefined && (
-          <div className="text-muted-foreground ml-2">Text: {output.text}</div>
+          <div className="ml-2 text-muted-foreground">Text: {output.text}</div>
         )}
         {output.reasoning !== undefined && (
-          <div className="text-muted-foreground ml-2">
+          <div className="ml-2 text-muted-foreground">
             Reasoning: {output.reasoning}
           </div>
         )}
       </div>
       {raw !== undefined && (
-        <div className="pt-1 border-t border-border mt-1">
+        <div className="pt-1 mt-1 border-t border-border">
           <div className="text-muted-foreground/70 font-mono text-[10px] max-w-[200px] truncate">
             Raw: {JSON.stringify(raw)}
           </div>
@@ -326,9 +326,9 @@ export function ReasoningBlock({ content }: { content: string }) {
     content.length > 200 ? content.slice(0, 200) + '…' : content;
 
   return (
-    <div className="rounded-md border border-amber-500/30 overflow-hidden">
+    <div className="overflow-hidden rounded-md border border-amber-500/30">
       <button
-        className="w-full flex items-center gap-2 px-3 py-2 bg-amber-500/10 hover:bg-amber-500/20 transition-colors"
+        className="flex gap-2 items-center px-3 py-2 w-full transition-colors bg-amber-500/10 hover:bg-amber-500/20"
         onClick={() => setExpanded(!expanded)}
       >
         <ChevronRight
@@ -336,7 +336,7 @@ export function ReasoningBlock({ content }: { content: string }) {
             expanded ? 'rotate-90' : ''
           }`}
         />
-        <Brain className="size-3 text-amber-500 shrink-0" />
+        <Brain className="text-amber-500 size-3 shrink-0" />
         <span className="text-xs font-medium text-amber-500">Thinking</span>
         {!expanded && (
           <span className="text-[11px] text-amber-500/70 truncate ml-1">
@@ -346,8 +346,8 @@ export function ReasoningBlock({ content }: { content: string }) {
       </button>
 
       {expanded && (
-        <div className="p-3 bg-card/50 border-t border-amber-500/30">
-          <div className="text-xs text-foreground/80 leading-relaxed whitespace-pre-wrap">
+        <div className="p-3 border-t bg-card/50 border-amber-500/30">
+          <div className="text-xs leading-relaxed whitespace-pre-wrap text-foreground/80">
             {content}
           </div>
         </div>
@@ -385,9 +385,9 @@ export function TextBlock({
   };
 
   return (
-    <div className={`rounded-md border ${borderColor} overflow-hidden`}>
+    <div className={`overflow-hidden rounded-md border ${borderColor}`}>
       <button
-        className={`w-full flex items-center gap-2 px-3 py-2 ${bgColor} ${hoverBgColor} transition-colors`}
+        className={`flex gap-2 items-center px-3 py-2 w-full transition-colors ${bgColor} ${hoverBgColor}`}
         onClick={() => setExpanded(!expanded)}
       >
         <ChevronRight
@@ -408,7 +408,7 @@ export function TextBlock({
 
       {expanded && (
         <div
-          className={`p-3 bg-card/50 border-t ${borderColor} group relative`}
+          className={`relative p-3 border-t bg-card/50 ${borderColor} group`}
         >
           <button
             onClick={handleCopy}
@@ -421,7 +421,7 @@ export function TextBlock({
               <Copy className="size-3 text-muted-foreground" />
             )}
           </button>
-          <div className="text-xs text-foreground leading-relaxed whitespace-pre-wrap max-h-60 overflow-y-auto">
+          <div className="overflow-y-auto max-h-60 text-xs leading-relaxed whitespace-pre-wrap text-foreground">
             {content}
           </div>
         </div>
@@ -434,12 +434,12 @@ export function ToolItem({ tool }: { tool: ToolDefinition }) {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="rounded-md border border-border bg-background overflow-hidden">
+    <div className="overflow-hidden rounded-md border border-border bg-background">
       <button
         className="w-full flex items-center justify-between p-2.5 hover:bg-accent/50 transition-colors"
         onClick={() => setExpanded(!expanded)}
       >
-        <span className="text-sm font-mono text-purple">{tool.name}</span>
+        <span className="font-mono text-sm text-purple">{tool.name}</span>
         {tool.parameters && (
           <ChevronRight
             className={`size-3 text-muted-foreground transition-transform ${
@@ -451,7 +451,7 @@ export function ToolItem({ tool }: { tool: ToolDefinition }) {
       {expanded && tool.parameters && (
         <div className="px-2.5 pb-2.5 border-t border-border">
           {tool.description && (
-            <p className="text-xs text-muted-foreground mb-2 pt-2">
+            <p className="pt-2 mb-2 text-xs text-muted-foreground">
               {tool.description}
             </p>
           )}
@@ -482,9 +482,9 @@ export function CollapsibleToolCall({
   const parsedData = typeof data === 'string' ? safeParseJson(data) : data;
 
   return (
-    <div className="rounded-md border border-purple/30 overflow-hidden">
+    <div className="overflow-hidden rounded-md border border-purple/30">
       <button
-        className="w-full flex items-center gap-2 px-3 py-2 bg-purple/10 hover:bg-purple/20 transition-colors"
+        className="flex gap-2 items-center px-3 py-2 w-full transition-colors bg-purple/10 hover:bg-purple/20"
         onClick={() => setExpanded(!expanded)}
       >
         <ChevronRight
@@ -493,7 +493,7 @@ export function CollapsibleToolCall({
           }`}
         />
         <Wrench className="size-3 text-purple shrink-0" />
-        <span className="text-xs font-mono font-medium text-purple">
+        <span className="font-mono text-xs font-medium text-purple">
           {toolName}
         </span>
         {!expanded &&
@@ -511,7 +511,7 @@ export function CollapsibleToolCall({
         )}
       </button>
       {expanded && (
-        <div className="p-3 bg-card/50 border-t border-purple/30">
+        <div className="p-3 border-t bg-card/50 border-purple/30">
           <JsonBlock data={parsedData} />
         </div>
       )}
@@ -531,9 +531,9 @@ export function CollapsibleToolResult({
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="rounded-md border border-success/30 overflow-hidden">
+    <div className="overflow-hidden rounded-md border border-success/30">
       <button
-        className="w-full flex items-center gap-2 px-3 py-2 bg-success/10 hover:bg-success/20 transition-colors"
+        className="flex gap-2 items-center px-3 py-2 w-full transition-colors bg-success/10 hover:bg-success/20"
         onClick={() => setExpanded(!expanded)}
       >
         <ChevronRight
@@ -554,7 +554,7 @@ export function CollapsibleToolResult({
         )}
       </button>
       {expanded && (
-        <div className="p-3 bg-card/50 border-t border-success/30">
+        <div className="p-3 border-t bg-card/50 border-success/30">
           <JsonBlock data={data} />
         </div>
       )}
@@ -610,7 +610,7 @@ export function StepConfigBar({
             <span key={i}>
               {p.label}: <span className="text-foreground">{p.value}</span>
               {i < params.length - 1 && (
-                <span className="text-muted-foreground/30 mx-1">·</span>
+                <span className="mx-1 text-muted-foreground/30">·</span>
               )}
             </span>
           ))}
@@ -622,7 +622,7 @@ export function StepConfigBar({
           <span className="text-muted-foreground/30">·</span>
           <Drawer direction="right">
             <DrawerTrigger asChild>
-              <button className="inline-flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer">
+              <button className="inline-flex gap-1 items-center transition-colors cursor-pointer hover:text-foreground">
                 <Wrench className="size-3" />
                 {toolCount} available {toolCount === 1 ? 'tool' : 'tools'}
               </button>
@@ -631,7 +631,7 @@ export function StepConfigBar({
               <DrawerHeader className="border-b border-border shrink-0">
                 <DrawerTitle>Available Tools ({toolCount})</DrawerTitle>
               </DrawerHeader>
-              <div className="flex-1 overflow-y-auto p-4">
+              <div className="overflow-y-auto flex-1 p-4">
                 <div className="space-y-3">
                   {input?.tools?.map((tool: ToolDefinition, i: number) => (
                     <ToolItem key={i} tool={tool} />
@@ -648,7 +648,7 @@ export function StepConfigBar({
           <span className="text-muted-foreground/30">·</span>
           <Drawer direction="right">
             <DrawerTrigger asChild>
-              <button className="inline-flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer">
+              <button className="inline-flex gap-1 items-center transition-colors cursor-pointer hover:text-foreground">
                 <Settings className="size-3" />
                 Provider options
               </button>
@@ -657,7 +657,7 @@ export function StepConfigBar({
               <DrawerHeader className="border-b border-border shrink-0">
                 <DrawerTitle>Provider Options</DrawerTitle>
               </DrawerHeader>
-              <div className="flex-1 overflow-y-auto p-4">
+              <div className="overflow-y-auto flex-1 p-4">
                 <JsonBlock data={providerOptions} size="lg" />
               </div>
             </DrawerContent>
@@ -670,7 +670,7 @@ export function StepConfigBar({
           <span className="text-muted-foreground/30">·</span>
           <Drawer direction="right">
             <DrawerTrigger asChild>
-              <button className="inline-flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer">
+              <button className="inline-flex gap-1 items-center transition-colors cursor-pointer hover:text-foreground">
                 <BarChart3 className="size-3" />
                 Usage
               </button>
@@ -679,7 +679,7 @@ export function StepConfigBar({
               <DrawerHeader className="border-b border-border shrink-0">
                 <DrawerTitle>Token Usage</DrawerTitle>
               </DrawerHeader>
-              <div className="flex-1 overflow-y-auto p-4">
+              <div className="overflow-y-auto flex-1 p-4">
                 <UsageDetails usage={usage} />
               </div>
             </DrawerContent>

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -52,7 +52,7 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "vitest": "^4.1.0",
+    "vitest": "^4.1.5",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HttpMCPTransport } from './mcp-http-transport';
 import { LATEST_PROTOCOL_VERSION } from './types';
 import { MCPClientError } from '../error/mcp-client-error';
+import { delay } from '@ai-sdk/provider-utils';
 
 describe('HttpMCPTransport', () => {
   const server = createTestServer({
@@ -194,7 +195,7 @@ describe('HttpMCPTransport', () => {
         ) {
           resolve();
         } else {
-          setTimeout(check, 0);
+          delay(0).then(check);
         }
       };
       check();

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -2,11 +2,10 @@ import {
   createTestServer,
   TestResponseController,
 } from '@ai-sdk/test-server/with-vitest';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HttpMCPTransport } from './mcp-http-transport';
 import { LATEST_PROTOCOL_VERSION } from './types';
 import { MCPClientError } from '../error/mcp-client-error';
-import { delay } from '@ai-sdk/provider-utils';
 
 describe('HttpMCPTransport', () => {
   const server = createTestServer({
@@ -23,7 +22,12 @@ describe('HttpMCPTransport', () => {
   let transport: HttpMCPTransport;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     transport = new HttpMCPTransport({ url: 'http://localhost:4000/mcp' });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should POST JSON and receive JSON response', async () => {
@@ -187,19 +191,11 @@ describe('HttpMCPTransport', () => {
 
     await transport.start();
 
-    await new Promise<void>(resolve => {
-      const check = () => {
-        if (
-          server.calls.length > 0 &&
-          server.calls[0].requestMethod === 'GET'
-        ) {
-          resolve();
-        } else {
-          delay(0).then(check);
-        }
-      };
-      check();
-    });
+    while (
+      !(server.calls.length > 0 && server.calls[0].requestMethod === 'GET')
+    ) {
+      await vi.advanceTimersByTimeAsync(0);
+    }
 
     // Now make POST fail
     server.urls['http://localhost:4000/mcp'].response = {

--- a/packages/provider-utils/src/convert-async-iterator-to-readable-stream.test.ts
+++ b/packages/provider-utils/src/convert-async-iterator-to-readable-stream.test.ts
@@ -1,12 +1,11 @@
 import { convertAsyncIteratorToReadableStream } from './convert-async-iterator-to-readable-stream';
-import { describe, it, expect } from 'vitest';
-import { delay } from './delay';
+import { describe, expect, it } from 'vitest';
 
 async function* makeGenerator(onFinally: () => void) {
   try {
     let i = 0;
     while (true) {
-      await delay(0);
+      await Promise.resolve();
       yield i++;
     }
   } finally {
@@ -24,11 +23,10 @@ describe('convertAsyncIteratorToReadableStream', () => {
     const reader = stream.getReader();
 
     await reader.read();
-
     await reader.cancel('stop');
 
     // give microtasks a tick for finally to run
-    await delay(0);
+    await Promise.resolve();
 
     expect(finallyCalled).toBe(true);
   });

--- a/packages/provider-utils/src/convert-async-iterator-to-readable-stream.test.ts
+++ b/packages/provider-utils/src/convert-async-iterator-to-readable-stream.test.ts
@@ -1,11 +1,12 @@
 import { convertAsyncIteratorToReadableStream } from './convert-async-iterator-to-readable-stream';
 import { describe, it, expect } from 'vitest';
+import { delay } from './delay';
 
 async function* makeGenerator(onFinally: () => void) {
   try {
     let i = 0;
     while (true) {
-      await new Promise(r => setTimeout(r, 0));
+      await delay(0);
       yield i++;
     }
   } finally {
@@ -27,7 +28,7 @@ describe('convertAsyncIteratorToReadableStream', () => {
     await reader.cancel('stop');
 
     // give microtasks a tick for finally to run
-    await new Promise(r => setTimeout(r, 0));
+    await delay(0);
 
     expect(finallyCalled).toBe(true);
   });

--- a/packages/provider-utils/src/delayed-promise.test.ts
+++ b/packages/provider-utils/src/delayed-promise.test.ts
@@ -1,8 +1,15 @@
 import { DelayedPromise } from './delayed-promise';
-import { delay } from '@ai-sdk/provider-utils';
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('DelayedPromise', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should resolve when accessed after resolution', async () => {
     const dp = new DelayedPromise<string>();
     dp.resolve('success');
@@ -60,7 +67,7 @@ describe('DelayedPromise', () => {
     expect(resolved).toBe(false);
 
     // Wait a bit to ensure it's truly blocking
-    await delay(10);
+    await vi.advanceTimersByTimeAsync(10);
     expect(resolved).toBe(false);
 
     // Now resolve it
@@ -86,7 +93,7 @@ describe('DelayedPromise', () => {
     expect(rejected).toBe(false);
 
     // Wait a bit to ensure it's truly blocking
-    await delay(10);
+    await vi.advanceTimersByTimeAsync(10);
     expect(rejected).toBe(false);
 
     // Now reject it
@@ -117,7 +124,7 @@ describe('DelayedPromise', () => {
     expect(results).toHaveLength(0);
 
     // Wait to ensure they're blocking
-    await delay(10);
+    await vi.advanceTimersByTimeAsync(10);
     expect(results).toHaveLength(0);
 
     // Resolve the promise

--- a/packages/provider-utils/src/to-json-schema/zod3-to-json-schema/zod3-to-json-schema.test.ts
+++ b/packages/provider-utils/src/to-json-schema/zod3-to-json-schema/zod3-to-json-schema.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JSONSchema7 } from '@ai-sdk/provider';
 import { z } from 'zod/v3';
 import {
@@ -10,6 +10,14 @@ import { zod3ToJsonSchema } from './zod3-to-json-schema';
 import { delay } from '../../delay';
 
 describe('zod3-to-json-schema', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe('override', () => {
     it('the readme example', () => {
       expect(

--- a/packages/provider-utils/src/to-json-schema/zod3-to-json-schema/zod3-to-json-schema.test.ts
+++ b/packages/provider-utils/src/to-json-schema/zod3-to-json-schema/zod3-to-json-schema.test.ts
@@ -7,6 +7,7 @@ import {
   PostProcessCallback,
 } from './options';
 import { zod3ToJsonSchema } from './zod3-to-json-schema';
+import { delay } from '../../delay';
 
 describe('zod3-to-json-schema', () => {
   describe('override', () => {
@@ -323,7 +324,7 @@ describe('zod3-to-json-schema', () => {
         .string()
         .optional()
         .superRefine(async (value, ctx) => {
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await delay(100);
           if (value === 'fail') {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -49,7 +49,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@vercel/ai-tsconfig": "workspace:*",
-    "@vitejs/plugin-react": "4.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "jsdom": "^24.0.0",
     "msw": "2.6.4",
     "react-dom": "^18 || ^19",

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -31,6 +31,14 @@ const server = createTestServer({
 });
 
 describe('initial messages', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   setupTestComponent(
     ({ id: idParam }: { id: string }) => {
       const [id, _setId] = React.useState<string>(idParam);
@@ -2271,8 +2279,6 @@ describe('experimental_throttle', () => {
     await userEvent.click(screen.getByTestId('do-send'));
     expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
 
-    vi.useFakeTimers();
-
     controller.write(formatChunk({ type: 'text-start', id: '0' }));
     controller.write(
       formatChunk({ type: 'text-delta', id: '0', delta: 'Hel' }),
@@ -2303,8 +2309,6 @@ describe('experimental_throttle', () => {
     expect(screen.getByTestId('message-1')).toHaveTextContent(
       'AI: Hello There',
     );
-
-    vi.useRealTimers();
   });
 });
 

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -5,7 +5,7 @@ import {
   TestResponseController,
 } from '@ai-sdk/test-server/with-vitest';
 import { mockId } from '@ai-sdk/provider-utils/test';
-import { screen, waitFor, render } from '@testing-library/react';
+import { fireEvent, screen, waitFor, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   DefaultChatTransport,
@@ -30,227 +30,270 @@ const server = createTestServer({
   '/api/chat/123/stream': {},
 });
 
-describe('initial messages', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  setupTestComponent(
-    ({ id: idParam }: { id: string }) => {
-      const [id, _setId] = React.useState<string>(idParam);
-      const {
-        messages,
-        status,
-        id: idKey,
-      } = useChat({
-        id,
-        messages: [
-          {
-            id: 'id-0',
-            role: 'user',
-            parts: [{ text: 'hi', type: 'text' }],
-          },
-        ],
-      });
-
-      return (
-        <div>
-          <div data-testid="id">{idKey}</div>
-          <div data-testid="status">{status.toString()}</div>
-          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
-        </div>
-      );
-    },
-    {
-      // use a random id to avoid conflicts:
-      init: TestComponent => <TestComponent id={`first-${mockId()()}`} />,
-    },
-  );
-
-  it('should show initial messages', async () => {
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toStrictEqual([
-        {
-          role: 'user',
-          parts: [
+describe('use-chat', () => {
+  describe('initial messages', () => {
+    setupTestComponent(
+      ({ id: idParam }: { id: string }) => {
+        const [id, _setId] = React.useState<string>(idParam);
+        const {
+          messages,
+          status,
+          id: idKey,
+        } = useChat({
+          id,
+          messages: [
             {
-              text: 'hi',
-              type: 'text',
+              id: 'id-0',
+              role: 'user',
+              parts: [{ text: 'hi', type: 'text' }],
             },
           ],
-          id: 'id-0',
-        },
-      ]);
-    });
-  });
-});
+        });
 
-describe('data protocol stream', () => {
-  let onFinishCalls: Array<{
-    message: UIMessage;
-    messages: UIMessage[];
-    isAbort: boolean;
-    isDisconnect: boolean;
-    isError: boolean;
-    finishReason?: FinishReason;
-  }> = [];
-
-  setupTestComponent(
-    ({ id: idParam }: { id: string }) => {
-      const [id, setId] = React.useState<string>(idParam);
-      const {
-        messages,
-        sendMessage,
-        error,
-        status,
-        id: idKey,
-      } = useChat({
-        id,
-        onFinish: options => {
-          onFinishCalls.push(options);
-        },
-        generateId: mockId(),
-      });
-
-      return (
-        <div>
-          <div data-testid="id">{idKey}</div>
-          <div data-testid="status">{status.toString()}</div>
-          {error && <div data-testid="error">{error.toString()}</div>}
-          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
-          <button
-            data-testid="do-send"
-            onClick={() => {
-              sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
-            }}
-          />
-          <button
-            data-testid="do-change-id"
-            onClick={() => {
-              setId('second-id');
-            }}
-          />
-        </div>
-      );
-    },
-    {
-      // use a random id to avoid conflicts:
-      init: TestComponent => <TestComponent id={`first-${mockId()()}`} />,
-    },
-  );
-
-  beforeEach(() => {
-    onFinishCalls = [];
-  });
-
-  it('should show streamed response', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        formatChunk({ type: 'text-start', id: '0' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
-        formatChunk({ type: 'text-end', id: '0' }),
-      ],
-    };
-
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toStrictEqual([
-        {
-          role: 'user',
-          parts: [
-            {
-              text: 'hi',
-              type: 'text',
-            },
-          ],
-          id: 'id-0',
-        },
-        {
-          id: 'id-1',
-          role: 'assistant',
-          parts: [
-            {
-              type: 'text',
-              text: 'Hello, world.',
-              state: 'done',
-            },
-          ],
-        },
-      ]);
-    });
-  });
-
-  it('should show user message immediately', async () => {
-    const controller = new TestResponseController();
-    server.urls['/api/chat'].response = {
-      type: 'controlled-stream',
-      controller,
-    };
-
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toStrictEqual([
-        {
-          role: 'user',
-          parts: [
-            {
-              text: 'hi',
-              type: 'text',
-            },
-          ],
-          id: 'id-0',
-        },
-      ]);
-    });
-  });
-
-  it('should show error response when there is a server error', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'error',
-      status: 404,
-      body: 'Not found',
-    };
-
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    await screen.findByTestId('error');
-    expect(screen.getByTestId('error')).toHaveTextContent('Error: Not found');
-  });
-
-  it('should show error response when there is a streaming error', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        formatChunk({ type: 'error', errorText: 'custom error message' }),
-      ],
-    };
-
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    await screen.findByTestId('error');
-    expect(screen.getByTestId('error')).toHaveTextContent(
-      'Error: custom error message',
+        return (
+          <div>
+            <div data-testid="id">{idKey}</div>
+            <div data-testid="status">{status.toString()}</div>
+            <div data-testid="messages">
+              {JSON.stringify(messages, null, 2)}
+            </div>
+          </div>
+        );
+      },
+      {
+        // use a random id to avoid conflicts:
+        init: TestComponent => <TestComponent id={`first-${mockId()()}`} />,
+      },
     );
+
+    it('should show initial messages', async () => {
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'hi',
+                type: 'text',
+              },
+            ],
+            id: 'id-0',
+          },
+        ]);
+      });
+    });
   });
 
-  describe('status', () => {
-    it('should show status', async () => {
+  describe('data protocol stream', () => {
+    let onFinishCalls: Array<{
+      message: UIMessage;
+      messages: UIMessage[];
+      isAbort: boolean;
+      isDisconnect: boolean;
+      isError: boolean;
+      finishReason?: FinishReason;
+    }> = [];
+
+    setupTestComponent(
+      ({ id: idParam }: { id: string }) => {
+        const [id, setId] = React.useState<string>(idParam);
+        const {
+          messages,
+          sendMessage,
+          error,
+          status,
+          id: idKey,
+        } = useChat({
+          id,
+          onFinish: options => {
+            onFinishCalls.push(options);
+          },
+          generateId: mockId(),
+        });
+
+        return (
+          <div>
+            <div data-testid="id">{idKey}</div>
+            <div data-testid="status">{status.toString()}</div>
+            {error && <div data-testid="error">{error.toString()}</div>}
+            <div data-testid="messages">
+              {JSON.stringify(messages, null, 2)}
+            </div>
+            <button
+              data-testid="do-send"
+              onClick={() => {
+                sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+              }}
+            />
+            <button
+              data-testid="do-change-id"
+              onClick={() => {
+                setId('second-id');
+              }}
+            />
+          </div>
+        );
+      },
+      {
+        // use a random id to avoid conflicts:
+        init: TestComponent => <TestComponent id={`first-${mockId()()}`} />,
+      },
+    );
+
+    beforeEach(() => {
+      onFinishCalls = [];
+    });
+
+    it('should show streamed response', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'hi',
+                type: 'text',
+              },
+            ],
+            id: 'id-0',
+          },
+          {
+            id: 'id-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'text',
+                text: 'Hello, world.',
+                state: 'done',
+              },
+            ],
+          },
+        ]);
+      });
+    });
+
+    it('should show user message immediately', async () => {
+      const controller = new TestResponseController();
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'hi',
+                type: 'text',
+              },
+            ],
+            id: 'id-0',
+          },
+        ]);
+      });
+    });
+
+    it('should show error response when there is a server error', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'error',
+        status: 404,
+        body: 'Not found',
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await screen.findByTestId('error');
+      expect(screen.getByTestId('error')).toHaveTextContent('Error: Not found');
+    });
+
+    it('should show error response when there is a streaming error', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'error', errorText: 'custom error message' }),
+        ],
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await screen.findByTestId('error');
+      expect(screen.getByTestId('error')).toHaveTextContent(
+        'Error: custom error message',
+      );
+    });
+
+    describe('status', () => {
+      it('should show status', async () => {
+        const controller = new TestResponseController();
+
+        server.urls['/api/chat'].response = {
+          type: 'controlled-stream',
+          controller,
+        };
+
+        await userEvent.click(screen.getByTestId('do-send'));
+
+        await waitFor(() => {
+          expect(screen.getByTestId('status')).toHaveTextContent('submitted');
+        });
+
+        controller.write(formatChunk({ type: 'text-start', id: '0' }));
+        controller.write(
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        );
+        controller.write(formatChunk({ type: 'text-end', id: '0' }));
+
+        await waitFor(() => {
+          expect(screen.getByTestId('status')).toHaveTextContent('streaming');
+        });
+
+        controller.close();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('status')).toHaveTextContent('ready');
+        });
+      });
+
+      it('should set status to error when there is a server error', async () => {
+        server.urls['/api/chat'].response = {
+          type: 'error',
+          status: 404,
+          body: 'Not found',
+        };
+
+        await userEvent.click(screen.getByTestId('do-send'));
+
+        await waitFor(() => {
+          expect(screen.getByTestId('status')).toHaveTextContent('error');
+        });
+      });
+    });
+
+    it('should invoke onFinish when the stream finishes', async () => {
       const controller = new TestResponseController();
 
       server.urls['/api/chat'].response = {
@@ -260,106 +303,64 @@ describe('data protocol stream', () => {
 
       await userEvent.click(screen.getByTestId('do-send'));
 
-      await waitFor(() => {
-        expect(screen.getByTestId('status')).toHaveTextContent('submitted');
-      });
-
       controller.write(formatChunk({ type: 'text-start', id: '0' }));
       controller.write(
         formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
       );
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+      );
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+      );
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+      );
       controller.write(formatChunk({ type: 'text-end', id: '0' }));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('status')).toHaveTextContent('streaming');
-      });
+      controller.write(
+        formatChunk({
+          type: 'finish',
+          finishReason: 'stop',
+          messageMetadata: {
+            example: 'metadata',
+          },
+        }),
+      );
 
       controller.close();
 
       await waitFor(() => {
-        expect(screen.getByTestId('status')).toHaveTextContent('ready');
-      });
-    });
-
-    it('should set status to error when there is a server error', async () => {
-      server.urls['/api/chat'].response = {
-        type: 'error',
-        status: 404,
-        body: 'Not found',
-      };
-
-      await userEvent.click(screen.getByTestId('do-send'));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('status')).toHaveTextContent('error');
-      });
-    });
-  });
-
-  it('should invoke onFinish when the stream finishes', async () => {
-    const controller = new TestResponseController();
-
-    server.urls['/api/chat'].response = {
-      type: 'controlled-stream',
-      controller,
-    };
-
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    controller.write(formatChunk({ type: 'text-start', id: '0' }));
-    controller.write(
-      formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
-    );
-    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: ',' }));
-    controller.write(
-      formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
-    );
-    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: '.' }));
-    controller.write(formatChunk({ type: 'text-end', id: '0' }));
-    controller.write(
-      formatChunk({
-        type: 'finish',
-        finishReason: 'stop',
-        messageMetadata: {
-          example: 'metadata',
-        },
-      }),
-    );
-
-    controller.close();
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toStrictEqual([
-        {
-          role: 'user',
-          parts: [
-            {
-              text: 'hi',
-              type: 'text',
-            },
-          ],
-          id: 'id-0',
-        },
-        {
-          id: 'id-1',
-          role: 'assistant',
-          metadata: {
-            example: 'metadata',
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            role: 'user',
+            parts: [
+              {
+                text: 'hi',
+                type: 'text',
+              },
+            ],
+            id: 'id-0',
           },
-          parts: [
-            {
-              type: 'text',
-              text: 'Hello, world.',
-              state: 'done',
+          {
+            id: 'id-1',
+            role: 'assistant',
+            metadata: {
+              example: 'metadata',
             },
-          ],
-        },
-      ]);
-    });
+            parts: [
+              {
+                type: 'text',
+                text: 'Hello, world.',
+                state: 'done',
+              },
+            ],
+          },
+        ]);
+      });
 
-    expect(onFinishCalls).toMatchInlineSnapshot(`
+      expect(onFinishCalls).toMatchInlineSnapshot(`
       [
         {
           "finishReason": "stop",
@@ -412,25 +413,25 @@ describe('data protocol stream', () => {
         },
       ]
     `);
-  });
+    });
 
-  describe('id', () => {
-    it('send the id to the server', async () => {
-      server.urls['/api/chat'].response = {
-        type: 'stream-chunks',
-        chunks: [
-          formatChunk({ type: 'text-start', id: '0' }),
-          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
-          formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
-          formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
-          formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
-          formatChunk({ type: 'text-end', id: '0' }),
-        ],
-      };
+    describe('id', () => {
+      it('send the id to the server', async () => {
+        server.urls['/api/chat'].response = {
+          type: 'stream-chunks',
+          chunks: [
+            formatChunk({ type: 'text-start', id: '0' }),
+            formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+            formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+            formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+            formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+            formatChunk({ type: 'text-end', id: '0' }),
+          ],
+        };
 
-      await userEvent.click(screen.getByTestId('do-send'));
+        await userEvent.click(screen.getByTestId('do-send'));
 
-      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
         {
           "id": "first-id-0",
           "messages": [
@@ -448,117 +449,119 @@ describe('data protocol stream', () => {
           "trigger": "submit-message",
         }
       `);
+      });
     });
   });
-});
 
-describe('text stream', () => {
-  let onFinishCalls: Array<{
-    message: UIMessage;
-    messages: UIMessage[];
-    isAbort: boolean;
-    isDisconnect: boolean;
-    isError: boolean;
-    finishReason?: FinishReason;
-  }> = [];
+  describe('text stream', () => {
+    let onFinishCalls: Array<{
+      message: UIMessage;
+      messages: UIMessage[];
+      isAbort: boolean;
+      isDisconnect: boolean;
+      isError: boolean;
+      finishReason?: FinishReason;
+    }> = [];
 
-  setupTestComponent(() => {
-    const { messages, sendMessage } = useChat({
-      onFinish: options => {
-        onFinishCalls.push(options);
-      },
-      generateId: mockId(),
-      transport: new TextStreamChatTransport({
-        api: '/api/chat',
-      }),
+    setupTestComponent(() => {
+      const { messages, sendMessage } = useChat({
+        onFinish: options => {
+          onFinishCalls.push(options);
+        },
+        generateId: mockId(),
+        transport: new TextStreamChatTransport({
+          api: '/api/chat',
+        }),
+      });
+
+      return (
+        <div>
+          {messages.map((m, idx) => (
+            <div data-testid={`message-${idx}-text-stream`} key={m.id}>
+              <div data-testid={`message-${idx}-id`}>{m.id}</div>
+              <div data-testid={`message-${idx}-role`}>
+                {m.role === 'user' ? 'User: ' : 'AI: '}
+              </div>
+              <div data-testid={`message-${idx}-content`}>
+                {m.parts
+                  .map(part => (part.type === 'text' ? part.text : ''))
+                  .join('')}
+              </div>
+            </div>
+          ))}
+
+          <button
+            data-testid="do-send"
+            onClick={() => {
+              sendMessage({
+                role: 'user',
+                parts: [{ text: 'hi', type: 'text' }],
+              });
+            }}
+          />
+        </div>
+      );
     });
 
-    return (
-      <div>
-        {messages.map((m, idx) => (
-          <div data-testid={`message-${idx}-text-stream`} key={m.id}>
-            <div data-testid={`message-${idx}-id`}>{m.id}</div>
-            <div data-testid={`message-${idx}-role`}>
-              {m.role === 'user' ? 'User: ' : 'AI: '}
-            </div>
-            <div data-testid={`message-${idx}-content`}>
-              {m.parts
-                .map(part => (part.type === 'text' ? part.text : ''))
-                .join('')}
-            </div>
-          </div>
-        ))}
+    beforeEach(() => {
+      onFinishCalls = [];
+    });
 
-        <button
-          data-testid="do-send"
-          onClick={() => {
-            sendMessage({
-              role: 'user',
-              parts: [{ text: 'hi', type: 'text' }],
-            });
-          }}
-        />
-      </div>
-    );
-  });
+    it('should show streamed response', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: ['Hello', ',', ' world', '.'],
+      };
 
-  beforeEach(() => {
-    onFinishCalls = [];
-  });
+      await userEvent.click(screen.getByTestId('do-send'));
 
-  it('should show streamed response', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: ['Hello', ',', ' world', '.'],
-    };
+      await screen.findByTestId('message-0-content');
+      expect(screen.getByTestId('message-0-content')).toHaveTextContent('hi');
 
-    await userEvent.click(screen.getByTestId('do-send'));
+      await screen.findByTestId('message-1-content');
+      expect(screen.getByTestId('message-1-content')).toHaveTextContent(
+        'Hello, world.',
+      );
+    });
 
-    await screen.findByTestId('message-0-content');
-    expect(screen.getByTestId('message-0-content')).toHaveTextContent('hi');
+    it('should have stable message ids', async () => {
+      const controller = new TestResponseController();
 
-    await screen.findByTestId('message-1-content');
-    expect(screen.getByTestId('message-1-content')).toHaveTextContent(
-      'Hello, world.',
-    );
-  });
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
 
-  it('should have stable message ids', async () => {
-    const controller = new TestResponseController();
+      await userEvent.click(screen.getByTestId('do-send'));
 
-    server.urls['/api/chat'].response = {
-      type: 'controlled-stream',
-      controller,
-    };
+      controller.write('He');
 
-    await userEvent.click(screen.getByTestId('do-send'));
+      await screen.findByTestId('message-1-content');
+      expect(screen.getByTestId('message-1-content')).toHaveTextContent('He');
 
-    controller.write('He');
+      const id = screen.getByTestId('message-1-id').textContent;
 
-    await screen.findByTestId('message-1-content');
-    expect(screen.getByTestId('message-1-content')).toHaveTextContent('He');
+      controller.write('llo');
+      controller.close();
 
-    const id = screen.getByTestId('message-1-id').textContent;
+      await screen.findByTestId('message-1-content');
+      expect(screen.getByTestId('message-1-content')).toHaveTextContent(
+        'Hello',
+      );
+      expect(screen.getByTestId('message-1-id').textContent).toBe(id);
+    });
 
-    controller.write('llo');
-    controller.close();
+    it('should invoke onFinish when the stream finishes', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: ['Hello', ',', ' world', '.'],
+      };
 
-    await screen.findByTestId('message-1-content');
-    expect(screen.getByTestId('message-1-content')).toHaveTextContent('Hello');
-    expect(screen.getByTestId('message-1-id').textContent).toBe(id);
-  });
+      await userEvent.click(screen.getByTestId('do-send'));
 
-  it('should invoke onFinish when the stream finishes', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: ['Hello', ',', ' world', '.'],
-    };
+      await screen.findByTestId('message-1-text-stream');
 
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    await screen.findByTestId('message-1-text-stream');
-
-    expect(onFinishCalls).toMatchInlineSnapshot(`
+      expect(onFinishCalls).toMatchInlineSnapshot(`
       [
         {
           "finishReason": undefined,
@@ -613,82 +616,84 @@ describe('text stream', () => {
         },
       ]
     `);
+    });
   });
-});
 
-describe('prepareChatRequest', () => {
-  let options: any;
+  describe('prepareChatRequest', () => {
+    let options: any;
 
-  setupTestComponent(() => {
-    const { messages, sendMessage, status } = useChat({
-      transport: new DefaultChatTransport({
-        body: { 'body-key': 'body-value' },
-        headers: { 'header-key': 'header-value' },
-        prepareSendMessagesRequest(optionsArg) {
-          options = optionsArg;
-          return {
-            body: { 'request-body-key': 'request-body-value' },
-            headers: { 'header-key': 'header-value' },
-          };
-        },
-      }),
-      generateId: mockId(),
+    setupTestComponent(() => {
+      const { messages, sendMessage, status } = useChat({
+        transport: new DefaultChatTransport({
+          body: { 'body-key': 'body-value' },
+          headers: { 'header-key': 'header-value' },
+          prepareSendMessagesRequest(optionsArg) {
+            options = optionsArg;
+            return {
+              body: { 'request-body-key': 'request-body-value' },
+              headers: { 'header-key': 'header-value' },
+            };
+          },
+        }),
+        generateId: mockId(),
+      });
+
+      return (
+        <div>
+          <div data-testid="status">{status.toString()}</div>
+          {messages.map((m, idx) => (
+            <div data-testid={`message-${idx}`} key={m.id}>
+              {m.role === 'user' ? 'User: ' : 'AI: '}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
+            </div>
+          ))}
+
+          <button
+            data-testid="do-send"
+            onClick={() => {
+              sendMessage(
+                {
+                  parts: [{ text: 'hi', type: 'text' }],
+                },
+                {
+                  body: { 'request-body-key': 'request-body-value' },
+                  headers: { 'request-header-key': 'request-header-value' },
+                  metadata: {
+                    'request-metadata-key': 'request-metadata-value',
+                  },
+                },
+              );
+            }}
+          />
+        </div>
+      );
     });
 
-    return (
-      <div>
-        <div data-testid="status">{status.toString()}</div>
-        {messages.map((m, idx) => (
-          <div data-testid={`message-${idx}`} key={m.id}>
-            {m.role === 'user' ? 'User: ' : 'AI: '}
-            {m.parts
-              .map(part => (part.type === 'text' ? part.text : ''))
-              .join('')}
-          </div>
-        ))}
+    afterEach(() => {
+      options = undefined;
+    });
 
-        <button
-          data-testid="do-send"
-          onClick={() => {
-            sendMessage(
-              {
-                parts: [{ text: 'hi', type: 'text' }],
-              },
-              {
-                body: { 'request-body-key': 'request-body-value' },
-                headers: { 'request-header-key': 'request-header-value' },
-                metadata: { 'request-metadata-key': 'request-metadata-value' },
-              },
-            );
-          }}
-        />
-      </div>
-    );
-  });
+    it('should show streamed response', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
 
-  afterEach(() => {
-    options = undefined;
-  });
+      await userEvent.click(screen.getByTestId('do-send'));
 
-  it('should show streamed response', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        formatChunk({ type: 'text-start', id: '0' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
-        formatChunk({ type: 'text-end', id: '0' }),
-      ],
-    };
+      await screen.findByTestId('message-0');
+      expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
 
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    await screen.findByTestId('message-0');
-    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
-
-    expect(options).toMatchInlineSnapshot(`
+      expect(options).toMatchInlineSnapshot(`
       {
         "api": "/api/chat",
         "body": {
@@ -722,127 +727,55 @@ describe('prepareChatRequest', () => {
       }
     `);
 
-    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
       {
         "request-body-key": "request-body-value",
       }
     `);
-    expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+      expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
       {
         "content-type": "application/json",
         "header-key": "header-value",
       }
     `);
 
-    await screen.findByTestId('message-1');
-    expect(screen.getByTestId('message-1')).toHaveTextContent(
-      'AI: Hello, world.',
-    );
-  });
-});
-
-describe('onToolCall', () => {
-  let resolve: () => void;
-  let toolCallPromise: Promise<void>;
-
-  setupTestComponent(() => {
-    const { messages, sendMessage, addToolOutput } = useChat({
-      async onToolCall({ toolCall }) {
-        await toolCallPromise;
-        addToolOutput({
-          tool: 'test-tool',
-          toolCallId: toolCall.toolCallId,
-          output: `test-tool-response: ${toolCall.toolName} ${
-            toolCall.toolCallId
-          } ${JSON.stringify(toolCall.input)}`,
-        });
-      },
-    });
-
-    return (
-      <div>
-        {messages.map((m, idx) => (
-          <div data-testid={`message-${idx}`} key={m.id}>
-            {m.parts.filter(isStaticToolUIPart).map((toolPart, toolIdx) => (
-              <div key={toolIdx} data-testid={`tool-${toolIdx}`}>
-                {JSON.stringify(toolPart)}
-              </div>
-            ))}
-          </div>
-        ))}
-
-        <button
-          data-testid="do-send"
-          onClick={() => {
-            sendMessage({
-              parts: [{ text: 'hi', type: 'text' }],
-            });
-          }}
-        />
-      </div>
-    );
-  });
-
-  beforeEach(() => {
-    toolCallPromise = new Promise(resolveArg => {
-      resolve = resolveArg;
+      await screen.findByTestId('message-1');
+      expect(screen.getByTestId('message-1')).toHaveTextContent(
+        'AI: Hello, world.',
+      );
     });
   });
 
-  it("should invoke onToolCall when a tool call is received from the server's response", async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        formatChunk({
-          type: 'tool-input-available',
-          toolCallId: 'tool-call-0',
-          toolName: 'test-tool',
-          input: { testArg: 'test-value' },
-        }),
-      ],
-    };
+  describe('onToolCall', () => {
+    let resolve: () => void;
+    let toolCallPromise: Promise<void>;
 
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    await screen.findByTestId('message-1');
-    expect(
-      JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
-    ).toStrictEqual({
-      state: 'input-available',
-      input: { testArg: 'test-value' },
-      toolCallId: 'tool-call-0',
-      type: 'tool-test-tool',
-    });
-
-    resolve();
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
-      ).toStrictEqual({
-        state: 'output-available',
-        input: { testArg: 'test-value' },
-        toolCallId: 'tool-call-0',
-        type: 'tool-test-tool',
-        output:
-          'test-tool-response: test-tool tool-call-0 {"testArg":"test-value"}',
-      });
-    });
-  });
-
-  it('should call the latest onToolCall after prop change (no stale closure)', async () => {
-    const onToolCallA = vi.fn(async () => {});
-    const onToolCallB = vi.fn(async () => {});
-
-    const Test = () => {
-      const [useB, setUseB] = React.useState(false);
-      const { sendMessage } = useChat({
-        onToolCall: useB ? onToolCallB : onToolCallA,
+    setupTestComponent(() => {
+      const { messages, sendMessage, addToolOutput } = useChat({
+        async onToolCall({ toolCall }) {
+          await toolCallPromise;
+          addToolOutput({
+            tool: 'test-tool',
+            toolCallId: toolCall.toolCallId,
+            output: `test-tool-response: ${toolCall.toolName} ${
+              toolCall.toolCallId
+            } ${JSON.stringify(toolCall.input)}`,
+          });
+        },
       });
 
       return (
         <div>
-          <button data-testid="toggle" onClick={() => setUseB(true)} />
+          {messages.map((m, idx) => (
+            <div data-testid={`message-${idx}`} key={m.id}>
+              {m.parts.filter(isStaticToolUIPart).map((toolPart, toolIdx) => (
+                <div key={toolIdx} data-testid={`tool-${toolIdx}`}>
+                  {JSON.stringify(toolPart)}
+                </div>
+              ))}
+            </div>
+          ))}
+
           <button
             data-testid="do-send"
             onClick={() => {
@@ -853,459 +786,531 @@ describe('onToolCall', () => {
           />
         </div>
       );
-    };
+    });
 
-    render(<Test />);
+    beforeEach(() => {
+      toolCallPromise = new Promise(resolveArg => {
+        resolve = resolveArg;
+      });
+    });
 
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
+    it("should invoke onToolCall when a tool call is received from the server's response", async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({
+            type: 'tool-input-available',
+            toolCallId: 'tool-call-0',
+            toolName: 'test-tool',
+            input: { testArg: 'test-value' },
+          }),
+        ],
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await screen.findByTestId('message-1');
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'input-available',
+        input: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        type: 'tool-test-tool',
+      });
+
+      resolve();
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+        ).toStrictEqual({
+          state: 'output-available',
+          input: { testArg: 'test-value' },
+          toolCallId: 'tool-call-0',
+          type: 'tool-test-tool',
+          output:
+            'test-tool-response: test-tool tool-call-0 {"testArg":"test-value"}',
+        });
+      });
+    });
+
+    it('should call the latest onToolCall after prop change (no stale closure)', async () => {
+      const onToolCallA = vi.fn(async () => {});
+      const onToolCallB = vi.fn(async () => {});
+
+      const Test = () => {
+        const [useB, setUseB] = React.useState(false);
+        const { sendMessage } = useChat({
+          onToolCall: useB ? onToolCallB : onToolCallA,
+        });
+
+        return (
+          <div>
+            <button data-testid="toggle" onClick={() => setUseB(true)} />
+            <button
+              data-testid="do-send"
+              onClick={() => {
+                sendMessage({
+                  parts: [{ text: 'hi', type: 'text' }],
+                });
+              }}
+            />
+          </div>
+        );
+      };
+
+      render(<Test />);
+
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({
+            type: 'tool-input-available',
+            toolCallId: 'tool-call-0',
+            toolName: 'test-tool',
+            input: { testArg: 'test-value' },
+          }),
+        ],
+      };
+
+      await userEvent.click(screen.getByTestId('toggle'));
+      const sendButtons = screen.getAllByTestId('do-send');
+      await userEvent.click(sendButtons[sendButtons.length - 1]);
+
+      await vi.waitUntil(() => onToolCallB.mock.calls.length > 0, {
+        timeout: 2000,
+      });
+
+      expect(onToolCallA).toHaveBeenCalledTimes(0);
+      expect(onToolCallB).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('tool invocations', () => {
+    setupTestComponent(() => {
+      const { messages, sendMessage, addToolOutput } = useChat({
+        generateId: mockId(),
+      });
+
+      return (
+        <div>
+          {messages.map((m, idx) => (
+            <div data-testid={`message-${idx}`} key={m.id}>
+              {m.parts.filter(isStaticToolUIPart).map((toolPart, toolIdx) => {
+                return (
+                  <div key={toolIdx}>
+                    <div data-testid={`tool-invocation-${toolIdx}`}>
+                      {JSON.stringify(toolPart)}
+                    </div>
+                    {toolPart.state === 'input-available' && (
+                      <button
+                        data-testid={`add-result-${toolIdx}`}
+                        onClick={() => {
+                          addToolOutput({
+                            tool: 'test-tool',
+                            toolCallId: toolPart.toolCallId,
+                            output: 'test-result',
+                          });
+                        }}
+                      />
+                    )}
+                  </div>
+                );
+              })}
+              {m.role === 'assistant' && (
+                <div data-testid={`message-${idx}-text`}>
+                  {m.parts
+                    .map(part => (part.type === 'text' ? part.text : ''))
+                    .join('')}
+                </div>
+              )}
+            </div>
+          ))}
+
+          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
+
+          <button
+            data-testid="do-send"
+            onClick={() => {
+              sendMessage({
+                parts: [{ text: 'hi', type: 'text' }],
+              });
+            }}
+          />
+        </div>
+      );
+    });
+
+    it('should display partial tool call, tool call, and tool result', async () => {
+      const controller = new TestResponseController();
+
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      controller.write(
+        formatChunk({
+          type: 'tool-input-start',
+          toolCallId: 'tool-call-0',
+          toolName: 'test-tool',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+        ).toStrictEqual({
+          state: 'input-streaming',
+          toolCallId: 'tool-call-0',
+          type: 'tool-test-tool',
+        });
+      });
+
+      controller.write(
+        formatChunk({
+          type: 'tool-input-delta',
+          toolCallId: 'tool-call-0',
+          inputTextDelta: '{"testArg":"t',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+        ).toStrictEqual({
+          state: 'input-streaming',
+          toolCallId: 'tool-call-0',
+          type: 'tool-test-tool',
+          input: { testArg: 't' },
+        });
+      });
+
+      controller.write(
+        formatChunk({
+          type: 'tool-input-delta',
+          toolCallId: 'tool-call-0',
+          inputTextDelta: 'est-value"}}',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+        ).toStrictEqual({
+          state: 'input-streaming',
+          toolCallId: 'tool-call-0',
+          type: 'tool-test-tool',
+          input: { testArg: 'test-value' },
+        });
+      });
+
+      controller.write(
         formatChunk({
           type: 'tool-input-available',
           toolCallId: 'tool-call-0',
           toolName: 'test-tool',
           input: { testArg: 'test-value' },
         }),
-      ],
-    };
+      );
 
-    await userEvent.click(screen.getByTestId('toggle'));
-    const sendButtons = screen.getAllByTestId('do-send');
-    await userEvent.click(sendButtons[sendButtons.length - 1]);
-
-    await vi.waitUntil(() => onToolCallB.mock.calls.length > 0, {
-      timeout: 2000,
-    });
-
-    expect(onToolCallA).toHaveBeenCalledTimes(0);
-    expect(onToolCallB).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('tool invocations', () => {
-  setupTestComponent(() => {
-    const { messages, sendMessage, addToolOutput } = useChat({
-      generateId: mockId(),
-    });
-
-    return (
-      <div>
-        {messages.map((m, idx) => (
-          <div data-testid={`message-${idx}`} key={m.id}>
-            {m.parts.filter(isStaticToolUIPart).map((toolPart, toolIdx) => {
-              return (
-                <div key={toolIdx}>
-                  <div data-testid={`tool-invocation-${toolIdx}`}>
-                    {JSON.stringify(toolPart)}
-                  </div>
-                  {toolPart.state === 'input-available' && (
-                    <button
-                      data-testid={`add-result-${toolIdx}`}
-                      onClick={() => {
-                        addToolOutput({
-                          tool: 'test-tool',
-                          toolCallId: toolPart.toolCallId,
-                          output: 'test-result',
-                        });
-                      }}
-                    />
-                  )}
-                </div>
-              );
-            })}
-            {m.role === 'assistant' && (
-              <div data-testid={`message-${idx}-text`}>
-                {m.parts
-                  .map(part => (part.type === 'text' ? part.text : ''))
-                  .join('')}
-              </div>
-            )}
-          </div>
-        ))}
-
-        <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
-
-        <button
-          data-testid="do-send"
-          onClick={() => {
-            sendMessage({
-              parts: [{ text: 'hi', type: 'text' }],
-            });
-          }}
-        />
-      </div>
-    );
-  });
-
-  it('should display partial tool call, tool call, and tool result', async () => {
-    const controller = new TestResponseController();
-
-    server.urls['/api/chat'].response = {
-      type: 'controlled-stream',
-      controller,
-    };
-
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    controller.write(
-      formatChunk({
-        type: 'tool-input-start',
-        toolCallId: 'tool-call-0',
-        toolName: 'test-tool',
-      }),
-    );
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
-      ).toStrictEqual({
-        state: 'input-streaming',
-        toolCallId: 'tool-call-0',
-        type: 'tool-test-tool',
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+        ).toStrictEqual({
+          state: 'input-available',
+          input: { testArg: 'test-value' },
+          toolCallId: 'tool-call-0',
+          type: 'tool-test-tool',
+        });
       });
-    });
 
-    controller.write(
-      formatChunk({
-        type: 'tool-input-delta',
-        toolCallId: 'tool-call-0',
-        inputTextDelta: '{"testArg":"t',
-      }),
-    );
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
-      ).toStrictEqual({
-        state: 'input-streaming',
-        toolCallId: 'tool-call-0',
-        type: 'tool-test-tool',
-        input: { testArg: 't' },
-      });
-    });
-
-    controller.write(
-      formatChunk({
-        type: 'tool-input-delta',
-        toolCallId: 'tool-call-0',
-        inputTextDelta: 'est-value"}}',
-      }),
-    );
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
-      ).toStrictEqual({
-        state: 'input-streaming',
-        toolCallId: 'tool-call-0',
-        type: 'tool-test-tool',
-        input: { testArg: 'test-value' },
-      });
-    });
-
-    controller.write(
-      formatChunk({
-        type: 'tool-input-available',
-        toolCallId: 'tool-call-0',
-        toolName: 'test-tool',
-        input: { testArg: 'test-value' },
-      }),
-    );
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
-      ).toStrictEqual({
-        state: 'input-available',
-        input: { testArg: 'test-value' },
-        toolCallId: 'tool-call-0',
-        type: 'tool-test-tool',
-      });
-    });
-
-    controller.write(
-      formatChunk({
-        type: 'tool-output-available',
-        toolCallId: 'tool-call-0',
-        output: 'test-result',
-      }),
-    );
-    controller.close();
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
-      ).toStrictEqual({
-        state: 'output-available',
-        input: { testArg: 'test-value' },
-        toolCallId: 'tool-call-0',
-        type: 'tool-test-tool',
-        output: 'test-result',
-      });
-    });
-  });
-
-  it('should display tool call and tool result (when there is no tool call streaming)', async () => {
-    const controller = new TestResponseController();
-    server.urls['/api/chat'].response = {
-      type: 'controlled-stream',
-      controller,
-    };
-
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    controller.write(
-      formatChunk({
-        type: 'tool-input-available',
-        toolCallId: 'tool-call-0',
-        toolName: 'test-tool',
-        input: { testArg: 'test-value' },
-      }),
-    );
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
-      ).toStrictEqual({
-        state: 'input-available',
-        input: { testArg: 'test-value' },
-        toolCallId: 'tool-call-0',
-        type: 'tool-test-tool',
-      });
-    });
-
-    controller.write(
-      formatChunk({
-        type: 'tool-output-available',
-        toolCallId: 'tool-call-0',
-        output: 'test-result',
-      }),
-    );
-    controller.close();
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
-      ).toStrictEqual({
-        state: 'output-available',
-        input: { testArg: 'test-value' },
-        toolCallId: 'tool-call-0',
-        type: 'tool-test-tool',
-        output: 'test-result',
-      });
-    });
-  });
-
-  it('should update tool call to result when addToolOutput is called', async () => {
-    const controller = new TestResponseController();
-    server.urls['/api/chat'].response = {
-      type: 'controlled-stream',
-      controller,
-    };
-
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    controller.write(formatChunk({ type: 'start' }));
-    controller.write(formatChunk({ type: 'start-step' }));
-    controller.write(
-      formatChunk({
-        type: 'tool-input-available',
-        toolCallId: 'tool-call-0',
-        toolName: 'test-tool',
-        input: { testArg: 'test-value' },
-      }),
-    );
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
-      ).toStrictEqual({
-        state: 'input-available',
-        input: { testArg: 'test-value' },
-        toolCallId: 'tool-call-0',
-        type: 'tool-test-tool',
-      });
-    });
-
-    await userEvent.click(screen.getByTestId('add-result-0'));
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
-      ).toStrictEqual({
-        state: 'output-available',
-        input: { testArg: 'test-value' },
-        toolCallId: 'tool-call-0',
-        type: 'tool-test-tool',
-        output: 'test-result',
-      });
-    });
-
-    controller.write(formatChunk({ type: 'text-start', id: '0' }));
-    controller.write(
-      formatChunk({
-        type: 'text-delta',
-        id: '0',
-        delta: 'more text',
-      }),
-    );
-    controller.write(formatChunk({ type: 'text-end', id: '0' }));
-    controller.close();
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toStrictEqual([
-        {
-          id: 'id-1',
-          parts: [
-            {
-              text: 'hi',
-              type: 'text',
-            },
-          ],
-          role: 'user',
-        },
-        {
-          id: 'id-2',
-          parts: [
-            {
-              type: 'step-start',
-            },
-            {
-              type: 'tool-test-tool',
-              toolCallId: 'tool-call-0',
-              input: { testArg: 'test-value' },
-              output: 'test-result',
-              state: 'output-available',
-            },
-            {
-              text: 'more text',
-              type: 'text',
-              state: 'done',
-            },
-          ],
-          role: 'assistant',
-        },
-      ]);
-    });
-  });
-});
-
-describe('file attachments with data url', () => {
-  setupTestComponent(() => {
-    const { messages, status, sendMessage } = useChat({
-      generateId: mockId(),
-    });
-
-    const [files, setFiles] = useState<FileList | undefined>(undefined);
-    const fileInputRef = useRef<HTMLInputElement>(null);
-    const [input, setInput] = useState('');
-
-    return (
-      <div>
-        <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
-
-        <form
-          onSubmit={() => {
-            sendMessage({ text: input, files });
-            setFiles(undefined);
-            if (fileInputRef.current) {
-              fileInputRef.current.value = '';
-            }
-          }}
-          data-testid="chat-form"
-        >
-          <input
-            type="file"
-            onChange={event => {
-              if (event.target.files) {
-                setFiles(event.target.files);
-              }
-            }}
-            multiple
-            ref={fileInputRef}
-            data-testid="file-input"
-          />
-          <input
-            value={input}
-            onChange={e => setInput(e.target.value)}
-            disabled={status !== 'ready'}
-            data-testid="message-input"
-          />
-          <button type="submit" data-testid="submit-button">
-            Send
-          </button>
-        </form>
-      </div>
-    );
-  });
-
-  it('should handle text file attachment and submission', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
+      controller.write(
         formatChunk({
-          type: 'text-start',
-          id: '0',
+          type: 'tool-output-available',
+          toolCallId: 'tool-call-0',
+          output: 'test-result',
         }),
+      );
+      controller.close();
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+        ).toStrictEqual({
+          state: 'output-available',
+          input: { testArg: 'test-value' },
+          toolCallId: 'tool-call-0',
+          type: 'tool-test-tool',
+          output: 'test-result',
+        });
+      });
+    });
+
+    it('should display tool call and tool result (when there is no tool call streaming)', async () => {
+      const controller = new TestResponseController();
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      controller.write(
+        formatChunk({
+          type: 'tool-input-available',
+          toolCallId: 'tool-call-0',
+          toolName: 'test-tool',
+          input: { testArg: 'test-value' },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+        ).toStrictEqual({
+          state: 'input-available',
+          input: { testArg: 'test-value' },
+          toolCallId: 'tool-call-0',
+          type: 'tool-test-tool',
+        });
+      });
+
+      controller.write(
+        formatChunk({
+          type: 'tool-output-available',
+          toolCallId: 'tool-call-0',
+          output: 'test-result',
+        }),
+      );
+      controller.close();
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+        ).toStrictEqual({
+          state: 'output-available',
+          input: { testArg: 'test-value' },
+          toolCallId: 'tool-call-0',
+          type: 'tool-test-tool',
+          output: 'test-result',
+        });
+      });
+    });
+
+    it('should update tool call to result when addToolOutput is called', async () => {
+      const controller = new TestResponseController();
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      controller.write(formatChunk({ type: 'start' }));
+      controller.write(formatChunk({ type: 'start-step' }));
+      controller.write(
+        formatChunk({
+          type: 'tool-input-available',
+          toolCallId: 'tool-call-0',
+          toolName: 'test-tool',
+          input: { testArg: 'test-value' },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+        ).toStrictEqual({
+          state: 'input-available',
+          input: { testArg: 'test-value' },
+          toolCallId: 'tool-call-0',
+          type: 'tool-test-tool',
+        });
+      });
+
+      await userEvent.click(screen.getByTestId('add-result-0'));
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+        ).toStrictEqual({
+          state: 'output-available',
+          input: { testArg: 'test-value' },
+          toolCallId: 'tool-call-0',
+          type: 'tool-test-tool',
+          output: 'test-result',
+        });
+      });
+
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      controller.write(
         formatChunk({
           type: 'text-delta',
           id: '0',
-          delta: 'Response to message with text attachment',
+          delta: 'more text',
         }),
-        formatChunk({ type: 'text-end', id: '0' }),
-      ],
-    };
+      );
+      controller.write(formatChunk({ type: 'text-end', id: '0' }));
+      controller.close();
 
-    const file = new File(['test file content'], 'test.txt', {
-      type: 'text/plain',
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            id: 'id-1',
+            parts: [
+              {
+                text: 'hi',
+                type: 'text',
+              },
+            ],
+            role: 'user',
+          },
+          {
+            id: 'id-2',
+            parts: [
+              {
+                type: 'step-start',
+              },
+              {
+                type: 'tool-test-tool',
+                toolCallId: 'tool-call-0',
+                input: { testArg: 'test-value' },
+                output: 'test-result',
+                state: 'output-available',
+              },
+              {
+                text: 'more text',
+                type: 'text',
+                state: 'done',
+              },
+            ],
+            role: 'assistant',
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('file attachments with data url', () => {
+    setupTestComponent(() => {
+      const { messages, status, sendMessage } = useChat({
+        generateId: mockId(),
+      });
+
+      const [files, setFiles] = useState<FileList | undefined>(undefined);
+      const fileInputRef = useRef<HTMLInputElement>(null);
+      const [input, setInput] = useState('');
+
+      return (
+        <div>
+          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
+
+          <form
+            onSubmit={() => {
+              sendMessage({ text: input, files });
+              setFiles(undefined);
+              if (fileInputRef.current) {
+                fileInputRef.current.value = '';
+              }
+            }}
+            data-testid="chat-form"
+          >
+            <input
+              type="file"
+              onChange={event => {
+                if (event.target.files) {
+                  setFiles(event.target.files);
+                }
+              }}
+              multiple
+              ref={fileInputRef}
+              data-testid="file-input"
+            />
+            <input
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              disabled={status !== 'ready'}
+              data-testid="message-input"
+            />
+            <button type="submit" data-testid="submit-button">
+              Send
+            </button>
+          </form>
+        </div>
+      );
     });
 
-    const fileInput = screen.getByTestId('file-input');
-    await userEvent.upload(fileInput, file);
+    it('should handle text file attachment and submission', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({
+            type: 'text-start',
+            id: '0',
+          }),
+          formatChunk({
+            type: 'text-delta',
+            id: '0',
+            delta: 'Response to message with text attachment',
+          }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
 
-    const messageInput = screen.getByTestId('message-input');
-    await userEvent.type(messageInput, 'Message with text attachment');
+      const file = new File(['test file content'], 'test.txt', {
+        type: 'text/plain',
+      });
 
-    const submitButton = screen.getByTestId('submit-button');
-    await userEvent.click(submitButton);
+      const fileInput = screen.getByTestId('file-input');
+      await userEvent.upload(fileInput, file);
 
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toStrictEqual([
-        {
-          id: 'id-1',
-          role: 'user',
-          parts: [
-            {
-              type: 'file',
-              mediaType: 'text/plain',
-              filename: 'test.txt',
-              url: 'data:text/plain;base64,dGVzdCBmaWxlIGNvbnRlbnQ=',
-            },
-            {
-              type: 'text',
-              text: 'Message with text attachment',
-            },
-          ],
-        },
-        {
-          id: 'id-2',
-          parts: [
-            {
-              text: 'Response to message with text attachment',
-              type: 'text',
-              state: 'done',
-            },
-          ],
-          role: 'assistant',
-        },
-      ]);
-    });
+      const messageInput = screen.getByTestId('message-input');
+      await userEvent.type(messageInput, 'Message with text attachment');
 
-    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      const submitButton = screen.getByTestId('submit-button');
+      await userEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            id: 'id-1',
+            role: 'user',
+            parts: [
+              {
+                type: 'file',
+                mediaType: 'text/plain',
+                filename: 'test.txt',
+                url: 'data:text/plain;base64,dGVzdCBmaWxlIGNvbnRlbnQ=',
+              },
+              {
+                type: 'text',
+                text: 'Message with text attachment',
+              },
+            ],
+          },
+          {
+            id: 'id-2',
+            parts: [
+              {
+                text: 'Response to message with text attachment',
+                type: 'text',
+                state: 'done',
+              },
+            ],
+            role: 'assistant',
+          },
+        ]);
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
       {
         "id": "id-0",
         "messages": [
@@ -1329,73 +1334,73 @@ describe('file attachments with data url', () => {
         "trigger": "submit-message",
       }
     `);
-  });
-
-  it('should handle image file attachment and submission', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        formatChunk({
-          type: 'text-start',
-          id: '0',
-        }),
-        formatChunk({
-          type: 'text-delta',
-          id: '0',
-          delta: 'Response to message with image attachment',
-        }),
-        formatChunk({ type: 'text-end', id: '0' }),
-      ],
-    };
-
-    const file = new File(['test image content'], 'test.png', {
-      type: 'image/png',
     });
 
-    const fileInput = screen.getByTestId('file-input');
-    await userEvent.upload(fileInput, file);
+    it('should handle image file attachment and submission', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({
+            type: 'text-start',
+            id: '0',
+          }),
+          formatChunk({
+            type: 'text-delta',
+            id: '0',
+            delta: 'Response to message with image attachment',
+          }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
 
-    const messageInput = screen.getByTestId('message-input');
-    await userEvent.type(messageInput, 'Message with image attachment');
+      const file = new File(['test image content'], 'test.png', {
+        type: 'image/png',
+      });
 
-    const submitButton = screen.getByTestId('submit-button');
-    await userEvent.click(submitButton);
+      const fileInput = screen.getByTestId('file-input');
+      await userEvent.upload(fileInput, file);
 
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toStrictEqual([
-        {
-          role: 'user',
-          id: 'id-1',
-          parts: [
-            {
-              type: 'file',
-              mediaType: 'image/png',
-              filename: 'test.png',
-              url: 'data:image/png;base64,dGVzdCBpbWFnZSBjb250ZW50',
-            },
-            {
-              type: 'text',
-              text: 'Message with image attachment',
-            },
-          ],
-        },
-        {
-          role: 'assistant',
-          id: 'id-2',
-          parts: [
-            {
-              type: 'text',
-              text: 'Response to message with image attachment',
-              state: 'done',
-            },
-          ],
-        },
-      ]);
-    });
+      const messageInput = screen.getByTestId('message-input');
+      await userEvent.type(messageInput, 'Message with image attachment');
 
-    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      const submitButton = screen.getByTestId('submit-button');
+      await userEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            role: 'user',
+            id: 'id-1',
+            parts: [
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                filename: 'test.png',
+                url: 'data:image/png;base64,dGVzdCBpbWFnZSBjb250ZW50',
+              },
+              {
+                type: 'text',
+                text: 'Message with image attachment',
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            id: 'id-2',
+            parts: [
+              {
+                type: 'text',
+                text: 'Response to message with image attachment',
+                state: 'done',
+              },
+            ],
+          },
+        ]);
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
       {
         "id": "id-0",
         "messages": [
@@ -1419,107 +1424,107 @@ describe('file attachments with data url', () => {
         "trigger": "submit-message",
       }
     `);
-  });
-});
-
-describe('file attachments with url', () => {
-  setupTestComponent(() => {
-    const { messages, sendMessage, status } = useChat({
-      generateId: mockId(),
     });
-
-    const [input, setInput] = useState('');
-
-    return (
-      <div>
-        <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
-
-        <form
-          onSubmit={() => {
-            sendMessage({
-              text: input,
-              files: [
-                {
-                  type: 'file',
-                  mediaType: 'image/png',
-                  url: 'https://example.com/image.png',
-                },
-              ],
-            });
-          }}
-          data-testid="chat-form"
-        >
-          <input
-            value={input}
-            onChange={e => setInput(e.target.value)}
-            disabled={status !== 'ready'}
-            data-testid="message-input"
-          />
-          <button type="submit" data-testid="submit-button">
-            Send
-          </button>
-        </form>
-      </div>
-    );
   });
 
-  it('should handle image file attachment and submission', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        formatChunk({
-          type: 'text-start',
-          id: '0',
-        }),
-        formatChunk({
-          type: 'text-delta',
-          id: '0',
-          delta: 'Response to message with image attachment',
-        }),
-        formatChunk({ type: 'text-end', id: '0' }),
-      ],
-    };
+  describe('file attachments with url', () => {
+    setupTestComponent(() => {
+      const { messages, sendMessage, status } = useChat({
+        generateId: mockId(),
+      });
 
-    const messageInput = screen.getByTestId('message-input');
-    await userEvent.type(messageInput, 'Message with image attachment');
+      const [input, setInput] = useState('');
 
-    const submitButton = screen.getByTestId('submit-button');
-    await userEvent.click(submitButton);
+      return (
+        <div>
+          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
 
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toStrictEqual([
-        {
-          role: 'user',
-          id: 'id-1',
-          parts: [
-            {
-              type: 'file',
-              mediaType: 'image/png',
-              url: 'https://example.com/image.png',
-            },
-            {
-              type: 'text',
-              text: 'Message with image attachment',
-            },
-          ],
-        },
-        {
-          role: 'assistant',
-          id: 'id-2',
-          parts: [
-            {
-              type: 'text',
-              text: 'Response to message with image attachment',
-              state: 'done',
-            },
-          ],
-        },
-      ]);
+          <form
+            onSubmit={() => {
+              sendMessage({
+                text: input,
+                files: [
+                  {
+                    type: 'file',
+                    mediaType: 'image/png',
+                    url: 'https://example.com/image.png',
+                  },
+                ],
+              });
+            }}
+            data-testid="chat-form"
+          >
+            <input
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              disabled={status !== 'ready'}
+              data-testid="message-input"
+            />
+            <button type="submit" data-testid="submit-button">
+              Send
+            </button>
+          </form>
+        </div>
+      );
     });
 
-    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+    it('should handle image file attachment and submission', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({
+            type: 'text-start',
+            id: '0',
+          }),
+          formatChunk({
+            type: 'text-delta',
+            id: '0',
+            delta: 'Response to message with image attachment',
+          }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
+
+      const messageInput = screen.getByTestId('message-input');
+      await userEvent.type(messageInput, 'Message with image attachment');
+
+      const submitButton = screen.getByTestId('submit-button');
+      await userEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            role: 'user',
+            id: 'id-1',
+            parts: [
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                url: 'https://example.com/image.png',
+              },
+              {
+                type: 'text',
+                text: 'Message with image attachment',
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            id: 'id-2',
+            parts: [
+              {
+                type: 'text',
+                text: 'Response to message with image attachment',
+                state: 'done',
+              },
+            ],
+          },
+        ]);
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
       {
         "id": "id-0",
         "messages": [
@@ -1542,90 +1547,90 @@ describe('file attachments with url', () => {
         "trigger": "submit-message",
       }
     `);
-  });
-});
-
-describe('attachments with empty submit', () => {
-  setupTestComponent(() => {
-    const { messages, sendMessage } = useChat({
-      generateId: mockId(),
     });
-
-    return (
-      <div>
-        <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
-
-        <form
-          onSubmit={() => {
-            sendMessage({
-              files: [
-                {
-                  type: 'file',
-                  filename: 'test.png',
-                  mediaType: 'image/png',
-                  url: 'https://example.com/image.png',
-                },
-              ],
-            });
-          }}
-          data-testid="chat-form"
-        >
-          <button type="submit" data-testid="submit-button">
-            Send
-          </button>
-        </form>
-      </div>
-    );
   });
 
-  it('should handle image file attachment and submission', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        formatChunk({ type: 'text-start', id: '0' }),
-        formatChunk({
-          type: 'text-delta',
-          id: '0',
-          delta: 'Response to message with image attachment',
-        }),
-        formatChunk({ type: 'text-end', id: '0' }),
-      ],
-    };
+  describe('attachments with empty submit', () => {
+    setupTestComponent(() => {
+      const { messages, sendMessage } = useChat({
+        generateId: mockId(),
+      });
 
-    const submitButton = screen.getByTestId('submit-button');
-    await userEvent.click(submitButton);
+      return (
+        <div>
+          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
 
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toStrictEqual([
-        {
-          id: 'id-1',
-          role: 'user',
-          parts: [
-            {
-              type: 'file',
-              mediaType: 'image/png',
-              filename: 'test.png',
-              url: 'https://example.com/image.png',
-            },
-          ],
-        },
-        {
-          id: 'id-2',
-          role: 'assistant',
-          parts: [
-            {
-              type: 'text',
-              text: 'Response to message with image attachment',
-              state: 'done',
-            },
-          ],
-        },
-      ]);
+          <form
+            onSubmit={() => {
+              sendMessage({
+                files: [
+                  {
+                    type: 'file',
+                    filename: 'test.png',
+                    mediaType: 'image/png',
+                    url: 'https://example.com/image.png',
+                  },
+                ],
+              });
+            }}
+            data-testid="chat-form"
+          >
+            <button type="submit" data-testid="submit-button">
+              Send
+            </button>
+          </form>
+        </div>
+      );
     });
 
-    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+    it('should handle image file attachment and submission', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({
+            type: 'text-delta',
+            id: '0',
+            delta: 'Response to message with image attachment',
+          }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
+
+      const submitButton = screen.getByTestId('submit-button');
+      await userEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            id: 'id-1',
+            role: 'user',
+            parts: [
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                filename: 'test.png',
+                url: 'https://example.com/image.png',
+              },
+            ],
+          },
+          {
+            id: 'id-2',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'text',
+                text: 'Response to message with image attachment',
+                state: 'done',
+              },
+            ],
+          },
+        ]);
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
       {
         "id": "id-0",
         "messages": [
@@ -1645,98 +1650,98 @@ describe('attachments with empty submit', () => {
         "trigger": "submit-message",
       }
     `);
-  });
-});
-
-describe('should send message with attachments', () => {
-  setupTestComponent(() => {
-    const { messages, sendMessage } = useChat({
-      generateId: mockId(),
     });
-
-    return (
-      <div>
-        <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
-
-        <form
-          onSubmit={event => {
-            event.preventDefault();
-
-            sendMessage({
-              parts: [
-                {
-                  type: 'file',
-                  mediaType: 'image/png',
-                  url: 'https://example.com/image.png',
-                },
-                {
-                  type: 'text',
-                  text: 'Message with image attachment',
-                },
-              ],
-            });
-          }}
-          data-testid="chat-form"
-        >
-          <button type="submit" data-testid="submit-button">
-            Send
-          </button>
-        </form>
-      </div>
-    );
   });
 
-  it('should handle image file attachment and submission', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        formatChunk({ type: 'text-start', id: '0' }),
-        formatChunk({
-          type: 'text-delta',
-          id: '0',
-          delta: 'Response to message with image attachment',
-        }),
-        formatChunk({ type: 'text-end', id: '0' }),
-      ],
-    };
+  describe('should send message with attachments', () => {
+    setupTestComponent(() => {
+      const { messages, sendMessage } = useChat({
+        generateId: mockId(),
+      });
 
-    const submitButton = screen.getByTestId('submit-button');
-    await userEvent.click(submitButton);
+      return (
+        <div>
+          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
 
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toStrictEqual([
-        {
-          id: 'id-1',
-          parts: [
-            {
-              mediaType: 'image/png',
-              type: 'file',
-              url: 'https://example.com/image.png',
-            },
-            {
-              text: 'Message with image attachment',
-              type: 'text',
-            },
-          ],
-          role: 'user',
-        },
-        {
-          id: 'id-2',
-          parts: [
-            {
-              state: 'done',
-              text: 'Response to message with image attachment',
-              type: 'text',
-            },
-          ],
-          role: 'assistant',
-        },
-      ]);
+          <form
+            onSubmit={event => {
+              event.preventDefault();
+
+              sendMessage({
+                parts: [
+                  {
+                    type: 'file',
+                    mediaType: 'image/png',
+                    url: 'https://example.com/image.png',
+                  },
+                  {
+                    type: 'text',
+                    text: 'Message with image attachment',
+                  },
+                ],
+              });
+            }}
+            data-testid="chat-form"
+          >
+            <button type="submit" data-testid="submit-button">
+              Send
+            </button>
+          </form>
+        </div>
+      );
     });
 
-    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+    it('should handle image file attachment and submission', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({
+            type: 'text-delta',
+            id: '0',
+            delta: 'Response to message with image attachment',
+          }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
+
+      const submitButton = screen.getByTestId('submit-button');
+      await userEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            id: 'id-1',
+            parts: [
+              {
+                mediaType: 'image/png',
+                type: 'file',
+                url: 'https://example.com/image.png',
+              },
+              {
+                text: 'Message with image attachment',
+                type: 'text',
+              },
+            ],
+            role: 'user',
+          },
+          {
+            id: 'id-2',
+            parts: [
+              {
+                state: 'done',
+                text: 'Response to message with image attachment',
+                type: 'text',
+              },
+            ],
+            role: 'assistant',
+          },
+        ]);
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
       {
         "id": "id-0",
         "messages": [
@@ -1759,85 +1764,85 @@ describe('should send message with attachments', () => {
         "trigger": "submit-message",
       }
     `);
+    });
   });
-});
 
-describe('regenerate', () => {
-  setupTestComponent(() => {
-    const { messages, sendMessage, regenerate } = useChat({
-      generateId: mockId(),
+  describe('regenerate', () => {
+    setupTestComponent(() => {
+      const { messages, sendMessage, regenerate } = useChat({
+        generateId: mockId(),
+      });
+
+      return (
+        <div>
+          {messages.map((m, idx) => (
+            <div data-testid={`message-${idx}`} key={m.id}>
+              {m.role === 'user' ? 'User: ' : 'AI: '}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
+            </div>
+          ))}
+
+          <button
+            data-testid="do-send"
+            onClick={() => {
+              sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+            }}
+          />
+
+          <button
+            data-testid="do-regenerate"
+            onClick={() => {
+              regenerate({
+                body: { 'request-body-key': 'request-body-value' },
+                headers: { 'header-key': 'header-value' },
+              });
+            }}
+          />
+        </div>
+      );
     });
 
-    return (
-      <div>
-        {messages.map((m, idx) => (
-          <div data-testid={`message-${idx}`} key={m.id}>
-            {m.role === 'user' ? 'User: ' : 'AI: '}
-            {m.parts
-              .map(part => (part.type === 'text' ? part.text : ''))
-              .join('')}
-          </div>
-        ))}
+    it('should show streamed response', async () => {
+      server.urls['/api/chat'].response = [
+        {
+          type: 'stream-chunks',
+          chunks: [
+            formatChunk({ type: 'text-start', id: '0' }),
+            formatChunk({
+              type: 'text-delta',
+              id: '0',
+              delta: 'first response',
+            }),
+            formatChunk({ type: 'text-end', id: '0' }),
+          ],
+        },
+        {
+          type: 'stream-chunks',
+          chunks: [
+            formatChunk({ type: 'text-start', id: '0' }),
+            formatChunk({
+              type: 'text-delta',
+              id: '0',
+              delta: 'second response',
+            }),
+            formatChunk({ type: 'text-end', id: '0' }),
+          ],
+        },
+      ];
 
-        <button
-          data-testid="do-send"
-          onClick={() => {
-            sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
-          }}
-        />
+      await userEvent.click(screen.getByTestId('do-send'));
 
-        <button
-          data-testid="do-regenerate"
-          onClick={() => {
-            regenerate({
-              body: { 'request-body-key': 'request-body-value' },
-              headers: { 'header-key': 'header-value' },
-            });
-          }}
-        />
-      </div>
-    );
-  });
+      await screen.findByTestId('message-0');
+      expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
 
-  it('should show streamed response', async () => {
-    server.urls['/api/chat'].response = [
-      {
-        type: 'stream-chunks',
-        chunks: [
-          formatChunk({ type: 'text-start', id: '0' }),
-          formatChunk({
-            type: 'text-delta',
-            id: '0',
-            delta: 'first response',
-          }),
-          formatChunk({ type: 'text-end', id: '0' }),
-        ],
-      },
-      {
-        type: 'stream-chunks',
-        chunks: [
-          formatChunk({ type: 'text-start', id: '0' }),
-          formatChunk({
-            type: 'text-delta',
-            id: '0',
-            delta: 'second response',
-          }),
-          formatChunk({ type: 'text-end', id: '0' }),
-        ],
-      },
-    ];
+      await screen.findByTestId('message-1');
 
-    await userEvent.click(screen.getByTestId('do-send'));
+      // setup done, click reload:
+      await userEvent.click(screen.getByTestId('do-regenerate'));
 
-    await screen.findByTestId('message-0');
-    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
-
-    await screen.findByTestId('message-1');
-
-    // setup done, click reload:
-    await userEvent.click(screen.getByTestId('do-regenerate'));
-
-    expect(await server.calls[1].requestBodyJson).toMatchInlineSnapshot(`
+      expect(await server.calls[1].requestBodyJson).toMatchInlineSnapshot(`
       {
         "id": "id-0",
         "messages": [
@@ -1857,71 +1862,71 @@ describe('regenerate', () => {
       }
     `);
 
-    expect(server.calls[1].requestHeaders).toStrictEqual({
-      'content-type': 'application/json',
-      'header-key': 'header-value',
+      expect(server.calls[1].requestHeaders).toStrictEqual({
+        'content-type': 'application/json',
+        'header-key': 'header-value',
+      });
+
+      await screen.findByTestId('message-1');
+      expect(screen.getByTestId('message-1')).toHaveTextContent(
+        'AI: second response',
+      );
     });
-
-    await screen.findByTestId('message-1');
-    expect(screen.getByTestId('message-1')).toHaveTextContent(
-      'AI: second response',
-    );
-  });
-});
-
-describe('test sending additional fields during message submission', () => {
-  setupTestComponent(() => {
-    type Message = UIMessage<{ test: string }>;
-
-    const { messages, sendMessage } = useChat<Message>({
-      generateId: mockId(),
-    });
-
-    return (
-      <div>
-        {messages.map((m, idx) => (
-          <div data-testid={`message-${idx}`} key={m.id}>
-            {m.role === 'user' ? 'User: ' : 'AI: '}
-            {m.parts
-              .map(part => (part.type === 'text' ? part.text : ''))
-              .join('')}
-          </div>
-        ))}
-
-        <button
-          data-testid="do-send"
-          onClick={() => {
-            sendMessage({
-              role: 'user',
-              metadata: { test: 'example' },
-              parts: [{ text: 'hi', type: 'text' }],
-            });
-          }}
-        />
-      </div>
-    );
   });
 
-  it('should send metadata with the message', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        formatChunk({ type: 'text-start', id: '0' }),
-        formatChunk({
-          type: 'text-delta',
-          id: '0',
-          delta: 'first response',
-        }),
-        formatChunk({ type: 'text-end', id: '0' }),
-      ],
-    };
+  describe('test sending additional fields during message submission', () => {
+    setupTestComponent(() => {
+      type Message = UIMessage<{ test: string }>;
 
-    await userEvent.click(screen.getByTestId('do-send'));
+      const { messages, sendMessage } = useChat<Message>({
+        generateId: mockId(),
+      });
 
-    await screen.findByTestId('message-0');
-    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+      return (
+        <div>
+          {messages.map((m, idx) => (
+            <div data-testid={`message-${idx}`} key={m.id}>
+              {m.role === 'user' ? 'User: ' : 'AI: '}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
+            </div>
+          ))}
 
-    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          <button
+            data-testid="do-send"
+            onClick={() => {
+              sendMessage({
+                role: 'user',
+                metadata: { test: 'example' },
+                parts: [{ text: 'hi', type: 'text' }],
+              });
+            }}
+          />
+        </div>
+      );
+    });
+
+    it('should send metadata with the message', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({
+            type: 'text-delta',
+            id: '0',
+            delta: 'first response',
+          }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await screen.findByTestId('message-0');
+      expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
       {
         "id": "id-0",
         "messages": [
@@ -1942,725 +1947,755 @@ describe('test sending additional fields during message submission', () => {
         "trigger": "submit-message",
       }
     `);
-  });
-});
-
-describe('resume ongoing stream and return assistant message', () => {
-  const controller = new TestResponseController();
-
-  setupTestComponent(
-    () => {
-      const { messages, status } = useChat({
-        id: '123',
-        messages: [
-          {
-            id: 'msg_123',
-            role: 'user',
-            parts: [{ type: 'text', text: 'hi' }],
-          },
-        ],
-        generateId: mockId(),
-        resume: true,
-      });
-
-      return (
-        <div>
-          {messages.map((m, idx) => (
-            <div data-testid={`message-${idx}`} key={m.id}>
-              {m.role === 'user' ? 'User: ' : 'AI: '}
-              {m.parts
-                .map(part => (part.type === 'text' ? part.text : ''))
-                .join('')}
-            </div>
-          ))}
-
-          <div data-testid="status">{status}</div>
-        </div>
-      );
-    },
-    {
-      init: TestComponent => {
-        server.urls['/api/chat/123/stream'].response = {
-          type: 'controlled-stream',
-          controller,
-        };
-
-        return <TestComponent />;
-      },
-    },
-  );
-
-  it('construct messages from resumed stream', async () => {
-    await screen.findByTestId('message-0');
-    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
-
-    await waitFor(() => {
-      expect(screen.getByTestId('status')).toHaveTextContent('submitted');
-    });
-
-    controller.write(formatChunk({ type: 'text-start', id: '0' }));
-    controller.write(
-      formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('status')).toHaveTextContent('streaming');
-    });
-
-    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: ',' }));
-    controller.write(
-      formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
-    );
-    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: '.' }));
-    controller.write(formatChunk({ type: 'text-end', id: '0' }));
-
-    controller.close();
-
-    await screen.findByTestId('message-1');
-    expect(screen.getByTestId('message-1')).toHaveTextContent(
-      'AI: Hello, world.',
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('status')).toHaveTextContent('ready');
-
-      expect(server.calls.length).toBeGreaterThan(0);
-      const mostRecentCall = server.calls[0];
-
-      const { requestMethod, requestUrl } = mostRecentCall;
-      expect(requestMethod).toBe('GET');
-      expect(requestUrl).toBe('http://localhost:3000/api/chat/123/stream');
     });
   });
-});
 
-describe('resume with no active stream should not flash submitted status', () => {
-  setupTestComponent(
-    () => {
-      const { messages, status } = useChat({
-        id: '123',
-        messages: [
-          {
-            id: 'msg_123',
-            role: 'user',
-            parts: [{ type: 'text', text: 'hi' }],
-          },
-        ],
-        generateId: mockId(),
-        resume: true,
-      });
+  describe('resume ongoing stream and return assistant message', () => {
+    const controller = new TestResponseController();
 
-      const statusHistoryRef = useRef<string[]>([]);
-      if (statusHistoryRef.current.at(-1) !== status) {
-        statusHistoryRef.current.push(status);
-      }
-
-      return (
-        <div>
-          {messages.map((m, idx) => (
-            <div data-testid={`message-${idx}`} key={m.id}>
-              {m.role === 'user' ? 'User: ' : 'AI: '}
-              {m.parts
-                .map(part => (part.type === 'text' ? part.text : ''))
-                .join('')}
-            </div>
-          ))}
-
-          <div data-testid="status">{status}</div>
-          <div data-testid="status-history">
-            {statusHistoryRef.current.join(',')}
-          </div>
-        </div>
-      );
-    },
-    {
-      init: TestComponent => {
-        server.urls['/api/chat/123/stream'].response = {
-          type: 'empty',
-          status: 204,
-        };
-
-        return <TestComponent />;
-      },
-    },
-  );
-
-  it('should not transition to submitted when no active stream exists', async () => {
-    await waitFor(() => {
-      expect(server.calls.length).toBe(1);
-    });
-
-    expect(screen.getByTestId('status')).toHaveTextContent('ready');
-    expect(screen.getByTestId('status-history')).not.toHaveTextContent(
-      'submitted',
-    );
-  });
-});
-
-describe('resume with server error should set error status without flashing submitted', () => {
-  const onErrorCalls: Error[] = [];
-
-  setupTestComponent(
-    () => {
-      const { status, error } = useChat({
-        id: '123',
-        messages: [
-          {
-            id: 'msg_123',
-            role: 'user',
-            parts: [{ type: 'text', text: 'hi' }],
-          },
-        ],
-        generateId: mockId(),
-        resume: true,
-        onError(err) {
-          onErrorCalls.push(err);
-        },
-      });
-
-      const statusHistoryRef = useRef<string[]>([]);
-      if (statusHistoryRef.current.at(-1) !== status) {
-        statusHistoryRef.current.push(status);
-      }
-
-      return (
-        <div>
-          <div data-testid="status">{status}</div>
-          <div data-testid="status-history">
-            {statusHistoryRef.current.join(',')}
-          </div>
-          {error && <div data-testid="error">{error.toString()}</div>}
-        </div>
-      );
-    },
-    {
-      init: TestComponent => {
-        server.urls['/api/chat/123/stream'].response = {
-          type: 'error',
-          status: 500,
-          body: 'Internal server error',
-        };
-
-        return <TestComponent />;
-      },
-    },
-  );
-
-  beforeEach(() => {
-    onErrorCalls.length = 0;
-  });
-
-  it('should set error status and call onError', async () => {
-    await waitFor(() => {
-      expect(screen.getByTestId('status')).toHaveTextContent('error');
-    });
-
-    expect(screen.getByTestId('error')).toHaveTextContent(
-      'Internal server error',
-    );
-    expect(screen.getByTestId('status-history')).not.toHaveTextContent(
-      'submitted',
-    );
-    expect(onErrorCalls).toHaveLength(1);
-  });
-});
-
-describe('stop', () => {
-  setupTestComponent(() => {
-    const { messages, sendMessage, stop, status } = useChat({
-      generateId: mockId(),
-    });
-
-    return (
-      <div>
-        {messages.map((m, idx) => (
-          <div data-testid={`message-${idx}`} key={m.id}>
-            {m.role === 'user' ? 'User: ' : 'AI: '}
-            {m.parts
-              .map(part => (part.type === 'text' ? part.text : ''))
-              .join('')}
-          </div>
-        ))}
-
-        <button
-          data-testid="do-send"
-          onClick={() => {
-            sendMessage({
+    setupTestComponent(
+      () => {
+        const { messages, status } = useChat({
+          id: '123',
+          messages: [
+            {
+              id: 'msg_123',
               role: 'user',
-              parts: [{ text: 'hi', type: 'text' }],
-            });
-          }}
-        />
+              parts: [{ type: 'text', text: 'hi' }],
+            },
+          ],
+          generateId: mockId(),
+          resume: true,
+        });
 
-        <button data-testid="do-stop" onClick={stop} />
+        return (
+          <div>
+            {messages.map((m, idx) => (
+              <div data-testid={`message-${idx}`} key={m.id}>
+                {m.role === 'user' ? 'User: ' : 'AI: '}
+                {m.parts
+                  .map(part => (part.type === 'text' ? part.text : ''))
+                  .join('')}
+              </div>
+            ))}
 
-        <p data-testid="status">{status}</p>
-      </div>
+            <div data-testid="status">{status}</div>
+          </div>
+        );
+      },
+      {
+        init: TestComponent => {
+          server.urls['/api/chat/123/stream'].response = {
+            type: 'controlled-stream',
+            controller,
+          };
+
+          return <TestComponent />;
+        },
+      },
     );
+
+    it('construct messages from resumed stream', async () => {
+      await screen.findByTestId('message-0');
+      expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('status')).toHaveTextContent('submitted');
+      });
+
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('status')).toHaveTextContent('streaming');
+      });
+
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+      );
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+      );
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+      );
+      controller.write(formatChunk({ type: 'text-end', id: '0' }));
+
+      controller.close();
+
+      await screen.findByTestId('message-1');
+      expect(screen.getByTestId('message-1')).toHaveTextContent(
+        'AI: Hello, world.',
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('status')).toHaveTextContent('ready');
+
+        expect(server.calls.length).toBeGreaterThan(0);
+        const mostRecentCall = server.calls[0];
+
+        const { requestMethod, requestUrl } = mostRecentCall;
+        expect(requestMethod).toBe('GET');
+        expect(requestUrl).toBe('http://localhost:3000/api/chat/123/stream');
+      });
+    });
   });
 
-  it('should show stop response', async () => {
-    const controller = new TestResponseController();
+  describe('resume with no active stream should not flash submitted status', () => {
+    setupTestComponent(
+      () => {
+        const { messages, status } = useChat({
+          id: '123',
+          messages: [
+            {
+              id: 'msg_123',
+              role: 'user',
+              parts: [{ type: 'text', text: 'hi' }],
+            },
+          ],
+          generateId: mockId(),
+          resume: true,
+        });
 
-    server.urls['/api/chat'].response = {
-      type: 'controlled-stream',
-      controller,
-    };
+        const statusHistoryRef = useRef<string[]>([]);
+        if (statusHistoryRef.current.at(-1) !== status) {
+          statusHistoryRef.current.push(status);
+        }
 
-    await userEvent.click(screen.getByTestId('do-send'));
+        return (
+          <div>
+            {messages.map((m, idx) => (
+              <div data-testid={`message-${idx}`} key={m.id}>
+                {m.role === 'user' ? 'User: ' : 'AI: '}
+                {m.parts
+                  .map(part => (part.type === 'text' ? part.text : ''))
+                  .join('')}
+              </div>
+            ))}
 
-    controller.write(formatChunk({ type: 'text-start', id: '0' }));
-    controller.write(
-      formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+            <div data-testid="status">{status}</div>
+            <div data-testid="status-history">
+              {statusHistoryRef.current.join(',')}
+            </div>
+          </div>
+        );
+      },
+      {
+        init: TestComponent => {
+          server.urls['/api/chat/123/stream'].response = {
+            type: 'empty',
+            status: 204,
+          };
+
+          return <TestComponent />;
+        },
+      },
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
-      expect(screen.getByTestId('status')).toHaveTextContent('streaming');
+    it('should not transition to submitted when no active stream exists', async () => {
+      await waitFor(() => {
+        expect(server.calls.length).toBe(1);
+      });
+
+      expect(screen.getByTestId('status')).toHaveTextContent('ready');
+      expect(screen.getByTestId('status-history')).not.toHaveTextContent(
+        'submitted',
+      );
+    });
+  });
+
+  describe('resume with server error should set error status without flashing submitted', () => {
+    const onErrorCalls: Error[] = [];
+
+    setupTestComponent(
+      () => {
+        const { status, error } = useChat({
+          id: '123',
+          messages: [
+            {
+              id: 'msg_123',
+              role: 'user',
+              parts: [{ type: 'text', text: 'hi' }],
+            },
+          ],
+          generateId: mockId(),
+          resume: true,
+          onError(err) {
+            onErrorCalls.push(err);
+          },
+        });
+
+        const statusHistoryRef = useRef<string[]>([]);
+        if (statusHistoryRef.current.at(-1) !== status) {
+          statusHistoryRef.current.push(status);
+        }
+
+        return (
+          <div>
+            <div data-testid="status">{status}</div>
+            <div data-testid="status-history">
+              {statusHistoryRef.current.join(',')}
+            </div>
+            {error && <div data-testid="error">{error.toString()}</div>}
+          </div>
+        );
+      },
+      {
+        init: TestComponent => {
+          server.urls['/api/chat/123/stream'].response = {
+            type: 'error',
+            status: 500,
+            body: 'Internal server error',
+          };
+
+          return <TestComponent />;
+        },
+      },
+    );
+
+    beforeEach(() => {
+      onErrorCalls.length = 0;
     });
 
-    await userEvent.click(screen.getByTestId('do-stop'));
+    it('should set error status and call onError', async () => {
+      await waitFor(() => {
+        expect(screen.getByTestId('status')).toHaveTextContent('error');
+      });
 
-    await waitFor(() => {
+      expect(screen.getByTestId('error')).toHaveTextContent(
+        'Internal server error',
+      );
+      expect(screen.getByTestId('status-history')).not.toHaveTextContent(
+        'submitted',
+      );
+      expect(onErrorCalls).toHaveLength(1);
+    });
+  });
+
+  describe('stop', () => {
+    setupTestComponent(() => {
+      const { messages, sendMessage, stop, status } = useChat({
+        generateId: mockId(),
+      });
+
+      return (
+        <div>
+          {messages.map((m, idx) => (
+            <div data-testid={`message-${idx}`} key={m.id}>
+              {m.role === 'user' ? 'User: ' : 'AI: '}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
+            </div>
+          ))}
+
+          <button
+            data-testid="do-send"
+            onClick={() => {
+              sendMessage({
+                role: 'user',
+                parts: [{ text: 'hi', type: 'text' }],
+              });
+            }}
+          />
+
+          <button data-testid="do-stop" onClick={stop} />
+
+          <p data-testid="status">{status}</p>
+        </div>
+      );
+    });
+
+    it('should show stop response', async () => {
+      const controller = new TestResponseController();
+
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+        expect(screen.getByTestId('status')).toHaveTextContent('streaming');
+      });
+
+      await userEvent.click(screen.getByTestId('do-stop'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('status')).toHaveTextContent('ready');
+      });
+
+      await expect(
+        controller.write(
+          formatChunk({ type: 'text-delta', id: '0', delta: ', world!' }),
+        ),
+      ).rejects.toThrow();
+
+      await expect(controller.close()).rejects.toThrow();
+
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
       expect(screen.getByTestId('status')).toHaveTextContent('ready');
     });
-
-    await expect(
-      controller.write(
-        formatChunk({ type: 'text-delta', id: '0', delta: ', world!' }),
-      ),
-    ).rejects.toThrow();
-
-    await expect(controller.close()).rejects.toThrow();
-
-    expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
-    expect(screen.getByTestId('status')).toHaveTextContent('ready');
-  });
-});
-
-describe('experimental_throttle', () => {
-  const throttleMs = 50;
-
-  setupTestComponent(() => {
-    const { messages, sendMessage, status } = useChat({
-      experimental_throttle: throttleMs,
-      generateId: mockId(),
-    });
-
-    return (
-      <div>
-        <div data-testid="status">{status.toString()}</div>
-        {messages.map((m, idx) => (
-          <div data-testid={`message-${idx}`} key={m.id}>
-            {m.role === 'user' ? 'User: ' : 'AI: '}
-            {m.parts
-              .map(part => (part.type === 'text' ? part.text : ''))
-              .join('')}
-          </div>
-        ))}
-        <button
-          data-testid="do-send"
-          onClick={() => {
-            sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
-          }}
-        />
-      </div>
-    );
   });
 
-  it('should throttle UI updates when experimental_throttle is set', async () => {
-    const controller = new TestResponseController();
+  describe('experimental_throttle', () => {
+    const throttleMs = 50;
 
-    server.urls['/api/chat'].response = {
-      type: 'controlled-stream',
-      controller,
-    };
-
-    await userEvent.click(screen.getByTestId('do-send'));
-    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
-
-    controller.write(formatChunk({ type: 'text-start', id: '0' }));
-    controller.write(
-      formatChunk({ type: 'text-delta', id: '0', delta: 'Hel' }),
-    );
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(throttleMs + 10);
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
     });
 
-    expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hel');
-
-    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: 'lo' }));
-    controller.write(
-      formatChunk({ type: 'text-delta', id: '0', delta: ' Th' }),
-    );
-    controller.write(
-      formatChunk({ type: 'text-delta', id: '0', delta: 'ere' }),
-    );
-    controller.write(formatChunk({ type: 'text-end', id: '0' }));
-
-    expect(screen.getByTestId('message-1')).not.toHaveTextContent(
-      'AI: Hello There',
-    );
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(throttleMs + 10);
+    afterEach(() => {
+      vi.useRealTimers();
     });
 
-    expect(screen.getByTestId('message-1')).toHaveTextContent(
-      'AI: Hello There',
-    );
-  });
-});
-
-describe('id changes', () => {
-  setupTestComponent(
-    () => {
-      const [id, setId] = React.useState<string>('initial-id');
-
-      const {
-        messages,
-        sendMessage,
-        error,
-        status,
-        id: idKey,
-      } = useChat({
-        id,
-        generateId: mockId(),
-      });
-
-      return (
-        <div>
-          <div data-testid="id">{idKey}</div>
-          <div data-testid="status">{status.toString()}</div>
-          {error && <div data-testid="error">{error.toString()}</div>}
-          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
-          <button
-            data-testid="do-send"
-            onClick={() => {
-              sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
-            }}
-          />
-          <button
-            data-testid="do-change-id"
-            onClick={() => {
-              setId('second-id');
-            }}
-          />
-        </div>
-      );
-    },
-    {
-      init: TestComponent => <TestComponent />,
-    },
-  );
-
-  it('should update chat instance when the id changes', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        formatChunk({ type: 'text-start', id: '0' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
-        formatChunk({ type: 'text-end', id: '0' }),
-      ],
-    };
-
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toStrictEqual([
-        {
-          id: expect.any(String),
-          parts: [
-            {
-              text: 'hi',
-              type: 'text',
-            },
-          ],
-          role: 'user',
-        },
-        {
-          id: 'id-1',
-          parts: [
-            {
-              text: 'Hello, world.',
-              type: 'text',
-              state: 'done',
-            },
-          ],
-          role: 'assistant',
-        },
-      ]);
-    });
-    await userEvent.click(screen.getByTestId('do-change-id'));
-
-    expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
-  });
-});
-
-describe('chat instance changes', () => {
-  setupTestComponent(
-    () => {
-      const [chat, setChat] = React.useState<Chat<UIMessage>>(
-        new Chat({
-          id: 'initial-id',
-          generateId: mockId(),
-        }),
-      );
-
-      const {
-        messages,
-        sendMessage,
-        error,
-        status,
-        id: idKey,
-      } = useChat({
-        chat,
-      });
-
-      return (
-        <div>
-          <div data-testid="id">{idKey}</div>
-          <div data-testid="status">{status.toString()}</div>
-          {error && <div data-testid="error">{error.toString()}</div>}
-          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
-          <button
-            data-testid="do-send"
-            onClick={() => {
-              sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
-            }}
-          />
-          <button
-            data-testid="do-change-chat"
-            onClick={() => {
-              setChat(
-                new Chat({
-                  id: 'second-id',
-                  generateId: mockId(),
-                }),
-              );
-            }}
-          />
-        </div>
-      );
-    },
-    {
-      init: TestComponent => <TestComponent />,
-    },
-  );
-
-  it('should update chat instance when the id changes', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: [
-        formatChunk({ type: 'text-start', id: '0' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
-        formatChunk({ type: 'text-end', id: '0' }),
-      ],
-    };
-
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toStrictEqual([
-        {
-          id: expect.any(String),
-          parts: [
-            {
-              text: 'hi',
-              type: 'text',
-            },
-          ],
-          role: 'user',
-        },
-        {
-          id: 'id-1',
-          parts: [
-            {
-              text: 'Hello, world.',
-              type: 'text',
-              state: 'done',
-            },
-          ],
-          role: 'assistant',
-        },
-      ]);
-    });
-    await userEvent.click(screen.getByTestId('do-change-chat'));
-
-    expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
-  });
-
-  it('should handle streaming correctly when the id changes', async () => {
-    const controller = new TestResponseController();
-    server.urls['/api/chat'].response = {
-      type: 'controlled-stream',
-      controller,
-    };
-
-    // First, change the ID
-    await userEvent.click(screen.getByTestId('do-change-chat'));
-
-    // Then send a message
-    await userEvent.click(screen.getByTestId('do-send'));
-
-    await waitFor(() => {
-      expect(screen.getByTestId('status')).toHaveTextContent('submitted');
-    });
-
-    controller.write(formatChunk({ type: 'text-start', id: '0' }));
-    controller.write(
-      formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
-    );
-
-    // Verify streaming is working - text should appear immediately
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toContainEqual(
-        expect.objectContaining({
-          role: 'assistant',
-          parts: expect.arrayContaining([
-            expect.objectContaining({
-              type: 'text',
-              text: 'Hello',
-            }),
-          ]),
-        }),
-      );
-    });
-
-    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: ',' }));
-    controller.write(
-      formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
-    );
-    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: '.' }));
-    controller.write(formatChunk({ type: 'text-end', id: '0' }));
-    controller.close();
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toContainEqual(
-        expect.objectContaining({
-          role: 'assistant',
-          parts: expect.arrayContaining([
-            expect.objectContaining({
-              type: 'text',
-              text: 'Hello, world.',
-              state: 'done',
-            }),
-          ]),
-        }),
-      );
-    });
-  });
-});
-
-describe('streaming with id change from undefined to defined', () => {
-  setupTestComponent(
-    () => {
-      const [id, setId] = React.useState<string | undefined>(undefined);
+    setupTestComponent(() => {
       const { messages, sendMessage, status } = useChat({
-        id,
+        experimental_throttle: throttleMs,
         generateId: mockId(),
       });
 
       return (
         <div>
           <div data-testid="status">{status.toString()}</div>
-          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
+          {messages.map((m, idx) => (
+            <div data-testid={`message-${idx}`} key={m.id}>
+              {m.role === 'user' ? 'User: ' : 'AI: '}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
+            </div>
+          ))}
           <button
-            data-testid="change-id"
-            onClick={() => {
-              setId('chat-123');
-            }}
-          />
-          <button
-            data-testid="send-message"
+            data-testid="do-send"
             onClick={() => {
               sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
             }}
           />
         </div>
       );
-    },
-    {
-      init: TestComponent => <TestComponent />,
-    },
-  );
-
-  it('should handle streaming correctly when id changes from undefined to defined', async () => {
-    const controller = new TestResponseController();
-    server.urls['/api/chat'].response = {
-      type: 'controlled-stream',
-      controller,
-    };
-
-    // First, change the ID from undefined to 'chat-123'
-    await userEvent.click(screen.getByTestId('change-id'));
-
-    // Then send a message
-    await userEvent.click(screen.getByTestId('send-message'));
-
-    await waitFor(() => {
-      expect(screen.getByTestId('status')).toHaveTextContent('submitted');
     });
 
-    controller.write(formatChunk({ type: 'text-start', id: '0' }));
-    controller.write(
-      formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
-    );
+    it('should throttle UI updates when experimental_throttle is set', async () => {
+      const controller = new TestResponseController();
 
-    // Verify streaming is working - text should appear immediately
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toContainEqual(
-        expect.objectContaining({
-          role: 'assistant',
-          parts: expect.arrayContaining([
-            expect.objectContaining({
-              type: 'text',
-              text: 'Hello',
-            }),
-          ]),
-        }),
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      fireEvent.click(screen.getByTestId('do-send'));
+      expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hel' }),
+      );
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(throttleMs + 10);
+      });
+
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hel');
+
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'lo' }),
+      );
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: ' Th' }),
+      );
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'ere' }),
+      );
+      controller.write(formatChunk({ type: 'text-end', id: '0' }));
+
+      expect(screen.getByTestId('message-1')).not.toHaveTextContent(
+        'AI: Hello There',
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(throttleMs + 10);
+      });
+
+      expect(screen.getByTestId('message-1')).toHaveTextContent(
+        'AI: Hello There',
       );
     });
+  });
 
-    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: ',' }));
-    controller.write(
-      formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+  describe('id changes', () => {
+    setupTestComponent(
+      () => {
+        const [id, setId] = React.useState<string>('initial-id');
+
+        const {
+          messages,
+          sendMessage,
+          error,
+          status,
+          id: idKey,
+        } = useChat({
+          id,
+          generateId: mockId(),
+        });
+
+        return (
+          <div>
+            <div data-testid="id">{idKey}</div>
+            <div data-testid="status">{status.toString()}</div>
+            {error && <div data-testid="error">{error.toString()}</div>}
+            <div data-testid="messages">
+              {JSON.stringify(messages, null, 2)}
+            </div>
+            <button
+              data-testid="do-send"
+              onClick={() => {
+                sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+              }}
+            />
+            <button
+              data-testid="do-change-id"
+              onClick={() => {
+                setId('second-id');
+              }}
+            />
+          </div>
+        );
+      },
+      {
+        init: TestComponent => <TestComponent />,
+      },
     );
-    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: '.' }));
-    controller.write(formatChunk({ type: 'text-end', id: '0' }));
-    controller.close();
 
-    await waitFor(() => {
-      expect(
-        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-      ).toContainEqual(
-        expect.objectContaining({
-          role: 'assistant',
-          parts: expect.arrayContaining([
-            expect.objectContaining({
-              type: 'text',
-              text: 'Hello, world.',
-              state: 'done',
-            }),
-          ]),
-        }),
+    it('should update chat instance when the id changes', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            id: expect.any(String),
+            parts: [
+              {
+                text: 'hi',
+                type: 'text',
+              },
+            ],
+            role: 'user',
+          },
+          {
+            id: 'id-1',
+            parts: [
+              {
+                text: 'Hello, world.',
+                type: 'text',
+                state: 'done',
+              },
+            ],
+            role: 'assistant',
+          },
+        ]);
+      });
+      await userEvent.click(screen.getByTestId('do-change-id'));
+
+      expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('chat instance changes', () => {
+    setupTestComponent(
+      () => {
+        const [chat, setChat] = React.useState<Chat<UIMessage>>(
+          new Chat({
+            id: 'initial-id',
+            generateId: mockId(),
+          }),
+        );
+
+        const {
+          messages,
+          sendMessage,
+          error,
+          status,
+          id: idKey,
+        } = useChat({
+          chat,
+        });
+
+        return (
+          <div>
+            <div data-testid="id">{idKey}</div>
+            <div data-testid="status">{status.toString()}</div>
+            {error && <div data-testid="error">{error.toString()}</div>}
+            <div data-testid="messages">
+              {JSON.stringify(messages, null, 2)}
+            </div>
+            <button
+              data-testid="do-send"
+              onClick={() => {
+                sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+              }}
+            />
+            <button
+              data-testid="do-change-chat"
+              onClick={() => {
+                setChat(
+                  new Chat({
+                    id: 'second-id',
+                    generateId: mockId(),
+                  }),
+                );
+              }}
+            />
+          </div>
+        );
+      },
+      {
+        init: TestComponent => <TestComponent />,
+      },
+    );
+
+    it('should update chat instance when the id changes', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+          formatChunk({ type: 'text-end', id: '0' }),
+        ],
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toStrictEqual([
+          {
+            id: expect.any(String),
+            parts: [
+              {
+                text: 'hi',
+                type: 'text',
+              },
+            ],
+            role: 'user',
+          },
+          {
+            id: 'id-1',
+            parts: [
+              {
+                text: 'Hello, world.',
+                type: 'text',
+                state: 'done',
+              },
+            ],
+            role: 'assistant',
+          },
+        ]);
+      });
+      await userEvent.click(screen.getByTestId('do-change-chat'));
+
+      expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
+    });
+
+    it('should handle streaming correctly when the id changes', async () => {
+      const controller = new TestResponseController();
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      // First, change the ID
+      await userEvent.click(screen.getByTestId('do-change-chat'));
+
+      // Then send a message
+      await userEvent.click(screen.getByTestId('do-send'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('status')).toHaveTextContent('submitted');
+      });
+
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
       );
+
+      // Verify streaming is working - text should appear immediately
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toContainEqual(
+          expect.objectContaining({
+            role: 'assistant',
+            parts: expect.arrayContaining([
+              expect.objectContaining({
+                type: 'text',
+                text: 'Hello',
+              }),
+            ]),
+          }),
+        );
+      });
+
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+      );
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+      );
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+      );
+      controller.write(formatChunk({ type: 'text-end', id: '0' }));
+      controller.close();
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toContainEqual(
+          expect.objectContaining({
+            role: 'assistant',
+            parts: expect.arrayContaining([
+              expect.objectContaining({
+                type: 'text',
+                text: 'Hello, world.',
+                state: 'done',
+              }),
+            ]),
+          }),
+        );
+      });
+    });
+  });
+
+  describe('streaming with id change from undefined to defined', () => {
+    setupTestComponent(
+      () => {
+        const [id, setId] = React.useState<string | undefined>(undefined);
+        const { messages, sendMessage, status } = useChat({
+          id,
+          generateId: mockId(),
+        });
+
+        return (
+          <div>
+            <div data-testid="status">{status.toString()}</div>
+            <div data-testid="messages">
+              {JSON.stringify(messages, null, 2)}
+            </div>
+            <button
+              data-testid="change-id"
+              onClick={() => {
+                setId('chat-123');
+              }}
+            />
+            <button
+              data-testid="send-message"
+              onClick={() => {
+                sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+              }}
+            />
+          </div>
+        );
+      },
+      {
+        init: TestComponent => <TestComponent />,
+      },
+    );
+
+    it('should handle streaming correctly when id changes from undefined to defined', async () => {
+      const controller = new TestResponseController();
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      // First, change the ID from undefined to 'chat-123'
+      await userEvent.click(screen.getByTestId('change-id'));
+
+      // Then send a message
+      await userEvent.click(screen.getByTestId('send-message'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('status')).toHaveTextContent('submitted');
+      });
+
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+      );
+
+      // Verify streaming is working - text should appear immediately
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toContainEqual(
+          expect.objectContaining({
+            role: 'assistant',
+            parts: expect.arrayContaining([
+              expect.objectContaining({
+                type: 'text',
+                text: 'Hello',
+              }),
+            ]),
+          }),
+        );
+      });
+
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+      );
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+      );
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+      );
+      controller.write(formatChunk({ type: 'text-end', id: '0' }));
+      controller.close();
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+        ).toContainEqual(
+          expect.objectContaining({
+            role: 'assistant',
+            parts: expect.arrayContaining([
+              expect.objectContaining({
+                type: 'text',
+                text: 'Hello, world.',
+                state: 'done',
+              }),
+            ]),
+          }),
+        );
+      });
     });
   });
 });

--- a/packages/react/src/use-object.ui.test.tsx
+++ b/packages/react/src/use-object.ui.test.tsx
@@ -63,11 +63,13 @@ describe('text stream', () => {
   };
 
   beforeEach(() => {
+    vi.useFakeTimers();
     onErrorResult = undefined;
     onFinishCalls = [];
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     cleanup();
     onErrorResult = undefined;
@@ -305,6 +307,7 @@ describe('text stream', () => {
 
     render(<TestComponentWithAsyncHeaders />);
     await userEvent.click(screen.getByTestId('submit-async-headers'));
+    await vi.advanceTimersByTimeAsync(10);
 
     await waitFor(() => {
       expect(server.calls[0].requestHeaders).toStrictEqual({

--- a/packages/react/src/use-object.ui.test.tsx
+++ b/packages/react/src/use-object.ui.test.tsx
@@ -4,10 +4,9 @@ import {
 } from '@ai-sdk/test-server/with-vitest';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { experimental_useObject } from './use-object';
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { delay } from '@ai-sdk/provider-utils';
 
 const server = createTestServer({
   '/api/use-object': {},
@@ -63,13 +62,11 @@ describe('text stream', () => {
   };
 
   beforeEach(() => {
-    vi.useFakeTimers();
     onErrorResult = undefined;
     onFinishCalls = [];
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
     cleanup();
     onErrorResult = undefined;
@@ -287,7 +284,7 @@ describe('text stream', () => {
         schema: z.object({ content: z.string() }),
         headers: async () => {
           // Simulate async token fetch
-          await delay(10);
+          await Promise.resolve();
           return {
             Authorization: 'Bearer ASYNC_TOKEN',
             'X-Request-ID': 'async-123',
@@ -307,7 +304,6 @@ describe('text stream', () => {
 
     render(<TestComponentWithAsyncHeaders />);
     await userEvent.click(screen.getByTestId('submit-async-headers'));
-    await vi.advanceTimersByTimeAsync(10);
 
     await waitFor(() => {
       expect(server.calls[0].requestHeaders).toStrictEqual({

--- a/packages/react/src/use-object.ui.test.tsx
+++ b/packages/react/src/use-object.ui.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { z } from 'zod/v4';
 import { experimental_useObject } from './use-object';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { delay } from '@ai-sdk/provider-utils';
 
 const server = createTestServer({
   '/api/use-object': {},
@@ -284,7 +285,7 @@ describe('text stream', () => {
         schema: z.object({ content: z.string() }),
         headers: async () => {
           // Simulate async token fetch
-          await new Promise(resolve => setTimeout(resolve, 10));
+          await delay(10);
           return {
             Authorization: 'Bearer ASYNC_TOKEN',
             'X-Request-ID': 'async-123',

--- a/packages/rsc/src/stream-ui/stream-ui.ui.test.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.ui.test.tsx
@@ -4,7 +4,7 @@ import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
 import { asLanguageModelUsage } from 'ai/internal';
 import { MockLanguageModelV4 } from 'ai/test';
 import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { streamUI } from './stream-ui';
 
@@ -111,6 +111,14 @@ const mockToolModel = new MockLanguageModelV4({
 });
 
 describe('result.value', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should render text', async () => {
     const result = await streamUI({
       model: mockTextModel,
@@ -150,7 +158,9 @@ describe('result.value', () => {
       },
     });
 
-    const rendered = await simulateFlightServerRender(result.value);
+    const renderedPromise = simulateFlightServerRender(result.value);
+    await vi.runAllTimersAsync();
+    const rendered = await renderedPromise;
     expect(rendered).toMatchSnapshot();
   });
 
@@ -173,7 +183,9 @@ describe('result.value', () => {
       },
     });
 
-    const rendered = await simulateFlightServerRender(result.value);
+    const renderedPromise = simulateFlightServerRender(result.value);
+    await vi.runAllTimersAsync();
+    const rendered = await renderedPromise;
     expect(rendered).toMatchSnapshot();
   });
 
@@ -205,6 +217,8 @@ describe('rsc - streamUI() onFinish callback', () => {
   >[0];
 
   beforeEach(async () => {
+    vi.useFakeTimers();
+
     const ui = await streamUI({
       model: mockToolModel,
       prompt: '',
@@ -226,7 +240,13 @@ describe('rsc - streamUI() onFinish callback', () => {
     });
 
     // consume stream
-    await simulateFlightServerRender(ui.value);
+    const renderPromise = simulateFlightServerRender(ui.value);
+    await vi.runAllTimersAsync();
+    await renderPromise;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should contain token usage', () => {

--- a/packages/rsc/src/streamable-ui/create-streamable-ui.ui.test.tsx
+++ b/packages/rsc/src/streamable-ui/create-streamable-ui.ui.test.tsx
@@ -1,6 +1,6 @@
 import { delay } from '@ai-sdk/provider-utils';
 import { createStreamableUI } from './create-streamable-ui';
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // This is a workaround to render the Flight response in a test environment.
 async function flightRender(node: React.ReactNode, byChunk?: boolean) {
@@ -195,49 +195,60 @@ describe('rsc - createStreamableUI()', () => {
     `);
   });
 
-  it('should support streaming .append() result before .done()', async () => {
-    const ui = createStreamableUI(<div>1</div>);
-    ui.append(<div>2</div>);
-    ui.append(<div>3</div>);
+  describe('streaming append result checks', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
 
-    const currentResolved = (ui.value as React.ReactElement).props.children
-      .props.n;
-    const tryResolve1 = await Promise.race([currentResolved, delay()]);
-    expect(tryResolve1).toBeDefined();
-    const tryResolve2 = await Promise.race([tryResolve1.next, delay()]);
-    expect(tryResolve2).toBeDefined();
-    expect(getFinalValueFromResolved(tryResolve2.value)).toMatchInlineSnapshot(`
-      <div>
-        3
-      </div>
-    `);
+    afterEach(() => {
+      vi.useRealTimers();
+    });
 
-    ui.append(<div>4</div>);
-    ui.done();
+    it('should support streaming .append() result before .done()', async () => {
+      const ui = createStreamableUI(<div>1</div>);
+      ui.append(<div>2</div>);
+      ui.append(<div>3</div>);
 
-    const final = getFinalValueFromResolved(
-      await simulateFlightServerRender(ui.value),
-    );
-    expect(final).toMatchInlineSnapshot(`
-      <React.Fragment>
+      const currentResolved = (ui.value as React.ReactElement).props.children
+        .props.n;
+      const tryResolve1 = await Promise.race([currentResolved, delay()]);
+      expect(tryResolve1).toBeDefined();
+      const tryResolve2 = await Promise.race([tryResolve1.next, delay()]);
+      expect(tryResolve2).toBeDefined();
+      expect(getFinalValueFromResolved(tryResolve2.value))
+        .toMatchInlineSnapshot(`
+        <div>
+          3
+        </div>
+      `);
+
+      ui.append(<div>4</div>);
+      ui.done();
+
+      const final = getFinalValueFromResolved(
+        await simulateFlightServerRender(ui.value),
+      );
+      expect(final).toMatchInlineSnapshot(`
         <React.Fragment>
           <React.Fragment>
+            <React.Fragment>
+              <div>
+                1
+              </div>
+              <div>
+                2
+              </div>
+            </React.Fragment>
             <div>
-              1
-            </div>
-            <div>
-              2
+              3
             </div>
           </React.Fragment>
           <div>
-            3
+            4
           </div>
         </React.Fragment>
-        <div>
-          4
-        </div>
-      </React.Fragment>
-    `);
+      `);
+    });
   });
 
   it('should support updating the appended ui', async () => {

--- a/packages/rsc/src/streamable-value/create-streamable-value.test.tsx
+++ b/packages/rsc/src/streamable-value/create-streamable-value.test.tsx
@@ -2,7 +2,7 @@ import { delay } from '@ai-sdk/provider-utils';
 import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
 import { createStreamableValue } from './create-streamable-value';
 import { STREAMABLE_VALUE_TYPE, StreamableValue } from './streamable-value';
-import { it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 async function getRawChunks(streamableValue: StreamableValue<any, any>) {
   const chunks = [];
@@ -21,159 +21,172 @@ async function getRawChunks(streamableValue: StreamableValue<any, any>) {
   return chunks;
 }
 
-it('should return latest value', async () => {
-  const streamableValue = createStreamableValue(1).update(2).update(3).done(4);
-
-  expect(streamableValue.value.curr).toStrictEqual(4);
-});
-
-it('should be able to stream any JSON values', async () => {
-  const streamable = createStreamableValue();
-  streamable.update({ v: 123 });
-
-  expect(streamable.value.curr).toStrictEqual({ v: 123 });
-
-  streamable.done();
-});
-
-it('should support .error()', async () => {
-  const streamable = createStreamableValue();
-  streamable.error('This is an error');
-
-  expect(streamable.value).toStrictEqual({
-    error: 'This is an error',
-    type: STREAMABLE_VALUE_TYPE,
+describe('createStreamableValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
   });
-});
 
-it('should directly emit the final value when reading .value', async () => {
-  const streamable = createStreamableValue('1');
-  streamable.update('2');
-  streamable.update('3');
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
-  expect(streamable.value.curr).toStrictEqual('3');
+  it('should return latest value', async () => {
+    const streamableValue = createStreamableValue(1)
+      .update(2)
+      .update(3)
+      .done(4);
 
-  streamable.done('4');
+    expect(streamableValue.value.curr).toStrictEqual(4);
+  });
 
-  expect(streamable.value.curr).toStrictEqual('4');
-});
+  it('should be able to stream any JSON values', async () => {
+    const streamable = createStreamableValue();
+    streamable.update({ v: 123 });
 
-it('should be able to append strings as patch', async () => {
-  const streamable = createStreamableValue();
-  const value = streamable.value;
+    expect(streamable.value.curr).toStrictEqual({ v: 123 });
 
-  streamable.update('hello');
-  streamable.update('hello world');
-  streamable.update('hello world!');
-  streamable.update('new string');
-  streamable.done('new string with patch!');
+    streamable.done();
+  });
 
-  expect(await getRawChunks(value)).toStrictEqual([
-    { curr: undefined, type: STREAMABLE_VALUE_TYPE },
-    { curr: 'hello' },
-    { diff: [0, ' world'] },
-    { diff: [0, '!'] },
-    { curr: 'new string' },
-    { diff: [0, ' with patch!'] },
-  ]);
-});
+  it('should support .error()', async () => {
+    const streamable = createStreamableValue();
+    streamable.error('This is an error');
 
-it('should be able to call .append() to send patches', async () => {
-  const streamable = createStreamableValue();
-  const value = streamable.value;
+    expect(streamable.value).toStrictEqual({
+      error: 'This is an error',
+      type: STREAMABLE_VALUE_TYPE,
+    });
+  });
 
-  streamable.append('hello');
-  streamable.append(' world');
-  streamable.append('!');
-  streamable.done();
+  it('should directly emit the final value when reading .value', async () => {
+    const streamable = createStreamableValue('1');
+    streamable.update('2');
+    streamable.update('3');
 
-  expect(await getRawChunks(value)).toStrictEqual([
-    { curr: undefined, type: STREAMABLE_VALUE_TYPE },
-    { curr: 'hello' },
-    { diff: [0, ' world'] },
-    { diff: [0, '!'] },
-    {},
-  ]);
-});
+    expect(streamable.value.curr).toStrictEqual('3');
 
-it('should be able to mix .update() and .append() with optimized payloads', async () => {
-  const streamable = createStreamableValue('hello');
-  const value = streamable.value;
+    streamable.done('4');
 
-  streamable.append(' world');
-  streamable.update('hello world!!');
-  streamable.update('some new');
-  streamable.update('some new string');
-  streamable.append(' with patch!');
-  streamable.done();
+    expect(streamable.value.curr).toStrictEqual('4');
+  });
 
-  expect(await getRawChunks(value)).toStrictEqual([
-    { curr: 'hello', type: STREAMABLE_VALUE_TYPE },
-    { diff: [0, ' world'] },
-    { diff: [0, '!!'] },
-    { curr: 'some new' },
-    { diff: [0, ' string'] },
-    { diff: [0, ' with patch!'] },
-    {},
-  ]);
-});
+  it('should be able to append strings as patch', async () => {
+    const streamable = createStreamableValue();
+    const value = streamable.value;
 
-it('should behave like .update() with .append() and .done()', async () => {
-  const streamable = createStreamableValue('hello');
-  const value = streamable.value;
+    streamable.update('hello');
+    streamable.update('hello world');
+    streamable.update('hello world!');
+    streamable.update('new string');
+    streamable.done('new string with patch!');
 
-  streamable.append(' world');
-  streamable.done('fin');
+    expect(await getRawChunks(value)).toStrictEqual([
+      { curr: undefined, type: STREAMABLE_VALUE_TYPE },
+      { curr: 'hello' },
+      { diff: [0, ' world'] },
+      { diff: [0, '!'] },
+      { curr: 'new string' },
+      { diff: [0, ' with patch!'] },
+    ]);
+  });
 
-  expect(await getRawChunks(value)).toStrictEqual([
-    { curr: 'hello', type: STREAMABLE_VALUE_TYPE },
-    { diff: [0, ' world'] },
-    { curr: 'fin' },
-  ]);
-});
+  it('should be able to call .append() to send patches', async () => {
+    const streamable = createStreamableValue();
+    const value = streamable.value;
 
-it('should be able to accept readableStream as the source', async () => {
-  const streamable = createStreamableValue(
-    convertArrayToReadableStream(['hello', ' world', '!']),
-  );
-  const value = streamable.value;
+    streamable.append('hello');
+    streamable.append(' world');
+    streamable.append('!');
+    streamable.done();
 
-  expect(await getRawChunks(value)).toStrictEqual([
-    { curr: undefined, type: STREAMABLE_VALUE_TYPE },
-    { curr: 'hello' },
-    { diff: [0, ' world'] },
-    { diff: [0, '!'] },
-    {},
-  ]);
-});
+    expect(await getRawChunks(value)).toStrictEqual([
+      { curr: undefined, type: STREAMABLE_VALUE_TYPE },
+      { curr: 'hello' },
+      { diff: [0, ' world'] },
+      { diff: [0, '!'] },
+      {},
+    ]);
+  });
 
-it('should accept readableStream with JSON payloads', async () => {
-  const streamable = createStreamableValue(
-    convertArrayToReadableStream([{ v: 1 }, { v: 2 }, { v: 3 }]),
-  );
-  const value = streamable.value;
+  it('should be able to mix .update() and .append() with optimized payloads', async () => {
+    const streamable = createStreamableValue('hello');
+    const value = streamable.value;
 
-  expect(await getRawChunks(value)).toStrictEqual([
-    { curr: undefined, type: STREAMABLE_VALUE_TYPE },
-    { curr: { v: 1 } },
-    { curr: { v: 2 } },
-    { curr: { v: 3 } },
-    {},
-  ]);
-});
+    streamable.append(' world');
+    streamable.update('hello world!!');
+    streamable.update('some new');
+    streamable.update('some new string');
+    streamable.append(' with patch!');
+    streamable.done();
 
-it('should lock the streamable if from readableStream', async () => {
-  const streamable = createStreamableValue(
-    new ReadableStream({
-      async start(controller) {
-        await delay();
-        controller.enqueue('hello');
-        controller.close();
-      },
-    }),
-  );
+    expect(await getRawChunks(value)).toStrictEqual([
+      { curr: 'hello', type: STREAMABLE_VALUE_TYPE },
+      { diff: [0, ' world'] },
+      { diff: [0, '!!'] },
+      { curr: 'some new' },
+      { diff: [0, ' string'] },
+      { diff: [0, ' with patch!'] },
+      {},
+    ]);
+  });
 
-  expect(() => streamable.update('world')).toThrowErrorMatchingInlineSnapshot(
-    '[Error: .update(): Value stream is locked and cannot be updated.]',
-  );
+  it('should behave like .update() with .append() and .done()', async () => {
+    const streamable = createStreamableValue('hello');
+    const value = streamable.value;
+
+    streamable.append(' world');
+    streamable.done('fin');
+
+    expect(await getRawChunks(value)).toStrictEqual([
+      { curr: 'hello', type: STREAMABLE_VALUE_TYPE },
+      { diff: [0, ' world'] },
+      { curr: 'fin' },
+    ]);
+  });
+
+  it('should be able to accept readableStream as the source', async () => {
+    const streamable = createStreamableValue(
+      convertArrayToReadableStream(['hello', ' world', '!']),
+    );
+    const value = streamable.value;
+
+    expect(await getRawChunks(value)).toStrictEqual([
+      { curr: undefined, type: STREAMABLE_VALUE_TYPE },
+      { curr: 'hello' },
+      { diff: [0, ' world'] },
+      { diff: [0, '!'] },
+      {},
+    ]);
+  });
+
+  it('should accept readableStream with JSON payloads', async () => {
+    const streamable = createStreamableValue(
+      convertArrayToReadableStream([{ v: 1 }, { v: 2 }, { v: 3 }]),
+    );
+    const value = streamable.value;
+
+    expect(await getRawChunks(value)).toStrictEqual([
+      { curr: undefined, type: STREAMABLE_VALUE_TYPE },
+      { curr: { v: 1 } },
+      { curr: { v: 2 } },
+      { curr: { v: 3 } },
+      {},
+    ]);
+  });
+
+  it('should lock the streamable if from readableStream', async () => {
+    const streamable = createStreamableValue(
+      new ReadableStream({
+        async start(controller) {
+          await delay();
+          controller.enqueue('hello');
+          controller.close();
+        },
+      }),
+    );
+
+    expect(() => streamable.update('world')).toThrowErrorMatchingInlineSnapshot(
+      '[Error: .update(): Value stream is locked and cannot be updated.]',
+    );
+  });
 });

--- a/packages/rsc/src/streamable-value/read-streamable-value.ui.test.tsx
+++ b/packages/rsc/src/streamable-value/read-streamable-value.ui.test.tsx
@@ -1,165 +1,190 @@
 import { delay } from '@ai-sdk/provider-utils';
 import { createStreamableValue } from './create-streamable-value';
 import { readStreamableValue } from './read-streamable-value';
-import { it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-it('should return an async iterable', () => {
-  const streamable = createStreamableValue();
-  const result = readStreamableValue(streamable.value);
-  streamable.done();
+describe('readStreamableValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
 
-  expect(result).toBeDefined();
-  expect(result[Symbol.asyncIterator]).toBeDefined();
-});
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
-it('should support reading streamed values and errors', async () => {
-  const streamable = createStreamableValue(1);
+  it('should return an async iterable', () => {
+    const streamable = createStreamableValue();
+    const result = readStreamableValue(streamable.value);
+    streamable.done();
 
-  (async () => {
-    await delay();
-    streamable.update(2);
-    await delay();
-    streamable.update(3);
-    await delay();
-    streamable.error('This is an error');
-  })();
+    expect(result).toBeDefined();
+    expect(result[Symbol.asyncIterator]).toBeDefined();
+  });
 
-  const values = [];
+  it('should support reading streamed values and errors', async () => {
+    const streamable = createStreamableValue(1);
 
-  try {
-    for await (const v of readStreamableValue(streamable.value)) {
+    const updatePromise = (async () => {
+      await delay();
+      streamable.update(2);
+      await delay();
+      streamable.update(3);
+      await delay();
+      streamable.error('This is an error');
+    })();
+
+    const readPromise = (async () => {
+      const values = [];
+
+      try {
+        for await (const v of readStreamableValue(streamable.value)) {
+          values.push(v);
+        }
+        expect.fail('should not be reached');
+      } catch (e) {
+        expect(e).toStrictEqual('This is an error');
+      }
+
+      expect(values).toStrictEqual([1, 2, 3]);
+    })();
+
+    await vi.runAllTimersAsync();
+    await Promise.all([updatePromise, readPromise]);
+  });
+
+  it('should be able to read values asynchronously with different value types', async () => {
+    const streamable = createStreamableValue({});
+
+    const updatePromise = (async () => {
+      await delay();
+      streamable.update([1]);
+      streamable.update(['2']);
+      streamable.done({ 3: 3 });
+    })();
+
+    const values = [];
+    const readPromise = (async () => {
+      for await (const v of readStreamableValue(streamable.value)) {
+        values.push(v);
+      }
+    })();
+
+    await vi.runAllTimersAsync();
+    await Promise.all([updatePromise, readPromise]);
+
+    expect(values).toStrictEqual([{}, [1], ['2'], { '3': 3 }]);
+  });
+
+  it('should be able to replay errors', async () => {
+    const streamable = createStreamableValue(0);
+
+    const updatePromise = (async () => {
+      await delay();
+      streamable.update(1);
+      streamable.update(2);
+      streamable.error({ customErrorMessage: 'this is an error' });
+    })();
+
+    const readPromise = (async () => {
+      const values = [];
+
+      try {
+        for await (const v of readStreamableValue(streamable.value)) {
+          values.push(v);
+        }
+
+        expect.fail('should not be reached');
+      } catch (e) {
+        expect(e).toStrictEqual({
+          customErrorMessage: 'this is an error',
+        });
+      }
+      expect(values).toStrictEqual([0, 1, 2]);
+    })();
+
+    await vi.runAllTimersAsync();
+    await Promise.all([updatePromise, readPromise]);
+  });
+
+  it('should be able to append strings as patch', async () => {
+    const streamable = createStreamableValue();
+    const value = streamable.value;
+
+    streamable.update('hello');
+    streamable.update('hello world');
+    streamable.update('hello world!');
+    streamable.update('new string');
+    streamable.done('new string with patch!');
+
+    const values = [];
+    for await (const v of readStreamableValue(value)) {
       values.push(v);
     }
-    expect.fail('should not be reached');
-  } catch (e) {
-    expect(e).toStrictEqual('This is an error');
-  }
 
-  expect(values).toStrictEqual([1, 2, 3]);
-});
+    expect(values).toStrictEqual([
+      'hello',
+      'hello world',
+      'hello world!',
+      'new string',
+      'new string with patch!',
+    ]);
+  });
 
-it('should be able to read values asynchronously with different value types', async () => {
-  const streamable = createStreamableValue({});
+  it('should be able to call .append() to send patches', async () => {
+    const streamable = createStreamableValue();
+    const value = streamable.value;
 
-  (async () => {
-    await delay();
-    streamable.update([1]);
-    streamable.update(['2']);
-    streamable.done({ 3: 3 });
-  })();
+    streamable.append('hello');
+    streamable.append(' world');
+    streamable.append('!');
+    streamable.done();
 
-  const values = [];
-  for await (const v of readStreamableValue(streamable.value)) {
-    values.push(v);
-  }
-
-  expect(values).toStrictEqual([{}, [1], ['2'], { '3': 3 }]);
-});
-
-it('should be able to replay errors', async () => {
-  const streamable = createStreamableValue(0);
-
-  (async () => {
-    await delay();
-    streamable.update(1);
-    streamable.update(2);
-    streamable.error({ customErrorMessage: 'this is an error' });
-  })();
-
-  const values = [];
-
-  try {
-    for await (const v of readStreamableValue(streamable.value)) {
+    const values = [];
+    for await (const v of readStreamableValue(value)) {
       values.push(v);
     }
 
-    expect.fail('should not be reached');
-  } catch (e) {
-    expect(e).toStrictEqual({
-      customErrorMessage: 'this is an error',
-    });
-  }
-  expect(values).toStrictEqual([0, 1, 2]);
-});
+    expect(values).toStrictEqual(['hello', 'hello world', 'hello world!']);
+  });
 
-it('should be able to append strings as patch', async () => {
-  const streamable = createStreamableValue();
-  const value = streamable.value;
+  it('should be able to mix .update() and .append() with optimized payloads', async () => {
+    const streamable = createStreamableValue('hello');
+    const value = streamable.value;
 
-  streamable.update('hello');
-  streamable.update('hello world');
-  streamable.update('hello world!');
-  streamable.update('new string');
-  streamable.done('new string with patch!');
+    streamable.append(' world');
+    streamable.update('hello world!!');
+    streamable.update('some new');
+    streamable.update('some new string');
+    streamable.append(' with patch!');
+    streamable.done();
 
-  const values = [];
-  for await (const v of readStreamableValue(value)) {
-    values.push(v);
-  }
+    const values = [];
+    for await (const v of readStreamableValue(value)) {
+      values.push(v);
+    }
 
-  expect(values).toStrictEqual([
-    'hello',
-    'hello world',
-    'hello world!',
-    'new string',
-    'new string with patch!',
-  ]);
-});
+    expect(values).toStrictEqual([
+      'hello',
+      'hello world',
+      'hello world!!',
+      'some new',
+      'some new string',
+      'some new string with patch!',
+    ]);
+  });
 
-it('should be able to call .append() to send patches', async () => {
-  const streamable = createStreamableValue();
-  const value = streamable.value;
+  it('should behave like .update() with .append() and .done()', async () => {
+    const streamable = createStreamableValue('hello');
+    const value = streamable.value;
 
-  streamable.append('hello');
-  streamable.append(' world');
-  streamable.append('!');
-  streamable.done();
+    streamable.append(' world');
+    streamable.done('fin');
 
-  const values = [];
-  for await (const v of readStreamableValue(value)) {
-    values.push(v);
-  }
+    const values = [];
+    for await (const v of readStreamableValue(value)) {
+      values.push(v);
+    }
 
-  expect(values).toStrictEqual(['hello', 'hello world', 'hello world!']);
-});
-
-it('should be able to mix .update() and .append() with optimized payloads', async () => {
-  const streamable = createStreamableValue('hello');
-  const value = streamable.value;
-
-  streamable.append(' world');
-  streamable.update('hello world!!');
-  streamable.update('some new');
-  streamable.update('some new string');
-  streamable.append(' with patch!');
-  streamable.done();
-
-  const values = [];
-  for await (const v of readStreamableValue(value)) {
-    values.push(v);
-  }
-
-  expect(values).toStrictEqual([
-    'hello',
-    'hello world',
-    'hello world!!',
-    'some new',
-    'some new string',
-    'some new string with patch!',
-  ]);
-});
-
-it('should behave like .update() with .append() and .done()', async () => {
-  const streamable = createStreamableValue('hello');
-  const value = streamable.value;
-
-  streamable.append(' world');
-  streamable.done('fin');
-
-  const values = [];
-  for await (const v of readStreamableValue(value)) {
-    values.push(v);
-  }
-
-  expect(values).toStrictEqual(['hello', 'hello world', 'fin']);
+    expect(values).toStrictEqual(['hello', 'hello world', 'fin']);
+  });
 });

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -63,7 +63,7 @@
     "svelte-check": "^4.0.0",
     "typescript": "^5.0.0",
     "vite": "^6.0.0",
-    "vitest": "^4.1.0",
+    "vitest": "^4.1.5",
     "zod": "3.25.76"
   },
   "homepage": "https://ai-sdk.dev/docs",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -51,7 +51,7 @@
     "msw": "2.6.4",
     "tsup": "^7.2.0",
     "typescript": "5.8.3",
-    "vitest": "^4.1.0",
+    "vitest": "^4.1.5",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/workflow/src/workflow-chat-transport.test.ts
+++ b/packages/workflow/src/workflow-chat-transport.test.ts
@@ -7,7 +7,6 @@
 import type { UIMessage } from 'ai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WorkflowChatTransport } from './workflow-chat-transport.js';
-import { delay } from '@ai-sdk/provider-utils';
 
 describe('WorkflowChatTransport', () => {
   let mockFetch: ReturnType<typeof vi.fn> & typeof fetch;

--- a/packages/workflow/src/workflow-chat-transport.test.ts
+++ b/packages/workflow/src/workflow-chat-transport.test.ts
@@ -7,6 +7,7 @@
 import type { UIMessage } from 'ai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WorkflowChatTransport } from './workflow-chat-transport.js';
+import { delay } from '@ai-sdk/provider-utils';
 
 describe('WorkflowChatTransport', () => {
   let mockFetch: ReturnType<typeof vi.fn> & typeof fetch;
@@ -653,7 +654,7 @@ describe('WorkflowChatTransport', () => {
       }
 
       // Give some time for the callback to be called
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await delay(100);
 
       expect(onChatEnd).toHaveBeenCalledWith({
         chatId: 'test-chat',

--- a/packages/workflow/src/workflow-chat-transport.test.ts
+++ b/packages/workflow/src/workflow-chat-transport.test.ts
@@ -16,9 +16,11 @@ describe('WorkflowChatTransport', () => {
   beforeEach(() => {
     mockFetch = vi.fn() as ReturnType<typeof vi.fn> & typeof fetch;
     vi.clearAllMocks();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -654,7 +656,7 @@ describe('WorkflowChatTransport', () => {
       }
 
       // Give some time for the callback to be called
-      await delay(100);
+      await vi.advanceTimersByTimeAsync(100);
 
       expect(onChatEnd).toHaveBeenCalledWith({
         chatId: 'test-chat',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^3.6.0
         version: 3.6.2
       vitest:
-        specifier: 4.1.0
-        version: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.7.4)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+        specifier: 4.1.5
+        version: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.7.4)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
 
   examples/ai-e2e-next:
     dependencies:
@@ -1546,8 +1546,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@24.1.3)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+        specifier: ^4.1.5
+        version: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@24.1.3)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -1803,8 +1803,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: 2.1.4
-        version: 2.1.4(@edge-runtime/vm@5.0.0)(@types/node@20.17.24)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)
+        specifier: ^4.1.5
+        version: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))
 
   packages/cohere:
     dependencies:
@@ -2009,8 +2009,8 @@ importers:
         specifier: ^6.0.3
         version: 6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
       vitest:
-        specifier: ^3.2.1
-        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
+        specifier: ^4.1.5
+        version: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -2478,8 +2478,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+        specifier: ^4.1.5
+        version: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -2992,7 +2992,7 @@ importers:
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.2.4
-        version: 5.3.1(svelte@5.53.6)(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))
+        version: 5.3.1(svelte@5.53.6)(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))
       '@types/node':
         specifier: 20.17.24
         version: 20.17.24
@@ -3018,8 +3018,8 @@ importers:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+        specifier: ^4.1.5
+        version: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -3204,8 +3204,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@24.1.3)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+        specifier: ^4.1.5
+        version: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@24.1.3)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -3233,7 +3233,7 @@ importers:
         version: link:../../tools/tsconfig
       '@workflow/vitest':
         specifier: 4.0.1
-        version: 4.0.1(@opentelemetry/api@1.9.1)(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(zod@3.25.76)
+        version: 4.0.1(@opentelemetry/api@1.9.1)(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(zod@3.25.76)
       tsup:
         specifier: ^8
         version: 8.5.1(@swc/core@1.15.3)(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.7.0)
@@ -10956,25 +10956,11 @@ packages:
       vite: ^5.0.0
       vue: ^3.2.25
 
-  '@vitest/expect@2.1.4':
-    resolution: {integrity: sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==}
-
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/expect@4.1.0':
-    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
-
-  '@vitest/mocker@2.1.4':
-    resolution: {integrity: sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^5.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -10987,64 +10973,46 @@ packages:
       vite:
         optional: true
 
-  '@vitest/mocker@4.1.0':
-    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.1.4':
-    resolution: {integrity: sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==}
-
-  '@vitest/pretty-format@2.1.9':
-    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
-
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/pretty-format@4.1.0':
-    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
-
-  '@vitest/runner@2.1.4':
-    resolution: {integrity: sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==}
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
-  '@vitest/runner@4.1.0':
-    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
-
-  '@vitest/snapshot@2.1.4':
-    resolution: {integrity: sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==}
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
 
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
-  '@vitest/snapshot@4.1.0':
-    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
-
-  '@vitest/spy@2.1.4':
-    resolution: {integrity: sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==}
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/spy@4.1.0':
-    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
-
-  '@vitest/utils@2.1.4':
-    resolution: {integrity: sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==}
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@vitest/utils@4.1.0':
-    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   '@vue-macros/common@1.15.0':
     resolution: {integrity: sha512-yg5VqW7+HRfJGimdKvFYzx8zorHUYo0hzPwuraoC1DWa7HHazbTMoVsHDvk3JHa1SGfSL87fRnzmlvgjEHhszA==}
@@ -19046,20 +19014,12 @@ packages:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
-  tinyrainbow@1.2.0:
-    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
-    engines: {node: '>=14.0.0'}
-
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -20001,31 +19961,6 @@ packages:
       vite:
         optional: true
 
-  vitest@2.1.4:
-    resolution: {integrity: sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.4
-      '@vitest/ui': 2.1.4
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-
   vitest@3.2.4:
     resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -20054,21 +19989,23 @@ packages:
       jsdom:
         optional: true
 
-  vitest@4.1.0:
-    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.0
-      '@vitest/browser-preview': 4.1.0
-      '@vitest/browser-webdriverio': 4.1.0
-      '@vitest/ui': 4.1.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -20081,6 +20018,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -28384,7 +28325,7 @@ snapshots:
       '@sentry/bundler-plugin-core': 5.1.1(encoding@0.1.13)
       '@sentry/core': 10.40.0
       '@sentry/node': 10.40.0
-      '@sentry/opentelemetry': 10.40.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)
+      '@sentry/opentelemetry': 10.40.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.37.0)
       '@sentry/react': 10.40.0(react@18.3.1)
       '@sentry/vercel-edge': 10.40.0
       '@sentry/webpack-plugin': 5.1.1(encoding@0.1.13)(webpack@5.105.0(@swc/core@1.15.3))
@@ -28454,7 +28395,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/opentelemetry@10.40.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)':
+  '@sentry/opentelemetry@10.40.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.37.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.1)
@@ -29181,14 +29122,14 @@ snapshots:
     dependencies:
       svelte: 5.53.6
 
-  '@testing-library/svelte@5.3.1(svelte@5.53.6)(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))':
+  '@testing-library/svelte@5.3.1(svelte@5.53.6)(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/svelte-core': 1.0.0(svelte@5.53.6)
       svelte: 5.53.6
     optionalDependencies:
       vite: 6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
-      vitest: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      vitest: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
@@ -29894,13 +29835,6 @@ snapshots:
       vite: 7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
       vue: 3.5.13(typescript@5.8.3)
 
-  '@vitest/expect@2.1.4':
-    dependencies:
-      '@vitest/spy': 2.1.4
-      '@vitest/utils': 2.1.4
-      chai: 5.2.0
-      tinyrainbow: 1.2.0
-
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -29908,24 +29842,16 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.2.0
       tinyrainbow: 2.0.0
+    optional: true
 
-  '@vitest/expect@4.1.0':
+  '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@2.1.4(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))':
-    dependencies:
-      '@vitest/spy': 2.1.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.6.4(@types/node@20.17.24)(typescript@5.8.3)
-      vite: 5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)
 
   '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
@@ -29935,119 +29861,114 @@ snapshots:
     optionalDependencies:
       msw: 2.12.10(@types/node@20.17.24)(typescript@5.8.3)
       vite: 6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
+    optional: true
 
-  '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
+  '@vitest/mocker@4.1.5(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
-      '@vitest/spy': 4.1.0
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@20.17.24)(typescript@5.8.3)
+      vite: 6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
+
+  '@vitest/mocker@4.1.5(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.10(@types/node@20.17.24)(typescript@5.8.3)
       vite: 6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
 
-  '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
+  '@vitest/mocker@4.1.5(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
     dependencies:
-      '@vitest/spy': 4.1.0
+      '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.10(@types/node@20.17.24)(typescript@5.8.3)
       vite: 7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
 
-  '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
+  '@vitest/mocker@4.1.5(msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
     dependencies:
-      '@vitest/spy': 4.1.0
+      '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.10(@types/node@22.7.4)(typescript@5.8.3)
       vite: 7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
 
-  '@vitest/mocker@4.1.0(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
+  '@vitest/mocker@4.1.5(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
-      '@vitest/spy': 4.1.0
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.6.4(@types/node@20.17.24)(typescript@5.8.3)
+      vite: 7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
+
+  '@vitest/mocker@4.1.5(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.6.4(@types/node@20.17.24)(typescript@5.8.3)
       vite: 7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
 
-  '@vitest/pretty-format@2.1.4':
-    dependencies:
-      tinyrainbow: 1.2.0
-
-  '@vitest/pretty-format@2.1.9':
-    dependencies:
-      tinyrainbow: 1.2.0
-
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
+    optional: true
 
-  '@vitest/pretty-format@4.1.0':
+  '@vitest/pretty-format@4.1.5':
     dependencies:
       tinyrainbow: 3.1.0
-
-  '@vitest/runner@2.1.4':
-    dependencies:
-      '@vitest/utils': 2.1.4
-      pathe: 1.1.2
 
   '@vitest/runner@3.2.4':
     dependencies:
       '@vitest/utils': 3.2.4
       pathe: 2.0.3
       strip-literal: 3.1.0
+    optional: true
 
-  '@vitest/runner@4.1.0':
+  '@vitest/runner@4.1.5':
     dependencies:
-      '@vitest/utils': 4.1.0
+      '@vitest/utils': 4.1.5
       pathe: 2.0.3
-
-  '@vitest/snapshot@2.1.4':
-    dependencies:
-      '@vitest/pretty-format': 2.1.4
-      magic-string: 0.30.21
-      pathe: 1.1.2
 
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.21
       pathe: 2.0.3
+    optional: true
 
-  '@vitest/snapshot@4.1.0':
+  '@vitest/snapshot@4.1.5':
     dependencies:
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
       magic-string: 0.30.21
       pathe: 2.0.3
-
-  '@vitest/spy@2.1.4':
-    dependencies:
-      tinyspy: 3.0.2
 
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+    optional: true
 
-  '@vitest/spy@4.1.0': {}
-
-  '@vitest/utils@2.1.4':
-    dependencies:
-      '@vitest/pretty-format': 2.1.4
-      loupe: 3.2.1
-      tinyrainbow: 1.2.0
+  '@vitest/spy@4.1.5': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+    optional: true
 
-  '@vitest/utils@4.1.0':
+  '@vitest/utils@4.1.5':
     dependencies:
-      '@vitest/pretty-format': 4.1.0
+      '@vitest/pretty-format': 4.1.5
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -30507,14 +30428,14 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/vitest@4.0.1(@opentelemetry/api@1.9.1)(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(zod@3.25.76)':
+  '@workflow/vitest@4.0.1(@opentelemetry/api@1.9.1)(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)))(zod@3.25.76)':
     dependencies:
       '@workflow/builders': 4.0.1(@opentelemetry/api@1.9.1)
       '@workflow/core': 4.2.0(@opentelemetry/api@1.9.1)
       '@workflow/rollup': 4.0.0(@opentelemetry/api@1.9.1)
       '@workflow/world': 4.1.0(zod@3.25.76)
       '@workflow/world-local': 4.1.0(@opentelemetry/api@1.9.1)
-      vitest: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      vitest: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
     optionalDependencies:
       vite: 7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
     transitivePeerDependencies:
@@ -31523,6 +31444,7 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.0
+    optional: true
 
   chai@6.2.2: {}
 
@@ -31551,7 +31473,8 @@ snapshots:
 
   chardet@2.1.0: {}
 
-  check-error@2.1.1: {}
+  check-error@2.1.1:
+    optional: true
 
   chevrotain-allstar@0.3.1(chevrotain@11.0.3):
     dependencies:
@@ -32384,7 +32307,8 @@ snapshots:
 
   dedent@1.7.1: {}
 
-  deep-eql@5.0.2: {}
+  deep-eql@5.0.2:
+    optional: true
 
   deep-equal@1.0.1: {}
 
@@ -35899,7 +35823,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loupe@3.2.1: {}
+  loupe@3.2.1:
+    optional: true
 
   lower-case@2.0.2:
     dependencies:
@@ -38086,7 +38011,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pathval@2.0.0: {}
+  pathval@2.0.0:
+    optional: true
 
   peek-readable@4.1.0: {}
 
@@ -40094,6 +40020,7 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+    optional: true
 
   strnum@2.2.3: {}
 
@@ -40649,19 +40576,18 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@1.1.1: {}
+  tinypool@1.1.1:
+    optional: true
 
   tinypool@2.1.0: {}
 
-  tinyrainbow@1.2.0: {}
-
-  tinyrainbow@2.0.0: {}
+  tinyrainbow@2.0.0:
+    optional: true
 
   tinyrainbow@3.1.0: {}
 
-  tinyspy@3.0.2: {}
-
-  tinyspy@4.0.4: {}
+  tinyspy@4.0.4:
+    optional: true
 
   tldts-core@6.1.82: {}
 
@@ -41590,6 +41516,7 @@ snapshots:
       - terser
       - tsx
       - yaml
+    optional: true
 
   vite-plugin-checker@0.8.0(eslint@9.39.3(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)):
     dependencies:
@@ -41735,6 +41662,25 @@ snapshots:
       tsx: 4.19.2
       yaml: 2.7.0
 
+  vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.9
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.17.24
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      less: 4.4.0
+      lightningcss: 1.31.1
+      sass: 1.90.0
+      terser: 5.43.1
+      tsx: 4.19.2
+      yaml: 2.7.0
+
   vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.27.3
@@ -41781,43 +41727,6 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
 
-  vitest@2.1.4(@edge-runtime/vm@5.0.0)(@types/node@20.17.24)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1):
-    dependencies:
-      '@vitest/expect': 2.1.4
-      '@vitest/mocker': 2.1.4(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.4
-      '@vitest/snapshot': 2.1.4
-      '@vitest/spy': 2.1.4
-      '@vitest/utils': 2.1.4
-      chai: 5.2.0
-      debug: 4.4.3(supports-color@9.4.0)
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinypool: 1.1.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)
-      vite-node: 2.1.4(@types/node@20.17.24)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@edge-runtime/vm': 5.0.0
-      '@types/node': 20.17.24
-      jsdom: 26.1.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0):
     dependencies:
       '@types/chai': 5.2.3
@@ -41861,16 +41770,17 @@ snapshots:
       - terser
       - tsx
       - yaml
+    optional: true
 
-  vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@24.1.3)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
+  vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@24.1.3)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
     dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -41892,15 +41802,15 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@24.1.3)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
+  vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@24.1.3)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
     dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -41922,15 +41832,45 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
+  vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)):
     dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 5.0.0
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 20.17.24
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -41952,15 +41892,15 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
+  vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
     dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -41982,15 +41922,45 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.7.4)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
+  vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.17.24)(jsdom@26.1.0)(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)):
     dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.6.4(@types/node@20.17.24)(typescript@5.8.3))(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 5.0.0
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 20.17.24
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.7.4)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.12.10(@types/node@22.7.4)(typescript@5.8.3))(vite@7.3.1(@types/node@22.7.4)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2813,8 +2813,8 @@ importers:
         specifier: workspace:*
         version: link:../../tools/tsconfig
       '@vitejs/plugin-react':
-        specifier: 4.3.3
-        version: 4.3.3(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
+        specifier: ^4.3.4
+        version: 4.7.0(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
       jsdom:
         specifier: ^24.0.0
         version: 24.1.3
@@ -29812,6 +29812,18 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 6.4.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.3)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 7.3.1(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Background

Unit tests should run without any delays. However, we use `delay` and `setTimeout` in our tests and production code, leading to slower running tests.

## Summary

* upgrade `vitest` to `4.1.5` everywhere
  * add ci test setup patch for codemod testing to prevent test timeouts
* use `delay` instead of `setTimeout`
* use `vi.useFakeTimers()` and `vi.useRealTimers()` consistently in tests
* advance the simulated clock with `vi.advanceTimersByTimeAsync`
