### PR TITLE
fix(bedrock): part-level cache points

### DIFF
--- a/.changeset/soft-buckets-remember.md
+++ b/.changeset/soft-buckets-remember.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix (provider/amazon-bedrock): preserve cache points on message content parts

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -439,6 +439,40 @@ describe('user messages', () => {
       "'file parts with provider references' functionality not supported",
     );
   });
+
+  it('should add cache point to user content part when specified', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'text',
+            text: 'cached',
+            providerOptions: {
+              bedrock: { cachePoint: { type: 'default', ttl: '5m' } },
+            },
+          },
+          { type: 'text', text: 'World' },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { text: 'Hello' },
+            { text: 'cached' },
+            { cachePoint: { type: 'default', ttl: '5m' } },
+            { text: 'World' },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
 });
 
 describe('assistant messages', () => {
@@ -617,6 +651,40 @@ describe('assistant messages', () => {
           content: [
             { text: 'Hello' },
             { cachePoint: { type: 'default', ttl: '1h' } },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
+
+  it('should add cache point to assistant content part when specified', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'text',
+            text: 'cached',
+            providerOptions: {
+              bedrock: { cachePoint: { type: 'default', ttl: '1h' } },
+            },
+          },
+          { type: 'text', text: 'World' },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { text: 'Hello' },
+            { text: 'cached' },
+            { cachePoint: { type: 'default', ttl: '1h' } },
+            { text: 'World' },
           ],
         },
       ],

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -45,6 +45,18 @@ function getCachePoint(
   return { cachePoint: cachePointConfig };
 }
 
+function pushCachePoint(
+  content:
+    | AmazonBedrockUserMessage['content']
+    | AmazonBedrockAssistantMessage['content'],
+  providerMetadata: SharedV4ProviderMetadata | undefined,
+) {
+  const cachePoint = getCachePoint(providerMetadata);
+  if (cachePoint) {
+    content.push(cachePoint);
+  }
+}
+
 async function shouldEnableCitations(
   providerMetadata: SharedV4ProviderMetadata | undefined,
 ): Promise<boolean> {
@@ -201,6 +213,8 @@ export async function convertToAmazonBedrockChatMessages(
                     break;
                   }
                 }
+
+                pushCachePoint(amazonBedrockContent, part.providerOptions);
               }
 
               break;
@@ -269,6 +283,7 @@ export async function convertToAmazonBedrockChatMessages(
                     content: toolResultContent,
                   },
                 });
+                pushCachePoint(amazonBedrockContent, part.providerOptions);
               }
 
               break;
@@ -279,10 +294,7 @@ export async function convertToAmazonBedrockChatMessages(
             }
           }
 
-          const cachePoint = getCachePoint(providerOptions);
-          if (cachePoint) {
-            amazonBedrockContent.push(cachePoint);
-          }
+          pushCachePoint(amazonBedrockContent, providerOptions);
         }
 
         messages.push({ role: 'user', content: amazonBedrockContent });
@@ -404,11 +416,10 @@ export async function convertToAmazonBedrockChatMessages(
                 break;
               }
             }
+
+            pushCachePoint(amazonBedrockContent, part.providerOptions);
           }
-          const cachePoint = getCachePoint(message.providerOptions);
-          if (cachePoint) {
-            amazonBedrockContent.push(cachePoint);
-          }
+          pushCachePoint(amazonBedrockContent, message.providerOptions);
         }
 
         messages.push({ role: 'assistant', content: amazonBedrockContent });


### PR DESCRIPTION
## Background

Bedrock Converse supports prompt cache checkpoints inside `messages[].content[]`, but `@ai-sdk/amazon-bedrock` only preserved `providerOptions.bedrock.cachePoint` from message-level provider options.

This meant cache points attached to individual user or assistant content parts were dropped during conversion to Bedrock messages. Requests still succeeded, but Bedrock did not create or read prompt cache entries.

## Summary

This PR preserves part-level Bedrock cache points when converting AI SDK messages to Bedrock Converse messages.

It adds cache points immediately after the content part that specified `providerOptions.bedrock.cachePoint`, for both user and assistant message content. Existing message-level cache point behavior is unchanged.

Regression tests were added for user and assistant content parts to verify cache point placement.

## Manual Verification

Ran the Amazon Bedrock provider checks locally:

- `pnpm --dir packages/amazon-bedrock type-check`
- `pnpm --dir packages/amazon-bedrock test`
- `pnpm check`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14808
