### PR TITLE
documentation: tools and runtime context

### DIFF
--- a/content/docs/03-agents/01-overview.mdx
+++ b/content/docs/03-agents/01-overview.mdx
@@ -15,6 +15,21 @@ These components work together:
   - **Context management** - Maintaining conversation history and deciding what the model sees (input) at each step
   - **Stopping conditions** - Determining when the loop (task) is complete
 
+## Agent State and Context
+
+Agents often need server-side state that should not be placed directly in the
+prompt, such as tenant settings, request IDs, feature flags, credentials, or
+progress through a task.
+
+Use `runtimeContext` as the agent's shared runtime state. It flows through the
+agent loop, is available in `prepareStep` and lifecycle callbacks, and can be
+updated between steps. Use `toolsContext` for per-tool values such as API keys
+or scoped permissions; each tool receives only its own typed `context` based on
+its `contextSchema`.
+
+Learn more in [Runtime and Tool
+Context](/docs/ai-sdk-core/runtime-and-tool-context).
+
 ## ToolLoopAgent Class
 
 The ToolLoopAgent class handles these three components. Here's an agent that uses multiple tools in a loop to accomplish a task:
@@ -90,5 +105,6 @@ Agents are flexible and powerful, but non-deterministic. When you need reliable,
 ## Next Steps
 
 - **[Building Agents](/docs/agents/building-agents)** - Guide to creating agents with the ToolLoopAgent
