### PR TITLE
Fix stale example README links

### DIFF
--- a/examples/next-google-vertex/README.md
+++ b/examples/next-google-vertex/README.md
@@ -6,14 +6,14 @@ This example shows how to use the [AI SDK](https://ai-sdk.dev/docs) with [Next.j
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=ai-sdk-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-google-vertex-edge&env=GOOGLE_VERTEX_API_KEY&project-name=ai-sdk-vertex-edge&repository-name=ai-sdk-vertex-edge)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-google-vertex&env=GOOGLE_VERTEX_API_KEY&project-name=ai-sdk-vertex-edge&repository-name=ai-sdk-vertex-edge)
 
 ## How to use
 
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
 
 ```bash
-npx create-next-app --example https://github.com/vercel/ai/tree/main/examples/next-google-vertex-edge next-vertex-edge-app
+npx create-next-app --example https://github.com/vercel/ai/tree/main/examples/next-google-vertex next-vertex-edge-app
 ```
 
 To run the example locally you need to:

--- a/examples/next-openai-upstash-rate-limits/README.md
+++ b/examples/next-openai-upstash-rate-limits/README.md
@@ -8,22 +8,22 @@ This example shows how to use the [AI SDK](https://ai-sdk.dev/docs) with [Next.j
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=ai-sdk-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-openai-rate-limits&env=OPENAI_API_KEY&envDescription=OpenAI%20API%20Key&envLink=https%3A%2F%2Fplatform.openai.com%2Faccount%2Fapi-keys&project-name=vercel-ai-chat-openai&repository-name=vercel-ai-chat-openai)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-openai-upstash-rate-limits&env=OPENAI_API_KEY&envDescription=OpenAI%20API%20Key&envLink=https%3A%2F%2Fplatform.openai.com%2Faccount%2Fapi-keys&project-name=vercel-ai-chat-openai&repository-name=vercel-ai-chat-openai)
 
 ## How to use
 
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
 
 ```bash
-npx create-next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-rate-limits next-openai-rate-limits-app
+npx create-next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-upstash-rate-limits next-openai-rate-limits-app
 ```
 
 ```bash
-yarn create next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-rate-limits next-openai-rate-limits-app
+yarn create next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-upstash-rate-limits next-openai-rate-limits-app
 ```
 
 ```bash
-pnpm create next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-rate-limits next-openai-rate-limits-app
+pnpm create next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-upstash-rate-limits next-openai-rate-limits-app
 ```
 
 To run the example locally you need to:


### PR DESCRIPTION
Updates example README links that point to non-existent example directories:\n\n- `examples/next-openai-rate-limits` -> `examples/next-openai-upstash-rate-limits`\n- `examples/next-google-vertex-edge` -> `examples/next-google-vertex`\n\nVerification:\n- Confirmed the new target directories exist locally.