### PR TITLE
fix(openai): preserve shell output item references

### DIFF
--- a/.changeset/fuzzy-shells-reference.md
+++ b/.changeset/fuzzy-shells-reference.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+Preserve OpenAI Responses shell output item IDs and reuse them as item references when replaying stored shell results.

--- a/.changeset/quiet-shells-order.md
+++ b/.changeset/quiet-shells-order.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Keep provider-executed tool results adjacent to their matching tool calls when serializing response messages.

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -1348,6 +1348,83 @@ describe('toResponseMessages', () => {
         ]
       `);
     });
+
+    it('should keep provider-executed tool results adjacent to their tool calls', async () => {
+      const result = await toResponseMessages({
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-shell-1',
+            toolName: 'shell',
+            input: { action: { commands: ['echo first'] } },
+            providerExecuted: true,
+            dynamic: true,
+            providerMetadata: { openai: { itemId: 'sh_prev' } },
+          },
+          {
+            type: 'reasoning',
+            text: '',
+            providerMetadata: { openai: { itemId: 'rs_next' } },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-shell-1',
+            toolName: 'shell',
+            input: { action: { commands: ['echo first'] } },
+            output: { output: 'first' },
+            providerExecuted: true,
+            dynamic: true,
+            providerMetadata: { openai: { itemId: 'sho_prev' } },
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-shell-2',
+            toolName: 'shell',
+            input: { action: { commands: ['echo second'] } },
+            providerExecuted: true,
+            dynamic: true,
+            providerMetadata: { openai: { itemId: 'sh_next' } },
+          },
+        ],
+        tools: {},
+      });
+
+      expect(result).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call-shell-1',
+              toolName: 'shell',
+              input: { action: { commands: ['echo first'] } },
+              providerExecuted: true,
+              providerOptions: { openai: { itemId: 'sh_prev' } },
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'call-shell-1',
+              toolName: 'shell',
+              output: { type: 'json', value: { output: 'first' } },
+              providerOptions: { openai: { itemId: 'sho_prev' } },
+            },
+            {
+              type: 'reasoning',
+              text: '',
+              providerOptions: { openai: { itemId: 'rs_next' } },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-shell-2',
+              toolName: 'shell',
+              input: { action: { commands: ['echo second'] } },
+              providerExecuted: true,
+              providerOptions: { openai: { itemId: 'sh_next' } },
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   it('should sanitize invalid tool call with non-object input to empty object', async () => {

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -8,6 +8,47 @@ import { createToolModelOutput } from '../prompt/create-tool-model-output';
 import { ContentPart } from './content-part';
 import type { ToolSet } from '@ai-sdk/provider-utils';
 
+type AssistantContentArray = Exclude<AssistantContent, string>;
+
+function addProviderExecutedToolResult({
+  content,
+  part,
+}: {
+  content: AssistantContentArray;
+  part: Extract<AssistantContentArray[number], { type: 'tool-result' }>;
+}) {
+  const toolCallIndex = content.findIndex(
+    contentPart =>
+      contentPart.type === 'tool-call' &&
+      contentPart.providerExecuted &&
+      contentPart.toolCallId === part.toolCallId,
+  );
+
+  if (toolCallIndex === -1) {
+    content.push(part);
+    return;
+  }
+
+  let insertIndex = toolCallIndex + 1;
+
+  while (insertIndex < content.length) {
+    const contentPart = content[insertIndex];
+
+    if (
+      (contentPart.type === 'tool-result' ||
+        contentPart.type === 'tool-approval-request') &&
+      contentPart.toolCallId === part.toolCallId
+    ) {
+      insertIndex++;
+      continue;
+    }
+
+    break;
+  }
+
+  content.splice(insertIndex, 0, part);
+}
+
 /**
  * Converts the result of a `generateText` or `streamText` call to a list of response messages.
  */
@@ -97,12 +138,15 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
           output: part.output,
           errorMode: 'none',
         });
-        content.push({
-          type: 'tool-result',
-          toolCallId: part.toolCallId,
-          toolName: part.toolName,
-          output,
-          providerOptions: part.providerMetadata,
+        addProviderExecutedToolResult({
+          content,
+          part: {
+            type: 'tool-result',
+            toolCallId: part.toolCallId,
+            toolName: part.toolName,
+            output,
+            providerOptions: part.providerMetadata,
+          },
         });
         break;
       }
@@ -114,12 +158,15 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
           output: part.error,
           errorMode: 'json',
         });
-        content.push({
-          type: 'tool-result',
-          toolCallId: part.toolCallId,
-          toolName: part.toolName,
-          output,
-          providerOptions: part.providerMetadata,
+        addProviderExecutedToolResult({
+          content,
+          part: {
+            type: 'tool-result',
+            toolCallId: part.toolCallId,
+            toolName: part.toolName,
+            output,
+            providerOptions: part.providerMetadata,
+          },
         });
         break;
       }

--- a/packages/openai/src/responses/__snapshots__/openai-responses-language-model.test.ts.snap
+++ b/packages/openai/src/responses/__snapshots__/openai-responses-language-model.test.ts.snap
@@ -9704,6 +9704,11 @@ exports[`OpenAIResponsesLanguageModel > doStream > shell tool with container (no
     "type": "tool-call",
   },
   {
+    "providerMetadata": {
+      "openai": {
+        "itemId": "sho_0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e51",
+      },
+    },
     "result": {
       "output": [
         {
@@ -9973,6 +9978,11 @@ exports[`OpenAIResponsesLanguageModel > doStream > shell tool with environment >
     "type": "tool-call",
   },
   {
+    "providerMetadata": {
+      "openai": {
+        "itemId": "sho_049350089f7281c400698f7180b2408191b71d13d85b8fd6ed",
+      },
+    },
     "result": {
       "output": [
         {
@@ -10004,6 +10014,11 @@ SKILL.md
     "type": "tool-call",
   },
   {
+    "providerMetadata": {
+      "openai": {
+        "itemId": "sho_049350089f7281c400698f7182652481919b62a516ce0fbf5a",
+      },
+    },
     "result": {
       "output": [
         {

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -3639,6 +3639,52 @@ describe('convertToOpenAIResponsesInput', () => {
   });
 
   describe('provider tool outputs', () => {
+    it('should reference stored shell output items when item id is preserved', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call-shell',
+                toolName: 'shell',
+                output: {
+                  type: 'json',
+                  value: {
+                    output: [
+                      {
+                        stdout: 'hi\n',
+                        stderr: '',
+                        outcome: { type: 'exit', exitCode: 0 },
+                      },
+                    ],
+                  },
+                },
+                providerOptions: {
+                  openai: {
+                    itemId: 'sho_123',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        hasShellTool: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'item_reference',
+          id: 'sho_123',
+        },
+      ]);
+    });
+
     it('should include apply_patch output when multiple tool results are present', async () => {
       const result = await convertToOpenAIResponsesInput({
         toolNameMapping: testToolNameMapping,

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -392,6 +392,20 @@ export async function convertToOpenAIResponsesInput({
                 break;
               }
 
+              const providerResultItemId = (
+                part.providerOptions?.[providerOptionsName] as
+                  | { itemId?: string }
+                  | undefined
+              )?.itemId;
+
+              if (store && providerResultItemId != null) {
+                input.push({
+                  type: 'item_reference',
+                  id: providerResultItemId,
+                });
+                break;
+              }
+
               const resolvedResultToolName = toolNameMapping.toProviderToolName(
                 part.toolName,
               );
@@ -425,13 +439,11 @@ export async function convertToOpenAIResponsesInput({
                 break;
               }
 
-              /*
-               * Shell tool results are separate output items (shell_call_output)
-               * with their own item IDs distinct from the shell_call's item ID.
-               * Since the pipeline only preserves the shell_call's item ID in
-               * callProviderMetadata, we reconstruct the full shell_call_output
-               * instead of using an item_reference with the wrong ID.
-               */
+              // Shell tool results are separate output items
+              // (shell_call_output) with their own item IDs distinct from the
+              // shell_call's item ID. If that output item ID was not preserved,
+              // reconstruct the full shell_call_output instead of using an
+              // item_reference with the wrong ID.
               if (hasShellTool && resolvedResultToolName === 'shell') {
                 if (part.output.type === 'json') {
                   const parsedOutput = await validateTypes({

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -3097,6 +3097,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               "type": "tool-call",
             },
             {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "sho_0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e51",
+                },
+              },
               "result": {
                 "output": [
                   {
@@ -3512,6 +3517,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               "type": "tool-call",
             },
             {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "sho_01b6b3812d7541bd00698f71a46d808196b944595186d5d2b6",
+                },
+              },
               "result": {
                 "output": [
                   {
@@ -3543,6 +3553,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               "type": "tool-call",
             },
             {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "sho_01b6b3812d7541bd00698f71a5a2688196a39d7a371d282f14",
+                },
+              },
               "result": {
                 "output": [
                   {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -690,6 +690,13 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                     : { type: 'timeout' as const },
               })),
             } satisfies InferSchema<typeof shellOutputSchema>,
+            ...(part.id != null && {
+              providerMetadata: {
+                [providerOptionsName]: {
+                  itemId: part.id,
+                },
+              },
+            }),
           });
           break;
         }
@@ -1799,6 +1806,13 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                       }),
                     ),
                   } satisfies InferSchema<typeof shellOutputSchema>,
+                  ...(value.item.id != null && {
+                    providerMetadata: {
+                      [providerOptionsName]: {
+                        itemId: value.item.id,
+                      },
+                    },
+                  }),
                 });
               } else if (value.item.type === 'reasoning') {
                 const activeReasoningPart = activeReasoning[value.item.id];


### PR DESCRIPTION
## Background

OpenAI Responses returns `shell_call_output` as its own stored output item with a distinct item ID from the corresponding `shell_call`. The provider already referenced stored shell calls by item ID when replaying history, but shell outputs were reconstructed because that output item ID was not preserved in provider metadata.

Responses reasoning items also have ordering constraints relative to the output item they explain. When a stored provider-executed tool result is reconstructed after a later reasoning item, OpenAI can reject the next request because the reasoning appears to be associated with the wrong following item.

## Summary

- Preserve `shell_call_output` item IDs in `providerMetadata` for both `doGenerate` and `doStream`.
- Reuse stored provider tool result item IDs as `item_reference`s when `store` is enabled.
- Keep provider-executed tool results adjacent to their matching tool calls when serializing response messages, so later reasoning remains immediately before the item it belongs to.
- Keep the existing shell output reconstruction fallback for cases where the output item ID is unavailable.
- Add/refresh tests and snapshots covering stored shell output references and provider-executed result ordering.

## Manual Verification

Verified with the OpenAI Responses shell fixtures that `shell_call_output` parts now retain their OpenAI item IDs and are converted to `item_reference` entries when replaying stored shell results.

Also verified the provider-executed result ordering fix with the focused `toResponseMessages` regression test.

## Local Verification

- `pnpm exec vitest --config vitest.node.config.js --run src/generate-text/to-response-messages.test.ts`
- `pnpm turbo build --filter=ai...`
- `pnpm --filter ai test:node`
- `pnpm --filter ai test:edge`
- `pnpm check`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

A separate improvement could add an OpenAI helper for forwarding the previous Responses API response ID between tool-loop steps, similar to existing provider-specific step helpers.

## Related Issues

Related to stored OpenAI Responses replay with shell tool outputs and reasoning/tool context.
