### PR TITLE
ci(release): sign commits by changesets/acion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,8 @@ jobs:
           version: pnpm ci:version
           publish: pnpm ci:release
           setupGitUser: false
+          # When using "github-api", all commits and tags are GPG-signed and attributed to the user or app who owns the GITHUB_TOKEN
+          commitMode: 'github-api'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
form the docs:
https://github.com/changesets/action#inputs

> commitMode - Specifies the commit mode. Use "git-cli" to push changes using the Git CLI, or "github-api" to push changes via the GitHub API. When using "github-api", all commits and tags are GPG-signed and attributed to the user or app who owns the GITHUB_TOKEN. Default to git-cli.