### PR TITLE
docs: fix outdated APIs and broken MCP example in cookbook

### DIFF
--- a/content/cookbook/01-next/73-mcp-tools.mdx
+++ b/content/cookbook/01-next/73-mcp-tools.mdx
@@ -103,7 +103,7 @@ export async function POST(req: Request) {
       },
     });
 
-    return response.toDataStreamResponse();
+    return response.toUIMessageStreamResponse();
   } catch (error) {
     return new Response('Internal Server Error', { status: 500 });
   }

--- a/content/cookbook/05-node/54-mcp-tools.mdx
+++ b/content/cookbook/05-node/54-mcp-tools.mdx
@@ -13,7 +13,7 @@ If you prefer to use the official transports (optional), install the official Mo
 <Snippet text="pnpm install @modelcontextprotocol/sdk" />
 
 ```ts
-import { createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient, type MCPClient } from '@ai-sdk/mcp';
 import { generateText, isStepCount } from 'ai';
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 import { openai } from '@ai-sdk/openai';
@@ -22,9 +22,9 @@ import { openai } from '@ai-sdk/openai';
 // import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse';
 // import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp';
 
-let clientOne;
-let clientTwo;
-let clientThree;
+let clientOne: MCPClient | undefined;
+let clientTwo: MCPClient | undefined;
+let clientThree: MCPClient | undefined;
 
 try {
   // Initialize an MCP client to connect to a `stdio` MCP server (local only):
@@ -33,12 +33,12 @@ try {
     args: ['src/stdio/dist/server.js'],
   });
 
-  const clientOne = await createMCPClient({
+  clientOne = await createMCPClient({
     transport,
   });
 
   // Connect to an HTTP MCP server directly via the client transport config
-  const clientTwo = await createMCPClient({
+  clientTwo = await createMCPClient({
     transport: {
       type: 'http',
       url: 'http://localhost:3000/mcp',
@@ -52,7 +52,7 @@ try {
   });
 
   // Connect to a Server-Sent Events (SSE) MCP server directly via the client transport config
-  const clientThree = await createMCPClient({
+  clientThree = await createMCPClient({
     transport: {
       type: 'sse',
       url: 'http://localhost:3000/sse',
@@ -96,10 +96,12 @@ try {
 } catch (error) {
   console.error(error);
 } finally {
+  // Use optional chaining so partially-initialized clients are skipped
+  // and we don't crash if a `createMCPClient` call threw before assignment.
   await Promise.all([
-    clientOne.close(),
-    clientTwo.close(),
-    clientThree.close(),
+    clientOne?.close(),
+    clientTwo?.close(),
+    clientThree?.close(),
   ]);
 }
 ```

--- a/content/docs/09-troubleshooting/12-use-chat-an-error-occurred.mdx
+++ b/content/docs/09-troubleshooting/12-use-chat-an-error-occurred.mdx
@@ -11,12 +11,12 @@ I am using [`useChat`](/docs/reference/ai-sdk-ui/use-chat) and I get the error "
 
 ## Background
 
-Error messages from `streamText` are masked by default when using `toDataStreamResponse` for security reasons (secure-by-default).
+Error messages from `streamText` are masked by default when using `toUIMessageStreamResponse` for security reasons (secure-by-default).
 This prevents leaking sensitive information to the client.
 
 ## Solution
 
-To forward error details to the client or to log errors, use the `getErrorMessage` function when calling `toDataStreamResponse`.
+To forward error details to the client or to log errors, pass an `onError` function when calling `toUIMessageStreamResponse`.
 
 ```tsx
 export function errorHandler(error: unknown) {
@@ -42,18 +42,19 @@ const result = streamText({
 });
 
 return result.toUIMessageStreamResponse({
-  getErrorMessage: errorHandler,
+  onError: errorHandler,
 });
 ```
 
-In case you are using `createDataStreamResponse`, you can use the `onError` function when calling `toDataStreamResponse`:
+In case you are using `createUIMessageStream`, you can pass `onError` directly:
 
 ```tsx
-const response = createDataStreamResponse({
-  // ...
-  async execute(dataStream) {
+const stream = createUIMessageStream({
+  execute({ writer }) {
     // ...
   },
   onError: errorHandler,
 });
+
+return createUIMessageStreamResponse({ stream });
 ```


### PR DESCRIPTION
## Summary

Three small but real bugs in `content/`, all confirmed against current `main`:

1. **`content/cookbook/01-next/73-mcp-tools.mdx`** — calls `response.toDataStreamResponse()`, which was renamed to `toUIMessageStreamResponse()` in v5 and no longer exists on `StreamTextResult` (`packages/ai/src/generate-text/stream-text-result.ts:359`). Copy-pasting the cookbook into a Next route handler produces a `TypeError` at runtime.

2. **`content/cookbook/05-node/54-mcp-tools.mdx`** — variable shadowing bug. The example declares `let clientOne / clientTwo / clientThree` outside the `try`, then re-declares each as `const` inside. The inner `const` shadows the outer `let`, so the outer bindings stay `undefined`. The `finally` block then calls `clientOne.close()` on `undefined` and the process always crashes — even on the happy path, and before any actual cleanup runs.

   Fix: drop the inner `const` keywords so the outer bindings get assigned, type them as `MCPClient | undefined` (`MCPClient` is a stable export from `@ai-sdk/mcp`), and use optional chaining in `finally` so partial-init failures still clean up clients that did connect.

3. **`content/docs/09-troubleshooting/12-use-chat-an-error-occurred.mdx`** — three pre-v5 API names: `toDataStreamResponse`, `getErrorMessage:`, and `createDataStreamResponse`. Per the v5 migration guide (`content/docs/08-migration-guides/26-migration-guide-5-0.mdx`, §"Error Handling: getErrorMessage → onError"), these are now `toUIMessageStreamResponse`, `onError:`, and the split `createUIMessageStream` + `createUIMessageStreamResponse` pair. The doc was already internally inconsistent — line 44 used the new `toUIMessageStreamResponse` but still passed the old `getErrorMessage:` option to it.

Docs-only, no package changes, no changeset (matches the precedent of #12097 "docs: fix incorrect and outdated cookbooks").

## Test plan

- [ ] Maintainer review of the three diffs
- [ ] Confirm `MCPClient` is the right stable type to expose in the cookbook (vs. inferring via `Awaited<ReturnType<typeof createMCPClient>>`)
- [ ] Confirm the v5+ replacement names match the maintainers' preferred naming in cookbook copy