### PR TITLE
fix(provider/anthropic): stop sending obsolete effort-2025-11-24 beta header

### DIFF
--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -4712,7 +4712,7 @@ describe('AnthropicLanguageModel', () => {
       });
     });
 
-    it('should set effort', async () => {
+    it('should set effort without legacy anthropic-beta header', async () => {
       prepareJsonFixtureResponse('anthropic-text');
 
       const result = await model.doGenerate({
@@ -4746,7 +4746,6 @@ describe('AnthropicLanguageModel', () => {
       `);
       expect(await server.calls[0].requestHeaders).toMatchInlineSnapshot(`
         {
-          "anthropic-beta": "effort-2025-11-24",
           "anthropic-version": "2023-06-01",
           "content-type": "application/json",
           "x-api-key": "test-api-key",

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -703,10 +703,6 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       }
     }
 
-    if (anthropicOptions?.effort) {
-      betas.add('effort-2025-11-24');
-    }
-
     if (anthropicOptions?.taskBudget) {
       betas.add('task-budgets-2026-03-13');
     }


### PR DESCRIPTION
## Summary\nRemove the obsolete anthropic-beta effort header from Anthropic requests. Effort is already sent via output_config, and Vertex rejects the legacy beta header.\n\n## Testing\n- pnpm --dir packages/anthropic test:node\n- pnpm --dir packages/anthropic test:edge