### PR TITLE
v5: fix(ai): warn about system messages in messages or prompt

### DIFF
--- a/.changeset/yellow-buckets-peel.md
+++ b/.changeset/yellow-buckets-peel.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): add allowSystemInMessages option and warn by default when system messages are found in prompt or messages

--- a/content/docs/02-foundations/03-prompts.mdx
+++ b/content/docs/02-foundations/03-prompts.mdx
@@ -45,6 +45,15 @@ const result = await generateText({
 System prompts are the initial set of instructions given to models that help guide and constrain the models' behaviors and responses.
 You can set system prompts using the `system` property.
 System prompts work with both the `prompt` and the `messages` properties.
+System messages in `prompt` or `messages` are allowed by default with a warning; use the `system` property for system instructions, set `allowSystemInMessages: true` when you need to send existing message histories that contain system messages, or set `allowSystemInMessages: false` to reject them.
+
+<Note type="warning">
+  System messages in `prompt` or `messages` can create a prompt injection
+  attack risk, where users can override or set the system prompt by injecting
+  system messages. Ideally, provide system instructions through the `system`
+  option instead. Set `allowSystemInMessages: true` to suppress the warning, or
+  `allowSystemInMessages: false` to throw an error.
+</Note>
 
 ```ts highlight="3-6"
 const result = await generateText({
@@ -58,11 +67,6 @@ const result = await generateText({
     `Please suggest the best tourist activities for me to do.`,
 });
 ```
-
-<Note>
-  When you use a message prompt, you can also use system messages instead of a
-  system prompt.
-</Note>
 
 ## Message Prompts
 
@@ -118,10 +122,9 @@ const { text } = await generateText({
 For granular control over applying provider options at the message level, you can pass `providerOptions` to the message object:
 
 ```ts
-import { ModelMessage } from 'ai';
-
-const messages: ModelMessage[] = [
-  {
+const result = await generateText({
+  model: __MODEL__,
+  system: {
     role: 'system',
     content: 'Cached system message',
     providerOptions: {
@@ -129,7 +132,8 @@ const messages: ModelMessage[] = [
       anthropic: { cacheControl: { type: 'ephemeral' } },
     },
   },
-];
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
 ```
 
 #### Message Part Level

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -302,6 +302,13 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'allowSystemInMessages',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning because they can create a prompt injection attack risk. Ideally, use the `system` option instead. Set to `true` to suppress the warning, or `false` to reject system messages in `prompt` or `messages`.',
+    },
+    {
       name: 'tools',
       type: 'ToolSet',
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -303,6 +303,13 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'allowSystemInMessages',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning because they can create a prompt injection attack risk. Ideally, use the `system` option instead. Set to `true` to suppress the warning, or `false` to reject system messages in `prompt` or `messages`.',
+    },
+    {
       name: 'tools',
       type: 'ToolSet',
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
@@ -26,8 +26,11 @@ type SystemModelMessage = {
 You can access the Zod schema for `SystemModelMessage` with the `systemModelMessageSchema` export.
 
 <Note>
-  Using the "system" property instead of a system message is recommended to
-  enhance resilience against prompt injection attacks.
+  Use the top-level `system` property instead of a system message for system
+  instructions. AI SDK functions allow system messages in `prompt` or
+  `messages` by default with a warning. Set `allowSystemInMessages` to `true`
+  to suppress the warning, or `false` to reject them. System messages in
+  `prompt` or `messages` can create a prompt injection attack risk.
 </Note>
 
 ### `UserModelMessage`

--- a/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
+++ b/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
@@ -256,6 +256,13 @@ To see `streamUI` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'allowSystemInMessages',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'Whether system messages are allowed in the `prompt` or `messages` fields. When unset, system messages are allowed with a warning because they can create a prompt injection attack risk. Ideally, use the `system` option instead. Set to `true` to suppress the warning, or `false` to reject system messages in `prompt` or `messages`.',
+    },
+    {
       name: 'maxOutputTokens',
       type: 'number',
       isOptional: true,

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -196,6 +196,7 @@ via tool or schema description.
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     maxRetries: maxRetriesArg,
     abortSignal,
     headers,
@@ -293,6 +294,7 @@ via tool or schema description.
           system,
           prompt,
           messages,
+          allowSystemInMessages,
         } as Prompt);
 
         const promptMessages = await convertToLanguageModelPrompt({

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -279,6 +279,7 @@ Callback that is called when the LLM response and the final object validation ar
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     maxRetries,
     abortSignal,
     headers,
@@ -332,6 +333,7 @@ Callback that is called when the LLM response and the final object validation ar
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     schemaName,
     schemaDescription,
     providerOptions,
@@ -381,6 +383,7 @@ class DefaultStreamObjectResult<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     schemaName,
     schemaDescription,
     providerOptions,
@@ -402,6 +405,7 @@ class DefaultStreamObjectResult<
     system: Prompt['system'];
     prompt: Prompt['prompt'];
     messages: Prompt['messages'];
+    allowSystemInMessages: Prompt['allowSystemInMessages'];
     schemaName: string | undefined;
     schemaDescription: string | undefined;
     providerOptions: ProviderOptions | undefined;
@@ -480,6 +484,7 @@ class DefaultStreamObjectResult<
           system,
           prompt,
           messages,
+          allowSystemInMessages,
         } as Prompt);
 
         const callOptions = {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -129,6 +129,7 @@ export async function generateText<
   system,
   prompt,
   messages,
+  allowSystemInMessages,
   maxRetries: maxRetriesArg,
   abortSignal,
   headers,
@@ -273,6 +274,7 @@ A function that attempts to repair a tool call that failed to parse.
     system,
     prompt,
     messages,
+    allowSystemInMessages,
   } as Prompt);
 
   const tracer = getTracer(telemetry);

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -234,6 +234,7 @@ export function streamText<
   system,
   prompt,
   messages,
+  allowSystemInMessages,
   maxRetries,
   abortSignal,
   headers,
@@ -415,6 +416,7 @@ Internal. For test use only. May change without notice.
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     tools,
     toolChoice,
     transforms: asArray(transform),
@@ -586,6 +588,7 @@ class DefaultStreamTextResult<
     system,
     prompt,
     messages,
+    allowSystemInMessages,
     tools,
     toolChoice,
     transforms,
@@ -616,6 +619,7 @@ class DefaultStreamTextResult<
     system: Prompt['system'];
     prompt: Prompt['prompt'];
     messages: Prompt['messages'];
+    allowSystemInMessages: Prompt['allowSystemInMessages'];
     tools: TOOLS | undefined;
     toolChoice: ToolChoice<TOOLS> | undefined;
     transforms: Array<StreamTextTransform<TOOLS>>;
@@ -1074,6 +1078,7 @@ class DefaultStreamTextResult<
             system,
             prompt,
             messages,
+            allowSystemInMessages,
           } as Prompt);
 
           const stepInputMessages = [

--- a/packages/ai/src/prompt/prompt.ts
+++ b/packages/ai/src/prompt/prompt.ts
@@ -9,6 +9,16 @@ export type Prompt = {
 System message to include in the prompt. Can be used with `prompt` or `messages`.
    */
   system?: string;
+
+  /**
+   * Whether system messages are allowed in the `prompt` or `messages` fields.
+   *
+   * When disabled, system messages must be provided through the `system`
+   * option. When unset, system messages are allowed with a warning.
+   *
+   * @default undefined
+   */
+  allowSystemInMessages?: boolean;
 } & (
   | {
       /**

--- a/packages/ai/src/prompt/standardize-prompt.test.ts
+++ b/packages/ai/src/prompt/standardize-prompt.test.ts
@@ -1,11 +1,176 @@
 import { InvalidPromptError } from '@ai-sdk/provider';
 import { standardizePrompt } from './standardize-prompt';
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe('message prompt', () => {
-  it('should throw InvalidPromptError when system message has parts', async () => {
+describe('standardizePrompt', () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should warn when messages contain a system message by default', async () => {
+    const result = await standardizePrompt({
+      messages: [
+        {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+        },
+      ],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+        ],
+        "system": undefined,
+      }
+    `);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'AI SDK Warning: System messages in the prompt or messages fields ' +
+        'can be a security risk because they may enable prompt injection ' +
+        'attacks. Use the system option instead when possible. Set ' +
+        'allowSystemInMessages to true to suppress this warning, or false ' +
+        'to throw an error.',
+    );
+  });
+
+  it('should warn when prompt messages contain a system message by default', async () => {
+    const result = await standardizePrompt({
+      prompt: [
+        {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+        },
+      ],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+        ],
+        "system": undefined,
+      }
+    `);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'AI SDK Warning: System messages in the prompt or messages fields ' +
+        'can be a security risk because they may enable prompt injection ' +
+        'attacks. Use the system option instead when possible. Set ' +
+        'allowSystemInMessages to true to suppress this warning, or false ' +
+        'to throw an error.',
+    );
+  });
+
+  it('should throw InvalidPromptError when messages contain a system message and allowSystemInMessages is false', async () => {
     await expect(async () => {
       await standardizePrompt({
+        allowSystemInMessages: false,
+        messages: [
+          {
+            role: 'system',
+            content: 'INSTRUCTIONS',
+          },
+        ],
+      });
+    }).rejects.toThrow(InvalidPromptError);
+  });
+
+  it('should throw InvalidPromptError when prompt messages contain a system message and allowSystemInMessages is false', async () => {
+    await expect(async () => {
+      await standardizePrompt({
+        allowSystemInMessages: false,
+        prompt: [
+          {
+            role: 'system',
+            content: 'INSTRUCTIONS',
+          },
+        ],
+      });
+    }).rejects.toThrow(InvalidPromptError);
+  });
+
+  it('should allow system messages in messages when allowSystemInMessages is true', async () => {
+    const result = await standardizePrompt({
+      allowSystemInMessages: true,
+      messages: [
+        {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+        },
+        {
+          role: 'user',
+          content: 'Hello, world!',
+        },
+      ],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+          {
+            "content": "Hello, world!",
+            "role": "user",
+          },
+        ],
+        "system": undefined,
+      }
+    `);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should allow system messages in prompt messages when allowSystemInMessages is true', async () => {
+    const result = await standardizePrompt({
+      allowSystemInMessages: true,
+      prompt: [
+        {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+        },
+        {
+          role: 'user',
+          content: 'Hello, world!',
+        },
+      ],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+          {
+            "content": "Hello, world!",
+            "role": "user",
+          },
+        ],
+        "system": undefined,
+      }
+    `);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should throw InvalidPromptError when an allowed system message has parts', async () => {
+    await expect(async () => {
+      await standardizePrompt({
+        allowSystemInMessages: true,
         messages: [
           {
             role: 'system',

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -16,17 +16,31 @@ export type StandardizedPrompt = {
   messages: ModelMessage[];
 };
 
-export async function standardizePrompt(
-  prompt: Prompt,
-): Promise<StandardizedPrompt> {
-  if (prompt.prompt == null && prompt.messages == null) {
+/**
+ * Converts a prompt input into a standardized prompt with validated model
+ * messages.
+ *
+ * @param prompt - The prompt definition to standardize.
+ * Set `allowSystemInMessages` to false to reject system messages in the
+ * `prompt` or `messages` fields. When unset, system messages are allowed with a
+ * warning. System messages in the `system` option are always allowed.
+ * @returns The standardized prompt.
+ * @throws {InvalidPromptError} When the prompt is invalid.
+ */
+export async function standardizePrompt({
+  allowSystemInMessages,
+  system,
+  prompt,
+  messages,
+}: Prompt): Promise<StandardizedPrompt> {
+  if (prompt == null && messages == null) {
     throw new InvalidPromptError({
       prompt,
       message: 'prompt or messages must be defined',
     });
   }
 
-  if (prompt.prompt != null && prompt.messages != null) {
+  if (prompt != null && messages != null) {
     throw new InvalidPromptError({
       prompt,
       message: 'prompt and messages cannot be defined at the same time',
@@ -34,22 +48,18 @@ export async function standardizePrompt(
   }
 
   // validate that system is a string
-  if (prompt.system != null && typeof prompt.system !== 'string') {
+  if (system != null && typeof system !== 'string') {
     throw new InvalidPromptError({
       prompt,
       message: 'system must be a string',
     });
   }
 
-  let messages: ModelMessage[];
-
-  if (prompt.prompt != null && typeof prompt.prompt === 'string') {
-    messages = [{ role: 'user', content: prompt.prompt }];
-  } else if (prompt.prompt != null && Array.isArray(prompt.prompt)) {
-    messages = prompt.prompt;
-  } else if (prompt.messages != null) {
-    messages = prompt.messages;
-  } else {
+  if (prompt != null && typeof prompt === 'string') {
+    messages = [{ role: 'user', content: prompt }];
+  } else if (prompt != null && Array.isArray(prompt)) {
+    messages = prompt;
+  } else if (messages == null) {
     throw new InvalidPromptError({
       prompt,
       message: 'prompt or messages must be defined',
@@ -61,6 +71,26 @@ export async function standardizePrompt(
       prompt,
       message: 'messages must not be empty',
     });
+  }
+
+  if (messages.some(message => message.role === 'system')) {
+    if (allowSystemInMessages === false) {
+      throw new InvalidPromptError({
+        prompt,
+        message:
+          'System messages are not allowed in the prompt or messages fields. Use the system option instead.',
+      });
+    }
+
+    if (allowSystemInMessages === undefined) {
+      console.warn(
+        'AI SDK Warning: System messages in the prompt or messages fields ' +
+          'can be a security risk because they may enable prompt injection ' +
+          'attacks. Use the system option instead when possible. Set ' +
+          'allowSystemInMessages to true to suppress this warning, or false ' +
+          'to throw an error.',
+      );
+    }
   }
 
   const validationResult = await safeValidateTypes({
@@ -78,8 +108,5 @@ export async function standardizePrompt(
     });
   }
 
-  return {
-    messages,
-    system: prompt.system,
-  };
+  return { messages, system };
 }

--- a/packages/rsc/src/stream-ui/stream-ui.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.tsx
@@ -96,6 +96,7 @@ export async function streamUI<
   system,
   prompt,
   messages,
+  allowSystemInMessages,
   maxRetries,
   abortSignal,
   headers,
@@ -263,6 +264,7 @@ functionality that can be fully encapsulated in the provider.
     system,
     prompt,
     messages,
+    allowSystemInMessages,
   } as Prompt);
   const result = await retry(async () =>
     model.doStream({


### PR DESCRIPTION
## Background

For historical and convenience reasons, system messages can be part of user messages or prompts, e.g. to allow interleaving regular messages and system messages.

However, this creates a prompt injection risk where the user (e.g. by modifying the messages in a web ui) can override or set the system prompt. In most cases, it should only be possible to set the system prompt via the system (or instructions) property, and users should not be able to inject system messages.

## Summary

* `allowSystemInMessages === undefined`: print warning when there are system messages in the messages or prompt options
* `allowSystemInMessages === true`: throw InvalidPromptError when there are system messages in the messages or prompt options
* `allowSystemInMessages === false`: ignore system messages in the messages or prompt options

## Related Issues

Adjusted backport of #14810 and #14752
Issue reported in #14749