### PR TITLE
[workflow] support tools factory function for step-scoped resolution

### DIFF
--- a/packages/workflow/src/do-stream-step.ts
+++ b/packages/workflow/src/do-stream-step.ts
@@ -1,6 +1,8 @@
 import type {
+  JSONValue,
   LanguageModelV4CallOptions,
   LanguageModelV4Prompt,
+  LanguageModelV4ToolResultPart,
 } from '@ai-sdk/provider';
 import {
   experimental_streamLanguageModelCall as streamModelCall,
@@ -16,11 +18,25 @@ import {
   type ToolChoice,
   type ToolSet,
 } from 'ai';
-import type { ProviderOptions, TelemetryOptions } from './workflow-agent.js';
+import type {
+  ProviderOptions,
+  TelemetryOptions,
+  PrepareStepCallback,
+  WorkflowAgentOnStepFinishCallback,
+  WorkflowAgentOnToolExecutionStartCallback,
+  WorkflowAgentOnToolExecutionEndCallback,
+  ToolCall,
+  ToolsInput,
+} from './workflow-agent.js';
 import {
   resolveSerializableTools,
   type SerializableToolDef,
 } from './serializable-schema.js';
+import {
+  applyPrepareStepResult,
+  filterToolsByActiveTools,
+  getErrorMessage,
+} from './prepare-step-utils.js';
 export type { Experimental_LanguageModelStreamPart as ModelCallStreamPart } from 'ai';
 
 export type ModelStopCondition = StopCondition<NoInfer<ToolSet>, any>;
@@ -56,6 +72,15 @@ export interface DoStreamStepOptions {
   telemetry?: TelemetryOptions;
   repairToolCall?: ToolCallRepairFunction<ToolSet>;
   responseFormat?: LanguageModelV4CallOptions['responseFormat'];
+  toolsResolver?: ToolsInput<ToolSet>;
+  prepareStep?: PrepareStepCallback<ToolSet>;
+  onStepFinish?: WorkflowAgentOnStepFinishCallback<ToolSet>;
+  onToolExecutionStart?: WorkflowAgentOnToolExecutionStartCallback;
+  onToolExecutionEnd?: WorkflowAgentOnToolExecutionEndCallback;
+  stepNumber?: number;
+  steps?: StepResult<ToolSet, any>[];
+  experimentalContext?: unknown;
+  activeTools?: string[];
 }
 
 /**
@@ -83,56 +108,156 @@ export interface StreamFinish {
   providerMetadata?: Record<string, unknown>;
 }
 
+export interface DoStreamStepResult {
+  toolCalls: ParsedToolCall[];
+  finish: StreamFinish | undefined;
+  step: StepResult<ToolSet, any>;
+  providerExecutedToolResults: Map<string, ProviderExecutedToolResult>;
+  toolResults: LanguageModelV4ToolResultPart[];
+  updatedContext?: unknown;
+  updatedModel?: LanguageModel;
+  updatedActiveTools?: string[];
+}
+
+async function resolveTools(
+  toolsInput: ToolsInput<ToolSet> | undefined,
+): Promise<ToolSet> {
+  if (!toolsInput) return {};
+  if (typeof toolsInput === 'function') {
+    return await toolsInput();
+  }
+  return toolsInput;
+}
+
+async function executeToolInStep(
+  toolCall: { toolCallId: string; toolName: string; input: unknown },
+  tools: ToolSet,
+  messages: LanguageModelV4Prompt,
+  experimentalContext?: unknown,
+): Promise<LanguageModelV4ToolResultPart> {
+  const tool = tools[toolCall.toolName];
+  if (!tool) throw new Error(`Tool "${toolCall.toolName}" not found`);
+  if (typeof tool.execute !== 'function') {
+    throw new Error(
+      `Tool "${toolCall.toolName}" does not have an execute function. ` +
+        `Client-side tools should be filtered before calling executeToolInStep.`,
+    );
+  }
+
+  try {
+    const { execute } = tool;
+    const toolResult = await execute(toolCall.input, {
+      toolCallId: toolCall.toolCallId,
+      messages,
+      context: experimentalContext,
+    });
+
+    const output =
+      typeof toolResult === 'string'
+        ? { type: 'text' as const, value: toolResult }
+        : { type: 'json' as const, value: toolResult as JSONValue };
+
+    return {
+      type: 'tool-result' as const,
+      toolCallId: toolCall.toolCallId,
+      toolName: toolCall.toolName,
+      output,
+    };
+  } catch (error) {
+    return {
+      type: 'tool-result',
+      toolCallId: toolCall.toolCallId,
+      toolName: toolCall.toolName,
+      output: {
+        type: 'error-text',
+        value: getErrorMessage(error),
+      },
+    };
+  }
+}
+
 export async function doStreamStep(
   conversationPrompt: LanguageModelV4Prompt,
   modelInit: LanguageModel,
   writable?: WritableStream<ModelCallStreamPart<ToolSet>>,
   serializedTools?: Record<string, SerializableToolDef>,
   options?: DoStreamStepOptions,
-) {
+): Promise<DoStreamStepResult> {
   'use step';
 
-  // Resolve model inside step (must happen here for serialization boundary)
-  const model: LanguageModel =
+  let model: LanguageModel =
     typeof modelInit === 'string'
       ? gateway.languageModel(modelInit)
       : modelInit;
 
-  // Reconstruct tools from serializable definitions with Ajv validation.
-  // Tools are serialized before crossing the step boundary because zod schemas
-  // contain functions that can't be serialized by the workflow runtime.
-  const tools = serializedTools
-    ? resolveSerializableTools(serializedTools)
-    : undefined;
+  let tools: ToolSet | undefined;
+  if (options?.toolsResolver) {
+    tools = await resolveTools(options.toolsResolver);
+  } else if (serializedTools) {
+    tools = resolveSerializableTools(serializedTools);
+  }
 
-  // streamModelCall handles: prompt standardization, tool preparation,
-  // model.doStream(), retry logic, and stream part transformation
-  // (tool call parsing, finish reason mapping, file wrapping).
+  if (tools && options?.activeTools && options.activeTools.length > 0) {
+    tools = filterToolsByActiveTools(tools, options.activeTools);
+  }
+
+  let currentPrompt = conversationPrompt;
+  let currentContext = options?.experimentalContext;
+  let updatedActiveTools = options?.activeTools;
+  let effectiveOptions = options;
+
+  if (options?.prepareStep) {
+    const prepareResult = await options.prepareStep({
+      model,
+      stepNumber: options.stepNumber ?? 0,
+      steps: options.steps ?? [],
+      messages: currentPrompt,
+      experimental_context: currentContext,
+    });
+
+    const applied = applyPrepareStepResult(prepareResult, currentPrompt);
+
+    if (applied.model) model = applied.model;
+    if (applied.messages) currentPrompt = applied.messages;
+    if (applied.context !== undefined) currentContext = applied.context;
+    if (applied.activeTools) {
+      updatedActiveTools = applied.activeTools;
+      if (tools) {
+        tools = filterToolsByActiveTools(tools, updatedActiveTools);
+      }
+    }
+    if (applied.toolChoice) {
+      effectiveOptions = {
+        ...effectiveOptions,
+        toolChoice: applied.toolChoice,
+      };
+    }
+    if (Object.keys(applied.generationSettings).length > 0) {
+      effectiveOptions = { ...effectiveOptions, ...applied.generationSettings };
+    }
+  }
+
   const { stream: modelStream } = await streamModelCall({
     model,
-    // streamModelCall expects Prompt (ModelMessage[]) but we pass the
-    // pre-converted LanguageModelV4Prompt. standardizePrompt inside
-    // streamModelCall handles both formats.
-    messages: conversationPrompt as unknown as ModelMessage[],
+    messages: currentPrompt as unknown as ModelMessage[],
     allowSystemInMessages: true,
     tools,
-    toolChoice: options?.toolChoice,
-    includeRawChunks: options?.includeRawChunks,
-    providerOptions: options?.providerOptions,
-    abortSignal: options?.abortSignal,
-    headers: options?.headers,
-    maxOutputTokens: options?.maxOutputTokens,
-    temperature: options?.temperature,
-    topP: options?.topP,
-    topK: options?.topK,
-    presencePenalty: options?.presencePenalty,
-    frequencyPenalty: options?.frequencyPenalty,
-    stopSequences: options?.stopSequences,
-    seed: options?.seed,
-    repairToolCall: options?.repairToolCall,
+    toolChoice: effectiveOptions?.toolChoice,
+    includeRawChunks: effectiveOptions?.includeRawChunks,
+    providerOptions: effectiveOptions?.providerOptions,
+    abortSignal: effectiveOptions?.abortSignal,
+    headers: effectiveOptions?.headers,
+    maxOutputTokens: effectiveOptions?.maxOutputTokens,
+    temperature: effectiveOptions?.temperature,
+    topP: effectiveOptions?.topP,
+    topK: effectiveOptions?.topK,
+    presencePenalty: effectiveOptions?.presencePenalty,
+    frequencyPenalty: effectiveOptions?.frequencyPenalty,
+    stopSequences: effectiveOptions?.stopSequences,
+    seed: effectiveOptions?.seed,
+    repairToolCall: effectiveOptions?.repairToolCall,
   });
 
-  // Consume the stream: capture data and write to writable in real-time
   const toolCalls: ParsedToolCall[] = [];
   const providerExecutedToolResults = new Map<
     string,
@@ -140,7 +265,6 @@ export async function doStreamStep(
   >();
   let finish: StreamFinish | undefined;
 
-  // Aggregation for StepResult
   let text = '';
   const reasoningParts: Array<{ text: string }> = [];
   let responseMetadata:
@@ -148,7 +272,6 @@ export async function doStreamStep(
     | undefined;
   let warnings: unknown[] | undefined;
 
-  // Acquire writer once before the loop to avoid per-chunk lock overhead
   const writer = writable?.getWriter();
 
   try {
@@ -161,7 +284,6 @@ export async function doStreamStep(
           reasoningParts.push({ text: part.text });
           break;
         case 'tool-call': {
-          // parseToolCall adds dynamic/invalid/error at runtime
           const toolCallPart = part as typeof part & Partial<ParsedToolCall>;
           toolCalls.push({
             type: 'tool-call',
@@ -220,7 +342,6 @@ export async function doStreamStep(
           break;
       }
 
-      // Write to writable in real-time
       if (writer) {
         await writer.write(part);
       }
@@ -229,12 +350,143 @@ export async function doStreamStep(
     writer?.releaseLock();
   }
 
-  // Build StepResult
+  const toolResults: LanguageModelV4ToolResultPart[] = [];
+
+  if (finish?.finishReason === 'tool-calls' && tools) {
+    const invalidToolCalls = toolCalls.filter(tc => tc.invalid === true);
+    const validToolCalls = toolCalls.filter(tc => tc.invalid !== true);
+    const nonProviderToolCalls = validToolCalls.filter(
+      tc => !tc.providerExecuted,
+    );
+    const providerToolCalls = validToolCalls.filter(tc => tc.providerExecuted);
+
+    const executableToolCalls = nonProviderToolCalls.filter(tc => {
+      const tool = tools[tc.toolName];
+      if (!tool || typeof tool.execute !== 'function') return false;
+      if (tool.needsApproval != null) return false;
+      return true;
+    });
+
+    for (const toolCall of executableToolCalls) {
+      const toolCallEvent: ToolCall = {
+        type: 'tool-call',
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
+        input: toolCall.input,
+      };
+
+      if (options?.onToolExecutionStart) {
+        await options.onToolExecutionStart({
+          toolCall: toolCallEvent,
+          stepNumber: options.stepNumber ?? 0,
+        });
+      }
+
+      const startTime = Date.now();
+      let result: LanguageModelV4ToolResultPart;
+      let executionError: unknown;
+
+      try {
+        result = await executeToolInStep(
+          toolCall,
+          tools,
+          currentPrompt,
+          currentContext,
+        );
+      } catch (err) {
+        executionError = err;
+        result = {
+          type: 'tool-result',
+          toolCallId: toolCall.toolCallId,
+          toolName: toolCall.toolName,
+          output: {
+            type: 'error-text',
+            value: getErrorMessage(err),
+          },
+        };
+      }
+
+      const durationMs = Date.now() - startTime;
+
+      if (options?.onToolExecutionEnd) {
+        const isError =
+          result.output &&
+          'type' in result.output &&
+          (result.output.type === 'error-text' ||
+            result.output.type === 'error-json');
+        if (isError || executionError) {
+          await options.onToolExecutionEnd({
+            toolCall: toolCallEvent,
+            stepNumber: options.stepNumber ?? 0,
+            durationMs,
+            success: false,
+            error:
+              executionError ??
+              ('value' in result.output ? result.output.value : undefined),
+          });
+        } else {
+          await options.onToolExecutionEnd({
+            toolCall: toolCallEvent,
+            stepNumber: options.stepNumber ?? 0,
+            durationMs,
+            success: true,
+            output:
+              result.output && 'value' in result.output
+                ? result.output.value
+                : undefined,
+          });
+        }
+      }
+
+      toolResults.push(result);
+    }
+
+    for (const tc of providerToolCalls) {
+      const streamResult = providerExecutedToolResults.get(tc.toolCallId);
+      if (streamResult) {
+        const isString = typeof streamResult.result === 'string';
+        toolResults.push({
+          type: 'tool-result',
+          toolCallId: tc.toolCallId,
+          toolName: tc.toolName,
+          output: isString
+            ? streamResult.isError
+              ? {
+                  type: 'error-text' as const,
+                  value: streamResult.result as string,
+                }
+              : { type: 'text' as const, value: streamResult.result as string }
+            : streamResult.isError
+              ? {
+                  type: 'error-json' as const,
+                  value: streamResult.result as JSONValue,
+                }
+              : {
+                  type: 'json' as const,
+                  value: streamResult.result as JSONValue,
+                },
+        });
+      }
+    }
+
+    for (const tc of invalidToolCalls) {
+      toolResults.push({
+        type: 'tool-result',
+        toolCallId: tc.toolCallId,
+        toolName: tc.toolName,
+        output: {
+          type: 'error-text',
+          value: getErrorMessage(tc.error),
+        },
+      });
+    }
+  }
+
   const reasoningText = reasoningParts.map(r => r.text).join('') || undefined;
 
   const step: StepResult<ToolSet, any> = {
     callId: 'workflow-agent',
-    stepNumber: 0,
+    stepNumber: options?.stepNumber ?? 0,
     model: {
       provider: responseMetadata?.modelId?.split(':')[0] ?? 'unknown',
       modelId: responseMetadata?.modelId ?? 'unknown',
@@ -282,7 +534,16 @@ export async function doStreamStep(
         input: tc.input,
         dynamic: true as const,
       })),
-    toolResults: [],
+    toolResults: toolResults.map(r => {
+      const tc = toolCalls.find(tc => tc.toolCallId === r.toolCallId);
+      return {
+        type: 'tool-result' as const,
+        toolCallId: r.toolCallId,
+        toolName: r.toolName,
+        input: tc?.input,
+        output: 'value' in r.output ? r.output.value : undefined,
+      };
+    }),
     staticToolResults: [],
     dynamicToolResults: [],
     finishReason: finish?.finishReason ?? 'other',
@@ -314,10 +575,18 @@ export async function doStreamStep(
     providerMetadata: finish?.providerMetadata ?? {},
   } as StepResult<ToolSet, any>;
 
+  if (options?.onStepFinish) {
+    await options.onStepFinish(step);
+  }
+
   return {
     toolCalls,
     finish,
     step,
     providerExecutedToolResults,
+    toolResults,
+    updatedContext: currentContext,
+    updatedModel: model,
+    updatedActiveTools,
   };
 }

--- a/packages/workflow/src/prepare-step-utils.test.ts
+++ b/packages/workflow/src/prepare-step-utils.test.ts
@@ -1,0 +1,196 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import {
+  applyPrepareStepResult,
+  filterToolsByActiveTools,
+  getErrorMessage,
+} from './prepare-step-utils.js';
+
+describe('applyPrepareStepResult', () => {
+  const createMockPrompt = (): LanguageModelV4Prompt => [
+    { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+  ];
+
+  it('returns empty result for empty prepareResult', () => {
+    const result = applyPrepareStepResult({}, createMockPrompt());
+    expect(result.model).toBeUndefined();
+    expect(result.messages).toBeUndefined();
+    expect(result.context).toBeUndefined();
+    expect(result.activeTools).toBeUndefined();
+    expect(result.toolChoice).toBeUndefined();
+    expect(Object.keys(result.generationSettings)).toHaveLength(0);
+  });
+
+  it('applies model override', () => {
+    const mockModel = { provider: 'test', modelId: 'test-model' } as any;
+    const result = applyPrepareStepResult(
+      { model: mockModel },
+      createMockPrompt(),
+    );
+    expect(result.model).toBe(mockModel);
+  });
+
+  it('applies messages override', () => {
+    const newMessages: LanguageModelV4Prompt = [
+      { role: 'user', content: [{ type: 'text', text: 'New message' }] },
+    ];
+    const result = applyPrepareStepResult(
+      { messages: newMessages },
+      createMockPrompt(),
+    );
+    expect(result.messages).toEqual(newMessages);
+  });
+
+  it('prepends system message to prompt without one', () => {
+    const prompt = createMockPrompt();
+    const result = applyPrepareStepResult(
+      { system: 'You are a helper' },
+      prompt,
+    );
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages![0]).toEqual({
+      role: 'system',
+      content: 'You are a helper',
+    });
+  });
+
+  it('replaces existing system message in prompt', () => {
+    const promptWithSystem: LanguageModelV4Prompt = [
+      { role: 'system', content: 'Old system' },
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    ];
+    const result = applyPrepareStepResult(
+      { system: 'New system' },
+      promptWithSystem,
+    );
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages![0]).toEqual({
+      role: 'system',
+      content: 'New system',
+    });
+  });
+
+  it('applies system after messages override', () => {
+    const newMessages: LanguageModelV4Prompt = [
+      { role: 'user', content: [{ type: 'text', text: 'New' }] },
+    ];
+    const result = applyPrepareStepResult(
+      { messages: newMessages, system: 'System' },
+      createMockPrompt(),
+    );
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages![0].role).toBe('system');
+  });
+
+  it('applies context override', () => {
+    const context = { userId: '123' };
+    const result = applyPrepareStepResult(
+      { experimental_context: context },
+      createMockPrompt(),
+    );
+    expect(result.context).toBe(context);
+  });
+
+  it('applies activeTools override', () => {
+    const result = applyPrepareStepResult(
+      { activeTools: ['tool1', 'tool2'] },
+      createMockPrompt(),
+    );
+    expect(result.activeTools).toEqual(['tool1', 'tool2']);
+  });
+
+  it('applies toolChoice override', () => {
+    const result = applyPrepareStepResult(
+      { toolChoice: 'auto' },
+      createMockPrompt(),
+    );
+    expect(result.toolChoice).toBe('auto');
+  });
+
+  it('merges generation settings', () => {
+    const result = applyPrepareStepResult(
+      {
+        maxOutputTokens: 1000,
+        temperature: 0.7,
+        topP: 0.9,
+        seed: 42,
+      },
+      createMockPrompt(),
+    );
+    expect(result.generationSettings).toEqual({
+      maxOutputTokens: 1000,
+      temperature: 0.7,
+      topP: 0.9,
+      seed: 42,
+    });
+  });
+
+  it('applies all settings together', () => {
+    const mockModel = { provider: 'test', modelId: 'test' } as any;
+    const result = applyPrepareStepResult(
+      {
+        model: mockModel,
+        system: 'Helper',
+        experimental_context: { key: 'value' },
+        activeTools: ['tool1'],
+        toolChoice: 'required',
+        temperature: 0.5,
+      },
+      createMockPrompt(),
+    );
+
+    expect(result.model).toBe(mockModel);
+    expect(result.messages![0].role).toBe('system');
+    expect(result.context).toEqual({ key: 'value' });
+    expect(result.activeTools).toEqual(['tool1']);
+    expect(result.toolChoice).toBe('required');
+    expect(result.generationSettings.temperature).toBe(0.5);
+  });
+});
+
+describe('filterToolsByActiveTools', () => {
+  const mockTools = {
+    tool1: { description: 'Tool 1' },
+    tool2: { description: 'Tool 2' },
+    tool3: { description: 'Tool 3' },
+  } as any;
+
+  it('returns all tools when activeTools is empty', () => {
+    const result = filterToolsByActiveTools(mockTools, []);
+    expect(result).toBe(mockTools);
+  });
+
+  it('filters tools by activeTools list', () => {
+    const result = filterToolsByActiveTools(mockTools, ['tool1', 'tool3']);
+    expect(Object.keys(result)).toEqual(['tool1', 'tool3']);
+  });
+
+  it('returns empty object when no tools match', () => {
+    const result = filterToolsByActiveTools(mockTools, ['nonexistent']);
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+});
+
+describe('getErrorMessage', () => {
+  it('returns "unknown error" for null', () => {
+    expect(getErrorMessage(null)).toBe('unknown error');
+  });
+
+  it('returns "unknown error" for undefined', () => {
+    expect(getErrorMessage(undefined)).toBe('unknown error');
+  });
+
+  it('returns string directly', () => {
+    expect(getErrorMessage('Something went wrong')).toBe(
+      'Something went wrong',
+    );
+  });
+
+  it('returns message from Error object', () => {
+    expect(getErrorMessage(new Error('Test error'))).toBe('Test error');
+  });
+
+  it('returns JSON for other objects', () => {
+    expect(getErrorMessage({ code: 500 })).toBe('{"code":500}');
+  });
+});

--- a/packages/workflow/src/prepare-step-utils.ts
+++ b/packages/workflow/src/prepare-step-utils.ts
@@ -1,0 +1,108 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import type { LanguageModel, ToolChoice, ToolSet } from 'ai';
+import type {
+  GenerationSettings,
+  PrepareStepResult,
+} from './workflow-agent.js';
+
+export interface AppliedPrepareStepResult {
+  model?: LanguageModel;
+  messages?: LanguageModelV4Prompt;
+  context?: unknown;
+  activeTools?: string[];
+  generationSettings: Partial<GenerationSettings>;
+  toolChoice?: ToolChoice<ToolSet>;
+}
+
+export function applyPrepareStepResult(
+  prepareResult: PrepareStepResult,
+  currentMessages: LanguageModelV4Prompt,
+): AppliedPrepareStepResult {
+  const result: AppliedPrepareStepResult = {
+    generationSettings: {},
+  };
+
+  if (prepareResult.model !== undefined) {
+    result.model = prepareResult.model;
+  }
+
+  if (prepareResult.messages !== undefined) {
+    result.messages = [...prepareResult.messages];
+  }
+
+  if (prepareResult.system !== undefined) {
+    const messages = result.messages ?? [...currentMessages];
+    if (messages.length > 0 && messages[0].role === 'system') {
+      messages[0] = { role: 'system', content: prepareResult.system };
+    } else {
+      messages.unshift({ role: 'system', content: prepareResult.system });
+    }
+    result.messages = messages;
+  }
+
+  if (prepareResult.experimental_context !== undefined) {
+    result.context = prepareResult.experimental_context;
+  }
+
+  if (prepareResult.activeTools !== undefined) {
+    result.activeTools = prepareResult.activeTools;
+  }
+
+  if (prepareResult.toolChoice !== undefined) {
+    result.toolChoice = prepareResult.toolChoice;
+  }
+
+  if (prepareResult.maxOutputTokens !== undefined) {
+    result.generationSettings.maxOutputTokens = prepareResult.maxOutputTokens;
+  }
+  if (prepareResult.temperature !== undefined) {
+    result.generationSettings.temperature = prepareResult.temperature;
+  }
+  if (prepareResult.topP !== undefined) {
+    result.generationSettings.topP = prepareResult.topP;
+  }
+  if (prepareResult.topK !== undefined) {
+    result.generationSettings.topK = prepareResult.topK;
+  }
+  if (prepareResult.presencePenalty !== undefined) {
+    result.generationSettings.presencePenalty = prepareResult.presencePenalty;
+  }
+  if (prepareResult.frequencyPenalty !== undefined) {
+    result.generationSettings.frequencyPenalty = prepareResult.frequencyPenalty;
+  }
+  if (prepareResult.stopSequences !== undefined) {
+    result.generationSettings.stopSequences = prepareResult.stopSequences;
+  }
+  if (prepareResult.seed !== undefined) {
+    result.generationSettings.seed = prepareResult.seed;
+  }
+  if (prepareResult.maxRetries !== undefined) {
+    result.generationSettings.maxRetries = prepareResult.maxRetries;
+  }
+  if (prepareResult.headers !== undefined) {
+    result.generationSettings.headers = prepareResult.headers;
+  }
+  if (prepareResult.providerOptions !== undefined) {
+    result.generationSettings.providerOptions = prepareResult.providerOptions;
+  }
+
+  return result;
+}
+
+export function filterToolsByActiveTools(
+  tools: ToolSet,
+  activeTools: string[],
+): ToolSet {
+  if (activeTools.length === 0) return tools;
+  const activeToolsSet = new Set(activeTools);
+  return Object.fromEntries(
+    Object.entries(tools).filter(([name]) => activeToolsSet.has(name)),
+  );
+}
+
+export function getErrorMessage(error: unknown): string {
+  if (error == null) return 'unknown error';
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.message;
+  return JSON.stringify(error);
+}

--- a/packages/workflow/src/stream-text-iterator.test.ts
+++ b/packages/workflow/src/stream-text-iterator.test.ts
@@ -120,11 +120,13 @@ function createMockDoStreamStepResult({
   finishReason = 'stop' as 'stop' | 'tool-calls',
   finishRaw = 'stop',
   stepOverrides = {},
+  toolResults = [],
 }: {
   toolCalls?: ParsedToolCall[];
   finishReason?: 'stop' | 'tool-calls';
   finishRaw?: string;
   stepOverrides?: Partial<StepResult<ToolSet, any>>;
+  toolResults?: LanguageModelV4ToolResultPart[];
 } = {}) {
   return {
     toolCalls,
@@ -134,6 +136,7 @@ function createMockDoStreamStepResult({
       ...stepOverrides,
     }),
     providerExecutedToolResults: new Map(),
+    toolResults,
   };
 }
 

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -13,6 +13,8 @@ import {
   type ToolChoice,
   type ToolSet,
 } from 'ai';
+import type {
+  DoStreamStepResult} from './do-stream-step.js';
 import {
   doStreamStep,
   type ModelStopCondition,
@@ -20,13 +22,17 @@ import {
   type ProviderExecutedToolResult,
 } from './do-stream-step.js';
 import { serializeToolSet } from './serializable-schema.js';
+import { applyPrepareStepResult } from './prepare-step-utils.js';
 import type {
   GenerationSettings,
   PrepareStepCallback,
   WorkflowAgentOnErrorCallback,
   WorkflowAgentOnStepFinishCallback,
+  WorkflowAgentOnToolExecutionStartCallback,
+  WorkflowAgentOnToolExecutionEndCallback,
   TelemetryOptions,
   WorkflowAgentOnStepStartCallback,
+  ToolsInput,
 } from './workflow-agent.js';
 
 // Re-export for consumers
@@ -53,11 +59,14 @@ export interface StreamTextIteratorYieldValue {
 export async function* streamTextIterator({
   prompt,
   tools = {},
+  toolsResolver,
   writable,
   model,
   stopConditions,
   onStepFinish,
   onStepStart,
+  onToolExecutionStart,
+  onToolExecutionEnd,
   onError,
   prepareStep,
   generationSettings,
@@ -67,14 +76,20 @@ export async function* streamTextIterator({
   includeRawChunks = false,
   repairToolCall,
   responseFormat,
+  activeTools,
 }: {
   prompt: LanguageModelV4Prompt;
-  tools: ToolSet;
+  /** @deprecated Use toolsResolver instead for factory pattern */
+  tools?: ToolSet;
+  /** Tools resolver - static ToolSet or factory function (resolved inside step) */
+  toolsResolver?: ToolsInput<ToolSet>;
   writable?: WritableStream<ModelCallStreamPart<ToolSet>>;
   model: LanguageModel;
   stopConditions?: ModelStopCondition[] | ModelStopCondition;
   onStepFinish?: WorkflowAgentOnStepFinishCallback<any>;
   onStepStart?: WorkflowAgentOnStepStartCallback;
+  onToolExecutionStart?: WorkflowAgentOnToolExecutionStartCallback;
+  onToolExecutionEnd?: WorkflowAgentOnToolExecutionEndCallback;
   onError?: WorkflowAgentOnErrorCallback;
   prepareStep?: PrepareStepCallback<any>;
   generationSettings?: GenerationSettings;
@@ -84,6 +99,7 @@ export async function* streamTextIterator({
   includeRawChunks?: boolean;
   repairToolCall?: ToolCallRepairFunction<ToolSet>;
   responseFormat?: LanguageModelV4CallOptions['responseFormat'];
+  activeTools?: string[];
 }): AsyncGenerator<
   StreamTextIteratorYieldValue,
   LanguageModelV4Prompt,
@@ -94,7 +110,9 @@ export async function* streamTextIterator({
   let currentGenerationSettings = generationSettings ?? {};
   let currentToolChoice = toolChoice;
   let currentContext = experimental_context;
-  let currentActiveTools: string[] | undefined;
+  let currentActiveTools: string[] | undefined = activeTools;
+
+  const useToolsResolver = toolsResolver !== undefined;
 
   const steps: StepResult<any, any>[] = [];
   let done = false;
@@ -109,124 +127,6 @@ export async function* streamTextIterator({
       break;
     }
 
-    // Call prepareStep callback before each step if provided
-    if (prepareStep) {
-      const prepareResult = await prepareStep({
-        model: currentModel,
-        stepNumber,
-        steps,
-        messages: conversationPrompt,
-        experimental_context: currentContext,
-      });
-
-      // Apply any overrides from prepareStep
-      if (prepareResult.model !== undefined) {
-        currentModel = prepareResult.model;
-      }
-      // Apply messages override BEFORE system so the system message
-      // isn't lost when messages replaces the prompt.
-      if (prepareResult.messages !== undefined) {
-        conversationPrompt = [...prepareResult.messages];
-      }
-      if (prepareResult.system !== undefined) {
-        // Update or prepend system message in the conversation prompt.
-        // Applied AFTER messages override so the system message isn't
-        // lost when messages replaces the prompt.
-        if (
-          conversationPrompt.length > 0 &&
-          conversationPrompt[0].role === 'system'
-        ) {
-          // Replace existing system message
-          conversationPrompt[0] = {
-            role: 'system',
-            content: prepareResult.system,
-          };
-        } else {
-          // Prepend new system message
-          conversationPrompt.unshift({
-            role: 'system',
-            content: prepareResult.system,
-          });
-        }
-      }
-      if (prepareResult.experimental_context !== undefined) {
-        currentContext = prepareResult.experimental_context;
-      }
-      if (prepareResult.activeTools !== undefined) {
-        currentActiveTools = prepareResult.activeTools;
-      }
-      // Apply generation settings overrides
-      if (prepareResult.maxOutputTokens !== undefined) {
-        currentGenerationSettings = {
-          ...currentGenerationSettings,
-          maxOutputTokens: prepareResult.maxOutputTokens,
-        };
-      }
-      if (prepareResult.temperature !== undefined) {
-        currentGenerationSettings = {
-          ...currentGenerationSettings,
-          temperature: prepareResult.temperature,
-        };
-      }
-      if (prepareResult.topP !== undefined) {
-        currentGenerationSettings = {
-          ...currentGenerationSettings,
-          topP: prepareResult.topP,
-        };
-      }
-      if (prepareResult.topK !== undefined) {
-        currentGenerationSettings = {
-          ...currentGenerationSettings,
-          topK: prepareResult.topK,
-        };
-      }
-      if (prepareResult.presencePenalty !== undefined) {
-        currentGenerationSettings = {
-          ...currentGenerationSettings,
-          presencePenalty: prepareResult.presencePenalty,
-        };
-      }
-      if (prepareResult.frequencyPenalty !== undefined) {
-        currentGenerationSettings = {
-          ...currentGenerationSettings,
-          frequencyPenalty: prepareResult.frequencyPenalty,
-        };
-      }
-      if (prepareResult.stopSequences !== undefined) {
-        currentGenerationSettings = {
-          ...currentGenerationSettings,
-          stopSequences: prepareResult.stopSequences,
-        };
-      }
-      if (prepareResult.seed !== undefined) {
-        currentGenerationSettings = {
-          ...currentGenerationSettings,
-          seed: prepareResult.seed,
-        };
-      }
-      if (prepareResult.maxRetries !== undefined) {
-        currentGenerationSettings = {
-          ...currentGenerationSettings,
-          maxRetries: prepareResult.maxRetries,
-        };
-      }
-      if (prepareResult.headers !== undefined) {
-        currentGenerationSettings = {
-          ...currentGenerationSettings,
-          headers: prepareResult.headers,
-        };
-      }
-      if (prepareResult.providerOptions !== undefined) {
-        currentGenerationSettings = {
-          ...currentGenerationSettings,
-          providerOptions: prepareResult.providerOptions,
-        };
-      }
-      if (prepareResult.toolChoice !== undefined) {
-        currentToolChoice = prepareResult.toolChoice;
-      }
-    }
-
     if (onStepStart) {
       await onStepStart({
         stepNumber,
@@ -237,22 +137,84 @@ export async function* streamTextIterator({
     }
 
     try {
-      // Filter tools if activeTools is specified
-      const effectiveTools =
-        currentActiveTools && currentActiveTools.length > 0
-          ? (filterActiveTools({
-              tools,
-              activeTools: currentActiveTools,
-            }) ?? tools)
-          : tools;
+      let stepResult: DoStreamStepResult;
 
-      // Serialize tools before crossing the step boundary — zod schemas
-      // contain functions that can't be serialized by the workflow runtime.
-      // Tools are reconstructed with Ajv validation inside doStreamStep.
-      const serializedTools = serializeToolSet(effectiveTools);
+      if (useToolsResolver) {
+        stepResult = await doStreamStep(
+          conversationPrompt,
+          currentModel,
+          writable,
+          undefined, // No serialized tools - using resolver
+          {
+            ...currentGenerationSettings,
+            toolChoice: currentToolChoice,
+            includeRawChunks,
+            telemetry,
+            repairToolCall,
+            responseFormat,
+            // Pass tools resolver and callbacks to run inside the step
+            toolsResolver,
+            prepareStep,
+            onStepFinish,
+            onToolExecutionStart,
+            onToolExecutionEnd,
+            stepNumber,
+            steps: [...steps],
+            experimentalContext: currentContext,
+            activeTools: currentActiveTools,
+          },
+        );
 
-      const { toolCalls, finish, step, providerExecutedToolResults } =
-        await doStreamStep(
+        if (stepResult.updatedContext !== undefined) {
+          currentContext = stepResult.updatedContext;
+        }
+        if (stepResult.updatedModel !== undefined) {
+          currentModel = stepResult.updatedModel;
+        }
+        if (stepResult.updatedActiveTools !== undefined) {
+          currentActiveTools = stepResult.updatedActiveTools;
+        }
+      } else {
+        if (prepareStep) {
+          const prepareResult = await prepareStep({
+            model: currentModel,
+            stepNumber,
+            steps,
+            messages: conversationPrompt,
+            experimental_context: currentContext,
+          });
+
+          const applied = applyPrepareStepResult(
+            prepareResult,
+            conversationPrompt,
+          );
+
+          if (applied.model) currentModel = applied.model;
+          if (applied.messages) conversationPrompt = applied.messages;
+          if (applied.context !== undefined) currentContext = applied.context;
+          if (applied.activeTools) currentActiveTools = applied.activeTools;
+          if (applied.toolChoice) currentToolChoice = applied.toolChoice;
+          if (Object.keys(applied.generationSettings).length > 0) {
+            currentGenerationSettings = {
+              ...currentGenerationSettings,
+              ...applied.generationSettings,
+            };
+          }
+        }
+
+        const effectiveTools =
+          currentActiveTools && currentActiveTools.length > 0
+            ? (filterActiveTools({
+                tools: tools ?? {},
+                activeTools: currentActiveTools,
+              }) ??
+              tools ??
+              {})
+            : (tools ?? {});
+
+        const serializedTools = serializeToolSet(effectiveTools);
+
+        stepResult = await doStreamStep(
           conversationPrompt,
           currentModel,
           writable,
@@ -264,8 +226,20 @@ export async function* streamTextIterator({
             telemetry,
             repairToolCall,
             responseFormat,
+            stepNumber,
+            steps: [...steps],
+            experimentalContext: currentContext,
           },
         );
+      }
+
+      const {
+        toolCalls,
+        finish,
+        step,
+        providerExecutedToolResults,
+        toolResults,
+      } = stepResult;
 
       _isFirstIteration = false;
       stepNumber++;
@@ -278,11 +252,6 @@ export async function* streamTextIterator({
       if (finishReason === 'tool-calls') {
         lastStepWasToolCalls = true;
 
-        // Add assistant message with tool calls to the conversation
-        // Note: providerMetadata from the tool call is mapped to providerOptions
-        // in the prompt format, following the AI SDK convention. This is critical
-        // for providers like Gemini that require thoughtSignature to be preserved
-        // across multi-turn tool calls. Some fields are sanitized before mapping.
         conversationPrompt.push({
           role: 'assistant',
           content: toolCalls.map(toolCall => {
@@ -301,21 +270,25 @@ export async function* streamTextIterator({
           }) as typeof toolCalls,
         });
 
-        // Yield the tool calls along with the current conversation messages
-        // This allows executeTool to pass the conversation context to tool execute functions
-        // Also include provider-executed tool results so they can be used instead of local execution
-        const toolResults = yield {
-          toolCalls,
-          messages: conversationPrompt,
-          step,
-          context: currentContext,
-          providerExecutedToolResults,
-        };
+        if (useToolsResolver && toolResults && toolResults.length > 0) {
+          conversationPrompt.push({
+            role: 'tool',
+            content: toolResults,
+          });
+        } else {
+          const externalToolResults = yield {
+            toolCalls,
+            messages: conversationPrompt,
+            step,
+            context: currentContext,
+            providerExecutedToolResults,
+          };
 
-        conversationPrompt.push({
-          role: 'tool',
-          content: toolResults,
-        });
+          conversationPrompt.push({
+            role: 'tool',
+            content: externalToolResults,
+          });
+        }
 
         if (stopConditions) {
           const stopConditionList = Array.isArray(stopConditions)
@@ -326,9 +299,8 @@ export async function* streamTextIterator({
           }
         }
       } else if (finishReason === 'stop') {
-        // Add assistant message with text content to the conversation
         const textContent = step.content.filter(
-          item => item.type === 'text',
+          (item: { type: string }) => item.type === 'text',
         ) as Array<{ type: 'text'; text: string }>;
 
         if (textContent.length > 0) {
@@ -340,22 +312,16 @@ export async function* streamTextIterator({
 
         done = true;
       } else if (finishReason === 'length') {
-        // Model hit max tokens - stop but don't throw
         done = true;
       } else if (finishReason === 'content-filter') {
-        // Content filter triggered - stop but don't throw
         done = true;
       } else if (finishReason === 'error') {
-        // Model error - stop but don't throw
         done = true;
       } else if (finishReason === 'other') {
-        // Other reason - stop but don't throw
         done = true;
       } else if (finishReason === 'unknown') {
-        // Unknown reason - stop but don't throw
         done = true;
       } else if (!finishReason) {
-        // No finish reason - this might happen on incomplete streams
         done = true;
       } else {
         throw new Error(
@@ -363,7 +329,7 @@ export async function* streamTextIterator({
         );
       }
 
-      if (onStepFinish) {
+      if (!useToolsResolver && onStepFinish) {
         await onStepFinish(step);
       }
     } catch (error) {
@@ -374,7 +340,6 @@ export async function* streamTextIterator({
     }
   }
 
-  // Yield the final step if it wasn't already yielded (tool-calls steps are yielded inside the loop)
   if (lastStep && !lastStepWasToolCalls) {
     yield {
       toolCalls: [],

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -13,10 +13,9 @@ import {
   type ToolChoice,
   type ToolSet,
 } from 'ai';
-import type {
-  DoStreamStepResult} from './do-stream-step.js';
 import {
   doStreamStep,
+  type DoStreamStepResult,
   type ModelStopCondition,
   type ParsedToolCall,
   type ProviderExecutedToolResult,

--- a/packages/workflow/src/test/agent-e2e-workflows.ts
+++ b/packages/workflow/src/test/agent-e2e-workflows.ts
@@ -505,3 +505,153 @@ export async function agentToolInputSchemaE2e(a: number, b: number) {
     lastStepText: result.steps[result.steps.length - 1]?.text,
   };
 }
+
+// ============================================================================
+// toolsResolver pattern tests
+// ============================================================================
+
+function buildTools() {
+  return {
+    addNumbers: tool({
+      description: 'Add two numbers',
+      inputSchema: z.object({ a: z.number(), b: z.number() }),
+      execute: async (input: { a: number; b: number }) => input.a + input.b,
+    }),
+  };
+}
+
+export async function agentToolsResolverE2e(a: number, b: number) {
+  'use workflow';
+  const agent = new WorkflowAgent({
+    model: mockSequenceModel([
+      {
+        type: 'tool-call',
+        toolName: 'addNumbers',
+        input: JSON.stringify({ a, b }),
+      },
+      { type: 'text', text: `The sum is ${a + b}` },
+    ]),
+    tools: () => buildTools(),
+    instructions: 'You are a calculator assistant.',
+  });
+  const result = await agent.stream({
+    messages: [{ role: 'user', content: `Add ${a} and ${b}` }],
+    writable: getWritable(),
+  });
+  return {
+    stepCount: result.steps.length,
+    toolResults: result.toolResults,
+    lastStepText: result.steps[result.steps.length - 1]?.text,
+  };
+}
+
+export async function agentToolsResolverPrepareStepE2e() {
+  'use workflow';
+  const prepareStepCalls: number[] = [];
+
+  const agent = new WorkflowAgent({
+    model: mockSequenceModel([
+      {
+        type: 'tool-call',
+        toolName: 'echoStep',
+        input: JSON.stringify({ step: 1 }),
+      },
+      { type: 'text', text: 'Done' },
+    ]),
+    tools: () => ({
+      echoStep: tool({
+        description: 'Echo the step',
+        inputSchema: z.object({ step: z.number() }),
+        execute: async (input: { step: number }) => `step-${input.step}`,
+      }),
+    }),
+    prepareStep: ({ stepNumber }) => {
+      prepareStepCalls.push(stepNumber);
+      return {};
+    },
+  });
+  const result = await agent.stream({
+    messages: [{ role: 'user', content: 'Run a step' }],
+    writable: getWritable(),
+  });
+  return {
+    stepCount: result.steps.length,
+    prepareStepCalls,
+    lastStepText: result.steps[result.steps.length - 1]?.text,
+  };
+}
+
+export async function agentToolsResolverOnStepFinishE2e() {
+  'use workflow';
+  const stepFinishCalls: number[] = [];
+
+  const agent = new WorkflowAgent({
+    model: mockSequenceModel([
+      {
+        type: 'tool-call',
+        toolName: 'echoStep',
+        input: JSON.stringify({ step: 1 }),
+      },
+      { type: 'text', text: 'Done' },
+    ]),
+    tools: () => ({
+      echoStep: tool({
+        description: 'Echo the step',
+        inputSchema: z.object({ step: z.number() }),
+        execute: async (input: { step: number }) => `step-${input.step}`,
+      }),
+    }),
+    onStepFinish: step => {
+      stepFinishCalls.push(step.stepNumber);
+    },
+  });
+  const result = await agent.stream({
+    messages: [{ role: 'user', content: 'Run a step' }],
+    writable: getWritable(),
+  });
+  return {
+    stepCount: result.steps.length,
+    stepFinishCalls,
+    lastStepText: result.steps[result.steps.length - 1]?.text,
+  };
+}
+
+export async function agentToolsResolverToolExecutionCallbacksE2e() {
+  'use workflow';
+  const toolExecutionStarts: string[] = [];
+  const toolExecutionEnds: Array<{ name: string; success: boolean }> = [];
+
+  const agent = new WorkflowAgent({
+    model: mockSequenceModel([
+      {
+        type: 'tool-call',
+        toolName: 'addNumbers',
+        input: JSON.stringify({ a: 3, b: 4 }),
+      },
+      { type: 'text', text: 'Done' },
+    ]),
+    tools: () => ({
+      addNumbers: tool({
+        description: 'Add two numbers',
+        inputSchema: z.object({ a: z.number(), b: z.number() }),
+        execute: async (input: { a: number; b: number }) => input.a + input.b,
+      }),
+    }),
+    experimental_onToolExecutionStart: ({ toolCall }) => {
+      toolExecutionStarts.push(toolCall.toolName);
+    },
+    experimental_onToolExecutionEnd: ({ toolCall, success }) => {
+      toolExecutionEnds.push({ name: toolCall.toolName, success });
+    },
+  });
+  const result = await agent.stream({
+    messages: [{ role: 'user', content: 'Add 3 and 4' }],
+    writable: getWritable(),
+  });
+  return {
+    stepCount: result.steps.length,
+    toolExecutionStarts,
+    toolExecutionEnds,
+    lastStepText: result.steps[result.steps.length - 1]?.text,
+  };
+}

--- a/packages/workflow/src/workflow-agent-e2e.integration.test.ts
+++ b/packages/workflow/src/workflow-agent-e2e.integration.test.ts
@@ -26,6 +26,10 @@ import {
   agentToolApprovalE2e,
   agentToolCallE2e,
   agentToolInputSchemaE2e,
+  agentToolsResolverE2e,
+  agentToolsResolverPrepareStepE2e,
+  agentToolsResolverOnStepFinishE2e,
+  agentToolsResolverToolExecutionCallbacksE2e,
 } from './test/agent-e2e-workflows.js';
 
 describe('WorkflowAgent integration', { timeout: 120_000 }, () => {
@@ -222,6 +226,46 @@ describe('WorkflowAgent integration', { timeout: 120_000 }, () => {
       // with toolCallsCount=1 and toolResultsCount=0 (awaiting approval).
       // Currently needsApproval is ignored, so the tool executes immediately.
       expect(rv.stepCount).toBe(2);
+    });
+  });
+
+  // ==========================================================================
+  // toolsResolver pattern tests
+  // ==========================================================================
+
+  describe('toolsResolver pattern', () => {
+    it('resolves tools from factory function', async () => {
+      const run = await start(agentToolsResolverE2e, [3, 7]);
+      const rv = await run.returnValue;
+      expect(rv).toMatchObject({ stepCount: 2 });
+      expect(rv.lastStepText).toBe('The sum is 10');
+    });
+
+    it('prepareStep callback works with toolsResolver', async () => {
+      const run = await start(agentToolsResolverPrepareStepE2e, []);
+      const rv = await run.returnValue;
+      expect(rv.stepCount).toBe(2);
+      expect(rv.prepareStepCalls).toEqual([0, 1]);
+      expect(rv.lastStepText).toBe('Done');
+    });
+
+    it('onStepFinish callback works with toolsResolver', async () => {
+      const run = await start(agentToolsResolverOnStepFinishE2e, []);
+      const rv = await run.returnValue;
+      expect(rv.stepCount).toBe(2);
+      expect(rv.stepFinishCalls).toEqual([0, 1]);
+      expect(rv.lastStepText).toBe('Done');
+    });
+
+    it('tool execution callbacks fire with toolsResolver', async () => {
+      const run = await start(agentToolsResolverToolExecutionCallbacksE2e, []);
+      const rv = await run.returnValue;
+      expect(rv.stepCount).toBe(2);
+      expect(rv.toolExecutionStarts).toEqual(['addNumbers']);
+      expect(rv.toolExecutionEnds).toEqual([
+        { name: 'addNumbers', success: true },
+      ]);
+      expect(rv.lastStepText).toBe('Done');
     });
   });
 });

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -1752,7 +1752,7 @@ describe('WorkflowAgent', () => {
       // Verify only active tools are passed (get the most recent call)
       const calls = vi.mocked(streamTextIterator).mock.calls;
       const lastCall = calls[calls.length - 1][0];
-      expect(Object.keys(lastCall.tools).sort()).toEqual(['tool1', 'tool3']);
+      expect(Object.keys(lastCall.tools!).sort()).toEqual(['tool1', 'tool3']);
     });
   });
 
@@ -1870,7 +1870,7 @@ describe('WorkflowAgent', () => {
 
       const calls = vi.mocked(streamTextIterator).mock.calls;
       const lastCall = calls[calls.length - 1][0];
-      expect(Object.keys(lastCall.tools)).toEqual(['tool1']);
+      expect(Object.keys(lastCall.tools!)).toEqual(['tool1']);
     });
 
     it('should use constructor experimental_repairToolCall when not specified in stream()', async () => {

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -368,6 +368,15 @@ export type PrepareCallCallback<TTools extends ToolSet = ToolSet> = (
 ) => PrepareCallResult<TTools> | Promise<PrepareCallResult<TTools>>;
 
 /**
+ * Tools can be provided as a static ToolSet or as a factory function.
+ * Factory functions are resolved inside the workflow step, allowing
+ * closures and Node.js imports that would otherwise fail serialization.
+ */
+export type ToolsInput<TTools extends ToolSet = ToolSet> =
+  | TTools
+  | (() => TTools | Promise<TTools>);
+
+/**
  * Configuration options for creating a {@link WorkflowAgent} instance.
  */
 export interface WorkflowAgentOptions<
@@ -387,11 +396,24 @@ export interface WorkflowAgentOptions<
   model: LanguageModel;
 
   /**
-   * A set of tools available to the agent.
+   * A set of tools available to the agent, or a factory function that returns tools.
+   *
+   * Factory functions are resolved inside the workflow step, allowing closures
+   * and Node.js imports that would otherwise fail the serialization boundary.
+   *
    * Tools can be implemented as workflow steps for automatic retries and persistence,
    * or as regular workflow-level logic using core library features like sleep() and Hooks.
+   *
+   * @example
+   * ```typescript
+   * // Static tools
+   * tools: { myTool: tool({ ... }) }
+   *
+   * // Factory function (resolved inside step - closures work)
+   * tools: () => buildTools(db)
+   * ```
    */
-  tools?: TTools;
+  tools?: ToolsInput<TTools>;
 
   /**
    * Agent instructions. Can be a string, a SystemModelMessage, or an array of SystemModelMessages.
@@ -1008,10 +1030,16 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
   public readonly id: string | undefined;
 
   private model: LanguageModel;
+  private toolsInput: ToolsInput<TBaseTools>;
   /**
-   * The tool set configured for this agent.
+   * @deprecated Access tools via the factory pattern for workflow compatibility.
    */
-  public readonly tools: TBaseTools;
+  public get tools(): TBaseTools {
+    if (typeof this.toolsInput === 'function') {
+      return {} as TBaseTools;
+    }
+    return this.toolsInput;
+  }
   private instructions?:
     | string
     | SystemModelMessage
@@ -1039,7 +1067,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
   constructor(options: WorkflowAgentOptions<TBaseTools>) {
     this.id = options.id;
     this.model = options.model;
-    this.tools = (options.tools ?? {}) as TBaseTools;
+    this.toolsInput = (options.tools ?? {}) as ToolsInput<TBaseTools>;
     // `instructions` takes precedence over deprecated `system`
     this.instructions = options.instructions ?? options.system;
     this.toolChoice = options.toolChoice;
@@ -1373,15 +1401,20 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
     // Merge telemetry settings
     const effectiveTelemetry = effectiveTelemetryFromPrepare;
 
+    // Determine if using new toolsResolver pattern (factory function) or legacy static tools
+    const useToolsResolver = typeof this.toolsInput === 'function';
+
     // Filter tools if activeTools is specified (stream-level overrides constructor default)
     const effectiveActiveTools = options.activeTools ?? this.activeTools;
-    const effectiveTools =
-      effectiveActiveTools && effectiveActiveTools.length > 0
+
+    const effectiveTools = !useToolsResolver
+      ? effectiveActiveTools && effectiveActiveTools.length > 0
         ? (filterActiveTools({
             tools: this.tools,
             activeTools: effectiveActiveTools,
           }) ?? this.tools)
-        : this.tools;
+        : this.tools
+      : ({} as TBaseTools); // Empty for new pattern - tools resolved in step
 
     // Initialize context
     let experimentalContext = effectiveExperimentalContext;
@@ -1400,7 +1433,6 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       });
     }
 
-    // Helper to wrap executeTool with onToolExecutionStart/onToolExecutionEnd callbacks
     const executeToolWithCallbacks = async (
       toolCall: { toolCallId: string; toolName: string; input: unknown },
       tools: ToolSet,
@@ -1487,13 +1519,16 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
 
     const iterator = streamTextIterator({
       model: effectiveModel,
-      tools: effectiveTools as ToolSet,
+      ...(useToolsResolver
+        ? { toolsResolver: this.toolsInput as ToolsInput<ToolSet> }
+        : { tools: effectiveTools as ToolSet }),
       writable: options.writable,
       prompt: modelPrompt,
       stopConditions: options.stopWhen ?? this.stopWhen,
-
       onStepFinish: mergedOnStepFinish,
       onStepStart: mergedOnStepStart,
+      onToolExecutionStart: mergedOnToolExecutionStart,
+      onToolExecutionEnd: mergedOnToolExecutionEnd,
       onError: options.onError,
       prepareStep:
         options.prepareStep ??
@@ -1508,6 +1543,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
         | ToolCallRepairFunction<ToolSet>
         | undefined,
       responseFormat: await (options.output ?? this.output)?.responseFormat,
+      activeTools: effectiveActiveTools as string[] | undefined,
     });
 
     // Track the final conversation messages from the iterator


### PR DESCRIPTION
Adds support for providing tools as a factory function to `WorkflowAgent`:
```ts
const agent = new WorkflowAgent({
  model: "anthropic/claude-opus-4.5"
  tools: () => ({
    queryDatabase: tool({
      description: 'Query the database',
      inputSchema: z.object({ query: z.string() }),
      execute: async (input) => {
        'use step';
        return db.query(input.query); // Node.js imports work
      },
    }),
  }),
  prepareStep: ({ stepNumber }) => {
    // Runs inside step - full Node.js access, no serialization issues
    return { temperature: stepNumber === 0 ? 0.7 : 0.3 };
  },
  onStepFinish: (step) => {
    // Also runs inside step
    console.log(`Step ${step.stepNumber} finished`);
  },
});
```