### PR TITLE
feat(ai): create a diagnostics channel to push event data

### DIFF
--- a/.changeset/tiny-shirts-crash.md
+++ b/.changeset/tiny-shirts-crash.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): create a diagnostics channel to push event data

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -238,6 +238,33 @@ telemetry: {
 
 Errors inside integrations are caught and do not break the generation flow.
 
+### Diagnostic channel
+
+In Node.js, AI SDK telemetry lifecycle events are also published to the
+`ai.telemetry` [diagnostics channel](https://nodejs.org/api/diagnostics_channel.html).
+This lets observability providers subscribe to AI SDK telemetry events without
+requiring users to register a separate telemetry integration.
+
+```ts
+import { channel } from 'node:diagnostics_channel';
+import {
+  AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL,
+  type TelemetryDiagnosticChannelMessage,
+} from 'ai';
+
+channel(AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL).subscribe(message => {
+  const telemetryMessage = message as TelemetryDiagnosticChannelMessage;
+
+  if (telemetryMessage.type === 'onStart') {
+    // Inspect telemetryMessage.event and forward it to your provider.
+  }
+});
+```
+
+Diagnostic-channel events follow the same per-call telemetry settings as other
+telemetry integrations. Setting `telemetry: { isEnabled: false }` disables both
+registered integrations and diagnostic-channel publication for that call.
+
 ### Building a custom integration
 
 Implement the `Telemetry` interface from the `ai` package. All methods are optional — implement only the lifecycle events you care about:

--- a/examples/ai-functions/src/telemetry/diagnostic-channel/generate-text.ts
+++ b/examples/ai-functions/src/telemetry/diagnostic-channel/generate-text.ts
@@ -1,0 +1,27 @@
+import { subscribe } from 'node:diagnostics_channel';
+import {
+  AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL,
+  generateText,
+  gateway,
+  type TelemetryDiagnosticChannelMessage,
+} from 'ai';
+import { run } from '../../lib/run';
+
+subscribe(AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL, message => {
+  const telemetry = message as TelemetryDiagnosticChannelMessage;
+
+  console.log(
+    `[diagnostic-channel] ${telemetry.type}`,
+    JSON.stringify(telemetry.event, null, 2),
+  );
+});
+
+run(async () => {
+  await generateText({
+    model: gateway('openai/gpt-5-nano'),
+    prompt: 'Say hello in 5 words.',
+    telemetry: {
+      functionId: 'diagnostic-channel-example',
+    },
+  });
+});

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
@@ -6,6 +6,8 @@ import type {
   Telemetry,
   TelemetryDispatcher,
 } from './telemetry';
+import { type TelemetryDiagnosticEventType } from './diagnostic-channel';
+import { publishTelemetryDiagnosticChannelMessage } from './diagnostic-channel-publisher';
 import { getGlobalTelemetryIntegrations } from './telemetry-registry';
 import type { TelemetryOptions } from './telemetry-options';
 
@@ -83,7 +85,14 @@ export function createTelemetryDispatcher({
   const mergeTelemetryCallback = <KEY extends TelemetryCallbackKey>(
     key: KEY,
   ): Callback<TelemetryEvent<KEY>> => {
+    const publishDiagnosticChannelMessage = ((event: TelemetryEvent<KEY>) =>
+      publishTelemetryDiagnosticChannelMessage({
+        type: key as TelemetryDiagnosticEventType,
+        event: augmentEvent(event, telemetryMetadata),
+      })) as Callback<TelemetryEvent<KEY>>;
+
     return mergeCallbacks(
+      publishDiagnosticChannelMessage,
       ...(
         integrations
           .map(integration => integration[key]?.bind(integration))

--- a/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
+++ b/packages/ai/src/telemetry/create-telemetry-dispatcher.ts
@@ -85,6 +85,7 @@ export function createTelemetryDispatcher({
   const mergeTelemetryCallback = <KEY extends TelemetryCallbackKey>(
     key: KEY,
   ): Callback<TelemetryEvent<KEY>> => {
+    // event data is now automatically published to the diagnostic channel
     const publishDiagnosticChannelMessage = ((event: TelemetryEvent<KEY>) =>
       publishTelemetryDiagnosticChannelMessage({
         type: key as TelemetryDiagnosticEventType,

--- a/packages/ai/src/telemetry/diagnostic-channel-publisher.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel-publisher.ts
@@ -23,9 +23,10 @@ async function loadDiagnosticsChannel(): Promise<
 
   if (diagnosticsChannelPromise == null) {
     diagnosticsChannelPromise = (
-      Function(
-        'return import("node:diagnostics_channel")',
-      )() as Promise<DiagnosticsChannel>
+      import(
+        /* webpackIgnore: true */
+        'node:diagnostics_channel'
+      ) as Promise<DiagnosticsChannel>
     ).catch(() => undefined);
   }
 

--- a/packages/ai/src/telemetry/diagnostic-channel-publisher.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel-publisher.ts
@@ -3,16 +3,13 @@ import {
   AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL,
   type TelemetryDiagnosticChannelMessage,
 } from './diagnostic-channel';
+import { isNodeRuntime } from '../util/is-node-runtime';
 
 type DiagnosticsChannel = typeof diagnosticsChannelModule;
 
 let diagnosticsChannelPromise:
   | Promise<DiagnosticsChannel | undefined>
   | undefined;
-
-function isNodeRuntime(): boolean {
-  return typeof process !== 'undefined' && process.release?.name === 'node';
-}
 
 async function loadDiagnosticsChannel(): Promise<
   DiagnosticsChannel | undefined

--- a/packages/ai/src/telemetry/diagnostic-channel-publisher.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel-publisher.ts
@@ -1,0 +1,52 @@
+import type * as diagnosticsChannelModule from 'node:diagnostics_channel';
+import {
+  AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL,
+  type TelemetryDiagnosticChannelMessage,
+} from './diagnostic-channel';
+
+type DiagnosticsChannel = typeof diagnosticsChannelModule;
+
+let diagnosticsChannelPromise:
+  | Promise<DiagnosticsChannel | undefined>
+  | undefined;
+
+function isNodeRuntime(): boolean {
+  return typeof process !== 'undefined' && process.release?.name === 'node';
+}
+
+async function loadDiagnosticsChannel(): Promise<
+  DiagnosticsChannel | undefined
+> {
+  if (!isNodeRuntime()) {
+    return undefined;
+  }
+
+  if (diagnosticsChannelPromise == null) {
+    diagnosticsChannelPromise = (
+      Function(
+        'return import("node:diagnostics_channel")',
+      )() as Promise<DiagnosticsChannel>
+    ).catch(() => undefined);
+  }
+
+  return diagnosticsChannelPromise;
+}
+
+export async function publishTelemetryDiagnosticChannelMessage(
+  message: TelemetryDiagnosticChannelMessage,
+): Promise<void> {
+  const diagnosticsChannel = await loadDiagnosticsChannel();
+
+  if (
+    diagnosticsChannel?.hasSubscribers(AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL) !==
+    true
+  ) {
+    return;
+  }
+
+  try {
+    diagnosticsChannel
+      .channel(AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL)
+      .publish(message);
+  } catch {}
+}

--- a/packages/ai/src/telemetry/diagnostic-channel.test.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel.test.ts
@@ -1,0 +1,118 @@
+import * as diagnosticsChannel from 'node:diagnostics_channel';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createTelemetryDispatcher } from './create-telemetry-dispatcher';
+import {
+  AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL,
+  type TelemetryDiagnosticChannelMessage,
+} from './diagnostic-channel';
+
+const isNodeRuntime =
+  typeof process !== 'undefined' && process.release?.name === 'node';
+
+async function collectDiagnosticChannelMessages(
+  run: () => Promise<void>,
+): Promise<TelemetryDiagnosticChannelMessage[]> {
+  const messages: TelemetryDiagnosticChannelMessage[] = [];
+  const subscriber = (message: unknown) => {
+    messages.push(message as TelemetryDiagnosticChannelMessage);
+  };
+
+  diagnosticsChannel.subscribe(AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL, subscriber);
+
+  try {
+    await run();
+  } finally {
+    diagnosticsChannel.unsubscribe(
+      AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL,
+      subscriber,
+    );
+  }
+
+  return messages;
+}
+
+describe.runIf(isNodeRuntime)('diagnostic channel telemetry publisher', () => {
+  beforeEach(() => {
+    globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = undefined;
+  });
+
+  it('publishes lifecycle events even when no integrations are configured', async () => {
+    const event = { callId: 'diagnostic-channel-without-integrations' };
+
+    const messages = await collectDiagnosticChannelMessages(async () => {
+      const telemetry = createTelemetryDispatcher({});
+
+      await telemetry.onStart!(event as any);
+    });
+
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        {
+          "event": {
+            "callId": "diagnostic-channel-without-integrations",
+            "functionId": undefined,
+            "recordInputs": undefined,
+            "recordOutputs": undefined,
+          },
+          "type": "onStart",
+        },
+      ]
+    `);
+  });
+
+  it('does not publish lifecycle events when telemetry is disabled', async () => {
+    const event = { callId: 'diagnostic-channel-disabled' };
+
+    const messages = await collectDiagnosticChannelMessages(async () => {
+      const telemetry = createTelemetryDispatcher({
+        telemetry: { isEnabled: false },
+      });
+
+      await telemetry.onStart?.(event as any);
+    });
+
+    expect(
+      messages.filter(message => {
+        return (message.event as { callId?: string }).callId === event.callId;
+      }),
+    ).toEqual([]);
+  });
+
+  it('applies telemetry settings per call', async () => {
+    const enabledEvent = { callId: 'diagnostic-channel-enabled-call' };
+    const disabledEvent = { callId: 'diagnostic-channel-disabled-call' };
+
+    const messages = await collectDiagnosticChannelMessages(async () => {
+      const enabledTelemetry = createTelemetryDispatcher({
+        telemetry: { functionId: 'enabled-function' },
+      });
+      const disabledTelemetry = createTelemetryDispatcher({
+        telemetry: { isEnabled: false, functionId: 'disabled-function' },
+      });
+
+      await disabledTelemetry.onStart?.(disabledEvent as any);
+      await enabledTelemetry.onStart!(enabledEvent as any);
+    });
+
+    expect(
+      messages.filter(message => {
+        const callId = (message.event as { callId?: string }).callId;
+        return (
+          callId === enabledEvent.callId || callId === disabledEvent.callId
+        );
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "event": {
+            "callId": "diagnostic-channel-enabled-call",
+            "functionId": "enabled-function",
+            "recordInputs": undefined,
+            "recordOutputs": undefined,
+          },
+          "type": "onStart",
+        },
+      ]
+    `);
+  });
+});

--- a/packages/ai/src/telemetry/diagnostic-channel.test.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel.test.ts
@@ -5,9 +5,7 @@ import {
   AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL,
   type TelemetryDiagnosticChannelMessage,
 } from './diagnostic-channel';
-
-const isNodeRuntime =
-  typeof process !== 'undefined' && process.release?.name === 'node';
+import { isNodeRuntime } from '../util/is-node-runtime';
 
 async function collectDiagnosticChannelMessages(
   run: () => Promise<void>,
@@ -31,21 +29,23 @@ async function collectDiagnosticChannelMessages(
   return messages;
 }
 
-describe.runIf(isNodeRuntime)('diagnostic channel telemetry publisher', () => {
-  beforeEach(() => {
-    globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = undefined;
-  });
-
-  it('publishes lifecycle events even when no integrations are configured', async () => {
-    const event = { callId: 'diagnostic-channel-without-integrations' };
-
-    const messages = await collectDiagnosticChannelMessages(async () => {
-      const telemetry = createTelemetryDispatcher({});
-
-      await telemetry.onStart!(event as any);
+describe.runIf(isNodeRuntime())(
+  'diagnostic channel telemetry publisher',
+  () => {
+    beforeEach(() => {
+      globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = undefined;
     });
 
-    expect(messages).toMatchInlineSnapshot(`
+    it('publishes lifecycle events even when no integrations are configured', async () => {
+      const event = { callId: 'diagnostic-channel-without-integrations' };
+
+      const messages = await collectDiagnosticChannelMessages(async () => {
+        const telemetry = createTelemetryDispatcher({});
+
+        await telemetry.onStart!(event as any);
+      });
+
+      expect(messages).toMatchInlineSnapshot(`
       [
         {
           "event": {
@@ -58,50 +58,50 @@ describe.runIf(isNodeRuntime)('diagnostic channel telemetry publisher', () => {
         },
       ]
     `);
-  });
-
-  it('does not publish lifecycle events when telemetry is disabled', async () => {
-    const event = { callId: 'diagnostic-channel-disabled' };
-
-    const messages = await collectDiagnosticChannelMessages(async () => {
-      const telemetry = createTelemetryDispatcher({
-        telemetry: { isEnabled: false },
-      });
-
-      await telemetry.onStart?.(event as any);
     });
 
-    expect(
-      messages.filter(message => {
-        return (message.event as { callId?: string }).callId === event.callId;
-      }),
-    ).toEqual([]);
-  });
+    it('does not publish lifecycle events when telemetry is disabled', async () => {
+      const event = { callId: 'diagnostic-channel-disabled' };
 
-  it('applies telemetry settings per call', async () => {
-    const enabledEvent = { callId: 'diagnostic-channel-enabled-call' };
-    const disabledEvent = { callId: 'diagnostic-channel-disabled-call' };
+      const messages = await collectDiagnosticChannelMessages(async () => {
+        const telemetry = createTelemetryDispatcher({
+          telemetry: { isEnabled: false },
+        });
 
-    const messages = await collectDiagnosticChannelMessages(async () => {
-      const enabledTelemetry = createTelemetryDispatcher({
-        telemetry: { functionId: 'enabled-function' },
-      });
-      const disabledTelemetry = createTelemetryDispatcher({
-        telemetry: { isEnabled: false, functionId: 'disabled-function' },
+        await telemetry.onStart?.(event as any);
       });
 
-      await disabledTelemetry.onStart?.(disabledEvent as any);
-      await enabledTelemetry.onStart!(enabledEvent as any);
+      expect(
+        messages.filter(message => {
+          return (message.event as { callId?: string }).callId === event.callId;
+        }),
+      ).toEqual([]);
     });
 
-    expect(
-      messages.filter(message => {
-        const callId = (message.event as { callId?: string }).callId;
-        return (
-          callId === enabledEvent.callId || callId === disabledEvent.callId
-        );
-      }),
-    ).toMatchInlineSnapshot(`
+    it('applies telemetry settings per call', async () => {
+      const enabledEvent = { callId: 'diagnostic-channel-enabled-call' };
+      const disabledEvent = { callId: 'diagnostic-channel-disabled-call' };
+
+      const messages = await collectDiagnosticChannelMessages(async () => {
+        const enabledTelemetry = createTelemetryDispatcher({
+          telemetry: { functionId: 'enabled-function' },
+        });
+        const disabledTelemetry = createTelemetryDispatcher({
+          telemetry: { isEnabled: false, functionId: 'disabled-function' },
+        });
+
+        await disabledTelemetry.onStart?.(disabledEvent as any);
+        await enabledTelemetry.onStart!(enabledEvent as any);
+      });
+
+      expect(
+        messages.filter(message => {
+          const callId = (message.event as { callId?: string }).callId;
+          return (
+            callId === enabledEvent.callId || callId === disabledEvent.callId
+          );
+        }),
+      ).toMatchInlineSnapshot(`
       [
         {
           "event": {
@@ -114,5 +114,6 @@ describe.runIf(isNodeRuntime)('diagnostic channel telemetry publisher', () => {
         },
       ]
     `);
-  });
-});
+    });
+  },
+);

--- a/packages/ai/src/telemetry/diagnostic-channel.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel.ts
@@ -1,0 +1,24 @@
+export const AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL = 'ai.telemetry';
+
+export type TelemetryDiagnosticEventType =
+  | 'onStart'
+  | 'onStepStart'
+  | 'onLanguageModelCallStart'
+  | 'onLanguageModelCallEnd'
+  | 'onToolExecutionStart'
+  | 'onToolExecutionEnd'
+  | 'onChunk'
+  | 'onStepFinish'
+  | 'onObjectStepStart'
+  | 'onObjectStepFinish'
+  | 'onEmbedStart'
+  | 'onEmbedFinish'
+  | 'onRerankStart'
+  | 'onRerankFinish'
+  | 'onFinish'
+  | 'onError';
+
+export type TelemetryDiagnosticChannelMessage<EVENT = unknown> = {
+  readonly type: TelemetryDiagnosticEventType;
+  readonly event: EVENT;
+};

--- a/packages/ai/src/telemetry/diagnostic-channel.ts
+++ b/packages/ai/src/telemetry/diagnostic-channel.ts
@@ -1,4 +1,4 @@
-export const AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL = 'ai.telemetry';
+export const AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL = 'aisdk:telemetry';
 
 export type TelemetryDiagnosticEventType =
   | 'onStart'

--- a/packages/ai/src/telemetry/index.ts
+++ b/packages/ai/src/telemetry/index.ts
@@ -1,3 +1,8 @@
 export type { TelemetryOptions } from './telemetry-options';
 export type { InferTelemetryEvent, Telemetry } from './telemetry';
 export { registerTelemetry } from './telemetry-registry';
+export {
+  AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL,
+  type TelemetryDiagnosticChannelMessage,
+  type TelemetryDiagnosticEventType,
+} from './diagnostic-channel';

--- a/packages/ai/src/util/is-node-runtime.ts
+++ b/packages/ai/src/util/is-node-runtime.ts
@@ -1,0 +1,3 @@
+export function isNodeRuntime(): boolean {
+  return typeof process !== 'undefined' && process.release?.name === 'node';
+}


### PR DESCRIPTION
## Background

Diagnostics channels are a way to relay event data and it works on a publisher/subscriber mechanism.

Some o11y providers had a request from us to emit the event data for telemetry through diagnostics channels instead of the callbacks

## Summary

the telemetry dispatcher now also publishes the same augmented lifecycle event to the diagnostics channel named `aisdk:telemetry`

## Manual Verification

ran the example `examples/ai-functions/src/telemetry/diagnostic-channel/generate-text.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)