### PR TITLE
fix(ai): unify generate text event callbacks

### DIFF
--- a/.changeset/fair-kangaroos-unite.md
+++ b/.changeset/fair-kangaroos-unite.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): unify generate text event callbacks

--- a/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
@@ -68,11 +68,11 @@ export type AgentCallParameters<CALL_OPTIONS, TOOLS extends ToolSet = {}> = ([
     /**
      * Callback that is called when the agent operation begins, before any LLM calls.
      */
-    experimental_onStart?: ToolLoopAgentOnStartCallback<TOOLS>;
+    experimental_onStart?: GenerateTextOnStartCallback<TOOLS>;
     /**
      * Callback that is called when a step (LLM call) begins, before the provider is called.
      */
-    experimental_onStepStart?: ToolLoopAgentOnStepStartCallback<TOOLS>;
+    experimental_onStepStart?: GenerateTextOnStepStartCallback<TOOLS>;
     /**
      * Callback that is called before each tool execution begins.
      */
@@ -84,11 +84,11 @@ export type AgentCallParameters<CALL_OPTIONS, TOOLS extends ToolSet = {}> = ([
     /**
      * Callback that is called when each step (LLM call) is finished, including intermediate steps.
      */
-    onStepFinish?: ToolLoopAgentOnStepFinishCallback<TOOLS>;
+    onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
     /**
      * Callback that is called when all steps are finished and the response is complete.
      */
-    onFinish?: ToolLoopAgentOnFinishCallback<TOOLS>;
+    onFinish?: GenerateTextOnFinishCallback<TOOLS>;
   };
 
 /**

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -113,7 +113,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
     },
     {
       name: 'experimental_onStart',
-      type: 'ToolLoopAgentOnStartCallback',
+      type: 'GenerateTextOnStartCallback',
       isOptional: true,
       description:
         'Callback that is called when the agent operation begins, before any LLM calls are made. Useful for logging, analytics, or initializing state. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first). Experimental (can break in patch releases).',
@@ -252,7 +252,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
     },
     {
       name: 'experimental_onStepStart',
-      type: 'ToolLoopAgentOnStepStartCallback',
+      type: 'GenerateTextOnStepStartCallback',
       isOptional: true,
       description:
         'Callback that is called when a step (LLM call) begins, before the provider is called. Each step represents a single LLM invocation. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first). Experimental (can break in patch releases).',
@@ -444,14 +444,14 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
     },
     {
       name: 'onStepFinish',
-      type: 'ToolLoopAgentOnStepFinishCallback',
+      type: 'GenerateTextOnStepFinishCallback',
       isOptional: true,
       description:
         'Callback invoked after each agent step (LLM/tool call) completes. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first).',
     },
     {
       name: 'onFinish',
-      type: 'ToolLoopAgentOnFinishCallback',
+      type: 'GenerateTextOnFinishCallback',
       isOptional: true,
       description:
         'Callback that is called when all agent steps are finished and the response is complete. Receives step results, total usage, shared `runtimeContext`, and `toolsContext`. If also specified in `generate()` or `stream()`, both callbacks are called (constructor first).',
@@ -639,14 +639,14 @@ const result = await agent.generate({
     },
     {
       name: 'experimental_onStart',
-      type: 'ToolLoopAgentOnStartCallback',
+      type: 'GenerateTextOnStartCallback',
       isOptional: true,
       description:
         'Callback that is called when the agent operation begins, before any LLM calls are made. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).',
     },
     {
       name: 'experimental_onStepStart',
-      type: 'ToolLoopAgentOnStepStartCallback',
+      type: 'GenerateTextOnStepStartCallback',
       isOptional: true,
       description:
         'Callback that is called when a step (LLM call) begins, before the provider is called. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).',
@@ -667,14 +667,14 @@ const result = await agent.generate({
     },
     {
       name: 'onStepFinish',
-      type: 'ToolLoopAgentOnStepFinishCallback',
+      type: 'GenerateTextOnStepFinishCallback',
       isOptional: true,
       description:
         'Callback invoked after each agent step (LLM/tool call) completes. If also specified in the constructor, both callbacks are called (constructor first, then this one).',
     },
     {
       name: 'onFinish',
-      type: 'ToolLoopAgentOnFinishCallback',
+      type: 'GenerateTextOnFinishCallback',
       isOptional: true,
       description:
         'Callback that is called when all agent steps are finished and the response is complete. If also specified in the constructor, both callbacks are called (constructor first, then this one).',
@@ -742,14 +742,14 @@ for await (const chunk of stream.textStream) {
     },
     {
       name: 'experimental_onStart',
-      type: 'ToolLoopAgentOnStartCallback',
+      type: 'GenerateTextOnStartCallback',
       isOptional: true,
       description:
         'Callback that is called when the agent operation begins, before any LLM calls are made. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).',
     },
     {
       name: 'experimental_onStepStart',
-      type: 'ToolLoopAgentOnStepStartCallback',
+      type: 'GenerateTextOnStepStartCallback',
       isOptional: true,
       description:
         'Callback that is called when a step (LLM call) begins, before the provider is called. If also specified in the constructor, both callbacks are called (constructor first). Experimental (can break in patch releases).',
@@ -770,14 +770,14 @@ for await (const chunk of stream.textStream) {
     },
     {
       name: 'onStepFinish',
-      type: 'ToolLoopAgentOnStepFinishCallback',
+      type: 'GenerateTextOnStepFinishCallback',
       isOptional: true,
       description:
         'Callback invoked after each agent step (LLM/tool call) completes. If also specified in the constructor, both callbacks are called (constructor first, then this one).',
     },
     {
       name: 'onFinish',
-      type: 'ToolLoopAgentOnFinishCallback',
+      type: 'GenerateTextOnFinishCallback',
       isOptional: true,
       description:
         'Callback that is called when all agent steps are finished and the response is complete. If also specified in the constructor, both callbacks are called (constructor first, then this one).',

--- a/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
@@ -88,7 +88,7 @@ export async function* streamAgent(
     },
     {
       name: 'onStepFinish',
-      type: 'ToolLoopAgentOnStepFinishCallback',
+      type: 'GenerateTextOnStepFinishCallback',
       isRequired: false,
       description:
         'Callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage or logging intermediate steps.',

--- a/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
@@ -89,7 +89,7 @@ export async function POST(request: Request) {
     },
     {
       name: 'onStepFinish',
-      type: 'ToolLoopAgentOnStepFinishCallback',
+      type: 'GenerateTextOnStepFinishCallback',
       isRequired: false,
       description:
         'Callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage or logging intermediate steps.',

--- a/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-pipe-agent-ui-stream-to-response.mdx
@@ -90,7 +90,7 @@ export async function handler(req, res) {
     },
     {
       name: 'onStepFinish',
-      type: 'ToolLoopAgentOnStepFinishCallback',
+      type: 'GenerateTextOnStepFinishCallback',
       isRequired: false,
       description:
         'Callback invoked after each agent step (LLM/tool call) completes. Useful for tracking token usage or logging intermediate steps.',

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -1,5 +1,11 @@
 import type { Arrayable, Context, ToolSet } from '@ai-sdk/provider-utils';
 import { ModelMessage } from '@ai-sdk/provider-utils';
+import {
+  GenerateTextOnFinishCallback,
+  GenerateTextOnStartCallback,
+  GenerateTextOnStepFinishCallback,
+  GenerateTextOnStepStartCallback,
+} from '../generate-text/generate-text-events';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
 import { Output } from '../generate-text/output';
 import { StreamTextTransform } from '../generate-text/stream-text';
@@ -9,12 +15,6 @@ import {
   OnToolExecutionStartCallback,
 } from '../generate-text/tool-execution-events';
 import { TimeoutConfiguration } from '../prompt/request-options';
-import type {
-  ToolLoopAgentOnFinishCallback,
-  ToolLoopAgentOnStartCallback,
-  ToolLoopAgentOnStepFinishCallback,
-  ToolLoopAgentOnStepStartCallback,
-} from './tool-loop-agent-settings';
 
 /**
  * Parameters for calling an agent.
@@ -71,12 +71,12 @@ export type AgentCallParameters<
     /**
      * Callback that is called when the agent operation begins, before any LLM calls.
      */
-    experimental_onStart?: ToolLoopAgentOnStartCallback<TOOLS, RUNTIME_CONTEXT>;
+    experimental_onStart?: GenerateTextOnStartCallback<TOOLS, RUNTIME_CONTEXT>;
 
     /**
      * Callback that is called when a step (LLM call) begins, before the provider is called.
      */
-    experimental_onStepStart?: ToolLoopAgentOnStepStartCallback<
+    experimental_onStepStart?: GenerateTextOnStepStartCallback<
       TOOLS,
       RUNTIME_CONTEXT
     >;
@@ -94,12 +94,12 @@ export type AgentCallParameters<
     /**
      * Callback that is called when each step (LLM call) is finished, including intermediate steps.
      */
-    onStepFinish?: ToolLoopAgentOnStepFinishCallback<TOOLS, RUNTIME_CONTEXT>;
+    onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS, RUNTIME_CONTEXT>;
 
     /**
      * Callback that is called when all steps are finished and the response is complete.
      */
-    onFinish?: ToolLoopAgentOnFinishCallback<TOOLS, RUNTIME_CONTEXT>;
+    onFinish?: GenerateTextOnFinishCallback<TOOLS, RUNTIME_CONTEXT>;
   };
 
 /**

--- a/packages/ai/src/agent/create-agent-ui-stream-response.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.ts
@@ -1,13 +1,14 @@
-import { StreamTextTransform, UIMessageStreamOptions } from '../generate-text';
-import { Output } from '../generate-text/output';
 import type { Arrayable, Context, ToolSet } from '@ai-sdk/provider-utils';
+import { GenerateTextOnStepFinishCallback } from '../generate-text/generate-text-events';
+import { Output } from '../generate-text/output';
+import { StreamTextTransform } from '../generate-text/stream-text';
+import { UIMessageStreamOptions } from '../generate-text/stream-text-result';
 import { TimeoutConfiguration } from '../prompt/request-options';
 import { createUIMessageStreamResponse } from '../ui-message-stream';
 import { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-stream-response-init';
 import { InferUITools, UIMessage } from '../ui/ui-messages';
 import { Agent } from './agent';
 import { createAgentUIStream } from './create-agent-ui-stream';
-import type { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-settings';
 
 /**
  * Runs the agent and returns a response object with a UI message stream.
@@ -45,7 +46,7 @@ export async function createAgentUIStreamResponse<
   timeout?: TimeoutConfiguration<TOOLS>;
   options?: CALL_OPTIONS;
   experimental_transform?: Arrayable<StreamTextTransform<TOOLS>>;
-  onStepFinish?: ToolLoopAgentOnStepFinishCallback<TOOLS>;
+  onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
 } & UIMessageStreamResponseInit &
   UIMessageStreamOptions<
     UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>

--- a/packages/ai/src/agent/create-agent-ui-stream.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.ts
@@ -1,6 +1,8 @@
-import { StreamTextTransform, UIMessageStreamOptions } from '../generate-text';
-import { Output } from '../generate-text/output';
 import type { Arrayable, Context, ToolSet } from '@ai-sdk/provider-utils';
+import { GenerateTextOnStepFinishCallback } from '../generate-text/generate-text-events';
+import { Output } from '../generate-text/output';
+import { StreamTextTransform } from '../generate-text/stream-text';
+import { UIMessageStreamOptions } from '../generate-text/stream-text-result';
 import { TimeoutConfiguration } from '../prompt/request-options';
 import { InferUIMessageChunk } from '../ui-message-stream';
 import { convertToModelMessages } from '../ui/convert-to-model-messages';
@@ -8,7 +10,6 @@ import { InferUITools, UIMessage } from '../ui/ui-messages';
 import { validateUIMessages } from '../ui/validate-ui-messages';
 import { AsyncIterableStream } from '../util/async-iterable-stream';
 import { Agent } from './agent';
-import type { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-settings';
 
 /**
  * Runs the agent and stream the output as a UI message stream.
@@ -45,7 +46,7 @@ export async function createAgentUIStream<
   timeout?: TimeoutConfiguration<TOOLS>;
   options?: CALL_OPTIONS;
   experimental_transform?: Arrayable<StreamTextTransform<TOOLS>>;
-  onStepFinish?: ToolLoopAgentOnStepFinishCallback<TOOLS>;
+  onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
   // TODO `originalMessages` is part of this for bc, omit in v7
 } & UIMessageStreamOptions<
   UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -4,10 +4,6 @@ export {
   type AgentStreamParameters,
 } from './agent';
 export {
-  type ToolLoopAgentOnFinishCallback,
-  type ToolLoopAgentOnStartCallback,
-  type ToolLoopAgentOnStepFinishCallback,
-  type ToolLoopAgentOnStepStartCallback,
   type ToolLoopAgentSettings,
 
   /**

--- a/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
+++ b/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
@@ -1,14 +1,15 @@
-import { ServerResponse } from 'node:http';
-import { StreamTextTransform, UIMessageStreamOptions } from '../generate-text';
-import { Output } from '../generate-text/output';
 import type { Arrayable, Context, ToolSet } from '@ai-sdk/provider-utils';
+import { ServerResponse } from 'node:http';
+import { GenerateTextOnStepFinishCallback } from '../generate-text/generate-text-events';
+import { Output } from '../generate-text/output';
+import { StreamTextTransform } from '../generate-text/stream-text';
+import { UIMessageStreamOptions } from '../generate-text/stream-text-result';
 import { TimeoutConfiguration } from '../prompt/request-options';
 import { pipeUIMessageStreamToResponse } from '../ui-message-stream';
 import { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-stream-response-init';
 import { InferUITools, UIMessage } from '../ui/ui-messages';
 import { Agent } from './agent';
 import { createAgentUIStream } from './create-agent-ui-stream';
-import type { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-settings';
 
 /**
  * Pipes the agent UI message stream to a Node.js ServerResponse object.
@@ -47,7 +48,7 @@ export async function pipeAgentUIStreamToResponse<
   timeout?: TimeoutConfiguration<TOOLS>;
   options?: CALL_OPTIONS;
   experimental_transform?: Arrayable<StreamTextTransform<TOOLS>>;
-  onStepFinish?: ToolLoopAgentOnStepFinishCallback<TOOLS>;
+  onStepFinish?: GenerateTextOnStepFinishCallback<TOOLS>;
 } & UIMessageStreamResponseInit &
   UIMessageStreamOptions<
     UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -12,11 +12,11 @@ import {
   SystemModelMessage,
 } from '@ai-sdk/provider-utils';
 import type {
-  GenerateTextEndEvent,
-  GenerateTextStartEvent,
-  GenerateTextStepEndEvent,
-  GenerateTextStepStartEvent,
-} from '../generate-text/core-events';
+  GenerateTextOnFinishCallback,
+  GenerateTextOnStartCallback,
+  GenerateTextOnStepFinishCallback,
+  GenerateTextOnStepStartCallback,
+} from '../generate-text/generate-text-events';
 import { Output } from '../generate-text/output';
 import { PrepareStepFunction } from '../generate-text/prepare-step';
 import { StopCondition } from '../generate-text/stop-condition';
@@ -32,31 +32,8 @@ import { Prompt } from '../prompt/prompt';
 import { RequestOptions } from '../prompt/request-options';
 import { TelemetryOptions } from '../telemetry/telemetry-options';
 import { LanguageModel, ToolChoice } from '../types/language-model';
-import type { Callback } from '../util/callback';
 import { DownloadFunction } from '../util/download/download-function';
 import { AgentCallParameters } from './agent';
-
-export type ToolLoopAgentOnStartCallback<
-  TOOLS extends ToolSet = ToolSet,
-  RUNTIME_CONTEXT extends Context = Context,
-  OUTPUT extends Output = Output,
-> = Callback<GenerateTextStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
-
-export type ToolLoopAgentOnStepStartCallback<
-  TOOLS extends ToolSet = ToolSet,
-  RUNTIME_CONTEXT extends Context = Context,
-  OUTPUT extends Output = Output,
-> = Callback<GenerateTextStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
-
-export type ToolLoopAgentOnStepFinishCallback<
-  TOOLS extends ToolSet = ToolSet,
-  RUNTIME_CONTEXT extends Context = Context,
-> = Callback<GenerateTextStepEndEvent<TOOLS, RUNTIME_CONTEXT>>;
-
-export type ToolLoopAgentOnFinishCallback<
-  TOOLS extends ToolSet = ToolSet,
-  RUNTIME_CONTEXT extends Context = Context,
-> = Callback<GenerateTextEndEvent<TOOLS, RUNTIME_CONTEXT>>;
 
 /**
  * Configuration options for an agent.
@@ -148,7 +125,7 @@ export type ToolLoopAgentSettings<
     /**
      * Callback that is called when the agent operation begins, before any LLM calls.
      */
-    experimental_onStart?: ToolLoopAgentOnStartCallback<
+    experimental_onStart?: GenerateTextOnStartCallback<
       NoInfer<TOOLS>,
       RUNTIME_CONTEXT,
       NoInfer<OUTPUT>
@@ -157,7 +134,7 @@ export type ToolLoopAgentSettings<
     /**
      * Callback that is called when a step (LLM call) begins, before the provider is called.
      */
-    experimental_onStepStart?: ToolLoopAgentOnStepStartCallback<
+    experimental_onStepStart?: GenerateTextOnStepStartCallback<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>,
       NoInfer<OUTPUT>
@@ -180,7 +157,7 @@ export type ToolLoopAgentSettings<
     /**
      * Callback that is called when each step (LLM call) is finished, including intermediate steps.
      */
-    onStepFinish?: ToolLoopAgentOnStepFinishCallback<
+    onStepFinish?: GenerateTextOnStepFinishCallback<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>
     >;
@@ -188,7 +165,7 @@ export type ToolLoopAgentSettings<
     /**
      * Callback that is called when all steps are finished and the response is complete.
      */
-    onFinish?: ToolLoopAgentOnFinishCallback<
+    onFinish?: GenerateTextOnFinishCallback<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>
     >;

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -2,8 +2,8 @@ import { Context, tool } from '@ai-sdk/provider-utils';
 import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
 import {
+  GenerateTextOnFinishCallback,
   Output,
-  StreamTextOnFinishCallback,
   ToolApprovalConfiguration,
 } from '../generate-text';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
@@ -11,12 +11,11 @@ import { AsyncIterableStream } from '../util/async-iterable-stream';
 import { DeepPartial } from '../util/deep-partial';
 import { AgentCallParameters, AgentStreamParameters } from './agent';
 import { ToolLoopAgent } from './tool-loop-agent';
-import type { ToolLoopAgentOnFinishCallback } from './tool-loop-agent-settings';
 
 describe('ToolLoopAgent', () => {
   describe('onFinish callback type compatibility', () => {
     it('should allow StreamTextOnFinishCallback where ToolLoopAgentOnFinishCallback is expected', () => {
-      const streamTextCallback: StreamTextOnFinishCallback<
+      const streamTextCallback: GenerateTextOnFinishCallback<
         {},
         {}
       > = async event => {
@@ -25,18 +24,18 @@ describe('ToolLoopAgent', () => {
       };
 
       expectTypeOf(streamTextCallback).toMatchTypeOf<
-        ToolLoopAgentOnFinishCallback<{}>
+        GenerateTextOnFinishCallback<{}>
       >();
     });
 
-    it('should allow ToolLoopAgentOnFinishCallback where StreamTextOnFinishCallback is expected', () => {
-      const agentCallback: ToolLoopAgentOnFinishCallback<{}> = async event => {
+    it('should allow ToolLoopAgentOnFinishCallback where GenerateTextOnFinishCallback is expected', () => {
+      const agentCallback: GenerateTextOnFinishCallback<{}> = async event => {
         const runtimeContext: unknown = event.runtimeContext;
         runtimeContext;
       };
 
       expectTypeOf(agentCallback).toMatchTypeOf<
-        StreamTextOnFinishCallback<{}, {}>
+        GenerateTextOnFinishCallback<{}, {}>
       >();
     });
   });

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -8,11 +8,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
 import { ToolLoopAgent } from './tool-loop-agent';
-import type {
-  ToolLoopAgentOnFinishCallback,
-  ToolLoopAgentOnStartCallback,
-  ToolLoopAgentOnStepStartCallback,
-} from './tool-loop-agent-settings';
 import {
   ToolExecutionEndEvent,
   ToolExecutionStartEvent,
@@ -23,6 +18,11 @@ vi.mock('../util/now', () => ({
   now: vi.fn(),
 }));
 import { now } from '../util/now';
+import {
+  GenerateTextOnFinishCallback,
+  GenerateTextOnStartCallback,
+  GenerateTextOnStepStartCallback,
+} from '../generate-text/generate-text-events';
 const mockNow = vi.mocked(now);
 
 const testSettings = {
@@ -931,7 +931,7 @@ describe('ToolLoopAgent', () => {
 
       it('should pass correct event information', async () => {
         let startEvent!: Parameters<
-          ToolLoopAgentOnStartCallback<{}, { userId: string }>
+          GenerateTextOnStartCallback<{}, { userId: string }>
         >[0];
 
         const agent = new ToolLoopAgent({
@@ -978,7 +978,7 @@ describe('ToolLoopAgent', () => {
       });
 
       it('should pass messages when using messages option', async () => {
-        let startEvent!: Parameters<ToolLoopAgentOnStartCallback<{}>>[0];
+        let startEvent!: Parameters<GenerateTextOnStartCallback<{}>>[0];
 
         const agent = new ToolLoopAgent({
           model: mockModel,
@@ -1116,7 +1116,7 @@ describe('ToolLoopAgent', () => {
 
       it('should pass correct event information', async () => {
         let startEvent!: Parameters<
-          ToolLoopAgentOnStartCallback<{}, { userId: string }>
+          GenerateTextOnStartCallback<{}, { userId: string }>
         >[0];
 
         const agent = new ToolLoopAgent({
@@ -1325,7 +1325,7 @@ describe('ToolLoopAgent', () => {
 
       it('should pass correct event information', async () => {
         let stepStartEvent!: Parameters<
-          ToolLoopAgentOnStepStartCallback<{}, { userId: string }>
+          GenerateTextOnStepStartCallback<{}, { userId: string }>
         >[0];
 
         const agent = new ToolLoopAgent({
@@ -1479,7 +1479,7 @@ describe('ToolLoopAgent', () => {
 
       it('should pass correct event information', async () => {
         let stepStartEvent!: Parameters<
-          ToolLoopAgentOnStepStartCallback<{}, { userId: string }>
+          GenerateTextOnStepStartCallback<{}, { userId: string }>
         >[0];
 
         const agent = new ToolLoopAgent({
@@ -2755,7 +2755,7 @@ describe('ToolLoopAgent', () => {
       });
 
       it('should pass correct event information', async () => {
-        let event!: Parameters<ToolLoopAgentOnFinishCallback>[0];
+        let event!: Parameters<GenerateTextOnFinishCallback<{}>>[0];
 
         const agent = new ToolLoopAgent({
           model: mockModel,
@@ -2906,7 +2906,7 @@ describe('ToolLoopAgent', () => {
       });
 
       it('should pass correct event information', async () => {
-        let event!: Parameters<ToolLoopAgentOnFinishCallback>[0];
+        let event!: Parameters<GenerateTextOnFinishCallback<{}>>[0];
 
         const agent = new ToolLoopAgent({
           model: mockModel,

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -1,5 +1,9 @@
 import type { Context, ModelMessage, ToolSet } from '@ai-sdk/provider-utils';
 import { generateText } from '../generate-text/generate-text';
+import {
+  GenerateTextOnStartCallback,
+  GenerateTextOnStepStartCallback,
+} from '../generate-text/generate-text-events';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
 import { Output } from '../generate-text/output';
 import { isStepCount } from '../generate-text/stop-condition';
@@ -8,11 +12,7 @@ import { StreamTextResult } from '../generate-text/stream-text-result';
 import { Prompt } from '../prompt';
 import { mergeCallbacks } from '../util/merge-callbacks';
 import { Agent, AgentCallParameters, AgentStreamParameters } from './agent';
-import {
-  ToolLoopAgentOnStartCallback,
-  ToolLoopAgentOnStepStartCallback,
-  ToolLoopAgentSettings,
-} from './tool-loop-agent-settings';
+import type { ToolLoopAgentSettings } from './tool-loop-agent-settings';
 
 /**
  * A tool loop agent is an agent that runs tools in a loop. In each step,
@@ -156,13 +156,13 @@ export class ToolLoopAgent<
       experimental_onStart: mergeCallbacks(
         this.settings.experimental_onStart,
         experimental_onStart as
-          | ToolLoopAgentOnStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
+          | GenerateTextOnStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
           | undefined,
       ),
       experimental_onStepStart: mergeCallbacks(
         this.settings.experimental_onStepStart,
         experimental_onStepStart as
-          | ToolLoopAgentOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
+          | GenerateTextOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
           | undefined,
       ),
       experimental_onToolExecutionStart: mergeCallbacks(
@@ -209,13 +209,13 @@ export class ToolLoopAgent<
       experimental_onStart: mergeCallbacks(
         this.settings.experimental_onStart,
         experimental_onStart as
-          | ToolLoopAgentOnStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
+          | GenerateTextOnStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
           | undefined,
       ),
       experimental_onStepStart: mergeCallbacks(
         this.settings.experimental_onStepStart,
         experimental_onStepStart as
-          | ToolLoopAgentOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
+          | GenerateTextOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
           | undefined,
       ),
       experimental_onToolExecutionStart: mergeCallbacks(

--- a/packages/ai/src/generate-text/generate-text-events.ts
+++ b/packages/ai/src/generate-text/generate-text-events.ts
@@ -9,6 +9,7 @@ import type { TimeoutConfiguration } from '../prompt/request-options';
 import type { StandardizedPrompt } from '../prompt/standardize-prompt';
 import type { ToolChoice } from '../types/language-model';
 import type { LanguageModelUsage } from '../types/usage';
+import { Callback } from '../util/callback';
 import type { Output } from './output';
 import type { StepResult } from './step-result';
 import { TextStreamPart } from './stream-text-result';
@@ -202,3 +203,60 @@ export type OnFinishEvent<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
 > = GenerateTextEndEvent<TOOLS, RUNTIME_CONTEXT>;
+
+/**
+ * Callback that is set using the `experimental_onStart` option.
+ *
+ * Called when the generateText operation begins, before any LLM calls.
+ * Use this callback for logging, analytics, or initializing state at the
+ * start of a generation.
+ *
+ * @param event - The event object containing generation configuration.
+ */
+export type GenerateTextOnStartCallback<
+  TOOLS extends ToolSet = ToolSet,
+  RUNTIME_CONTEXT extends Context = Context,
+  OUTPUT extends Output = Output,
+> = Callback<GenerateTextStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
+
+/**
+ * Callback that is set using the `experimental_onStepStart` option.
+ *
+ * Called when a step (LLM call) begins, before the provider is called.
+ * Each step represents a single LLM invocation. Multiple steps occur when
+ * using tool calls (the model may be called multiple times in a loop).
+ *
+ * @param event - The event object containing step configuration.
+ */
+export type GenerateTextOnStepStartCallback<
+  TOOLS extends ToolSet = ToolSet,
+  RUNTIME_CONTEXT extends Context = Context,
+  OUTPUT extends Output = Output,
+> = Callback<GenerateTextStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
+
+/**
+ * Callback that is set using the `onStepFinish` option.
+ *
+ * Called when a step (LLM call) completes. The event includes all step result
+ * properties (text, tool calls, usage, etc.) along with additional metadata.
+ *
+ * @param stepResult - The result of the step.
+ */
+export type GenerateTextOnStepFinishCallback<
+  TOOLS extends ToolSet = ToolSet,
+  RUNTIME_CONTEXT extends Context = Context,
+> = Callback<GenerateTextStepEndEvent<TOOLS, RUNTIME_CONTEXT>>;
+
+/**
+ * Callback that is set using the `onFinish` option.
+ *
+ * Called when the entire generation completes (all steps finished).
+ * The event includes the final step's result properties along with
+ * aggregated data from all steps.
+ *
+ * @param event - The final result along with aggregated step data.
+ */
+export type GenerateTextOnFinishCallback<
+  TOOLS extends ToolSet = ToolSet,
+  RUNTIME_CONTEXT extends Context = Context,
+> = Callback<GenerateTextEndEvent<TOOLS, RUNTIME_CONTEXT>>;

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -25,25 +25,27 @@ import {
   vitest,
 } from 'vitest';
 import { z } from 'zod/v4';
-import {
-  LanguageModelCallStartEvent,
-  LanguageModelCallEndEvent,
-  Output,
-  ToolExecutionEndEvent,
-  ToolExecutionStartEvent,
-} from '.';
 import * as logWarningsModule from '../logger/log-warnings';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import { generateText } from './generate-text';
 import {
-  generateText,
   GenerateTextOnFinishCallback,
   GenerateTextOnStartCallback,
   GenerateTextOnStepFinishCallback,
   GenerateTextOnStepStartCallback,
-} from './generate-text';
+} from './generate-text-events';
 import { GenerateTextResult } from './generate-text-result';
+import * as Output from './output';
 import { StepResult } from './step-result';
 import { isLoopFinished, isStepCount } from './stop-condition';
+import {
+  ToolExecutionEndEvent,
+  ToolExecutionStartEvent,
+} from './tool-execution-events';
+import {
+  LanguageModelCallEndEvent,
+  LanguageModelCallStartEvent,
+} from './language-model-events';
 
 vi.mock('../version', () => {
   return {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -50,7 +50,6 @@ import {
   asLanguageModelUsage,
   LanguageModelUsage,
 } from '../types/usage';
-import type { Callback } from '../util/callback';
 import { DownloadFunction } from '../util/download/download-function';
 import { mergeAbortSignals } from '../util/merge-abort-signals';
 import { mergeObjects } from '../util/merge-objects';
@@ -59,26 +58,26 @@ import { prepareRetries } from '../util/prepare-retries';
 import { VERSION } from '../version';
 import { collectToolApprovals } from './collect-tool-approvals';
 import { ContentPart } from './content-part';
+import { executeToolCall } from './execute-tool-call';
+import { filterActiveTools } from './filter-active-tool';
 import type {
-  GenerateTextEndEvent,
-  GenerateTextStartEvent,
-  GenerateTextStepEndEvent,
-  GenerateTextStepStartEvent,
-} from './core-events';
+  GenerateTextOnFinishCallback,
+  GenerateTextOnStartCallback,
+  GenerateTextOnStepFinishCallback,
+  GenerateTextOnStepStartCallback,
+} from './generate-text-events';
+import { GenerateTextResult } from './generate-text-result';
+import { DefaultGeneratedFile } from './generated-file';
 import type {
   OnLanguageModelCallEndCallback,
   OnLanguageModelCallStartCallback,
 } from './language-model-events';
-import { executeToolCall } from './execute-tool-call';
-import { filterActiveTools } from './filter-active-tool';
-import { GenerateTextResult } from './generate-text-result';
-import { DefaultGeneratedFile } from './generated-file';
-import { resolveToolApproval } from './resolve-tool-approval';
 import { Output, text } from './output';
 import { InferCompleteOutput } from './output-utils';
 import { parseToolCall } from './parse-tool-call';
 import { PrepareStepFunction } from './prepare-step';
 import { convertToReasoningOutputs } from './reasoning-output';
+import { resolveToolApproval } from './resolve-tool-approval';
 import { ResponseMessage } from './response-message';
 import { DefaultStepResult, StepResult } from './step-result';
 import {
@@ -110,64 +109,6 @@ const originalGenerateCallId = createIdGenerator({
   prefix: 'call',
   size: 24,
 });
-
-/**
- * Callback that is set using the `experimental_onStart` option.
- *
- * Called when the generateText operation begins, before any LLM calls.
- * Use this callback for logging, analytics, or initializing state at the
- * start of a generation.
- *
- * @param event - The event object containing generation configuration.
- */
-export type GenerateTextOnStartCallback<
-  TOOLS extends ToolSet = ToolSet,
-  RUNTIME_CONTEXT extends Context = Context,
-  OUTPUT extends Output = Output,
-> = Callback<GenerateTextStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
-
-/**
- * Callback that is set using the `experimental_onStepStart` option.
- *
- * Called when a step (LLM call) begins, before the provider is called.
- * Each step represents a single LLM invocation. Multiple steps occur when
- * using tool calls (the model may be called multiple times in a loop).
- *
- * @param event - The event object containing step configuration.
- */
-export type GenerateTextOnStepStartCallback<
-  TOOLS extends ToolSet = ToolSet,
-  RUNTIME_CONTEXT extends Context = Context,
-  OUTPUT extends Output = Output,
-> = Callback<GenerateTextStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
-
-/**
- * Callback that is set using the `onStepFinish` option.
- *
- * Called when a step (LLM call) completes. The event includes all step result
- * properties (text, tool calls, usage, etc.) along with additional metadata.
- *
- * @param stepResult - The result of the step.
- */
-export type GenerateTextOnStepFinishCallback<
-  TOOLS extends ToolSet = ToolSet,
-  RUNTIME_CONTEXT extends Context = Context,
-> = Callback<GenerateTextStepEndEvent<TOOLS, RUNTIME_CONTEXT>>;
-
-/**
- * Callback that is set using the `onFinish` option.
- *
- * Called when the entire generation completes (all steps finished).
- * The event includes the final step's result properties along with
- * aggregated data from all steps.
- *
- * @param event - The final result along with aggregated step data.
- */
-export type GenerateTextOnFinishCallback<
-  TOOLS extends ToolSet = ToolSet,
-  RUNTIME_CONTEXT extends Context = Context,
-> = Callback<GenerateTextEndEvent<TOOLS, RUNTIME_CONTEXT>>;
-
 /**
  * Generate a text and call tools for a given prompt using a language model.
  *

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -1,7 +1,12 @@
 export type { ContentPart } from './content-part';
+export { filterActiveTools as experimental_filterActiveTools } from './filter-active-tool';
+export { generateText } from './generate-text';
 export type {
-  StreamTextChunkEvent,
   GenerateTextEndEvent,
+  GenerateTextOnFinishCallback,
+  GenerateTextOnStartCallback,
+  GenerateTextOnStepFinishCallback,
+  GenerateTextOnStepStartCallback,
   GenerateTextStartEvent,
   GenerateTextStepEndEvent,
   GenerateTextStepStartEvent,
@@ -10,28 +15,21 @@ export type {
   OnStartEvent,
   OnStepFinishEvent,
   OnStepStartEvent,
-} from './core-events';
-export type {
-  ModelInfo,
-  LanguageModelCallEndEvent,
-  LanguageModelCallStartEvent,
-  OnLanguageModelCallEndCallback,
-  OnLanguageModelCallStartCallback,
-} from './language-model-events';
-export { filterActiveTools as experimental_filterActiveTools } from './filter-active-tool';
-export {
-  generateText,
-  type GenerateTextOnFinishCallback,
-  type GenerateTextOnStartCallback,
-  type GenerateTextOnStepFinishCallback,
-  type GenerateTextOnStepStartCallback,
-} from './generate-text';
+  StreamTextChunkEvent,
+} from './generate-text-events';
 export type { GenerateTextResult } from './generate-text-result';
 export {
   DefaultGeneratedFile,
   type GeneratedFile as Experimental_GeneratedImage, // Image for backwards compatibility, TODO remove in v7
   type GeneratedFile,
 } from './generated-file';
+export type {
+  LanguageModelCallEndEvent,
+  LanguageModelCallStartEvent,
+  ModelInfo,
+  OnLanguageModelCallEndCallback,
+  OnLanguageModelCallStartCallback,
+} from './language-model-events';
 export * as Output from './output';
 export type { Output as OutputInterface } from './output';
 export type {
@@ -62,10 +60,6 @@ export {
   streamText,
   type StreamTextOnChunkCallback,
   type StreamTextOnErrorCallback,
-  type StreamTextOnFinishCallback,
-  type StreamTextOnStartCallback,
-  type StreamTextOnStepFinishCallback,
-  type StreamTextOnStepStartCallback,
   type StreamTextTransform,
 } from './stream-text';
 export type {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -51,17 +51,17 @@ import {
 } from '../types/usage';
 import { StepResult } from './step-result';
 import { isLoopFinished, isStepCount } from './stop-condition';
-import {
-  streamText,
-  StreamTextOnFinishCallback,
-  StreamTextOnStartCallback,
-  StreamTextOnStepStartCallback,
-} from './stream-text';
+import { streamText } from './stream-text';
 import { StreamTextResult, TextStreamPart } from './stream-text-result';
 import {
   OnToolExecutionEndCallback,
   OnToolExecutionStartCallback,
 } from './tool-execution-events';
+import {
+  GenerateTextOnFinishCallback,
+  GenerateTextOnStartCallback,
+  GenerateTextOnStepStartCallback,
+} from './generate-text-events';
 
 const defaultSettings = () =>
   ({
@@ -5576,7 +5576,7 @@ describe('streamText', () => {
 
   describe('options.experimental_onStart', () => {
     it('should send correct information with text prompt', async () => {
-      let startEvent!: Parameters<StreamTextOnStartCallback>[0];
+      let startEvent!: Parameters<GenerateTextOnStartCallback>[0];
 
       const result = streamText({
         model: createTestModel(),
@@ -5600,7 +5600,7 @@ describe('streamText', () => {
     });
 
     it('should accept deprecated experimental_telemetry as an alias for telemetry', async () => {
-      let startEvent!: Parameters<StreamTextOnStartCallback>[0];
+      let startEvent!: Parameters<GenerateTextOnStartCallback>[0];
 
       const result = streamText({
         model: createTestModel(),
@@ -5643,7 +5643,7 @@ describe('streamText', () => {
     });
 
     it('should send correct information with system and messages', async () => {
-      let startEvent!: Parameters<StreamTextOnStartCallback>[0];
+      let startEvent!: Parameters<GenerateTextOnStartCallback>[0];
 
       const result = streamText({
         model: createTestModel(),
@@ -5728,7 +5728,7 @@ describe('streamText', () => {
     });
 
     it('should expose tools and toolChoice', async () => {
-      let startEvent!: Parameters<StreamTextOnStartCallback<any>>[0];
+      let startEvent!: Parameters<GenerateTextOnStartCallback<any>>[0];
 
       const testTool = tool({
         inputSchema: z.object({ value: z.string() }),
@@ -5752,7 +5752,7 @@ describe('streamText', () => {
     });
 
     it('should expose providerOptions', async () => {
-      let startEvent!: Parameters<StreamTextOnStartCallback>[0];
+      let startEvent!: Parameters<GenerateTextOnStartCallback>[0];
 
       const result = streamText({
         model: createTestModel(),
@@ -5772,7 +5772,7 @@ describe('streamText', () => {
     });
 
     it('should expose timeout and stopWhen', async () => {
-      let startEvent!: Parameters<StreamTextOnStartCallback>[0];
+      let startEvent!: Parameters<GenerateTextOnStartCallback>[0];
 
       const result = streamText({
         model: createTestModel(),
@@ -5794,7 +5794,7 @@ describe('streamText', () => {
   describe('options.experimental_onStepStart', () => {
     it('should be called with correct data for a single step', async () => {
       let stepStartEvent!: Parameters<
-        StreamTextOnStepStartCallback<any, any>
+        GenerateTextOnStepStartCallback<any, any>
       >[0];
 
       const result = streamText({
@@ -5823,7 +5823,7 @@ describe('streamText', () => {
 
     it('should be called once per step in a multi-step tool loop', async () => {
       const stepStartEvents: Parameters<
-        StreamTextOnStepStartCallback<any, any>
+        GenerateTextOnStepStartCallback<any, any>
       >[0][] = [];
       let responseCount = 0;
 
@@ -5968,7 +5968,7 @@ describe('streamText', () => {
 
     it('should reflect model changes from prepareStep', async () => {
       const stepStartEvents: Parameters<
-        StreamTextOnStepStartCallback<any, any>
+        GenerateTextOnStepStartCallback<any, any>
       >[0][] = [];
       let responseCount = 0;
 
@@ -6056,7 +6056,7 @@ describe('streamText', () => {
 
     it('should expose providerOptions and runtimeContext', async () => {
       let stepStartEvent!: Parameters<
-        StreamTextOnStepStartCallback<any, any>
+        GenerateTextOnStepStartCallback<any, any>
       >[0];
 
       const result = streamText({
@@ -6082,7 +6082,7 @@ describe('streamText', () => {
 
     it('should not expose telemetry metadata in onStepStart', async () => {
       let stepStartEvent!: Parameters<
-        StreamTextOnStepStartCallback<any, any>
+        GenerateTextOnStepStartCallback<any, any>
       >[0];
 
       const result = streamText({
@@ -6105,7 +6105,7 @@ describe('streamText', () => {
     it('should pass updated toolsContext from prepareStep', async () => {
       const prepareStepToolsContexts: Array<unknown> = [];
       const stepStartEvents: Parameters<
-        StreamTextOnStepStartCallback<any, any>
+        GenerateTextOnStepStartCallback<any, any>
       >[0][] = [];
       let responseCount = 0;
       let recordedToolContext: unknown;
@@ -7469,7 +7469,7 @@ describe('streamText', () => {
 
   describe('options.onFinish', () => {
     it('should send correct information', async () => {
-      let result!: Parameters<StreamTextOnFinishCallback<any, any>>[0];
+      let result!: Parameters<GenerateTextOnFinishCallback<any, any>>[0];
 
       const resultObject = streamText({
         model: createTestModel({
@@ -8446,7 +8446,7 @@ describe('streamText', () => {
 
   describe('options.stopWhen', () => {
     let result: StreamTextResult<any, any, any>;
-    let onFinishResult: Parameters<StreamTextOnFinishCallback<any, any>>[0];
+    let onFinishResult: Parameters<GenerateTextOnFinishCallback<any, any>>[0];
     let onStepFinishResults: StepResult<any, any>[];
     let stepInputs: Array<any>;
 
@@ -19104,7 +19104,7 @@ describe('streamText', () => {
   describe('programmatic tool calling', () => {
     describe('5 steps: code_execution triggers client tool across multiple turns (dice game fixture)', () => {
       let result: StreamTextResult<any, any, any>;
-      let onFinishResult: Parameters<StreamTextOnFinishCallback<any, any>>[0];
+      let onFinishResult: Parameters<GenerateTextOnFinishCallback<any, any>>[0];
       let onStepFinishResults: StepResult<any, any>[];
       let doStreamCalls: Array<LanguageModelV4CallOptions>;
       let prepareStepCalls: Array<{

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -84,12 +84,6 @@ import { prepareRetries } from '../util/prepare-retries';
 import { collectToolApprovals } from './collect-tool-approvals';
 import { ContentPart } from './content-part';
 import type {
-  GenerateTextEndEvent,
-  GenerateTextStartEvent,
-  GenerateTextStepEndEvent,
-  GenerateTextStepStartEvent,
-} from './core-events';
-import type {
   OnLanguageModelCallEndCallback,
   OnLanguageModelCallStartCallback,
 } from './language-model-events';
@@ -133,6 +127,12 @@ import {
 import { ToolOutput } from './tool-output';
 import { StaticToolOutputDenied } from './tool-output-denied';
 import { ToolsContextParameter } from './tools-context-parameter';
+import {
+  GenerateTextOnFinishCallback,
+  GenerateTextOnStartCallback,
+  GenerateTextOnStepFinishCallback,
+  GenerateTextOnStepStartCallback,
+} from './generate-text-events';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -165,16 +165,6 @@ export type StreamTextOnErrorCallback = Callback<{
 }>;
 
 /**
- * Callback that is set using the `onStepFinish` option.
- *
- * @param stepResult - The result of the step.
- */
-export type StreamTextOnStepFinishCallback<
-  TOOLS extends ToolSet,
-  RUNTIME_CONTEXT extends Context,
-> = Callback<GenerateTextStepEndEvent<TOOLS, RUNTIME_CONTEXT>>;
-
-/**
  * Callback that is set using the `onChunk` option.
  *
  * @param event - The event that is passed to the callback.
@@ -198,16 +188,6 @@ export type StreamTextOnChunkCallback<TOOLS extends ToolSet> = (event: {
 }) => PromiseLike<void> | void;
 
 /**
- * Callback that is set using the `onFinish` option.
- *
- * @param event - The event that is passed to the callback.
- */
-export type StreamTextOnFinishCallback<
-  TOOLS extends ToolSet,
-  RUNTIME_CONTEXT extends Context,
-> = Callback<GenerateTextEndEvent<TOOLS, RUNTIME_CONTEXT>>;
-
-/**
  * Callback that is set using the `onAbort` option.
  *
  * @param event - The event that is passed to the callback.
@@ -221,36 +201,6 @@ export type StreamTextOnAbortCallback<
    */
   readonly steps: StepResult<TOOLS, RUNTIME_CONTEXT>[];
 }>;
-
-/**
- * Callback that is set using the `experimental_onStart` option.
- *
- * Called when the streamText operation begins, before any LLM calls.
- * Use this callback for logging, analytics, or initializing state at the
- * start of a generation.
- *
- * @param event - The event object containing generation configuration.
- */
-export type StreamTextOnStartCallback<
-  TOOLS extends ToolSet = ToolSet,
-  RUNTIME_CONTEXT extends Context = Context,
-  OUTPUT extends Output = Output,
-> = Callback<GenerateTextStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
-
-/**
- * Callback that is set using the `experimental_onStepStart` option.
- *
- * Called when a step (LLM call) begins, before the provider is called.
- * Each step represents a single LLM invocation. Multiple steps occur when
- * using tool calls (the model may be called multiple times in a loop).
- *
- * @param event - The event object containing step configuration.
- */
-export type StreamTextOnStepStartCallback<
-  TOOLS extends ToolSet = ToolSet,
-  RUNTIME_CONTEXT extends Context = Context,
-  OUTPUT extends Output = Output,
-> = Callback<GenerateTextStepStartEvent<TOOLS, RUNTIME_CONTEXT, OUTPUT>>;
 
 /**
  * Generate a text and call tools for a given prompt using a language model.
@@ -473,7 +423,7 @@ export function streamText<
      *
      * The usage is the combined usage of all steps.
      */
-    onFinish?: StreamTextOnFinishCallback<
+    onFinish?: GenerateTextOnFinishCallback<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>
     >;
@@ -486,7 +436,7 @@ export function streamText<
     /**
      * Callback that is called when each step (LLM call) is finished, including intermediate steps.
      */
-    onStepFinish?: StreamTextOnStepFinishCallback<
+    onStepFinish?: GenerateTextOnStepFinishCallback<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>
     >;
@@ -495,7 +445,7 @@ export function streamText<
      * Callback that is called when the streamText operation begins,
      * before any LLM calls are made.
      */
-    experimental_onStart?: StreamTextOnStartCallback<
+    experimental_onStart?: GenerateTextOnStartCallback<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>,
       NoInfer<OUTPUT>
@@ -505,7 +455,7 @@ export function streamText<
      * Callback that is called when a step (LLM call) begins,
      * before the provider is called.
      */
-    experimental_onStepStart?: StreamTextOnStepStartCallback<
+    experimental_onStepStart?: GenerateTextOnStepStartCallback<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>,
       NoInfer<OUTPUT>
@@ -849,26 +799,26 @@ class DefaultStreamTextResult<
     onError: StreamTextOnErrorCallback;
     onFinish:
       | undefined
-      | StreamTextOnFinishCallback<NoInfer<TOOLS>, NoInfer<RUNTIME_CONTEXT>>;
+      | GenerateTextOnFinishCallback<NoInfer<TOOLS>, NoInfer<RUNTIME_CONTEXT>>;
     onAbort:
       | undefined
       | StreamTextOnAbortCallback<NoInfer<TOOLS>, NoInfer<RUNTIME_CONTEXT>>;
     onStepFinish:
       | undefined
-      | StreamTextOnStepFinishCallback<
+      | GenerateTextOnStepFinishCallback<
           NoInfer<TOOLS>,
           NoInfer<RUNTIME_CONTEXT>
         >;
     onStart:
       | undefined
-      | StreamTextOnStartCallback<
+      | GenerateTextOnStartCallback<
           NoInfer<TOOLS>,
           NoInfer<RUNTIME_CONTEXT>,
           NoInfer<OUTPUT>
         >;
     onStepStart:
       | undefined
-      | StreamTextOnStepStartCallback<
+      | GenerateTextOnStepStartCallback<
           NoInfer<TOOLS>,
           NoInfer<RUNTIME_CONTEXT>,
           NoInfer<OUTPUT>
@@ -1206,7 +1156,7 @@ class DefaultStreamTextResult<
               onFinish,
               telemetryDispatcher.onFinish as
                 | undefined
-                | StreamTextOnFinishCallback<
+                | GenerateTextOnFinishCallback<
                     NoInfer<TOOLS>,
                     NoInfer<RUNTIME_CONTEXT>
                   >,
@@ -1356,7 +1306,7 @@ class DefaultStreamTextResult<
           onStart,
           telemetryDispatcher.onStart as
             | undefined
-            | StreamTextOnStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>,
+            | GenerateTextOnStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>,
         ],
       });
 
@@ -1637,7 +1587,7 @@ class DefaultStreamTextResult<
                     onStepStart,
                     telemetryDispatcher.onStepStart as
                       | undefined
-                      | StreamTextOnStepStartCallback<
+                      | GenerateTextOnStepStartCallback<
                           TOOLS,
                           RUNTIME_CONTEXT,
                           OUTPUT

--- a/packages/ai/src/telemetry/telemetry.ts
+++ b/packages/ai/src/telemetry/telemetry.ts
@@ -17,7 +17,7 @@ import type {
   GenerateTextStartEvent,
   GenerateTextStepEndEvent,
   GenerateTextStepStartEvent,
-} from '../generate-text/core-events';
+} from '../generate-text/generate-text-events';
 import type {
   LanguageModelCallEndEvent,
   LanguageModelCallStartEvent,

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -16,7 +16,7 @@ import {
   Output,
   type StepResult,
   type StopCondition,
-  type StreamTextOnStepFinishCallback,
+  type GenerateTextOnStepFinishCallback,
   type SystemModelMessage,
   type ToolCallRepairFunction,
   type ToolChoice,
@@ -37,12 +37,12 @@ export type { CompatibleLanguageModel } from './types.js';
 
 /**
  * Callback function to be called after each step completes.
- * Alias for the AI SDK's StreamTextOnStepFinishCallback, using
+ * Alias for the AI SDK's GenerateTextOnStepFinishCallback, using
  * WorkflowAgent-consistent naming.
  */
 export type WorkflowAgentOnStepFinishCallback<
   TTools extends ToolSet = ToolSet,
-> = StreamTextOnStepFinishCallback<TTools, any>;
+> = GenerateTextOnStepFinishCallback<TTools, any>;
 
 /**
  * Infer the type of the tools of a workflow agent.


### PR DESCRIPTION
## Background

The start, end, step start, step end callback were duplicated in `ToolLoopAgent`, `generateText`, `streamText`.

This duplication is unnecessary and leads to a risk of type shifts and subsequent typechecking issues.

## Summary

* unify the callbacks into `GenerateText*` callbacks
* rename `core-events.ts` to `generate-text-events.ts`
* move the callbacks into `generate-text-events.ts`
