### PR TITLE
backport v5: feat (provider/anthropic): sanitize unsupported json schema validation properties

### DIFF
--- a/.changeset/empty-deers-tell.md
+++ b/.changeset/empty-deers-tell.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+feat(anthropic): sanitize the unsupported JSON schema validation properties

--- a/examples/ai-core/src/generate-object/anthropic-output-zod-min-max.ts
+++ b/examples/ai-core/src/generate-object/anthropic-output-zod-min-max.ts
@@ -1,0 +1,30 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateObject({
+    model: anthropic('claude-sonnet-4-5'),
+    providerOptions: {
+      anthropic: {
+        structuredOutputMode: 'outputFormat',
+      },
+    },
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z
+          .array(z.object({ name: z.string(), amount: z.string() }))
+          .min(10)
+          .max(12),
+        steps: z.array(z.string()),
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+  });
+
+  console.dir(result.request.body, { depth: Infinity });
+  console.log();
+  console.log(JSON.stringify(result.object, null, 2));
+});

--- a/examples/ai-core/src/generate-object/anthropic-output-zod-positive-number.ts
+++ b/examples/ai-core/src/generate-object/anthropic-output-zod-positive-number.ts
@@ -1,0 +1,24 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateObject({
+    model: anthropic('claude-sonnet-4-5'),
+    providerOptions: {
+      anthropic: {
+        structuredOutputMode: 'outputFormat',
+      },
+    },
+    schema: z.object({
+      recurringIntervalMinutes: z.number().int().min(0).max(40),
+    }),
+    prompt:
+      'Return a JSON object with recurringIntervalMinutes set to a positive number.',
+  });
+
+  console.dir(result.request.body, { depth: Infinity });
+  console.log();
+  console.log(JSON.stringify(result.object, null, 2));
+});

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -6,12 +6,14 @@ import {
   LanguageModelV2StreamPart,
 } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { asSchema } from '@ai-sdk/provider-utils';
 import {
   convertReadableStreamToArray,
   mockId,
 } from '@ai-sdk/provider-utils/test';
 import fs from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import { AnthropicProviderOptions } from './anthropic-messages-options';
 import { createAnthropic } from './anthropic-provider';
 import { Citation } from './anthropic-messages-api';
@@ -642,6 +644,184 @@ describe('AnthropicMessagesLanguageModel', () => {
       it('should send stop finish reason', async () => {
         expect(result.finishReason).toBe('stop');
       });
+    });
+
+    it('should sanitize unsupported JSON schema keywords for output format', async () => {
+      prepareJsonFixtureResponse('anthropic-json-output-format.1');
+
+      await provider('claude-sonnet-4-5').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            structuredOutputMode: 'outputFormat',
+          } satisfies AnthropicProviderOptions,
+        },
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              recurringIntervalMinutes: {
+                type: 'number',
+                exclusiveMinimum: 0,
+              },
+              tags: {
+                type: 'array',
+                minItems: 2,
+                maxItems: 4,
+                items: {
+                  type: 'string',
+                  minLength: 1,
+                },
+              },
+            },
+            required: ['recurringIntervalMinutes', 'tags'],
+            additionalProperties: false,
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+
+      expect(requestBody.output_config.format.schema).toMatchInlineSnapshot(`
+        {
+          "additionalProperties": false,
+          "properties": {
+            "recurringIntervalMinutes": {
+              "description": "exclusive minimum: 0.",
+              "type": "number",
+            },
+            "tags": {
+              "description": "min items: 2; max items: 4.",
+              "items": {
+                "description": "min length: 1.",
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          "required": [
+            "recurringIntervalMinutes",
+            "tags",
+          ],
+          "type": "object",
+        }
+      `);
+
+      expect(requestBody.output_format.schema).toMatchInlineSnapshot(`
+        {
+          "additionalProperties": false,
+          "properties": {
+            "recurringIntervalMinutes": {
+              "description": "exclusive minimum: 0.",
+              "type": "number",
+            },
+            "tags": {
+              "description": "min items: 2; max items: 4.",
+              "items": {
+                "description": "min length: 1.",
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          "required": [
+            "recurringIntervalMinutes",
+            "tags",
+          ],
+          "type": "object",
+        }
+      `);
+    });
+
+    it('should pass sanitized zod output schema as output_config.format', async () => {
+      prepareJsonFixtureResponse('anthropic-json-output-format.1');
+
+      const schema = asSchema(
+        z.object({
+          recipe: z.object({
+            name: z.string(),
+            ingredients: z
+              .array(z.object({ name: z.string(), amount: z.string() }))
+              .min(10)
+              .max(12),
+            steps: z.array(z.string()),
+          }),
+        }),
+      );
+
+      await provider('claude-sonnet-4-5').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            structuredOutputMode: 'outputFormat',
+          } satisfies AnthropicProviderOptions,
+        },
+        responseFormat: {
+          type: 'json',
+          schema: await schema.jsonSchema,
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+
+      expect(requestBody.output_config).toMatchInlineSnapshot(`
+        {
+          "format": {
+            "schema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {
+                "recipe": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ingredients": {
+                      "description": "min items: 10; max items: 12.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "amount": {
+                            "type": "string",
+                          },
+                          "name": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "name",
+                          "amount",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                    "steps": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "ingredients",
+                    "steps",
+                  ],
+                  "type": "object",
+                },
+              },
+              "required": [
+                "recipe",
+              ],
+              "type": "object",
+            },
+            "type": "json_schema",
+          },
+        }
+      `);
     });
 
     describe('json schema response format with output format (unknown model, forced)', () => {

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -610,22 +610,6 @@ describe('AnthropicMessagesLanguageModel', () => {
                 "type": "json_schema",
               },
             },
-            "output_format": {
-              "schema": {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "type": "string",
-                  },
-                },
-                "required": [
-                  "name",
-                ],
-                "type": "object",
-              },
-              "type": "json_schema",
-            },
           }
         `);
       });
@@ -708,30 +692,7 @@ describe('AnthropicMessagesLanguageModel', () => {
         }
       `);
 
