### PR TITLE
backport v6: fix(ai): enforce callOptionsSchema at runtime in ToolLoopAgent

### DIFF
--- a/.changeset/enforce-call-options-schema.md
+++ b/.changeset/enforce-call-options-schema.md
@@ -1,0 +1,9 @@
+---
+"ai": patch
+---
+
+fix(ai): enforce `callOptionsSchema` at runtime in `ToolLoopAgent`
+
+`ToolLoopAgentSettings.callOptionsSchema` was declared and documented as a runtime schema for `options`, but `tool-loop-agent.ts` never invoked it. Any invariant a developer encoded in the schema was silently bypassed at runtime, and unchecked `options` flowed straight into `prepareCall` and any `instructions` template that interpolated them.
+
+`ToolLoopAgent.prepareCall` now validates caller-supplied `options` against `callOptionsSchema` (when set) via `safeValidateTypes`, throwing `InvalidArgumentError` on failure before forwarding to `prepareCall` / `generateText` / `streamText`.

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -1,6 +1,7 @@
 import type { LanguageModelV3CallOptions } from '@ai-sdk/provider';
 import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import { MockLanguageModelV3 } from '../test/mock-language-model-v3';
 import { ToolLoopAgent } from './tool-loop-agent';
 
@@ -718,6 +719,88 @@ describe('ToolLoopAgent', () => {
           }
         `);
       });
+    });
+  });
+  describe('callOptionsSchema', () => {
+    it('should reject options that fail callOptionsSchema validation before invoking the model', async () => {
+      let modelCalled = false;
+      const agent = new ToolLoopAgent<{ topic: 'legal' | 'medical' }>({
+        model: new MockLanguageModelV3({
+          doGenerate: async () => {
+            modelCalled = true;
+            return {
+              content: [{ type: 'text', text: 'reply' }],
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                cachedInputTokens: undefined,
+                inputTokens: {
+                  total: 1,
+                  noCache: 1,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: {
+                  total: 1,
+                  text: 1,
+                  reasoning: undefined,
+                },
+              },
+              warnings: [],
+            };
+          },
+        }),
+        callOptionsSchema: z.object({
+          topic: z.enum(['legal', 'medical']),
+        }),
+      });
+
+      await expect(
+        agent.generate({
+          prompt: 'hi',
+          // intentionally outside the enum to exercise schema enforcement
+          options: { topic: 'evil' as 'legal' },
+        }),
+      ).rejects.toThrow(/Type validation failed for options/);
+
+      expect(modelCalled).toBe(false);
+    });
+
+    it('should pass through options that satisfy callOptionsSchema', async () => {
+      const agent = new ToolLoopAgent<{ topic: 'legal' | 'medical' }>({
+        model: new MockLanguageModelV3({
+          doGenerate: async () => {
+            return {
+              content: [{ type: 'text', text: 'reply' }],
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                cachedInputTokens: undefined,
+                inputTokens: {
+                  total: 1,
+                  noCache: 1,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: {
+                  total: 1,
+                  text: 1,
+                  reasoning: undefined,
+                },
+              },
+              warnings: [],
+            };
+          },
+        }),
+        callOptionsSchema: z.object({
+          topic: z.enum(['legal', 'medical']),
+        }),
+      });
+
+      const result = await agent.generate({
+        prompt: 'hi',
+        options: { topic: 'legal' },
+      });
+
+      expect(result.text).toBe('reply');
     });
   });
 });

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -1,4 +1,4 @@
-import type { ModelMessage } from '@ai-sdk/provider-utils';
+import { validateTypes, type ModelMessage } from '@ai-sdk/provider-utils';
 import { generateText } from '../generate-text/generate-text';
 import type { GenerateTextResult } from '../generate-text/generate-text-result';
 import type { Output } from '../generate-text/output';
@@ -67,6 +67,18 @@ export class ToolLoopAgent<
     > &
       Prompt
   > {
+    if (
+      this.settings.callOptionsSchema != null &&
+      options.options !== undefined
+    ) {
+      const validatedOptions = await validateTypes({
+        value: options.options,
+        schema: this.settings.callOptionsSchema,
+        context: { field: 'options' },
+      });
+      options = { ...options, options: validatedOptions };
+    }
+
     const { onStepFinish: _settingsOnStepFinish, ...settingsWithoutCallback } =
       this.settings;
     const baseCallArgs = {


### PR DESCRIPTION
## background

backport of #14750 from main to release-v6.0

## related issues

backport of #14750