### PR TITLE
fix(openai-compatible): buffer tool call deltas until function.name arrives

### DIFF
--- a/.changeset/breezy-eagles-care.md
+++ b/.changeset/breezy-eagles-care.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai-compatible": patch
+---
+
+fix(openai-compatible): buffer tool call deltas until function.name arrives

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2276,6 +2276,165 @@ describe('doStream', () => {
     `);
   });
 
+  it('should stream tool deltas when function.name arrives in a later chunk', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1711357598,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":null},"finish_reason":null}]}\n\n`,
+        // First tool_calls delta carries id and (empty) arguments but no function.name
+        `data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1711357598,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_late","type":"function","function":{"arguments":""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        // function.name arrives in the next chunk together with the start of the arguments
+        `data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1711357598,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_late","type":"function","function":{"name":"test-tool","arguments":"{\\""}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1711357598,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"value"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1711357598,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\":\\"hi\\"}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-late-name","object":"chat.completion.chunk","created":1729171479,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"prompt_tokens":18,"completion_tokens":10,"total_tokens":28}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-late-name",
+          "modelId": "grok-3",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "call_late",
+          "toolName": "test-tool",
+          "type": "tool-input-start",
+        },
+        {
+          "delta": "{"",
+          "id": "call_late",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "value",
+          "id": "call_late",
+          "type": "tool-input-delta",
+        },
+        {
+          "delta": "":"hi"}",
+          "id": "call_late",
+          "type": "tool-input-delta",
+        },
+        {
+          "id": "call_late",
+          "type": "tool-input-end",
+        },
+        {
+          "input": "{"value":"hi"}",
+          "toolCallId": "call_late",
+          "toolName": "test-tool",
+          "type": "tool-call",
+        },
+        {
+          "finishReason": {
+            "raw": "tool_calls",
+            "unified": "tool-calls",
+          },
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": undefined,
+              "noCache": 18,
+              "total": 18,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 10,
+              "total": 10,
+            },
+            "raw": {
+              "completion_tokens": 10,
+              "prompt_tokens": 18,
+              "total_tokens": 28,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should error when streamed tool call never receives a function.name', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-no-name","object":"chat.completion.chunk","created":1711357598,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":null},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-no-name","object":"chat.completion.chunk","created":1711357598,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_missing","type":"function","function":{"arguments":"{}"}}]},` +
+          `"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-no-name","object":"chat.completion.chunk","created":1729171479,"model":"grok-3",` +
+          `"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],` +
+          `"usage":{"prompt_tokens":18,"completion_tokens":10,"total_tokens":28}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    await expect(
+      convertReadableStreamToArray(stream),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[AI_InvalidResponseDataError: Expected 'function.name' to be a string.]`,
+    );
+  });
+
   it('should stream tool call with thought signature from extra_content', async () => {
     server.urls['https://my.api.com/v1/chat/completions'].response = {
       type: 'stream-chunks',

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -23,6 +23,7 @@ import {
   postJsonToApi,
   ResponseHandler,
   serializeModelOptions,
+  StreamingToolCallDelta,
   StreamingToolCallTracker,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
@@ -73,6 +74,20 @@ export type OpenAICompatibleChatConfig = {
    * than the official OpenAI API.
    */
   transformRequestBody?: (args: Record<string, any>) => Record<string, any>;
+};
+
+type OpenAICompatibleToolCallDelta = StreamingToolCallDelta & {
+  extra_content?: {
+    google?: {
+      thought_signature?: string | null;
+    } | null;
+  } | null;
+};
+
+type PendingToolCall = {
+  id: string | null;
+  bufferedArguments: string;
+  extraContent: OpenAICompatibleToolCallDelta['extra_content'];
 };
 
 export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
@@ -433,13 +448,73 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
     const toolCallTracker = new StreamingToolCallTracker({
       generateId,
       extractMetadata: delta => {
-        const sig = (delta as any).extra_content?.google?.thought_signature;
+        const sig = (delta as OpenAICompatibleToolCallDelta).extra_content
+          ?.google?.thought_signature;
         return sig
           ? { [providerOptionsName]: { thoughtSignature: sig } }
           : undefined;
       },
       buildToolCallProviderMetadata: metadata => metadata,
     });
+
+    // Buffers tool-call deltas by `index` until `function.name` is known.
+    // Some OpenAI-compatible providers send the first delta without
+    // `function.name`, which the shared tracker rejects on first chunk.
+    const pendingToolCalls = new Map<number, PendingToolCall>();
+    const forwardedToolCallIndices = new Set<number>();
+
+    const processToolCallDelta = (
+      toolCallDelta: OpenAICompatibleToolCallDelta,
+      enqueue: (part: LanguageModelV4StreamPart) => void,
+    ) => {
+      const index = toolCallDelta.index;
+
+      if (index == null || forwardedToolCallIndices.has(index)) {
+        toolCallTracker.processDelta(toolCallDelta, enqueue);
+        return;
+      }
+
+      let pending = pendingToolCalls.get(index);
+      if (pending == null) {
+        pending = {
+          id: toolCallDelta.id ?? null,
+          bufferedArguments: '',
+          extraContent: toolCallDelta.extra_content ?? null,
+        };
+        pendingToolCalls.set(index, pending);
+      } else {
+        if (pending.id == null && toolCallDelta.id != null) {
+          pending.id = toolCallDelta.id;
+        }
+        if (
+          pending.extraContent == null &&
+          toolCallDelta.extra_content != null
+        ) {
+          pending.extraContent = toolCallDelta.extra_content;
+        }
+      }
+
+      const argumentsDelta = toolCallDelta.function?.arguments;
+      if (argumentsDelta != null) {
+        pending.bufferedArguments += argumentsDelta;
+      }
+
+      const name = toolCallDelta.function?.name;
+      if (name != null) {
+        const forwardDelta: OpenAICompatibleToolCallDelta = {
+          index,
+          id: pending.id,
+          function: {
+            name,
+            arguments: pending.bufferedArguments,
+          },
+          extra_content: pending.extraContent ?? undefined,
+        };
+        toolCallTracker.processDelta(forwardDelta, enqueue);
+        pendingToolCalls.delete(index);
+        forwardedToolCallIndices.add(index);
+      }
+    };
 
     let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
@@ -569,7 +644,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
               }
 
               for (const toolCallDelta of delta.tool_calls) {
-                toolCallTracker.processDelta(
+                processToolCallDelta(
                   toolCallDelta,
                   controller.enqueue.bind(controller),
                 );
@@ -585,6 +660,20 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
             if (isActiveText) {
               controller.enqueue({ type: 'text-end', id: 'txt-0' });
             }
+
+            // Forward any tool-call deltas that never received a
+            // `function.name`
+            for (const [index, pending] of pendingToolCalls) {
+              toolCallTracker.processDelta(
+                {
+                  index,
+                  id: pending.id,
+                  function: { arguments: pending.bufferedArguments },
+                },
+                controller.enqueue.bind(controller),
+              );
+            }
+            pendingToolCalls.clear();
 
             toolCallTracker.flush(controller.enqueue.bind(controller));
 


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/14722

Some OpenAI-compatible providers send the first tool_calls delta with an `id` and `function.arguments` but without `function.name`, then provide function.name in a subsequent delta. The `StreamingToolCallTracker` previously threw AI_InvalidResponseDataError on the first delta because it required function.name to be present immediately.

## Summary

added a small buffering layer in front of the tracker that:
- holds onto deltas (per index) until function.name is seen
- while buffering, it accumulates id, arguments, and extra_content
- when function.name shows up, it forwards a single combined delta to StreamingToolCallTracker.processDelta
- once forwarded, the tool-call index is marked as forwarded and all subsequent deltas (argument-only chunks) pass straight through to the tracker unchanged.

## Manual Verification

verified by running this repro before and after the fix

<details>
<summary>repro:</summary>

```ts
import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
import { streamText, tool } from 'ai';
import { z } from 'zod';
import { run } from '../../lib/run';

const encoder = new TextEncoder();

const chunks = [
  {
    choices: [
      {
        finish_reason: null,
        index: 0,
        delta: { role: 'assistant', content: null },
      },
    ],
  },
  {
    choices: [
      {
        finish_reason: null,
        index: 0,
        delta: {
          tool_calls: [
            {
              index: 0,
              id: 'call_123',
              type: 'function',
              function: { arguments: '' },
            },
          ],
        },
      },
    ],
  },
  {
    choices: [
      {
        finish_reason: null,
        index: 0,
        delta: {
          tool_calls: [
            {
              index: 0,
              id: 'call_123',
              type: 'function',
              function: { name: 'bash', arguments: '{' },
            },
          ],
        },
      },
    ],
  },
  {
    choices: [
      {
        finish_reason: null,
        index: 0,
        delta: {
          tool_calls: [
            { index: 0, function: { arguments: '"command"' } },
          ],
        },
      },
    ],
  },
  {
    choices: [
      {
        finish_reason: null,
        index: 0,
        delta: {
          tool_calls: [
            { index: 0, function: { arguments: ': "ls -la"}' } },
          ],
        },
      },
    ],
  },
  {
    choices: [
      {
        finish_reason: 'tool_calls',
        index: 0,
        delta: {},
      },
    ],
  },
];

const openaiCompatible = createOpenAICompatible({
  name: 'late-tool-name-repro',
  baseURL: 'https://example.test/v1',
  apiKey: 'test-key',
  fetch: async () =>
    new Response(
      new ReadableStream({
        start(controller) {
          for (const chunk of chunks) {
            controller.enqueue(
              encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`),
            );
          }

          controller.enqueue(encoder.encode('data: [DONE]\n\n'));
          controller.close();
        },
      }),
      {
        headers: {
          'content-type': 'text/event-stream',
        },
      },
    ),
});

run(async () => {
  const result = streamText({
    model: openaiCompatible.chatModel('mock-model'),
    prompt: 'Run ls -la.',
    maxRetries: 0,
    toolChoice: 'required',
    tools: {
      bash: tool({
        description: 'Run a shell command.',
        inputSchema: z.object({
          command: z.string(),
        }),
        execute: async input => input,
      }),
    },
  });

  try {
    for await (const part of result.fullStream) {
      console.log(part.type, part);
    }
  } catch (error) {
    console.error('\nReproduced error:');
    console.error(error);
    process.exitCode = 1;
  }
});

```
</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #14722