### PR TITLE
Re-enable v6 releases

### DIFF
--- a/.changeset/long-actors-tie.md
+++ b/.changeset/long-actors-tie.md
@@ -1,0 +1,56 @@
+---
+"ai": patch
+"@ai-sdk/alibaba": patch
+"@ai-sdk/amazon-bedrock": patch
+"@ai-sdk/anthropic": patch
+"@ai-sdk/assemblyai": patch
+"@ai-sdk/azure": patch
+"@ai-sdk/baseten": patch
+"@ai-sdk/black-forest-labs": patch
+"@ai-sdk/bytedance": patch
+"@ai-sdk/cerebras": patch
+"@ai-sdk/codemod": patch
+"@ai-sdk/cohere": patch
+"@ai-sdk/deepgram": patch
+"@ai-sdk/deepinfra": patch
+"@ai-sdk/deepseek": patch
+"@ai-sdk/elevenlabs": patch
+"@ai-sdk/fal": patch
+"@ai-sdk/fireworks": patch
+"@ai-sdk/gateway": patch
+"@ai-sdk/gladia": patch
+"@ai-sdk/google": patch
+"@ai-sdk/google-vertex": patch
+"@ai-sdk/groq": patch
+"@ai-sdk/huggingface": patch
+"@ai-sdk/hume": patch
+"@ai-sdk/klingai": patch
+"@ai-sdk/langchain": patch
+"@ai-sdk/llamaindex": patch
+"@ai-sdk/lmnt": patch
+"@ai-sdk/luma": patch
+"@ai-sdk/mcp": patch
+"@ai-sdk/mistral": patch
+"@ai-sdk/moonshotai": patch
+"@ai-sdk/open-responses": patch
+"@ai-sdk/openai": patch
+"@ai-sdk/openai-compatible": patch
+"@ai-sdk/perplexity": patch
+"@ai-sdk/prodia": patch
+"@ai-sdk/provider": patch
+"@ai-sdk/provider-utils": patch
+"@ai-sdk/react": patch
+"@ai-sdk/replicate": patch
+"@ai-sdk/revai": patch
+"@ai-sdk/rsc": patch
+"@ai-sdk/svelte": patch
+"@ai-sdk/test-server": patch
+"@ai-sdk/togetherai": patch
+"@ai-sdk/valibot": patch
+"@ai-sdk/vercel": patch
+"@ai-sdk/voyage": patch
+"@ai-sdk/vue": patch
+"@ai-sdk/xai": patch
+---
+
+trigger release for all packages after provenance setup

--- a/.github/workflows/auto-merge-release-prs.yml
+++ b/.github/workflows/auto-merge-release-prs.yml
@@ -13,9 +13,9 @@ jobs:
     name: Enable Auto-merge for Release PRs
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Only run if PR is created by vercel-ai-sdk[bot] and branch starts with changeset-release/
+    # Only run if PR is created by an app branch starts with changeset-release/
     if: |
-      github.event.pull_request.user.login == 'vercel-ai-sdk[bot]' &&
+      github.event.pull_request.user.type == 'Bot' &&
       startsWith(github.event.pull_request.head.ref, 'changeset-release/')
 
     steps:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -75,23 +75,10 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'backport')
 
     steps:
-      - name: Create access token for GitHub App
-        uses: actions/create-github-app-token@v3
-        id: app-token
-        with:
-          app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8 }}
-
-      - name: Get GitHub App User ID
-        id: app-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Configure git user for GitHub App
+      - name: Configure Git
         run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.app-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
 
       - name: Check for existing backport PR
         id: check-existing
@@ -103,31 +90,30 @@ jobs:
             echo "existing-pr=$EXISTING_PR" >> "$GITHUB_OUTPUT"
           fi
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove backport label (already backported)
         if: steps.check-existing.outputs.existing-pr
         run: |
           gh pr edit ${{ github.event.pull_request.number }} --remove-label backport || true
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout Repository
-        if: '!steps.check-existing.outputs.existing-pr'
+        if: "!steps.check-existing.outputs.existing-pr"
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ needs.find-branch.outputs.release-branch }}
 
       - name: Create backport branch
