### PR TITLE
backport v6: feat (provider/anthropic): sanitize unsupported json schema validation properties

### DIFF
--- a/.changeset/empty-deers-tell.md
+++ b/.changeset/empty-deers-tell.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+feat(anthropic): sanitize the unsupported JSON schema validation properties

--- a/examples/ai-functions/src/generate-text/anthropic/output-object-zod-positive-number.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/output-object-zod-positive-number.ts
@@ -9,17 +9,11 @@ run(async () => {
     model: anthropic('claude-sonnet-4-5'),
     output: Output.object({
       schema: z.object({
-        recipe: z.object({
-          name: z.string(),
-          ingredients: z
-            .array(z.object({ name: z.string(), amount: z.string() }))
-            .min(10)
-            .max(12),
-          steps: z.array(z.string()),
-        }),
+        recurringIntervalMinutes: z.number().int().min(0).max(40),
       }),
     }),
-    prompt: 'Generate a lasagna recipe.',
+    prompt:
+      'Return a JSON object with recurringIntervalMinutes set to a positive number.',
   });
 
   print('Output:', result.output);

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -10,9 +10,11 @@ import {
   convertReadableStreamToArray,
   mockId,
 } from '@ai-sdk/provider-utils/test';
+import { asSchema } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import fs from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import { AnthropicLanguageModelOptions } from './anthropic-messages-options';
 import { createAnthropic } from './anthropic-provider';
 
