### PR TITLE
feat(provider/google-vertex): allow overriding Vertex Anthropic auth token generation

### DIFF
--- a/.changeset/vertex-anthropic-generate-auth-token-option.md
+++ b/.changeset/vertex-anthropic-generate-auth-token-option.md
@@ -1,0 +1,11 @@
+---
+"@ai-sdk/google-vertex": patch
+---
+
+feat(provider/google-vertex): allow overriding Vertex Anthropic auth token generation
+
+Adds an optional `generateAuthToken` setting to `createVertexAnthropic` (both
+edge and node variants). When provided, the SDK calls this function instead
+of performing the default OAuth exchange. Useful for tests, custom auth
+providers, and proxy/relay scenarios where the caller supplies the auth
+token directly. Default behavior is unchanged.

--- a/.changeset/vertex-anthropic-generate-auth-token-option.md
+++ b/.changeset/vertex-anthropic-generate-auth-token-option.md
@@ -3,9 +3,3 @@
 ---
 
 feat(provider/google-vertex): allow overriding Vertex Anthropic auth token generation
-
-Adds an optional `generateAuthToken` setting to `createVertexAnthropic` (both
-edge and node variants). When provided, the SDK calls this function instead
-of performing the default OAuth exchange. Useful for tests, custom auth
-providers, and proxy/relay scenarios where the caller supplies the auth
-token directly. Default behavior is unchanged.

--- a/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.test.ts
+++ b/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.test.ts
@@ -84,4 +84,22 @@ describe('google-vertex-anthropic-provider-edge', () => {
       privateKey: 'test-key',
     });
   });
+
+  it('uses custom generateAuthToken when provided and skips the default', async () => {
+    const customGenerate = vi.fn().mockResolvedValue('custom-token');
+
+    createVertexAnthropicEdge({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const mockCreateVertex = vi.mocked(createVertexAnthropicOriginal);
+    const passedOptions = mockCreateVertex.mock.calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer custom-token',
+    });
+    expect(customGenerate).toHaveBeenCalledTimes(1);
+    expect(edgeAuth.generateAuthToken).not.toHaveBeenCalled();
+  });
 });

--- a/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.test.ts
+++ b/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.test.ts
@@ -102,4 +102,81 @@ describe('google-vertex-anthropic-provider-edge', () => {
     expect(customGenerate).toHaveBeenCalledTimes(1);
     expect(edgeAuth.generateAuthToken).not.toHaveBeenCalled();
   });
+
+  it('merges custom generateAuthToken with user-provided headers', async () => {
+    const customGenerate = vi.fn().mockResolvedValue('custom-token');
+
+    createVertexAnthropicEdge({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+      headers: async () => ({ 'Custom-Header': 'custom-value' }),
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer custom-token',
+      'Custom-Header': 'custom-value',
+    });
+  });
+
+  it('invokes custom generateAuthToken on each headers resolution', async () => {
+    let callCount = 0;
+    const customGenerate = vi.fn().mockImplementation(async () => {
+      callCount += 1;
+      return `token-${callCount}`;
+    });
+
+    createVertexAnthropicEdge({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer token-1',
+    });
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer token-2',
+    });
+    expect(customGenerate).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates errors thrown from custom generateAuthToken', async () => {
+    const customGenerate = vi
+      .fn()
+      .mockRejectedValue(new Error('token mint failed'));
+
+    createVertexAnthropicEdge({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    await expect(resolve(passedOptions?.headers)).rejects.toThrow(
+      'token mint failed',
+    );
+  });
+
+  it('user-provided Authorization in headers overrides the generated token', async () => {
+    const customGenerate = vi.fn().mockResolvedValue('custom-token');
+
+    createVertexAnthropicEdge({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+      headers: async () => ({ Authorization: 'Bearer user-override' }),
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer user-override',
+    });
+  });
 });

