### PR TITLE
fix(ai): preserve allowSystemInMessages across streamText retries

### DIFF
--- a/.changeset/four-pants-repeat.md
+++ b/.changeset/four-pants-repeat.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): preserve `allowSystemInMessages` across `streamText` retries

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -2211,6 +2211,69 @@ describe('streamText', () => {
   });
 
   describe('retries', () => {
+    it('should preserve allowSystemInMessages when retrying after a 500 error', async () => {
+      const doStream = vi
+        .fn<LanguageModelV4['doStream']>()
+        .mockImplementationOnce(async () => {
+          throw new APICallError({
+            message: 'Internal Server Error',
+            url: 'https://api.example.com/v1/chat',
+            requestBodyValues: { prompt: 'test-input' },
+            statusCode: 500,
+            responseHeaders: {
+              'retry-after-ms': '1',
+            },
+          });
+        })
+        .mockImplementationOnce(async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'hello' },
+            { type: 'text-delta', id: '1', delta: ' ' },
+            { type: 'text-delta', id: '1', delta: 'world' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+            },
+          ]),
+        }));
+
+      const model = new MockLanguageModelV4({ doStream });
+
+      const result = streamText({
+        model,
+        allowSystemInMessages: true,
+        messages: [
+          { role: 'system', content: 'INSTRUCTIONS' },
+          { role: 'user', content: 'test-input' },
+        ],
+      });
+
+      const textStreamPromise = convertAsyncIterableToArray(result.textStream);
+
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(await textStreamPromise).toStrictEqual(['hello', ' ', 'world']);
+      expect(doStream).toHaveBeenCalledTimes(2);
+      expect(model.doStreamCalls[0].prompt).toEqual([
+        {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+          providerOptions: undefined,
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'test-input' }],
+          providerOptions: undefined,
+        },
+      ]);
+      expect(model.doStreamCalls[1].prompt).toEqual(
+        model.doStreamCalls[0].prompt,
+      );
+    });
+
     it('should retry after a 500 error and stream the successful response', async () => {
       const doStream = vi
         .fn<LanguageModelV4['doStream']>()

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1551,6 +1551,7 @@ class DefaultStreamTextResult<
               toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
               system: stepSystem,
               messages: stepMessages,
+              allowSystemInMessages,
               repairToolCall,
               abortSignal,
               headers,


### PR DESCRIPTION
## Background

Using the latest beta version of the `ai` SDK, `streamText` is throwing `Invalid prompt: System messages are not allowed in the prompt or messages fields. Use the system option instead.` even when  `allowSystemInMessages: true` is passed to `streamText`. It looks like it's happening only when retrying errors.

## Summary

This PR makes sure that `allowSystemInMessages` is passed during retries.

## Manual Verification

To be honest, I haven't tested this change manually yet as it's quite long to link the SDK to my project. But the change is minor and covered by tests.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
