### PR TITLE
Re-enable v5 releases

### DIFF
--- a/.changeset/long-actors-tie.md
+++ b/.changeset/long-actors-tie.md
@@ -1,0 +1,52 @@
+---
+"ai": patch
+"@ai-sdk/alibaba": patch
+"@ai-sdk/amazon-bedrock": patch
+"@ai-sdk/anthropic": patch
+"@ai-sdk/assemblyai": patch
+"@ai-sdk/azure": patch
+"@ai-sdk/baseten": patch
+"@ai-sdk/black-forest-labs": patch
+"@ai-sdk/cerebras": patch
+"@ai-sdk/codemod": patch
+"@ai-sdk/cohere": patch
+"@ai-sdk/deepgram": patch
+"@ai-sdk/deepinfra": patch
+"@ai-sdk/deepseek": patch
+"@ai-sdk/elevenlabs": patch
+"@ai-sdk/fal": patch
+"@ai-sdk/fireworks": patch
+"@ai-sdk/gateway": patch
+"@ai-sdk/gladia": patch
+"@ai-sdk/google": patch
+"@ai-sdk/google-vertex": patch
+"@ai-sdk/groq": patch
+"@ai-sdk/huggingface": patch
+"@ai-sdk/hume": patch
+"@ai-sdk/langchain": patch
+"@ai-sdk/llamaindex": patch
+"@ai-sdk/lmnt": patch
+"@ai-sdk/luma": patch
+"@ai-sdk/mcp": patch
+"@ai-sdk/mistral": patch
+"@ai-sdk/moonshotai": patch
+"@ai-sdk/openai": patch
+"@ai-sdk/openai-compatible": patch
+"@ai-sdk/perplexity": patch
+"@ai-sdk/prodia": patch
+"@ai-sdk/provider": patch
+"@ai-sdk/provider-utils": patch
+"@ai-sdk/react": patch
+"@ai-sdk/replicate": patch
+"@ai-sdk/revai": patch
+"@ai-sdk/rsc": patch
+"@ai-sdk/svelte": patch
+"@ai-sdk/test-server": patch
+"@ai-sdk/togetherai": patch
+"@ai-sdk/valibot": patch
+"@ai-sdk/vercel": patch
+"@ai-sdk/vue": patch
+"@ai-sdk/xai": patch
+---
+
+trigger release for all packages after provenance setup

--- a/.github/workflows/auto-merge-release-prs.yml
+++ b/.github/workflows/auto-merge-release-prs.yml
@@ -13,9 +13,9 @@ jobs:
     name: Enable Auto-merge for Release PRs
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Only run if PR is created by vercel-ai-sdk[bot] and branch starts with changeset-release/
+    # Only run if PR is created by an app branch starts with changeset-release/
     if: |
-      github.event.pull_request.user.login == 'vercel-ai-sdk[bot]' &&
+      github.event.pull_request.user.type == 'Bot' &&
       startsWith(github.event.pull_request.head.ref, 'changeset-release/')
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,12 @@ concurrency:
   group: 'release'
   cancel-in-progress: false
 
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   release:
     name: Release
@@ -21,29 +27,15 @@ jobs:
     # do not attempt running in forks
     if: github.repository_owner == 'vercel'
     steps:
-      - name: Create access token for GitHub App
-        uses: actions/create-github-app-token@v3
-        id: app-token
-        with:
-          app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8 }}
-
-      - name: Get GitHub App User ID
-        id: app-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Configure git user for GitHub App
+      - name: Configure Git
         run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.app-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
 
       - name: Checkout Repo
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - name: Setup pnpm
@@ -51,10 +43,10 @@ jobs:
         with:
           version: 10.11.0
 
-      - name: Setup Node.js 22
+      - name: Setup Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install Dependencies
         run: pnpm i
@@ -66,6 +58,8 @@ jobs:
           version: pnpm ci:version
           publish: pnpm ci:release
           setupGitUser: false
+          # When using "github-api", all commits and tags are GPG-signed and attributed to the user or app who owns the GITHUB_TOKEN
+          commitMode: 'github-api'
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai"
   },
   "license": "Apache License",
   "bugs": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -75,7 +75,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/ai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/alibaba/package.json
+++ b/packages/alibaba/package.json
@@ -54,7 +54,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/alibaba"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/amazon-bedrock/package.json
+++ b/packages/amazon-bedrock/package.json
@@ -63,7 +63,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/amazon-bedrock"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -46,5 +46,19 @@
   },
   "engines": {
     "node": ">=18"
-  }
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/angular"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "sideEffects": false,
+  "keywords": [
+    "ai",
+    "angular"
+  ]
 }

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -60,7 +60,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/anthropic"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/assemblyai/package.json
+++ b/packages/assemblyai/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/assemblyai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -54,7 +54,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/azure"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/baseten/package.json
+++ b/packages/baseten/package.json
@@ -54,7 +54,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/baseten"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/black-forest-labs/package.json
+++ b/packages/black-forest-labs/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/black-forest-labs"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/cerebras/package.json
+++ b/packages/cerebras/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/cerebras"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"
@@ -62,6 +63,5 @@
     "ai"
   ],
   "description": "The **Cerebras provider** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for [Cerebras](https://cerebras.ai), offering high-speed AI model inference powered by Cerebras Wafer-Scale Engines and CS-3 systems.",
