### PR TITLE
fix(amazon-bedrock): drop foreign-provider reasoning blocks instead of sending them unsigned

### DIFF
--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -712,6 +712,88 @@ describe('assistant messages', () => {
     });
   });
 
+  it('should omit assistant message reasoning parts signed by a foreign provider', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Explain your reasoning' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'Anthropic-signed reasoning replayed to Bedrock',
+            providerOptions: {
+              anthropic: { signature: 'anthropic-signature' },
+            },
+          },
+          { type: 'text', text: 'final answer' },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Explain your reasoning' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ text: 'final answer' }],
+        },
+      ],
+      system: [],
+    });
+  });
+
+  it('should preserve assistant message reasoning parts with amazonBedrock providerOptions', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Explain your reasoning' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'Bedrock-signed reasoning round-tripped to Bedrock',
+            providerOptions: {
+              amazonBedrock: { signature: 'bedrock-signature' },
+            },
+          },
+          { type: 'text', text: 'final answer' },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Explain your reasoning' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              reasoningContent: {
+                reasoningText: {
+                  text: 'Bedrock-signed reasoning round-tripped to Bedrock',
+                  signature: 'bedrock-signature',
+                },
+              },
+            },
+            { text: 'final answer' },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
+
   it('should not trim reasoning text when a signature is present', async () => {
     const result = await convertToAmazonBedrockChatMessages([
       {

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -361,9 +361,20 @@ export async function convertToAmazonBedrockChatMessages(
                       },
                     },
                   });
-                } else {
-                  // trim the last text part if it's the last message in the block
-                  // because Bedrock does not allow trailing whitespace
+                } else if (
+                  part.providerOptions == null ||
+                  Object.keys(part.providerOptions).every(
+                    k => k === 'bedrock' || k === 'amazonBedrock',
+                  )
+                ) {
+                  // No foreign-provider metadata — preserve text. This covers
+                  // the prefill case where the caller hand-crafts a reasoning
+                  // block without a signature. Forwarding reasoning that was
+                  // signed by a different provider (e.g. anthropic) would
+                  // cause Bedrock to reject with
+                  // `thinking.signature: Field required`, so we drop those.
+                  // trim the last text part if it's the last message in the
+                  // block because Bedrock does not allow trailing whitespace
                   // in pre-filled assistant responses
                   amazonBedrockContent.push({
                     reasoningContent: {


### PR DESCRIPTION
## Background

  When a conversation contains reasoning blocks signed by a different provider
  (e.g. Anthropic-signed reasoning replayed through Bedrock during cross-provider
  fallback), the converter pushes the reasoning text without a signature, and
  Bedrock's converse API rejects the request with:

    messages.N.content.M.thinking.signature: Field required

  `@ai-sdk/anthropic` already handles the symmetric case gracefully — it drops
  unrecognized reasoning metadata and emits a warning.

  ## Fix

  In the `case 'reasoning'` branch of `convertToBedrockChatMessages`, only fall
  through to the unsigned-reasoning push when `providerOptions` is empty or
  contains exclusively the `bedrock` key. Foreign-provider metadata (e.g.
  `anthropic`) causes the block to be dropped instead.

  This preserves the existing prefill behavior introduced in #13972 while
  fixing the cross-provider replay case.

  ## Repro

  A conversation that has assistant turns with `providerOptions.anthropic`
  on its reasoning parts, sent through `bedrock(...).doStream(...)`, currently
  reproduces the validation error. The added test covers this.

  After gh pr create runs, it'll print the PR URL. CI will run automatically; the CLA bot will comment with a sign link if you
  haven't signed before.