@@ -603,6 +605,149 @@ describe('AnthropicMessagesLanguageModel', () => {
           }
         `);
       });
+    });
+
+    it('should sanitize unsupported JSON schema keywords for output format', async () => {
+      prepareJsonFixtureResponse('anthropic-json-output-format.1');
+
+      await provider('claude-sonnet-4-5').doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              recurringIntervalMinutes: {
+                type: 'number',
+                exclusiveMinimum: 0,
+              },
+              tags: {
+                type: 'array',
+                minItems: 2,
+                maxItems: 4,
+                items: {
+                  type: 'string',
+                  minLength: 1,
+                },
+              },
+            },
+            required: ['recurringIntervalMinutes', 'tags'],
+            additionalProperties: false,
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+
+      expect(requestBody.output_config.format.schema).toMatchInlineSnapshot(`
+        {
+          "additionalProperties": false,
+          "properties": {
+            "recurringIntervalMinutes": {
+              "description": "exclusive minimum: 0.",
+              "type": "number",
+            },
+            "tags": {
+              "description": "min items: 2; max items: 4.",
+              "items": {
+                "description": "min length: 1.",
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          "required": [
+            "recurringIntervalMinutes",
+            "tags",
+          ],
+          "type": "object",
+        }
+      `);
+    });
+
+    it('should pass sanitized zod output schema as output_config.format', async () => {
+      prepareJsonFixtureResponse('anthropic-json-output-format.1');
+
+      const schema = asSchema(
+        z.object({
+          recipe: z.object({
+            name: z.string(),
+            ingredients: z
+              .array(z.object({ name: z.string(), amount: z.string() }))
+              .min(10)
+              .max(12),
+            steps: z.array(z.string()),
+          }),
+        }),
+      );
+
+      await provider('claude-sonnet-4-5').doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: await schema.jsonSchema,
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+
+      expect(requestBody.output_config).toMatchInlineSnapshot(`
+        {
+          "format": {
+            "schema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {
+                "recipe": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ingredients": {
+                      "description": "min items: 10; max items: 12.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "amount": {
+                            "type": "string",
+                          },
+                          "name": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "name",
+                          "amount",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                    "steps": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "ingredients",
+                    "steps",
+                  ],
+                  "type": "object",
+                },
+              },
+              "required": [
+                "recipe",
+              ],
+              "type": "object",
+            },
+            "type": "json_schema",
+          },
+        }
+      `);
     });
 
     describe('json schema response format with output format (unknown model, forced)', () => {

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -52,6 +52,7 @@ import {
 import { convertToAnthropicMessagesPrompt } from './convert-to-anthropic-messages-prompt';
 import { CacheControlValidator } from './get-cache-control';
 import { mapAnthropicStopReason } from './map-anthropic-stop-reason';
+import { sanitizeJsonSchema } from './sanitize-json-schema';
 
 function createCitationSource(
   citation: Citation,
@@ -422,7 +423,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
             responseFormat.schema != null && {
               format: {
                 type: 'json_schema',
-                schema: responseFormat.schema,
+                schema: sanitizeJsonSchema(responseFormat.schema),
               },
             }),
         },

--- a/packages/anthropic/src/sanitize-json-schema.test.ts
+++ b/packages/anthropic/src/sanitize-json-schema.test.ts
@@ -1,0 +1,178 @@
+import type { JSONSchema7 } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { sanitizeJsonSchema } from './sanitize-json-schema';
+
+describe('sanitizeJsonSchema', () => {
+  it('strips unsupported number constraints and adds readable descriptions', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        recurringIntervalMinutes: {
+          type: 'number',
+          exclusiveMinimum: 0,
+          minimum: 1,
+          maximum: 60,
+          exclusiveMaximum: 120,
+        },
+      },
+      required: ['recurringIntervalMinutes'],
+      additionalProperties: false,
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "additionalProperties": false,
+        "properties": {
+          "recurringIntervalMinutes": {
+            "description": "minimum: 1; maximum: 60; exclusive minimum: 0; exclusive maximum: 120.",
+            "type": "number",
+          },
+        },
+        "required": [
+          "recurringIntervalMinutes",
+        ],
+        "type": "object",
+      }
+    `);
+  });
+
+  it('strips unsupported string constraints and unsupported formats', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        slug: {
+          type: 'string',
+          description: 'A URL slug',
+          minLength: 1,
+          maxLength: 20,
+          pattern: '^[a-z0-9-]+$',
+          format: 'regex',
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "additionalProperties": false,
+        "properties": {
+          "slug": {
+            "description": "A URL slug
+      min length: 1; max length: 20; pattern: ^[a-z0-9-]+$; format: regex.",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      }
+    `);
+  });
+
+  it('recursively sanitizes arrays, definitions, and composition schemas', () => {
+    const schema = {
+      type: 'object',
+      $defs: {
+        PositiveInteger: {
+          type: 'integer',
+          minimum: 1,
+        },
+      },
+      properties: {
+        count: { $ref: '#/$defs/PositiveInteger' },
+        tags: {
+          type: 'array',
+          minItems: 2,
+          maxItems: 4,
+          uniqueItems: true,
+          items: {
+            anyOf: [
+              { type: 'string', minLength: 1 },
+              { type: 'number', maximum: 10 },
+            ],
+          },
+        },
+      },
+    } as JSONSchema7 & {
+      $defs: Record<string, JSONSchema7>;
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "$defs": {
+          "PositiveInteger": {
+            "description": "minimum: 1.",
+            "type": "integer",
+          },
+        },
+        "additionalProperties": false,
+        "properties": {
+          "count": {
+            "$ref": "#/$defs/PositiveInteger",
+          },
+          "tags": {
+            "description": "min items: 2; max items: 4; unique items: true.",
+            "items": {
+              "anyOf": [
+                {
+                  "description": "min length: 1.",
+                  "type": "string",
+                },
+                {
+                  "description": "maximum: 10.",
+                  "type": "number",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "type": "object",
+      }
+    `);
+  });
+
+  it('converts oneOf to anyOf', () => {
+    const schema: JSONSchema7 = {
+      oneOf: [
+        { type: 'string', minLength: 1 },
+        { type: 'number', minimum: 0 },
+      ],
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "anyOf": [
+          {
+            "description": "min length: 1.",
+            "type": "string",
+          },
+          {
+            "description": "minimum: 0.",
+            "type": "number",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        value: { type: 'number', exclusiveMinimum: 0 },
+      },
+    };
+
+    sanitizeJsonSchema(schema);
+
+    expect(schema).toMatchInlineSnapshot(`
+      {
+        "properties": {
+          "value": {
+            "exclusiveMinimum": 0,
+            "type": "number",
+          },
+        },
+        "type": "object",
+      }
+    `);
+  });
+});

