### PR TITLE
refactoring(provider-utils): add controller as property to StreamingToolCallTracker

### DIFF
--- a/.changeset/perfect-lamps-walk.md
+++ b/.changeset/perfect-lamps-walk.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+refactoring(provider-utils): add controller as property to StreamingToolCallTracker

--- a/packages/alibaba/src/alibaba-chat-language-model.ts
+++ b/packages/alibaba/src/alibaba-chat-language-model.ts
@@ -280,7 +280,7 @@ export class AlibabaLanguageModel implements LanguageModelV4 {
     let activeText = false;
     let activeReasoningId: string | null = null;
 
-    const toolCallTracker = new StreamingToolCallTracker({ generateId });
+    let toolCallTracker: StreamingToolCallTracker;
 
     return {
       stream: response.pipeThrough(
@@ -289,6 +289,9 @@ export class AlibabaLanguageModel implements LanguageModelV4 {
           LanguageModelV4StreamPart
         >({
           start(controller) {
+            toolCallTracker = new StreamingToolCallTracker(controller, {
+              generateId,
+            });
             controller.enqueue({ type: 'stream-start', warnings });
           },
 
@@ -393,10 +396,7 @@ export class AlibabaLanguageModel implements LanguageModelV4 {
               }
 
               for (const toolCallDelta of delta.tool_calls) {
-                toolCallTracker.processDelta(
-                  toolCallDelta,
-                  controller.enqueue.bind(controller),
-                );
+                toolCallTracker.processDelta(toolCallDelta);
               }
             }
 
@@ -421,7 +421,7 @@ export class AlibabaLanguageModel implements LanguageModelV4 {
               controller.enqueue({ type: 'text-end', id: '0' });
             }
 
-            toolCallTracker.flush(controller.enqueue.bind(controller));
+            toolCallTracker.flush();
 
             controller.enqueue({
               type: 'finish',

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.ts
@@ -265,7 +265,7 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
       fetch: this.config.fetch,
     });
 
-    const toolCallTracker = new StreamingToolCallTracker({ generateId });
+    let toolCallTracker: StreamingToolCallTracker;
 
     let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
@@ -284,6 +284,9 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
           LanguageModelV4StreamPart
         >({
           start(controller) {
+            toolCallTracker = new StreamingToolCallTracker(controller, {
+              generateId,
+            });
             controller.enqueue({ type: 'stream-start', warnings });
           },
 
@@ -387,10 +390,7 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
               }
 
               for (const toolCallDelta of delta.tool_calls) {
-                toolCallTracker.processDelta(
-                  toolCallDelta,
-                  controller.enqueue.bind(controller),
-                );
+                toolCallTracker.processDelta(toolCallDelta);
               }
             }
           },
@@ -404,7 +404,7 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
               controller.enqueue({ type: 'text-end', id: 'txt-0' });
             }
 
-            toolCallTracker.flush(controller.enqueue.bind(controller));
+            toolCallTracker.flush();
 
             controller.enqueue({
               type: 'finish',

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -283,10 +283,7 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
       fetch: this.config.fetch,
     });
 
-    const toolCallTracker = new StreamingToolCallTracker({
-      generateId,
-      typeValidation: 'required',
-    });
+    let toolCallTracker: StreamingToolCallTracker;
 
     let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
@@ -322,6 +319,10 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
           LanguageModelV4StreamPart
         >({
           start(controller) {
+            toolCallTracker = new StreamingToolCallTracker(controller, {
+              generateId,
+              typeValidation: 'required',
+            });
             controller.enqueue({ type: 'stream-start', warnings });
           },
 
@@ -430,10 +431,7 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
               }
 
               for (const toolCallDelta of delta.tool_calls) {
-                toolCallTracker.processDelta(
-                  toolCallDelta,
-                  controller.enqueue.bind(controller),
-                );
+                toolCallTracker.processDelta(toolCallDelta);
               }
             }
           },
@@ -447,7 +445,7 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
               controller.enqueue({ type: 'text-end', id: 'txt-0' });
             }
 
-            toolCallTracker.flush(controller.enqueue.bind(controller));
+            toolCallTracker.flush();
 
             controller.enqueue({
               type: 'finish',

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -23,6 +23,7 @@ import {
   postJsonToApi,
   ResponseHandler,
   serializeModelOptions,
+  type StreamingToolCallDelta,
   StreamingToolCallTracker,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
@@ -47,6 +48,14 @@ import {
 } from './openai-compatible-chat-options';
 import { MetadataExtractor } from './openai-compatible-metadata-extractor';
 import { prepareTools } from './openai-compatible-prepare-tools';
+
+type OpenAICompatibleStreamingToolCallDelta = StreamingToolCallDelta & {
+  extra_content?: {
+    google?: {
+      thought_signature?: string | null;
+    } | null;
+  } | null;
+};
 
 export type OpenAICompatibleChatConfig = {
   provider: string;
@@ -430,7 +439,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
     });
 
     const providerOptionsName = metadataKey;
-    let toolCallTracker: StreamingToolCallTracker;
+    let toolCallTracker: StreamingToolCallTracker<OpenAICompatibleStreamingToolCallDelta>;
 
     let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
@@ -449,17 +458,22 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
           LanguageModelV4StreamPart
         >({
           start(controller) {
-            toolCallTracker = new StreamingToolCallTracker(controller, {
-              generateId,
-              extractMetadata: delta => {
-                const sig = (delta as any).extra_content?.google
-                  ?.thought_signature;
-                return sig
-                  ? { [providerOptionsName]: { thoughtSignature: sig } }
-                  : undefined;
-              },
-              buildToolCallProviderMetadata: metadata => metadata,
-            });
+            toolCallTracker =
+              new StreamingToolCallTracker<OpenAICompatibleStreamingToolCallDelta>(
+                controller,
+                {
+                  generateId,
+                  extractMetadata: delta => {
+                    const thoughtSignature =
+                      delta.extra_content?.google?.thought_signature;
+
+                    return thoughtSignature
+                      ? { [providerOptionsName]: { thoughtSignature } }
+                      : undefined;
+                  },
+                  buildToolCallProviderMetadata: metadata => metadata,
+                },
+              );
             controller.enqueue({ type: 'stream-start', warnings });
           },
 

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -430,16 +430,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
     });
 
     const providerOptionsName = metadataKey;
-    const toolCallTracker = new StreamingToolCallTracker({
-      generateId,
-      extractMetadata: delta => {
-        const sig = (delta as any).extra_content?.google?.thought_signature;
-        return sig
-          ? { [providerOptionsName]: { thoughtSignature: sig } }
-          : undefined;
-      },
-      buildToolCallProviderMetadata: metadata => metadata,
-    });
+    let toolCallTracker: StreamingToolCallTracker;
 
     let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
@@ -458,6 +449,17 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
           LanguageModelV4StreamPart
         >({
           start(controller) {
+            toolCallTracker = new StreamingToolCallTracker(controller, {
+              generateId,
+              extractMetadata: delta => {
+                const sig = (delta as any).extra_content?.google
+                  ?.thought_signature;
+                return sig
+                  ? { [providerOptionsName]: { thoughtSignature: sig } }
+                  : undefined;
+              },
+              buildToolCallProviderMetadata: metadata => metadata,
+            });
             controller.enqueue({ type: 'stream-start', warnings });
           },
 
@@ -569,10 +571,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
               }
 
               for (const toolCallDelta of delta.tool_calls) {
-                toolCallTracker.processDelta(
-                  toolCallDelta,
-                  controller.enqueue.bind(controller),
-                );
+                toolCallTracker.processDelta(toolCallDelta);
               }
             }
           },
@@ -586,7 +585,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
               controller.enqueue({ type: 'text-end', id: 'txt-0' });
             }
 
-            toolCallTracker.flush(controller.enqueue.bind(controller));
+            toolCallTracker.flush();
 
             const providerMetadata: SharedV4ProviderMetadata = {
               [providerOptionsName]: {},

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -452,10 +452,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
       fetch: this.config.fetch,
     });
 
