### PR TITLE
fix(workflow): expose totalUsage and finishReason on stream result

### DIFF
--- a/.changeset/workflow-agent-stream-result-totalusage.md
+++ b/.changeset/workflow-agent-stream-result-totalusage.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Expose `totalUsage` and `finishReason` on the `WorkflowAgent.stream()` result, mirroring `GenerateTextResult`/`StreamTextResult` and the existing `onFinish` event payload.

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -1330,6 +1330,30 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
           }
         `);
       });
+
+      it('should expose finishReason and totalUsage on the stream result', async () => {
+        const agent = new WorkflowAgent({
+          model: mockModel,
+        });
+
+        const { writable } = createMockWritable();
+        const result = await agent.stream({
+          messages: [{ role: 'user' as const, content: 'test' }],
+          writable,
+        });
+
+        expect({
+          finishReason: result.finishReason,
+          inputTokens: result.totalUsage.inputTokens,
+          outputTokens: result.totalUsage.outputTokens,
+        }).toMatchInlineSnapshot(`
+          {
+            "finishReason": "stop",
+            "inputTokens": 3,
+            "outputTokens": 10,
+          }
+        `);
+      });
     });
   });
 

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -948,6 +948,16 @@ export interface WorkflowAgentStreamResult<
   toolResults: ToolResult[];
 
   /**
+   * The finish reason from the last step.
+   */
+  finishReason: FinishReason;
+
+  /**
+   * The total token usage across all steps.
+   */
+  totalUsage: LanguageModelUsage;
+
+  /**
    * The generated structured output. It uses the `output` specification.
    * Only available when `output` is specified.
    */
@@ -1454,6 +1464,8 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
         steps,
         toolCalls: [],
         toolResults: [],
+        finishReason: 'other',
+        totalUsage: aggregateUsage(steps),
         output: undefined as OUTPUT,
       };
     }
@@ -1612,15 +1624,17 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
             }
 
             const messages = iterMessages as unknown as ModelMessage[];
+            const lastStep = steps[steps.length - 1];
+            const totalUsage = aggregateUsage(steps);
+            const finishReason = lastStep?.finishReason ?? 'other';
 
             if (mergedOnFinish && !wasAborted) {
-              const lastStep = steps[steps.length - 1];
               await mergedOnFinish({
                 steps,
                 messages,
                 text: lastStep?.text ?? '',
-                finishReason: lastStep?.finishReason ?? 'other',
-                totalUsage: aggregateUsage(steps),
+                finishReason,
+                totalUsage,
                 experimental_context: experimentalContext,
                 output: undefined as OUTPUT,
               });
@@ -1660,6 +1674,8 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
               steps,
               toolCalls: allToolCalls,
               toolResults: allToolResults,
+              finishReason,
+              totalUsage,
               output: undefined as OUTPUT,
             };
           }
@@ -1792,15 +1808,18 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       }
     }
 
+    const lastStep = steps[steps.length - 1];
+    const totalUsage = aggregateUsage(steps);
+    const finishReason = lastStep?.finishReason ?? 'other';
+
     // Call onFinish callback if provided (always call, even on errors, but not on abort)
     if (mergedOnFinish && !wasAborted) {
-      const lastStep = steps[steps.length - 1];
       await mergedOnFinish({
         steps,
         messages: messages as ModelMessage[],
         text: lastStep?.text ?? '',
-        finishReason: lastStep?.finishReason ?? 'other',
-        totalUsage: aggregateUsage(steps),
+        finishReason,
+        totalUsage,
         experimental_context: experimentalContext,
         output: experimentalOutput,
       });
@@ -1833,6 +1852,8 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       steps,
       toolCalls: lastStepToolCalls,
       toolResults: lastStepToolResults,
+      finishReason,
+      totalUsage,
       output: experimentalOutput,
     };
   }


### PR DESCRIPTION
## Summary

`WorkflowAgentStreamResult` (the awaited return of `agent.stream()`) is missing `totalUsage` and `finishReason`. Both fields are already computed in the runtime and passed to the `onFinish` callback, so the omission from the result is asymmetric and diverges from `GenerateTextResult`/`StreamTextResult`, which expose them directly.

This adds them to the interface and to all three return sites (early-abort, paused-tools, and the final return), reusing the existing `aggregateUsage(steps)` helper.

Targets the `workflow-agent-unify-callbacks` branch since the `WorkflowAgent` work is gated behind it.

See also https://github.com/vercel/workflow/pull/1863

## Test plan

- [x] New regression test in `workflow-agent-compat.test.ts` asserts `result.totalUsage` and `result.finishReason` after a normal stream
- [x] Existing 107 tests still pass (108 with the new one), 5 expected-fails unchanged
- [x] `pnpm turbo run build --filter=@ai-sdk/workflow` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)