### PR TITLE
fix(provider/deepseek): preserve reasoning_content for deepseek-v4 in multi-turn requests

### DIFF
--- a/.changeset/fix-deepseek-v4-reasoning-content.md
+++ b/.changeset/fix-deepseek-v4-reasoning-content.md
@@ -3,5 +3,3 @@
 ---
 
 fix(provider/deepseek): preserve `reasoning_content` for `deepseek-v4` in multi-turn requests
-
-DeepSeek V4 thinking mode requires `reasoning_content` on every assistant message in multi-turn requests; otherwise the API returns `400 The reasoning_content in the thinking mode must be passed back to the API.` The converter now preserves prior reasoning for `deepseek-v4*` models and back-fills an empty string when no reasoning part is present. `deepseek-reasoner` (R1) behavior — which forbids echoing prior reasoning — is unchanged.

--- a/.changeset/fix-deepseek-v4-reasoning-content.md
+++ b/.changeset/fix-deepseek-v4-reasoning-content.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/deepseek": patch
+---
+
+fix(provider/deepseek): preserve `reasoning_content` for `deepseek-v4` in multi-turn requests
+
+DeepSeek V4 thinking mode requires `reasoning_content` on every assistant message in multi-turn requests; otherwise the API returns `400 The reasoning_content in the thinking mode must be passed back to the API.` The converter now preserves prior reasoning for `deepseek-v4*` models and back-fills an empty string when no reasoning part is present. `deepseek-reasoner` (R1) behavior — which forbids echoing prior reasoning — is unchanged.

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
@@ -12,6 +12,7 @@ describe('convertToDeepSeekChatMessages', () => {
           },
         ],
         responseFormat: undefined,
+        modelId: 'deepseek-chat',
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -43,6 +44,7 @@ describe('convertToDeepSeekChatMessages', () => {
           },
         ],
         responseFormat: undefined,
+        modelId: 'deepseek-chat',
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -92,6 +94,7 @@ describe('convertToDeepSeekChatMessages', () => {
           },
         ],
         responseFormat: undefined,
+        modelId: 'deepseek-chat',
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -150,6 +153,7 @@ describe('convertToDeepSeekChatMessages', () => {
           },
         ],
         responseFormat: undefined,
+        modelId: 'deepseek-chat',
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -216,6 +220,7 @@ describe('convertToDeepSeekChatMessages', () => {
           },
         ],
         responseFormat: undefined,
+        modelId: 'deepseek-chat',
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -290,6 +295,7 @@ describe('convertToDeepSeekChatMessages', () => {
           },
         ],
         responseFormat: undefined,
