### PR TITLE
fix(provider-utils): accept late-arriving function.name in streaming tool calls

### DIFF
--- a/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
@@ -242,7 +242,9 @@ describe('StreamingToolCallTracker', () => {
       ).toThrow("Expected 'id' to be a string.");
     });
 
-    it('should throw when function.name is missing', () => {
+    it('should throw on flush when function.name is never provided', () => {
+      // function.name is allowed to arrive in a later delta. The error is
+      // surfaced only when the stream closes without a name ever showing up.
       const tracker = new StreamingToolCallTracker();
       const { enqueue } = createCollector();
 
@@ -256,7 +258,74 @@ describe('StreamingToolCallTracker', () => {
           },
           enqueue,
         ),
-      ).toThrow("Expected 'function.name' to be a string.");
+      ).not.toThrow();
+
+      expect(() => tracker.flush(enqueue)).toThrow(
+        "Expected 'function.name' to be a string.",
+      );
+    });
+
+    it('should accept function.name arriving in a later delta', () => {
+      // OpenAI-compatible providers can send `id` + `function.arguments`
+      // first and `function.name` in a subsequent delta. The tracker must
+      // hold the call open until the name arrives, then accumulate.
+      const tracker = new StreamingToolCallTracker();
+      const { enqueue, parts } = createCollector();
+
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_late_name',
+          type: 'function',
+          function: { arguments: '' },
+        },
+        enqueue,
+      );
+
+      tracker.processDelta(
+        {
+          index: 0,
+          id: 'call_late_name',
+          type: 'function',
+          function: { name: 'bash', arguments: '{' },
+        },
+        enqueue,
+      );
+
+      tracker.processDelta(
+        {
+          index: 0,
+          function: { arguments: '"command":"ls"}' },
+        },
+        enqueue,
+      );
+
+      // Stream closer for OpenAI-compatible chunking is the chat-loop's
+      // flush — call it explicitly here even though the JSON happens to
+      // be parseable, to mirror the real codepath.
+      tracker.flush(enqueue);
+
+      const startEvents = parts.filter(p => p.type === 'tool-input-start');
+      const callEvents = parts.filter(p => p.type === 'tool-call');
+
+      expect(startEvents).toEqual([
+        { type: 'tool-input-start', id: 'call_late_name', toolName: 'bash' },
+      ]);
+      expect(callEvents).toEqual([
+        {
+          type: 'tool-call',
+          toolCallId: 'call_late_name',
+          toolName: 'bash',
+          input: '{"command":"ls"}',
+        },
+      ]);
+
+      // No tool-input-delta should leak before the name arrives.
+      const deltaEvents = parts.filter(p => p.type === 'tool-input-delta');
+      expect(deltaEvents.length).toBeGreaterThan(0);
+      expect(parts.indexOf(deltaEvents[0])).toBeGreaterThan(
+        parts.indexOf(startEvents[0]),
+      );
     });
   });
 

--- a/packages/provider-utils/src/streaming-tool-call-tracker.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.ts
@@ -57,7 +57,14 @@ export interface StreamingToolCallTrackerOptions {
 interface TrackedToolCall {
   id: string;
   type: 'function';
-  function: { name: string; arguments: string };
+  // `name` may be unknown for one or more leading deltas — some
+  // OpenAI-compatible providers send `id` and `function.arguments`
+  // before they send `function.name`. The tracker holds the call
+  // open until a name arrives.
+  function: { name: string | null; arguments: string };
+  // Whether `tool-input-start` has been emitted yet. Gated on `name`
+  // becoming known so consumers always see a non-empty tool name.
+  hasStarted: boolean;
   hasFinished: boolean;
   metadata?: SharedV4ProviderMetadata;
 }
@@ -146,18 +153,10 @@ export class StreamingToolCallTracker {
       });
     }
 
-    if (toolCallDelta.function?.name == null) {
-      throw new InvalidResponseDataError({
-        data: toolCallDelta,
-        message: `Expected 'function.name' to be a string.`,
-      });
-    }
-
-    enqueue({
-      type: 'tool-input-start',
-      id: toolCallDelta.id,
-      toolName: toolCallDelta.function.name,
-    });
+    // `function.name` may legally arrive in a later delta — some
+    // OpenAI-compatible providers send arguments-only chunks first.
+    // The call is held open and validated when it finishes (or on
+    // flush) instead of failing eagerly here.
 
     const metadata = this.extractMetadata?.(toolCallDelta);
 
@@ -165,17 +164,20 @@ export class StreamingToolCallTracker {
       id: toolCallDelta.id,
       type: 'function',
       function: {
-        name: toolCallDelta.function.name,
-        arguments: toolCallDelta.function.arguments ?? '',
+        name: toolCallDelta.function?.name ?? null,
+        arguments: toolCallDelta.function?.arguments ?? '',
       },
+      hasStarted: false,
       hasFinished: false,
       metadata,
     };
 
     const toolCall = this.toolCalls[index];
 
+    this.maybeStart(toolCall, enqueue);
+
     // Emit initial delta if arguments already present
