### PR TITLE
chore: gitignore v6+ example dirs that don't exist on v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dist
 dist-ssr
 dist-bundle-check
 examples/*/build
+examples/ai-e2e-next
+examples/ai-functions
 node_modules
 public/dist
 server/dist


### PR DESCRIPTION
## background

`examples/ai-e2e-next` and `examples/ai-functions` were added in v6+ and don't exist on v5. when switching between branches in the same working dir they show up as untracked on v5 which makes accidental commits possible. gitignoring them prevents that

## related issues

n/a