-  "author": "",
   "type": "commonjs"
 }

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -44,7 +44,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/codemod"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/cohere/package.json
+++ b/packages/cohere/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/cohere"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/deepgram/package.json
+++ b/packages/deepgram/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/deepgram"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/deepinfra/package.json
+++ b/packages/deepinfra/package.json
@@ -54,7 +54,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/deepinfra"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/deepseek/package.json
+++ b/packages/deepseek/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/deepseek"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/elevenlabs/package.json
+++ b/packages/elevenlabs/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/elevenlabs"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/fal/package.json
+++ b/packages/fal/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/fal"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/fireworks/package.json
+++ b/packages/fireworks/package.json
@@ -54,7 +54,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/fireworks"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -57,7 +57,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/gateway"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/gladia/package.json
+++ b/packages/gladia/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/gladia"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -87,7 +87,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/google-vertex"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -60,7 +60,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/google"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/groq"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/huggingface/package.json
+++ b/packages/huggingface/package.json
@@ -54,7 +54,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/huggingface"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/hume/package.json
+++ b/packages/hume/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/hume"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -47,7 +47,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/langchain"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/llamaindex/package.json
+++ b/packages/llamaindex/package.json
@@ -47,7 +47,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/llamaindex"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/lmnt/package.json
+++ b/packages/lmnt/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/lmnt"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/luma/package.json
+++ b/packages/luma/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/luma"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -62,7 +62,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/mcp"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/mistral/package.json
+++ b/packages/mistral/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/mistral"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/moonshotai/package.json
+++ b/packages/moonshotai/package.json
@@ -60,7 +60,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/moonshotai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/openai-compatible/package.json
+++ b/packages/openai-compatible/package.json
@@ -60,7 +60,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/openai-compatible"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -60,7 +60,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/openai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/perplexity/package.json
+++ b/packages/perplexity/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/perplexity"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/prodia/package.json
+++ b/packages/prodia/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/prodia"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -61,7 +61,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/provider-utils"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -43,7 +43,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/provider"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -66,7 +66,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/react"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/replicate/package.json
+++ b/packages/replicate/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/replicate"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/revai/package.json
+++ b/packages/revai/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/revai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -77,7 +77,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/rsc"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -73,7 +73,7 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git",
+    "url": "https://github.com/vercel/ai",
     "directory": "packages/svelte"
   },
   "bugs": {
@@ -82,5 +82,8 @@
   "keywords": [
     "ai",
     "svelte"
-  ]
+  ],
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/test-server"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/togetherai/package.json
+++ b/packages/togetherai/package.json
@@ -54,7 +54,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/togetherai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -48,7 +48,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/valibot"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/vercel"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -67,7 +67,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/vue"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"

--- a/packages/xai/package.json
+++ b/packages/xai/package.json
@@ -54,7 +54,8 @@
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel/ai.git"
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/xai"
   },
   "bugs": {
     "url": "https://github.com/vercel/ai/issues"


### PR DESCRIPTION
Backports the recent main-branch fixes that re-enabled releases after the GitHub App was retired and provenance was configured.

## Backported PRs

- #14784 — `ci(release): use \`secrets.GITHUB_TOKEN\``
- #14785 — `ci(release): git config for GITHUB_TOKEN`
- #14787 — `ci(release): sign commits by changesets/acion`
- #14791 — `ci(release): use Node 24`
- #14793 — `build(pkg): set \`repository.url\` to https://github.com/vercel/ai`
- #14794 — `normalize package json files`
- #14795 — `fix: trigger releases after provenance setup`
- #14798 — `remove github app use in workflows` (the auto-merge bot-type check + `id-token: write` follow-up)

## Notes on differences from main / v6

- v5 lacks the `@ai-sdk/bytedance`, `@ai-sdk/devtools`, `@ai-sdk/klingai`, `@ai-sdk/open-responses`, `@ai-sdk/otel`, `@ai-sdk/voyage`, and `@ai-sdk/workflow` packages — all excluded from the changeset and the package.json sweep.
- v5 has no `backport.yml` or `update-model-settings.yml` workflows, so the corresponding parts of #14798 do not apply.
- v5's `release.yml` is simpler than main's (no snapshot path, no notify-released-PRs step), so only the relevant subset of #14784/#14785/#14787/#14791 was applied. `NPM_TOKEN: secrets.NPM_TOKEN_ELEVATED` was kept since OIDC trusted publishing has not been configured for v5 packages.
- `auto-merge-release-prs.yml` keeps the existing `GR2M_PR_REVIEW_TOKEN` (still needed for PR approval); only the `Bot` user-type check from #14798 was applied.
- `permissions` block added to `release.yml` with `id-token: write`, matching the v6 backport.