### PR TITLE
fix(ai): reject system messages in messages or prompt by default (opt-in)

### DIFF
--- a/.changeset/yellow-buckets-peel.md
+++ b/.changeset/yellow-buckets-peel.md
@@ -1,0 +1,5 @@
+---
+"ai": major
+---
+
+fix(ai): reject system messages in messages or prompt by default (opt-in)

--- a/content/docs/02-foundations/03-prompts.mdx
+++ b/content/docs/02-foundations/03-prompts.mdx
@@ -45,6 +45,14 @@ const result = await generateText({
 System prompts are the initial set of instructions given to models that help guide and constrain the models' behaviors and responses.
 You can set system prompts using the `system` property.
 System prompts work with both the `prompt` and the `messages` properties.
+System messages in `prompt` or `messages` are rejected by default; use the `system` property for system instructions, or set `allowSystemInMessages: true` when you need to send existing message histories that contain system messages.
+
+<Note type="warning">
+  Opting in with `allowSystemInMessages` can create a prompt injection risk
+  where users can override or set the system prompt by injecting system
+  messages. In most cases, only trusted server-side code should set system
+  instructions via the `system` or `instructions` property.
+</Note>
 
 ```ts highlight="3-6"
 const result = await generateText({
@@ -58,11 +66,6 @@ const result = await generateText({
     `Please suggest the best tourist activities for me to do.`,
 });
 ```
-
-<Note>
-  When you use a message prompt, you can also use system messages instead of a
-  system prompt.
-</Note>
 
 ## Message Prompts
 
@@ -118,10 +121,9 @@ const { text } = await generateText({
 For granular control over applying provider options at the message level, you can pass `providerOptions` to the message object:
 
 ```ts
-import { ModelMessage } from 'ai';
-
-const messages: ModelMessage[] = [
-  {
+const result = await generateText({
+  model: __MODEL__,
+  system: {
     role: 'system',
     content: 'Cached system message',
     providerOptions: {
@@ -129,7 +131,8 @@ const messages: ModelMessage[] = [
       anthropic: { cacheControl: { type: 'ephemeral' } },
     },
   },
-];
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
 ```
 
 #### Message Part Level

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -323,6 +323,13 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'allowSystemInMessages',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `system` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
+    },
+    {
       name: 'tools',
       type: 'ToolSet',
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -324,6 +324,13 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'allowSystemInMessages',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `system` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
+    },
+    {
       name: 'tools',
       type: 'ToolSet',
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
@@ -26,8 +26,11 @@ type SystemModelMessage = {
 You can access the Zod schema for `SystemModelMessage` with the `systemModelMessageSchema` export.
 
 <Note>
-  Using the "system" property instead of a system message is recommended to
-  enhance resilience against prompt injection attacks.
+  Use the top-level `system` property instead of a system message for system
+  instructions. AI SDK functions reject system messages in `prompt` or
+  `messages` by default unless `allowSystemInMessages` is set to `true`.
+  Opting in can create a prompt injection risk if users can inject system
+  messages.
 </Note>
 
 ### `UserModelMessage`

--- a/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
+++ b/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
@@ -256,6 +256,13 @@ To see `streamUI` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'allowSystemInMessages',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `system` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
+    },
+    {
       name: 'maxOutputTokens',
       type: 'number',
       isOptional: true,

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -41,6 +41,51 @@ If your `package.json` does not already include `"type": "module"`, add it or re
 
 ## AI SDK Core
 
+### Prompt Messages: System Messages in `prompt` or `messages` Are Rejected by Default
+
+AI SDK 7 rejects system messages in the `prompt` or `messages` fields by default. System instructions should usually be passed with the top-level `system` option.
+
+This can break older persisted chats or custom prompt arrays that include `{ role: 'system' }` messages:
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  messages: [
+    { role: 'system', content: 'You are a helpful assistant.' },
+    { role: 'user', content: 'Hello!' },
+  ],
+});
+```
+
+Move system instructions to the `system` option when possible:
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  system: 'You are a helpful assistant.',
+  messages: [{ role: 'user', content: 'Hello!' }],
+});
+```
+
+If you need to keep existing chat histories that already contain system messages, opt in to the previous behavior with `allowSystemInMessages: true`:
+
+<Note type="warning">
+  Only use `allowSystemInMessages` for trusted messages. If users can submit or
+  edit these messages, they could inject a system message that overrides or sets
+  the system prompt. In most cases, system instructions should only be set by
+  trusted server-side code through the `system` or `instructions` property.
+</Note>
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  allowSystemInMessages: true,
+  messages: persistedMessages,
+});
+```
+
+This applies to AI SDK functions that accept `prompt` or `messages`, including `generateText`, `streamText`, `generateObject`, `streamObject`, and `streamUI`.
+
 ### Telemetry: OpenTelemetry Moved to `@ai-sdk/otel` — Explicit Registration Required
 
 OpenTelemetry span collection is no longer built into the `ai` package. To continue receiving OpenTelemetry traces, you must install the new `@ai-sdk/otel` package and register the `OpenTelemetry` instance globally.

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -322,10 +322,12 @@ export async function generateObject<
 
   try {
     const standardizedPrompt = await standardizePrompt({
-      system,
-      prompt,
-      messages,
-    } as Prompt);
+      prompt: {
+        system,
+        prompt,
+        messages,
+      } as Prompt,
+    });
 
     const promptMessages = await convertToLanguageModelPrompt({
       prompt: standardizedPrompt,

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -54,6 +54,7 @@ const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.
@@ -232,6 +233,7 @@ export async function generateObject<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     maxRetries: maxRetriesArg,
     abortSignal,
     headers,
@@ -326,6 +328,7 @@ export async function generateObject<
         system,
         prompt,
         messages,
+        allowSystemInMessages,
       } as Prompt,
     });
 

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -324,13 +324,11 @@ export async function generateObject<
 
   try {
     const standardizedPrompt = await standardizePrompt({
-      prompt: {
-        system,
-        prompt,
-        messages,
-        allowSystemInMessages,
-      } as Prompt,
-    });
+      system,
+      prompt,
+      messages,
+      allowSystemInMessages,
+    } as Prompt);
 
     const promptMessages = await convertToLanguageModelPrompt({
       prompt: standardizedPrompt,

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -535,13 +535,11 @@ class DefaultStreamObjectResult<
       });
 
       const standardizedPrompt = await standardizePrompt({
-        prompt: {
-          system,
-          prompt,
-          messages,
-          allowSystemInMessages,
-        } as Prompt,
-      });
+        system,
+        prompt,
+        messages,
+        allowSystemInMessages,
+      } as Prompt);
 
       const callOptions = {
         responseFormat: {

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -530,10 +530,12 @@ class DefaultStreamObjectResult<
       });
 
       const standardizedPrompt = await standardizePrompt({
-        system,
-        prompt,
-        messages,
-      } as Prompt);
+        prompt: {
+          system,
+          prompt,
+          messages,
+        } as Prompt,
+      });
 
       const callOptions = {
         responseFormat: {

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -123,6 +123,7 @@ export type StreamObjectOnFinishCallback<RESULT> = (event: {
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.
@@ -313,6 +314,7 @@ export function streamObject<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     maxRetries,
     abortSignal,
     headers,
@@ -370,6 +372,7 @@ export function streamObject<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     schemaName,
     schemaDescription,
     providerOptions,
@@ -422,6 +425,7 @@ class DefaultStreamObjectResult<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     schemaName,
     schemaDescription,
     providerOptions,
@@ -446,6 +450,7 @@ class DefaultStreamObjectResult<
     system: Prompt['system'];
     prompt: Prompt['prompt'];
     messages: Prompt['messages'];
+    allowSystemInMessages: Prompt['allowSystemInMessages'];
     schemaName: string | undefined;
     schemaDescription: string | undefined;
     providerOptions: ProviderOptions | undefined;
@@ -534,6 +539,7 @@ class DefaultStreamObjectResult<
           system,
           prompt,
           messages,
+          allowSystemInMessages,
         } as Prompt,
       });
 

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1,4 +1,5 @@
 import {
+  InvalidPromptError,
   LanguageModelV4CallOptions,
   LanguageModelV4FunctionTool,
   LanguageModelV4Prompt,
@@ -935,6 +936,39 @@ describe('generateText', () => {
       expect(startEvent.maxOutputTokens).toBe(100);
       expect(startEvent.temperature).toBe(0.5);
       expect(startEvent.maxRetries).toBe(2);
+    });
+
+    it('should reject system messages in messages by default', async () => {
+      await expect(async () => {
+        await generateText({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => ({
+              content: [{ type: 'text', text: 'Hello!' }],
+              ...dummyResponseValues,
+            }),
+          }),
+          messages: [{ role: 'system', content: 'INSTRUCTIONS' }],
+        });
+      }).rejects.toThrow(InvalidPromptError);
+    });
+
+    it('should allow system messages in messages when allowSystemInMessages is true', async () => {
+      const model = new MockLanguageModelV4({
+        doGenerate: async () => ({
+          content: [{ type: 'text', text: 'Hello!' }],
+          ...dummyResponseValues,
+        }),
+      });
+
+      await generateText({
+        model,
+        allowSystemInMessages: true,
+        messages: [{ role: 'system', content: 'INSTRUCTIONS' }],
+      });
+
+      expect(model.doGenerateCalls[0].prompt).toEqual([
+        { role: 'system', content: 'INSTRUCTIONS' },
+      ]);
     });
 
     it('should be called before doGenerate', async () => {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -465,10 +465,12 @@ export async function generateText<
   );
 
   const initialPrompt = await standardizePrompt({
-    system,
-    prompt,
-    messages,
-  } as Prompt);
+    prompt: {
+      system,
+      prompt,
+      messages,
+    } as Prompt,
+  });
 
   const callId = generateCallId();
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -181,6 +181,7 @@ export type GenerateTextOnFinishCallback<
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.
@@ -234,6 +235,7 @@ export async function generateText<
   system,
   prompt,
   messages,
+  allowSystemInMessages,
   maxRetries: maxRetriesArg,
   abortSignal,
   timeout,
@@ -469,6 +471,7 @@ export async function generateText<
       system,
       prompt,
       messages,
+      allowSystemInMessages,
     } as Prompt,
   });
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -467,13 +467,11 @@ export async function generateText<
   );
 
   const initialPrompt = await standardizePrompt({
-    prompt: {
-      system,
-      prompt,
-      messages,
-      allowSystemInMessages,
-    } as Prompt,
-  });
+    system,
+    prompt,
+    messages,
+    allowSystemInMessages,
+  } as Prompt);
 
   const callId = generateCallId();
 

--- a/packages/ai/src/generate-text/stream-language-model-call.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.ts
@@ -244,10 +244,12 @@ export async function streamLanguageModelCall<
   const effectiveCallId = callId ?? generateCallId();
 
   const standardizedPrompt = await standardizePrompt({
-    system,
-    prompt,
-    messages,
-  } as Prompt);
+    prompt: {
+      system,
+      prompt,
+      messages,
+    } as Prompt,
+  });
 
   const promptMessages = await convertToLanguageModelPrompt({
     prompt: {

--- a/packages/ai/src/generate-text/stream-language-model-call.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.ts
@@ -135,6 +135,7 @@ export type LanguageModelStreamPart<TOOLS extends ToolSet = ToolSet> =
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.
@@ -179,6 +180,7 @@ export async function streamLanguageModelCall<
   prompt,
   system,
   messages,
+  allowSystemInMessages,
   download,
   abortSignal,
   headers,
@@ -248,6 +250,7 @@ export async function streamLanguageModelCall<
       system,
       prompt,
       messages,
+      allowSystemInMessages,
     } as Prompt,
   });
 

--- a/packages/ai/src/generate-text/stream-language-model-call.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.ts
@@ -246,13 +246,11 @@ export async function streamLanguageModelCall<
   const effectiveCallId = callId ?? generateCallId();
 
   const standardizedPrompt = await standardizePrompt({
-    prompt: {
-      system,
-      prompt,
-      messages,
-      allowSystemInMessages,
-    } as Prompt,
-  });
+    system,
+    prompt,
+    messages,
+    allowSystemInMessages,
+  } as Prompt);
 
   const promptMessages = await convertToLanguageModelPrompt({
     prompt: {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -263,6 +263,7 @@ export type StreamTextOnStepStartCallback<
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.
@@ -311,6 +312,7 @@ export function streamText<
   system,
   prompt,
   messages,
+  allowSystemInMessages,
   maxRetries,
   abortSignal,
   timeout,
@@ -589,6 +591,7 @@ export function streamText<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     tools,
     toolsContext,
     runtimeContext,
@@ -777,6 +780,7 @@ class DefaultStreamTextResult<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     tools,
     toolChoice,
     transforms,
@@ -824,6 +828,7 @@ class DefaultStreamTextResult<
     system: Prompt['system'];
     prompt: Prompt['prompt'];
     messages: Prompt['messages'];
+    allowSystemInMessages: Prompt['allowSystemInMessages'];
     tools: TOOLS | undefined;
     toolChoice: ToolChoice<TOOLS> | undefined;
     transforms: Array<StreamTextTransform<TOOLS>>;
@@ -1328,6 +1333,7 @@ class DefaultStreamTextResult<
           system,
           prompt,
           messages,
+          allowSystemInMessages,
         } as Prompt,
       });
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1329,13 +1329,11 @@ class DefaultStreamTextResult<
 
     (async () => {
       const initialPrompt = await standardizePrompt({
-        prompt: {
-          system,
-          prompt,
-          messages,
-          allowSystemInMessages,
-        } as Prompt,
-      });
+        system,
+        prompt,
+        messages,
+        allowSystemInMessages,
+      } as Prompt);
 
       await notify({
         event: {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1324,10 +1324,12 @@ class DefaultStreamTextResult<
 
     (async () => {
       const initialPrompt = await standardizePrompt({
-        system,
-        prompt,
-        messages,
-      } as Prompt);
+        prompt: {
+          system,
+          prompt,
+          messages,
+        } as Prompt,
+      });
 
       await notify({
         event: {

--- a/packages/ai/src/prompt/prompt.ts
+++ b/packages/ai/src/prompt/prompt.ts
@@ -9,6 +9,15 @@ export type Prompt = {
    * System message to include in the prompt. Can be used with `prompt` or `messages`.
    */
   system?: string | SystemModelMessage | Array<SystemModelMessage>;
+
+  /**
+   * Whether system messages are allowed in the `prompt` or `messages` fields.
+   *
+   * When disabled, system messages must be provided through the `system` option.
+   *
+   * @default false
+   */
+  allowSystemInMessages?: boolean;
 } & (
   | {
       /**

--- a/packages/ai/src/prompt/standardize-prompt.test.ts
+++ b/packages/ai/src/prompt/standardize-prompt.test.ts
@@ -6,14 +6,12 @@ describe('standardizePrompt', () => {
   it('should throw InvalidPromptError when messages contain a system message by default', async () => {
     await expect(async () => {
       await standardizePrompt({
-        prompt: {
-          messages: [
-            {
-              role: 'system',
-              content: 'INSTRUCTIONS',
-            },
-          ],
-        },
+        messages: [
+          {
+            role: 'system',
+            content: 'INSTRUCTIONS',
+          },
+        ],
       });
     }).rejects.toThrow(InvalidPromptError);
   });
@@ -21,33 +19,29 @@ describe('standardizePrompt', () => {
   it('should throw InvalidPromptError when prompt messages contain a system message by default', async () => {
     await expect(async () => {
       await standardizePrompt({
-        prompt: {
-          prompt: [
-            {
-              role: 'system',
-              content: 'INSTRUCTIONS',
-            },
-          ],
-        },
+        prompt: [
+          {
+            role: 'system',
+            content: 'INSTRUCTIONS',
+          },
+        ],
       });
     }).rejects.toThrow(InvalidPromptError);
   });
 
   it('should allow system messages in messages when allowSystemInMessages is true', async () => {
     const result = await standardizePrompt({
-      prompt: {
-        allowSystemInMessages: true,
-        messages: [
-          {
-            role: 'system',
-            content: 'INSTRUCTIONS',
-          },
-          {
-            role: 'user',
-            content: 'Hello, world!',
-          },
-        ],
-      },
+      allowSystemInMessages: true,
+      messages: [
+        {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+        },
+        {
+          role: 'user',
+          content: 'Hello, world!',
+        },
+      ],
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -69,19 +63,17 @@ describe('standardizePrompt', () => {
 
   it('should allow system messages in prompt messages when allowSystemInMessages is true', async () => {
     const result = await standardizePrompt({
-      prompt: {
-        allowSystemInMessages: true,
-        prompt: [
-          {
-            role: 'system',
-            content: 'INSTRUCTIONS',
-          },
-          {
-            role: 'user',
-            content: 'Hello, world!',
-          },
-        ],
-      },
+      allowSystemInMessages: true,
+      prompt: [
+        {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+        },
+        {
+          role: 'user',
+          content: 'Hello, world!',
+        },
+      ],
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -104,15 +96,13 @@ describe('standardizePrompt', () => {
   it('should throw InvalidPromptError when an allowed system message has parts', async () => {
     await expect(async () => {
       await standardizePrompt({
-        prompt: {
-          allowSystemInMessages: true,
-          messages: [
-            {
-              role: 'system',
-              content: [{ type: 'text', text: 'test' }] as any,
-            },
-          ],
-        },
+        allowSystemInMessages: true,
+        messages: [
+          {
+            role: 'system',
+            content: [{ type: 'text', text: 'test' }] as any,
+          },
+        ],
       });
     }).rejects.toThrow(InvalidPromptError);
   });
@@ -120,22 +110,18 @@ describe('standardizePrompt', () => {
   it('should throw InvalidPromptError when messages array is empty', async () => {
     await expect(async () => {
       await standardizePrompt({
-        prompt: {
-          messages: [],
-        },
+        messages: [],
       });
     }).rejects.toThrow(InvalidPromptError);
   });
 
   it('should support SystemModelMessage system message', async () => {
     const result = await standardizePrompt({
-      prompt: {
-        system: {
-          role: 'system',
-          content: 'INSTRUCTIONS',
-        },
-        prompt: 'Hello, world!',
+      system: {
+        role: 'system',
+        content: 'INSTRUCTIONS',
       },
+      prompt: 'Hello, world!',
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -156,13 +142,11 @@ describe('standardizePrompt', () => {
 
   it('should support array of SystemModelMessage system messages', async () => {
     const result = await standardizePrompt({
-      prompt: {
-        system: [
-          { role: 'system', content: 'INSTRUCTIONS' },
-          { role: 'system', content: 'INSTRUCTIONS 2' },
-        ],
-        prompt: 'Hello, world!',
-      },
+      system: [
+        { role: 'system', content: 'INSTRUCTIONS' },
+        { role: 'system', content: 'INSTRUCTIONS 2' },
+      ],
+      prompt: 'Hello, world!',
     });
 
     expect(result).toMatchInlineSnapshot(`

--- a/packages/ai/src/prompt/standardize-prompt.test.ts
+++ b/packages/ai/src/prompt/standardize-prompt.test.ts
@@ -6,12 +6,14 @@ describe('standardizePrompt', () => {
   it('should throw InvalidPromptError when system message has parts', async () => {
     await expect(async () => {
       await standardizePrompt({
-        messages: [
-          {
-            role: 'system',
-            content: [{ type: 'text', text: 'test' }] as any,
-          },
-        ],
+        prompt: {
+          messages: [
+            {
+              role: 'system',
+              content: [{ type: 'text', text: 'test' }] as any,
+            },
+          ],
+        },
       });
     }).rejects.toThrow(InvalidPromptError);
   });
@@ -19,18 +21,22 @@ describe('standardizePrompt', () => {
   it('should throw InvalidPromptError when messages array is empty', async () => {
     await expect(async () => {
       await standardizePrompt({
-        messages: [],
+        prompt: {
+          messages: [],
+        },
       });
     }).rejects.toThrow(InvalidPromptError);
   });
 
   it('should support SystemModelMessage system message', async () => {
     const result = await standardizePrompt({
-      system: {
-        role: 'system',
-        content: 'INSTRUCTIONS',
+      prompt: {
+        system: {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+        },
+        prompt: 'Hello, world!',
       },
-      prompt: 'Hello, world!',
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -51,11 +57,13 @@ describe('standardizePrompt', () => {
 
   it('should support array of SystemModelMessage system messages', async () => {
     const result = await standardizePrompt({
-      system: [
-        { role: 'system', content: 'INSTRUCTIONS' },
-        { role: 'system', content: 'INSTRUCTIONS 2' },
-      ],
-      prompt: 'Hello, world!',
+      prompt: {
+        system: [
+          { role: 'system', content: 'INSTRUCTIONS' },
+          { role: 'system', content: 'INSTRUCTIONS 2' },
+        ],
+        prompt: 'Hello, world!',
+      },
     });
 
     expect(result).toMatchInlineSnapshot(`

--- a/packages/ai/src/prompt/standardize-prompt.test.ts
+++ b/packages/ai/src/prompt/standardize-prompt.test.ts
@@ -3,10 +3,109 @@ import { standardizePrompt } from './standardize-prompt';
 import { describe, it, expect } from 'vitest';
 
 describe('standardizePrompt', () => {
-  it('should throw InvalidPromptError when system message has parts', async () => {
+  it('should throw InvalidPromptError when messages contain a system message by default', async () => {
     await expect(async () => {
       await standardizePrompt({
         prompt: {
+          messages: [
+            {
+              role: 'system',
+              content: 'INSTRUCTIONS',
+            },
+          ],
+        },
+      });
+    }).rejects.toThrow(InvalidPromptError);
+  });
+
+  it('should throw InvalidPromptError when prompt messages contain a system message by default', async () => {
+    await expect(async () => {
+      await standardizePrompt({
+        prompt: {
+          prompt: [
+            {
+              role: 'system',
+              content: 'INSTRUCTIONS',
+            },
+          ],
+        },
+      });
+    }).rejects.toThrow(InvalidPromptError);
+  });
+
+  it('should allow system messages in messages when allowSystemInMessages is true', async () => {
+    const result = await standardizePrompt({
+      prompt: {
+        allowSystemInMessages: true,
+        messages: [
+          {
+            role: 'system',
+            content: 'INSTRUCTIONS',
+          },
+          {
+            role: 'user',
+            content: 'Hello, world!',
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+          {
+            "content": "Hello, world!",
+            "role": "user",
+          },
+        ],
+        "system": undefined,
+      }
+    `);
+  });
+
+  it('should allow system messages in prompt messages when allowSystemInMessages is true', async () => {
+    const result = await standardizePrompt({
+      prompt: {
+        allowSystemInMessages: true,
+        prompt: [
+          {
+            role: 'system',
+            content: 'INSTRUCTIONS',
+          },
+          {
+            role: 'user',
+            content: 'Hello, world!',
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+          {
+            "content": "Hello, world!",
+            "role": "user",
+          },
+        ],
+        "system": undefined,
+      }
+    `);
+  });
+
+  it('should throw InvalidPromptError when an allowed system message has parts', async () => {
+    await expect(async () => {
+      await standardizePrompt({
+        prompt: {
+          allowSystemInMessages: true,
           messages: [
             {
               role: 'system',

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -32,11 +32,9 @@ export type StandardizedPrompt = {
  * @returns The standardized prompt.
  * @throws {InvalidPromptError} When the prompt is invalid.
  */
-export async function standardizePrompt({
-  prompt,
-}: {
-  prompt: Prompt;
-}): Promise<StandardizedPrompt> {
+export async function standardizePrompt(
+  prompt: Prompt,
+): Promise<StandardizedPrompt> {
   const { allowSystemInMessages = false } = prompt;
 
   if (prompt.prompt == null && prompt.messages == null) {

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -32,19 +32,20 @@ export type StandardizedPrompt = {
  * @returns The standardized prompt.
  * @throws {InvalidPromptError} When the prompt is invalid.
  */
-export async function standardizePrompt(
-  prompt: Prompt,
-): Promise<StandardizedPrompt> {
-  const { allowSystemInMessages = false } = prompt;
-
-  if (prompt.prompt == null && prompt.messages == null) {
+export async function standardizePrompt({
+  allowSystemInMessages = false,
+  system,
+  prompt,
+  messages,
+}: Prompt): Promise<StandardizedPrompt> {
+  if (prompt == null && messages == null) {
     throw new InvalidPromptError({
       prompt,
       message: 'prompt or messages must be defined',
     });
   }
 
-  if (prompt.prompt != null && prompt.messages != null) {
+  if (prompt != null && messages != null) {
     throw new InvalidPromptError({
       prompt,
       message: 'prompt and messages cannot be defined at the same time',
@@ -53,15 +54,8 @@ export async function standardizePrompt(
 
   // validate that system is a string or a SystemModelMessage
   if (
-    prompt.system != null &&
-    typeof prompt.system !== 'string' &&
-    !asArray(prompt.system).every(
-      message =>
-        typeof message === 'object' &&
-        message !== null &&
-        'role' in message &&
-        message.role === 'system',
-    )
+    typeof system !== 'string' &&
+    !asArray(system).every(message => message.role === 'system')
   ) {
     throw new InvalidPromptError({
       prompt,
@@ -70,15 +64,11 @@ export async function standardizePrompt(
     });
   }
 
-  let messages: ModelMessage[];
-
-  if (prompt.prompt != null && typeof prompt.prompt === 'string') {
-    messages = [{ role: 'user', content: prompt.prompt }];
-  } else if (prompt.prompt != null && Array.isArray(prompt.prompt)) {
-    messages = prompt.prompt;
-  } else if (prompt.messages != null) {
-    messages = prompt.messages;
-  } else {
+  if (prompt != null && typeof prompt === 'string') {
+    messages = [{ role: 'user', content: prompt }];
+  } else if (prompt != null && Array.isArray(prompt)) {
+    messages = prompt;
+  } else if (messages == null) {
     throw new InvalidPromptError({
       prompt,
       message: 'prompt or messages must be defined',
@@ -116,8 +106,5 @@ export async function standardizePrompt(
     });
   }
 
-  return {
-    messages,
-    system: prompt.system,
-  };
+  return { messages, system };
 }

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -26,6 +26,9 @@ export type StandardizedPrompt = {
  * messages.
  *
  * @param prompt - The prompt definition to standardize.
+ * Set `allowSystemInMessages` to true to allow system messages in the
+ * `prompt` or `messages` fields. System messages in the `system` option are
+ * always allowed.
  * @returns The standardized prompt.
  * @throws {InvalidPromptError} When the prompt is invalid.
  */
@@ -34,6 +37,8 @@ export async function standardizePrompt({
 }: {
   prompt: Prompt;
 }): Promise<StandardizedPrompt> {
+  const { allowSystemInMessages = false } = prompt;
+
   if (prompt.prompt == null && prompt.messages == null) {
     throw new InvalidPromptError({
       prompt,
@@ -86,6 +91,24 @@ export async function standardizePrompt({
     throw new InvalidPromptError({
       prompt,
       message: 'messages must not be empty',
+    });
+  }
+
+  if (
+    !allowSystemInMessages &&
+    Array.isArray(messages) &&
+    messages.some(
+      message =>
+        message != null &&
+        typeof message === 'object' &&
+        'role' in message &&
+        message.role === 'system',
+    )
+  ) {
+    throw new InvalidPromptError({
+      prompt,
+      message:
+        'System messages are not allowed in the prompt or messages fields. Use the system option instead.',
     });
   }
 

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -21,9 +21,13 @@ export type StandardizedPrompt = {
   messages: ModelMessage[];
 };
 
-export async function standardizePrompt(
-  prompt: Prompt,
-): Promise<StandardizedPrompt> {
+export type StandardizePromptOptions = {
+  prompt: Prompt;
+};
+
+export async function standardizePrompt({
+  prompt,
+}: StandardizePromptOptions): Promise<StandardizedPrompt> {
   if (prompt.prompt == null && prompt.messages == null) {
     throw new InvalidPromptError({
       prompt,

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -21,13 +21,19 @@ export type StandardizedPrompt = {
   messages: ModelMessage[];
 };
 
-export type StandardizePromptOptions = {
-  prompt: Prompt;
-};
-
+/**
+ * Converts a prompt input into a standardized prompt with validated model
+ * messages.
+ *
+ * @param prompt - The prompt definition to standardize.
+ * @returns The standardized prompt.
+ * @throws {InvalidPromptError} When the prompt is invalid.
+ */
 export async function standardizePrompt({
   prompt,
-}: StandardizePromptOptions): Promise<StandardizedPrompt> {
+}: {
+  prompt: Prompt;
+}): Promise<StandardizedPrompt> {
   if (prompt.prompt == null && prompt.messages == null) {
     throw new InvalidPromptError({
       prompt,

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -94,14 +94,7 @@ export async function standardizePrompt(
 
   if (
     !allowSystemInMessages &&
-    Array.isArray(messages) &&
-    messages.some(
-      message =>
-        message != null &&
-        typeof message === 'object' &&
-        'role' in message &&
-        message.role === 'system',
-    )
+    messages.some(message => message.role === 'system')
   ) {
     throw new InvalidPromptError({
       prompt,

--- a/packages/rsc/src/stream-ui/stream-ui.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.tsx
@@ -104,6 +104,7 @@ export async function streamUI<
   system,
   prompt,
   messages,
+  allowSystemInMessages,
   maxRetries,
   abortSignal,
   headers,
@@ -269,12 +270,11 @@ export async function streamUI<
   const { retry } = prepareRetries({ maxRetries, abortSignal });
 
   const validatedPrompt = await standardizePrompt({
-    prompt: {
-      system,
-      prompt,
-      messages,
-    } as Prompt,
-  });
+    system,
+    prompt,
+    messages,
+    allowSystemInMessages,
+  } as Prompt);
   const languageModelTools = await prepareTools({
     tools: tools,
   });

--- a/packages/rsc/src/stream-ui/stream-ui.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.tsx
@@ -269,10 +269,12 @@ export async function streamUI<
   const { retry } = prepareRetries({ maxRetries, abortSignal });
 
   const validatedPrompt = await standardizePrompt({
-    system,
-    prompt,
-    messages,
-  } as Prompt);
+    prompt: {
+      system,
+      prompt,
+      messages,
+    } as Prompt,
+  });
   const languageModelTools = await prepareTools({
     tools: tools,
   });

--- a/packages/workflow/src/do-stream-step.ts
+++ b/packages/workflow/src/do-stream-step.ts
@@ -115,6 +115,7 @@ export async function doStreamStep(
     // pre-converted LanguageModelV4Prompt. standardizePrompt inside
     // streamModelCall handles both formats.
     messages: conversationPrompt as unknown as ModelMessage[],
+    allowSystemInMessages: true,
     tools,
     toolChoice: options?.toolChoice,
     includeRawChunks: options?.includeRawChunks,

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1163,6 +1163,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
 
     const prompt = await standardizePrompt({
       system: effectiveInstructions,
+      allowSystemInMessages: true, // TODO: consider exposing this as a parameter
       ...(effectivePrompt != null
         ? { prompt: effectivePrompt }
         : { messages: effectiveMessages! }),

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1161,10 +1161,12 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
     }
 
     const prompt = await standardizePrompt({
-      system: effectiveInstructions,
-      ...(effectivePrompt != null
-        ? { prompt: effectivePrompt }
-        : { messages: effectiveMessages! }),
+      prompt: {
+        system: effectiveInstructions,
+        ...(effectivePrompt != null
+          ? { prompt: effectivePrompt }
+          : { messages: effectiveMessages! }),
+      },
     });
 
     // Process tool approval responses before starting the agent loop.

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -14,6 +14,7 @@ import {
   type Experimental_LanguageModelStreamPart as ModelCallStreamPart,
   type ModelMessage,
   Output,
+  Prompt,
   type StepResult,
   type StopCondition,
   type StreamTextOnStepFinishCallback,
@@ -1161,13 +1162,11 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
     }
 
     const prompt = await standardizePrompt({
-      prompt: {
-        system: effectiveInstructions,
-        ...(effectivePrompt != null
-          ? { prompt: effectivePrompt }
-          : { messages: effectiveMessages! }),
-      },
-    });
+      system: effectiveInstructions,
+      ...(effectivePrompt != null
+        ? { prompt: effectivePrompt }
+        : { messages: effectiveMessages! }),
+    } as Prompt);
 
     // Process tool approval responses before starting the agent loop.
     // This mirrors how stream-text.ts handles tool-approval-response parts:


### PR DESCRIPTION
## Background

For historical and convenience reasons, system messages can be part of user messages or prompts, e.g. to allow interleaving regular messages and system messages.

However, this creates a prompt injection risk where the user (e.g. by modifying the messages in a web ui) can override or set the system prompt. In most cases, it should only be possible to set the system prompt via the system (or instructions) property, and users should not be able to inject system messages.

## Summary
* throw `InvalidPromptError` when there are system messages in the messages or prompt options
* add `allowSystemInMessages` option for opting into allowing system messages in messages or prompt options

## Future Work

* add `allowSystemInMessages` opt-in support to `WorkflowAgent` (if desired) @gr2m 

## Related Issues

Issue reported in #14749