### PR TITLE
test(openai-compatible): fix "to to" typo in test name

### DIFF
--- a/packages/openai-compatible/src/openai-compatible-provider.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.test.ts
@@ -275,7 +275,7 @@ describe('OpenAICompatibleProvider', () => {
   });
 
   describe('supportsStructuredOutputs setting', () => {
-    it('should pass supportsStructuredOutputs to to .chatModel() and .languageModel() only', () => {
+    it('should pass supportsStructuredOutputs to .chatModel() and .languageModel() only', () => {
       const options = {
         baseURL: 'https://api.example.com',
         name: 'test-provider',


### PR DESCRIPTION
One-character fix in `packages/openai-compatible/src/openai-compatible-provider.test.ts`.

The test description has a stray duplicated `to`:

> 'should pass supportsStructuredOutputs **to to** .chatModel() and .languageModel() only'

Reads cleanly as just "to .chatModel()". No behavioral change; the test still runs identically.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>