-        if: '!steps.check-existing.outputs.existing-pr'
+        if: "!steps.check-existing.outputs.existing-pr"
         run: |
           # Create a new branch from the latest release branch for the backport
           git checkout -b backport-pr-${{ github.event.pull_request.number }}-to-${{ needs.find-branch.outputs.release-branch }} origin/${{ needs.find-branch.outputs.release-branch }}
 
       - name: Cherry-pick commits
-        if: '!steps.check-existing.outputs.existing-pr'
+        if: "!steps.check-existing.outputs.existing-pr"
         id: cherry-pick
         run: |
           # Get the merge commit hash
@@ -182,7 +168,7 @@ jobs:
           git add .
           git commit -m "Backport conflicts for PR #${{ github.event.pull_request.number }} to ${{ needs.find-branch.outputs.release-branch }}"
       - name: Push backport branch
-        if: '!steps.check-existing.outputs.existing-pr'
+        if: "!steps.check-existing.outputs.existing-pr"
         run: |
           BACKPORT_BRANCH="backport-pr-${{ github.event.pull_request.number }}-to-${{ needs.find-branch.outputs.release-branch }}"
           if git ls-remote --exit-code origin "refs/heads/${BACKPORT_BRANCH}" > /dev/null 2>&1; then
@@ -193,7 +179,7 @@ jobs:
           fi
 
       - name: Determine PR assignee
-        if: '!steps.check-existing.outputs.existing-pr'
+        if: "!steps.check-existing.outputs.existing-pr"
         id: assignee
         run: |
           if [ "$MERGED_BY_TYPE" = "User" ]; then
@@ -208,14 +194,14 @@ jobs:
             fi
           fi
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGED_BY_TYPE: ${{ github.event.pull_request.merged_by.type }}
           MERGED_BY_LOGIN: ${{ github.event.pull_request.merged_by.login }}
           PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
           PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
 
       - name: Create backport pull request
-        if: '!steps.check-existing.outputs.existing-pr'
+        if: "!steps.check-existing.outputs.existing-pr"
         id: create-pr
         run: |
           ASSIGNEE_FLAG=""
@@ -244,10 +230,10 @@ jobs:
           gh pr merge "$PR_URL" --auto --squash || echo "Auto-merge could not be enabled"
           echo "Created backport PR $PR_URL"
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ASSIGNEE_LOGIN: ${{ steps.assignee.outputs.login }}
-          PR_TITLE: 'Backport: ${{ github.event.pull_request.title }}'
-          PR_BODY_NO_CONFLICTS: 'This is an automated backport of #${{ github.event.pull_request.number }} to the ${{ needs.find-branch.outputs.release-branch }} branch. FYI @${{ github.event.pull_request.user.login }}'
+          PR_TITLE: "Backport: ${{ github.event.pull_request.title }}"
+          PR_BODY_NO_CONFLICTS: "This is an automated backport of #${{ github.event.pull_request.number }} to the ${{ needs.find-branch.outputs.release-branch }} branch. FYI @${{ github.event.pull_request.user.login }}"
           PR_BODY_CONFLICTS: |
 
             This is an automated backport of #${{ github.event.pull_request.number }} to the ${{ needs.find-branch.outputs.release-branch }} branch. FYI @${{ github.event.pull_request.user.login }}
