### PR TITLE
backport v6: fix(mcp): prevent prototype pollution by using secureJsonParse

### DIFF
--- a/.changeset/wet-poets-attack.md
+++ b/.changeset/wet-poets-attack.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/mcp": patch
+"ai": patch
+---
+
+fix(mcp): prevent prototype pollution by using secureJsonParse

--- a/packages/ai/src/util/merge-objects.test.ts
+++ b/packages/ai/src/util/merge-objects.test.ts
@@ -115,4 +115,44 @@ describe('mergeObjects', () => {
     expect(mergeObjects({ a: 1 }, undefined)).toEqual({ a: 1 });
     expect(mergeObjects(undefined, { b: 2 })).toEqual({ b: 2 });
   });
+
+  it('should not pollute Object.prototype via __proto__', () => {
+    const malicious = JSON.parse('{"__proto__": {"polluted": true}}');
+
+    const result = mergeObjects({}, malicious) as Record<string, unknown>;
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(result.polluted).toBeUndefined();
+    expect(Object.hasOwn(Object.prototype, 'polluted')).toBe(false);
+  });
+
+  it('should ignore __proto__, constructor, and prototype keys', () => {
+    const malicious = JSON.parse(
+      '{"__proto__": {"a": 1}, "constructor": {"prototype": {"b": 2}}, "prototype": {"c": 3}, "safe": "value"}',
+    );
+
+    const result = mergeObjects({ existing: 'ok' }, malicious) as Record<
+      string,
+      unknown
+    >;
+
+    expect(result).toEqual({ existing: 'ok', safe: 'value' });
+    expect(({} as Record<string, unknown>).a).toBeUndefined();
+    expect(({} as Record<string, unknown>).b).toBeUndefined();
+    expect(({} as Record<string, unknown>).c).toBeUndefined();
+  });
+
+  it('should ignore dangerous keys nested in mergeable objects', () => {
+    const base = { metadata: { user: 'alice' } };
+    const malicious = JSON.parse(
+      '{"metadata": {"__proto__": {"polluted": true}, "role": "admin"}}',
+    );
+
+    const result = mergeObjects(base, malicious) as {
+      metadata: Record<string, unknown>;
+    };
+
+    expect(result.metadata).toEqual({ user: 'alice', role: 'admin' });
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
 });

