### PR TITLE
fix(langchain): emit file content blocks from contentBlocks to stream

### DIFF
--- a/.changeset/gold-otters-tap.md
+++ b/.changeset/gold-otters-tap.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/langchain": patch
+---
+
+Parse file content blocks from assistant such as nano banana

--- a/packages/langchain/src/adapter.ts
+++ b/packages/langchain/src/adapter.ts
@@ -18,6 +18,7 @@ import {
   parseLangGraphEvent,
   isToolResultPart,
   extractReasoningFromContentBlocks,
+  extractFileContentBlocks,
 } from './utils';
 import { type LangGraphEventState } from './types';
 import { type StreamCallbacks } from './stream-callbacks';
@@ -132,6 +133,7 @@ function processStreamEventsEvent(
     textStarted: boolean;
     textMessageId: string | null;
     reasoningMessageId: string | null;
+    emittedImages?: Set<string>;
   },
   controller: ReadableStreamDefaultController<UIMessageChunk>,
 ): void {
@@ -194,6 +196,27 @@ function processStreamEventsEvent(
             delta: reasoning,
             id: state.reasoningMessageId ?? state.messageId,
           });
+        }
+
+        /**
+         * Handle file content blocks from contentBlocks or content array
+         * Skips blocks with empty data (common during streaming before data arrives)
+         */
+        const fileBlocks = extractFileContentBlocks(chunk);
+        for (const fileBlock of fileBlocks) {
+          if (!state.emittedImages) {
+            state.emittedImages = new Set<string>();
+          }
+          const fileKey = `cb-file:${fileBlock.mediaType}:${fileBlock.data.length}:${fileBlock.data.substring(0, Math.min(50, fileBlock.data.length))}`;
+          if (!state.emittedImages.has(fileKey)) {
+            state.emittedImages.add(fileKey);
+            controller.enqueue({
+              type: 'file',
+              mediaType: fileBlock.mediaType,
+              url: `data:${fileBlock.mediaType};base64,${fileBlock.data}`,
+            });
+            state.started = true;
+          }
         }
 
         /**

--- a/packages/langchain/src/adapter.ts
+++ b/packages/langchain/src/adapter.ts
@@ -133,7 +133,7 @@ function processStreamEventsEvent(
     textStarted: boolean;
     textMessageId: string | null;
     reasoningMessageId: string | null;
-    emittedImages?: Set<string>;
+    emittedImages: Set<string>;
   },
   controller: ReadableStreamDefaultController<UIMessageChunk>,
 ): void {
@@ -204,9 +204,6 @@ function processStreamEventsEvent(
          */
         const fileBlocks = extractFileContentBlocks(chunk);
         for (const fileBlock of fileBlocks) {
-          if (!state.emittedImages) {
-            state.emittedImages = new Set<string>();
-          }
           const fileKey = `cb-file:${fileBlock.mediaType}:${fileBlock.data.length}:${fileBlock.data.substring(0, Math.min(50, fileBlock.data.length))}`;
           if (!state.emittedImages.has(fileKey)) {
             state.emittedImages.add(fileKey);
@@ -401,6 +398,7 @@ export function toUIMessageStream<TState = unknown>(
     textMessageId: null as string | null,
     /** Track the ID used for reasoning-start to ensure reasoning-end uses the same ID */
     reasoningMessageId: null as string | null,
+    emittedImages: new Set<string>(),
   };
 
   /**

--- a/packages/langchain/src/types.ts
+++ b/packages/langchain/src/types.ts
@@ -60,6 +60,15 @@ export interface GPT5ReasoningOutput {
 }
 
 /**
+ * Type for file content blocks in contentBlocks (e.g., from Anthropic)
+ */
+export interface FileContentBlock {
+  type: 'file';
+  mimeType?: string;
+  data?: string;
+}
+
+/**
  * Type for image generation tool outputs from LangChain/OpenAI
  */
 export interface ImageGenerationOutput {

--- a/packages/langchain/src/utils.test.ts
+++ b/packages/langchain/src/utils.test.ts
@@ -23,6 +23,7 @@ import {
   getMessageText,
   isImageGenerationOutput,
   extractImageOutputs,
+  extractFileContentBlocks,
   processLangGraphEvent,
 } from './utils';
 
@@ -711,6 +712,128 @@ describe('processModelChunk', () => {
     expect(state.messageId).toBe('msg-xyz789');
   });
 
+  it('should handle file content blocks from contentBlocks', () => {
+    const chunk = new AIMessageChunk({
+      content: '',
+      id: 'msg-1',
+    });
+    Object.defineProperty(chunk, 'contentBlocks', {
+      get: () => [{ type: 'file', mimeType: 'image/png', data: 'iVBORwkg=' }],
+    });
+
+    const state = {
+      started: false,
+      messageId: 'default',
+      reasoningStarted: false,
+      textStarted: false,
+    };
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    processModelChunk(chunk, state, controller);
+
+    expect(state.started).toBe(true);
+    expect(chunks).toEqual([
+      {
+        type: 'file',
+        mediaType: 'image/png',
+        url: 'data:image/png;base64,iVBORwkg=',
+      },
+    ]);
+  });
+
+  it('should skip file content blocks with empty data', () => {
+    const chunk = new AIMessageChunk({
+      content: '',
+      id: 'msg-1',
+    });
+    Object.defineProperty(chunk, 'contentBlocks', {
+      get: () => [{ type: 'file', mimeType: 'image/png', data: '' }],
+    });
+
+    const state = {
+      started: false,
+      messageId: 'default',
+      reasoningStarted: false,
+      textStarted: false,
+    };
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    processModelChunk(chunk, state, controller);
+
+    expect(chunks).toHaveLength(0);
+    expect(state.started).toBe(false);
+  });
+
+  it('should handle file content blocks alongside text content', () => {
+    const chunk = new AIMessageChunk({
+      content: 'Here is an image:',
+      id: 'msg-1',
+    });
+    Object.defineProperty(chunk, 'contentBlocks', {
+      get: () => [{ type: 'file', mimeType: 'image/png', data: 'abc123' }],
+    });
+
+    const state = {
+      started: false,
+      messageId: 'default',
+      reasoningStarted: false,
+      textStarted: false,
+    };
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    processModelChunk(chunk, state, controller);
+
+    expect(chunks).toEqual([
+      {
+        type: 'file',
+        mediaType: 'image/png',
+        url: 'data:image/png;base64,abc123',
+      },
+      { type: 'text-start', id: 'msg-1' },
+      { type: 'text-delta', delta: 'Here is an image:', id: 'msg-1' },
+    ]);
+  });
+
+  it('should deduplicate file content blocks across chunks', () => {
+    const state = {
+      started: false,
+      messageId: 'default',
+      reasoningStarted: false,
+      textStarted: false,
+    };
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    const chunk1 = new AIMessageChunk({
+      content: '',
+      id: 'msg-1',
+    });
+    Object.defineProperty(chunk1, 'contentBlocks', {
+      get: () => [{ type: 'file', mimeType: 'image/png', data: 'abc123' }],
+    });
+    processModelChunk(chunk1, state, controller);
+
+    const chunk2 = new AIMessageChunk({
+      content: '',
+      id: 'msg-1',
+    });
+    Object.defineProperty(chunk2, 'contentBlocks', {
+      get: () => [{ type: 'file', mimeType: 'image/png', data: 'abc123' }],
+    });
+    processModelChunk(chunk2, state, controller);
+
+    expect(chunks).toEqual([
+      {
+        type: 'file',
+        mediaType: 'image/png',
+        url: 'data:image/png;base64,abc123',
+      },
+    ]);
+  });
+
   it('should maintain consistent text IDs when chunk.id changes during text streaming', () => {
     // Similar bug can occur with text-only streaming if the ID changes between chunks
 
@@ -918,6 +1041,104 @@ describe('extractImageOutputs', () => {
   it('should return empty array when tool_outputs is not an array', () => {
     expect(extractImageOutputs({ tool_outputs: 'not-array' })).toEqual([]);
     expect(extractImageOutputs({})).toEqual([]);
+  });
+});
+
+describe('extractFileContentBlocks', () => {
+  it('should extract file content blocks from contentBlocks', () => {
+    const msg = new AIMessageChunk({ content: '', id: 'msg-1' });
+    Object.defineProperty(msg, 'contentBlocks', {
+      get: () => [{ type: 'file', mimeType: 'image/png', data: 'iVBORwkg=' }],
+    });
+
+    const result = extractFileContentBlocks(msg);
+
+    expect(result).toEqual([{ mediaType: 'image/png', data: 'iVBORwkg=' }]);
+  });
+
+  it('should skip file content blocks with empty data', () => {
+    const msg = new AIMessageChunk({ content: '', id: 'msg-1' });
+    Object.defineProperty(msg, 'contentBlocks', {
+      get: () => [{ type: 'file', mimeType: 'image/png', data: '' }],
+    });
+
+    const result = extractFileContentBlocks(msg);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should default to image/png when mimeType is not provided', () => {
+    const msg = new AIMessageChunk({ content: '', id: 'msg-1' });
+    Object.defineProperty(msg, 'contentBlocks', {
+      get: () => [{ type: 'file', data: 'abc123' }],
+    });
+
+    const result = extractFileContentBlocks(msg);
+
+    expect(result).toEqual([{ mediaType: 'image/png', data: 'abc123' }]);
+  });
+
+  it('should extract file content blocks from content array', () => {
+    const msg = {
+      content: [
+        { type: 'text', text: 'Here is an image:' },
+        { type: 'file', mimeType: 'image/jpeg', data: '/9j/4AAQ' },
+      ],
+    };
+
+    const result = extractFileContentBlocks(msg);
+
+    expect(result).toEqual([{ mediaType: 'image/jpeg', data: '/9j/4AAQ' }]);
+  });
+
+  it('should extract file blocks from both contentBlocks and content array', () => {
+    const msg = {
+      content: [{ type: 'file', mimeType: 'image/jpeg', data: 'jpegdata' }],
+      contentBlocks: [{ type: 'file', mimeType: 'image/png', data: 'pngdata' }],
+    };
+
+    const result = extractFileContentBlocks(msg);
+
+    expect(result).toEqual([
+      { mediaType: 'image/png', data: 'pngdata' },
+      { mediaType: 'image/jpeg', data: 'jpegdata' },
+    ]);
+  });
+
+  it('should return empty array for null/undefined', () => {
+    expect(extractFileContentBlocks(null)).toEqual([]);
+    expect(extractFileContentBlocks(undefined)).toEqual([]);
+  });
+
+  it('should return empty array when no file blocks are present', () => {
+    const msg = new AIMessageChunk({ content: 'Hello', id: 'msg-1' });
+    Object.defineProperty(msg, 'contentBlocks', {
+      get: () => [{ type: 'text', text: 'Hello' }],
+    });
+
+    const result = extractFileContentBlocks(msg);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should handle serialized LangChain messages', () => {
+    const msg = {
+      type: 'constructor',
+      id: ['langchain', 'AIMessageChunk'],
+      kwargs: {
+        content: '',
+        id: 'msg-1',
+        contentBlocks: [
+          { type: 'file', mimeType: 'image/png', data: 'serializeddata' },
+        ],
+      },
+    };
+
+    const result = extractFileContentBlocks(msg);
+
+    expect(result).toEqual([
+      { mediaType: 'image/png', data: 'serializeddata' },
+    ]);
   });
 });
 
@@ -1978,5 +2199,73 @@ describe('processLangGraphEvent', () => {
       approvalId: toolCallId,
       toolCallId: toolCallId,
     });
+  });
+
+  it('should handle file content blocks in messages event', () => {
+    const state = createMockState();
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    const msg = new AIMessageChunk({
+      content: '',
+      id: 'msg-1',
+    });
+    Object.defineProperty(msg, 'contentBlocks', {
+      get: () => [{ type: 'file', mimeType: 'image/png', data: 'base64data' }],
+    });
+
+    processLangGraphEvent(
+      ['messages', [msg, { langgraph_step: 1 }]],
+      state,
+      controller,
+    );
+
+    const fileChunks = chunks.filter(
+      c => (c as { type: string }).type === 'file',
+    );
+    expect(fileChunks).toHaveLength(1);
+    expect(fileChunks[0]).toEqual({
+      type: 'file',
+      mediaType: 'image/png',
+      url: 'data:image/png;base64,base64data',
+    });
+  });
+
+  it('should deduplicate file content blocks between messages and values events', () => {
+    const state = createMockState();
+    const chunks: unknown[] = [];
+    const controller = createMockController(chunks);
+
+    // First: emit file content block in messages event
+    const msg = new AIMessageChunk({
+      content: '',
+      id: 'msg-1',
+    });
+    Object.defineProperty(msg, 'contentBlocks', {
+      get: () => [{ type: 'file', mimeType: 'image/png', data: 'imagedata' }],
+    });
+
+    processLangGraphEvent(
+      ['messages', [msg, { langgraph_step: 1 }]],
+      state,
+      controller,
+    );
+
+    // Then: same file in values event should not be re-emitted
+    const valuesMsg = new AIMessage({
+      content: '',
+      id: 'msg-1',
+    });
+    Object.defineProperty(valuesMsg, 'contentBlocks', {
+      get: () => [{ type: 'file', mimeType: 'image/png', data: 'imagedata' }],
+    });
+    const values = { messages: [valuesMsg] };
+
+    processLangGraphEvent(['values', values], state, controller);
+
+    const fileChunks = chunks.filter(
+      c => (c as { type: string }).type === 'file',
+    );
+    expect(fileChunks).toHaveLength(1);
   });
 });

--- a/packages/langchain/src/utils.test.ts
+++ b/packages/langchain/src/utils.test.ts
@@ -397,6 +397,7 @@ describe('processModelChunk', () => {
       messageId: 'default',
       reasoningStarted: false,
       textStarted: false,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -422,6 +423,7 @@ describe('processModelChunk', () => {
       messageId: 'msg-1',
       reasoningStarted: false,
       textStarted: true,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -443,6 +445,7 @@ describe('processModelChunk', () => {
       messageId: 'default',
       reasoningStarted: false,
       textStarted: false,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -466,6 +469,7 @@ describe('processModelChunk', () => {
       messageId: 'default',
       reasoningStarted: false,
       textStarted: false,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -490,6 +494,7 @@ describe('processModelChunk', () => {
       messageId: 'default',
       reasoningStarted: false,
       textStarted: false,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -518,6 +523,7 @@ describe('processModelChunk', () => {
       messageId: 'default',
       reasoningStarted: false,
       textStarted: false,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -557,6 +563,7 @@ describe('processModelChunk', () => {
       messageId: 'default',
       reasoningStarted: false,
       textStarted: false,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -597,6 +604,7 @@ describe('processModelChunk', () => {
       messageId: 'default',
       reasoningStarted: false,
       textStarted: false,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -629,6 +637,7 @@ describe('processModelChunk', () => {
       messageId: 'default',
       reasoningStarted: false,
       textStarted: false,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -666,6 +675,7 @@ describe('processModelChunk', () => {
       textStarted: false,
       reasoningMessageId: null as string | null,
       textMessageId: null as string | null,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -726,6 +736,7 @@ describe('processModelChunk', () => {
       messageId: 'default',
       reasoningStarted: false,
       textStarted: false,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -756,6 +767,7 @@ describe('processModelChunk', () => {
       messageId: 'default',
       reasoningStarted: false,
       textStarted: false,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -780,6 +792,7 @@ describe('processModelChunk', () => {
       messageId: 'default',
       reasoningStarted: false,
       textStarted: false,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -803,6 +816,7 @@ describe('processModelChunk', () => {
       messageId: 'default',
       reasoningStarted: false,
       textStarted: false,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);
@@ -844,6 +858,7 @@ describe('processModelChunk', () => {
       textStarted: false,
       reasoningMessageId: null as string | null,
       textMessageId: null as string | null,
+      emittedImages: new Set<string>(),
     };
     const chunks: unknown[] = [];
     const controller = createMockController(chunks);

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -393,17 +393,10 @@ export function processModelChunk(
     reasoningMessageId?: string | null;
     /** Track the ID used for text-start to ensure text-end uses the same ID */
     textMessageId?: string | null;
-    emittedImages?: Set<string>;
+    emittedImages: Set<string>;
   },
   controller: ReadableStreamDefaultController<UIMessageChunk>,
 ): void {
-  /**
-   * Initialize emittedImages set if not present
-   */
-  if (!state.emittedImages) {
-    state.emittedImages = new Set<string>();
-  }
-
   /**
    * Get the message ID from the chunk if available
    */
@@ -447,8 +440,8 @@ export function processModelChunk(
   const fileBlocks = extractFileContentBlocks(chunk);
   for (const fileBlock of fileBlocks) {
     const fileKey = `cb-file:${fileBlock.mediaType}:${fileBlock.data.length}:${fileBlock.data.substring(0, Math.min(50, fileBlock.data.length))}`;
-    if (!state.emittedImages!.has(fileKey)) {
-      state.emittedImages!.add(fileKey);
+    if (!state.emittedImages.has(fileKey)) {
+      state.emittedImages.add(fileKey);
       controller.enqueue({
         type: 'file',
         mediaType: fileBlock.mediaType,

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -22,6 +22,7 @@ import {
   type ThinkingContentBlock,
   type GPT5ReasoningOutput,
   type ImageGenerationOutput,
+  type FileContentBlock,
 } from './types';
 
 /**
@@ -434,6 +435,24 @@ export function processModelChunk(
         type: 'file',
         mediaType,
         url: `data:${mediaType};base64,${imageOutput.result}`,
+      });
+      state.started = true;
+    }
+  }
+
+  /**
+   * Handle file content blocks from contentBlocks or content array
+   * Skips blocks with empty data (common during streaming before data arrives)
+   */
+  const fileBlocks = extractFileContentBlocks(chunk);
+  for (const fileBlock of fileBlocks) {
+    const fileKey = `cb-file:${fileBlock.mediaType}:${fileBlock.data.length}:${fileBlock.data.substring(0, Math.min(50, fileBlock.data.length))}`;
+    if (!state.emittedImages!.has(fileKey)) {
+      state.emittedImages!.add(fileKey);
+      controller.enqueue({
+        type: 'file',
+        mediaType: fileBlock.mediaType,
+        url: `data:${fileBlock.mediaType};base64,${fileBlock.data}`,
       });
       state.started = true;
     }
@@ -951,6 +970,69 @@ export function extractImageOutputs(
 }
 
 /**
+ * Extracts file content blocks from contentBlocks or content array.
+ * Returns file blocks that have non-empty data, skipping empty ones.
+ *
+ * @param msg - The message to extract file content blocks from.
+ * @returns Array of extracted file blocks with mediaType and data.
+ */
+export function extractFileContentBlocks(
+  msg: unknown,
+): Array<{ mediaType: string; data: string }> {
+  if (msg == null || typeof msg !== 'object') return [];
+
+  const msgObj = msg as Record<string, unknown>;
+  const kwargs =
+    msgObj.kwargs && typeof msgObj.kwargs === 'object'
+      ? (msgObj.kwargs as Record<string, unknown>)
+      : msgObj;
+
+  const results: Array<{ mediaType: string; data: string }> = [];
+
+  const contentBlocks = (kwargs as { contentBlocks?: unknown[] }).contentBlocks;
+  if (Array.isArray(contentBlocks)) {
+    for (const block of contentBlocks) {
+      if (
+        block != null &&
+        typeof block === 'object' &&
+        'type' in block &&
+        (block as { type: string }).type === 'file'
+      ) {
+        const fileBlock = block as FileContentBlock;
+        if (fileBlock.data) {
+          results.push({
+            mediaType: fileBlock.mimeType || 'image/png',
+            data: fileBlock.data,
+          });
+        }
+      }
+    }
+  }
+
+  const content = (kwargs as { content?: unknown }).content;
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (
+        block != null &&
+        typeof block === 'object' &&
+        'type' in block &&
+        (block as { type: string }).type === 'file'
+      ) {
+        const fileBlock = block as FileContentBlock;
+        if (fileBlock.data) {
+          results.push({
+            mediaType: fileBlock.mimeType || 'image/png',
+            data: fileBlock.data,
+          });
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
  * Processes a LangGraph event and emits UI message chunks.
  *
  * @param event - The event to process.
@@ -1097,6 +1179,23 @@ export function processLangGraphEvent(
               type: 'file',
               mediaType,
               url: `data:${mediaType};base64,${imageOutput.result}`,
+            });
+          }
+        }
+
+        /**
+         * Handle file content blocks from contentBlocks or content array
+         * Skips blocks with empty data (common during streaming before data arrives)
+         */
+        const fileBlocks = extractFileContentBlocks(msg);
+        for (const fileBlock of fileBlocks) {
+          const fileKey = `cb-file:${fileBlock.mediaType}:${fileBlock.data.length}:${fileBlock.data.substring(0, Math.min(50, fileBlock.data.length))}`;
+          if (!emittedImages.has(fileKey)) {
+            emittedImages.add(fileKey);
+            controller.enqueue({
+              type: 'file',
+              mediaType: fileBlock.mediaType,
+              url: `data:${fileBlock.mediaType};base64,${fileBlock.data}`,
             });
           }
         }
@@ -1521,6 +1620,24 @@ export function processLangGraphEvent(
                 });
                 controller.enqueue({ type: 'reasoning-end', id: msgId });
                 emittedReasoningIds.add(reasoningId);
+              }
+            }
+
+            /**
+             * Check for file content blocks that weren't streamed
+             * Skip blocks we've already emitted during the messages phase
+             */
+            const fileBlocks = extractFileContentBlocks(msg);
+            for (let i = 0; i < fileBlocks.length; i++) {
+              const fileBlock = fileBlocks[i];
+              const fileKey = `cb-file:${fileBlock.mediaType}:${fileBlock.data.length}:${fileBlock.data.substring(0, Math.min(50, fileBlock.data.length))}`;
+              if (!emittedImages.has(fileKey)) {
+                emittedImages.add(fileKey);
+                controller.enqueue({
+                  type: 'file',
+                  mediaType: fileBlock.mediaType,
+                  url: `data:${fileBlock.mediaType};base64,${fileBlock.data}`,
+                });
               }
             }
           }


### PR DESCRIPTION
## Background

File content blocks (type: 'file') in contentBlocks were silently dropped instead of being emitted as UIMessageChunk file events to the stream. This caused image/file responses from providers like google nano banana to be missing when streaming.

## Summary

File content blocks (type: 'file') in contentBlocks from providers like Anthropic and GPT-5 were silently dropped instead of being emitted as UIMessageChunk file events to the stream. This caused image/file responses to be missing when streaming.

For example, a response containing:

```
[
  { "type": "text", "text": "Here is a crayon drawing of a house with the sun shining overhead: " },
  { "type": "file", "mimeType": "image/png", "data": "<base64...>" }
]
```

Would only emit the text deltas — the file block was completely ignored.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
