### PR TITLE
fix(google): omit passing includeServerSideToolInvocations for Vertex tool_config

### DIFF
--- a/.changeset/thin-seals-bathe.md
+++ b/.changeset/thin-seals-bathe.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(google): omit passing includeServerSideToolInvocations for Vertex tool_config

--- a/examples/ai-functions/src/stream-text/google/vertex-combined-tools.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-combined-tools.ts
@@ -1,0 +1,40 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { isStepCount, streamText, tool } from 'ai';
+import { z } from 'zod';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: vertex('gemini-3.1-pro-preview'),
+    stopWhen: isStepCount(5),
+    prompt:
+      'Search for current San Francisco news, then call ping with "done".',
+    tools: {
+      google_search: vertex.tools.googleSearch({}),
+      ping: tool({
+        description: 'No-op ping tool.',
+        inputSchema: z.object({
+          value: z.string(),
+        }),
+        execute: async ({ value }) => `pong: ${value}`,
+      }),
+    },
+    includeRawChunks: true,
+    maxRetries: 0,
+  });
+
+  const rawChunks: unknown[] = [];
+  for await (const part of result.fullStream) {
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    } else if (part.type === 'raw') {
+      rawChunks.push(part.rawValue);
+    }
+  }
+
+  console.log();
+  print('Request body:', (await result.request).body);
+  print('Raw response chunks:', rawChunks);
+  print('Response metadata:', await result.response);
+});

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -5555,6 +5555,105 @@ describe('doStream', () => {
     `);
   });
 
+  it('should omit server-side tool invocation flag for Vertex Gemini 3', async () => {
+    server.urls[TEST_URL_GEMINI_3_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: { parts: [{ text: 'Hello' }], role: 'model' },
+              finishReason: 'STOP',
+              safetyRatings: SAFETY_RATINGS,
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 1,
+            candidatesTokenCount: 1,
+            totalTokenCount: 2,
+          },
+        })}\n\n`,
+      ],
+    };
+
+    const vertexModel = new GoogleLanguageModel('gemini-3-pro-preview', {
+      provider: 'google.vertex.chat',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      headers: { 'x-goog-api-key': 'test-api-key' },
+      generateId: () => 'test-id',
+    });
+
+    const { stream } = await vertexModel.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+        {
+          type: 'provider',
+          id: 'google.google_search',
+          name: 'google_search',
+          args: {},
+        },
+      ],
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect({
+      toolConfig: requestBody.toolConfig,
+      tools: requestBody.tools,
+    }).toMatchInlineSnapshot(`
+      {
+        "toolConfig": {
+          "functionCallingConfig": {
+            "mode": "VALIDATED",
+          },
+        },
+        "tools": [
+          {
+            "googleSearch": {},
+          },
+          {
+            "functionDeclarations": [
+              {
+                "description": "",
+                "name": "test-tool",
+                "parameters": {
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "value",
+                  ],
+                  "type": "object",
+                },
+              },
+            ],
+          },
+        ],
+      }
+    `);
+
+    const events = await convertReadableStreamToArray(stream);
+    expect(events[0]).toMatchInlineSnapshot(`
+      {
+        "type": "stream-start",
+        "warnings": [],
+      }
+    `);
+  });
+
   it('should send streamFunctionCallArguments in toolConfig when provider option is set with Vertex provider', async () => {
     server.urls[TEST_URL_GEMINI_PRO].response = {
       type: 'stream-chunks',

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -190,6 +190,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       tools,
       toolChoice,
       modelId: this.modelId,
+      isVertexProvider,
     });
 
     const resolvedThinking = resolveThinkingConfig({

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -404,6 +404,52 @@ it('should combine function and provider-defined tools on Gemini 3 models', () =
   expect(result.toolWarnings).toEqual([]);
 });
 
+it('should omit server-side tool invocation flag for Vertex Gemini 3', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'testFunction',
+        description: 'A test function',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      {
+        type: 'provider',
+        id: 'google.google_search',
+        name: 'google_search',
+        args: {},
+      },
+    ],
+    modelId: 'gemini-3-flash-preview',
+    isVertexProvider: true,
+  });
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "toolConfig": {
+        "functionCallingConfig": {
+          "mode": "VALIDATED",
+        },
+      },
+      "toolWarnings": [],
+      "tools": [
+        {
+          "googleSearch": {},
+        },
+        {
+          "functionDeclarations": [
+            {
+              "description": "A test function",
+              "name": "testFunction",
+              "parameters": undefined,
+            },
+          ],
+        },
+      ],
+    }
+  `);
+});
+
 it('should combine multiple provider tools with function tools on Gemini 3', () => {
   const result = prepareTools({
     tools: [

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -10,10 +10,12 @@ export function prepareTools({
   tools,
   toolChoice,
   modelId,
+  isVertexProvider = false,
 }: {
   tools: LanguageModelV4CallOptions['tools'];
   toolChoice?: LanguageModelV4CallOptions['toolChoice'];
   modelId: GoogleModelId;
+  isVertexProvider?: boolean;
 }): {
   tools:
     | Array<
@@ -202,10 +204,12 @@ export function prepareTools({
           mode: 'VALIDATED' | 'ANY' | 'NONE';
           allowedFunctionNames?: string[];
         };
-        includeServerSideToolInvocations: true;
+        includeServerSideToolInvocations?: true;
       } = {
         functionCallingConfig: { mode: 'VALIDATED' },
-        includeServerSideToolInvocations: true,
+        ...(!isVertexProvider && {
+          includeServerSideToolInvocations: true,
+        }),
       };
 
       if (toolChoice != null) {


### PR DESCRIPTION
## Background

alternate to https://github.com/vercel/ai/pull/14708 (with signed commit)

towards the issue https://github.com/vercel/ai/issues/14655

The Vertex streamGenerateContent endpoint does not accept the tool_config.includeServerSideToolInvocations field. 

## Summary

Add an `isVertexProvider` parameter to prepareTools (defaults to false) and only include `includeServerSideToolInvocations: true `when the provider is not Vertex

## Manual Verification

verified by running the example `examples/ai-functions/src/stream-text/google/vertex-combined-tools.ts` before and after the fix!

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #14655 