-      expect(requestBody.output_format.schema).toMatchInlineSnapshot(`
-        {
-          "additionalProperties": false,
-          "properties": {
-            "recurringIntervalMinutes": {
-              "description": "exclusive minimum: 0.",
-              "type": "number",
-            },
-            "tags": {
-              "description": "min items: 2; max items: 4.",
-              "items": {
-                "description": "min length: 1.",
-                "type": "string",
-              },
-              "type": "array",
-            },
-          },
-          "required": [
-            "recurringIntervalMinutes",
-            "tags",
-          ],
-          "type": "object",
-        }
-      `);
+      expect(requestBody.output_format).toBeUndefined();
     });
 
     it('should pass sanitized zod output schema as output_config.format', async () => {
@@ -885,22 +846,6 @@ describe('AnthropicMessagesLanguageModel', () => {
                 },
                 "type": "json_schema",
               },
-            },
-            "output_format": {
-              "schema": {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "type": "string",
-                  },
-                },
-                "required": [
-                  "name",
-                ],
-                "type": "object",
-              },
-              "type": "json_schema",
             },
           }
         `);
@@ -4240,42 +4185,6 @@ describe('AnthropicMessagesLanguageModel', () => {
                 },
                 "type": "json_schema",
               },
-            },
-            "output_format": {
-              "schema": {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "characters": {
-                    "items": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "class": {
-                          "type": "string",
-                        },
-                        "description": {
-                          "type": "string",
-                        },
-                        "name": {
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "name",
-                        "class",
-                        "description",
-                      ],
-                      "type": "object",
-                    },
-                    "type": "array",
-                  },
-                },
-                "required": [
-                  "characters",
-                ],
-                "type": "object",
-              },
-              "type": "json_schema",
             },
             "stream": true,
           }

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -352,16 +352,6 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
         metadata: { user_id: anthropicOptions.metadata.userId },
       }),
 
-      // structured output:
-      ...(useStructuredOutput &&
-        responseFormat?.type === 'json' &&
-        responseFormat.schema != null && {
-          output_format: {
-            type: 'json_schema',
-            schema: sanitizeJsonSchema(responseFormat.schema),
-          },
-        }),
-
       // container with agent skills:
       ...(anthropicOptions?.container && {
         container: {

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -42,6 +42,7 @@ import { prepareTools } from './anthropic-prepare-tools';
 import { convertToAnthropicMessagesPrompt } from './convert-to-anthropic-messages-prompt';
 import { CacheControlValidator } from './get-cache-control';
 import { mapAnthropicStopReason } from './map-anthropic-stop-reason';
+import { sanitizeJsonSchema } from './sanitize-json-schema';
 
 function createCitationSource(
   citation: Citation,
@@ -333,7 +334,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
             responseFormat.schema != null && {
               format: {
                 type: 'json_schema',
-                schema: responseFormat.schema,
+                schema: sanitizeJsonSchema(responseFormat.schema),
               },
             }),
         },
@@ -357,7 +358,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
         responseFormat.schema != null && {
           output_format: {
             type: 'json_schema',
-            schema: responseFormat.schema,
+            schema: sanitizeJsonSchema(responseFormat.schema),
           },
         }),
 

--- a/packages/anthropic/src/sanitize-json-schema.test.ts
+++ b/packages/anthropic/src/sanitize-json-schema.test.ts
@@ -1,0 +1,178 @@
+import type { JSONSchema7 } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { sanitizeJsonSchema } from './sanitize-json-schema';
+
+describe('sanitizeJsonSchema', () => {
+  it('strips unsupported number constraints and adds readable descriptions', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        recurringIntervalMinutes: {
+          type: 'number',
+          exclusiveMinimum: 0,
+          minimum: 1,
+          maximum: 60,
+          exclusiveMaximum: 120,
+        },
+      },
+      required: ['recurringIntervalMinutes'],
+      additionalProperties: false,
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "additionalProperties": false,
+        "properties": {
+          "recurringIntervalMinutes": {
+            "description": "minimum: 1; maximum: 60; exclusive minimum: 0; exclusive maximum: 120.",
+            "type": "number",
+          },
+        },
+        "required": [
+          "recurringIntervalMinutes",
+        ],
+        "type": "object",
+      }
+    `);
+  });
+
+  it('strips unsupported string constraints and unsupported formats', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        slug: {
+          type: 'string',
+          description: 'A URL slug',
+          minLength: 1,
+          maxLength: 20,
+          pattern: '^[a-z0-9-]+$',
+          format: 'regex',
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "additionalProperties": false,
+        "properties": {
+          "slug": {
+            "description": "A URL slug
+      min length: 1; max length: 20; pattern: ^[a-z0-9-]+$; format: regex.",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      }
+    `);
+  });
+
+  it('recursively sanitizes arrays, definitions, and composition schemas', () => {
+    const schema = {
+      type: 'object',
+      $defs: {
+        PositiveInteger: {
+          type: 'integer',
+          minimum: 1,
+        },
+      },
+      properties: {
+        count: { $ref: '#/$defs/PositiveInteger' },
+        tags: {
+          type: 'array',
+          minItems: 2,
+          maxItems: 4,
+          uniqueItems: true,
+          items: {
+            anyOf: [
+              { type: 'string', minLength: 1 },
+              { type: 'number', maximum: 10 },
+            ],
+          },
+        },
+      },
+    } as JSONSchema7 & {
+      $defs: Record<string, JSONSchema7>;
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "$defs": {
+          "PositiveInteger": {
+            "description": "minimum: 1.",
+            "type": "integer",
+          },
+        },
+        "additionalProperties": false,
+        "properties": {
+          "count": {
+            "$ref": "#/$defs/PositiveInteger",
+          },
+          "tags": {
+            "description": "min items: 2; max items: 4; unique items: true.",
+            "items": {
+              "anyOf": [
+                {
+                  "description": "min length: 1.",
+                  "type": "string",
+                },
+                {
+                  "description": "maximum: 10.",
+                  "type": "number",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "type": "object",
+      }
+    `);
+  });
+
+  it('converts oneOf to anyOf', () => {
+    const schema: JSONSchema7 = {
+      oneOf: [
+        { type: 'string', minLength: 1 },
+        { type: 'number', minimum: 0 },
+      ],
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "anyOf": [
+          {
+            "description": "min length: 1.",
+            "type": "string",
+          },
+          {
+            "description": "minimum: 0.",
+            "type": "number",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        value: { type: 'number', exclusiveMinimum: 0 },
+      },
+    };
+
+    sanitizeJsonSchema(schema);
+
+    expect(schema).toMatchInlineSnapshot(`
+      {
+        "properties": {
+          "value": {
+            "exclusiveMinimum": 0,
+            "type": "number",
+          },
+        },
+        "type": "object",
+      }
+    `);
+  });
+});

