### PR TITLE
feat(provider/deepseek): support DeepSeek V4 reasoning effort

### DIFF
--- a/.changeset/great-forks-matter.md
+++ b/.changeset/great-forks-matter.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/deepseek": patch
+---
+
+feat(provider/deepseek): add DeepSeek V4 reasoning effort support

--- a/content/providers/01-ai-sdk-providers/30-deepseek.mdx
+++ b/content/providers/01-ai-sdk-providers/30-deepseek.mdx
@@ -99,7 +99,13 @@ The following optional provider options are available for DeepSeek models:
 
   - `type`: `'enabled' | 'disabled'` - Enable or disable thinking mode.
 
-```ts highlight="7-11"
+- `reasoningEffort` _'high' | 'max'_
+
+  Optional. Controls thinking strength for DeepSeek V4 reasoning models. When
+  using the top-level `reasoning` setting, `low`, `medium`, and `high` are sent
+  as `high`, while `xhigh` is sent as `max`.
+
+```ts highlight="7-12"
 import { deepseek, type DeepSeekLanguageModelOptions } from '@ai-sdk/deepseek';
 import { generateText } from 'ai';
 
@@ -109,6 +115,7 @@ const { text, reasoning } = await generateText({
   providerOptions: {
     deepseek: {
       thinking: { type: 'enabled' },
+      reasoningEffort: 'high',
     } satisfies DeepSeekLanguageModelOptions,
   },
 });

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.test.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.test.ts
@@ -134,9 +134,11 @@ describe('DeepSeekChatLanguageModel', () => {
           reasoning: 'high',
         });
 
