### PR TITLE
feat(google): expose functionCallingConfig in provider options

### DIFF
--- a/.changeset/google-function-calling-config.md
+++ b/.changeset/google-function-calling-config.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(google): expose functionCallingConfig in provider options. Lets callers set the function-calling mode (AUTO/ANY/NONE/VALIDATED) and allowedFunctionNames directly without going through `toolChoice`. When provided, the supplied fields take precedence over the configuration derived from `toolChoice` and strict tools.

--- a/packages/google/src/google-language-model-options.ts
+++ b/packages/google/src/google-language-model-options.ts
@@ -206,6 +206,21 @@ export const googleLanguageModelOptions = lazySchema(() =>
       streamFunctionCallArguments: z.boolean().optional(),
 
       /**
+       * Optional. Override Google's functionCallingConfig. Lets callers set the
+       * function-calling mode and allowed function names without going through
+       * `toolChoice`. When provided, the supplied fields take precedence over
+       * the configuration derived from `toolChoice` and strict tools.
+       *
+       * https://ai.google.dev/gemini-api/docs/function-calling#function_calling_modes
+       */
+      functionCallingConfig: z
+        .object({
+          mode: z.enum(['AUTO', 'ANY', 'NONE', 'VALIDATED']).optional(),
+          allowedFunctionNames: z.array(z.string()).optional(),
+        })
+        .optional(),
+
+      /**
        * Optional. The service tier to use for the request.
        */
       serviceTier: z.enum(['standard', 'flex', 'priority']).optional(),

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -2924,6 +2924,89 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should pass functionCallingConfig from provider options when no tools are configured', async () => {
+    prepareJsonResponse({});
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        google: {
+          functionCallingConfig: {
+            mode: 'ANY',
+            allowedFunctionNames: ['get_weather'],
+          },
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      toolConfig: {
+        functionCallingConfig: {
+          mode: 'ANY',
+          allowedFunctionNames: ['get_weather'],
+        },
+      },
+    });
+  });
+
+  it('should let provider options functionCallingConfig.mode override the toolChoice-derived mode', async () => {
+    prepareJsonResponse({});
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: 'Get the weather',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+      toolChoice: { type: 'required' },
+      providerOptions: {
+        google: {
+          functionCallingConfig: { mode: 'NONE' },
+        },
+      },
+    });
+
+    expect(
+      (await server.calls[0].requestBodyJson).toolConfig.functionCallingConfig
+        .mode,
+    ).toBe('NONE');
+  });
+
+  it('should merge provider options functionCallingConfig with toolChoice-derived config', async () => {
+    prepareJsonResponse({});
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: 'Get the weather',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+      toolChoice: { type: 'required' },
+      providerOptions: {
+        google: {
+          functionCallingConfig: {
+            allowedFunctionNames: ['get_weather'],
+          },
+        },
+      },
+    });
+
+    expect(
+      (await server.calls[0].requestBodyJson).toolConfig.functionCallingConfig,
+    ).toMatchObject({
+      mode: 'ANY',
+      allowedFunctionNames: ['get_weather'],
+    });
+  });
+
   it('should include non-image inlineData parts', async () => {
     server.urls[TEST_URL_GEMINI_PRO].response = {
       type: 'json-value',

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -224,17 +224,27 @@ export class GoogleLanguageModel implements LanguageModelV4 {
         ? (googleOptions?.streamFunctionCallArguments ?? false)
         : undefined;
 
+    const resolvedFunctionCallingConfig =
+      googleToolConfig?.functionCallingConfig ||
+      streamFunctionCallArguments ||
+      googleOptions?.functionCallingConfig
+        ? {
+            ...googleToolConfig?.functionCallingConfig,
+            ...(streamFunctionCallArguments && {
+              streamFunctionCallArguments: true as const,
+            }),
+            ...googleOptions?.functionCallingConfig,
+          }
+        : undefined;
+
     const toolConfig =
       googleToolConfig ||
-      streamFunctionCallArguments ||
+      resolvedFunctionCallingConfig ||
       googleOptions?.retrievalConfig
         ? {
             ...googleToolConfig,
-            ...(streamFunctionCallArguments && {
-              functionCallingConfig: {
-                ...googleToolConfig?.functionCallingConfig,
-                streamFunctionCallArguments: true as const,
-              },
+            ...(resolvedFunctionCallingConfig && {
+              functionCallingConfig: resolvedFunctionCallingConfig,
             }),
             ...(googleOptions?.retrievalConfig && {
               retrievalConfig: googleOptions.retrievalConfig,


### PR DESCRIPTION
## 🔍 Description

### What changed?

Added `functionCallingConfig` to `@ai-sdk/google` provider options. Callers can now set Google's function-calling `mode` (`AUTO` / `ANY` / `NONE` / `VALIDATED`) and `allowedFunctionNames` directly via provider options, instead of being limited to whatever is derived from `toolChoice`.

When provided, the supplied fields take precedence over the configuration derived from `toolChoice` and strict tools, and still compose correctly with `streamFunctionCallArguments` on Vertex.

```ts
import { generateText } from 'ai';
import { google } from '@ai-sdk/google';

await generateText({
  model: google('gemini-2.5-flash'),
  tools: { get_weather, get_news },
  providerOptions: {
    google: {
      functionCallingConfig: {
        mode: 'ANY',
        allowedFunctionNames: ['get_weather'],
      },
    },
  },
  prompt: 'What is the weather in Lisbon?',
});
```

### Why was this change needed?

The Google Gemini API supports four `function_calling_config.mode` values (`AUTO`, `ANY`, `NONE`, `VALIDATED`) plus `allowedFunctionNames` ([docs](https://ai.google.dev/gemini-api/docs/function-calling#function_calling_modes)). Until now, the SDK exposed only the subset that could be expressed through `toolChoice` — there was no way to pin the model to a specific allowed function while still letting other tools be visible, no way to opt into `VALIDATED` mode for a non-strict tool, and no way to override the derived mode at all.

Closes #10006

## 📸 Screenshots/Examples

Test cases added under `Body Payload Tests` cover the three scenarios:

1. `functionCallingConfig` passed in provider options when no tools are configured (config flows through to `toolConfig`).
2. `functionCallingConfig.mode` from provider options overriding the `toolChoice`-derived mode (e.g. `toolChoice: 'required'` + provider options `mode: 'NONE'` → request body has `mode: 'NONE'`).
3. `functionCallingConfig` from provider options merging with `toolChoice`-derived config (`toolChoice: 'required'` + provider options `allowedFunctionNames: [...]` → request body has both `mode: 'ANY'` and `allowedFunctionNames`).

## 🔄 Breaking changes

- [x] This PR contains no breaking changes

`functionCallingConfig` is an additive optional field on Google provider options. Existing callers that rely on the `toolChoice`-derived behavior continue to work unchanged.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/vercel/ai/blob/main/CONTRIBUTING.md)
- [x] My PR title follows the [conventional commit format](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
- [ ] I have run `npx nx format` to ensure consistent code formatting — see note below
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)

## 📝 Additional notes

- Includes a `patch` changeset under `.changeset/google-function-calling-config.md`.
- Local verification: `pnpm -F @ai-sdk/google test` → 396/396 passing; `tsc --noEmit` clean.
- I could not run `ultracite check` / `nx format` cleanly in my local environment (the workspace `oxlint` plugin config did not load — `Rule 'no-unresolved' not found in plugin 'import'`). The added code matches the existing style in the same files (single quotes, JSDoc with docs link, `z.object({ ... }).optional()` pattern). Happy to push a follow-up format commit once CI runs and reports any specific findings.
- Diff is additive only: a new optional field on `googleLanguageModelOptions`, a refactor of the `toolConfig` assembly that preserves all existing behavior (including `streamFunctionCallArguments` on Vertex), and three new tests under `Body Payload Tests`. `pnpm-lock.yaml` is intentionally not committed (no dependency changes).

I noticed PR #10172 targets the same issue but was opened against the pre-refactor filenames (`google-generative-ai-language-model.ts` / `google-generative-ai-options.ts`) and has been stale for ~5 months without review activity. This PR targets the current filenames and includes test coverage for the merge precedence between provider-options config and the `toolChoice`-derived config. Happy to close this in favor of rebasing and reviving #10172 if that's preferred.