--- a/packages/ai/src/util/merge-objects.ts
+++ b/packages/ai/src/util/merge-objects.ts
@@ -35,6 +35,11 @@ export function mergeObjects<T extends object, U extends object>(
 
   // Iterate through all keys in the source object
   for (const key in overrides) {
+    // Skip prototype-polluting keys when merging untrusted input
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
+
     if (Object.prototype.hasOwnProperty.call(overrides, key)) {
       const overridesValue = overrides[key];
 

--- a/packages/mcp/src/tool/json-rpc-message.ts
+++ b/packages/mcp/src/tool/json-rpc-message.ts
@@ -1,3 +1,4 @@
+import { parseJSON } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { BaseParamsSchema, RequestSchema, ResultSchema } from './types';
 
@@ -59,3 +60,9 @@ export const JSONRPCMessageSchema = z.union([
 ]);
 
 export type JSONRPCMessage = z.infer<typeof JSONRPCMessageSchema>;
+
+export async function parseJSONRPCMessage(
+  text: string,
+): Promise<JSONRPCMessage> {
+  return JSONRPCMessageSchema.parse(await parseJSON({ text }));
+}

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -5,7 +5,11 @@ import {
   getRuntimeEnvironmentUserAgent,
 } from '@ai-sdk/provider-utils';
 import { MCPClientError } from '../error/mcp-client-error';
-import { JSONRPCMessage, JSONRPCMessageSchema } from './json-rpc-message';
+import {
+  JSONRPCMessage,
+  JSONRPCMessageSchema,
+  parseJSONRPCMessage,
+} from './json-rpc-message';
 import { MCPTransport } from './mcp-transport';
 import { VERSION } from '../version';
 import {
@@ -238,7 +242,7 @@ export class HttpMCPTransport implements MCPTransport {
                 const { event, data } = value;
                 if (event === 'message') {
                   try {
-                    const msg = JSONRPCMessageSchema.parse(JSON.parse(data));
+                    const msg = await parseJSONRPCMessage(data);
                     this.onmessage?.(msg);
                   } catch (error) {
                     const e = new MCPClientError({
@@ -386,7 +390,7 @@ export class HttpMCPTransport implements MCPTransport {
 
             if (event === 'message') {
               try {
-                const msg = JSONRPCMessageSchema.parse(JSON.parse(data));
+                const msg = await parseJSONRPCMessage(data);
                 this.onmessage?.(msg);
               } catch (error) {
                 const e = new MCPClientError({

--- a/packages/mcp/src/tool/mcp-sse-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.test.ts
@@ -3,7 +3,7 @@ import {
   TestResponseController,
 } from '@ai-sdk/test-server/with-vitest';
 import { MCPClientError } from '../error/mcp-client-error';
-import { SseMCPTransport } from './mcp-sse-transport';
+import { deserializeMessage, SseMCPTransport } from './mcp-sse-transport';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LATEST_PROTOCOL_VERSION } from './types';
 
@@ -130,6 +130,46 @@ describe('SseMCPTransport', () => {
     const error = await errorPromise;
     expect(error).toBeInstanceOf(MCPClientError);
     expect((error as Error).message).toContain('Failed to parse message');
+
+    await transport.close();
+  });
+
+  it('should reject SSE messages containing __proto__ (prototype pollution)', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['http://localhost:3000/sse'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    const errorPromise = new Promise<unknown>(resolve => {
+      transport.onerror = err => resolve(err);
+    });
+
+    const connectPromise = transport.start();
+
+    controller.write(
+      'event: endpoint\ndata: http://localhost:3000/messages\n\n',
+    );
+    await connectPromise;
+
+    const malicious =
+      '{"jsonrpc":"2.0","id":1,"result":{"__proto__":{"polluted":true}}}';
+    controller.write(`event: message\ndata: ${malicious}\n\n`);
+
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(MCPClientError);
+    expect({
+      message: (error as Error).message,
+      cause: ((error as { cause?: Error }).cause as Error | undefined)?.message,
+    }).toMatchInlineSnapshot(`
+      {
+        "cause": "JSON parsing failed: Text: {"jsonrpc":"2.0","id":1,"result":{"__proto__":{"polluted":true}}}.
+      Error message: Object contains forbidden prototype property",
+        "message": "MCP SSE Transport Error: Failed to parse message",
+      }
+    `);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
 
     await transport.close();
   });
@@ -451,5 +491,37 @@ describe('SseMCPTransport', () => {
 
       await transport.close();
     });
+  });
+});
+
+describe('deserializeMessage', () => {
+  it('should reject payloads containing __proto__ (prototype pollution)', async () => {
+    const malicious =
+      '{"jsonrpc":"2.0","id":1,"result":{"__proto__":{"polluted":true}}}';
+
+    await expect(
+      deserializeMessage(malicious),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `
+      [AI_JSONParseError: JSON parsing failed: Text: {"jsonrpc":"2.0","id":1,"result":{"__proto__":{"polluted":true}}}.
+      Error message: Object contains forbidden prototype property]
+    `,
+    );
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('should reject payloads containing constructor.prototype', async () => {
+    const malicious =
+      '{"jsonrpc":"2.0","id":1,"result":{"constructor":{"prototype":{"polluted":true}}}}';
+
+    await expect(
+      deserializeMessage(malicious),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `
+      [AI_JSONParseError: JSON parsing failed: Text: {"jsonrpc":"2.0","id":1,"result":{"constructor":{"prototype":{"polluted":true}}}}.
+      Error message: Object contains forbidden prototype property]
+    `,
+    );
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
 });

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -5,7 +5,7 @@ import {
   getRuntimeEnvironmentUserAgent,
 } from '@ai-sdk/provider-utils';
 import { MCPClientError } from '../error/mcp-client-error';
-import { JSONRPCMessage, JSONRPCMessageSchema } from './json-rpc-message';
+import { JSONRPCMessage, parseJSONRPCMessage } from './json-rpc-message';
 import { MCPTransport } from './mcp-transport';
 import { VERSION } from '../version';
 import {
@@ -168,9 +168,7 @@ export class SseMCPTransport implements MCPTransport {
                   resolve();
                 } else if (event === 'message') {
                   try {
-                    const message = JSONRPCMessageSchema.parse(
-                      JSON.parse(data),
-                    );
+                    const message = await parseJSONRPCMessage(data);
                     this.onmessage?.(message);
                   } catch (error) {
                     const e = new MCPClientError({
@@ -280,6 +278,8 @@ export class SseMCPTransport implements MCPTransport {
   }
 }
 
-export function deserializeMessage(line: string): JSONRPCMessage {
-  return JSONRPCMessageSchema.parse(JSON.parse(line));
+export async function deserializeMessage(
+  line: string,
+): Promise<JSONRPCMessage> {
+  return parseJSONRPCMessage(line);
 }

--- a/packages/mcp/src/tool/mcp-stdio/mcp-stdio-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-stdio/mcp-stdio-transport.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { JSONRPCMessage } from '../json-rpc-message';
 import { MCPClientError } from '../../error/mcp-client-error';
 import { createChildProcess } from './create-child-process';
-import { StdioMCPTransport } from './mcp-stdio-transport';
+import { deserializeMessage, StdioMCPTransport } from './mcp-stdio-transport';
 
 vi.mock('./create-child-process', { spy: true });
 
@@ -201,7 +201,9 @@ describe('StdioMCPTransport', () => {
       };
 
       mockStdout.emit('data', Buffer.from(JSON.stringify(message) + '\n'));
-      expect(onMessageSpy).toHaveBeenCalledWith(message);
+      await vi.waitFor(() => {
+        expect(onMessageSpy).toHaveBeenCalledWith(message);
+      });
     });
 
     it('should handle partial messages correctly', async () => {
@@ -215,7 +217,41 @@ describe('StdioMCPTransport', () => {
       const messageStr = JSON.stringify(message);
       mockStdout.emit('data', Buffer.from(messageStr.slice(0, 10)));
       mockStdout.emit('data', Buffer.from(messageStr.slice(10) + '\n'));
-      expect(onMessageSpy).toHaveBeenCalledWith(message);
+      await vi.waitFor(() => {
+        expect(onMessageSpy).toHaveBeenCalledWith(message);
+      });
+    });
+  });
+
+  describe('deserializeMessage', () => {
+    it('should reject payloads containing __proto__ (prototype pollution)', async () => {
+      const malicious =
+        '{"jsonrpc":"2.0","id":1,"result":{"__proto__":{"polluted":true}}}';
+
+      await expect(
+        deserializeMessage(malicious),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `
+        [AI_JSONParseError: JSON parsing failed: Text: {"jsonrpc":"2.0","id":1,"result":{"__proto__":{"polluted":true}}}.
+        Error message: Object contains forbidden prototype property]
+      `,
+      );
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('should reject payloads containing constructor.prototype', async () => {
+      const malicious =
+        '{"jsonrpc":"2.0","id":1,"result":{"constructor":{"prototype":{"polluted":true}}}}';
+
+      await expect(
+        deserializeMessage(malicious),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `
+        [AI_JSONParseError: JSON parsing failed: Text: {"jsonrpc":"2.0","id":1,"result":{"constructor":{"prototype":{"polluted":true}}}}.
+        Error message: Object contains forbidden prototype property]
+      `,
+      );
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
     });
   });
 

--- a/packages/mcp/src/tool/mcp-stdio/mcp-stdio-transport.ts
+++ b/packages/mcp/src/tool/mcp-stdio/mcp-stdio-transport.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess, IOType } from 'node:child_process';
 import { Stream } from 'node:stream';
-import { JSONRPCMessage, JSONRPCMessageSchema } from '../json-rpc-message';
+import { JSONRPCMessage, parseJSONRPCMessage } from '../json-rpc-message';
 import { MCPTransport } from '../mcp-transport';
 import { MCPClientError } from '../../error/mcp-client-error';
 import { createChildProcess } from './create-child-process';
@@ -68,7 +68,7 @@ export class StdioMCPTransport implements MCPTransport {
 
         this.process.stdout?.on('data', chunk => {
           this.readBuffer.append(chunk);
-          this.processReadBuffer();
+          void this.processReadBuffer();
         });
 
         this.process.stdout?.on('error', error => {
@@ -81,14 +81,15 @@ export class StdioMCPTransport implements MCPTransport {
     });
   }
 
-  private processReadBuffer() {
+  private async processReadBuffer() {
     while (true) {
-      try {
-        const message = this.readBuffer.readMessage();
-        if (message === null) {
-          break;
-        }
+      const line = this.readBuffer.readLine();
+      if (line === null) {
+        break;
+      }
 
+      try {
+        const message = await deserializeMessage(line);
         this.onmessage?.(message);
       } catch (error) {
         this.onerror?.(error as Error);
@@ -127,7 +128,7 @@ class ReadBuffer {
     this.buffer = this.buffer ? Buffer.concat([this.buffer, chunk]) : chunk;
   }
 
-  readMessage(): JSONRPCMessage | null {
+  readLine(): string | null {
     if (!this.buffer) return null;
 
     const index = this.buffer.indexOf('\n');
@@ -137,7 +138,7 @@ class ReadBuffer {
 
     const line = this.buffer.toString('utf8', 0, index);
     this.buffer = this.buffer.subarray(index + 1);
-    return deserializeMessage(line);
+    return line;
   }
 
   clear(): void {
@@ -149,6 +150,8 @@ function serializeMessage(message: JSONRPCMessage): string {
   return JSON.stringify(message) + '\n';
 }
 
-export function deserializeMessage(line: string): JSONRPCMessage {
-  return JSONRPCMessageSchema.parse(JSON.parse(line));
+export async function deserializeMessage(
+  line: string,
+): Promise<JSONRPCMessage> {
+  return parseJSONRPCMessage(line);
 }

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -27,7 +27,7 @@ import {
   resourceUrlStripSlash,
 } from '../util/oauth-util';
 import { LATEST_PROTOCOL_VERSION } from './types';
-import { FetchFunction } from '@ai-sdk/provider-utils';
+import { FetchFunction, parseJSON } from '@ai-sdk/provider-utils';
 
 export type AuthResult = 'AUTHORIZED' | 'REDIRECT';
 
@@ -591,7 +591,9 @@ export async function parseErrorResponse(
   const body = input instanceof Response ? await input.text() : input;
 
   try {
-    const result = OAuthErrorResponseSchema.parse(JSON.parse(body));
+    const result = OAuthErrorResponseSchema.parse(
+      await parseJSON({ text: body }),
+    );
     const { error, error_description, error_uri } = result;
     const errorClass = OAUTH_ERRORS[error] || ServerError;
     return new errorClass({


### PR DESCRIPTION
## background

backport of #14763 from main to release-v6.0

## related issues

backport of #14763
fixes #14309