-    const toolCallTracker = new StreamingToolCallTracker({
-      generateId,
-      typeValidation: 'if-present',
-    });
+    let toolCallTracker: StreamingToolCallTracker;
 
     let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
@@ -474,6 +471,10 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
           LanguageModelV4StreamPart
         >({
           start(controller) {
+            toolCallTracker = new StreamingToolCallTracker(controller, {
+              generateId,
+              typeValidation: 'if-present',
+            });
             controller.enqueue({ type: 'stream-start', warnings });
           },
 
@@ -565,10 +566,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
 
             if (delta.tool_calls != null) {
               for (const toolCallDelta of delta.tool_calls) {
-                toolCallTracker.processDelta(
-                  toolCallDelta,
-                  controller.enqueue.bind(controller),
-                );
+                toolCallTracker.processDelta(toolCallDelta);
               }
             }
 
@@ -591,7 +589,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
               controller.enqueue({ type: 'text-end', id: '0' });
             }
 
-            toolCallTracker.flush(controller.enqueue.bind(controller));
+            toolCallTracker.flush();
 
             controller.enqueue({
               type: 'finish',

--- a/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
@@ -4,26 +4,25 @@ import { StreamingToolCallTracker } from './streaming-tool-call-tracker';
 
 function createCollector() {
   const parts: LanguageModelV4StreamPart[] = [];
-  const enqueue = (part: LanguageModelV4StreamPart) => parts.push(part);
-  return { parts, enqueue };
+  const controller = {
+    enqueue: (part: LanguageModelV4StreamPart) => parts.push(part),
+  };
+  return { parts, controller };
 }
 
 describe('StreamingToolCallTracker', () => {
   describe('processDelta', () => {
     it('should handle a single tool call accumulated across multiple deltas', () => {
-      const tracker = new StreamingToolCallTracker();
-      const { parts, enqueue } = createCollector();
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
 
       // First delta: new tool call with id and name
-      tracker.processDelta(
-        {
-          index: 0,
-          id: 'call_1',
-          type: 'function',
-          function: { name: 'get_weather', arguments: '{"ci' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'get_weather', arguments: '{"ci' },
+      });
 
       expect(parts).toEqual([
         { type: 'tool-input-start', id: 'call_1', toolName: 'get_weather' },
@@ -33,13 +32,10 @@ describe('StreamingToolCallTracker', () => {
       parts.length = 0;
 
       // Second delta: more arguments
-      tracker.processDelta(
-        {
-          index: 0,
-          function: { arguments: 'ty": "San' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        function: { arguments: 'ty": "San' },
+      });
 
       expect(parts).toEqual([
         {
@@ -52,13 +48,10 @@ describe('StreamingToolCallTracker', () => {
       parts.length = 0;
 
       // Third delta: completes the JSON
-      tracker.processDelta(
-        {
-          index: 0,
-          function: { arguments: ' Francisco"}' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        function: { arguments: ' Francisco"}' },
+      });
 
       expect(parts).toEqual([
         {
@@ -77,21 +70,18 @@ describe('StreamingToolCallTracker', () => {
     });
 
     it('should handle a full tool call in a single chunk', () => {
-      const tracker = new StreamingToolCallTracker();
-      const { parts, enqueue } = createCollector();
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
 
-      tracker.processDelta(
-        {
-          index: 0,
-          id: 'call_1',
-          type: 'function',
-          function: {
-            name: 'get_weather',
-            arguments: '{"city": "London"}',
-          },
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: {
+          name: 'get_weather',
+          arguments: '{"city": "London"}',
         },
-        enqueue,
-      );
+      });
 
       expect(parts).toEqual([
         { type: 'tool-input-start', id: 'call_1', toolName: 'get_weather' },
@@ -111,28 +101,22 @@ describe('StreamingToolCallTracker', () => {
     });
 
     it('should handle multiple concurrent tool calls', () => {
-      const tracker = new StreamingToolCallTracker();
-      const { parts, enqueue } = createCollector();
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
 
-      tracker.processDelta(
-        {
-          index: 0,
-          id: 'call_1',
-          type: 'function',
-          function: { name: 'get_weather', arguments: '' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'get_weather', arguments: '' },
+      });
 
-      tracker.processDelta(
-        {
-          index: 1,
-          id: 'call_2',
-          type: 'function',
-          function: { name: 'get_time', arguments: '' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 1,
+        id: 'call_2',
+        type: 'function',
+        function: { name: 'get_time', arguments: '' },
+      });
 
       expect(parts).toEqual([
         { type: 'tool-input-start', id: 'call_1', toolName: 'get_weather' },
@@ -141,84 +125,66 @@ describe('StreamingToolCallTracker', () => {
     });
 
     it('should skip deltas for already-finished tool calls', () => {
-      const tracker = new StreamingToolCallTracker();
-      const { parts, enqueue } = createCollector();
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
 
       // Complete tool call in one chunk
-      tracker.processDelta(
-        {
-          index: 0,
-          id: 'call_1',
-          type: 'function',
-          function: { name: 'fn', arguments: '{}' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'fn', arguments: '{}' },
+      });
 
       parts.length = 0;
 
       // Late delta for the same tool call
-      tracker.processDelta(
-        {
-          index: 0,
-          function: { arguments: 'extra' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        function: { arguments: 'extra' },
+      });
 
       expect(parts).toEqual([]);
     });
 
     it('should skip delta emission when arguments are null', () => {
-      const tracker = new StreamingToolCallTracker();
-      const { parts, enqueue } = createCollector();
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
 
       // Create tool call
-      tracker.processDelta(
-        {
-          index: 0,
-          id: 'call_1',
-          type: 'function',
-          function: { name: 'fn', arguments: '' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'fn', arguments: '' },
+      });
 
       parts.length = 0;
 
       // Delta with null arguments
-      tracker.processDelta(
-        {
-          index: 0,
-          function: { arguments: null },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        function: { arguments: null },
+      });
 
       expect(parts).toEqual([]);
     });
 
     it('should use index fallback when index is not provided', () => {
-      const tracker = new StreamingToolCallTracker();
-      const { parts, enqueue } = createCollector();
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
 
-      tracker.processDelta(
-        {
-          id: 'call_1',
-          type: 'function',
-          function: { name: 'fn1', arguments: '{}' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'fn1', arguments: '{}' },
+      });
 
-      tracker.processDelta(
-        {
-          id: 'call_2',
-          type: 'function',
-          function: { name: 'fn2', arguments: '{}' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        id: 'call_2',
+        type: 'function',
+        function: { name: 'fn2', arguments: '{}' },
+      });
 
       expect(parts.filter(p => p.type === 'tool-input-start')).toEqual([
         { type: 'tool-input-start', id: 'call_1', toolName: 'fn1' },
@@ -227,145 +193,121 @@ describe('StreamingToolCallTracker', () => {
     });
 
     it('should throw when id is missing', () => {
-      const tracker = new StreamingToolCallTracker();
-      const { enqueue } = createCollector();
+      const { controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
 
       expect(() =>
-        tracker.processDelta(
-          {
-            index: 0,
-            type: 'function',
-            function: { name: 'fn' },
-          },
-          enqueue,
-        ),
+        tracker.processDelta({
+          index: 0,
+          type: 'function',
+          function: { name: 'fn' },
+        }),
       ).toThrow("Expected 'id' to be a string.");
     });
 
     it('should throw when function.name is missing', () => {
-      const tracker = new StreamingToolCallTracker();
-      const { enqueue } = createCollector();
+      const { controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
 
       expect(() =>
-        tracker.processDelta(
-          {
-            index: 0,
-            id: 'call_1',
-            type: 'function',
-            function: {},
-          },
-          enqueue,
-        ),
+        tracker.processDelta({
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: {},
+        }),
       ).toThrow("Expected 'function.name' to be a string.");
     });
   });
 
   describe('typeValidation', () => {
     it('should not validate type with typeValidation: none', () => {
-      const tracker = new StreamingToolCallTracker({
+      const { controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller, {
         typeValidation: 'none',
       });
-      const { enqueue } = createCollector();
 
       // Should not throw even with a non-function type
       expect(() =>
-        tracker.processDelta(
-          {
-            index: 0,
-            id: 'call_1',
-            type: 'custom',
-            function: { name: 'fn', arguments: '' },
-          },
-          enqueue,
-        ),
+        tracker.processDelta({
+          index: 0,
+          id: 'call_1',
+          type: 'custom',
+          function: { name: 'fn', arguments: '' },
+        }),
       ).not.toThrow();
     });
 
     it('should validate type when present with typeValidation: if-present', () => {
-      const tracker = new StreamingToolCallTracker({
+      const { controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller, {
         typeValidation: 'if-present',
       });
-      const { enqueue } = createCollector();
 
       // Should throw for non-function type
       expect(() =>
-        tracker.processDelta(
-          {
-            index: 0,
-            id: 'call_1',
-            type: 'custom',
-            function: { name: 'fn', arguments: '' },
-          },
-          enqueue,
-        ),
+        tracker.processDelta({
+          index: 0,
+          id: 'call_1',
+          type: 'custom',
+          function: { name: 'fn', arguments: '' },
+        }),
       ).toThrow("Expected 'function' type.");
 
       // Should not throw when type is null
       expect(() =>
-        tracker.processDelta(
-          {
-            index: 0,
-            id: 'call_1',
-            function: { name: 'fn', arguments: '' },
-          },
-          enqueue,
-        ),
+        tracker.processDelta({
+          index: 0,
+          id: 'call_1',
+          function: { name: 'fn', arguments: '' },
+        }),
       ).not.toThrow();
     });
 
     it('should require function type with typeValidation: required', () => {
-      const tracker = new StreamingToolCallTracker({
+      const { controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller, {
         typeValidation: 'required',
       });
-      const { enqueue } = createCollector();
 
       // Should throw when type is null/undefined
       expect(() =>
-        tracker.processDelta(
-          {
-            index: 0,
-            id: 'call_1',
-            function: { name: 'fn', arguments: '' },
-          },
-          enqueue,
-        ),
+        tracker.processDelta({
+          index: 0,
+          id: 'call_1',
+          function: { name: 'fn', arguments: '' },
+        }),
       ).toThrow("Expected 'function' type.");
 
       // Should not throw for 'function' type
       expect(() =>
-        tracker.processDelta(
-          {
-            index: 0,
-            id: 'call_1',
-            type: 'function',
-            function: { name: 'fn', arguments: '' },
-          },
-          enqueue,
-        ),
+        tracker.processDelta({
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'fn', arguments: '' },
+        }),
       ).not.toThrow();
     });
   });
 
   describe('flush', () => {
     it('should finalize unfinished tool calls on flush', () => {
-      const tracker = new StreamingToolCallTracker();
-      const { parts, enqueue } = createCollector();
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
 
       // Start a tool call but don't complete it
-      tracker.processDelta(
-        {
-          index: 0,
-          id: 'call_1',
-          type: 'function',
-          function: { name: 'fn', arguments: '{"key": "val' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'fn', arguments: '{"key": "val' },
+      });
 
       parts.length = 0;
 
       // Flush should finalize
-      tracker.flush(enqueue);
+      tracker.flush();
 
       expect(parts).toEqual([
         { type: 'tool-input-end', id: 'call_1' },
@@ -379,23 +321,20 @@ describe('StreamingToolCallTracker', () => {
     });
 
     it('should not re-finalize already finished tool calls', () => {
-      const tracker = new StreamingToolCallTracker();
-      const { parts, enqueue } = createCollector();
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
 
       // Complete tool call in one chunk
-      tracker.processDelta(
-        {
-          index: 0,
-          id: 'call_1',
-          type: 'function',
-          function: { name: 'fn', arguments: '{}' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'fn', arguments: '{}' },
+      });
 
       parts.length = 0;
 
-      tracker.flush(enqueue);
+      tracker.flush();
 
       // No events should be emitted since tool call was already finished
       expect(parts).toEqual([]);
@@ -404,7 +343,8 @@ describe('StreamingToolCallTracker', () => {
 
   describe('metadata', () => {
     it('should extract and include provider metadata in tool-call events', () => {
-      const tracker = new StreamingToolCallTracker({
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller, {
         extractMetadata: delta => {
           const sig = (delta as any).extra_content?.google?.thought_signature;
           return sig ? { thoughtSignature: sig } : undefined;
@@ -416,18 +356,14 @@ describe('StreamingToolCallTracker', () => {
           return undefined;
         },
       });
-      const { parts, enqueue } = createCollector();
 
-      tracker.processDelta(
-        {
-          index: 0,
-          id: 'call_1',
-          type: 'function',
-          function: { name: 'fn', arguments: '{}' },
-          extra_content: { google: { thought_signature: 'sig123' } },
-        } as any,
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'fn', arguments: '{}' },
+        extra_content: { google: { thought_signature: 'sig123' } },
+      } as any);
 
       const toolCallEvent = parts.find(p => p.type === 'tool-call');
       expect(toolCallEvent).toEqual({
@@ -442,27 +378,24 @@ describe('StreamingToolCallTracker', () => {
     });
 
     it('should include provider metadata for unfinished tool calls finalized in flush', () => {
-      const tracker = new StreamingToolCallTracker({
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller, {
         extractMetadata: () => ({ custom: { key: 'value' } }),
         buildToolCallProviderMetadata: metadata => {
           return metadata ? { provider: metadata } : undefined;
         },
       });
-      const { parts, enqueue } = createCollector();
 
-      tracker.processDelta(
-        {
-          index: 0,
-          id: 'call_1',
-          type: 'function',
-          function: { name: 'fn', arguments: '{"incomplete' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'fn', arguments: '{"incomplete' },
+      });
 
       parts.length = 0;
 
-      tracker.flush(enqueue);
+      tracker.flush();
 
       const toolCallEvent = parts.find(p => p.type === 'tool-call');
       expect(toolCallEvent).toEqual({
@@ -475,21 +408,18 @@ describe('StreamingToolCallTracker', () => {
     });
 
     it('should not include providerMetadata when buildToolCallProviderMetadata returns undefined', () => {
-      const tracker = new StreamingToolCallTracker({
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller, {
         extractMetadata: () => undefined,
         buildToolCallProviderMetadata: () => undefined,
       });
-      const { parts, enqueue } = createCollector();
 
-      tracker.processDelta(
-        {
-          index: 0,
-          id: 'call_1',
-          type: 'function',
-          function: { name: 'fn', arguments: '{}' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'fn', arguments: '{}' },
+      });
 
       const toolCallEvent = parts.find(p => p.type === 'tool-call');
       expect(toolCallEvent).toEqual({
@@ -505,26 +435,23 @@ describe('StreamingToolCallTracker', () => {
   describe('generateId', () => {
     it('should use custom generateId for tool call IDs when id is missing in fallback', () => {
       const mockGenerateId = vi.fn(() => 'custom-id');
-      const tracker = new StreamingToolCallTracker({
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller, {
         generateId: mockGenerateId,
       });
-      const { parts, enqueue } = createCollector();
 
       // Start a tool call
-      tracker.processDelta(
-        {
-          index: 0,
-          id: 'call_1',
-          type: 'function',
-          function: { name: 'fn', arguments: '{"key": "val' },
-        },
-        enqueue,
-      );
+      tracker.processDelta({
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'fn', arguments: '{"key": "val' },
+      });
 
       parts.length = 0;
 
       // Flush to finalize
-      tracker.flush(enqueue);
+      tracker.flush();
 
       // The toolCallId should use the original id since it's present
       const toolCallEvent = parts.find(p => p.type === 'tool-call');

--- a/packages/provider-utils/src/streaming-tool-call-tracker.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.ts
@@ -62,6 +62,11 @@ interface TrackedToolCall {
   metadata?: SharedV4ProviderMetadata;
 }
 
+type StreamingToolCallTrackerController = Pick<
+  TransformStreamDefaultController<LanguageModelV4StreamPart>,
+  'enqueue'
+>;
+
 /**
  * Tracks streaming tool call state across multiple deltas from an
  * OpenAI-compatible chat completion stream. Handles argument accumulation,
@@ -72,6 +77,7 @@ interface TrackedToolCall {
  */
 export class StreamingToolCallTracker {
   private toolCalls: TrackedToolCall[] = [];
+  private readonly controller: StreamingToolCallTrackerController;
   private readonly _generateId: () => string;
   private readonly typeValidation: 'none' | 'if-present' | 'required';
   private readonly extractMetadata?: (
@@ -81,7 +87,11 @@ export class StreamingToolCallTracker {
     metadata: SharedV4ProviderMetadata | undefined,
   ) => SharedV4ProviderMetadata | undefined;
 
-  constructor(options: StreamingToolCallTrackerOptions = {}) {
+  constructor(
+    controller: StreamingToolCallTrackerController,
+    options: StreamingToolCallTrackerOptions = {},
+  ) {
+    this.controller = controller;
     this._generateId = options.generateId ?? defaultGenerateId;
     this.typeValidation = options.typeValidation ?? 'none';
     this.extractMetadata = options.extractMetadata;
@@ -93,16 +103,13 @@ export class StreamingToolCallTracker {
    * Emits tool-input-start, tool-input-delta, tool-input-end, and tool-call
    * events as appropriate.
    */
-  processDelta(
-    toolCallDelta: StreamingToolCallDelta,
-    enqueue: (part: LanguageModelV4StreamPart) => void,
-  ): void {
+  processDelta(toolCallDelta: StreamingToolCallDelta): void {
     const index = toolCallDelta.index ?? this.toolCalls.length;
 
     if (this.toolCalls[index] == null) {
-      this.processNewToolCall(index, toolCallDelta, enqueue);
+      this.processNewToolCall(index, toolCallDelta);
     } else {
-      this.processExistingToolCall(index, toolCallDelta, enqueue);
+      this.processExistingToolCall(index, toolCallDelta);
     }
   }
 
@@ -110,10 +117,10 @@ export class StreamingToolCallTracker {
    * Finalize any unfinished tool calls. Should be called during the stream's
    * flush handler to ensure all tool calls are properly completed.
    */
-  flush(enqueue: (part: LanguageModelV4StreamPart) => void): void {
+  flush(): void {
     for (const toolCall of this.toolCalls) {
       if (!toolCall.hasFinished) {
-        this.finishToolCall(toolCall, enqueue);
+        this.finishToolCall(toolCall);
       }
     }
   }
@@ -121,7 +128,6 @@ export class StreamingToolCallTracker {
   private processNewToolCall(
     index: number,
     toolCallDelta: StreamingToolCallDelta,
-    enqueue: (part: LanguageModelV4StreamPart) => void,
   ): void {
     if (this.typeValidation === 'required') {
       if (toolCallDelta.type !== 'function') {
@@ -153,7 +159,7 @@ export class StreamingToolCallTracker {
       });
     }
 
-    enqueue({
+    this.controller.enqueue({
       type: 'tool-input-start',
       id: toolCallDelta.id,
       toolName: toolCallDelta.function.name,
@@ -176,7 +182,7 @@ export class StreamingToolCallTracker {
 
     // Emit initial delta if arguments already present
     if (toolCall.function.arguments.length > 0) {
-      enqueue({
+      this.controller.enqueue({
         type: 'tool-input-delta',
         id: toolCall.id,
         delta: toolCall.function.arguments,
@@ -186,14 +192,13 @@ export class StreamingToolCallTracker {
     // Check if tool call is complete
     // (some providers send the full tool call in one chunk)
     if (isParsableJson(toolCall.function.arguments)) {
-      this.finishToolCall(toolCall, enqueue);
+      this.finishToolCall(toolCall);
     }
   }
 
   private processExistingToolCall(
     index: number,
     toolCallDelta: StreamingToolCallDelta,
-    enqueue: (part: LanguageModelV4StreamPart) => void,
   ): void {
     const toolCall = this.toolCalls[index];
 
@@ -204,7 +209,7 @@ export class StreamingToolCallTracker {
     if (toolCallDelta.function?.arguments != null) {
       toolCall.function.arguments += toolCallDelta.function.arguments;
 
-      enqueue({
+      this.controller.enqueue({
         type: 'tool-input-delta',
         id: toolCall.id,
         delta: toolCallDelta.function.arguments,
@@ -213,15 +218,12 @@ export class StreamingToolCallTracker {
 
     // Check if tool call is complete
     if (isParsableJson(toolCall.function.arguments)) {
-      this.finishToolCall(toolCall, enqueue);
+      this.finishToolCall(toolCall);
     }
   }
 
-  private finishToolCall(
-    toolCall: TrackedToolCall,
-    enqueue: (part: LanguageModelV4StreamPart) => void,
-  ): void {
-    enqueue({
+  private finishToolCall(toolCall: TrackedToolCall): void {
+    this.controller.enqueue({
       type: 'tool-input-end',
       id: toolCall.id,
     });
@@ -230,7 +232,7 @@ export class StreamingToolCallTracker {
       toolCall.metadata,
     );
 
-    enqueue({
+    this.controller.enqueue({
       type: 'tool-call',
       toolCallId: toolCall.id ?? this._generateId(),
       toolName: toolCall.function.name,

--- a/packages/provider-utils/src/streaming-tool-call-tracker.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.ts
@@ -19,7 +19,9 @@ export interface StreamingToolCallDelta {
   } | null;
 }
 
-export interface StreamingToolCallTrackerOptions {
+export interface StreamingToolCallTrackerOptions<
+  DELTA extends StreamingToolCallDelta = StreamingToolCallDelta,
+> {
   /**
    * ID generator function for tool call IDs.
    * Defaults to the standard generateId.
@@ -40,9 +42,7 @@ export interface StreamingToolCallTrackerOptions {
    * The returned metadata is stored on the tool call and passed to
    * `buildToolCallProviderMetadata` when the tool call is finalized.
    */
-  extractMetadata?: (
-    delta: StreamingToolCallDelta,
-  ) => SharedV4ProviderMetadata | undefined;
+  extractMetadata?: (delta: DELTA) => SharedV4ProviderMetadata | undefined;
 
   /**
    * Build the `providerMetadata` object for a `tool-call` event.
@@ -75,13 +75,15 @@ type StreamingToolCallTrackerController = Pick<
  *
  * Used by openai, openai-compatible, groq, deepseek, and alibaba providers.
  */
-export class StreamingToolCallTracker {
+export class StreamingToolCallTracker<
+  DELTA extends StreamingToolCallDelta = StreamingToolCallDelta,
+> {
   private toolCalls: TrackedToolCall[] = [];
   private readonly controller: StreamingToolCallTrackerController;
   private readonly _generateId: () => string;
   private readonly typeValidation: 'none' | 'if-present' | 'required';
   private readonly extractMetadata?: (
-    delta: StreamingToolCallDelta,
+    delta: DELTA,
   ) => SharedV4ProviderMetadata | undefined;
   private readonly buildToolCallProviderMetadata?: (
     metadata: SharedV4ProviderMetadata | undefined,
@@ -89,7 +91,7 @@ export class StreamingToolCallTracker {
 
   constructor(
     controller: StreamingToolCallTrackerController,
-    options: StreamingToolCallTrackerOptions = {},
+    options: StreamingToolCallTrackerOptions<DELTA> = {},
   ) {
     this.controller = controller;
     this._generateId = options.generateId ?? defaultGenerateId;
@@ -103,7 +105,7 @@ export class StreamingToolCallTracker {
    * Emits tool-input-start, tool-input-delta, tool-input-end, and tool-call
    * events as appropriate.
    */
-  processDelta(toolCallDelta: StreamingToolCallDelta): void {
+  processDelta(toolCallDelta: DELTA): void {
     const index = toolCallDelta.index ?? this.toolCalls.length;
 
     if (this.toolCalls[index] == null) {
@@ -125,10 +127,7 @@ export class StreamingToolCallTracker {
     }
   }
 
-  private processNewToolCall(
-    index: number,
-    toolCallDelta: StreamingToolCallDelta,
-  ): void {
+  private processNewToolCall(index: number, toolCallDelta: DELTA): void {
     if (this.typeValidation === 'required') {
       if (toolCallDelta.type !== 'function') {
         throw new InvalidResponseDataError({
@@ -196,10 +195,7 @@ export class StreamingToolCallTracker {
     }
   }
 
-  private processExistingToolCall(
-    index: number,
-    toolCallDelta: StreamingToolCallDelta,
-  ): void {
+  private processExistingToolCall(index: number, toolCallDelta: DELTA): void {
     const toolCall = this.toolCalls[index];
 
     if (toolCall.hasFinished) {


### PR DESCRIPTION
## Background

#14565 introduced `StreamingToolCallTracker`. In the PR several improvements were identified, but not added since the PR was auto-merged.

## Summary

* `controller` is a property of `StreamingToolCallTracker`
* add delta generics for type safety

## Related Issues

Follow up from #14565