@@ -260,31 +246,31 @@ jobs:
             ```
 
       - name: Remove backport label from original PR
-        if: '!steps.check-existing.outputs.existing-pr && steps.create-pr.outputs.backport-pr-url'
+        if: "!steps.check-existing.outputs.existing-pr && steps.create-pr.outputs.backport-pr-url"
         run: |
           # Remove the backport label from the original PR
           gh pr edit ${{ github.event.pull_request.number }} --remove-label backport
           echo "Removed backport label from original PR #${{ github.event.pull_request.number }}"
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Success Comment on original PR
         if: "!steps.check-existing.outputs.existing-pr && steps.cherry-pick.outputs.has-conflicts == 'false' && steps.create-pr.outputs.backport-pr-url"
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body "✅ Backport PR created: ${{ steps.create-pr.outputs.backport-pr-url }}"
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Error Comment on original PR
         if: "!steps.check-existing.outputs.existing-pr && steps.cherry-pick.outputs.has-conflicts == 'true' && steps.create-pr.outputs.backport-pr-url"
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body "⚠️ Backport to ${{ needs.find-branch.outputs.release-branch }} created but has conflicts: ${{ steps.create-pr.outputs.backport-pr-url }}"
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull request failure Comment on original PR
         if: "!steps.check-existing.outputs.existing-pr && steps.cherry-pick.outputs.has-conflicts == 'true' && !steps.create-pr.outputs.backport-pr-url"
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body "❌ Backport to ${{ needs.find-branch.outputs.release-branch }} failed. This backport requires manual intervention. [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -100,20 +100,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout Repository
-        if: "!steps.check-existing.outputs.existing-pr"
+        if: '!steps.check-existing.outputs.existing-pr'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ needs.find-branch.outputs.release-branch }}
 
       - name: Create backport branch
-        if: "!steps.check-existing.outputs.existing-pr"
+        if: '!steps.check-existing.outputs.existing-pr'
         run: |
           # Create a new branch from the latest release branch for the backport
           git checkout -b backport-pr-${{ github.event.pull_request.number }}-to-${{ needs.find-branch.outputs.release-branch }} origin/${{ needs.find-branch.outputs.release-branch }}
 
       - name: Cherry-pick commits
-        if: "!steps.check-existing.outputs.existing-pr"
+        if: '!steps.check-existing.outputs.existing-pr'
         id: cherry-pick
         run: |
           # Get the merge commit hash
@@ -168,7 +168,7 @@ jobs:
           git add .
           git commit -m "Backport conflicts for PR #${{ github.event.pull_request.number }} to ${{ needs.find-branch.outputs.release-branch }}"
       - name: Push backport branch
-        if: "!steps.check-existing.outputs.existing-pr"
+        if: '!steps.check-existing.outputs.existing-pr'
         run: |
           BACKPORT_BRANCH="backport-pr-${{ github.event.pull_request.number }}-to-${{ needs.find-branch.outputs.release-branch }}"
           if git ls-remote --exit-code origin "refs/heads/${BACKPORT_BRANCH}" > /dev/null 2>&1; then
@@ -179,7 +179,7 @@ jobs:
           fi
 
       - name: Determine PR assignee
-        if: "!steps.check-existing.outputs.existing-pr"
+        if: '!steps.check-existing.outputs.existing-pr'
         id: assignee
         run: |
           if [ "$MERGED_BY_TYPE" = "User" ]; then
@@ -201,7 +201,7 @@ jobs:
           PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
 
       - name: Create backport pull request
-        if: "!steps.check-existing.outputs.existing-pr"
+        if: '!steps.check-existing.outputs.existing-pr'
         id: create-pr
         run: |
           ASSIGNEE_FLAG=""
@@ -232,8 +232,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ASSIGNEE_LOGIN: ${{ steps.assignee.outputs.login }}
-          PR_TITLE: "Backport: ${{ github.event.pull_request.title }}"
-          PR_BODY_NO_CONFLICTS: "This is an automated backport of #${{ github.event.pull_request.number }} to the ${{ needs.find-branch.outputs.release-branch }} branch. FYI @${{ github.event.pull_request.user.login }}"
+          PR_TITLE: 'Backport: ${{ github.event.pull_request.title }}'
+          PR_BODY_NO_CONFLICTS: 'This is an automated backport of #${{ github.event.pull_request.number }} to the ${{ needs.find-branch.outputs.release-branch }} branch. FYI @${{ github.event.pull_request.user.login }}'
           PR_BODY_CONFLICTS: |
 
             This is an automated backport of #${{ github.event.pull_request.number }} to the ${{ needs.find-branch.outputs.release-branch }} branch. FYI @${{ github.event.pull_request.user.login }}
@@ -246,7 +246,7 @@ jobs:
             ```
 
       - name: Remove backport label from original PR
-        if: "!steps.check-existing.outputs.existing-pr && steps.create-pr.outputs.backport-pr-url"
+        if: '!steps.check-existing.outputs.existing-pr && steps.create-pr.outputs.backport-pr-url'
         run: |
           # Remove the backport label from the original PR
           gh pr edit ${{ github.event.pull_request.number }} --remove-label backport

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.event.pull_request.number }}
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  id-token: write
   contents: write
   pull-requests: write
   issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ concurrency:
   group: 'release'
   cancel-in-progress: false
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   release:
     name: Release
