### PR TITLE
ci(release): use Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,10 @@ jobs:
         with:
           version: 10.11.0
 
-      - name: Setup Node.js 22
+      - name: Setup Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install Dependencies
         run: pnpm i


### PR DESCRIPTION
OIDC trusted publishing in the npm CLI requires npm ≥ 11.5.1 (introduced July 2025). Node 22 comes currently with npm@10.9.7. Node 24 comes with npm@11.12.1
