### PR TITLE
Fix stale next-openai docs links

### DIFF
--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -327,6 +327,6 @@ const result = streamText({
 
 ## Full Example
 
-To see this code in action, check out the [`next-openai` example](https://github.com/vercel/ai/tree/main/examples/next-openai) in the AI SDK repository. Navigate to the `/test-tool-approval` page and associated route handler.
+To see this code in action, check out the [`ai-e2e-next` example](https://github.com/vercel/ai/tree/main/examples/ai-e2e-next) in the AI SDK repository. Navigate to the `/test-tool-approval` page and associated route handler.
 
 For more details on tool execution approval, see the [Tool Execution Approval](/docs/ai-sdk-core/tools-and-tool-calling#tool-execution-approval) and [Chatbot Tool Usage](/docs/ai-sdk-ui/chatbot-tool-usage#tool-execution-approval) documentation.

--- a/content/docs/04-ai-sdk-ui/01-overview.mdx
+++ b/content/docs/04-ai-sdk-ui/01-overview.mdx
@@ -34,7 +34,7 @@ Here is a comparison of the supported functions across these frameworks:
 
 Explore these example implementations for different frameworks:
 
-- [**Next.js**](https://github.com/vercel/ai/tree/main/examples/next-openai)
+- [**Next.js**](https://github.com/vercel/ai/tree/main/examples/ai-e2e-next)
 - [**Nuxt**](https://github.com/vercel/ai/tree/main/examples/nuxt-openai)
 - [**SvelteKit**](https://github.com/vercel/ai/tree/main/examples/sveltekit-openai)
 - [**Angular**](https://github.com/vercel/ai/tree/main/examples/angular)

--- a/content/providers/05-observability/langfuse.mdx
+++ b/content/providers/05-observability/langfuse.mdx
@@ -154,7 +154,7 @@ Done! All traces that contain AI SDK spans are automatically captured in Langfus
 ## Example Application
 
 Check out the sample repository ([langfuse/langfuse-vercel-ai-nextjs-example](https://github.com/langfuse/langfuse-vercel-ai-nextjs-example)) based
-on the [next-openai](https://github.com/vercel/ai/tree/main/examples/next-openai) template to showcase the integration of Langfuse with Next.js and AI SDK.
+on the [ai-e2e-next](https://github.com/vercel/ai/tree/main/examples/ai-e2e-next) template to showcase the integration of Langfuse with Next.js and AI SDK.
 
 ## Configuration
 


### PR DESCRIPTION
Fixes stale documentation links that still point to the removed `examples/next-openai` path by updating them to the existing `examples/ai-e2e-next` example.\n\nCloses #14705.\n\nVerification:\n- `rg "examples/next-openai\)" content examples -n` returns no matches