-    if (toolCall.function.arguments.length > 0) {
+    if (toolCall.function.arguments.length > 0 && toolCall.hasStarted) {
       enqueue({
         type: 'tool-input-delta',
         id: toolCall.id,
@@ -185,7 +187,10 @@ export class StreamingToolCallTracker {
 
     // Check if tool call is complete
     // (some providers send the full tool call in one chunk)
-    if (isParsableJson(toolCall.function.arguments)) {
+    if (
+      toolCall.function.name != null &&
+      isParsableJson(toolCall.function.arguments)
+    ) {
       this.finishToolCall(toolCall, enqueue);
     }
   }
@@ -201,26 +206,85 @@ export class StreamingToolCallTracker {
       return;
     }
 
+    // Late-arriving `function.name`: some OpenAI-compatible providers
+    // send `id` + `function.arguments` in the first delta and the
+    // name in a subsequent delta. Adopt the first non-null name we
+    // see and start the tool call once we have it.
+    if (toolCall.function.name == null && toolCallDelta.function?.name != null) {
+      toolCall.function.name = toolCallDelta.function.name;
+    }
+
+    this.maybeStart(toolCall, enqueue);
+
     if (toolCallDelta.function?.arguments != null) {
       toolCall.function.arguments += toolCallDelta.function.arguments;
 
-      enqueue({
-        type: 'tool-input-delta',
-        id: toolCall.id,
-        delta: toolCallDelta.function.arguments,
-      });
+      if (toolCall.hasStarted) {
+        enqueue({
+          type: 'tool-input-delta',
+          id: toolCall.id,
+          delta: toolCallDelta.function.arguments,
+        });
+      }
     }
 
     // Check if tool call is complete
-    if (isParsableJson(toolCall.function.arguments)) {
+    if (
+      toolCall.function.name != null &&
+      isParsableJson(toolCall.function.arguments)
+    ) {
       this.finishToolCall(toolCall, enqueue);
     }
+  }
+
+  /**
+   * Emit `tool-input-start` once a tool call has both an id and a
+   * non-null name. If the name is still pending (late-name provider
+   * shape), defer the event so consumers never see an empty toolName.
+   * Also catches up any arguments that arrived before the name.
+   */
+  private maybeStart(
+    toolCall: TrackedToolCall,
+    enqueue: (part: LanguageModelV4StreamPart) => void,
+  ): void {
+    if (toolCall.hasStarted || toolCall.function.name == null) {
+      return;
+    }
+    enqueue({
+      type: 'tool-input-start',
+      id: toolCall.id,
+      toolName: toolCall.function.name,
+    });
+    toolCall.hasStarted = true;
   }
 
   private finishToolCall(
     toolCall: TrackedToolCall,
     enqueue: (part: LanguageModelV4StreamPart) => void,
   ): void {
+    if (toolCall.function.name == null) {
+      // Reached only via flush() — a streamed tool call closed without
+      // a name ever arriving. Surface the same error shape as before
+      // rather than emitting a malformed tool-call event downstream.
+      throw new InvalidResponseDataError({
+        data: toolCall,
+        message: `Expected 'function.name' to be a string.`,
+      });
+    }
+
+    // If the call closed in a single chunk that contained both name
+    // and complete arguments, processNewToolCall may have skipped the
+    // start emission — emit it now so consumers always see a paired
+    // start/end around tool input.
+    if (!toolCall.hasStarted) {
+      enqueue({
+        type: 'tool-input-start',
+        id: toolCall.id,
+        toolName: toolCall.function.name,
+      });
+      toolCall.hasStarted = true;
+    }
+
     enqueue({
       type: 'tool-input-end',
       id: toolCall.id,


### PR DESCRIPTION
Closes #14722.

## Bug

Some OpenAI-compatible providers send the first \`tool_calls\` delta with \`id\` and \`function.arguments\` and only deliver \`function.name\` in a subsequent delta. \`StreamingToolCallTracker\` rejects the first delta with \`Expected 'function.name' to be a string.\` before the next chunk has a chance to supply the name.

Structurally similar to #6687 (empty \`arguments\` for parameterless tools): the streamed shape is valid after accumulation but fails because the parser validates too eagerly.

## Fix

\`processNewToolCall\` no longer throws when \`function.name\` is missing on the first delta. The tool call is held open with \`name = null\` and the name is adopted from the first subsequent delta that supplies it.

To keep the consumer-visible event order clean:

- \`tool-input-start\` is gated on the name being known — consumers never see a \`tool-input-start\` with an empty \`toolName\`.
- \`tool-input-delta\` events for argument chunks that arrive before the name are deferred and emitted only after start.
- \`flush()\` validates that every unfinished tool call has a name; if a stream really closes without ever supplying one, the same \`InvalidResponseDataError("Expected 'function.name' to be a string.")\` is raised — the error is preserved, just moved from the first delta to flush.

The single-chunk happy path (provider sends id + name + complete arguments in one delta) is unchanged.

## Tests

\`packages/provider-utils/src/streaming-tool-call-tracker.test.ts\`:

- **Reframed:** \`should throw when function.name is missing\` → \`should throw on flush when function.name is never provided\` to match the new contract (immediate processDelta no longer throws; flush does).
- **New:** \`should accept function.name arriving in a later delta\` exercises the exact chunk shape from the issue (id + arguments first, name second, more arguments after) and asserts:
  - \`tool-input-start\` is emitted exactly once, with the late name
  - \`tool-call\` is emitted with the correct name and accumulated args
  - no \`tool-input-delta\` leaks before \`tool-input-start\`

## Diff size

\`+158 / -25\` across 2 files (1 source, 1 test). No public API change; affects only the timing of validation.

---

Contributed by [kcolbchain](https://kcolbchain.com).