+        modelId: 'deepseek-chat',
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -321,6 +327,134 @@ describe('convertToDeepSeekChatMessages', () => {
             },
             {
               "content": "Goodbye",
+              "role": "user",
+            },
+          ],
+          "warnings": [],
+        }
+      `);
+    });
+  });
+
+  describe('deepseek-v4 thinking mode', () => {
+    // V4 demands `reasoning_content` on every assistant turn — including ones
+    // before the last user message. Stripping it like we do for R1 makes the
+    // API reject multi-turn requests with "The `reasoning_content` in the
+    // thinking mode must be passed back to the API."
+    it('should preserve reasoning_content from prior turns for deepseek-v4', () => {
+      const result = convertToDeepSeekChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'reasoning',
+                text: 'I think the tool will return the correct value.',
+              },
+              {
+                type: 'tool-call',
+                input: { foo: 'bar123' },
+                toolCallId: 'quux',
+                toolName: 'thwomp',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'quux',
+                toolName: 'thwomp',
+                output: { type: 'json', value: { oof: '321rab' } },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Goodbye' }],
+          },
+        ],
+        responseFormat: undefined,
+        modelId: 'deepseek-v4-pro',
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "Hello",
+              "role": "user",
+            },
+            {
+              "content": "",
+              "reasoning_content": "I think the tool will return the correct value.",
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "function": {
+                    "arguments": "{"foo":"bar123"}",
+                    "name": "thwomp",
+                  },
+                  "id": "quux",
+                  "type": "function",
+                },
+              ],
+            },
+            {
+              "content": "{"oof":"321rab"}",
+              "role": "tool",
+              "tool_call_id": "quux",
+            },
+            {
+              "content": "Goodbye",
+              "role": "user",
+            },
+          ],
+          "warnings": [],
+        }
+      `);
+    });
+
+    it('should back-fill empty reasoning_content for deepseek-v4 assistant messages with no reasoning part', () => {
+      const result = convertToDeepSeekChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hi there' }],
+          },
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Again' }],
+          },
+        ],
+        responseFormat: undefined,
+        modelId: 'deepseek-v4-pro',
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "Hello",
+              "role": "user",
+            },
+            {
+              "content": "Hi there",
+              "reasoning_content": "",
+              "role": "assistant",
+              "tool_calls": undefined,
+            },
+            {
+              "content": "Again",
               "role": "user",
             },
           ],

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -8,13 +8,22 @@ import { DeepSeekChatPrompt } from './deepseek-chat-api-types';
 export function convertToDeepSeekChatMessages({
   prompt,
   responseFormat,
+  modelId,
 }: {
   prompt: LanguageModelV4Prompt;
   responseFormat: LanguageModelV4CallOptions['responseFormat'];
+  modelId: string;
 }): {
   messages: DeepSeekChatPrompt;
   warnings: Array<SharedV4Warning>;
 } {
+  // DeepSeek V4 thinking mode requires `reasoning_content` on every assistant
+  // message in multi-turn requests; without it the API returns 400 with
+  // "The `reasoning_content` in the thinking mode must be passed back to the
+  // API." DeepSeek R1 (deepseek-reasoner) requires the opposite — never echo
+  // prior reasoning back. Detect V4 by model ID so each family gets the
+  // shape it expects.
+  const isDeepSeekV4 = modelId.includes('deepseek-v4');
   const messages: DeepSeekChatPrompt = [];
   const warnings: Array<SharedV4Warning> = [];
 
@@ -96,7 +105,8 @@ export function convertToDeepSeekChatMessages({
               break;
             }
             case 'reasoning': {
-              if (index <= lastUserMessageIndex) {
+              // R1 must not receive prior reasoning; V4 requires it.
+              if (index <= lastUserMessageIndex && !isDeepSeekV4) {
                 break;
               }
 
@@ -121,10 +131,12 @@ export function convertToDeepSeekChatMessages({
           }
         }
 
+        // V4 demands the field on every assistant turn — back-fill an empty
+        // string when the source message had no reasoning part at all.
         messages.push({
           role: 'assistant',
           content: text,
-          reasoning_content: reasoning,
+          reasoning_content: reasoning ?? (isDeepSeekV4 ? '' : undefined),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.ts
@@ -117,6 +117,7 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
     const { messages, warnings } = convertToDeepSeekChatMessages({
       prompt,
       responseFormat,
+      modelId: this.modelId,
     });
 
     if (topK != null) {


### PR DESCRIPTION
## Background

DeepSeek released two model families with **opposite** requirements for `reasoning_content` in multi-turn chat completions:

- **`deepseek-reasoner` (R1)** — per the [DeepSeek docs](https://api-docs.deepseek.com/guides/reasoning_model), callers must **not** echo `reasoning_content` from previous assistant turns. The current converter (introduced in #10785) correctly strips it via ``if (index <= lastUserMessageIndex) break``.
- **`deepseek-v4` / `deepseek-v4-pro` (V4 thinking mode)** — the API **requires** every assistant message to carry a `reasoning_content` field. Multi-turn requests without it fail with:

  ``400 The `reasoning_content` in the thinking mode must be passed back to the API.``

The current converter applies the R1 stripping rule to V4 too, which breaks every V4 conversation after the first turn.

## Reproduction

```ts
import { deepseek } from '@ai-sdk/deepseek';
import { isStepCount, streamText } from 'ai';
import { printFullStream } from '../../lib/print-full-stream';
import { run } from '../../lib/run';
import { weatherTool } from '../../tools/weather-tool';

run(async () => {
  const model = deepseek('deepseek-v4-pro');

  console.log('\n=== TURN 1 (tool call) ===');
  const t1 = streamText({
    model,
    tools: { weather: weatherTool },
    stopWhen: isStepCount(3),
    messages: [
      { role: 'user', content: 'What is the weather in San Francisco?' },
    ],
  });
  await printFullStream({ result: t1 });

  const t1Messages = (await t1.response).messages;

  console.log('\n\n=== TURN 2 (replay + new user turn) ===');
  const t2 = streamText({
    model,
    tools: { weather: weatherTool },
    stopWhen: isStepCount(3),
    messages: [
      { role: 'user', content: 'What is the weather in San Francisco?' },
      ...t1Messages,
      { role: 'user', content: 'How about in New York?' },
    ],
  });
  await printFullStream({ result: t2 });
});
```

## Fix

In `convertToDeepSeekChatMessages`:

1. Add a `modelId` parameter (the function is internal — only callers are the test file and `deepseek-chat-language-model.ts`).
2. Detect V4 with `modelId.includes('deepseek-v4')`.
3. For V4: skip the strip-on-old-turn `break` so prior reasoning is preserved, and back-fill `reasoning_content: ''` when an assistant message has no `reasoning` part at all.
4. For R1 / other models: behavior unchanged.

## Test plan

- New unit tests in `convert-to-deepseek-chat-messages.test.ts`:
  - V4 with prior assistant turn → output preserves `reasoning_content`
  - V4 with assistant turn lacking a reasoning part → output emits `reasoning_content: ''`
- Existing R1/`deepseek-chat` tests continue to pass unchanged.
- All 29 tests in `@ai-sdk/deepseek` pass locally.
- Manual: a `streamText` multi-turn loop with `deepseek-v4-pro` no longer 400s after turn 1.