### PR TITLE
fix(ai): deduplicate onError callback in toUIMessageStream

### DIFF
--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -4190,6 +4190,37 @@ describe('streamText', () => {
       // Verify that onFinish was NOT called when stream was cancelled
       expect(onFinishCallback).not.toHaveBeenCalled();
     });
+
+    it('should call onError exactly once per error', async () => {
+      const onErrorCallback = vi.fn(() => 'error');
+      const onFinishCallback = vi.fn();
+
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'error', error: new Error('test error') },
+          ]),
+        }),
+        prompt: 'test-input',
+      });
+
+      const chunks = await convertReadableStreamToArray(
+        result.toUIMessageStream({
+          onError: onErrorCallback,
+          onFinish: onFinishCallback,
+        }),
+      );
+
+      // Verify onError was called exactly once
+      expect(onErrorCallback).toHaveBeenCalledTimes(1);
+      // Verify the error chunk is in the stream
+      expect(chunks).toContainEqual(
+        expect.objectContaining({
+          type: 'error',
+        }),
+      );
+    });
   });
 
   describe('result.toUIMessageStreamResponse', () => {

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -78,7 +78,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
   messageMetadataSchema,
   dataPartSchemas,
   runUpdateMessageJob,
-  onError,
+  onError: _onError,
   onToolCall,
   onData,
 }: {
@@ -832,7 +832,8 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'error': {
-              onError?.(new Error(chunk.errorText));
+              // Error callback already invoked in stream-text.ts formatter stage
+              // with the original error. The errorText here is the formatted result.
               break;
             }
 


### PR DESCRIPTION
## Problem

The `onError` callback passed to `result.toUIMessageStream({ onError })` is invoked **twice** per upstream error when both `onError` and `onFinish` callbacks are provided.

### Root Cause

Two distinct call sites share the same `onError` reference:

1. **Formatter stage** (`generate-text/stream-text.ts:2542`): Invokes `onError(part.error)` with the original provider error and queues the formatted result as `errorText`
2. **Processor stage** (`ui/process-ui-message-stream.ts:835`): Invokes `onError` again with a newly constructed Error wrapping the already-formatted `errorText`

The handoff occurs in `handle-ui-message-stream-finish.ts`, which forwards the same `onError` callback to `processUIMessageStream`. This second invocation is redundant.

## Solution

Remove the duplicate `onError` invocation in `process-ui-message-stream.ts`. The error has already been processed during the formatter stage with the original error object. The processor stage doesn't need to re-invoke the callback.

### Changes

1. Remove `onError?.(new Error(chunk.errorText))` from the error case handler in `process-ui-message-stream.ts`
2. Mark the `onError` parameter as intentionally unused (`_onError`) to satisfy lint rules
3. Add a regression test to ensure `onError` is called exactly once

## Testing

Added regression test in `stream-text.test.ts` that verifies:
- `onError` is called exactly once when an error occurs with both `onError` and `onFinish` callbacks
- The error chunk is properly included in the stream

Fixes #14726