### PR TITLE
feat(mcp): expose server instructions to be accessible through client

### DIFF
--- a/.changeset/friendly-lizards-punch.md
+++ b/.changeset/friendly-lizards-punch.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+feat(mcp): expose server instructions to be accessible through client

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -153,10 +153,23 @@ It currently does not support accepting notifications from an MCP server, and cu
 
 ### Returns
 
-Returns a Promise that resolves to an `MCPClient` with the following methods:
+Returns a Promise that resolves to an `MCPClient` with the following properties and methods:
 
 <PropertiesTable
   content={[
+    {
+      name: 'serverInfo',
+      type: 'Configuration',
+      description:
+        'Information about the connected MCP server (name, version, optional title), as reported during the initialize handshake.',
+    },
+    {
+      name: 'instructions',
+      type: 'string',
+      isOptional: true,
+      description:
+        'Optional instructions provided by the server during the initialize handshake. Describes how to use the server and its features. Useful for inclusion in the LLM system prompt.',
+    },
     {
       name: 'tools',
       type: `async (options?: {

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -20,6 +20,8 @@
     "server:elicitation-ui": "tsx src/elicitation-ui/server.ts",
     "server:tool-meta": "tsx src/tool-meta/server.ts",
     "client:tool-meta": "tsx src/tool-meta/client.ts",
+    "server:server-instructions": "tsx src/server-instructions/server.ts",
+    "client:server-instructions": "tsx src/server-instructions/client.ts",
     "stdio:build": "tsc src/stdio/server.ts --outDir src/stdio/dist --target es2023 --module nodenext",
     "client:stdio": "tsx src/stdio/client.ts",
     "custom-transport:build": "tsc src/custom-transport/server.ts --outDir src/custom-transport/dist --target es2023 --module nodenext",

--- a/examples/mcp/src/server-instructions/client.ts
+++ b/examples/mcp/src/server-instructions/client.ts
@@ -1,0 +1,17 @@
+import { createMCPClient } from '@ai-sdk/mcp';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+async function main() {
+  const client = await createMCPClient({
+    transport: new StreamableHTTPClientTransport(
+      new URL('http://localhost:3000/mcp'),
+    ),
+  });
+
+  console.log('serverInfo:', client.serverInfo);
+  console.log('instructions:', client.instructions);
+
+  await client.close();
+}
+
+main().catch(console.error);

--- a/examples/mcp/src/server-instructions/server.ts
+++ b/examples/mcp/src/server-instructions/server.ts
@@ -1,0 +1,37 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+app.post('/mcp', async (req, res) => {
+  const server = new McpServer(
+    {
+      name: 'server-with-instructions',
+      version: '1.0.0',
+    },
+    {
+      instructions:
+        'Use search tools to resolve IDs — never ask the user. Always confirm destructive actions before executing.',
+    },
+  );
+
+  server.tool('ping', 'A simple ping tool', async () => {
+    return { content: [{ type: 'text', text: 'pong' }] };
+  });
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
+  await server.connect(transport);
+  await transport.handleRequest(req, res, req.body);
+  res.on('close', () => {
+    transport.close();
+    server.close();
+  });
+});
+
+app.listen(3000, () => {
+  console.log('server-instructions example server listening on port 3000');
+});

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -966,6 +966,40 @@ describe('MCPClient', () => {
     `);
   });
 
+  it('should expose instructions from initialization when server provides them', async () => {
+    createMockTransport.mockImplementation(
+      () =>
+        new MockMCPTransport({
+          initializeResult: {
+            protocolVersion: '2025-11-25',
+            serverInfo: {
+              name: 'mock-mcp-server',
+              version: '1.0.0',
+            },
+            capabilities: { tools: {} },
+            instructions:
+              'Use search tools to resolve IDs — never ask the user.',
+          },
+        }),
+    );
+
+    client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+    });
+
+    expect(client.instructions).toBe(
+      'Use search tools to resolve IDs — never ask the user.',
+    );
+  });
+
+  it('should expose undefined instructions when server omits them', async () => {
+    client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+    });
+
+    expect(client.instructions).toBeUndefined();
+  });
+
   it('should close transport when client is closed', async () => {
     const mockTransport = new MockMCPTransport();
     const closeSpy = vi.spyOn(mockTransport, 'close');

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -126,6 +126,16 @@ export interface MCPClient {
    */
   readonly serverInfo: Configuration;
 
+  /**
+   * Optional instructions provided by the server during the initialize handshake.
+   *
+   * These describe how to use the server and its features, and can be used by clients
+   * to improve LLM interactions (e.g. by including them in the system prompt).
+   *
+   * @see https://modelcontextprotocol.io/specification/2025-11-25/schema#initializeresult
+   */
+  readonly instructions?: string;
+
   tools<TOOL_SCHEMAS extends ToolSchemas = 'automatic'>(options?: {
     schemas?: TOOL_SCHEMAS;
   }): Promise<McpToolSet<TOOL_SCHEMAS>>;
@@ -209,6 +219,7 @@ class DefaultMCPClient implements MCPClient {
   > = new Map();
   private serverCapabilities: ServerCapabilities = {};
   private _serverInfo: Configuration = { name: '', version: '' };
+  private _serverInstructions?: string;
   private isClosed = true;
   private elicitationRequestHandler?: (
     request: ElicitationRequest,
@@ -259,6 +270,10 @@ class DefaultMCPClient implements MCPClient {
     return this._serverInfo;
   }
 
+  get instructions(): string | undefined {
+    return this._serverInstructions;
+  }
+
   async init(): Promise<this> {
     try {
       await this.transport.start();
@@ -290,6 +305,7 @@ class DefaultMCPClient implements MCPClient {
 
       this.serverCapabilities = result.capabilities;
       this._serverInfo = result.serverInfo;
+      this._serverInstructions = result.instructions;
 
       // Complete initialization handshake:
       await this.notification({


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/14669

The `@ai-sdk/mcp` client received instructions from the MCP server in the initialize handshake response but silently dropped them.

## Summary

added `instructions?: string` to the MCPClient interface + added a get instructions() getter returning that field.

then stored `result.instructions` alongside serverInfo/capabilities in init().

## Manual Verification

verified by running `examples/mcp/src/server-instructions/server.ts` and `examples/mcp/src/server-instructions/client.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #14669