### PR TITLE
docs: repoint broken examples/next-openai links to examples/next

### DIFF
--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -327,6 +327,6 @@ const result = streamText({
 
 ## Full Example
 
-To see this code in action, check out the [`next-openai` example](https://github.com/vercel/ai/tree/main/examples/next-openai) in the AI SDK repository. Navigate to the `/test-tool-approval` page and associated route handler.
+To see this code in action, check out the [`next` example](https://github.com/vercel/ai/tree/main/examples/next) in the AI SDK repository.
 
 For more details on tool execution approval, see the [Tool Execution Approval](/docs/ai-sdk-core/tools-and-tool-calling#tool-execution-approval) and [Chatbot Tool Usage](/docs/ai-sdk-ui/chatbot-tool-usage#tool-execution-approval) documentation.

--- a/content/docs/04-ai-sdk-ui/01-overview.mdx
+++ b/content/docs/04-ai-sdk-ui/01-overview.mdx
@@ -34,7 +34,7 @@ Here is a comparison of the supported functions across these frameworks:
 
 Explore these example implementations for different frameworks:
 
-- [**Next.js**](https://github.com/vercel/ai/tree/main/examples/next-openai)
+- [**Next.js**](https://github.com/vercel/ai/tree/main/examples/next)
 - [**Nuxt**](https://github.com/vercel/ai/tree/main/examples/nuxt-openai)
 - [**SvelteKit**](https://github.com/vercel/ai/tree/main/examples/sveltekit-openai)
 - [**Angular**](https://github.com/vercel/ai/tree/main/examples/angular)

--- a/content/providers/05-observability/langfuse.mdx
+++ b/content/providers/05-observability/langfuse.mdx
@@ -154,7 +154,7 @@ Done! All traces that contain AI SDK spans are automatically captured in Langfus
 ## Example Application
 
 Check out the sample repository ([langfuse/langfuse-vercel-ai-nextjs-example](https://github.com/langfuse/langfuse-vercel-ai-nextjs-example)) based
-on the [next-openai](https://github.com/vercel/ai/tree/main/examples/next-openai) template to showcase the integration of Langfuse with Next.js and AI SDK.
+on the [next](https://github.com/vercel/ai/tree/main/examples/next) template to showcase the integration of Langfuse with Next.js and AI SDK.
 
 ## Configuration
 

--- a/examples/ai-e2e-next/README.md
+++ b/examples/ai-e2e-next/README.md
@@ -6,7 +6,7 @@ This example shows how to use the [AI SDK](https://ai-sdk.dev/docs) with [Next.j
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=ai-sdk-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-openai&env=OPENAI_API_KEY&project-name=ai-sdk-next-openai&repository-name=ai-sdk-next-openai)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fai-e2e-next&env=OPENAI_API_KEY&project-name=ai-sdk-next-openai&repository-name=ai-sdk-next-openai)
 
 ## How to use
 


### PR DESCRIPTION
Closes #14705.

`https://github.com/vercel/ai/tree/main/examples/next-openai` returns 404 — the directory was renamed/removed. Four references still point at it; this PR repoints each to `examples/next` (the modern minimal Next.js example already in the tree).

| File | Change |
|---|---|
| `content/providers/05-observability/langfuse.mdx` | link target |
| `content/cookbook/01-next/75-human-in-the-loop.mdx` | link target; trim "Navigate to `/test-tool-approval`" since that sub-page also lived under the old example and is not present in `examples/next` |
| `content/docs/04-ai-sdk-ui/01-overview.mdx` | Next.js framework-examples link |
| `examples/ai-e2e-next/README.md` | Vercel deploy-button URL — repointed to `ai-e2e-next` itself, the example the README documents |

Total: +4 / -4. No code changes.

The companion `examples/nuxt-openai` and `examples/sveltekit-openai` paths in `01-overview.mdx` (lines 38-39) appear unaffected by this issue, so they're left alone in this PR. Happy to expand scope if those are also broken.

---

Contributed by [kcolbchain](https://kcolbchain.com).