### PR TITLE
feat(google-vertex): support eu/us multi-region Anthropic endpoints

### DIFF
--- a/.changeset/google-vertex-anthropic-multiregion.md
+++ b/.changeset/google-vertex-anthropic-multiregion.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+feat(google-vertex): support eu/us multi-region endpoints for Vertex Anthropic provider

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -192,6 +192,40 @@ describe('google-vertex-anthropic-provider', () => {
     );
   });
 
+  it('should use multi-region URL for eu location', () => {
+    const provider = createVertexAnthropic({
+      project: 'test-project',
+      location: 'eu',
+    });
+    provider('test-model-id');
+
+    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      expect.objectContaining({
+        baseURL:
+          'https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/publishers/anthropic/models',
+        provider: 'vertex.anthropic.messages',
+      }),
+    );
+  });
+
+  it('should use multi-region URL for us location', () => {
+    const provider = createVertexAnthropic({
+      project: 'test-project',
+      location: 'us',
+    });
+    provider('test-model-id');
+
+    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      expect.objectContaining({
+        baseURL:
+          'https://aiplatform.us.rep.googleapis.com/v1/projects/test-project/locations/us/publishers/anthropic/models',
+        provider: 'vertex.anthropic.messages',
+      }),
+    );
+  });
+
   it('should support combining tools with structured outputs (inherited from Anthropic)', () => {
     const provider = createVertexAnthropic({
       project: 'test-project',

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -173,9 +173,19 @@ export function createVertexAnthropic(
       environmentVariableName: 'GOOGLE_VERTEX_PROJECT',
     });
 
+    const getHost = () => {
+      if (location === 'global') {
+        return 'aiplatform.googleapis.com';
+      } else if (location === 'eu' || location === 'us') {
+        return `aiplatform.${location}.rep.googleapis.com`;
+      } else {
+        return `${location}-aiplatform.googleapis.com`;
+      }
+    };
+
     return (
       withoutTrailingSlash(options.baseURL) ??
-      `https://${location === 'global' ? '' : location + '-'}aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`
+      `https://${getHost()}/v1/projects/${project}/locations/${location}/publishers/anthropic/models`
     );
   };
 


### PR DESCRIPTION
## Summary

- The `eu` and `us` locations on Vertex AI use a different hostname pattern (`aiplatform.{region}.rep.googleapis.com`) than other regions (`{region}-aiplatform.googleapis.com`)
- The previous code produced 404s for `location: 'eu'` and `location: 'us'` because it built the wrong hostname
- This fix adds a `getHost()` helper that selects the correct hostname based on the location value, matching the behavior of the upstream `@anthropic-ai/vertex-sdk`

## Test plan

- Added tests for `location: 'eu'` and `location: 'us'` that verify the correct multi-region hostname is used
- Existing tests for `global` and standard region (e.g. `us-east5`) continue to pass

Fixes #14634