### PR TITLE
fix(ai): remove ExtractLiteralUnion export

### DIFF
--- a/.changeset/fuzzy-pianos-explain.md
+++ b/.changeset/fuzzy-pianos-explain.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): remove ExtractLiteralUnion export

--- a/packages/ai/src/util/index.ts
+++ b/packages/ai/src/util/index.ts
@@ -4,7 +4,6 @@ export { cosineSimilarity } from './cosine-similarity';
 export { createDownload } from './download/create-download';
 export { getTextFromDataUrl } from './data-url';
 export type { DeepPartial } from './deep-partial';
-export type { ExtractLiteralUnion } from './extract-literal-union';
 export type { DownloadFunction as Experimental_DownloadFunction } from './download/download-function';
 export { type ErrorHandler } from './error-handler';
 export { isDeepEqualData } from './is-deep-equal-data';


### PR DESCRIPTION
## Background

`ExtractLiteralUnion` was exported in #14811 by mistake.

## Summary

Remove `ExtractLiteralUnion` export.