-        expect((await server.calls[0].requestBodyJson).thinking).toStrictEqual({
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.thinking).toStrictEqual({
           type: 'enabled',
         });
+        expect(requestBody.reasoning_effort).toBe('high');
       });
 
       it('should map top-level reasoning none to thinking disabled', async () => {
@@ -145,9 +147,62 @@ describe('DeepSeekChatLanguageModel', () => {
           reasoning: 'none',
         });
 
-        expect((await server.calls[0].requestBodyJson).thinking).toStrictEqual({
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.thinking).toStrictEqual({
           type: 'disabled',
         });
+        expect(requestBody.reasoning_effort).toBeUndefined();
+      });
+
+      it('should map top-level reasoning xhigh to reasoning_effort max', async () => {
+        const result = await provider.chat('deepseek-reasoner').doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'xhigh',
+        });
+
+        expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
+          'max',
+        );
+        expect(result.warnings).toContainEqual({
+          type: 'compatibility',
+          feature: 'reasoning',
+          details:
+            'reasoning "xhigh" is not directly supported by this model. mapped to effort "max".',
+        });
+      });
+
+      it('should map top-level reasoning low to reasoning_effort high with compatibility warning', async () => {
+        const result = await provider.chat('deepseek-reasoner').doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'low',
+        });
+
+        expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
+          'high',
+        );
+        expect(result.warnings).toContainEqual({
+          type: 'compatibility',
+          feature: 'reasoning',
+          details:
+            'reasoning "low" is not directly supported by this model. mapped to effort "high".',
+        });
+      });
+
+      it('should pass providerOptions reasoningEffort', async () => {
+        await provider.chat('deepseek-reasoner').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            deepseek: {
+              reasoningEffort: 'max',
+            } satisfies DeepSeekLanguageModelOptions,
+          },
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody.reasoning_effort).toBe('max');
+        // When only reasoningEffort is set without thinking, thinking should be
+        // undefined and rely on the API default (enabled).
+        expect(requestBody.thinking).toBeUndefined();
       });
 
       it('should prefer providerOptions thinking over top-level reasoning', async () => {
@@ -164,6 +219,22 @@ describe('DeepSeekChatLanguageModel', () => {
         expect((await server.calls[0].requestBodyJson).thinking).toStrictEqual({
           type: 'enabled',
         });
+      });
+
+      it('should prefer providerOptions reasoningEffort over top-level reasoning', async () => {
+        await provider.chat('deepseek-reasoner').doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'high',
+          providerOptions: {
+            deepseek: {
+              reasoningEffort: 'max',
+            } satisfies DeepSeekLanguageModelOptions,
+          },
+        });
+
+        expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
+          'max',
+        );
       });
 
       it('should not set thinking when reasoning is not specified', async () => {

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.ts
@@ -7,6 +7,7 @@ import {
   LanguageModelV4GenerateResult,
   LanguageModelV4StreamPart,
   LanguageModelV4StreamResult,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -17,6 +18,7 @@ import {
   generateId,
   InferSchema,
   isCustomReasoning,
+  mapReasoningToProviderEffort,
   parseProviderOptions,
   ParseResult,
   postJsonToApi,
@@ -119,13 +121,14 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
       responseFormat,
       modelId: this.modelId,
     });
+    const allWarnings: SharedV4Warning[] = [...warnings];
 
     if (topK != null) {
-      warnings.push({ type: 'unsupported', feature: 'topK' });
+      allWarnings.push({ type: 'unsupported', feature: 'topK' });
     }
 
     if (seed != null) {
-      warnings.push({ type: 'unsupported', feature: 'seed' });
+      allWarnings.push({ type: 'unsupported', feature: 'seed' });
     }
 
     const {
@@ -136,6 +139,29 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
       tools,
       toolChoice,
     });
+
+    const thinking =
+      deepseekOptions.thinking?.type != null
+        ? { type: deepseekOptions.thinking.type }
+        : isCustomReasoning(reasoning)
+          ? { type: reasoning === 'none' ? 'disabled' : 'enabled' }
+          : undefined;
+
+    const reasoningEffort =
+      deepseekOptions.reasoningEffort ??
+      (isCustomReasoning(reasoning) && reasoning !== 'none'
+        ? mapReasoningToProviderEffort({
+            reasoning,
+            effortMap: {
+              minimal: 'high',
+              low: 'high',
+              medium: 'high',
+              high: 'high',
+              xhigh: 'max',
+            },
+            warnings: allWarnings,
+          })
+        : undefined);
 
     return {
       args: {
@@ -151,14 +177,13 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
         messages,
         tools: deepseekTools,
         tool_choice: deepseekToolChoices,
-        thinking:
-          deepseekOptions.thinking?.type != null
-            ? { type: deepseekOptions.thinking.type }
-            : isCustomReasoning(reasoning)
-              ? { type: reasoning === 'none' ? 'disabled' : 'enabled' }
-              : undefined,
+        thinking,
+        ...(thinking?.type !== 'disabled' &&
+          reasoningEffort != null && {
+            reasoning_effort: reasoningEffort,
+          }),
       },
-      warnings: [...warnings, ...toolWarnings],
+      warnings: [...allWarnings, ...toolWarnings],
     };
   }
 

--- a/packages/deepseek/src/chat/deepseek-chat-options.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-options.ts
@@ -15,6 +15,11 @@ export const deepseekLanguageModelOptions = z.object({
       type: z.enum(['enabled', 'disabled']).optional(),
     })
     .optional(),
+
+  /**
+   * Controls the thinking strength for DeepSeek V4 reasoning models.
+   */
+  reasoningEffort: z.enum(['high', 'max']).optional(),
 });
 
 export type DeepSeekLanguageModelOptions = z.infer<


### PR DESCRIPTION
## Background

DeepSeek V4 thinking mode supports an OpenAI-compatible `reasoning_effort`
parameter for controlling thinking strength. The DeepSeek provider already
supports enabling or disabling thinking mode, but it did not expose the new V4
effort control.

## Summary

- Add `reasoningEffort: 'high' | 'max'` to DeepSeek provider options.
- Send `reasoning_effort` in DeepSeek chat completion requests when configured.
- Map the top-level `reasoning` setting to DeepSeek's supported effort values:
  - `minimal`, `low`, `medium`, and `high` -> `high`
  - `xhigh` -> `max`
- Add request-body tests for provider options, top-level reasoning mapping,
  precedence, and disabled thinking.
- Document the new DeepSeek provider option.

## Manual Verification

N/A - verified with package tests and type checking.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A