--- a/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.ts
+++ b/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.ts
@@ -18,10 +18,8 @@ export interface GoogleVertexAnthropicProviderSettings extends GoogleVertexAnthr
    */
   googleCredentials?: GoogleCredentials;
   /**
-   * Optional. Custom function to obtain the Bearer token attached to outbound
-   * requests. Defaults to performing the OAuth exchange with `googleCredentials`.
-   * Override for tests, custom auth providers, or proxies that supply their
-   * own auth.
+   * Optional. Override the Bearer token generator. Defaults to OAuth exchange
+   * with `googleCredentials`.
    */
   generateAuthToken?: () => Promise<string>;
 }

--- a/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.ts
+++ b/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.ts
@@ -1,6 +1,6 @@
 import { resolve } from '@ai-sdk/provider-utils';
 import {
-  generateAuthToken,
+  generateAuthToken as defaultGenerateAuthToken,
   type GoogleCredentials,
 } from '../../edge/google-vertex-auth-edge';
 import {
@@ -17,17 +17,25 @@ export interface GoogleVertexAnthropicProviderSettings extends GoogleVertexAnthr
    * load the credentials.
    */
   googleCredentials?: GoogleCredentials;
+  /**
+   * Optional. Custom function to obtain the Bearer token attached to outbound
+   * requests. Defaults to performing the OAuth exchange with `googleCredentials`.
+   * Override for tests, custom auth providers, or proxies that supply their
+   * own auth.
+   */
+  generateAuthToken?: () => Promise<string>;
 }
 
 export function createVertexAnthropic(
   options: GoogleVertexAnthropicProviderSettings = {},
 ): GoogleVertexAnthropicProvider {
+  const generateAuthToken =
+    options.generateAuthToken ??
+    (() => defaultGenerateAuthToken(options.googleCredentials));
   return createVertexAnthropicOriginal({
     ...options,
     headers: async () => ({
-      Authorization: `Bearer ${await generateAuthToken(
-        options.googleCredentials,
-      )}`,
+      Authorization: `Bearer ${await generateAuthToken()}`,
       ...(await resolve(options.headers)),
     }),
   });

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.test.ts
@@ -88,4 +88,97 @@ describe('google-vertex-anthropic-provider-node', () => {
     expect(customGenerate).toHaveBeenCalledTimes(1);
     expect(generateAuthToken).not.toHaveBeenCalled();
   });
+
+  it('merges custom generateAuthToken with user-provided headers', async () => {
+    const customGenerate = vi.fn().mockResolvedValue('custom-token');
+
+    createVertexAnthropicNode({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+      headers: async () => ({ 'Custom-Header': 'custom-value' }),
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer custom-token',
+      'Custom-Header': 'custom-value',
+    });
+  });
+
+  it('invokes custom generateAuthToken on each headers resolution', async () => {
+    let callCount = 0;
+    const customGenerate = vi.fn().mockImplementation(async () => {
+      callCount += 1;
+      return `token-${callCount}`;
+    });
+
+    createVertexAnthropicNode({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer token-1',
+    });
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer token-2',
+    });
+    expect(customGenerate).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates errors thrown from custom generateAuthToken', async () => {
+    const customGenerate = vi
+      .fn()
+      .mockRejectedValue(new Error('token mint failed'));
+
+    createVertexAnthropicNode({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    await expect(resolve(passedOptions?.headers)).rejects.toThrow(
+      'token mint failed',
+    );
+  });
+
+  it('user-provided Authorization in headers overrides the generated token', async () => {
+    const customGenerate = vi.fn().mockResolvedValue('custom-token');
+
+    createVertexAnthropicNode({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+      headers: async () => ({ Authorization: 'Bearer user-override' }),
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer user-override',
+    });
+  });
+
+  it('accepts a generateAuthToken that returns null (matches default signature)', async () => {
+    const customGenerate = vi.fn().mockResolvedValue(null);
+
+    createVertexAnthropicNode({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer null',
+    });
+  });
 });

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.test.ts
@@ -70,4 +70,22 @@ describe('google-vertex-anthropic-provider-node', () => {
       keyFile: 'path/to/key.json',
     });
   });
