### PR TITLE
feat(provider/xai): support non-image files in Responses API via input_file + file_url

### DIFF
--- a/.changeset/xai-responses-pdf-file-url.md
+++ b/.changeset/xai-responses-pdf-file-url.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(provider/xai): support non-image file parts (PDF, text, CSV) in the Responses API via `input_file` + `file_url`
+
+The xAI Responses API accepts `{ type: 'input_file', file_url }` for non-image documents (see https://docs.x.ai/docs/guides/chat-with-files), but the AI SDK xAI Responses provider previously threw `UnsupportedFunctionalityError` for any file part whose `mediaType` did not start with `image/`.
+
+When a file part is passed with `data: URL` and a non-image media type, the provider now emits `{ type: 'input_file', file_url }`. `application/pdf` and `text/*` are also added to `supportedUrls` so the SDK does not download them to bytes before reaching the converter.
+
+Inline-byte (base64) inputs for non-image media types continue to throw, since xAI's Responses API requires either a public URL or a pre-uploaded `file_id` for non-image documents.

--- a/packages/xai/src/responses/convert-to-xai-responses-input.test.ts
+++ b/packages/xai/src/responses/convert-to-xai-responses-input.test.ts
@@ -146,7 +146,80 @@ describe('convertToXaiResponsesInput', () => {
       `);
     });
 
-    it('should throw for unsupported file types', async () => {
+    it('should convert non-image file parts with URL to input_file with file_url', async () => {
+      const result = await convertToXaiResponsesInput({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'summarize this PDF' },
+              {
+                type: 'file',
+                mediaType: 'application/pdf',
+                data: new URL('https://example.com/document.pdf'),
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.input).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "summarize this PDF",
+                "type": "input_text",
+              },
+              {
+                "file_url": "https://example.com/document.pdf",
+                "type": "input_file",
+              },
+            ],
+            "role": "user",
+          },
+        ]
+      `);
+      expect(result.inputWarnings).toEqual([]);
+    });
+
+    it('should convert text/* file parts with URL to input_file with file_url', async () => {
+      const result = await convertToXaiResponsesInput({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'analyze this CSV' },
+              {
+                type: 'file',
+                mediaType: 'text/csv',
+                data: new URL('https://example.com/data.csv'),
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.input).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "analyze this CSV",
+                "type": "input_text",
+              },
+              {
+                "file_url": "https://example.com/data.csv",
+                "type": "input_file",
+              },
+            ],
+            "role": "user",
+          },
+        ]
+      `);
+    });
+
+    it('should throw for non-image file parts provided as inline bytes', async () => {
       await expect(
         convertToXaiResponsesInput({
           prompt: [

--- a/packages/xai/src/responses/convert-to-xai-responses-input.ts
+++ b/packages/xai/src/responses/convert-to-xai-responses-input.ts
@@ -66,9 +66,19 @@ export async function convertToXaiResponsesInput({
                     : `data:${mediaType};base64,${convertToBase64(block.data)}`;
 
                 contentParts.push({ type: 'input_image', image_url: imageUrl });
+              } else if (block.data instanceof URL) {
+                // xAI's Responses API accepts non-image documents (PDF, text, CSV, etc.)
+                // via `{ type: 'input_file', file_url }`. See
+                // https://docs.x.ai/docs/guides/chat-with-files. Inline bytes for
+                // non-image files are not supported by xAI; callers must upload via
+                // the Files API and pass a provider reference (file_id) instead.
+                contentParts.push({
+                  type: 'input_file',
+                  file_url: block.data.toString(),
+                });
               } else {
                 throw new UnsupportedFunctionalityError({
-                  functionality: `file part media type ${block.mediaType}`,
+                  functionality: `file part media type ${block.mediaType} as inline data (xAI Responses requires a URL or a Files API reference for non-image files)`,
                 });
               }
               break;

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -27,7 +27,8 @@ export type XaiResponsesSystemMessage = {
 export type XaiResponsesUserMessageContentPart =
   | { type: 'input_text'; text: string }
   | { type: 'input_image'; image_url: string }
-  | { type: 'input_file'; file_id: string };
+  | { type: 'input_file'; file_id: string }
+  | { type: 'input_file'; file_url: string };
 
 export type XaiResponsesUserMessage = {
   role: 'user';

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -80,6 +80,11 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
 
   readonly supportedUrls: Record<string, RegExp[]> = {
     'image/*': [/^https?:\/\/.*$/],
+    // xAI's Responses API accepts non-image documents (PDF, plain text, CSV, etc.) as
+    // `{ type: 'input_file', file_url }`. Whitelisting their URLs here keeps them as URLs
+    // through to the converter instead of being downloaded to bytes by the SDK.
+    'application/pdf': [/^https?:\/\/.*$/],
+    'text/*': [/^https?:\/\/.*$/],
   };
 
   private async getArgs({

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -81,7 +81,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
   readonly supportedUrls: Record<string, RegExp[]> = {
     'image/*': [/^https?:\/\/.*$/],
     // xAI's Responses API accepts non-image documents (PDF, plain text, CSV, etc.) as
-    // `{ type: 'input_file', file_url }`. Whitelisting their URLs here keeps them as URLs
+    // `{ type: 'input_file', file_url }`. Keeping these URLs intact here lets them pass
     // through to the converter instead of being downloaded to bytes by the SDK.
     'application/pdf': [/^https?:\/\/.*$/],
     'text/*': [/^https?:\/\/.*$/],


### PR DESCRIPTION
## Background

xAI's Responses API accepts non-image documents (PDF, plain text, CSV, etc.) as `{ type: 'input_file', file_url }` per the official [Chat with Files](https://docs.x.ai/docs/guides/chat-with-files) docs. The AI SDK xAI Responses provider previously threw `UnsupportedFunctionalityError` for any file part whose `mediaType` did not start with `image/`, even when the caller provided a public HTTPS URL — silently turning a fully supported xAI feature into a SDK-side rejection.

Closes #14804.

## Changes

- **`convert-to-xai-responses-input.ts`** — when a file part has `data: URL` and a non-image media type, emit `{ type: 'input_file', file_url }` instead of throwing. Inline-byte (base64) inputs for non-image media types still throw, with a clearer message pointing callers toward URLs or the Files API (xAI's Responses API does not accept inline bytes for non-image documents).
- **`xai-responses-language-model.ts`** — add `application/pdf` and `text/*` to `supportedUrls` so the SDK keeps these URLs as URLs rather than downloading them to bytes before reaching the converter.
- **`xai-responses-api.ts`** — extend the `input_file` content-part variant to include `file_url` alongside the existing `file_id`.
- **Tests** — add coverage for PDF-with-URL and text/csv-with-URL; the original "throws for unsupported file types" test is preserved (now scoped to inline bytes) since that case is still genuinely unsupported by the underlying API.

## Verification

```
$ pnpm --filter @ai-sdk/xai vitest run

 Test Files  12 passed (12)
      Tests  305 passed (305)
```

End-to-end repro against the fork resolves cleanly: a `mediaType: 'application/pdf'` + `data: URL` file part now produces a valid response from `xai.responses('grok-4-fast')` instead of throwing.

## Scope

- No public API changes outside the new `file_url` variant on `XaiResponsesUserMessageContentPart` (purely additive — the existing `file_id` variant is unchanged).
- No behavior change for image file parts.
- No behavior change for `xai.chat(...)` / `xai(...)` (chat completions endpoint), which does not support file parts at all.


Made with [Cursor](https://cursor.com)