### PR TITLE
chore: drop Node.js 20 support, require Node.js 22+

### DIFF
--- a/.changeset/drop-node-20.md
+++ b/.changeset/drop-node-20.md
@@ -1,0 +1,62 @@
+---
+"ai": patch
+"@ai-sdk/alibaba": patch
+"@ai-sdk/amazon-bedrock": patch
+"@ai-sdk/angular": patch
+"@ai-sdk/anthropic": patch
+"@ai-sdk/assemblyai": patch
+"@ai-sdk/azure": patch
+"@ai-sdk/baseten": patch
+"@ai-sdk/black-forest-labs": patch
+"@ai-sdk/bytedance": patch
+"@ai-sdk/cerebras": patch
+"@ai-sdk/codemod": patch
+"@ai-sdk/cohere": patch
+"@ai-sdk/deepgram": patch
+"@ai-sdk/deepinfra": patch
+"@ai-sdk/deepseek": patch
+"@ai-sdk/devtools": patch
+"@ai-sdk/elevenlabs": patch
+"@ai-sdk/fal": patch
+"@ai-sdk/fireworks": patch
+"@ai-sdk/gateway": patch
+"@ai-sdk/gladia": patch
+"@ai-sdk/google": patch
+"@ai-sdk/google-vertex": patch
+"@ai-sdk/groq": patch
+"@ai-sdk/huggingface": patch
+"@ai-sdk/hume": patch
+"@ai-sdk/klingai": patch
+"@ai-sdk/langchain": patch
+"@ai-sdk/llamaindex": patch
+"@ai-sdk/lmnt": patch
+"@ai-sdk/luma": patch
+"@ai-sdk/mcp": patch
+"@ai-sdk/mistral": patch
+"@ai-sdk/moonshotai": patch
+"@ai-sdk/open-responses": patch
+"@ai-sdk/openai": patch
+"@ai-sdk/openai-compatible": patch
+"@ai-sdk/otel": patch
+"@ai-sdk/perplexity": patch
+"@ai-sdk/prodia": patch
+"@ai-sdk/provider": patch
+"@ai-sdk/provider-utils": patch
+"@ai-sdk/react": patch
+"@ai-sdk/replicate": patch
+"@ai-sdk/revai": patch
+"@ai-sdk/rsc": patch
+"@ai-sdk/svelte": patch
+"@ai-sdk/test-server": patch
+"@ai-sdk/togetherai": patch
+"@ai-sdk/valibot": patch
+"@ai-sdk/vercel": patch
+"@ai-sdk/voyage": patch
+"@ai-sdk/vue": patch
+"@ai-sdk/workflow": patch
+"@ai-sdk/xai": patch
+---
+
+chore: drop Node.js 20 support, require Node.js 22+
+
+Node.js 20 reaches end of maintenance on April 30, 2026. The minimum required Node.js version is now 22. CI matrix and documentation are updated accordingly. Closes #13356.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ ai ─────────────────┬──▶ @ai-sdk/provi
 
 ### Requirements
 
-- **Node.js**: v18, v20, or v22 (v22 recommended for development)
+- **Node.js**: v22 or v24
 - **pnpm**: v10+ (`npm install -g pnpm@10`)
 
 ### Initial Setup

--- a/content/cookbook/00-guides/02-multi-modal-chatbot.mdx
+++ b/content/cookbook/00-guides/02-multi-modal-chatbot.mdx
@@ -21,7 +21,7 @@ We'll build this agent using OpenAI's GPT-4o, but the same code works seamlessly
 
 To follow this quickstart, you'll need:
 
-- Node.js 18+ and pnpm installed on your local development machine.
+- Node.js 22+ and pnpm installed on your local development machine.
 - A Vercel AI Gateway API key.
 
 If you haven't obtained your Vercel AI Gateway API key, you can do so by [signing up](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai&title=Go+to+AI+Gateway) on the Vercel website.