--- a/packages/anthropic/src/sanitize-json-schema.ts
+++ b/packages/anthropic/src/sanitize-json-schema.ts
@@ -1,0 +1,203 @@
+import type { JSONSchema7, JSONSchema7Definition } from '@ai-sdk/provider';
+
+const SUPPORTED_STRING_FORMATS = new Set([
+  'date-time',
+  'time',
+  'date',
+  'duration',
+  'email',
+  'hostname',
+  'uri',
+  'ipv4',
+  'ipv6',
+  'uuid',
+]);
+
+const DESCRIPTION_CONSTRAINT_KEYS = [
+  'minimum',
+  'maximum',
+  'exclusiveMinimum',
+  'exclusiveMaximum',
+  'multipleOf',
+  'minLength',
+  'maxLength',
+  'pattern',
+  'minItems',
+  'maxItems',
+  'uniqueItems',
+  'minProperties',
+  'maxProperties',
+  'not',
+] satisfies Array<keyof JSONSchema7>;
+
+/**
+ * Removes JSON Schema keywords that Anthropic rejects in
+ * `output_config.format.schema`.
+ *
+ * The full original schema is still used by AI SDK result validation. This
+ * only relaxes the schema sent to Anthropic's constrained decoder.
+ */
+export function sanitizeJsonSchema(schema: JSONSchema7): JSONSchema7 {
+  return sanitizeSchema(schema) as JSONSchema7;
+}
+
+function sanitizeDefinition(
+  definition: JSONSchema7Definition,
+): JSONSchema7Definition {
+  if (typeof definition === 'boolean' || !isPlainObject(definition)) {
+    return definition;
+  }
+
+  return sanitizeSchema(definition as JSONSchema7);
+}
+
+function sanitizeSchema(schema: JSONSchema7): JSONSchema7 {
+  const result: JSONSchema7 = {};
+  const schemaWithDefs = schema as JSONSchema7 & {
+    $defs?: Record<string, JSONSchema7Definition>;
+  };
+
+  if (schema.$ref != null) {
+    return { $ref: schema.$ref };
+  }
+
+  if (schema.$schema != null) {
+    result.$schema = schema.$schema;
+  }
+
+  if (schema.$id != null) {
+    result.$id = schema.$id;
+  }
+
+  if (schema.title != null) {
+    result.title = schema.title;
+  }
+
+  if (schema.description != null) {
+    result.description = schema.description;
+  }
+
+  if (schema.default !== undefined) {
+    result.default = schema.default;
+  }
+
+  if (schema.const !== undefined) {
+    result.const = schema.const;
+  }
+
+  if (schema.enum != null) {
+    result.enum = schema.enum;
+  }
+
+  if (schema.type != null) {
+    result.type = schema.type;
+  }
+
+  if (schema.anyOf != null) {
+    result.anyOf = schema.anyOf.map(sanitizeDefinition);
+  } else if (schema.oneOf != null) {
+    result.anyOf = schema.oneOf.map(sanitizeDefinition);
+  }
+
+  if (schema.allOf != null) {
+    result.allOf = schema.allOf.map(sanitizeDefinition);
+  }
+
+  if (schema.definitions != null) {
+    result.definitions = Object.fromEntries(
+      Object.entries(schema.definitions).map(([name, definition]) => [
+        name,
+        sanitizeDefinition(definition),
+      ]),
+    );
+  }
+
+  if (schemaWithDefs.$defs != null) {
+    const resultWithDefs = result as JSONSchema7 & {
+      $defs?: Record<string, JSONSchema7Definition>;
+    };
+    resultWithDefs.$defs = Object.fromEntries(
+      Object.entries(schemaWithDefs.$defs).map(([name, definition]) => [
+        name,
+        sanitizeDefinition(definition),
+      ]),
+    );
+  }
+
+  if (schema.type === 'object' || schema.properties != null) {
+    if (schema.properties != null) {
+      result.properties = Object.fromEntries(
+        Object.entries(schema.properties).map(([name, definition]) => [
+          name,
+          sanitizeDefinition(definition),
+        ]),
+      );
+    }
+
+    result.additionalProperties = false;
+
+    if (schema.required != null) {
+      result.required = schema.required;
+    }
+  }
+
+  if (schema.items != null) {
+    result.items = Array.isArray(schema.items)
+      ? schema.items.map(sanitizeDefinition)
+      : sanitizeDefinition(schema.items);
+  }
+
+  if (
+    typeof schema.format === 'string' &&
+    SUPPORTED_STRING_FORMATS.has(schema.format)
+  ) {
+    result.format = schema.format;
+  }
+
+  const constraintDescription = getConstraintDescription(schema);
+  if (constraintDescription != null) {
+    result.description =
+      result.description == null
+        ? constraintDescription
+        : `${result.description}\n${constraintDescription}`;
+  }
+
+  return result;
+}
+
+function getConstraintDescription(schema: JSONSchema7): string | undefined {
+  const descriptions = DESCRIPTION_CONSTRAINT_KEYS.flatMap(key => {
+    const value = schema[key];
+
+    if (value == null || value === false) {
+      return [];
+    }
+
+    return `${formatConstraintName(key)}: ${formatConstraintValue(value)}`;
+  });
+
+  if (
+    typeof schema.format === 'string' &&
+    !SUPPORTED_STRING_FORMATS.has(schema.format)
+  ) {
+    descriptions.push(`format: ${schema.format}`);
+  }
+
+  return descriptions.length === 0 ? undefined : `${descriptions.join('; ')}.`;
+}
+
+function formatConstraintName(key: string): string {
+  return key.replace(/[A-Z]/g, match => ` ${match.toLowerCase()}`);
+}
+
+function formatConstraintValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return JSON.stringify(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## background

backport of #14790 from main to release-v6.0

## related issues

backport of #14790