@@ -21,29 +26,15 @@ jobs:
     # do not attempt running in forks
     if: github.repository_owner == 'vercel'
     steps:
-      - name: Create access token for GitHub App
-        uses: actions/create-github-app-token@v3
-        id: app-token
-        with:
-          app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8 }}
-
-      - name: Get GitHub App User ID
-        id: app-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Configure git user for GitHub App
+      - name: Configure Git
         run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.app-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
 
       - name: Checkout Repo
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - name: Setup pnpm
@@ -51,10 +42,10 @@ jobs:
         with:
           version: 10.11.0
 
-      - name: Setup Node.js 22
+      - name: Setup Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install Dependencies
         run: pnpm i
@@ -66,8 +57,10 @@ jobs:
           version: pnpm ci:version
           publish: pnpm ci:release
           setupGitUser: false
+          # When using "github-api", all commits and tags are GPG-signed and attributed to the user or app who owns the GITHUB_TOKEN
+          commitMode: 'github-api'
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
       - name: Find release PR number
@@ -75,7 +68,7 @@ jobs:
         id: release-pr
         run: echo "number=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0].number')" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify released PRs and issues
         if: steps.changesets.outputs.published == 'true'
@@ -84,6 +77,6 @@ jobs:
           npm install --no-save
           node index.mjs
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
           PULL_REQUEST_NUMBER: ${{ steps.release-pr.outputs.number }}

--- a/.github/workflows/update-model-settings.yml
+++ b/.github/workflows/update-model-settings.yml
@@ -26,29 +26,15 @@ jobs:
             branch-prefix: update-gateway-models-v5
 
     steps:
-      - name: Create access token for GitHub App
-        uses: actions/create-github-app-token@v3
-        id: app-token
-        with:
-          app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8 }}
-
-      - name: Get GitHub App User ID
-        id: app-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Configure git user for GitHub App
+      - name: Configure Git
         run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.app-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
 
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
           ref: ${{ matrix.target-branch }}
-          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -145,7 +131,7 @@ jobs:
           echo "pr-title=$PR_TITLE" >> "$GITHUB_OUTPUT"
           echo "Changes updated, PR: $PR_URL"
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: No changes
         if: steps.check-changes.outputs.has-changes == 'false'

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "license": "Apache License",
   "bugs": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -87,7 +87,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/alibaba/package.json
+++ b/packages/alibaba/package.json
@@ -60,7 +60,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/alibaba"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/amazon-bedrock/package.json
+++ b/packages/amazon-bedrock/package.json
@@ -75,7 +75,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/amazon-bedrock"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -52,5 +52,19 @@
   },
   "engines": {
     "node": ">=18"
-  }
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/angular"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "sideEffects": false,
+  "keywords": [
+    "ai",
+    "angular"
+  ]
 }

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -72,7 +72,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/anthropic"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/assemblyai/package.json
+++ b/packages/assemblyai/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/assemblyai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -66,7 +66,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/azure"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/baseten/package.json
+++ b/packages/baseten/package.json
@@ -66,7 +66,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/baseten"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/black-forest-labs/package.json
+++ b/packages/black-forest-labs/package.json
@@ -64,7 +64,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/black-forest-labs"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/bytedance/package.json
+++ b/packages/bytedance/package.json
@@ -54,7 +54,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/bytedance"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/cerebras/package.json
+++ b/packages/cerebras/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/cerebras"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"
@@ -74,6 +75,5 @@
     "ai"
   ],
   "description": "The **Cerebras provider** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for [Cerebras](https://cerebras.ai), offering high-speed AI model inference powered by Cerebras Wafer-Scale Engines and CS-3 systems.",
-  "author": "",
   "type": "commonjs"
 }

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/codemod"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/cohere/package.json
+++ b/packages/cohere/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/cohere"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/deepgram/package.json
+++ b/packages/deepgram/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/deepgram"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/deepinfra/package.json
+++ b/packages/deepinfra/package.json
@@ -66,7 +66,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/deepinfra"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/deepseek/package.json
+++ b/packages/deepseek/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/deepseek"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -67,5 +67,22 @@
     "vaul": "^1.1.2",
     "vite": "^6.0.3",
     "zod": "3.25.76"
