### PR TITLE
feat(example): add stateless OpenAI Shell container example

### DIFF
--- a/examples/ai-e2e-next/app/api/chat/openai-shell-container-stateless/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/openai-shell-container-stateless/route.ts
@@ -1,0 +1,135 @@
+import {
+  openai,
+  type OpenAILanguageModelResponsesOptions,
+} from '@ai-sdk/openai';
+import {
+  convertToModelMessages,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  type InferUITools,
+  streamText,
+  type ToolSet,
+  type UIMessage,
+} from 'ai';
+
+const tools = {
+  shell: openai.tools.shell({
+    environment: {
+      type: 'containerAuto',
+    },
+  }),
+} satisfies ToolSet;
+type Tools = InferUITools<typeof tools>;
+
+export type StatelessContainerBody = {
+  messages: StatelessContainerUIMessage[];
+  containerId?: string;
+};
+
+export type StatelessContainerUIMessage = UIMessage<
+  never,
+  {
+    container: {
+      containerId: string | undefined;
+    };
+  },
+  Tools
+>;
+
+export async function POST(req: Request) {
+  const { messages: prevMessages, containerId }: StatelessContainerBody =
+    await req.json();
+
+  const messages = prevMessages.map(message => {
+    const parts = message.parts.filter(part => part.type != 'tool-shell');
+    const fixedMessage: StatelessContainerUIMessage = {
+      ...message,
+      parts,
+    };
+    return fixedMessage;
+  });
+
+  console.log('containerId:', containerId ?? 'undefined');
+  const tools = {
+    shell: openai.tools.shell({
+      environment: containerId
+        ? {
+            type: 'containerReference',
+            containerId,
+          }
+        : {
+            type: 'containerAuto',
+          },
+    }),
+  } satisfies ToolSet;
+
+  const stream = createUIMessageStream<StatelessContainerUIMessage>({
+    execute: async ({ writer }) => {
+      const result = streamText({
+        model: openai('gpt-5.4-mini'),
+        messages: await convertToModelMessages(messages),
+        tools,
+        includeRawChunks: true,
+        providerOptions: {
+          openai: {
+            store: false,
+          } satisfies OpenAILanguageModelResponsesOptions,
+        },
+      });
+
+      for await (const part of result.fullStream) {
+        if (part.type === 'raw') {
+          const { rawValue } = part;
+          if (
+            typeof rawValue === 'object' &&
+            !!rawValue &&
+            'type' in rawValue &&
+            rawValue.type === 'response.created' &&
+            'response' in rawValue
+          ) {
+            const { type, response } = rawValue;
+            // console.log('rawValueResponse:', JSON.stringify(response));
+            if (
+              typeof response === 'object' &&
+              response &&
+              'tools' in response &&
+              Array.isArray(response.tools)
+            ) {
+              const { tools } = response;
+              // console.log("tools",tools)
+              const shellTool = tools.find(
+                (
+                  tool,
+                ): tool is {
+                  type: 'shell';
+                  environment: { container_id: string };
+                } =>
+                  'type' in tool &&
+                  tool.type === 'shell' &&
+                  'environment' in tool &&
+                  typeof tool.environment === 'object' &&
+                  'container_id' in tool.environment &&
+                  typeof tool.environment.container_id === 'string',
+              );
+              if (shellTool) {
+                const {
+                  environment: { container_id },
+                } = shellTool;
+
+                writer.write({
+                  type: 'data-container',
+                  data: {
+                    containerId: container_id,
+                  },
+                });
+                break;
+              }
+            }
+          }
+        }
+      }
+      writer.merge(result.toUIMessageStream({ originalMessages: messages }));
+    },
+  });
+  return createUIMessageStreamResponse({ stream });
+}

--- a/examples/ai-e2e-next/app/api/chat/openai-shell-container-stateless/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/openai-shell-container-stateless/route.ts
@@ -36,11 +36,51 @@ export type StatelessContainerUIMessage = UIMessage<
   Tools
 >;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+// OpenAI includes the shell container id in the raw `response.created` chunk.