--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -15,7 +15,7 @@ If you are unfamiliar with the concepts of [Prompt Engineering](/docs/advanced/p
 
 To follow this quickstart, you'll need:
 
-- Node.js 18+ and pnpm installed on your local development machine.
+- Node.js 22+ and pnpm installed on your local development machine.
 - A [ Vercel AI Gateway ](https://vercel.com/ai-gateway) API key.
 
 If you haven't obtained your Vercel AI Gateway API key, you can do so by [signing up](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai&title=Go+to+AI+Gateway) on the Vercel website.

--- a/content/docs/02-getting-started/03-nextjs-pages-router.mdx
+++ b/content/docs/02-getting-started/03-nextjs-pages-router.mdx
@@ -15,7 +15,7 @@ If you are unfamiliar with the concepts of [Prompt Engineering](/docs/advanced/p
 
 To follow this quickstart, you'll need:
 
-- Node.js 18+ and pnpm installed on your local development machine.
+- Node.js 22+ and pnpm installed on your local development machine.
 - A [ Vercel AI Gateway ](https://vercel.com/ai-gateway) API key.
 
 If you haven't obtained your Vercel AI Gateway API key, you can do so by [signing up](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai&title=Go+to+AI+Gateway) on the Vercel website.

--- a/content/docs/02-getting-started/04-svelte.mdx
+++ b/content/docs/02-getting-started/04-svelte.mdx
@@ -15,7 +15,7 @@ If you are unfamiliar with the concepts of [Prompt Engineering](/docs/advanced/p
 
 To follow this quickstart, you'll need:
 
-- Node.js 18+ and pnpm installed on your local development machine.
+- Node.js 22+ and pnpm installed on your local development machine.
 - A [ Vercel AI Gateway ](https://vercel.com/ai-gateway) API key.
 
 If you haven't obtained your Vercel AI Gateway API key, you can do so by [signing up](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai&title=Go+to+AI+Gateway) on the Vercel website.

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -15,7 +15,7 @@ If you are unfamiliar with the concepts of [Prompt Engineering](/docs/advanced/p
 
 To follow this quickstart, you'll need:
 
-- Node.js 18+ and pnpm installed on your local development machine.
+- Node.js 22+ and pnpm installed on your local development machine.
 - A [ Vercel AI Gateway ](https://vercel.com/ai-gateway) API key.
 
 If you haven't obtained your Vercel AI Gateway API key, you can do so by [signing up](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai&title=Go+to+AI+Gateway) on the Vercel website.

--- a/content/docs/02-getting-started/06-nodejs.mdx
+++ b/content/docs/02-getting-started/06-nodejs.mdx
@@ -15,7 +15,7 @@ If you are unfamiliar with the concepts of [Prompt Engineering](/docs/advanced/p
 
 To follow this quickstart, you'll need:
 
-- Node.js 18+ and pnpm installed on your local development machine.
+- Node.js 22+ and pnpm installed on your local development machine.
 - A [ Vercel AI Gateway ](https://vercel.com/ai-gateway) API key.
 
 If you haven't obtained your Vercel AI Gateway API key, you can do so by [signing up](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai&title=Go+to+AI+Gateway) on the Vercel website.

--- a/content/docs/02-getting-started/07-expo.mdx
+++ b/content/docs/02-getting-started/07-expo.mdx
@@ -13,7 +13,7 @@ If you are unfamiliar with the concepts of [Prompt Engineering](/docs/advanced/p
 
 To follow this quickstart, you'll need:
 
-- Node.js 18+ and pnpm installed on your local development machine.
+- Node.js 22+ and pnpm installed on your local development machine.
 - A [ Vercel AI Gateway ](https://vercel.com/ai-gateway) API key.
 
 If you haven't obtained your Vercel AI Gateway API key, you can do so by [signing up](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai&title=Go+to+AI+Gateway) on the Vercel website.

--- a/content/docs/02-getting-started/08-tanstack-start.mdx
+++ b/content/docs/02-getting-started/08-tanstack-start.mdx
@@ -15,7 +15,7 @@ If you are unfamiliar with the concepts of [Prompt Engineering](/docs/advanced/p
 
 To follow this quickstart, you'll need:
 
-- Node.js 18+ and pnpm installed on your local development machine.
+- Node.js 22+ and pnpm installed on your local development machine.
 - A [ Vercel AI Gateway ](https://vercel.com/ai-gateway) API key.
 
 If you haven't obtained your Vercel AI Gateway API key, you can do so by [signing up](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai&title=Go+to+AI+Gateway) on the Vercel website.

--- a/content/providers/03-community-providers/10-claude-code.mdx
+++ b/content/providers/03-community-providers/10-claude-code.mdx
@@ -141,7 +141,7 @@ This opens a browser window for authentication. Once authenticated, the provider
 
 ## Requirements
 
-- Node.js 18 or higher
+- Node.js 22 or higher
 - Claude Code CLI installed (`npm install -g @anthropic-ai/claude-code`)
 - Claude Pro or Max subscription
 

--- a/content/providers/03-community-providers/13-codex-cli.mdx
+++ b/content/providers/03-community-providers/13-codex-cli.mdx
@@ -164,7 +164,7 @@ Alternatively, you can use an OpenAI API key by setting the `OPENAI_API_KEY` env
 
 ## Requirements
 
-- Node.js 18 or higher
+- Node.js 22 or higher
 - Codex CLI installed globally (v0.42.0+ for JSON support, v0.60.0+ recommended for latest models)
 - ChatGPT Plus/Pro subscription or OpenAI API key
 

--- a/content/providers/03-community-providers/18-gemini-cli.mdx
+++ b/content/providers/03-community-providers/18-gemini-cli.mdx
@@ -167,7 +167,7 @@ Then use OAuth authentication in your code with `authType: 'oauth-personal'`.
 
 ## Requirements
 
-- Node.js 20 or higher
+- Node.js 22 or higher
 - Gemini CLI installed globally for OAuth authentication
 - Valid Google account or Gemini API key
 

--- a/content/providers/03-community-providers/31-opencode-sdk.mdx
+++ b/content/providers/03-community-providers/31-opencode-sdk.mdx
@@ -162,7 +162,7 @@ The client manager automatically cleans up on process exit (SIGINT, SIGTERM).
 
 ## Requirements
 
-- Node.js 18 or higher
+- Node.js 22 or higher
 - OpenCode CLI installed (`npm install -g opencode`)
 - Provider credentials configured in OpenCode (Anthropic, OpenAI, or Google API keys)
 

--- a/content/providers/03-community-providers/46-codex-app-server.mdx
+++ b/content/providers/03-community-providers/46-codex-app-server.mdx
@@ -203,7 +203,7 @@ Use the **Codex CLI provider** for simple one-shot tasks. Use the **Codex App Se
 
 ## Requirements
 
-- Node.js 18 or higher
+- Node.js 22 or higher
 - Codex CLI installed globally (v0.60.0+ recommended)
 - ChatGPT Plus/Pro subscription or OpenAI API key
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "vitest": "4.1.5"
   },
   "engines": {
-    "node": "^18.0.0 || ^20.0.0 || ^22.0.0 || ^24.0.0"
+    "node": "^22.0.0 || ^24.0.0"
   },
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -8,7 +8,7 @@ To learn more about how to use the AI SDK, check out our [API Reference](https:/
 
 ## Installation
 
-You will need Node.js 18+ and npm (or another package manager) installed on your local development machine.
+You will need Node.js 22+ and npm (or another package manager) installed on your local development machine.
 
 ```shell
 npm install ai

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -76,7 +76,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/alibaba/package.json
+++ b/packages/alibaba/package.json
@@ -52,7 +52,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/amazon-bedrock/package.json
+++ b/packages/amazon-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-sdk/amazon-bedrock",
-  "version": "5.0.0-beta.44",
+  "version": "5.0.0-beta.43",
   "type": "module",
   "license": "Apache-2.0",
   "sideEffects": false,
@@ -67,7 +67,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/amazon-bedrock/package.json
+++ b/packages/amazon-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-sdk/amazon-bedrock",
-  "version": "5.0.0-beta.43",
+  "version": "5.0.0-beta.44",
   "type": "module",
   "license": "Apache-2.0",
   "sideEffects": false,

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -51,7 +51,7 @@
     "@angular/core": ">=16.0.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-sdk/anthropic",
-  "version": "4.0.0-beta.40",
+  "version": "4.0.0-beta.39",
   "type": "module",
   "license": "Apache-2.0",
   "sideEffects": false,
@@ -63,7 +63,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-sdk/anthropic",
-  "version": "4.0.0-beta.39",
+  "version": "4.0.0-beta.40",
   "type": "module",
   "license": "Apache-2.0",
   "sideEffects": false,

--- a/packages/assemblyai/package.json
+++ b/packages/assemblyai/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -58,7 +58,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/baseten/package.json
+++ b/packages/baseten/package.json
@@ -58,7 +58,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/black-forest-labs/package.json
+++ b/packages/black-forest-labs/package.json
@@ -56,7 +56,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/bytedance/package.json
+++ b/packages/bytedance/package.json
@@ -46,7 +46,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/cerebras/package.json
+++ b/packages/cerebras/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -45,7 +45,7 @@
     "codemod": "./dist/bin/codemod.js"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/cohere/package.json
+++ b/packages/cohere/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/deepgram/package.json
+++ b/packages/deepgram/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/deepinfra/package.json
+++ b/packages/deepinfra/package.json
@@ -58,7 +58,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/deepseek/package.json
+++ b/packages/deepseek/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -87,7 +87,7 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "keywords": [
     "ai"

--- a/packages/elevenlabs/package.json
+++ b/packages/elevenlabs/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/fal/package.json
+++ b/packages/fal/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/fireworks/package.json
+++ b/packages/fireworks/package.json
@@ -58,7 +58,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -61,7 +61,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/gladia/package.json
+++ b/packages/gladia/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-sdk/google-vertex",
-  "version": "5.0.0-beta.61",
+  "version": "5.0.0-beta.60",
   "type": "module",
   "license": "Apache-2.0",
   "sideEffects": false,
@@ -91,7 +91,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-sdk/google-vertex",
-  "version": "5.0.0-beta.60",
+  "version": "5.0.0-beta.61",
   "type": "module",
   "license": "Apache-2.0",
   "sideEffects": false,

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -63,7 +63,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/huggingface/package.json
+++ b/packages/huggingface/package.json
@@ -58,7 +58,7 @@
     "zod": "^3.25.76 || ^4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/hume/package.json
+++ b/packages/hume/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/klingai/package.json
+++ b/packages/klingai/package.json
@@ -51,7 +51,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -57,7 +57,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/llamaindex/package.json
+++ b/packages/llamaindex/package.json
@@ -45,7 +45,7 @@
     "typescript": "5.8.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/lmnt/package.json
+++ b/packages/lmnt/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/luma/package.json
+++ b/packages/luma/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -59,7 +59,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/mistral/package.json
+++ b/packages/mistral/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/moonshotai/package.json
+++ b/packages/moonshotai/package.json
@@ -52,7 +52,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/open-responses/package.json
+++ b/packages/open-responses/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/openai-compatible/package.json
+++ b/packages/openai-compatible/package.json
@@ -63,7 +63,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -63,7 +63,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -47,7 +47,7 @@
     "zod": "3.25.76"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/perplexity/package.json
+++ b/packages/perplexity/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/prodia/package.json
+++ b/packages/prodia/package.json
@@ -56,7 +56,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -60,7 +60,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -42,7 +42,7 @@
     "typescript": "5.8.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,7 +61,7 @@
     "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/replicate/package.json
+++ b/packages/replicate/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/revai/package.json
+++ b/packages/revai/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -76,7 +76,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -81,6 +81,6 @@
     "svelte"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -50,7 +50,7 @@
     "typescript": "5.8.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/togetherai/package.json
+++ b/packages/togetherai/package.json
@@ -58,7 +58,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -46,7 +46,7 @@
     "valibot": "^1.1.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -57,7 +57,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/voyage/package.json
+++ b/packages/voyage/package.json
@@ -51,7 +51,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -58,7 +58,7 @@
     "vue": "^3.3.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -56,7 +56,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xai/package.json
+++ b/packages/xai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-sdk/xai",
-  "version": "4.0.0-beta.46",
+  "version": "4.0.0-beta.45",
   "type": "module",
   "license": "Apache-2.0",
   "sideEffects": false,
@@ -58,7 +58,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/xai/package.json
+++ b/packages/xai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-sdk/xai",
-  "version": "4.0.0-beta.45",
+  "version": "4.0.0-beta.46",
   "type": "module",
   "license": "Apache-2.0",
   "sideEffects": false,


### PR DESCRIPTION
Node.js 20 reaches end of maintenance on April 30, 2026. This bumps the minimum supported Node.js version to 22 across the monorepo.

## Changes in this PR

- `engines.node` updated in root `package.json` and 56 published packages (`>=18` -> `>=22`, root drops `^18.0.0` and `^20.0.0`)
- 14 docs updated (getting-started guides, multi-modal-chatbot cookbook, community-provider integration docs)
- `AGENTS.md` and `packages/ai/README.md` Node version notes updated
- Patch changeset added covering all published packages

## CI matrix change (deferred to maintainer)

I could not include the `.github/workflows/ci.yml` change because modifying workflow files via the GitHub API requires the `workflow` token scope. The needed change is a one-line edit, included here for whoever merges this:

```diff
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
```

Happy to follow up with a separate PR if a maintainer prefers, just leave a comment.

Refs #13356.