### PR TITLE
build(pkg): set `repository.url` to https://github.com/vercel/ai

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "license": "Apache License",
   "bugs": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -85,7 +85,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/alibaba/package.json
+++ b/packages/alibaba/package.json
@@ -61,7 +61,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/amazon-bedrock/package.json
+++ b/packages/amazon-bedrock/package.json
@@ -76,7 +76,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -72,7 +72,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/assemblyai/package.json
+++ b/packages/assemblyai/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -67,7 +67,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/baseten/package.json
+++ b/packages/baseten/package.json
@@ -67,7 +67,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/black-forest-labs/package.json
+++ b/packages/black-forest-labs/package.json
@@ -65,7 +65,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/bytedance/package.json
+++ b/packages/bytedance/package.json
@@ -55,7 +55,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/cerebras/package.json
+++ b/packages/cerebras/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -54,7 +54,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/cohere/package.json
+++ b/packages/cohere/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/deepgram/package.json
+++ b/packages/deepgram/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/deepinfra/package.json
+++ b/packages/deepinfra/package.json
@@ -67,7 +67,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/deepseek/package.json
+++ b/packages/deepseek/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/elevenlabs/package.json
+++ b/packages/elevenlabs/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/fal/package.json
+++ b/packages/fal/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/fireworks/package.json
+++ b/packages/fireworks/package.json
@@ -67,7 +67,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -70,7 +70,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/gladia/package.json
+++ b/packages/gladia/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -100,7 +100,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -72,7 +72,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/huggingface/package.json
+++ b/packages/huggingface/package.json
@@ -67,7 +67,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/hume/package.json
+++ b/packages/hume/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/klingai/package.json
+++ b/packages/klingai/package.json
@@ -60,7 +60,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/llamaindex/package.json
+++ b/packages/llamaindex/package.json
@@ -54,7 +54,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/lmnt/package.json
+++ b/packages/lmnt/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/luma/package.json
+++ b/packages/luma/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -68,7 +68,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/mistral/package.json
+++ b/packages/mistral/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/moonshotai/package.json
+++ b/packages/moonshotai/package.json
@@ -61,7 +61,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/open-responses/package.json
+++ b/packages/open-responses/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/openai-compatible/package.json
+++ b/packages/openai-compatible/package.json
@@ -72,7 +72,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -72,7 +72,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -56,7 +56,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/perplexity/package.json
+++ b/packages/perplexity/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/prodia/package.json
+++ b/packages/prodia/package.json
@@ -65,7 +65,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -69,7 +69,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -51,7 +51,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -70,7 +70,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/replicate/package.json
+++ b/packages/replicate/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/revai/package.json
+++ b/packages/revai/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -85,7 +85,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -70,7 +70,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git",
+    "url": "https://github.com/vercel/ai",
     "directory": "packages/svelte"
   },
   "bugs": {

--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -59,7 +59,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/togetherai/package.json
+++ b/packages/togetherai/package.json
@@ -67,7 +67,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -55,7 +55,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/voyage/package.json
+++ b/packages/voyage/package.json
@@ -60,7 +60,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -67,7 +67,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -65,7 +65,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/xai/package.json
+++ b/packages/xai/package.json
@@ -67,7 +67,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"


### PR DESCRIPTION
This should fix this npm publish error:

> Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/vercel/ai" from provenance
