### PR TITLE
Backport: feat(provider/google-vertex): allow overriding Vertex Anthropic auth token generation

### DIFF
--- a/.changeset/vertex-anthropic-generate-auth-token-option.md
+++ b/.changeset/vertex-anthropic-generate-auth-token-option.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google-vertex": patch
+---
+
+feat(provider/google-vertex): allow overriding Vertex Anthropic auth token generation

--- a/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.test.ts
+++ b/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.test.ts
@@ -84,4 +84,99 @@ describe('google-vertex-anthropic-provider-edge', () => {
       privateKey: 'test-key',
     });
   });
+
+  it('uses custom generateAuthToken when provided and skips the default', async () => {
+    const customGenerate = vi.fn().mockResolvedValue('custom-token');
+
+    createVertexAnthropicEdge({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const mockCreateVertex = vi.mocked(createVertexAnthropicOriginal);
+    const passedOptions = mockCreateVertex.mock.calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer custom-token',
+    });
+    expect(customGenerate).toHaveBeenCalledTimes(1);
+    expect(edgeAuth.generateAuthToken).not.toHaveBeenCalled();
+  });
+
+  it('merges custom generateAuthToken with user-provided headers', async () => {
+    const customGenerate = vi.fn().mockResolvedValue('custom-token');
+
+    createVertexAnthropicEdge({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+      headers: async () => ({ 'Custom-Header': 'custom-value' }),
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer custom-token',
+      'Custom-Header': 'custom-value',
+    });
+  });
+
+  it('invokes custom generateAuthToken on each headers resolution', async () => {
+    let callCount = 0;
+    const customGenerate = vi.fn().mockImplementation(async () => {
+      callCount += 1;
+      return `token-${callCount}`;
+    });
+
+    createVertexAnthropicEdge({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer token-1',
+    });
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer token-2',
+    });
+    expect(customGenerate).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates errors thrown from custom generateAuthToken', async () => {
+    const customGenerate = vi
+      .fn()
+      .mockRejectedValue(new Error('token mint failed'));
+
+    createVertexAnthropicEdge({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    await expect(resolve(passedOptions?.headers)).rejects.toThrow(
+      'token mint failed',
+    );
+  });
+
+  it('user-provided Authorization in headers overrides the generated token', async () => {
+    const customGenerate = vi.fn().mockResolvedValue('custom-token');
+
+    createVertexAnthropicEdge({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+      headers: async () => ({ Authorization: 'Bearer user-override' }),
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer user-override',
+    });
+  });
 });

--- a/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.ts
+++ b/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.ts
@@ -1,7 +1,7 @@
 import { resolve } from '@ai-sdk/provider-utils';
 import {
   type GoogleCredentials,
-  generateAuthToken,
+  generateAuthToken as defaultGenerateAuthToken,
 } from '../../edge/google-vertex-auth-edge';
 import {
   type GoogleVertexAnthropicProvider,
@@ -18,17 +18,23 @@ export interface GoogleVertexAnthropicProviderSettings extends GoogleVertexAnthr
    * load the credentials.
    */
   googleCredentials?: GoogleCredentials;
+  /**
+   * Optional. Override the Bearer token generator. Defaults to OAuth exchange
+   * with `googleCredentials`.
+   */
+  generateAuthToken?: () => Promise<string>;
 }
 
 export function createVertexAnthropic(
   options: GoogleVertexAnthropicProviderSettings = {},
 ): GoogleVertexAnthropicProvider {
+  const generateAuthToken =
+    options.generateAuthToken ??
+    (() => defaultGenerateAuthToken(options.googleCredentials));
   return createVertexAnthropicOriginal({
     ...options,
     headers: async () => ({
-      Authorization: `Bearer ${await generateAuthToken(
-        options.googleCredentials,
-      )}`,
+      Authorization: `Bearer ${await generateAuthToken()}`,
       ...(await resolve(options.headers)),
     }),
   });

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.test.ts
@@ -70,4 +70,115 @@ describe('google-vertex-anthropic-provider-node', () => {
       keyFile: 'path/to/key.json',
     });
   });