+
+  it('uses custom generateAuthToken when provided and skips the default', async () => {
+    const customGenerate = vi.fn().mockResolvedValue('custom-token');
+
+    createVertexAnthropicNode({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer custom-token',
+    });
+    expect(customGenerate).toHaveBeenCalledTimes(1);
+    expect(generateAuthToken).not.toHaveBeenCalled();
+  });
 });

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.ts
@@ -17,10 +17,8 @@ export interface GoogleVertexAnthropicProviderSettings extends GoogleVertexAnthr
    */
   googleAuthOptions?: GoogleAuthOptions;
   /**
-   * Optional. Custom function to obtain the Bearer token attached to outbound
-   * requests. Defaults to performing the OAuth exchange via `google-auth-library`
-   * with `googleAuthOptions`. Override for tests, custom auth providers, or
-   * proxies that supply their own auth.
+   * Optional. Override the Bearer token generator. Defaults to OAuth exchange
+   * via `google-auth-library` with `googleAuthOptions`.
    */
   generateAuthToken?: () => Promise<string | null>;
 }

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.ts
@@ -1,6 +1,6 @@
 import { resolve } from '@ai-sdk/provider-utils';
 import type { GoogleAuthOptions } from 'google-auth-library';
-import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
+import { generateAuthToken as defaultGenerateAuthToken } from '../google-vertex-auth-google-auth-library';
 import {
   createVertexAnthropic as createVertexAnthropicOriginal,
   type GoogleVertexAnthropicProvider,
@@ -16,17 +16,25 @@ export interface GoogleVertexAnthropicProviderSettings extends GoogleVertexAnthr
    * https://github.com/googleapis/google-auth-library-nodejs/blob/main/src/auth/googleauth.ts.
    */
   googleAuthOptions?: GoogleAuthOptions;
+  /**
+   * Optional. Custom function to obtain the Bearer token attached to outbound
+   * requests. Defaults to performing the OAuth exchange via `google-auth-library`
+   * with `googleAuthOptions`. Override for tests, custom auth providers, or
+   * proxies that supply their own auth.
+   */
+  generateAuthToken?: () => Promise<string | null>;
 }
 
 export function createVertexAnthropic(
   options: GoogleVertexAnthropicProviderSettings = {},
 ): GoogleVertexAnthropicProvider {
+  const generateAuthToken =
+    options.generateAuthToken ??
+    (() => defaultGenerateAuthToken(options.googleAuthOptions));
   return createVertexAnthropicOriginal({
     ...options,
     headers: async () => ({
-      Authorization: `Bearer ${await generateAuthToken(
-        options.googleAuthOptions,
-      )}`,
+      Authorization: `Bearer ${await generateAuthToken()}`,
       ...(await resolve(options.headers)),
     }),
   });


### PR DESCRIPTION
## Background

Today \`createVertexAnthropic\` (edge and node variants) unconditionally performs an OAuth exchange to mint a Bearer token before each request. Useful default — but there are real cases where you want to skip it:

- Tests that don't want to spin up OAuth machinery
- Custom auth providers that mint tokens differently (on-prem token exchange, etc.)
- Proxy / relay scenarios where the caller already has a token to forward

## Change

Adds an optional \`generateAuthToken\` setting to \`GoogleVertexAnthropicProviderSettings\` on both edge and node variants. When provided, the SDK calls it in place of the default OAuth flow. When omitted, behavior is identical to today.

```
createVertexAnthropic({
  project: '...',
  location: '...',
  generateAuthToken: async () => myCustomToken(),
});
```

## Tests

Added one test per variant asserting that:
- A custom \`generateAuthToken\` produces the right \`Authorization\` header
- The default OAuth path is **not** called when the override is present

All existing anthropic tests still pass.

## Risk

Purely additive. New optional field, default unchanged. No breaking changes.