### PR TITLE
fix(ai): enforce callOptionsSchema at runtime in ToolLoopAgent

### DIFF
--- a/.changeset/enforce-call-options-schema.md
+++ b/.changeset/enforce-call-options-schema.md
@@ -1,0 +1,9 @@
+---
+"ai": patch
+---
+
+fix(ai): enforce `callOptionsSchema` at runtime in `ToolLoopAgent`
+
+`ToolLoopAgentSettings.callOptionsSchema` was declared and documented as a runtime schema for `options`, but `tool-loop-agent.ts` never invoked it. Any invariant a developer encoded in the schema was silently bypassed at runtime, and unchecked `options` flowed straight into `prepareCall` and any `instructions` template that interpolated them.
+
+`ToolLoopAgent.prepareCall` now validates caller-supplied `options` against `callOptionsSchema` (when set) via `safeValidateTypes`, throwing `InvalidArgumentError` on failure before forwarding to `prepareCall` / `generateText` / `streamText`.

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -3464,7 +3464,7 @@ describe('ToolLoopAgent', () => {
           // intentionally outside the enum to exercise schema enforcement
           options: { topic: 'evil' as 'legal' },
         }),
-      ).rejects.toThrow(/callOptionsSchema/);
+      ).rejects.toThrow(/Type validation failed for options/);
 
       expect(modelCalled).toBe(false);
     });

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -3424,4 +3424,87 @@ describe('ToolLoopAgent', () => {
       });
     });
   });
+
+  describe('callOptionsSchema', () => {
+    it('should reject options that fail callOptionsSchema validation before invoking the model', async () => {
+      let modelCalled = false;
+      const agent = new ToolLoopAgent<{ topic: 'legal' | 'medical' }>({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            modelCalled = true;
+            return {
+              content: [{ type: 'text', text: 'reply' }],
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                cachedInputTokens: undefined,
+                inputTokens: {
+                  total: 1,
+                  noCache: 1,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: {
+                  total: 1,
+                  text: 1,
+                  reasoning: undefined,
+                },
+              },
+              warnings: [],
+            };
+          },
+        }),
+        callOptionsSchema: z.object({
+          topic: z.enum(['legal', 'medical']),
+        }),
+      });
+
+      await expect(
+        agent.generate({
+          prompt: 'hi',
+          // intentionally outside the enum to exercise schema enforcement
+          options: { topic: 'evil' as 'legal' },
+        }),
+      ).rejects.toThrow(/callOptionsSchema/);
+
+      expect(modelCalled).toBe(false);
+    });
+
+    it('should pass through options that satisfy callOptionsSchema', async () => {
+      const agent = new ToolLoopAgent<{ topic: 'legal' | 'medical' }>({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            return {
+              content: [{ type: 'text', text: 'reply' }],
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                cachedInputTokens: undefined,
+                inputTokens: {
+                  total: 1,
+                  noCache: 1,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: {
+                  total: 1,
+                  text: 1,
+                  reasoning: undefined,
+                },
+              },
+              warnings: [],
+            };
+          },
+        }),
+        callOptionsSchema: z.object({
+          topic: z.enum(['legal', 'medical']),
+        }),
+      });
+
+      const result = await agent.generate({
+        prompt: 'hi',
+        options: { topic: 'legal' },
+      });
+
+      expect(result.text).toBe('reply');
+    });
+  });
 });

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -1,6 +1,5 @@
 import type { Context, ModelMessage, ToolSet } from '@ai-sdk/provider-utils';
-import { safeValidateTypes } from '@ai-sdk/provider-utils';
-import { InvalidArgumentError } from '../error';
+import { validateTypes } from '@ai-sdk/provider-utils';
 import { generateText } from '../generate-text/generate-text';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
 import { Output } from '../generate-text/output';
