### PR TITLE
fix(ai): remove stopWhen from onStart event

### DIFF
--- a/.changeset/soft-crabs-dream.md
+++ b/.changeset/soft-crabs-dream.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): remove stopWhen from onStart event

--- a/content/docs/03-ai-sdk-core/65-event-listeners.mdx
+++ b/content/docs/03-ai-sdk-core/65-event-listeners.mdx
@@ -238,11 +238,6 @@ const result = await generateText({
       description: 'Additional provider-specific options.',
     },
     {
-      name: 'stopWhen',
-      type: 'StopCondition | Array<StopCondition> | undefined',
-      description: 'Condition(s) for stopping the generation.',
-    },
-    {
       name: 'output',
       type: 'Output | undefined',
       description: 'The output specification for structured outputs.',

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -1022,12 +1022,6 @@ To see `generateText` in action, check out [these examples](#examples).
               description: 'Additional provider-specific options.',
             },
             {
-              name: 'stopWhen',
-              type: 'StopCondition<TOOLS> | Array<StopCondition<TOOLS>> | undefined',
-              description:
-                'Condition(s) for stopping the generation. When the condition is an array, any of the conditions can be met to stop.',
-            },
-            {
               name: 'output',
               type: 'OUTPUT | undefined',
               description:

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1929,12 +1929,6 @@ To see `streamText` in action, check out [these examples](#examples).
               description: 'Additional provider-specific options.',
             },
             {
-              name: 'stopWhen',
-              type: 'StopCondition<TOOLS> | Array<StopCondition<TOOLS>> | undefined',
-              description:
-                'Condition(s) for stopping the generation. When the condition is an array, any of the conditions can be met to stop.',
-            },
-            {
               name: 'output',
               type: 'OUTPUT | undefined',
               description:

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -218,11 +218,6 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
               description: 'Additional provider-specific options.',
             },
             {
-              name: 'stopWhen',
-              type: 'StopCondition<TOOLS> | Array<StopCondition<TOOLS>> | undefined',
-              description: 'Condition(s) for stopping the generation.',
-            },
-            {
               name: 'output',
               type: 'OUTPUT | undefined',
               description:

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -26,7 +26,6 @@ exports[`generateText > options.experimental_onStart > should send correct infor
   "runtimeContext": {},
   "seed": undefined,
   "stopSequences": undefined,
-  "stopWhen": [Function],
   "system": undefined,
   "temperature": undefined,
   "timeout": undefined,

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -26,7 +26,6 @@ exports[`streamText > options.experimental_onStart > should send correct informa
   "runtimeContext": {},
   "seed": undefined,
   "stopSequences": undefined,
-  "stopWhen": [Function],
   "system": undefined,
   "temperature": undefined,
   "timeout": undefined,

--- a/packages/ai/src/generate-text/core-events.ts
+++ b/packages/ai/src/generate-text/core-events.ts
@@ -1,5 +1,4 @@
 import type {
-  Arrayable,
   Context,
   InferToolSetContext,
   ProviderOptions,
@@ -7,13 +6,12 @@ import type {
 } from '@ai-sdk/provider-utils';
 import type { LanguageModelCallOptions } from '../prompt/language-model-call-options';
 import type { TimeoutConfiguration } from '../prompt/request-options';
+import type { StandardizedPrompt } from '../prompt/standardize-prompt';
 import type { ToolChoice } from '../types/language-model';
 import type { LanguageModelUsage } from '../types/usage';
 import type { Output } from './output';
 import type { StepResult } from './step-result';
-import type { StopCondition } from './stop-condition';
 import { TextStreamPart } from './stream-text-result';
-import type { StandardizedPrompt } from '../prompt/standardize-prompt';
 
 /**
  * Event passed to the `onStart` callback.
@@ -61,12 +59,6 @@ export type GenerateTextStartEvent<
 
   /** Additional provider-specific options. */
   readonly providerOptions: ProviderOptions | undefined;
-
-  /**
-   * Condition(s) for stopping the generation.
-   * When the condition is an array, any of the conditions can be met to stop.
-   */
-  readonly stopWhen: Arrayable<StopCondition<NoInfer<TOOLS>, RUNTIME_CONTEXT>>;
 
   /** The output specification for structured outputs, if configured. */
   readonly output: OUTPUT | undefined;

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -500,7 +500,6 @@ export async function generateText<
       timeout,
       headers: headersWithUserAgent,
       providerOptions,
-      stopWhen,
       output,
       runtimeContext,
       toolsContext,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -5788,7 +5788,6 @@ describe('streamText', () => {
       await result.consumeStream();
 
       expect(startEvent.timeout).toEqual({ totalMs: 5000, stepMs: 1000 });
-      expect(startEvent.stopWhen).toBeDefined();
     });
   });
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -603,7 +603,6 @@ export function streamText<
     prepareStep,
     includeRawChunks,
     timeout,
-    stopWhen,
     onChunk,
     onError,
     onFinish,
@@ -792,7 +791,6 @@ class DefaultStreamTextResult<
     generateId,
     generateCallId,
     timeout,
-    stopWhen,
     onChunk,
     onError,
     onFinish,
@@ -843,9 +841,6 @@ class DefaultStreamTextResult<
     generateId: () => string;
     generateCallId: () => string;
     timeout: TimeoutConfiguration<TOOLS> | undefined;
-    stopWhen: Arrayable<
-      StopCondition<NoInfer<TOOLS>, NoInfer<RUNTIME_CONTEXT>>
-    >;
     download: DownloadFunction | undefined;
     include: { requestBody?: boolean } | undefined;
 
@@ -1353,7 +1348,6 @@ class DefaultStreamTextResult<
           timeout,
           headers,
           providerOptions,
-          stopWhen,
           output,
           runtimeContext,
           toolsContext,


### PR DESCRIPTION
## Background

`stopWhen` is a function that is not helpful in simple events and complicates our generics usage (especially with the upcoming runtime context filtering).

## Summary

Remove `stopWhen` from start event.