### PR TITLE
feat(ai): wrap the model call in telemetry context

### DIFF
--- a/examples/ai-functions/src/stream-text-custom-loop/openai.ts
+++ b/examples/ai-functions/src/stream-text-custom-loop/openai.ts
@@ -9,6 +9,7 @@ import { run } from '../lib/run';
 run(async () => {
   const { stream }: { stream: AsyncIterableStream<LanguageModelStreamPart> } =
     await streamLanguageModelCall({
+      callId: 'stream-text-custom-loop-openai',
       model: openai('gpt-5.4'),
       prompt: 'How many people live in the capital of France?',
     });

--- a/examples/ai-functions/src/stream-text/anthropic/subagent-with-telemetry.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/subagent-with-telemetry.ts
@@ -17,7 +17,7 @@ sdk.start();
 registerTelemetry(new OpenTelemetry(), DevToolsTelemetry());
 
 const weatherAgent = new ToolLoopAgent({
-  model: anthropic('claude-sonnet-4-5-20250929'),
+  model: 'anthropic/claude-sonnet-4.5',
   instructions: 'You compare weather across cities. Use the researchCity tool.',
   tools: {
     researchCity: {
@@ -28,7 +28,7 @@ const weatherAgent = new ToolLoopAgent({
       }),
       execute: async ({ city }: { city: string }) => {
         const subResult = streamText({
-          model: anthropic('claude-sonnet-4-5-20250929'),
+          model: 'anthropic/claude-sonnet-4.5',
           prompt: `You are a weather expert. Provide a brief weather report for ${city} including temperature, conditions, and a fun fact about the climate.`,
           telemetry: {
             functionId: `weather-subagent-${city.toLowerCase()}`,

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -163,6 +163,42 @@ describe('generateText', () => {
     logWarningsSpy.mockRestore();
   });
 
+  describe('telemetry model-call context', () => {
+    it('should execute doGenerate inside executeLanguageModelCall context', async () => {
+      let activeContext: string | undefined;
+      let capturedContext: string | undefined;
+
+      await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            capturedContext = activeContext;
+
+            return {
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: 'done' }],
+            };
+          },
+        }),
+        telemetry: {
+          isEnabled: true,
+          integrations: {
+            executeLanguageModelCall: async ({ callId, execute }) => {
+              activeContext = callId;
+              try {
+                return await execute();
+              } finally {
+                activeContext = undefined;
+              }
+            },
+          },
+        },
+        ...defaultSettings(),
+      });
+
+      expect(capturedContext).toBe('test-telemetry-call-id');
+    });
+  });
+
   describe('result.content', () => {
     it('should generate content', async () => {
       const result = await generateText({

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -693,16 +693,29 @@ export async function generateText<
           ],
         });
 
+        const executeLanguageModelCallInTelemetryContext =
+          telemetryDispatcher.executeLanguageModelCall ??
+          (async <T>({
+            execute,
+          }: {
+            callId: string;
+            execute: () => PromiseLike<T>;
+          }) => await execute());
+
         currentModelResponse = await retry(async () => {
-          const result = await stepModel.doGenerate({
-            ...callSettings,
-            tools: stepTools,
-            toolChoice: stepToolChoice,
-            responseFormat: await output?.responseFormat,
-            prompt: promptMessages,
-            providerOptions: stepProviderOptions,
-            abortSignal: mergedAbortSignal,
-            headers: headersWithUserAgent,
+          const result = await executeLanguageModelCallInTelemetryContext({
+            callId,
+            execute: async () =>
+              await stepModel.doGenerate({
+                ...callSettings,
+                tools: stepTools,
+                toolChoice: stepToolChoice,
+                responseFormat: await output?.responseFormat,
+                prompt: promptMessages,
+                providerOptions: stepProviderOptions,
+                abortSignal: mergedAbortSignal,
+                headers: headersWithUserAgent,
+              }),
           });
 
           const responseData = {

--- a/packages/ai/src/generate-text/stream-language-model-call.test.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.test.ts
@@ -158,6 +158,7 @@ describe('streamLanguageModelCall', () => {
       let endEvent!: LanguageModelCallEndEvent;
       const generateId = vi.fn(() => 'aitxt-generated-response-id');
       const generateCallId = vi.fn(() => 'call-generated-call-id');
+      const callId = generateCallId();
 
       const { stream } = await streamLanguageModelCall({
         model: new MockLanguageModelV4({
@@ -172,9 +173,9 @@ describe('streamLanguageModelCall', () => {
           }),
         }),
         prompt: 'test prompt',
+        callId,
         _internal: {
           generateId,
-          generateCallId,
         },
         onLanguageModelCallStart: async event => {
           startEvent = event;

--- a/packages/ai/src/generate-text/stream-language-model-call.test.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.test.ts
@@ -50,6 +50,7 @@ async function streamLanguageModelCallResult<TOOLS extends ToolSet>({
     prompt: 'test prompt',
     system: undefined,
     repairToolCall,
+    callId: 'call-1',
   });
 
   return convertReadableStreamToArray(stream);
@@ -90,6 +91,7 @@ describe('streamLanguageModelCall', () => {
         prompt: 'test prompt',
         system: undefined,
         repairToolCall: undefined,
+        callId: 'call-1',
       });
 
       expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`

--- a/packages/ai/src/generate-text/stream-language-model-call.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.ts
@@ -169,6 +169,9 @@ export async function streamLanguageModelCall<
   includeRawChunks,
   providerOptions,
   repairToolCall,
+  callId,
+  executeLanguageModelCallInTelemetryContext = async ({ execute }) =>
+    await execute(),
   onStart,
   ...callSettings
 }: {
@@ -182,6 +185,11 @@ export async function streamLanguageModelCall<
   includeRawChunks?: boolean;
   providerOptions?: ProviderOptions;
   repairToolCall?: ToolCallRepairFunction<TOOLS> | undefined;
+  callId: string;
+  executeLanguageModelCallInTelemetryContext?: <T>(params: {
+    callId: string;
+    execute: () => PromiseLike<T>;
+  }) => PromiseLike<T>;
 
   // onStart is currently required because the telemetry callbacks need
   // LanguageModelV4Prompt and we only want download URLs at most once.
@@ -245,16 +253,20 @@ export async function streamLanguageModelCall<
     stream: languageModelStream,
     response,
     request,
-  } = await resolvedModel.doStream({
-    ...callSettings,
-    tools: stepTools,
-    toolChoice: stepToolChoice,
-    responseFormat: await output?.responseFormat,
-    prompt: promptMessages,
-    providerOptions,
-    abortSignal,
-    headers,
-    includeRawChunks,
+  } = await executeLanguageModelCallInTelemetryContext({
+    callId,
+    execute: async () =>
+      await resolvedModel.doStream({
+        ...callSettings,
+        tools: stepTools,
+        toolChoice: stepToolChoice,
+        responseFormat: await output?.responseFormat,
+        prompt: promptMessages,
+        providerOptions,
+        abortSignal,
+        headers,
+        includeRawChunks,
+      }),
   });
 
   const standardizedStream = languageModelStream.pipeThrough(

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -463,6 +463,58 @@ describe('streamText', () => {
     logWarningsSpy.mockRestore();
   });
 
+  describe('telemetry model-call context', () => {
+    it('should execute doStream inside executeLanguageModelCall context', async () => {
+      let activeContext: string | undefined;
+      let capturedContext: string | undefined;
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            capturedContext = activeContext;
+
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'done' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        telemetry: {
+          isEnabled: true,
+          integrations: {
+            executeLanguageModelCall: async ({ callId, execute }) => {
+              activeContext = callId;
+              try {
+                return await execute();
+              } finally {
+                activeContext = undefined;
+              }
+            },
+          },
+        },
+        ...defaultSettings(),
+      });
+
+      await result.consumeStream();
+
+      expect(capturedContext).toBe('test-telemetry-call-id');
+    });
+  });
+
   describe('result.textStream', () => {
     it('should send text deltas', async () => {
       const result = streamText({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1572,12 +1572,15 @@ class DefaultStreamTextResult<
               system: stepSystem,
               messages: stepMessages,
               repairToolCall,
+              callId,
               abortSignal,
               headers,
               includeRawChunks,
               providerOptions: stepProviderOptions,
               download,
               output,
+              executeLanguageModelCallInTelemetryContext:
+                telemetryDispatcher.executeLanguageModelCall,
               onStart: async ({ promptMessages }) => {
                 await notify({
                   event: {

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.test.ts
@@ -546,4 +546,72 @@ describe('createTelemetryDispatcher', () => {
       expect(integration.calls).toBe(1);
     });
   });
+
+  describe('executeLanguageModelCall', () => {
+    it('returns undefined when no integrations implement executeLanguageModelCall', () => {
+      const telemetry = createTelemetryDispatcher({
+        telemetry: { integrations: { onStart: vi.fn() } },
+      });
+
+      expect(telemetry.executeLanguageModelCall).toBeUndefined();
+    });
+
+    it('wraps execute with a single integration', async () => {
+      const execute = vi.fn().mockResolvedValue('result');
+      let wrapperCalls = 0;
+      const callOrder: string[] = [];
+      const wrapper: Telemetry['executeLanguageModelCall'] = async ({
+        execute,
+      }) => {
+        wrapperCalls += 1;
+        callOrder.push('wrapper-before');
+        const result = await execute();
+        callOrder.push('wrapper-after');
+        return result;
+      };
+
+      const telemetry = createTelemetryDispatcher({
+        telemetry: { integrations: { executeLanguageModelCall: wrapper } },
+      });
+
+      await expect(
+        telemetry.executeLanguageModelCall!({
+          callId: 'call-1',
+          execute,
+        }),
+      ).resolves.toBe('result');
+
+      expect(wrapperCalls).toBe(1);
+      expect(execute).toHaveBeenCalledOnce();
+      expect(callOrder).toEqual(['wrapper-before', 'wrapper-after']);
+    });
+
+    it('auto-binds class-based executeLanguageModelCall integrations', async () => {
+      class ExecuteLanguageModelCallIntegration implements Telemetry {
+        calls = 0;
+
+        async executeLanguageModelCall<T>({
+          execute,
+        }: {
+          callId: string;
+          execute: () => PromiseLike<T>;
+        }) {
+          this.calls += 1;
+          return execute();
+        }
+      }
+
+      const integration = new ExecuteLanguageModelCallIntegration();
+      const telemetry = createTelemetryDispatcher({
+        telemetry: { integrations: integration },
+      });
+
+      await telemetry.executeLanguageModelCall!({
+        callId: 'call-1',
+        execute: async () => 'done',
+      });
+
+      expect(integration.calls).toBe(1);
+    });
+  });
 });

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
@@ -101,6 +101,12 @@ export function createTelemetryDispatcher({
   };
 
   const executeWrappers = integrations
+    .map(integration => integration.executeLanguageModelCall?.bind(integration))
+    .filter(Boolean) as Array<
+    NonNullable<Telemetry['executeLanguageModelCall']>
+  >;
+
+  const executeToolWrappers = integrations
     .map(integration => integration.executeTool?.bind(integration))
     .filter(Boolean) as Array<NonNullable<Telemetry['executeTool']>>;
 
@@ -119,7 +125,18 @@ export function createTelemetryDispatcher({
     onRerankFinish: mergeTelemetryCallback('onRerankFinish'),
     onFinish: mergeTelemetryCallback('onFinish'),
     onError: mergeTelemetryCallback('onError'),
-
+    executeLanguageModelCall:
+      executeWrappers.length > 0
+        ? async args => {
+            let execute = args.execute;
+            for (const executeWrapper of executeWrappers) {
+              const innerExecute = execute;
+              execute = () =>
+                executeWrapper({ ...args, execute: innerExecute });
+            }
+            return await execute();
+          }
+        : undefined,
     /**
      * Composes all `executeTool` wrappers around the original tool execution.
      * Each wrapper receives an `execute` function that calls the next wrapper in
@@ -127,10 +144,10 @@ export function createTelemetryDispatcher({
      * delegating to the underlying tool.
      */
     executeTool:
-      executeWrappers.length > 0
+      executeToolWrappers.length > 0
         ? async args => {
             let execute = args.execute;
-            for (const executeWrapper of executeWrappers) {
+            for (const executeWrapper of executeToolWrappers) {
               const innerExecute = execute;
               execute = () =>
                 executeWrapper({ ...args, execute: innerExecute });

--- a/packages/ai/src/telemetry/telemetry.ts
+++ b/packages/ai/src/telemetry/telemetry.ts
@@ -61,6 +61,7 @@ export interface TelemetryDispatcher {
   onRerankFinish?: Callback<RerankingModelCallEndEvent>;
   onFinish?: Callback<OperationFinishEvent>;
   onError?: Callback<unknown>;
+  executeLanguageModelCall?: Telemetry['executeLanguageModelCall'];
   executeTool?: Telemetry['executeTool'];
 }
 
@@ -180,6 +181,19 @@ export interface Telemetry {
    * Use this to record error details on telemetry spans and set error status.
    */
   onError?: Callback<unknown>;
+
+  /**
+   * Optionally runs the language model call in a telemetry-integration-specific context. This enables
+   * auto-instrumented model provider requests to become children of the current
+   * model-call span.
+   *
+   * @param options.callId - The call ID of the generation.
+   * @param options.execute - The function that performs the model call.
+   */
+  executeLanguageModelCall?: <T>(options: {
+    callId: string;
+    execute: () => PromiseLike<T>;
+  }) => PromiseLike<T>;
 
   /**
    * Optionally runs the tool execute function in a telemetry-integration-specific context. This enables

--- a/packages/otel/src/gen-ai-open-telemetry.test.ts
+++ b/packages/otel/src/gen-ai-open-telemetry.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import {
-  Attributes,
-  Span,
-  SpanOptions,
-  SpanStatusCode,
-  Tracer,
-} from '@opentelemetry/api';
+import { Attributes, Span, SpanOptions, Tracer } from '@opentelemetry/api';
 import type { Telemetry } from 'ai';
 import { GenAIOpenTelemetry } from './gen-ai-open-telemetry';
 

--- a/packages/otel/src/gen-ai-open-telemetry.ts
+++ b/packages/otel/src/gen-ai-open-telemetry.ts
@@ -182,6 +182,23 @@ export class GenAIOpenTelemetry implements Telemetry {
     return context.with(toolSpanEntry.context, execute);
   }
 
+  executeLanguageModelCall<T>({
+    callId,
+    execute,
+  }: {
+    callId: string;
+    execute: () => PromiseLike<T>;
+  }): PromiseLike<T> {
+    const state = this.getCallState(callId);
+    const modelCallContext = state?.inferenceContext ?? state?.stepContext;
+
+    if (modelCallContext == null) {
+      return execute();
+    }
+
+    return context.with(modelCallContext, execute);
+  }
+
   onStart(
     event:
       | InferTelemetryEvent<GenerateTextStartEvent>

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -13,9 +13,11 @@ import * as assert from 'node:assert';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   Attributes,
+  context,
   Span,
   SpanOptions,
   SpanStatusCode,
+  trace,
   Tracer,
 } from '@opentelemetry/api';
 import { z } from 'zod/v4';
@@ -124,6 +126,86 @@ function createMockTracer(): MockTracer {
     startActiveSpan: vi.fn() as Tracer['startActiveSpan'],
   };
   return tracer;
+}
+
+const contextApi = context as typeof context & {
+  setGlobalContextManager: (manager: {
+    active: () => ReturnType<typeof context.active>;
+    with: <T>(
+      nextContext: ReturnType<typeof context.active>,
+      fn: (...args: any[]) => T,
+      thisArg?: any,
+      ...args: any[]
+    ) => T;
+    bind: <T>(nextContext: ReturnType<typeof context.active>, target: T) => T;
+    enable: () => unknown;
+    disable: () => unknown;
+  }) => boolean;
+  disable: () => void;
+};
+
+class TestContextManager {
+  private readonly rootContext = context.active();
+  private currentContext = this.rootContext;
+
+  active() {
+    return this.currentContext;
+  }
+
+  with<T>(
+    nextContext: ReturnType<typeof context.active>,
+    fn: (...args: any[]) => T,
+    thisArg?: any,
+    ...args: any[]
+  ): T {
+    const previousContext = this.currentContext;
+    this.currentContext = nextContext;
+
+    try {
+      const result = fn.call(thisArg, ...args);
+
+      if (
+        result != null &&
+        typeof (result as unknown as { then?: unknown }).then === 'function'
+      ) {
+        return Promise.resolve(result).finally(() => {
+          this.currentContext = previousContext;
+        }) as T;
+      }
+
+      this.currentContext = previousContext;
+      return result;
+    } catch (error) {
+      this.currentContext = previousContext;
+      throw error;
+    }
+  }
+
+  bind<T>(nextContext: ReturnType<typeof context.active>, target: T): T {
+    if (typeof target !== 'function') {
+      return target;
+    }
+
+    const manager = this;
+
+    return function (this: unknown, ...args: any[]) {
+      return manager.with(
+        nextContext,
+        target as (...args: any[]) => unknown,
+        this,
+        ...args,
+      );
+    } as T;
+  }
+
+  enable() {
+    return this;
+  }
+
+  disable() {
+    this.currentContext = this.rootContext;
+    return this;
+  }
 }
 
 function getStartSpanAttributes(
@@ -1811,6 +1893,116 @@ describe('OpenTelemetry integration with streamText', () => {
 
   beforeEach(() => {
     tracer = new IntegrationMockTracer();
+  });
+
+  it('should execute doStream inside the active doStream span context', async () => {
+    const contextManager = new TestContextManager();
+    contextApi.setGlobalContextManager(contextManager);
+
+    try {
+      let activeSpan: Span | undefined;
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            activeSpan = trace.getSpan(context.active()) ?? undefined;
+
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello, world!' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: integrationTestUsage,
+                },
+              ]),
+            };
+          },
+        }),
+        prompt: 'test-input',
+        telemetry: {
+          integrations: new OpenTelemetry({ tracer }),
+        },
+        _internal: {
+          now: mockValues(0, 100, 500),
+        },
+      });
+
+      await result.consumeStream();
+
+      const doStreamSpan = tracer.jsonSpans.find(
+        span => span.name === 'ai.streamText.doStream',
+      );
+      const activeSpanRecord = tracer.spans.find(span => span === activeSpan);
+
+      expect({
+        activeSpanName: activeSpanRecord?.name,
+        doStreamSpan,
+      }).toMatchInlineSnapshot(`
+        {
+          "activeSpanName": "ai.streamText.doStream",
+          "doStreamSpan": {
+            "attributes": {
+              "ai.model.id": "mock-model-id",
+              "ai.model.provider": "mock-provider",
+              "ai.operationId": "ai.streamText.doStream",
+              "ai.prompt.messages": "[{"role":"user","content":[{"type":"text","text":"test-input"}]}]",
+              "ai.prompt.toolChoice": "{"type":"auto"}",
+              "ai.response.avgOutputTokensPerSecond": 20,
+              "ai.response.finishReason": "stop",
+              "ai.response.id": "id-0",
+              "ai.response.model": "mock-model-id",
+              "ai.response.msToFinish": 500,
+              "ai.response.msToFirstChunk": 100,
+              "ai.response.text": "Hello, world!",
+              "ai.response.timestamp": "1970-01-01T00:00:00.000Z",
+              "ai.settings.maxRetries": 2,
+              "ai.usage.inputTokenDetails.noCacheTokens": 3,
+              "ai.usage.inputTokens": 3,
+              "ai.usage.outputTokenDetails.textTokens": 10,
+              "ai.usage.outputTokens": 10,
+              "ai.usage.totalTokens": 13,
+              "gen_ai.request.model": "mock-model-id",
+              "gen_ai.response.finish_reasons": [
+                "stop",
+              ],
+              "gen_ai.response.id": "id-0",
+              "gen_ai.response.model": "mock-model-id",
+              "gen_ai.system": "mock-provider",
+              "gen_ai.usage.input_tokens": 3,
+              "gen_ai.usage.output_tokens": 10,
+              "operation.name": "ai.streamText.doStream",
+            },
+            "events": [
+              {
+                "attributes": {
+                  "ai.response.msToFirstChunk": 100,
+                },
+                "name": "ai.stream.firstChunk",
+              },
+              {
+                "attributes": {
+                  "ai.response.avgOutputTokensPerSecond": 20,
+                  "ai.response.msToFinish": 500,
+                },
+                "name": "ai.stream.finish",
+              },
+            ],
+            "name": "ai.streamText.doStream",
+          },
+        }
+      `);
+    } finally {
+      contextApi.disable();
+    }
   });
 
   it('should record telemetry data when isEnabled is not explicitly set', async () => {

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -175,6 +175,22 @@ export class OpenTelemetry implements Telemetry {
     return context.with(toolSpanEntry.context, execute);
   }
 
+  executeLanguageModelCall<T>({
+    callId,
+    execute,
+  }: {
+    callId: string;
+    execute: () => PromiseLike<T>;
+  }): PromiseLike<T> {
+    const stepContext = this.getCallState(callId)?.stepContext;
+
+    if (stepContext == null) {
+      return execute();
+    }
+
+    return context.with(stepContext, execute);
+  }
+
   onStart(
     event:
       | InferTelemetryEvent<GenerateTextStartEvent>

--- a/packages/workflow/src/do-stream-step.ts
+++ b/packages/workflow/src/do-stream-step.ts
@@ -2,6 +2,7 @@ import type {
   LanguageModelV4CallOptions,
   LanguageModelV4Prompt,
 } from '@ai-sdk/provider';
+import { createIdGenerator } from '@ai-sdk/provider-utils';
 import {
   type Experimental_LanguageModelStreamPart as ModelCallStreamPart,
   experimental_streamLanguageModelCall as streamModelCall,
@@ -25,6 +26,11 @@ import {
 export type { Experimental_LanguageModelStreamPart as ModelCallStreamPart } from 'ai';
 
 export type ModelStopCondition = StopCondition<NoInfer<ToolSet>, any>;
+
+const generateCallId = createIdGenerator({
+  prefix: 'call',
+  size: 24,
+});
 
 /**
  * Provider-executed tool result captured from the stream.
@@ -111,6 +117,7 @@ export async function doStreamStep(
   // (tool call parsing, finish reason mapping, file wrapping).
   const { stream: modelStream } = await streamModelCall({
     model,
+    callId: generateCallId(),
     // streamModelCall expects Prompt (ModelMessage[]) but we pass the
     // pre-converted LanguageModelV4Prompt. standardizePrompt inside
     // streamModelCall handles both formats.


### PR DESCRIPTION
## Background

There seems to be a regression with telemetry spans from v6 -> v7 where the AI Gateway stream fetch request spans seem to be disconnected from the AI SDK traces.

For v6, those requests were visibly child spans. In v7, the AI Gateway requests are not child spans.

The reason seems to be that in v6, we used to wrap the entire `doStream` model call with OpenTelemetry `context` and so all subsequent calls/requests were nested properly

## Summary

introduce another helper execute composite (simialr to what we do for tool execution `executeTools`) that will help wrap the language model calls for generate text and stream text

## Manual Verification

not yet

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)