+function extractContainerIdFromRawChunk(rawValue: unknown): string | undefined {
+  if (
+    !isRecord(rawValue) ||
+    rawValue.type !== 'response.created' ||
+    !isRecord(rawValue.response)
+  ) {
+    return undefined;
+  }
+
+  const { tools } = rawValue.response;
+  if (!Array.isArray(tools)) {
+    return undefined;
+  }
+
+  for (const tool of tools) {
+    if (
+      !isRecord(tool) ||
+      tool.type !== 'shell' ||
+      !isRecord(tool.environment)
+    ) {
+      continue;
+    }
+
+    const containerId = tool.environment.container_id;
+    if (typeof containerId === 'string') {
+      return containerId;
+    }
+  }
+
+  return undefined;
+}
+
 export async function POST(req: Request) {
   const { messages: prevMessages, containerId }: StatelessContainerBody =
     await req.json();
 
   const messages = prevMessages.map(message => {
+    // Drop previous shell tool parts because their call ids are not available in
+    // a stateless follow-up request. Keeping them can cause:
+    // "No tool call found for shell call output with call_id call_xxxx."
     const parts = message.parts.filter(part => part.type != 'tool-shell');
     const fixedMessage: StatelessContainerUIMessage = {
       ...message,
@@ -49,7 +89,6 @@ export async function POST(req: Request) {
     return fixedMessage;
   });
 
-  console.log('containerId:', containerId ?? 'undefined');
   const tools = {
     shell: openai.tools.shell({
       environment: containerId
@@ -79,52 +118,17 @@ export async function POST(req: Request) {
 
       for await (const part of result.fullStream) {
         if (part.type === 'raw') {
-          const { rawValue } = part;
-          if (
-            typeof rawValue === 'object' &&
-            !!rawValue &&
-            'type' in rawValue &&
-            rawValue.type === 'response.created' &&
-            'response' in rawValue
-          ) {
-            const { type, response } = rawValue;
-            // console.log('rawValueResponse:', JSON.stringify(response));
-            if (
-              typeof response === 'object' &&
-              response &&
-              'tools' in response &&
-              Array.isArray(response.tools)
-            ) {
-              const { tools } = response;
-              // console.log("tools",tools)
-              const shellTool = tools.find(
-                (
-                  tool,
-                ): tool is {
-                  type: 'shell';
-                  environment: { container_id: string };
-                } =>
-                  'type' in tool &&
-                  tool.type === 'shell' &&
-                  'environment' in tool &&
-                  typeof tool.environment === 'object' &&
-                  'container_id' in tool.environment &&
-                  typeof tool.environment.container_id === 'string',
-              );
-              if (shellTool) {
-                const {
-                  environment: { container_id },
-                } = shellTool;
-
-                writer.write({
-                  type: 'data-container',
-                  data: {
-                    containerId: container_id,
-                  },
-                });
-                break;
-              }
-            }
+          const containerId = extractContainerIdFromRawChunk(part.rawValue);
+          if (containerId) {
+            // Send the container id to the client so it can be reused on the
+            // next request with `containerReference`.
+            writer.write({
+              type: 'data-container',
+              data: {
+                containerId,
+              },
+            });
+            break;
           }
         }
       }

--- a/examples/ai-e2e-next/app/chat/openai-shell-container-stateless/page.tsx
+++ b/examples/ai-e2e-next/app/chat/openai-shell-container-stateless/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import ChatInput from '@/components/chat-input';
+import type {
+  StatelessContainerBody,
+  StatelessContainerUIMessage,
+} from '@/app/api/chat/openai-shell-container-stateless/route';
+import { useRef } from 'react';
+
+export default function ChatOpenAIShellContainer() {
+  const containerIdRef = useRef<string | undefined>(undefined);
+  const { status, sendMessage, messages } =
+    useChat<StatelessContainerUIMessage>({
+      transport: new DefaultChatTransport({
+        api: '/api/chat/openai-shell-container-stateless',
+        prepareSendMessagesRequest: ({ messages }) => {
+          const body = {
+            messages,
+            containerId: containerIdRef.current,
+          } satisfies StatelessContainerBody;
+          return { body };
+        },
+      }),
+      onData: ({ data, type }) => {
+        switch (type) {
+          case 'data-container': {
+            if (!data) return;
+            containerIdRef.current = data.containerId;
+            break;
+          }
+        }
+      },
+    });
+
+  return (
+    <div className="flex flex-col py-24 mx-auto w-full max-w-4xl stretch">
+      <h1 className="mb-2 text-xl font-bold text-black">
+        OpenAI Shell Tool (Container)
+      </h1>
+      <h2 className="pb-2 mb-4 border-b text-black">
+        Commands are executed server-side by OpenAI in a hosted container. No
+        approval is needed since commands run remotely on OpenAI infrastructure.
+      </h2>
+
+      {messages.map(message => (
+        <div key={message.id} className="whitespace-pre-wrap mb-4">
+          <div className="mb-2">
+            <div className="text-sm font-semibold text-black mb-1">
+              {message.role === 'user' ? 'User:' : 'Assistant:'}
+            </div>
+            <div className="space-y-4">
+              {message.parts.map((part, index) => {
+                switch (part.type) {
+                  case 'text':
+                    return (
+                      <div key={index} className="text-black">
+                        {part.text}
+                      </div>
+                    );
+                  case 'tool-shell': {
+                    const commands = part.input?.action?.commands || [];
+                    const outputs =
+                      part.state === 'output-available'
+                        ? part.output?.output || []
+                        : [];
+
+                    return (
+                      <div
+                        key={index}
+                        className="p-2 mb-2 bg-white rounded-xl border border-gray-300 shadow-lg"
+                      >
+                        <div className="px-6 py-3 bg-gray-100 rounded-t-xl border-b border-gray-300">
+                          <div className="overflow-hidden tracking-wide text-black whitespace-nowrap text-xxs font-small text-ellipsis">
+                            Shell Execution (Container)
+                          </div>
+                        </div>
+
+                        <div className="p-6 space-y-4">
+                          {commands.map((cmd, cmdIndex) => {
+                            const output = outputs[cmdIndex];
+                            const outcome = output?.outcome;
+
+                            return (
+                              <div key={cmdIndex} className="space-y-2">
+                                <div>
+                                  <div className="mb-2 text-sm font-medium text-black">
+                                    Command {cmdIndex + 1}:
+                                  </div>
+                                  <pre className="overflow-x-auto p-4 text-sm text-black whitespace-pre-wrap bg-gray-100 rounded-lg border border-gray-300">
+                                    {cmd}
+                                  </pre>
+                                </div>
+
+                                {outcome && (
+                                  <div className="space-y-2">
+                                    <div className="p-3 bg-gray-100 border border-gray-300 rounded-lg">
+                                      <div className="text-xs text-black mb-1">
+                                        {outcome.type === 'timeout'
+                                          ? 'Timeout'
+                                          : `Exit Code: ${outcome.exitCode}`}
+                                      </div>
+                                    </div>
+
+                                    {output.stdout && (
+                                      <div>
+                                        <div className="mb-2 text-sm font-medium text-black">
+                                          Output:
+                                        </div>
+                                        <div className="p-3 bg-gray-100 rounded-lg border border-gray-300">
+                                          <div className="font-mono text-sm text-black whitespace-pre-wrap">
+                                            {output.stdout}
+                                          </div>
+                                        </div>
+                                      </div>
+                                    )}
+
+                                    {output.stderr && (
+                                      <div>
+                                        <div className="mb-2 text-sm font-medium text-black">
+                                          Error:
+                                        </div>
+                                        <div className="p-3 bg-red-50 rounded-lg border border-red-300">
+                                          <div className="font-mono text-sm text-red-600 whitespace-pre-wrap">
+                                            {output.stderr}
+                                          </div>
+                                        </div>
+                                      </div>
+                                    )}
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  }
+                  case 'data-container':
+                    return (
+                      <div key={index} className="text-sm text-gray-500">
+                        container: {part.data.containerId}
+                      </div>
+                    );
+
+                  default:
+                    return null;
+                }
+              })}
+            </div>
+          </div>
+        </div>
+      ))}
+
+      <ChatInput status={status} onSubmit={text => sendMessage({ text })} />
+    </div>
+  );
+}

--- a/examples/ai-e2e-next/app/chat/openai-shell-container-stateless/page.tsx
+++ b/examples/ai-e2e-next/app/chat/openai-shell-container-stateless/page.tsx
@@ -18,6 +18,7 @@ export default function ChatOpenAIShellContainer() {
         prepareSendMessagesRequest: ({ messages }) => {
           const body = {
             messages,
+            // Reuse the OpenAI-hosted shell container across stateless requests.
             containerId: containerIdRef.current,
           } satisfies StatelessContainerBody;
           return { body };
@@ -27,6 +28,8 @@ export default function ChatOpenAIShellContainer() {
         switch (type) {
           case 'data-container': {
             if (!data) return;
+            // The server streams this id after reading it from the raw OpenAI
+            // response chunk.
             containerIdRef.current = data.containerId;
             break;
           }


### PR DESCRIPTION
## Background

OpenAI-hosted Shell containers can preserve files and workspace state across chat turns when the same container is reused.

This example demonstrates a stateless pattern for doing that without relying on stored OpenAI response state. It is useful for apps that use `store: false` and need to manage chat state and container state explicitly on the application side.

## Summary

This PR adds a stateless OpenAI Shell container example.

The example demonstrates how to:

- run the OpenAI Shell tool with `store: false`
- use `containerAuto` for the first request
- extract the resolved `container_id` from the raw `response.created` chunk
- stream the container id back to the client using a data part
- reuse the container with `containerReference` on subsequent requests
- exclude previous `tool-shell` parts from the next model input

The example keeps shell execution results available in the UI, while avoiding re-sending previous hosted shell tool results as model input in stateless follow-up requests.

## Manual Verification

Manually verified the example end-to-end by running the Next.js example app and using the new stateless OpenAI Shell container chat route.

Verification steps:

1. Opened the stateless Shell container chat page.
2. Sent an initial message that caused the model to execute shell commands.
3. Confirmed that the first request used `containerAuto`.
4. Confirmed that the server extracted the resolved container id from the raw `response.created` chunk.
5. Confirmed that the container id was streamed back to the client using a `data-container` data part.
6. Sent follow-up messages in the same chat.
7. Confirmed that subsequent requests reused the container with `containerReference`.
8. Created files in the shell container across multiple turns.
9. Ran `ls` in later turns and confirmed that files created in previous turns were still present.
10. Confirmed that previous `tool-shell` parts were excluded from the next model input.
11. Confirmed that the chat continued to work with `store: false`.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

A follow-up issue can document and investigate what happens when previous `tool-shell` parts are re-sent in a stateless follow-up request.

In local testing, removing the `tool-shell` filtering can reproduce an error like:

`No tool call found for shell call output with call_id ...`

It is not yet confirmed whether this behavior originates from AI SDK message conversion or from OpenAI Responses API validation.

## Related Issues

N/A