### PR TITLE
fix(ai): remove experimental_customProvider

### DIFF
--- a/.changeset/moody-bananas-rest.md
+++ b/.changeset/moody-bananas-rest.md
@@ -1,0 +1,5 @@
+---
+"ai": major
+---
+
+fix(ai): remove experimental_customProvider

--- a/content/docs/07-reference/01-ai-sdk-core/42-custom-provider.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/42-custom-provider.mdx
@@ -56,7 +56,7 @@ export const myOpenAI = customProvider({
 
 ## Import
 
-<Snippet text={`import {  customProvider } from "ai"`} prompt={false} />
+<Snippet text={`import { customProvider } from "ai"`} prompt={false} />
 
 ## API Signature
 

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -41,6 +41,34 @@ If your `package.json` does not already include `"type": "module"`, add it or re
 
 ## AI SDK Core
 
+### Provider Management: Remove Deprecated `experimental_customProvider`
+
+The deprecated `experimental_customProvider` export has been removed in AI SDK
+7. Replace it with `customProvider`.
+
+```tsx filename="AI SDK 6"
+import { experimental_customProvider } from 'ai';
+
+export const myProvider = experimental_customProvider({
+  languageModels: {
+    // ...
+  },
+});
+```
+
+```tsx filename="AI SDK 7"
+import { customProvider } from 'ai';
+
+export const myProvider = customProvider({
+  languageModels: {
+    // ...
+  },
+});
+```
+
+This is only an import and symbol rename. The `customProvider` options and
+behavior are unchanged.
+
 ### Prompt Messages: System Messages in `prompt` or `messages` Are Rejected by Default
 
 AI SDK 7 rejects system messages in the `prompt` or `messages` fields by default. System instructions should usually be passed with the top-level `system` option.

--- a/packages/ai/src/registry/custom-provider.ts
+++ b/packages/ai/src/registry/custom-provider.ts
@@ -251,11 +251,6 @@ export function customProvider<
   return Object.assign(baseProvider, filesAndSkills);
 }
 
-/**
- * @deprecated Use `customProvider` instead.
- */
-export const experimental_customProvider = customProvider;
-
 type ExtractModelId<MODELS extends Record<string, unknown>> = Extract<
   keyof MODELS,
   string

--- a/packages/ai/src/registry/index.ts
+++ b/packages/ai/src/registry/index.ts
@@ -1,4 +1,4 @@
-export { customProvider, experimental_customProvider } from './custom-provider';
+export { customProvider } from './custom-provider';
 export { NoSuchProviderError } from './no-such-provider-error';
 export {
   createProviderRegistry,


### PR DESCRIPTION
## Background

`experimental_customProvider` was deprecated in AI SDK 5.

## Summary

Remove `experimental_customProvider`.

## Related Issues

Follow up from #4629