### PR TITLE
fix(amazon-bedrock): disable native structured output for claude-opus-4-7

### DIFF
--- a/.changeset/bedrock-opus-structured-output.md
+++ b/.changeset/bedrock-opus-structured-output.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): disable native structured output for claude-opus-4-7
+
+Bedrock rejects `output_config.format` for `claude-opus-4-7`, causing structured output requests to fail. The SDK now falls back to the `jsonResponseTool` path for this model.

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
@@ -532,6 +532,38 @@ describe('amazon-bedrock-anthropic-provider', () => {
     );
   });
 
+  it('should disable native structured output for claude-opus-4-7', () => {
+    const provider = createBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('anthropic.claude-opus-4-7');
+
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+      'anthropic.claude-opus-4-7',
+      expect.objectContaining({
+        supportsNativeStructuredOutput: false,
+      }),
+    );
+  });
+
+  it('should disable native structured output for eu.anthropic.claude-opus-4-7', () => {
+    const provider = createBedrockAnthropic({
+      region: 'eu-west-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('eu.anthropic.claude-opus-4-7');
+
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+      'eu.anthropic.claude-opus-4-7',
+      expect.objectContaining({
+        supportsNativeStructuredOutput: false,
+      }),
+    );
+  });
+
   it('should handle models with us. prefix for inference profiles', () => {
     const provider = createAmazonBedrockAnthropic({
       region: 'us-east-1',

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -331,8 +331,9 @@ export function createAmazonBedrockAnthropic(
 
       // Bedrock Anthropic doesn't support URL sources, force download and base64 conversion
       supportedUrls: () => ({}),
-      // native structured output via output_config.format is supported on Bedrock
-      supportsNativeStructuredOutput: true,
+      // native structured output via output_config.format is supported on Bedrock,
+      // but claude-opus-4-7 rejects output_config.format (see vercel/ai#14773)
+      supportsNativeStructuredOutput: !modelId.includes('claude-opus-4-7'),
     });
 
   const provider = function (modelId: AmazonBedrockAnthropicModelId) {


### PR DESCRIPTION
## Summary

Bedrock rejects `output_config.format` for `claude-opus-4-7`, causing structured output requests to fail with:

```
{"type":"error","error":{"type":"invalid_request_error","message":"output_config.format: Extra inputs are not permitted"}}
```

This PR makes `supportsNativeStructuredOutput` model-aware in the Bedrock Anthropic provider, setting it to `false` for `claude-opus-4-7` so the SDK falls back to the `jsonResponseTool` path.

## Changes

- `packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts`: Replace hardcoded `supportsNativeStructuredOutput: true` with `!modelId.includes('claude-opus-4-7')`
- `packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts`: Add tests for both direct and cross-region prefixed model IDs

## Why this approach

The fix follows the same pattern as the Anthropic SDK's per-model capability table — checking the model ID string. Using `includes()` ensures cross-region inference profiles (e.g. `eu.anthropic.claude-opus-4-7`, `us.anthropic.claude-opus-4-7`) are also handled correctly.

All other Bedrock Anthropic models continue to use native structured output as before.

Closes #14773

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.