### PR TITLE
fix(ai): harden getMediaTypeFromUrl against prototype-property collision

### DIFF
--- a/.changeset/get-media-type-from-url-prototype.md
+++ b/.changeset/get-media-type-from-url-prototype.md
@@ -1,0 +1,9 @@
+---
+"ai": patch
+---
+
+fix(ai): harden `getMediaTypeFromUrl` against prototype-property collisions
+
+`getMediaTypeFromUrl` (used to infer media types for `file-url` / `image-url` parts) used `ext in URL_EXTENSION_TO_MEDIA_TYPE` against a plain object literal. A URL ending in `.constructor` therefore resolved through the prototype chain and returned the `Object` constructor function, violating the helper's `: string` return type and forwarding a non-string value to provider adapters.
+
+Switch to `Object.hasOwn(...)` so attacker-controlled extensions like `.constructor` cannot resolve to inherited `Object.prototype` keys.

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -2247,6 +2247,41 @@ describe('convertToLanguageModelMessage', () => {
         );
       });
 
+      it('should fall back when file-url extension collides with Object.prototype (e.g. `.constructor`)', () => {
+        // Regression: a previous implementation used `ext in URL_EXTENSION_TO_MEDIA_TYPE`,
+        // which traverses the prototype chain and returned the `Object`
+        // constructor (a function) for attacker-controlled extensions like
+        // `.constructor`, breaking the helper's `: string` contract.
+        convertToLanguageModelMessage({
+          message: {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'toolName',
+                toolCallId: 'toolCallId',
+                output: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'file-url',
+                      url: 'https://example.com/foo.constructor',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          downloadedAssets: {},
+        });
+
+        expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
+        expect(mockProcessEmitWarning).toHaveBeenCalledWith(
+          `AI SDK Warning: Deprecated: ""tool-result" content of type "file-url" without mediaType". The "file-url" tool result content part with URL "https://example.com/foo.constructor" is missing a "mediaType". Unable to infer media type from URL. Defaulting to 'application/octet-stream'.`,
+          { type: 'DeprecationWarning' },
+        );
+      });
+
       it('should emit DeprecationWarning for deprecated types in assistant message tool-result content', () => {
         convertToLanguageModelMessage({
           message: {

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -742,9 +742,6 @@ function getMediaTypeFromUrl(
   try {
     const pathname = new URL(url).pathname;
     const ext = pathname.split('.').pop()?.toLowerCase();
-    // Use `Object.hasOwn` instead of `in` so attacker-controlled extensions
-    // like `constructor` cannot resolve to inherited `Object.prototype`
-    // members and leak a non-string value through this `: string` helper.
     if (ext && Object.hasOwn(URL_EXTENSION_TO_MEDIA_TYPE, ext)) {
       return URL_EXTENSION_TO_MEDIA_TYPE[ext];
     }

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -742,7 +742,10 @@ function getMediaTypeFromUrl(
   try {
     const pathname = new URL(url).pathname;
     const ext = pathname.split('.').pop()?.toLowerCase();
-    if (ext && ext in URL_EXTENSION_TO_MEDIA_TYPE) {
+    // Use `Object.hasOwn` instead of `in` so attacker-controlled extensions
+    // like `constructor` cannot resolve to inherited `Object.prototype`
+    // members and leak a non-string value through this `: string` helper.
+    if (ext && Object.hasOwn(URL_EXTENSION_TO_MEDIA_TYPE, ext)) {
       return URL_EXTENSION_TO_MEDIA_TYPE[ext];
     }
   } catch {


### PR DESCRIPTION
## Background

`getMediaTypeFromUrl` in `convert-to-language-model-prompt.ts` does an `ext in URL_EXTENSION_TO_MEDIA_TYPE` check on a plain object literal. Because plain objects inherit from `Object.prototype`, the `in` operator returns `true` for inherited keys like `constructor`, `toString`, `hasOwnProperty`, etc. A URL ending in `.constructor` (or any other `Object.prototype` member) therefore takes the lookup branch and returns the inherited value — for `.constructor`, that's the `Object` constructor function, which is then forwarded as `mediaType` to provider adapters.

This is a low-severity correctness/typing bug rather than an exploit path, but it's worth fixing: the helper's return type is `string | undefined` and a non-string slipping through can break downstream code paths that assume a string `mediaType`.

Splitting this out per maintainer feedback on #14749 that the media-type fix should be its own PR.

## Summary

- `packages/ai/src/prompt/convert-to-language-model-prompt.ts`: replace `ext in URL_EXTENSION_TO_MEDIA_TYPE` with `Object.hasOwn(URL_EXTENSION_TO_MEDIA_TYPE, ext)` so only own-property extensions are matched.
- `packages/ai/src/prompt/convert-to-language-model-prompt.test.ts`: regression test for a URL ending in `.constructor` — asserts the helper falls back to the no-extension behaviour instead of returning a non-string value from the prototype chain.
- Patch changeset.

The change is one line of production code; the table is treated as a closed lookup, which is what the original code intended.

## Manual Verification

- `pnpm --filter ai test:node -- src/prompt/convert-to-language-model-prompt.test.ts` — passes, including the new prototype-collision regression test.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

No documentation change — `getMediaTypeFromUrl` is internal.

## Future Work

None. If other helpers in the prompt layer use `in` against plain object literals indexed by user input, the same prototype-confusion fix would apply, but I didn't spot any others while looking at this one.

## Related Issues

- Split out from #14749 (closed) per maintainer feedback.

> Detected automatically by [https://github.com/etairl/Probus](Probus)