--- a/packages/anthropic/src/sanitize-json-schema.ts
+++ b/packages/anthropic/src/sanitize-json-schema.ts
@@ -1,0 +1,203 @@
+import type { JSONSchema7, JSONSchema7Definition } from '@ai-sdk/provider';
+
+const SUPPORTED_STRING_FORMATS = new Set([
+  'date-time',
+  'time',
+  'date',
+  'duration',
+  'email',
+  'hostname',
+  'uri',
+  'ipv4',
+  'ipv6',
+  'uuid',
+]);
+
+const DESCRIPTION_CONSTRAINT_KEYS = [
+  'minimum',
+  'maximum',
+  'exclusiveMinimum',
+  'exclusiveMaximum',
+  'multipleOf',
+  'minLength',
+  'maxLength',
+  'pattern',
+  'minItems',
+  'maxItems',
+  'uniqueItems',
+  'minProperties',
+  'maxProperties',
+  'not',
+] satisfies Array<keyof JSONSchema7>;
+
+/**
+ * Removes JSON Schema keywords that Anthropic rejects in
+ * `output_config.format.schema`.
+ *
+ * The full original schema is still used by AI SDK result validation. This
+ * only relaxes the schema sent to Anthropic's constrained decoder.
+ */
+export function sanitizeJsonSchema(schema: JSONSchema7): JSONSchema7 {
+  return sanitizeSchema(schema) as JSONSchema7;
+}
+
+function sanitizeDefinition(
+  definition: JSONSchema7Definition,
+): JSONSchema7Definition {
+  if (typeof definition === 'boolean' || !isPlainObject(definition)) {
+    return definition;
+  }
+
+  return sanitizeSchema(definition as JSONSchema7);
+}
+
+function sanitizeSchema(schema: JSONSchema7): JSONSchema7 {
+  const result: JSONSchema7 = {};
+  const schemaWithDefs = schema as JSONSchema7 & {
+    $defs?: Record<string, JSONSchema7Definition>;
+  };
+
+  if (schema.$ref != null) {
+    return { $ref: schema.$ref };
+  }
+
+  if (schema.$schema != null) {
+    result.$schema = schema.$schema;
+  }
+
+  if (schema.$id != null) {
+    result.$id = schema.$id;
+  }
+
+  if (schema.title != null) {
+    result.title = schema.title;
+  }
+
+  if (schema.description != null) {
+    result.description = schema.description;
+  }
+
+  if (schema.default !== undefined) {
+    result.default = schema.default;
+  }
+
+  if (schema.const !== undefined) {
+    result.const = schema.const;
+  }
+
+  if (schema.enum != null) {
+    result.enum = schema.enum;
+  }
+
+  if (schema.type != null) {
+    result.type = schema.type;
+  }
+
+  if (schema.anyOf != null) {
+    result.anyOf = schema.anyOf.map(sanitizeDefinition);
+  } else if (schema.oneOf != null) {
+    result.anyOf = schema.oneOf.map(sanitizeDefinition);
+  }
+
+  if (schema.allOf != null) {
+    result.allOf = schema.allOf.map(sanitizeDefinition);
+  }
+
+  if (schema.definitions != null) {
+    result.definitions = Object.fromEntries(
+      Object.entries(schema.definitions).map(([name, definition]) => [
+        name,
+        sanitizeDefinition(definition),
+      ]),
+    );
+  }
+
+  if (schemaWithDefs.$defs != null) {
+    const resultWithDefs = result as JSONSchema7 & {
+      $defs?: Record<string, JSONSchema7Definition>;
+    };
+    resultWithDefs.$defs = Object.fromEntries(
+      Object.entries(schemaWithDefs.$defs).map(([name, definition]) => [
+        name,
+        sanitizeDefinition(definition),
+      ]),
+    );
+  }
+
+  if (schema.type === 'object' || schema.properties != null) {
+    if (schema.properties != null) {
+      result.properties = Object.fromEntries(
+        Object.entries(schema.properties).map(([name, definition]) => [
+          name,
+          sanitizeDefinition(definition),
+        ]),
+      );
+    }
+
+    result.additionalProperties = false;
+
+    if (schema.required != null) {
+      result.required = schema.required;
+    }
+  }
+
+  if (schema.items != null) {
+    result.items = Array.isArray(schema.items)
+      ? schema.items.map(sanitizeDefinition)
+      : sanitizeDefinition(schema.items);
+  }
+
+  if (
+    typeof schema.format === 'string' &&
+    SUPPORTED_STRING_FORMATS.has(schema.format)
+  ) {
+    result.format = schema.format;
+  }
+
+  const constraintDescription = getConstraintDescription(schema);
+  if (constraintDescription != null) {
+    result.description =
+      result.description == null
+        ? constraintDescription
+        : `${result.description}\n${constraintDescription}`;
+  }
+
+  return result;
+}
+
+function getConstraintDescription(schema: JSONSchema7): string | undefined {
+  const descriptions = DESCRIPTION_CONSTRAINT_KEYS.flatMap(key => {
+    const value = schema[key];
+
+    if (value == null || value === false) {
+      return [];
+    }
+
+    return `${formatConstraintName(key)}: ${formatConstraintValue(value)}`;
+  });
+
+  if (
+    typeof schema.format === 'string' &&
+    !SUPPORTED_STRING_FORMATS.has(schema.format)
+  ) {
+    descriptions.push(`format: ${schema.format}`);
+  }
+
+  return descriptions.length === 0 ? undefined : `${descriptions.join('; ')}.`;
+}
+
+function formatConstraintName(key: string): string {
+  return key.replace(/[A-Z]/g, match => ` ${match.toLowerCase()}`);
+}
+
+function formatConstraintValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return JSON.stringify(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## background

backport of #14790 from main to release-v5.0

## summary

- backport sanitize fix from #14790
- additionally drops the legacy top-level `output_format` field (v5-only) since anthropic now rejects requests sending both `output_format` and `output_config.format` — without this, the sanitize fix would land but be unreachable end-to-end on v5

## related issues

backport of #14790