### PR TITLE
chore: remove konsistent exclusion for `openai-image-model` now that it's fixed

### DIFF
--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -206,7 +206,6 @@
             "packages/gateway/src/gateway-reranking-model.ts",
             "packages/mistral/src/mistral-embedding-model.ts",
             "packages/openai-compatible/src/image/openai-compatible-image-model.ts",
-            "packages/openai/src/image/openai-image-model.ts",
             "packages/perplexity/src/perplexity-language-model.ts"
           ]
         },


### PR DESCRIPTION
## Background

follow up to #14863 - missed removing the exclusion, related to #14859

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