+
+  it('uses custom generateAuthToken when provided and skips the default', async () => {
+    const customGenerate = vi.fn().mockResolvedValue('custom-token');
+
+    createVertexAnthropicNode({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer custom-token',
+    });
+    expect(customGenerate).toHaveBeenCalledTimes(1);
+    expect(generateAuthToken).not.toHaveBeenCalled();
+  });
+
+  it('merges custom generateAuthToken with user-provided headers', async () => {
+    const customGenerate = vi.fn().mockResolvedValue('custom-token');
+
+    createVertexAnthropicNode({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+      headers: async () => ({ 'Custom-Header': 'custom-value' }),
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer custom-token',
+      'Custom-Header': 'custom-value',
+    });
+  });
+
+  it('invokes custom generateAuthToken on each headers resolution', async () => {
+    let callCount = 0;
+    const customGenerate = vi.fn().mockImplementation(async () => {
+      callCount += 1;
+      return `token-${callCount}`;
+    });
+
+    createVertexAnthropicNode({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer token-1',
+    });
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer token-2',
+    });
+    expect(customGenerate).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates errors thrown from custom generateAuthToken', async () => {
+    const customGenerate = vi
+      .fn()
+      .mockRejectedValue(new Error('token mint failed'));
+
+    createVertexAnthropicNode({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    await expect(resolve(passedOptions?.headers)).rejects.toThrow(
+      'token mint failed',
+    );
+  });
+
+  it('user-provided Authorization in headers overrides the generated token', async () => {
+    const customGenerate = vi.fn().mockResolvedValue('custom-token');
+
+    createVertexAnthropicNode({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+      headers: async () => ({ Authorization: 'Bearer user-override' }),
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer user-override',
+    });
+  });
+
+  it('accepts a generateAuthToken that returns null (matches default signature)', async () => {
+    const customGenerate = vi.fn().mockResolvedValue(null);
+
+    createVertexAnthropicNode({
+      project: 'test-project',
+      generateAuthToken: customGenerate,
+    });
+
+    const passedOptions = vi.mocked(createVertexAnthropicOriginal).mock
+      .calls[0][0];
+
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer null',
+    });
+  });
 });

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.ts
@@ -1,6 +1,6 @@
 import { resolve } from '@ai-sdk/provider-utils';
 import type { GoogleAuthOptions } from 'google-auth-library';
-import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
+import { generateAuthToken as defaultGenerateAuthToken } from '../google-vertex-auth-google-auth-library';
 import {
   type GoogleVertexAnthropicProvider,
   type GoogleVertexAnthropicProviderSettings as GoogleVertexAnthropicProviderSettingsOriginal,
@@ -17,17 +17,23 @@ GoogleAuthOptions interface:
 https://github.com/googleapis/google-auth-library-nodejs/blob/main/src/auth/googleauth.ts.
    */
   googleAuthOptions?: GoogleAuthOptions;
+  /**
+   * Optional. Override the Bearer token generator. Defaults to OAuth exchange
+   * via `google-auth-library` with `googleAuthOptions`.
+   */
+  generateAuthToken?: () => Promise<string | null>;
 }
 
 export function createVertexAnthropic(
   options: GoogleVertexAnthropicProviderSettings = {},
 ): GoogleVertexAnthropicProvider {
+  const generateAuthToken =
+    options.generateAuthToken ??
+    (() => defaultGenerateAuthToken(options.googleAuthOptions));
   return createVertexAnthropicOriginal({
     ...options,
     headers: async () => ({
-      Authorization: `Bearer ${await generateAuthToken(
-        options.googleAuthOptions,
-      )}`,
+      Authorization: `Bearer ${await generateAuthToken()}`,
       ...(await resolve(options.headers)),
     }),
   });


### PR DESCRIPTION
Backport of #14857 to \`release-v5.0\`.

The v6 backport (#14861) is already merged. This brings the same change to v5 so the option is available across all live branches the AI Gateway depends on.

## Change

Adds optional \`generateAuthToken\` setting on \`createVertexAnthropic\` (edge + node). When provided, the SDK uses it instead of the default OAuth exchange. Default behavior unchanged.

\`\`\`ts
createVertexAnthropic({
  project: '...',
  location: '...',
  generateAuthToken: async () => myCustomToken(),
});
\`\`\`

## Tests

29 tests across edge + node, including merge order, fresh-call semantics, error propagation, user-header override, and (node-only) null return.

## Risk

Purely additive. No breaking changes.