-  }
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/devtools"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "ai"
+  ]
 }

--- a/packages/elevenlabs/package.json
+++ b/packages/elevenlabs/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/elevenlabs"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/fal/package.json
+++ b/packages/fal/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/fal"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/fireworks/package.json
+++ b/packages/fireworks/package.json
@@ -66,7 +66,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/fireworks"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -69,7 +69,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/gateway"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/gladia/package.json
+++ b/packages/gladia/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/gladia"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -99,7 +99,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/google-vertex"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -72,7 +72,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/google"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/groq"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/huggingface/package.json
+++ b/packages/huggingface/package.json
@@ -66,7 +66,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/huggingface"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/hume/package.json
+++ b/packages/hume/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/hume"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/klingai/package.json
+++ b/packages/klingai/package.json
@@ -59,7 +59,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/klingai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/langchain"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/llamaindex/package.json
+++ b/packages/llamaindex/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/llamaindex"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/lmnt/package.json
+++ b/packages/lmnt/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/lmnt"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/luma/package.json
+++ b/packages/luma/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/luma"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -68,7 +68,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/mcp"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/mistral/package.json
+++ b/packages/mistral/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/mistral"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/moonshotai/package.json
+++ b/packages/moonshotai/package.json
@@ -60,7 +60,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/moonshotai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/open-responses/package.json
+++ b/packages/open-responses/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/open-responses"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/openai-compatible/package.json
+++ b/packages/openai-compatible/package.json
@@ -72,7 +72,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/openai-compatible"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -72,7 +72,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/openai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/perplexity/package.json
+++ b/packages/perplexity/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/perplexity"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/prodia/package.json
+++ b/packages/prodia/package.json
@@ -64,7 +64,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/prodia"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -68,7 +68,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/provider-utils"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -50,7 +50,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/provider"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -68,7 +68,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/react"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/replicate/package.json
+++ b/packages/replicate/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/replicate"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/revai/package.json
+++ b/packages/revai/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/revai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -84,7 +84,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/rsc"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -70,7 +70,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git",
+    "url": "https://github.com/vercel/ai",
     "directory": "packages/svelte"
   },
   "bugs": {
@@ -79,5 +79,8 @@
   "keywords": [
     "ai",
     "svelte"
-  ]
+  ],
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -59,7 +59,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/test-server"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/togetherai/package.json
+++ b/packages/togetherai/package.json
@@ -66,7 +66,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/togetherai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -54,7 +54,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/valibot"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/vercel"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/voyage/package.json
+++ b/packages/voyage/package.json
@@ -59,7 +59,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/voyage"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -66,7 +66,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/vue"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/xai/package.json
+++ b/packages/xai/package.json
@@ -66,7 +66,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/xai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"


### PR DESCRIPTION
Backports the recent main-branch fixes that re-enabled releases after the GitHub App was retired and provenance was configured.

## Backported PRs

- #14784 — `ci(release): use \`secrets.GITHUB_TOKEN\``
- #14785 — `ci(release): git config for GITHUB_TOKEN`
- #14787 — `ci(release): sign commits by changesets/acion`
- #14791 — `ci(release): use Node 24`
- #14793 — `build(pkg): set \`repository.url\` to https://github.com/vercel/ai`
- #14794 — `normalize package json files`
- #14795 — `fix: trigger releases after provenance setup`
- #14798 — `remove github app use in workflows`

## Notes on differences from main

- v6 lacks the `@ai-sdk/otel` and `@ai-sdk/workflow` packages — both were excluded from the changeset and the package.json normalization sweep.
- `release.yml` on v6 does not have the snapshot-release path that exists on main, so only the relevant subset of #14784/#14785/#14787/#14791 was applied. `NPM_TOKEN: secrets.NPM_TOKEN_ELEVATED` was kept in v6 since OIDC trusted publishing has not been configured for v6 packages.
- `auto-merge-release-prs.yml` keeps the existing `GR2M_PR_REVIEW_TOKEN` (still needed for PR approval); only the `Bot` user-type check from #14798 was applied.