@@ -85,26 +84,16 @@ export class ToolLoopAgent<
     > &
       Prompt
   > {
-    // Validate caller-supplied `options` against `callOptionsSchema` if one
-    // was provided. Without this, the schema was effectively dead code:
-    // developers wiring untrusted input into `options` would get no runtime
-    // protection despite naming the field `callOptionsSchema`.
     if (
       this.settings.callOptionsSchema != null &&
       options.options !== undefined
     ) {
-      const result = await safeValidateTypes({
+      const validatedOptions = await validateTypes({
         value: options.options,
         schema: this.settings.callOptionsSchema,
+        context: { field: 'options' },
       });
-      if (!result.success) {
-        throw new InvalidArgumentError({
-          parameter: 'options',
-          value: options.options,
-          message: `options failed callOptionsSchema validation: ${result.error.message}`,
-        });
-      }
-      options = { ...options, options: result.value };
+      options = { ...options, options: validatedOptions };
     }
 
     const {

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -1,4 +1,6 @@
 import type { Context, ModelMessage, ToolSet } from '@ai-sdk/provider-utils';
+import { safeValidateTypes } from '@ai-sdk/provider-utils';
+import { InvalidArgumentError } from '../error';
 import { generateText } from '../generate-text/generate-text';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
 import { Output } from '../generate-text/output';
@@ -83,6 +85,28 @@ export class ToolLoopAgent<
     > &
       Prompt
   > {
+    // Validate caller-supplied `options` against `callOptionsSchema` if one
+    // was provided. Without this, the schema was effectively dead code:
+    // developers wiring untrusted input into `options` would get no runtime
+    // protection despite naming the field `callOptionsSchema`.
+    if (
+      this.settings.callOptionsSchema != null &&
+      options.options !== undefined
+    ) {
+      const result = await safeValidateTypes({
+        value: options.options,
+        schema: this.settings.callOptionsSchema,
+      });
+      if (!result.success) {
+        throw new InvalidArgumentError({
+          parameter: 'options',
+          value: options.options,
+          message: `options failed callOptionsSchema validation: ${result.error.message}`,
+        });
+      }
+      options = { ...options, options: result.value };
+    }
+
     const {
       experimental_onStart: _settingsOnStart,
       experimental_onStepStart: _settingsOnStepStart,


### PR DESCRIPTION
## Background

`ToolLoopAgentSettings.callOptionsSchema` is declared and documented as a runtime schema for caller-supplied `options`, but `ToolLoopAgent.prepareCall` never invokes it. Any invariant a developer encodes in that schema is silently bypassed at runtime, and unchecked `options` flow straight into `prepareCall` and any `instructions` template that interpolates them — defeating both the validation guarantee and any input-shape assumptions downstream code makes.

Splitting this out per maintainer feedback on #14749 that `callOptionsSchema` enforcement should be its own dedicated PR.

## Summary

- `packages/ai/src/agent/tool-loop-agent.ts`: at the top of `prepareCall`, when `callOptionsSchema` is set and the caller passed `options`, validate via `safeValidateTypes`. On failure, throw `InvalidArgumentError` with the schema's error message. On success, swap the caller-supplied `options` for the validated (parsed) value so any schema transforms or defaults take effect for the rest of the call.
- `packages/ai/src/agent/tool-loop-agent.test.ts`: regression tests covering the rejection path (out-of-enum value rejected before reaching the model) and the accept path (in-enum value passes through and the model is invoked normally).
- Patch changeset.

The check is gated on `options !== undefined`, so existing callers that don't supply `options` are unaffected. Only agents that opted into `callOptionsSchema` see new behaviour — and that behaviour is exactly what the field name and docs already promised.

## Manual Verification

- `pnpm --filter ai test:node -- src/agent/tool-loop-agent.test.ts` — passes, including the two new `callOptionsSchema` tests.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

Documentation is unchanged: the existing `callOptionsSchema` JSDoc already describes the intended behaviour; this PR makes the runtime match the docs.

## Future Work

None — this PR makes `callOptionsSchema` behave as documented.

## Related Issues

- Split out from #14749 (closed) per maintainer feedback.

> Detected automatically by [https://github.com/etairl/Probus](https://github.com/vercel/ai/pull/Probus)