+- **[Runtime and Tool Context](/docs/ai-sdk-core/runtime-and-tool-context)** - How to pass shared agent state and per-tool context
 - **[Workflow Patterns](/docs/agents/workflows)** - Structured patterns using core functions for complex workflows
 - **[Loop Control](/docs/agents/loop-control)** - Execution control with stopWhen and prepareStep

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -77,6 +77,62 @@ const codeAgent = new ToolLoopAgent({
 });
 ```
 
+### Context and Agent State
+
+Use `runtimeContext` as the agent's shared runtime state. It flows through the
+agent loop and is available in `prepareStep`, lifecycle callbacks, and final
+results. If a tool needs server-side values such as credentials, scoped
+permissions, or default settings, pass them through `toolsContext` and declare
+them with the tool's `contextSchema`.
+
+```ts highlight="8-15,21-31,37-49"
+import { ToolLoopAgent, tool } from 'ai';
+import { z } from 'zod';
+
+const agent = new ToolLoopAgent({
+  model: __MODEL__,
+  tools: {
+    searchTickets: tool({
+      description: 'Search support tickets',
+      inputSchema: z.object({
+        query: z.string(),
+      }),
+      contextSchema: z.object({
+        apiKey: z.string(),
+        accountId: z.string(),
+      }),
+      execute: async ({ query }, { context }) =>
+        searchTickets(query, context.accountId, context.apiKey),
+    }),
+  },
+  prepareStep: async ({ runtimeContext }) => {
+    if (runtimeContext.escalated) {
+      return { temperature: 0.1 };
+    }
+
+    return {};
+  },
+});
+
+const result = await agent.generate({
+  prompt: 'Find open billing tickets for this account.',
+  runtimeContext: {
+    requestId: 'req_abc',
+    escalated: false,
+  },
+  toolsContext: {
+    searchTickets: {
+      apiKey: process.env.SUPPORT_API_KEY!,
+      accountId: 'acct_123',
+    },
+  },
+});
+```
+
+For the full model, including sensitive context filtering and where each context
+value is available, see [Runtime and Tool
+Context](/docs/ai-sdk-core/runtime-and-tool-context).
+
 You can also require approval before a tool executes. Configure approval on the
 `ToolLoopAgent` with `toolApproval`. The older `needsApproval` property on
 tools is deprecated for `ToolLoopAgent`. `toolApproval` can be a

--- a/content/docs/03-agents/index.mdx
+++ b/content/docs/03-agents/index.mdx
@@ -11,12 +11,14 @@ The following section shows you how to build agents with the AI SDK - systems wh
   cards={[
     {
       title: 'Overview',
-      description: 'Learn what agents are and why to use the ToolLoopAgent.',
+      description:
+        'Learn what agents are, how they manage state, and why to use the ToolLoopAgent.',
       href: '/docs/agents/overview',
     },
     {
       title: 'Building Agents',
-      description: 'Complete guide to creating agents with the ToolLoopAgent.',
+      description:
+        'Create ToolLoopAgent instances with tools, runtime context, and loop control.',
       href: '/docs/agents/building-agents',
     },
     {

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -807,97 +807,9 @@ This is useful for values like tenant information, feature flags, session data, 
 
 Tool execution context is now separate. If a tool needs server-side values such as API keys, pass them via `toolsContext`, keyed by tool name. Each tool then receives only its own typed `context` value based on its `contextSchema`.
 
-At a high level:
-
-- Pass shared step-level state through `runtimeContext`
-- Read or update it in `prepareStep`
-- Pass per-tool values through `toolsContext`
-- Declare each tool's expected tool context with `contextSchema`
-- Mark sensitive tool context properties with `sensitiveContext` when they should be excluded from telemetry
-- Access the tool's typed context in `execute` together with other execution metadata such as `toolCallId`, `messages`, and `abortSignal`
-
-```ts
-import { openai } from '@ai-sdk/openai';
-import { streamText, tool } from 'ai';
-import { z } from 'zod';
-
-const result = streamText({
-  model: openai('gpt-5-mini'),
-  tools: {
-    weather: tool({
-      description: 'Get the weather in a location',
-      inputSchema: z.object({
-        location: z.string().describe('The location to get the weather for'),
-      }),
-      contextSchema: z.object({
-        weatherApiKey: z.string().describe('The API key for the weather API'),
-        defaultUnit: z.enum(['celsius', 'fahrenheit']),
-      }),
-      sensitiveContext: {
-        weatherApiKey: true,
-      },
-      execute: async (
-        { location },
-        { toolCallId, messages, abortSignal, context },
-      ) => {
-        const { weatherApiKey, defaultUnit } = context;
-
-        console.log('tool call:', toolCallId);
-        console.log('messages available to tool:', messages.length);
-        console.log('abortable:', abortSignal != null);
-        console.log('authenticated:', weatherApiKey != null);
-        console.log('default unit:', defaultUnit);
-
-        return {
-          location,
-          temperature: 72 + Math.floor(Math.random() * 21) - 10,
-        };
-      },
-    }),
-  },
-  runtimeContext: {
-    somethingElse: 'other-context',
-  },
-  toolsContext: {
-    weather: {
-      weatherApiKey: 'weather-123',
-      defaultUnit: 'fahrenheit',
-    },
-  },
-  prepareStep: async ({ runtimeContext, toolsContext }) => {
-    console.log('prepareStep runtimeContext:', runtimeContext);
-    console.log('prepareStep toolsContext:', toolsContext);
-
-    return {
-      // You can keep the runtimeContext unchanged or return a new one
-      // to affect the current and subsequent steps.
-      runtimeContext,
-    };
-  },
-  prompt: 'What is the weather in San Francisco?',
-});
-```
-
-In this example, `prepareStep` receives the full runtime context object:
-
-```ts
-{
-  somethingElse: string;
-}
-```
-
-`prepareStep` also receives the per-tool `toolsContext` map:
-
-```ts
-{
-  weather: {
-    weatherApiKey: string;
-    defaultUnit: 'celsius' | 'fahrenheit';
-  };
-}
-```
-
-The `weather` tool then receives only its own typed `context` based on its `contextSchema`. In this case, `execute` can access `weatherApiKey`, while the shared step-level `runtimeContext` remains separate.
+For the full mental model, examples, lifecycle details, and guidance on choosing
+between prompt context, runtime context, and tool context, see
+[Runtime and Tool Context](/docs/ai-sdk-core/runtime-and-tool-context).
 
 ### Sensitive Tool Context
 
@@ -945,7 +857,9 @@ Properties set to `false` or omitted are still sent.
 <Note>
   `sensitiveContext` only filters telemetry integrations. Tool execution,
   lifecycle callbacks, and returned results still receive the full typed tool
-  context.
+  context. See [Runtime and Tool
+  Context](/docs/ai-sdk-core/runtime-and-tool-context) for how tool context flows
+  through execution and telemetry.
 </Note>
 
 ## Tool Input Lifecycle Hooks

--- a/content/docs/03-ai-sdk-core/17-runtime-and-tool-context.mdx
+++ b/content/docs/03-ai-sdk-core/17-runtime-and-tool-context.mdx
@@ -1,0 +1,215 @@
+---
+title: Runtime and Tool Context
+description: Learn how runtime context, tool context, and sensitive context work together.
+---
+
+# Runtime and Tool Context
+
+Context lets you pass server-side state through a generation or agent loop
+without putting that state into the prompt. The AI SDK separates shared runtime
+state from per-tool execution state so agents can keep track of their work while
+tools only receive the values they need.
+
+Use context for values such as tenant information, feature flags, session data,
+request IDs, API credentials, access tokens, or other application state that
+should affect execution.
+
+## Context Types
+
+| Concept | Where you define it | Where you read it | Use it for |
+| --- | --- | --- | --- |
+| `runtimeContext` | `generateText`, `streamText`, or `ToolLoopAgent` calls | `prepareStep`, lifecycle callbacks, step results, and telemetry | Shared generation or agent state |
+| `toolsContext` | `generateText`, `streamText`, or `ToolLoopAgent` calls | `prepareStep`, approval callbacks, and tool context resolution | A map of per-tool context values keyed by tool name |
+| tool `context` | Each tool's `toolsContext` entry, validated by its `contextSchema` | Tool `execute`, `needsApproval`, and tool input lifecycle callbacks | Values needed by one tool |
+| `toolContext` | Derived from one tool's context | Tool approval callbacks and tool execution events | The event/callback name for one tool's context |
+| `sensitiveRuntimeContext` | The generation or agent call | Telemetry filtering | Top-level `runtimeContext` properties to omit from telemetry |
+| `sensitiveContext` | The tool definition | Telemetry filtering | Top-level tool context properties to omit from telemetry |
+
+In agents, `runtimeContext` is the agent's shared runtime state. It flows
+through the loop and can be read or updated in `prepareStep` between model
+calls. Tool-specific data stays in `toolsContext`, where each tool receives only
+its own validated `context`.
+
+```txt
+generateText / streamText / ToolLoopAgent
+  -> runtimeContext
+       -> prepareStep, lifecycle callbacks, step results
+       -> telemetry, filtered by sensitiveRuntimeContext
+  -> toolsContext
+       -> prepareStep
+       -> one tool's context / toolContext
+            -> execute, approval callbacks, tool events
+            -> telemetry, filtered by sensitiveContext
+```
+
+## Runtime Context
+
+Pass `runtimeContext` when you need shared state for the whole generation or
+agent loop. It is not added to the model prompt automatically. Use it to
+configure step preparation, track server-side state, or correlate lifecycle
+events.
+
+```ts
+const result = await generateText({
+  model: __MODEL__,
+  prompt: 'Help the user plan their trip.',
+  runtimeContext: {
+    tenantId: 'tenant_123',
+    plan: 'enterprise',
+    requestId: 'req_abc',
+  },
+  prepareStep: async ({ runtimeContext }) => {
+    if (runtimeContext.plan === 'enterprise') {
+      return { temperature: 0.2 };
+    }
+
+    return {};
+  },
+});
+```
+
+`prepareStep` can return a new `runtimeContext`. The new value affects the
+current step and all subsequent steps, which makes it the right place to update
+agent state between turns of the loop.
+
+## Tool Context
+
+Use `toolsContext` for values that belong to a specific tool. Each tool declares
+the context it expects with `contextSchema`; the matching `toolsContext` entry is
+validated and passed to the tool as `context`.
+
+```ts highlight="11-15,26-31"
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+const weatherTool = tool({
+  description: 'Get the weather in a location',
+  inputSchema: z.object({
+    location: z.string(),
+  }),
+  contextSchema: z.object({
+    weatherApiKey: z.string(),
+    defaultUnit: z.enum(['celsius', 'fahrenheit']),
+  }),
+  execute: async ({ location }, { context }) => {
+    return fetchWeather({
+      location,
+      apiKey: context.weatherApiKey,
+      unit: context.defaultUnit,
+    });
+  },
+});
+
+const result = await generateText({
+  model: __MODEL__,
+  tools: { weather: weatherTool },
+  toolsContext: {
+    weather: {
+      weatherApiKey: process.env.WEATHER_API_KEY!,
+      defaultUnit: 'fahrenheit',
+    },
+  },
+  prompt: 'What is the weather in San Francisco?',
+});
+```
+
+When at least one tool declares `contextSchema`, `toolsContext` is required for
+the tools that need context. A tool receives only its own context, not the full
+`toolsContext` map.
+
+Treat tool context as immutable inside tools. If you need to change tool context
+between steps, inspect the previous step in `prepareStep` and return an updated
+`toolsContext`.
+
+## Sensitive Context
+
+Context often contains values that are useful inside your application but should
+not be sent to telemetry providers. Mark top-level properties with
+`sensitiveRuntimeContext` or `sensitiveContext` to omit them from telemetry.
+
+```ts highlight="12-14,24-26,39-41,48-50"
+import { ToolLoopAgent, tool } from 'ai';
+import { z } from 'zod';
+
+const customerLookup = tool({
+  description: 'Look up customer account details',
+  inputSchema: z.object({
+    customerId: z.string(),
+  }),
+  contextSchema: z.object({
+    apiKey: z.string(),
+    region: z.string(),
+  }),
+  sensitiveContext: {
+    apiKey: true,
+  },
+  execute: async ({ customerId }, { context }) => {
+    return lookupCustomer({
+      customerId,
+      apiKey: context.apiKey,
+      region: context.region,
+    });
+  },
+});
+
+const agent = new ToolLoopAgent({
+  model: __MODEL__,
+  tools: { customerLookup },
+});
+
+const result = await agent.generate({
+  prompt: 'Check whether customer cust_123 is eligible for priority support.',
+  runtimeContext: {
+    requestId: 'req_abc',
+    tenantId: 'tenant_123',
+    userId: 'user_123',
+  },
+  sensitiveRuntimeContext: {
+    userId: true,
+  },
+  toolsContext: {
+    customerLookup: {
+      apiKey: process.env.CUSTOMER_API_KEY!,
+      region: 'us',
+    },
+  },
+});
+```
+
+In this example, telemetry receives `runtimeContext` without `userId` and the
+`customerLookup` context without `apiKey`.
+
+<Note>
+  Sensitive context only filters telemetry integrations, including OpenTelemetry
+  integrations. Tool execution, lifecycle callbacks, and returned results still
+  receive the full context values.
+</Note>
+
+Sensitive context filtering is shallow. Only top-level properties marked as
+`true` are omitted. Properties set to `false` or omitted are still sent.
+
+## Where Context Is Available
+
+| Location | `runtimeContext` | `toolsContext` | Tool `context` / `toolContext` |
+| --- | --- | --- | --- |
+| `prepareStep` | Read and update | Read and update | Not directly |
+| Tool `execute` | Not passed directly | Not passed directly | Read one tool's validated `context` |
+| Tool approval | Read in generic and per-tool callbacks | Read in generic callbacks | Read as `toolContext` in per-tool callbacks |
+| Tool execution events | Not included | Not included | Read as `toolContext` |
+| Step results and finish callbacks | Read final or per-step state | Read final or per-step state | Available through the per-tool entries in `toolsContext` |
+| Telemetry | Filtered by `sensitiveRuntimeContext` | Filtered per tool | Filtered by each tool's `sensitiveContext` |
+
+## Choosing the Right Context
+
+- Use `runtimeContext` for state shared by the whole generation or agent loop,
+  such as request metadata, tenant settings, feature flags, or agent progress.
+- Use `toolsContext` and `contextSchema` for values needed by a specific tool,
+  such as API keys, scoped clients, user permissions, or default tool settings.
+- Use prompt messages for information the model should reason about or mention
+  in its answer.
+- Use `sensitiveRuntimeContext` and `sensitiveContext` to reduce telemetry
+  exposure, not as a general security boundary.
+
+Learn more about [tools and tool calling](/docs/ai-sdk-core/tools-and-tool-calling),
+[event listeners](/docs/ai-sdk-core/event-listeners), and
+[telemetry](/docs/ai-sdk-core/telemetry).

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -75,6 +75,8 @@ To disable telemetry globally, do not register any telemetry integrations via th
 
 You can provide a `functionId` to identify the function that the telemetry data is for,
 and `runtimeContext` to include additional information in the telemetry data.
+For the broader context model, see
+[Runtime and Tool Context](/docs/ai-sdk-core/runtime-and-tool-context).
 
 ```ts highlight="4-10"
 const result = await generateText({
@@ -150,13 +152,15 @@ const result = await generateText({
 });
 ```
 
-In this example, telemetry integrations receive `toolsContext.weather` and tool execution `toolContext` as `{ defaultUnit: 'fahrenheit' }`.
+In this example, telemetry integrations receive `toolsContext.weather` and tool execution telemetry event `toolContext` as `{ defaultUnit: 'fahrenheit' }`.
 Properties set to `false` or omitted are still sent. `sensitiveContext` is supported by `generateText`, `streamText`, and `ToolLoopAgent`.
 
 <Note>
   `sensitiveContext` only filters telemetry integrations, including OpenTelemetry
   integrations. Tool execution, lifecycle callbacks, and returned results still
-  receive the full tool context.
+  receive the full tool context. See [Runtime and Tool
+  Context](/docs/ai-sdk-core/runtime-and-tool-context) for the difference between
+  tool execution context and telemetry event context.
 </Note>
 
 ## Custom Tracer

--- a/content/docs/03-ai-sdk-core/index.mdx
+++ b/content/docs/03-ai-sdk-core/index.mdx
@@ -29,6 +29,12 @@ description: Learn about AI SDK Core.
       href: '/docs/ai-sdk-core/tools-and-tool-calling',
     },
     {
+      title: 'Runtime and Tool Context',
+      description:
+        'Learn how to pass shared runtime state and per-tool context through generations and agents.',
+      href: '/docs/ai-sdk-core/runtime-and-tool-context',
+    },
+    {
       title: 'Prompt Engineering',
       description: 'Learn how to write prompts with AI SDK Core.',
       href: '/docs/ai-sdk-core/prompt-engineering',

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -21,6 +21,10 @@ const { text } = await generateText({
 console.log(text);
 ```
 
+For guidance on `runtimeContext`, `toolsContext`, tool `context`, and sensitive
+context filtering, see [Runtime and Tool
+Context](/docs/ai-sdk-core/runtime-and-tool-context).
+
 To see `generateText` in action, check out [these examples](#examples).
 
 ## Import

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -23,6 +23,10 @@ for await (const textPart of textStream) {
 }
 ```
 
+For guidance on `runtimeContext`, `toolsContext`, tool `context`, and sensitive
+context filtering, see [Runtime and Tool
+Context](/docs/ai-sdk-core/runtime-and-tool-context).
+
 To see `streamText` in action, check out [these examples](#examples).
 
 ## Import

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -29,6 +29,11 @@ const result = await agent.generate({
 console.log(result.text);
 ```
 
+For agents, `runtimeContext` is the shared runtime state that flows through the
+loop. For guidance on `runtimeContext`, `toolsContext`, tool `context`, and
+sensitive context filtering, see [Runtime and Tool
+Context](/docs/ai-sdk-core/runtime-and-tool-context).
+
 To see `ToolLoopAgent` in action, check out [these examples](#examples).
 
 ## Import

--- a/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
@@ -12,6 +12,10 @@ It does not have any runtime behavior, but it helps TypeScript infer the types f
 Without this helper function, TypeScript is unable to connect the `inputSchema` and `contextSchema` properties to the tool callbacks,
 and the callback argument types cannot be inferred.
 
+For the full model of `runtimeContext`, `toolsContext`, tool `context`, and
+sensitive context filtering, see [Runtime and Tool
+Context](/docs/ai-sdk-core/runtime-and-tool-context).
+
 ```ts highlight={"1,4,9,10"}
 import { tool } from 'ai';
 import { z } from 'zod';


### PR DESCRIPTION
## Background

The tools and runtime context documentation was dispersed in different pages, making it harder to grasp.

## Summary

Introduce a central documentation page for tools and runtime context that consolidates the information about the concepts.