### PR TITLE
fix(google): emit no-args streaming tool calls

### DIFF
--- a/.changeset/quiet-maps-hear.md
+++ b/.changeset/quiet-maps-hear.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+Fix Vertex streaming function calls without arguments so they emit a tool call with empty JSON input and preserve thoughtSignature metadata.

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -4067,6 +4067,107 @@ describe('doStream', () => {
 
       expect(await convertReadableStreamToArray(stream)).toMatchSnapshot();
     });
+
+    it('should emit no-args function calls with thoughtSignature', async () => {
+      server.urls[TEST_URL_GEMINI_PRO].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: ${JSON.stringify({
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      functionCall: { name: 'read_theme' },
+                      thoughtSignature: 'sig-no-args',
+                    },
+                  ],
+                  role: 'model',
+                },
+                finishReason: 'STOP',
+                safetyRatings: SAFETY_RATINGS,
+              },
+            ],
+            usageMetadata: {
+              promptTokenCount: 1,
+              candidatesTokenCount: 1,
+              totalTokenCount: 2,
+            },
+          })}\n\n`,
+        ],
+      };
+
+      const vertexModel = new GoogleLanguageModel('gemini-pro', {
+        provider: 'google.vertex.chat',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        headers: { 'x-goog-api-key': 'test-api-key' },
+        generateId: () => 'test-id',
+      });
+
+      const { stream } = await vertexModel.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+        tools: [
+          {
+            type: 'function',
+            name: 'read_theme',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        providerOptions: {
+          vertex: {
+            streamFunctionCallArguments: true,
+          },
+        },
+      });
+
+      const events = await convertReadableStreamToArray(stream);
+      const toolEvents = events.filter(event => event.type.startsWith('tool-'));
+
+      expect(toolEvents).toEqual([
+        {
+          type: 'tool-input-start',
+          id: 'test-id',
+          toolName: 'read_theme',
+          providerMetadata: {
+            googleVertex: { thoughtSignature: 'sig-no-args' },
+            vertex: { thoughtSignature: 'sig-no-args' },
+          },
+        },
+        {
+          type: 'tool-input-end',
+          id: 'test-id',
+          providerMetadata: {
+            googleVertex: { thoughtSignature: 'sig-no-args' },
+            vertex: { thoughtSignature: 'sig-no-args' },
+          },
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'test-id',
+          toolName: 'read_theme',
+          input: '{}',
+          providerMetadata: {
+            googleVertex: { thoughtSignature: 'sig-no-args' },
+            vertex: { thoughtSignature: 'sig-no-args' },
+          },
+        },
+      ]);
+      expect(events.some(event => event.type === 'tool-input-delta')).toBe(
+        false,
+      );
+
+      const finishEvent = events.find(event => event.type === 'finish');
+      expect(finishEvent?.finishReason).toEqual({
+        unified: 'tool-calls',
+        raw: 'STOP',
+      });
+    });
   });
 
   describe('streaming-tool-call-arguments-nested', () => {

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -829,6 +829,11 @@ export class GoogleLanguageModel implements LanguageModelV4 {
                   part.functionCall.name != null &&
                   part.functionCall.args != null &&
                   part.functionCall.partialArgs == null;
+                const isNoArgsCompleteCall =
+                  part.functionCall.name != null &&
+                  part.functionCall.args == null &&
+                  part.functionCall.partialArgs == null &&
+                  part.functionCall.willContinue !== true;
 
                 if (isStreamingChunk) {
                   if (
@@ -949,6 +954,32 @@ export class GoogleLanguageModel implements LanguageModelV4 {
                     toolCallId,
                     toolName,
                     input: args,
+                    providerMetadata: providerMeta,
+                  });
+
+                  hasToolCalls = true;
+                } else if (isNoArgsCompleteCall) {
+                  const toolCallId = generateId();
+                  const toolName = part.functionCall.name!;
+
+                  controller.enqueue({
+                    type: 'tool-input-start',
+                    id: toolCallId,
+                    toolName,
+                    providerMetadata: providerMeta,
+                  });
+
+                  controller.enqueue({
+                    type: 'tool-input-end',
+                    id: toolCallId,
+                    providerMetadata: providerMeta,
+                  });
+
+                  controller.enqueue({
+                    type: 'tool-call',
+                    toolCallId,
+                    toolName,
+                    input: '{}',
                     providerMetadata: providerMeta,
                   });
 


### PR DESCRIPTION
## Background

Vertex can stream a complete function call for a no-argument tool as `{ name: "tool" }`. The Google streaming parser did not classify that shape, so the call was dropped along with any `thoughtSignature` on the part.

## Summary

- Treat no-args Vertex streaming function calls as complete calls with `{}` input.
- Preserve `thoughtSignature` provider metadata on `tool-input-start`, `tool-input-end`, and `tool-call` events.
- Add a regression test for a no-args function call carrying `thoughtSignature`.

## Manual Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @ai-sdk/provider --filter @ai-sdk/provider-utils --filter @ai-sdk/test-server build`
- `cd packages/google && pnpm exec vitest --config vitest.node.config.js --run src/google-language-model.test.ts -t "should emit no-args function calls with thoughtSignature"`
- `cd packages/google && pnpm exec vitest --config vitest.node.config.js --run src/google-language-model.test.ts`
- `pnpm --filter @ai-sdk/google type-check`
- `cd packages/google && pnpm test:node`
- `cd packages/google && pnpm test:edge`
- `pnpm exec oxfmt --check packages/google/src/google-language-model.ts packages/google/src/google-language-model.test.ts .changeset/quiet-maps-hear.md`
- `pnpm exec oxlint packages/google/src/google-language-model.ts packages/google/src/google-language-model.test.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

The issue also notes a similar parser problem in the AI Gateway server path. This PR only covers the OSS `@ai-sdk/google` parser.

## Related Issues

Refs #14847
