### PR TITLE
v6: fix(ai): warn about system messages in messages or prompt

### DIFF
--- a/.changeset/yellow-buckets-peel.md
+++ b/.changeset/yellow-buckets-peel.md
@@ -1,0 +1,5 @@
+---
+"ai": major
+---
+
+fix(ai): reject system messages in messages or prompt by default (opt-in)

--- a/.changeset/yellow-buckets-peel.md
+++ b/.changeset/yellow-buckets-peel.md
@@ -1,5 +1,5 @@
 ---
-"ai": major
+"ai": patch
 ---
 
-fix(ai): reject system messages in messages or prompt by default (opt-in)
+fix(ai): add allowSystemInMessages option and warn by default when system messages are found in prompt or messages

--- a/content/docs/02-foundations/03-prompts.mdx
+++ b/content/docs/02-foundations/03-prompts.mdx
@@ -45,6 +45,14 @@ const result = await generateText({
 System prompts are the initial set of instructions given to models that help guide and constrain the models' behaviors and responses.
 You can set system prompts using the `system` property.
 System prompts work with both the `prompt` and the `messages` properties.
+System messages in `prompt` or `messages` are rejected by default; use the `system` property for system instructions, or set `allowSystemInMessages: true` when you need to send existing message histories that contain system messages.
+
+<Note type="warning">
+  Opting in with `allowSystemInMessages` can create a prompt injection risk
+  where users can override or set the system prompt by injecting system
+  messages. In most cases, only trusted server-side code should set system
+  instructions via the `system` or `instructions` property.
+</Note>
 
 ```ts highlight="3-6"
 const result = await generateText({
@@ -58,11 +66,6 @@ const result = await generateText({
     `Please suggest the best tourist activities for me to do.`,
 });
 ```
-
-<Note>
-  When you use a message prompt, you can also use system messages instead of a
-  system prompt.
-</Note>
 
 ## Message Prompts
 
@@ -118,10 +121,9 @@ const { text } = await generateText({
 For granular control over applying provider options at the message level, you can pass `providerOptions` to the message object:
 
 ```ts
-import { ModelMessage } from 'ai';
-
-const messages: ModelMessage[] = [
-  {
+const result = await generateText({
+  model: __MODEL__,
+  system: {
     role: 'system',
     content: 'Cached system message',
     providerOptions: {
@@ -129,7 +131,8 @@ const messages: ModelMessage[] = [
       anthropic: { cacheControl: { type: 'ephemeral' } },
     },
   },
-];
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
 ```
 
 #### Message Part Level

--- a/content/docs/02-foundations/03-prompts.mdx
+++ b/content/docs/02-foundations/03-prompts.mdx
@@ -45,7 +45,7 @@ const result = await generateText({
 System prompts are the initial set of instructions given to models that help guide and constrain the models' behaviors and responses.
 You can set system prompts using the `system` property.
 System prompts work with both the `prompt` and the `messages` properties.
-System messages in `prompt` or `messages` are rejected by default; use the `system` property for system instructions, or set `allowSystemInMessages: true` when you need to send existing message histories that contain system messages.
+System messages in `prompt` or `messages` are allowed by default with a warning; use the `system` property for system instructions, set `allowSystemInMessages: true` when you need to send existing message histories that contain system messages, or set `allowSystemInMessages: false` to reject them.
 
 <Note type="warning">
   Opting in with `allowSystemInMessages` can create a prompt injection risk

--- a/content/docs/02-foundations/03-prompts.mdx
+++ b/content/docs/02-foundations/03-prompts.mdx
@@ -48,10 +48,11 @@ System prompts work with both the `prompt` and the `messages` properties.
 System messages in `prompt` or `messages` are allowed by default with a warning; use the `system` property for system instructions, set `allowSystemInMessages: true` when you need to send existing message histories that contain system messages, or set `allowSystemInMessages: false` to reject them.
 
 <Note type="warning">
-  Opting in with `allowSystemInMessages` can create a prompt injection risk
-  where users can override or set the system prompt by injecting system
-  messages. In most cases, only trusted server-side code should set system
-  instructions via the `system` or `instructions` property.
+  System messages in `prompt` or `messages` can create a prompt injection
+  attack risk, where users can override or set the system prompt by injecting
+  system messages. Ideally, provide system instructions through the `system`
+  option instead. Set `allowSystemInMessages: true` to suppress the warning, or
+  `allowSystemInMessages: false` to throw an error.
 </Note>
 
 ```ts highlight="3-6"

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -306,7 +306,7 @@ To see `generateText` in action, check out [these examples](#examples).
       type: 'boolean',
       isOptional: true,
       description:
-        'Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning. Set to `true` to suppress the warning, or `false` to reject system messages in `prompt` or `messages`. System messages in the `system` option are always allowed. Allowing user-controlled system messages can create a prompt injection risk.',
+        'Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning because they can create a prompt injection attack risk. Ideally, use the `system` option instead. Set to `true` to suppress the warning, or `false` to reject system messages in `prompt` or `messages`.',
     },
     {
       name: 'tools',

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -306,7 +306,7 @@ To see `generateText` in action, check out [these examples](#examples).
       type: 'boolean',
       isOptional: true,
       description:
-        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `system` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
+        'Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning. Set to `true` to suppress the warning, or `false` to reject system messages in `prompt` or `messages`. System messages in the `system` option are always allowed. Allowing user-controlled system messages can create a prompt injection risk.',
     },
     {
       name: 'tools',

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -302,6 +302,13 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'allowSystemInMessages',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `system` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
+    },
+    {
       name: 'tools',
       type: 'ToolSet',
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -307,7 +307,7 @@ To see `streamText` in action, check out [these examples](#examples).
       type: 'boolean',
       isOptional: true,
       description:
-        'Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning. Set to `true` to suppress the warning, or `false` to reject system messages in `prompt` or `messages`. System messages in the `system` option are always allowed. Allowing user-controlled system messages can create a prompt injection risk.',
+        'Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning because they can create a prompt injection attack risk. Ideally, use the `system` option instead. Set to `true` to suppress the warning, or `false` to reject system messages in `prompt` or `messages`.',
     },
     {
       name: 'tools',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -307,7 +307,7 @@ To see `streamText` in action, check out [these examples](#examples).
       type: 'boolean',
       isOptional: true,
       description:
-        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `system` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
+        'Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning. Set to `true` to suppress the warning, or `false` to reject system messages in `prompt` or `messages`. System messages in the `system` option are always allowed. Allowing user-controlled system messages can create a prompt injection risk.',
     },
     {
       name: 'tools',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -303,6 +303,13 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'allowSystemInMessages',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `system` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
+    },
+    {
       name: 'tools',
       type: 'ToolSet',
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
@@ -26,8 +26,11 @@ type SystemModelMessage = {
 You can access the Zod schema for `SystemModelMessage` with the `systemModelMessageSchema` export.
 
 <Note>
-  Using the "system" property instead of a system message is recommended to
-  enhance resilience against prompt injection attacks.
+  Use the top-level `system` property instead of a system message for system
+  instructions. AI SDK functions reject system messages in `prompt` or
+  `messages` by default unless `allowSystemInMessages` is set to `true`.
+  Opting in can create a prompt injection risk if users can inject system
+  messages.
 </Note>
 
 ### `UserModelMessage`

--- a/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
@@ -29,8 +29,8 @@ You can access the Zod schema for `SystemModelMessage` with the `systemModelMess
   Use the top-level `system` property instead of a system message for system
   instructions. AI SDK functions allow system messages in `prompt` or
   `messages` by default with a warning. Set `allowSystemInMessages` to `true`
-  to suppress the warning, or `false` to reject them. Allowing user-controlled
-  system messages can create a prompt injection risk.
+  to suppress the warning, or `false` to reject them. System messages in
+  `prompt` or `messages` can create a prompt injection attack risk.
 </Note>
 
 ### `UserModelMessage`

--- a/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
@@ -27,10 +27,10 @@ You can access the Zod schema for `SystemModelMessage` with the `systemModelMess
 
 <Note>
   Use the top-level `system` property instead of a system message for system
-  instructions. AI SDK functions reject system messages in `prompt` or
-  `messages` by default unless `allowSystemInMessages` is set to `true`.
-  Opting in can create a prompt injection risk if users can inject system
-  messages.
+  instructions. AI SDK functions allow system messages in `prompt` or
+  `messages` by default with a warning. Set `allowSystemInMessages` to `true`
+  to suppress the warning, or `false` to reject them. Allowing user-controlled
+  system messages can create a prompt injection risk.
 </Note>
 
 ### `UserModelMessage`

--- a/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
+++ b/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
@@ -256,6 +256,13 @@ To see `streamUI` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'allowSystemInMessages',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `system` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
+    },
+    {
       name: 'maxOutputTokens',
       type: 'number',
       isOptional: true,

--- a/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
+++ b/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
@@ -260,7 +260,7 @@ To see `streamUI` in action, check out [these examples](#examples).
       type: 'boolean',
       isOptional: true,
       description:
-        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `system` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
+        'Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning. Set to `true` to suppress the warning, or `false` to reject system messages in `prompt` or `messages`. System messages in the `system` option are always allowed. Allowing user-controlled system messages can create a prompt injection risk.',
     },
     {
       name: 'maxOutputTokens',

--- a/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
+++ b/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
@@ -260,7 +260,7 @@ To see `streamUI` in action, check out [these examples](#examples).
       type: 'boolean',
       isOptional: true,
       description:
-        'Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning. Set to `true` to suppress the warning, or `false` to reject system messages in `prompt` or `messages`. System messages in the `system` option are always allowed. Allowing user-controlled system messages can create a prompt injection risk.',
+        'Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning because they can create a prompt injection attack risk. Ideally, use the `system` option instead. Set to `true` to suppress the warning, or `false` to reject system messages in `prompt` or `messages`.',
     },
     {
       name: 'maxOutputTokens',

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -55,7 +55,7 @@ const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
- * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -55,6 +55,7 @@ const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.
@@ -197,6 +198,7 @@ export async function generateObject<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     maxRetries: maxRetriesArg,
     abortSignal,
     headers,
@@ -295,6 +297,7 @@ export async function generateObject<
           system,
           prompt,
           messages,
+          allowSystemInMessages,
         } as Prompt);
 
         const promptMessages = await convertToLanguageModelPrompt({

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -119,6 +119,7 @@ export type StreamObjectOnFinishCallback<RESULT> = (event: {
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.
@@ -284,6 +285,7 @@ export function streamObject<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     maxRetries,
     abortSignal,
     headers,
@@ -337,6 +339,7 @@ export function streamObject<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     schemaName,
     schemaDescription,
     providerOptions,
@@ -386,6 +389,7 @@ class DefaultStreamObjectResult<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     schemaName,
     schemaDescription,
     providerOptions,
@@ -407,6 +411,7 @@ class DefaultStreamObjectResult<
     system: Prompt['system'];
     prompt: Prompt['prompt'];
     messages: Prompt['messages'];
+    allowSystemInMessages: Prompt['allowSystemInMessages'];
     schemaName: string | undefined;
     schemaDescription: string | undefined;
     providerOptions: ProviderOptions | undefined;
@@ -485,6 +490,7 @@ class DefaultStreamObjectResult<
           system,
           prompt,
           messages,
+          allowSystemInMessages,
         } as Prompt);
 
         const callOptions = {

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -119,7 +119,7 @@ export type StreamObjectOnFinishCallback<RESULT> = (event: {
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
- * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -793,7 +793,11 @@ describe('generateText', () => {
           { role: 'system', content: 'INSTRUCTIONS' },
         ]);
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'AI SDK Warning: System messages in the prompt or messages fields are allowed by default but should be provided through the system option instead. Set allowSystemInMessages to true to suppress this warning.',
+          'AI SDK Warning: System messages in the prompt or messages fields ' +
+            'can be a security risk because they may enable prompt injection ' +
+            'attacks. Use the system option instead when possible. Set ' +
+            'allowSystemInMessages to true to suppress this warning, or ' +
+            'false to throw an error.',
         );
       } finally {
         consoleWarnSpy.mockRestore();

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -770,6 +770,39 @@ describe('generateText', () => {
       expect(startEvent.maxRetries).toBe(2);
     });
 
+    it('should reject system messages in messages by default', async () => {
+      await expect(async () => {
+        await generateText({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => ({
+              content: [{ type: 'text', text: 'Hello!' }],
+              ...dummyResponseValues,
+            }),
+          }),
+          messages: [{ role: 'system', content: 'INSTRUCTIONS' }],
+        });
+      }).rejects.toThrow(InvalidPromptError);
+    });
+
+    it('should allow system messages in messages when allowSystemInMessages is true', async () => {
+      const model = new MockLanguageModelV4({
+        doGenerate: async () => ({
+          content: [{ type: 'text', text: 'Hello!' }],
+          ...dummyResponseValues,
+        }),
+      });
+
+      await generateText({
+        model,
+        allowSystemInMessages: true,
+        messages: [{ role: 'system', content: 'INSTRUCTIONS' }],
+      });
+
+      expect(model.doGenerateCalls[0].prompt).toEqual([
+        { role: 'system', content: 'INSTRUCTIONS' },
+      ]);
+    });
+
     it('should be called before doGenerate', async () => {
       const callOrder: string[] = [];
 

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1,4 +1,5 @@
 import {
+  InvalidPromptError,
   LanguageModelV3,
   LanguageModelV3CallOptions,
   LanguageModelV3FunctionTool,
@@ -773,7 +774,7 @@ describe('generateText', () => {
     it('should reject system messages in messages by default', async () => {
       await expect(async () => {
         await generateText({
-          model: new MockLanguageModelV4({
+          model: new MockLanguageModelV3({
             doGenerate: async () => ({
               content: [{ type: 'text', text: 'Hello!' }],
               ...dummyResponseValues,
@@ -785,7 +786,7 @@ describe('generateText', () => {
     });
 
     it('should allow system messages in messages when allowSystemInMessages is true', async () => {
-      const model = new MockLanguageModelV4({
+      const model = new MockLanguageModelV3({
         doGenerate: async () => ({
           content: [{ type: 'text', text: 'Hello!' }],
           ...dummyResponseValues,

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -771,7 +771,36 @@ describe('generateText', () => {
       expect(startEvent.maxRetries).toBe(2);
     });
 
-    it('should reject system messages in messages by default', async () => {
+    it('should warn for system messages in messages by default', async () => {
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      try {
+        const model = new MockLanguageModelV3({
+          doGenerate: async () => ({
+            content: [{ type: 'text', text: 'Hello!' }],
+            ...dummyResponseValues,
+          }),
+        });
+
+        await generateText({
+          model,
+          messages: [{ role: 'system', content: 'INSTRUCTIONS' }],
+        });
+
+        expect(model.doGenerateCalls[0].prompt).toEqual([
+          { role: 'system', content: 'INSTRUCTIONS' },
+        ]);
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          'AI SDK Warning: System messages in the prompt or messages fields are allowed by default but should be provided through the system option instead. Set allowSystemInMessages to true to suppress this warning.',
+        );
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
+    });
+
+    it('should reject system messages in messages when allowSystemInMessages is false', async () => {
       await expect(async () => {
         await generateText({
           model: new MockLanguageModelV3({
@@ -780,6 +809,7 @@ describe('generateText', () => {
               ...dummyResponseValues,
             }),
           }),
+          allowSystemInMessages: false,
           messages: [{ role: 'system', content: 'INSTRUCTIONS' }],
         });
       }).rejects.toThrow(InvalidPromptError);

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -201,7 +201,7 @@ export type GenerateTextOnFinishCallback<TOOLS extends ToolSet> = (
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
- * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -201,6 +201,7 @@ export type GenerateTextOnFinishCallback<TOOLS extends ToolSet> = (
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.
@@ -252,6 +253,7 @@ export async function generateText<
   system,
   prompt,
   messages,
+  allowSystemInMessages,
   maxRetries: maxRetriesArg,
   abortSignal,
   timeout,
@@ -477,6 +479,7 @@ export async function generateText<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
   } as Prompt);
 
   const globalTelemetry = createGlobalTelemetry(telemetry?.integrations);

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -252,6 +252,7 @@ export type StreamTextOnToolCallFinishCallback<
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.
@@ -297,6 +298,7 @@ export function streamText<
   system,
   prompt,
   messages,
+  allowSystemInMessages,
   maxRetries,
   abortSignal,
   timeout,
@@ -548,6 +550,7 @@ export function streamText<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     tools,
     toolChoice,
     transforms: asArray(transform),
@@ -731,6 +734,7 @@ class DefaultStreamTextResult<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     tools,
     toolChoice,
     transforms,
@@ -772,6 +776,7 @@ class DefaultStreamTextResult<
     system: Prompt['system'];
     prompt: Prompt['prompt'];
     messages: Prompt['messages'];
+    allowSystemInMessages: Prompt['allowSystemInMessages'];
     tools: TOOLS | undefined;
     toolChoice: ToolChoice<TOOLS> | undefined;
     transforms: Array<StreamTextTransform<TOOLS>>;
@@ -1307,6 +1312,7 @@ class DefaultStreamTextResult<
           system,
           prompt,
           messages,
+          allowSystemInMessages,
         } as Prompt);
 
         await notify({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -252,7 +252,7 @@ export type StreamTextOnToolCallFinishCallback<
  * @param system - A system message that will be part of the prompt.
  * @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
  * @param messages - A list of messages. You can either use `prompt` or `messages` but not both.
- * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. Default: false.
+ * @param allowSystemInMessages - Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning.
  *
  * @param maxOutputTokens - Maximum number of tokens to generate.
  * @param temperature - Temperature setting.

--- a/packages/ai/src/prompt/prompt.ts
+++ b/packages/ai/src/prompt/prompt.ts
@@ -9,6 +9,15 @@ export type Prompt = {
    * System message to include in the prompt. Can be used with `prompt` or `messages`.
    */
   system?: string | SystemModelMessage | Array<SystemModelMessage>;
+
+  /**
+   * Whether system messages are allowed in the `prompt` or `messages` fields.
+   *
+   * When disabled, system messages must be provided through the `system` option.
+   *
+   * @default false
+   */
+  allowSystemInMessages?: boolean;
 } & (
   | {
       /**

--- a/packages/ai/src/prompt/prompt.ts
+++ b/packages/ai/src/prompt/prompt.ts
@@ -13,9 +13,10 @@ export type Prompt = {
   /**
    * Whether system messages are allowed in the `prompt` or `messages` fields.
    *
-   * When disabled, system messages must be provided through the `system` option.
+   * When disabled, system messages must be provided through the `system`
+   * option. When unset, system messages are allowed with a warning.
    *
-   * @default false
+   * @default undefined
    */
   allowSystemInMessages?: boolean;
 } & (

--- a/packages/ai/src/prompt/standardize-prompt.test.ts
+++ b/packages/ai/src/prompt/standardize-prompt.test.ts
@@ -3,9 +3,100 @@ import { standardizePrompt } from './standardize-prompt';
 import { describe, it, expect } from 'vitest';
 
 describe('standardizePrompt', () => {
-  it('should throw InvalidPromptError when system message has parts', async () => {
+  it('should throw InvalidPromptError when messages contain a system message by default', async () => {
     await expect(async () => {
       await standardizePrompt({
+        messages: [
+          {
+            role: 'system',
+            content: 'INSTRUCTIONS',
+          },
+        ],
+      });
+    }).rejects.toThrow(InvalidPromptError);
+  });
+
+  it('should throw InvalidPromptError when prompt messages contain a system message by default', async () => {
+    await expect(async () => {
+      await standardizePrompt({
+        prompt: [
+          {
+            role: 'system',
+            content: 'INSTRUCTIONS',
+          },
+        ],
+      });
+    }).rejects.toThrow(InvalidPromptError);
+  });
+
+  it('should allow system messages in messages when allowSystemInMessages is true', async () => {
+    const result = await standardizePrompt({
+      allowSystemInMessages: true,
+      messages: [
+        {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+        },
+        {
+          role: 'user',
+          content: 'Hello, world!',
+        },
+      ],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+          {
+            "content": "Hello, world!",
+            "role": "user",
+          },
+        ],
+        "system": undefined,
+      }
+    `);
+  });
+
+  it('should allow system messages in prompt messages when allowSystemInMessages is true', async () => {
+    const result = await standardizePrompt({
+      allowSystemInMessages: true,
+      prompt: [
+        {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+        },
+        {
+          role: 'user',
+          content: 'Hello, world!',
+        },
+      ],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+          {
+            "content": "Hello, world!",
+            "role": "user",
+          },
+        ],
+        "system": undefined,
+      }
+    `);
+  });
+
+  it('should throw InvalidPromptError when an allowed system message has parts', async () => {
+    await expect(async () => {
+      await standardizePrompt({
+        allowSystemInMessages: true,
         messages: [
           {
             role: 'system',

--- a/packages/ai/src/prompt/standardize-prompt.test.ts
+++ b/packages/ai/src/prompt/standardize-prompt.test.ts
@@ -35,7 +35,11 @@ describe('standardizePrompt', () => {
       }
     `);
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-      'AI SDK Warning: System messages in the prompt or messages fields are allowed by default but should be provided through the system option instead. Set allowSystemInMessages to true to suppress this warning.',
+      'AI SDK Warning: System messages in the prompt or messages fields ' +
+        'can be a security risk because they may enable prompt injection ' +
+        'attacks. Use the system option instead when possible. Set ' +
+        'allowSystemInMessages to true to suppress this warning, or false ' +
+        'to throw an error.',
     );
   });
 
@@ -61,7 +65,11 @@ describe('standardizePrompt', () => {
       }
     `);
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-      'AI SDK Warning: System messages in the prompt or messages fields are allowed by default but should be provided through the system option instead. Set allowSystemInMessages to true to suppress this warning.',
+      'AI SDK Warning: System messages in the prompt or messages fields ' +
+        'can be a security risk because they may enable prompt injection ' +
+        'attacks. Use the system option instead when possible. Set ' +
+        'allowSystemInMessages to true to suppress this warning, or false ' +
+        'to throw an error.',
     );
   });
 

--- a/packages/ai/src/prompt/standardize-prompt.test.ts
+++ b/packages/ai/src/prompt/standardize-prompt.test.ts
@@ -1,11 +1,74 @@
 import { InvalidPromptError } from '@ai-sdk/provider';
 import { standardizePrompt } from './standardize-prompt';
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('standardizePrompt', () => {
-  it('should throw InvalidPromptError when messages contain a system message by default', async () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should warn when messages contain a system message by default', async () => {
+    const result = await standardizePrompt({
+      messages: [
+        {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+        },
+      ],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+        ],
+        "system": undefined,
+      }
+    `);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'AI SDK Warning: System messages in the prompt or messages fields are allowed by default but should be provided through the system option instead. Set allowSystemInMessages to true to suppress this warning.',
+    );
+  });
+
+  it('should warn when prompt messages contain a system message by default', async () => {
+    const result = await standardizePrompt({
+      prompt: [
+        {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+        },
+      ],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+        ],
+        "system": undefined,
+      }
+    `);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'AI SDK Warning: System messages in the prompt or messages fields are allowed by default but should be provided through the system option instead. Set allowSystemInMessages to true to suppress this warning.',
+    );
+  });
+
+  it('should throw InvalidPromptError when messages contain a system message and allowSystemInMessages is false', async () => {
     await expect(async () => {
       await standardizePrompt({
+        allowSystemInMessages: false,
         messages: [
           {
             role: 'system',
@@ -16,9 +79,10 @@ describe('standardizePrompt', () => {
     }).rejects.toThrow(InvalidPromptError);
   });
 
-  it('should throw InvalidPromptError when prompt messages contain a system message by default', async () => {
+  it('should throw InvalidPromptError when prompt messages contain a system message and allowSystemInMessages is false', async () => {
     await expect(async () => {
       await standardizePrompt({
+        allowSystemInMessages: false,
         prompt: [
           {
             role: 'system',
@@ -59,6 +123,7 @@ describe('standardizePrompt', () => {
         "system": undefined,
       }
     `);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   it('should allow system messages in prompt messages when allowSystemInMessages is true', async () => {
@@ -91,6 +156,7 @@ describe('standardizePrompt', () => {
         "system": undefined,
       }
     `);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   it('should throw InvalidPromptError when an allowed system message has parts', async () => {

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -21,17 +21,31 @@ export type StandardizedPrompt = {
   messages: ModelMessage[];
 };
 
-export async function standardizePrompt(
-  prompt: Prompt,
-): Promise<StandardizedPrompt> {
-  if (prompt.prompt == null && prompt.messages == null) {
+/**
+ * Converts a prompt input into a standardized prompt with validated model
+ * messages.
+ *
+ * @param prompt - The prompt definition to standardize.
+ * Set `allowSystemInMessages` to true to allow system messages in the
+ * `prompt` or `messages` fields. System messages in the `system` option are
+ * always allowed.
+ * @returns The standardized prompt.
+ * @throws {InvalidPromptError} When the prompt is invalid.
+ */
+export async function standardizePrompt({
+  allowSystemInMessages = false,
+  system,
+  prompt,
+  messages,
+}: Prompt): Promise<StandardizedPrompt> {
+  if (prompt == null && messages == null) {
     throw new InvalidPromptError({
       prompt,
       message: 'prompt or messages must be defined',
     });
   }
 
-  if (prompt.prompt != null && prompt.messages != null) {
+  if (prompt != null && messages != null) {
     throw new InvalidPromptError({
       prompt,
       message: 'prompt and messages cannot be defined at the same time',
@@ -40,15 +54,8 @@ export async function standardizePrompt(
 
   // validate that system is a string or a SystemModelMessage
   if (
-    prompt.system != null &&
-    typeof prompt.system !== 'string' &&
-    !asArray(prompt.system).every(
-      message =>
-        typeof message === 'object' &&
-        message !== null &&
-        'role' in message &&
-        message.role === 'system',
-    )
+    typeof system !== 'string' &&
+    !asArray(system).every(message => message.role === 'system')
   ) {
     throw new InvalidPromptError({
       prompt,
@@ -57,15 +64,11 @@ export async function standardizePrompt(
     });
   }
 
-  let messages: ModelMessage[];
-
-  if (prompt.prompt != null && typeof prompt.prompt === 'string') {
-    messages = [{ role: 'user', content: prompt.prompt }];
-  } else if (prompt.prompt != null && Array.isArray(prompt.prompt)) {
-    messages = prompt.prompt;
-  } else if (prompt.messages != null) {
-    messages = prompt.messages;
-  } else {
+  if (prompt != null && typeof prompt === 'string') {
+    messages = [{ role: 'user', content: prompt }];
+  } else if (prompt != null && Array.isArray(prompt)) {
+    messages = prompt;
+  } else if (messages == null) {
     throw new InvalidPromptError({
       prompt,
       message: 'prompt or messages must be defined',
@@ -76,6 +79,17 @@ export async function standardizePrompt(
     throw new InvalidPromptError({
       prompt,
       message: 'messages must not be empty',
+    });
+  }
+
+  if (
+    !allowSystemInMessages &&
+    messages.some(message => message.role === 'system')
+  ) {
+    throw new InvalidPromptError({
+      prompt,
+      message:
+        'System messages are not allowed in the prompt or messages fields. Use the system option instead.',
     });
   }
 
@@ -92,8 +106,5 @@ export async function standardizePrompt(
     });
   }
 
-  return {
-    messages,
-    system: prompt.system,
-  };
+  return { messages, system };
 }

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -26,14 +26,14 @@ export type StandardizedPrompt = {
  * messages.
  *
  * @param prompt - The prompt definition to standardize.
- * Set `allowSystemInMessages` to true to allow system messages in the
- * `prompt` or `messages` fields. System messages in the `system` option are
- * always allowed.
+ * Set `allowSystemInMessages` to false to reject system messages in the
+ * `prompt` or `messages` fields. When unset, system messages are allowed with a
+ * warning. System messages in the `system` option are always allowed.
  * @returns The standardized prompt.
  * @throws {InvalidPromptError} When the prompt is invalid.
  */
 export async function standardizePrompt({
-  allowSystemInMessages = false,
+  allowSystemInMessages,
   system,
   prompt,
   messages,
@@ -82,15 +82,20 @@ export async function standardizePrompt({
     });
   }
 
-  if (
-    !allowSystemInMessages &&
-    messages.some(message => message.role === 'system')
-  ) {
-    throw new InvalidPromptError({
-      prompt,
-      message:
-        'System messages are not allowed in the prompt or messages fields. Use the system option instead.',
-    });
+  if (messages.some(message => message.role === 'system')) {
+    if (allowSystemInMessages === false) {
+      throw new InvalidPromptError({
+        prompt,
+        message:
+          'System messages are not allowed in the prompt or messages fields. Use the system option instead.',
+      });
+    }
+
+    if (allowSystemInMessages === undefined) {
+      console.warn(
+        'AI SDK Warning: System messages in the prompt or messages fields are allowed by default but should be provided through the system option instead. Set allowSystemInMessages to true to suppress this warning.',
+      );
+    }
   }
 
   const validationResult = await safeValidateTypes({

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -93,7 +93,11 @@ export async function standardizePrompt({
 
     if (allowSystemInMessages === undefined) {
       console.warn(
-        'AI SDK Warning: System messages in the prompt or messages fields are allowed by default but should be provided through the system option instead. Set allowSystemInMessages to true to suppress this warning.',
+        'AI SDK Warning: System messages in the prompt or messages fields ' +
+          'can be a security risk because they may enable prompt injection ' +
+          'attacks. Use the system option instead when possible. Set ' +
+          'allowSystemInMessages to true to suppress this warning, or false ' +
+          'to throw an error.',
       );
     }
   }

--- a/packages/rsc/src/stream-ui/stream-ui.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.tsx
@@ -102,6 +102,7 @@ export async function streamUI<
   system,
   prompt,
   messages,
+  allowSystemInMessages,
   maxRetries,
   abortSignal,
   headers,
@@ -269,6 +270,7 @@ export async function streamUI<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
   } as Prompt);
   const result = await retry(async () =>
     model.doStream({


### PR DESCRIPTION
## Background

For historical and convenience reasons, system messages can be part of user messages or prompts, e.g. to allow interleaving regular messages and system messages.

However, this creates a prompt injection risk where the user (e.g. by modifying the messages in a web ui) can override or set the system prompt. In most cases, it should only be possible to set the system prompt via the system (or instructions) property, and users should not be able to inject system messages.

## Summary

* `allowSystemInMessages === undefined`: print warning when there are system messages in the messages or prompt options
* `allowSystemInMessages === true`: throw InvalidPromptError when there are system messages in the messages or prompt options
* `allowSystemInMessages === false`: ignore system messages in the messages or prompt options

## Related Issues

Adjusted backport of #14752
Issue reported in #14749