### PR TITLE
feat(vertex): add grok models to vertex provider

### DIFF
--- a/.changeset/famous-steaks-destroy.md
+++ b/.changeset/famous-steaks-destroy.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/openai-compatible": patch
+"@ai-sdk/google-vertex": patch
+---
+
+feat(vertex): add grok models to vertex provider

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -5,7 +5,7 @@ description: Learn how to use the Google Vertex AI provider.
 
 # Google Vertex Provider
 
-The Google Vertex provider for the [AI SDK](/docs) contains language model support for the [Google Vertex AI](https://cloud.google.com/vertex-ai) APIs. This includes support for [Google's Gemini models](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models), [Anthropic's Claude partner models](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude), and [MaaS (Model as a Service) open models](https://cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models).
+The Google Vertex provider for the [AI SDK](/docs) contains language model support for the [Google Vertex AI](https://cloud.google.com/vertex-ai) APIs. This includes support for [Google's Gemini models](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models), [Anthropic's Claude partner models](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude), [xAI's Grok partner models](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok), and [MaaS (Model as a Service) open models](https://cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models).
 
 <Note>
   The Google Vertex provider is compatible with both Node.js and Edge runtimes.
@@ -18,7 +18,7 @@ The Google Vertex provider for the [AI SDK](/docs) contains language model suppo
 
 ## Setup
 
-The Google Vertex and Google Vertex Anthropic providers are both available in the `@ai-sdk/google-vertex` module. You can install it with
+The Google Vertex, Google Vertex Anthropic, Google Vertex xAI, and Google Vertex MaaS providers are available in the `@ai-sdk/google-vertex` module. You can install it with
 
 <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
   <Tab>
@@ -1780,6 +1780,183 @@ See also [Anthropic Model Comparison](https://docs.anthropic.com/en/docs/about-c
 <Note>
   The table above lists popular models. You can also pass any available provider
   model ID as a string if needed.
+</Note>
+
+## Google Vertex xAI Provider Usage
+
+The Google Vertex xAI provider offers support for xAI's Grok partner models through the Google Vertex AI OpenAI-compatible Chat Completions API.
+
+For more information, see the [Vertex AI Grok documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok).
+
+### Provider Instance
+
+You can import the default provider instance `googleVertexXai` from `@ai-sdk/google-vertex/xai`:
+
+```typescript
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
+```
+
+If you need a customized setup, you can import `createGoogleVertexXai` from `@ai-sdk/google-vertex/xai` and create a provider instance with your settings:
+
+```typescript
+import { createGoogleVertexXai } from '@ai-sdk/google-vertex/xai';
+
+const googleVertexXai = createGoogleVertexXai({
+  project: 'my-project', // optional
+  location: 'global', // optional, defaults to 'global'
+});
+```
+
+#### Node.js Runtime
+
+For Node.js environments, the Google Vertex xAI provider supports all standard Google Cloud authentication options through the `google-auth-library`:
+
+```typescript
+import { createGoogleVertexXai } from '@ai-sdk/google-vertex/xai';
+
+const googleVertexXai = createGoogleVertexXai({
+  googleAuthOptions: {
+    credentials: {
+      client_email: 'my-email',
+      private_key: 'my-private-key',
+    },
+  },
+});
+```
+
+##### Optional Provider Settings
+
+- **project** _string_
+
+  The Google Cloud project ID. Defaults to the `GOOGLE_VERTEX_PROJECT` environment variable.
+
+- **location** _string_
+
+  The Google Cloud location. Grok models are available on the global endpoint. Defaults to the `GOOGLE_VERTEX_LOCATION` environment variable. If not set, defaults to `global`.
+
+- **googleAuthOptions** _object_
+
+  Optional. The Authentication options used by the [Google Auth Library](https://github.com/googleapis/google-auth-library-nodejs/).
+
+- **headers** _Resolvable&lt;Record&lt;string, string | undefined&gt;&gt;_
+
+  Headers to include in requests.
+
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+
+<a id="google-vertex-xai-edge-runtime"></a>
+
+#### Edge Runtime
+
+For Edge runtimes, import from `@ai-sdk/google-vertex/xai/edge`:
+
+```typescript
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai/edge';
+```
+
+```typescript
+import { createGoogleVertexXai } from '@ai-sdk/google-vertex/xai/edge';
+
+const googleVertexXai = createGoogleVertexXai({
+  project: 'my-project',
+  location: 'global',
+});
+```
+
+For Edge runtime authentication, set these environment variables:
+
+- `GOOGLE_CLIENT_EMAIL`
+- `GOOGLE_PRIVATE_KEY`
+- `GOOGLE_PRIVATE_KEY_ID` (optional)
+
+### Language Models
+
+You can create models using the provider instance. The first argument is the model ID:
+
+```ts
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: googleVertexXai('xai/grok-4.1-fast-reasoning'),
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
+```
+
+Streaming is also supported:
+
+```ts
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
+import { streamText } from 'ai';
+
+const result = streamText({
+  model: googleVertexXai('xai/grok-4.1-fast-reasoning'),
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
+
+for await (const textPart of result.textStream) {
+  process.stdout.write(textPart);
+}
+```
+
+### Function Calling
+
+Grok models on Vertex support OpenAI-compatible function calling. You can use AI SDK tools as usual:
+
+```ts
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+const result = await generateText({
+  model: googleVertexXai('xai/grok-4.1-fast-reasoning'),
+  tools: {
+    weather: tool({
+      description: 'Get the weather in a city',
+      inputSchema: z.object({ city: z.string() }),
+      execute: async ({ city }) => `The weather in ${city} is sunny.`,
+    }),
+  },
+  prompt: 'What is the weather in San Francisco?',
+});
+```
+
+### Structured Outputs
+
+Grok models on Vertex support JSON mode and schema-backed structured outputs:
+
+```ts
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+
+const result = await generateObject({
+  model: googleVertexXai('xai/grok-4.1-fast-reasoning'),
+  schema: z.object({
+    name: z.string(),
+    date: z.string(),
+    participants: z.array(z.string()),
+  }),
+  prompt: 'Alice and Bob are going to a science fair on Friday.',
+});
+```
+
+### Available Models
+
+The following models are available through the Google Vertex xAI provider. You can also pass any valid model ID as a string.
+
+| Model ID                            | Reasoning |
+| ----------------------------------- | --------- |
+| `xai/grok-4.20-reasoning`           | Yes       |
+| `xai/grok-4.20-non-reasoning`       | No        |
+| `xai/grok-4.1-fast-reasoning`       | Yes       |
+| `xai/grok-4.1-fast-non-reasoning`   | No        |
+
+<Note>
+  Grok reasoning models on Vertex report reasoning token counts in usage
+  metadata. They do not support the `reasoning_effort` request parameter.
 </Note>
 
 ## Google Vertex MaaS Provider Usage

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1929,7 +1929,7 @@ Grok models on Vertex support JSON mode and schema-backed structured outputs:
 
 ```ts
 import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
-import { generateObject } from 'ai';
+import { generateText, Output } from 'ai';
 import { z } from 'zod';
 
 const result = await generateText({

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -1932,12 +1932,14 @@ import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
 import { generateObject } from 'ai';
 import { z } from 'zod';
 
-const result = await generateObject({
+const result = await generateText({
   model: googleVertexXai('xai/grok-4.1-fast-reasoning'),
-  schema: z.object({
-    name: z.string(),
-    date: z.string(),
-    participants: z.array(z.string()),
+  output: Output.object({  
+    schema: z.object({
+      name: z.string(),
+      date: z.string(),
+      participants: z.array(z.string()),
+    }),
   }),
   prompt: 'Alice and Bob are going to a science fair on Friday.',
 });

--- a/examples/ai-functions/src/generate-text/google/vertex-xai-image-url.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-xai-image-url.ts
@@ -1,0 +1,25 @@
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const imageUrl =
+    'https://images.pexels.com/photos/36501108/pexels-photo-36501108.jpeg';
+  const result = await generateText({
+    model: googleVertexXai('xai/grok-4.20-reasoning'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this image briefly.' },
+          { type: 'file', mediaType: 'image', data: imageUrl },
+        ],
+      },
+    ],
+  });
+
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/generate-text/google/vertex-xai-output-object.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-xai-output-object.ts
@@ -1,0 +1,30 @@
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: googleVertexXai('xai/grok-4.20-reasoning'),
+    output: Output.object({
+      schema: z.object({
+        recipe: z.object({
+          name: z.string(),
+          ingredients: z.array(
+            z.object({
+              name: z.string(),
+              amount: z.string(),
+            }),
+          ),
+          steps: z.array(z.string()),
+        }),
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+  });
+
+  console.log(JSON.stringify(result.output, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/generate-text/google/vertex-xai-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-xai-tool-call.ts
@@ -1,0 +1,35 @@
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: googleVertexXai('xai/grok-4.1-fast-reasoning'),
+    tools: {
+      weather: tool({
+        description: 'Get the weather in a location (fahrenheit)',
+        inputSchema: z.object({
+          location: z.string().describe('The location to get the weather for'),
+        }),
+        outputSchema: z.object({
+          location: z.string(),
+          temperature: z.number(),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temperature: 72 + Math.floor(Math.random() * 21) - 10,
+        }),
+      }),
+    },
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Tool calls:', result.toolCalls);
+  console.log('Tool results:', result.toolResults);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/generate-text/google/vertex-xai.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-xai.ts
@@ -1,0 +1,15 @@
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: googleVertexXai('xai/grok-4.1-fast-reasoning'),
+    prompt: 'WHO INVENTED YOU?',
+  });
+
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/generate-text/google/vertex-xai.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-xai.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = await generateText({
     model: googleVertexXai('xai/grok-4.1-fast-reasoning'),
-    prompt: 'WHO INVENTED YOU?',
+    prompt: 'What is the meaning of life?',
   });
 
   console.log(result.text);

--- a/examples/ai-functions/src/stream-text/google/vertex-xai-output-object.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-xai-output-object.ts
@@ -1,0 +1,31 @@
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
+import { Output, streamText } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: googleVertexXai('xai/grok-4.20-reasoning'),
+    maxOutputTokens: 2000,
+    output: Output.object({
+      schema: z.object({
+        characters: z.array(
+          z.object({
+            name: z.string(),
+            class: z
+              .string()
+              .describe('Character class, e.g. warrior, mage, or thief.'),
+            description: z.string(),
+          }),
+        ),
+      }),
+    }),
+    prompt:
+      'Generate 3 character descriptions for a fantasy role playing game.',
+  });
+
+  for await (const partialOutput of result.partialOutputStream) {
+    console.clear();
+    console.log(partialOutput);
+  }
+});

--- a/examples/ai-functions/src/stream-text/google/vertex-xai-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-xai-tool-call.ts
@@ -1,0 +1,39 @@
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: googleVertexXai('xai/grok-4.1-fast-reasoning'),
+    tools: {
+      weather: tool({
+        description: 'Get the weather in a location (fahrenheit)',
+        inputSchema: z.object({
+          location: z.string().describe('The location to get the weather for'),
+        }),
+        outputSchema: z.object({
+          location: z.string(),
+          temperature: z.number(),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temperature: 72 + Math.floor(Math.random() * 21) - 10,
+        }),
+      }),
+    },
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log();
+  console.log('Tool calls:', await result.toolCalls);
+  console.log('Tool results:', await result.toolResults);
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/google/vertex-xai.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex-xai.ts
@@ -1,0 +1,18 @@
+import { googleVertexXai } from '@ai-sdk/google-vertex/xai';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: googleVertexXai('xai/grok-4.20-reasoning'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -20,7 +20,9 @@
     "anthropic/edge.d.ts",
     "anthropic/index.d.ts",
     "maas/edge.d.ts",
-    "maas/index.d.ts"
+    "maas/index.d.ts",
+    "xai/edge.d.ts",
+    "xai/index.d.ts"
   ],
   "directories": {
     "doc": "./docs"
@@ -69,6 +71,16 @@
       "types": "./dist/maas/edge/index.d.ts",
       "import": "./dist/maas/edge/index.js",
       "default": "./dist/maas/edge/index.js"
+    },
+    "./xai": {
+      "types": "./dist/xai/index.d.ts",
+      "import": "./dist/xai/index.js",
+      "default": "./dist/xai/index.js"
+    },
+    "./xai/edge": {
+      "types": "./dist/xai/edge/index.d.ts",
+      "import": "./dist/xai/edge/index.js",
+      "default": "./dist/xai/edge/index.js"
     }
   },
   "dependencies": {

--- a/packages/google-vertex/src/xai/edge/google-vertex-xai-provider-edge.test.ts
+++ b/packages/google-vertex/src/xai/edge/google-vertex-xai-provider-edge.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  createGoogleVertexXai,
+  googleVertexXai,
+} from './google-vertex-xai-provider-edge';
+import { generateAuthToken } from '../../edge/google-vertex-auth-edge';
+
+vi.mock('../../edge/google-vertex-auth-edge', () => ({
+  generateAuthToken: vi.fn(),
+}));
+
+vi.mock('../google-vertex-xai-provider', () => ({
+  createGoogleVertexXai: vi.fn(options => {
+    const provider: any = vi.fn();
+    provider.fetch = options.fetch;
+    provider.headers = options.headers;
+    return provider;
+  }),
+}));
+
+vi.mock('@ai-sdk/provider-utils', () => ({
+  resolve: vi.fn().mockImplementation(async value => {
+    if (typeof value === 'function') return value();
+    return value;
+  }),
+}));
+
+describe('google-vertex-xai-provider-edge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create provider with auth wrapper', async () => {
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+    });
+
+    expect(provider).toBeDefined();
+    const { createGoogleVertexXai: baseCreateGoogleVertexXai } = vi.mocked(
+      await import('../google-vertex-xai-provider'),
+    );
+    expect(baseCreateGoogleVertexXai).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: 'test-project',
+        fetch: expect.any(Function),
+        headers: undefined,
+      }),
+    );
+  });
+
+  it('should generate auth token and add to request headers', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+    });
+
+    const customFetch = (provider as any).fetch;
+    expect(customFetch).toBeDefined();
+
+    await customFetch('https://example.com/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(generateAuthToken).toHaveBeenCalledWith(undefined);
+
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/test', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer mock-auth-token',
+      },
+    });
+  });
+
+  it('should pass googleCredentials to generateAuthToken', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const googleCredentials = {
+      clientEmail: 'test@example.com',
+      privateKey: 'test-key',
+    };
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      googleCredentials,
+    });
+
+    const customFetch = (provider as any).fetch;
+    await customFetch('https://example.com/test', {});
+
+    expect(generateAuthToken).toHaveBeenCalledWith(googleCredentials);
+  });
+
+  it('should merge custom headers with auth header', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const customHeaders = { 'X-Custom': 'header-value' };
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      headers: customHeaders,
+    });
+
+    const customFetch = (provider as any).fetch;
+    await customFetch('https://example.com/test', {
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/test', {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Custom': 'header-value',
+        Authorization: 'Bearer mock-auth-token',
+      },
+    });
+  });
+
+  it('should use custom fetch when provided', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const customFetch = vi.fn().mockResolvedValue(new Response('{}'));
+
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      fetch: customFetch,
+    });
+
+    const authFetch = (provider as any).fetch;
+    await authFetch('https://example.com/test', {});
+
+    expect(customFetch).toHaveBeenCalledWith(
+      'https://example.com/test',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer mock-auth-token',
+        }),
+      }),
+    );
+  });
+
+  it('should export default googleVertexXai instance', () => {
+    expect(googleVertexXai).toBeDefined();
+    expect(typeof googleVertexXai).toBe('function');
+  });
+});

--- a/packages/google-vertex/src/xai/edge/google-vertex-xai-provider-edge.test.ts
+++ b/packages/google-vertex/src/xai/edge/google-vertex-xai-provider-edge.test.ts
@@ -39,13 +39,14 @@ describe('google-vertex-xai-provider-edge', () => {
     const { createGoogleVertexXai: baseCreateGoogleVertexXai } = vi.mocked(
       await import('../google-vertex-xai-provider'),
     );
-    expect(baseCreateGoogleVertexXai).toHaveBeenCalledWith(
-      expect.objectContaining({
-        project: 'test-project',
-        fetch: expect.any(Function),
-        headers: undefined,
-      }),
-    );
+    expect(baseCreateGoogleVertexXai).toHaveBeenCalledTimes(1);
+    expect(baseCreateGoogleVertexXai.mock.calls[0][0]).toMatchInlineSnapshot(`
+      {
+        "fetch": [Function],
+        "headers": undefined,
+        "project": "test-project",
+      }
+    `);
   });
 
   it('should generate auth token and add to request headers', async () => {
@@ -65,15 +66,28 @@ describe('google-vertex-xai-provider-edge', () => {
       headers: { 'Content-Type': 'application/json' },
     });
 
-    expect(generateAuthToken).toHaveBeenCalledWith(undefined);
+    expect(vi.mocked(generateAuthToken).mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          undefined,
+        ],
+      ]
+    `);
 
-    expect(mockFetch).toHaveBeenCalledWith('https://example.com/test', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer mock-auth-token',
-      },
-    });
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "https://example.com/test",
+          {
+            "headers": {
+              "Authorization": "Bearer mock-auth-token",
+              "Content-Type": "application/json",
+            },
+            "method": "POST",
+          },
+        ],
+      ]
+    `);
   });
 
   it('should pass googleCredentials to generateAuthToken', async () => {
@@ -93,7 +107,16 @@ describe('google-vertex-xai-provider-edge', () => {
     const customFetch = (provider as any).fetch;
     await customFetch('https://example.com/test', {});
 
-    expect(generateAuthToken).toHaveBeenCalledWith(googleCredentials);
+    expect(vi.mocked(generateAuthToken).mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "clientEmail": "test@example.com",
+            "privateKey": "test-key",
+          },
+        ],
+      ]
+    `);
   });
 
   it('should merge custom headers with auth header', async () => {
@@ -112,13 +135,20 @@ describe('google-vertex-xai-provider-edge', () => {
       headers: { 'Content-Type': 'application/json' },
     });
 
-    expect(mockFetch).toHaveBeenCalledWith('https://example.com/test', {
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Custom': 'header-value',
-        Authorization: 'Bearer mock-auth-token',
-      },
-    });
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "https://example.com/test",
+          {
+            "headers": {
+              "Authorization": "Bearer mock-auth-token",
+              "Content-Type": "application/json",
+              "X-Custom": "header-value",
+            },
+          },
+        ],
+      ]
+    `);
   });
 
   it('should use custom fetch when provided', async () => {
@@ -133,14 +163,18 @@ describe('google-vertex-xai-provider-edge', () => {
     const authFetch = (provider as any).fetch;
     await authFetch('https://example.com/test', {});
 
-    expect(customFetch).toHaveBeenCalledWith(
-      'https://example.com/test',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: 'Bearer mock-auth-token',
-        }),
-      }),
-    );
+    expect(customFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "https://example.com/test",
+          {
+            "headers": {
+              "Authorization": "Bearer mock-auth-token",
+            },
+          },
+        ],
+      ]
+    `);
   });
 
   it('should export default googleVertexXai instance', () => {

--- a/packages/google-vertex/src/xai/edge/google-vertex-xai-provider-edge.ts
+++ b/packages/google-vertex/src/xai/edge/google-vertex-xai-provider-edge.ts
@@ -1,0 +1,61 @@
+import { resolve, type FetchFunction } from '@ai-sdk/provider-utils';
+import {
+  generateAuthToken,
+  type GoogleCredentials,
+} from '../../edge/google-vertex-auth-edge';
+import {
+  createGoogleVertexXai as createGoogleVertexXaiOriginal,
+  type GoogleVertexXaiProvider,
+  type GoogleVertexXaiProviderSettings as GoogleVertexXaiProviderSettingsOriginal,
+} from '../google-vertex-xai-provider';
+export type { GoogleVertexXaiProvider };
+
+export interface GoogleVertexXaiProviderSettings extends GoogleVertexXaiProviderSettingsOriginal {
+  /**
+   * Optional. The Google credentials for the Google Cloud service account. If
+   * not provided, the Google Vertex provider will use environment variables to
+   * load the credentials.
+   */
+  googleCredentials?: GoogleCredentials;
+}
+
+/**
+ * Create a Google Vertex AI xAI provider instance for Edge runtimes.
+ * Uses the OpenAI-compatible Chat Completions API for Grok partner models.
+ * Automatically handles Google Cloud authentication.
+ *
+ * @see https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok
+ */
+export function createGoogleVertexXai(
+  options: GoogleVertexXaiProviderSettings = {},
+): GoogleVertexXaiProvider {
+  const customFetch: FetchFunction = async (url, init) => {
+    const token = await generateAuthToken(options.googleCredentials);
+    const resolvedHeaders = await resolve(options.headers);
+    const authHeaders = {
+      ...resolvedHeaders,
+      Authorization: `Bearer ${token}`,
+    };
+
+    const fetchInit = {
+      ...init,
+      headers: {
+        ...init?.headers,
+        ...authHeaders,
+      },
+    };
+
+    return (options.fetch ?? fetch)(url, fetchInit);
+  };
+
+  return createGoogleVertexXaiOriginal({
+    ...options,
+    fetch: customFetch,
+    headers: undefined,
+  });
+}
+
+/**
+ * Default Google Vertex AI xAI provider instance for Edge runtimes.
+ */
+export const googleVertexXai = createGoogleVertexXai();

--- a/packages/google-vertex/src/xai/edge/index.ts
+++ b/packages/google-vertex/src/xai/edge/index.ts
@@ -1,0 +1,9 @@
+export {
+  createGoogleVertexXai,
+  googleVertexXai,
+} from './google-vertex-xai-provider-edge';
+export type {
+  GoogleVertexXaiProvider,
+  GoogleVertexXaiProviderSettings,
+} from './google-vertex-xai-provider-edge';
+export type { GoogleVertexXaiModelId } from '../google-vertex-xai-options';

--- a/packages/google-vertex/src/xai/google-vertex-xai-options.ts
+++ b/packages/google-vertex/src/xai/google-vertex-xai-options.ts
@@ -1,0 +1,7 @@
+// https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok
+export type GoogleVertexXaiModelId =
+  | 'xai/grok-4.20-reasoning'
+  | 'xai/grok-4.20-non-reasoning'
+  | 'xai/grok-4.1-fast-reasoning'
+  | 'xai/grok-4.1-fast-non-reasoning'
+  | (string & {});

--- a/packages/google-vertex/src/xai/google-vertex-xai-provider-node.test.ts
+++ b/packages/google-vertex/src/xai/google-vertex-xai-provider-node.test.ts
@@ -39,13 +39,14 @@ describe('google-vertex-xai-provider-node', () => {
     const { createGoogleVertexXai: baseCreateGoogleVertexXai } = vi.mocked(
       await import('./google-vertex-xai-provider'),
     );
-    expect(baseCreateGoogleVertexXai).toHaveBeenCalledWith(
-      expect.objectContaining({
-        project: 'test-project',
-        fetch: expect.any(Function),
-        headers: undefined,
-      }),
-    );
+    expect(baseCreateGoogleVertexXai).toHaveBeenCalledTimes(1);
+    expect(baseCreateGoogleVertexXai.mock.calls[0][0]).toMatchInlineSnapshot(`
+      {
+        "fetch": [Function],
+        "headers": undefined,
+        "project": "test-project",
+      }
+    `);
   });
 
   it('should generate auth token and add to request headers', async () => {
@@ -65,15 +66,28 @@ describe('google-vertex-xai-provider-node', () => {
       headers: { 'Content-Type': 'application/json' },
     });
 
-    expect(generateAuthToken).toHaveBeenCalledWith(undefined);
+    expect(vi.mocked(generateAuthToken).mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          undefined,
+        ],
+      ]
+    `);
 
-    expect(mockFetch).toHaveBeenCalledWith('https://example.com/test', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer mock-auth-token',
-      },
-    });
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "https://example.com/test",
+          {
+            "headers": {
+              "Authorization": "Bearer mock-auth-token",
+              "Content-Type": "application/json",
+            },
+            "method": "POST",
+          },
+        ],
+      ]
+    `);
   });
 
   it('should pass googleAuthOptions to generateAuthToken', async () => {
@@ -90,7 +104,17 @@ describe('google-vertex-xai-provider-node', () => {
     const customFetch = (provider as any).fetch;
     await customFetch('https://example.com/test', {});
 
-    expect(generateAuthToken).toHaveBeenCalledWith(googleAuthOptions);
+    expect(vi.mocked(generateAuthToken).mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "scopes": [
+              "test-scope",
+            ],
+          },
+        ],
+      ]
+    `);
   });
 
   it('should merge custom headers with auth header', async () => {
@@ -109,13 +133,20 @@ describe('google-vertex-xai-provider-node', () => {
       headers: { 'Content-Type': 'application/json' },
     });
 
-    expect(mockFetch).toHaveBeenCalledWith('https://example.com/test', {
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Custom': 'header-value',
-        Authorization: 'Bearer mock-auth-token',
-      },
-    });
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "https://example.com/test",
+          {
+            "headers": {
+              "Authorization": "Bearer mock-auth-token",
+              "Content-Type": "application/json",
+              "X-Custom": "header-value",
+            },
+          },
+        ],
+      ]
+    `);
   });
 
   it('should use custom fetch when provided', async () => {
@@ -130,14 +161,18 @@ describe('google-vertex-xai-provider-node', () => {
     const authFetch = (provider as any).fetch;
     await authFetch('https://example.com/test', {});
 
-    expect(customFetch).toHaveBeenCalledWith(
-      'https://example.com/test',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: 'Bearer mock-auth-token',
-        }),
-      }),
-    );
+    expect(customFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "https://example.com/test",
+          {
+            "headers": {
+              "Authorization": "Bearer mock-auth-token",
+            },
+          },
+        ],
+      ]
+    `);
   });
 
   it('should export default googleVertexXai instance', () => {

--- a/packages/google-vertex/src/xai/google-vertex-xai-provider-node.test.ts
+++ b/packages/google-vertex/src/xai/google-vertex-xai-provider-node.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  createGoogleVertexXai,
+  googleVertexXai,
+} from './google-vertex-xai-provider-node';
+import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
+
+vi.mock('../google-vertex-auth-google-auth-library', () => ({
+  generateAuthToken: vi.fn(),
+}));
+
+vi.mock('./google-vertex-xai-provider', () => ({
+  createGoogleVertexXai: vi.fn(options => {
+    const provider: any = vi.fn();
+    provider.fetch = options.fetch;
+    provider.headers = options.headers;
+    return provider;
+  }),
+}));
+
+vi.mock('@ai-sdk/provider-utils', () => ({
+  resolve: vi.fn().mockImplementation(async value => {
+    if (typeof value === 'function') return value();
+    return value;
+  }),
+}));
+
+describe('google-vertex-xai-provider-node', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create provider with auth wrapper', async () => {
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+    });
+
+    expect(provider).toBeDefined();
+    const { createGoogleVertexXai: baseCreateGoogleVertexXai } = vi.mocked(
+      await import('./google-vertex-xai-provider'),
+    );
+    expect(baseCreateGoogleVertexXai).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: 'test-project',
+        fetch: expect.any(Function),
+        headers: undefined,
+      }),
+    );
+  });
+
+  it('should generate auth token and add to request headers', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+    });
+
+    const customFetch = (provider as any).fetch;
+    expect(customFetch).toBeDefined();
+
+    await customFetch('https://example.com/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(generateAuthToken).toHaveBeenCalledWith(undefined);
+
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/test', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer mock-auth-token',
+      },
+    });
+  });
+
+  it('should pass googleAuthOptions to generateAuthToken', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const googleAuthOptions = { scopes: ['test-scope'] };
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      googleAuthOptions,
+    });
+
+    const customFetch = (provider as any).fetch;
+    await customFetch('https://example.com/test', {});
+
+    expect(generateAuthToken).toHaveBeenCalledWith(googleAuthOptions);
+  });
+
+  it('should merge custom headers with auth header', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const customHeaders = { 'X-Custom': 'header-value' };
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      headers: customHeaders,
+    });
+
+    const customFetch = (provider as any).fetch;
+    await customFetch('https://example.com/test', {
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/test', {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Custom': 'header-value',
+        Authorization: 'Bearer mock-auth-token',
+      },
+    });
+  });
+
+  it('should use custom fetch when provided', async () => {
+    vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
+    const customFetch = vi.fn().mockResolvedValue(new Response('{}'));
+
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      fetch: customFetch,
+    });
+
+    const authFetch = (provider as any).fetch;
+    await authFetch('https://example.com/test', {});
+
+    expect(customFetch).toHaveBeenCalledWith(
+      'https://example.com/test',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer mock-auth-token',
+        }),
+      }),
+    );
+  });
+
+  it('should export default googleVertexXai instance', () => {
+    expect(googleVertexXai).toBeDefined();
+    expect(typeof googleVertexXai).toBe('function');
+  });
+});

--- a/packages/google-vertex/src/xai/google-vertex-xai-provider-node.ts
+++ b/packages/google-vertex/src/xai/google-vertex-xai-provider-node.ts
@@ -1,0 +1,60 @@
+import { resolve, type FetchFunction } from '@ai-sdk/provider-utils';
+import type { GoogleAuthOptions } from 'google-auth-library';
+import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
+import {
+  createGoogleVertexXai as createGoogleVertexXaiOriginal,
+  type GoogleVertexXaiProvider,
+  type GoogleVertexXaiProviderSettings as GoogleVertexXaiProviderSettingsOriginal,
+} from './google-vertex-xai-provider';
+export type { GoogleVertexXaiProvider };
+
+export interface GoogleVertexXaiProviderSettings extends GoogleVertexXaiProviderSettingsOriginal {
+  /**
+   * Optional. The Authentication options provided by google-auth-library.
+   * Complete list of authentication options is documented in the
+   * GoogleAuthOptions interface:
+   * https://github.com/googleapis/google-auth-library-nodejs/blob/main/src/auth/googleauth.ts.
+   */
+  googleAuthOptions?: GoogleAuthOptions;
+}
+
+/**
+ * Create a Google Vertex AI xAI provider instance for Node.js.
+ * Uses the OpenAI-compatible Chat Completions API for Grok partner models.
+ * Automatically handles Google Cloud authentication.
+ *
+ * @see https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok
+ */
+export function createGoogleVertexXai(
+  options: GoogleVertexXaiProviderSettings = {},
+): GoogleVertexXaiProvider {
+  const customFetch: FetchFunction = async (url, init) => {
+    const token = await generateAuthToken(options.googleAuthOptions);
+    const resolvedHeaders = await resolve(options.headers);
+    const authHeaders = {
+      ...resolvedHeaders,
+      Authorization: `Bearer ${token}`,
+    };
+
+    const fetchInit = {
+      ...init,
+      headers: {
+        ...init?.headers,
+        ...authHeaders,
+      },
+    };
+
+    return (options.fetch ?? fetch)(url, fetchInit);
+  };
+
+  return createGoogleVertexXaiOriginal({
+    ...options,
+    fetch: customFetch,
+    headers: undefined,
+  });
+}
+
+/**
+ * Default Google Vertex AI xAI provider instance for Node.js.
+ */
+export const googleVertexXai = createGoogleVertexXai();

--- a/packages/google-vertex/src/xai/google-vertex-xai-provider.test.ts
+++ b/packages/google-vertex/src/xai/google-vertex-xai-provider.test.ts
@@ -1,0 +1,204 @@
+import { NoSuchModelError } from '@ai-sdk/provider';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createGoogleVertexXai } from './google-vertex-xai-provider';
+
+vi.mock('@ai-sdk/openai-compatible', () => ({
+  createOpenAICompatible: vi.fn(() => {
+    const provider: any = vi.fn();
+    provider.specificationVersion = 'v4';
+    provider.languageModel = vi.fn();
+    provider.chatModel = vi.fn();
+    return provider;
+  }),
+}));
+
+vi.mock('@ai-sdk/provider-utils', () => ({
+  loadSetting: vi.fn().mockImplementation(({ settingValue }) => {
+    if (settingValue === undefined) {
+      throw new Error('Setting is missing');
+    }
+    return settingValue;
+  }),
+  loadOptionalSetting: vi
+    .fn()
+    .mockImplementation(({ settingValue }) => settingValue),
+  withoutTrailingSlash: vi.fn().mockImplementation(url => {
+    if (!url) return '';
+    return url?.endsWith('/') ? url.slice(0, -1) : url;
+  }),
+}));
+
+describe('google-vertex-xai-provider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should not call createOpenAICompatible at provider creation time', () => {
+    createGoogleVertexXai({
+      project: 'test-project',
+      location: 'global',
+    });
+
+    expect(createOpenAICompatible).not.toHaveBeenCalled();
+  });
+
+  it('should create a provider with correct base URL for global location', () => {
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      location: 'global',
+    });
+
+    provider('xai/grok-4.1-fast-reasoning');
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'googleVertex.xai',
+        baseURL:
+          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi',
+      }),
+    );
+  });
+
+  it('should create a provider with correct base URL for regional location', () => {
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      location: 'us-central1',
+    });
+
+    provider('xai/grok-4.1-fast-reasoning');
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'googleVertex.xai',
+        baseURL:
+          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi',
+      }),
+    );
+  });
+
+  it('should configure OpenAI-compatible behavior for Vertex Grok', () => {
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      location: 'global',
+    });
+
+    provider('xai/grok-4.1-fast-reasoning');
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeUsage: true,
+        supportsStructuredOutputs: true,
+        supportedUrls: expect.any(Function),
+        transformRequestBody: expect.any(Function),
+        convertUsage: expect.any(Function),
+      }),
+    );
+  });
+
+  it('should strip reasoning_effort from request bodies', () => {
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      location: 'global',
+    });
+
+    provider('xai/grok-4.1-fast-reasoning');
+
+    const [{ transformRequestBody }] = vi.mocked(createOpenAICompatible).mock
+      .calls[0];
+
+    expect(
+      transformRequestBody?.({
+        model: 'xai/grok-4.1-fast-reasoning',
+        reasoning_effort: 'high',
+        messages: [],
+      }),
+    ).toEqual({
+      model: 'xai/grok-4.1-fast-reasoning',
+      messages: [],
+    });
+  });
+
+  it('should count Grok reasoning tokens separately from completion tokens', () => {
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      location: 'global',
+    });
+
+    provider('xai/grok-4.1-fast-reasoning');
+
+    const [{ convertUsage }] = vi.mocked(createOpenAICompatible).mock.calls[0];
+
+    expect(
+      convertUsage?.({
+        prompt_tokens: 663,
+        prompt_tokens_details: { cached_tokens: 654 },
+        completion_tokens: 50,
+        completion_tokens_details: { reasoning_tokens: 124 },
+      }),
+    ).toEqual({
+      inputTokens: {
+        total: 663,
+        noCache: 9,
+        cacheRead: 654,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 174,
+        text: 50,
+        reasoning: 124,
+      },
+      raw: {
+        prompt_tokens: 663,
+        prompt_tokens_details: { cached_tokens: 654 },
+        completion_tokens: 50,
+        completion_tokens_details: { reasoning_tokens: 124 },
+      },
+    });
+  });
+
+  it('should support HTTP image URLs', () => {
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+      location: 'global',
+    });
+
+    provider('xai/grok-4.1-fast-reasoning');
+
+    const [{ supportedUrls }] = vi.mocked(createOpenAICompatible).mock.calls[0];
+
+    expect(supportedUrls?.()).toEqual({
+      'image/*': [/^https?:\/\/.*$/],
+    });
+  });
+
+  it('should throw an error when using new keyword', () => {
+    const provider = createGoogleVertexXai({ project: 'test-project' });
+
+    expect(() => new (provider as any)('test-model-id')).toThrow(
+      'The Google Vertex xAI model function cannot be called with the new keyword.',
+    );
+  });
+
+  it('should throw NoSuchModelError for embedding and image models', () => {
+    const provider = createGoogleVertexXai({ project: 'test-project' });
+
+    expect(() => provider.embeddingModel('invalid-model-id')).toThrow(
+      NoSuchModelError,
+    );
+    expect(() => provider.imageModel('invalid-model-id')).toThrow(
+      NoSuchModelError,
+    );
+  });
+
+  it('should cache the OpenAI-compatible provider after first access', () => {
+    const provider = createGoogleVertexXai({
+      project: 'test-project',
+    });
+
+    provider('xai/grok-4.1-fast-reasoning');
+    provider('xai/grok-4.20-reasoning');
+
+    expect(createOpenAICompatible).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/google-vertex/src/xai/google-vertex-xai-provider.test.ts
+++ b/packages/google-vertex/src/xai/google-vertex-xai-provider.test.ts
@@ -51,13 +51,19 @@ describe('google-vertex-xai-provider', () => {
 
     provider('xai/grok-4.1-fast-reasoning');
 
-    expect(createOpenAICompatible).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'googleVertex.xai',
-        baseURL:
-          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi',
-      }),
-    );
+    expect(vi.mocked(createOpenAICompatible).mock.calls[0][0])
+      .toMatchInlineSnapshot(`
+        {
+          "baseURL": "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi",
+          "convertUsage": [Function],
+          "fetch": undefined,
+          "includeUsage": true,
+          "name": "googleVertex.xai",
+          "supportedUrls": [Function],
+          "supportsStructuredOutputs": true,
+          "transformRequestBody": [Function],
+        }
+      `);
   });
 
   it('should create a provider with correct base URL for regional location', () => {
@@ -68,13 +74,19 @@ describe('google-vertex-xai-provider', () => {
 
     provider('xai/grok-4.1-fast-reasoning');
 
-    expect(createOpenAICompatible).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'googleVertex.xai',
-        baseURL:
-          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi',
-      }),
-    );
+    expect(vi.mocked(createOpenAICompatible).mock.calls[0][0])
+      .toMatchInlineSnapshot(`
+        {
+          "baseURL": "https://aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi",
+          "convertUsage": [Function],
+          "fetch": undefined,
+          "includeUsage": true,
+          "name": "googleVertex.xai",
+          "supportedUrls": [Function],
+          "supportsStructuredOutputs": true,
+          "transformRequestBody": [Function],
+        }
+      `);
   });
 
   it('should configure OpenAI-compatible behavior for Vertex Grok', () => {
@@ -85,15 +97,19 @@ describe('google-vertex-xai-provider', () => {
 
     provider('xai/grok-4.1-fast-reasoning');
 
-    expect(createOpenAICompatible).toHaveBeenCalledWith(
-      expect.objectContaining({
-        includeUsage: true,
-        supportsStructuredOutputs: true,
-        supportedUrls: expect.any(Function),
-        transformRequestBody: expect.any(Function),
-        convertUsage: expect.any(Function),
-      }),
-    );
+    expect(vi.mocked(createOpenAICompatible).mock.calls[0][0])
+      .toMatchInlineSnapshot(`
+        {
+          "baseURL": "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi",
+          "convertUsage": [Function],
+          "fetch": undefined,
+          "includeUsage": true,
+          "name": "googleVertex.xai",
+          "supportedUrls": [Function],
+          "supportsStructuredOutputs": true,
+          "transformRequestBody": [Function],
+        }
+      `);
   });
 
   it('should strip reasoning_effort from request bodies', () => {
@@ -113,10 +129,12 @@ describe('google-vertex-xai-provider', () => {
         reasoning_effort: 'high',
         messages: [],
       }),
-    ).toEqual({
-      model: 'xai/grok-4.1-fast-reasoning',
-      messages: [],
-    });
+    ).toMatchInlineSnapshot(`
+      {
+        "messages": [],
+        "model": "xai/grok-4.1-fast-reasoning",
+      }
+    `);
   });
 
   it('should count Grok reasoning tokens separately from completion tokens', () => {
@@ -136,25 +154,31 @@ describe('google-vertex-xai-provider', () => {
         completion_tokens: 50,
         completion_tokens_details: { reasoning_tokens: 124 },
       }),
-    ).toEqual({
-      inputTokens: {
-        total: 663,
-        noCache: 9,
-        cacheRead: 654,
-        cacheWrite: undefined,
-      },
-      outputTokens: {
-        total: 174,
-        text: 50,
-        reasoning: 124,
-      },
-      raw: {
-        prompt_tokens: 663,
-        prompt_tokens_details: { cached_tokens: 654 },
-        completion_tokens: 50,
-        completion_tokens_details: { reasoning_tokens: 124 },
-      },
-    });
+    ).toMatchInlineSnapshot(`
+      {
+        "inputTokens": {
+          "cacheRead": 654,
+          "cacheWrite": undefined,
+          "noCache": 9,
+          "total": 663,
+        },
+        "outputTokens": {
+          "reasoning": 124,
+          "text": 50,
+          "total": 174,
+        },
+        "raw": {
+          "completion_tokens": 50,
+          "completion_tokens_details": {
+            "reasoning_tokens": 124,
+          },
+          "prompt_tokens": 663,
+          "prompt_tokens_details": {
+            "cached_tokens": 654,
+          },
+        },
+      }
+    `);
   });
 
   it('should support HTTP image URLs', () => {
@@ -167,9 +191,13 @@ describe('google-vertex-xai-provider', () => {
 
     const [{ supportedUrls }] = vi.mocked(createOpenAICompatible).mock.calls[0];
 
-    expect(supportedUrls?.()).toEqual({
-      'image/*': [/^https?:\/\/.*$/],
-    });
+    expect(supportedUrls?.()).toMatchInlineSnapshot(`
+      {
+        "image/*": [
+          /\\^https\\?:\\\\/\\\\/\\.\\*\\$/,
+        ],
+      }
+    `);
   });
 
   it('should throw an error when using new keyword', () => {

--- a/packages/google-vertex/src/xai/google-vertex-xai-provider.ts
+++ b/packages/google-vertex/src/xai/google-vertex-xai-provider.ts
@@ -1,0 +1,212 @@
+import {
+  NoSuchModelError,
+  type LanguageModelV4,
+  type LanguageModelV4Usage,
+  type ProviderV4,
+} from '@ai-sdk/provider';
+import {
+  createOpenAICompatible,
+  type OpenAICompatibleProvider,
+} from '@ai-sdk/openai-compatible';
+import {
+  loadOptionalSetting,
+  loadSetting,
+  withoutTrailingSlash,
+  type FetchFunction,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import type { GoogleVertexXaiModelId } from './google-vertex-xai-options';
+
+export interface GoogleVertexXaiProvider extends ProviderV4 {
+  /**
+   * Creates a model for text generation.
+   */
+  (modelId: GoogleVertexXaiModelId): LanguageModelV4;
+
+  /**
+   * Creates a model for text generation.
+   */
+  languageModel(modelId: GoogleVertexXaiModelId): LanguageModelV4;
+
+  /**
+   * Creates a chat model for text generation.
+   */
+  chatModel(modelId: GoogleVertexXaiModelId): LanguageModelV4;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
+}
+
+export interface GoogleVertexXaiProviderSettings {
+  /**
+   * Google Cloud project ID. Defaults to the value of the `GOOGLE_VERTEX_PROJECT` environment variable.
+   */
+  project?: string;
+
+  /**
+   * Google Cloud location/region. Defaults to the value of the `GOOGLE_VERTEX_LOCATION` environment variable.
+   * Use 'global' for the global endpoint.
+   */
+  location?: string;
+
+  /**
+   * Base URL for the API calls. If not provided, will be constructed from project and location.
+   */
+  baseURL?: string;
+
+  /**
+   * Headers to use for requests. Can be:
+   * - A headers object
+   * - A Promise that resolves to a headers object
+   * - A function that returns a headers object
+   * - A function that returns a Promise of a headers object
+   */
+  headers?: Resolvable<Record<string, string | undefined>>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept requests,
+   * or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+}
+
+type GoogleVertexXaiUsage =
+  | {
+      prompt_tokens?: number | null;
+      completion_tokens?: number | null;
+      prompt_tokens_details?: {
+        cached_tokens?: number | null;
+      } | null;
+      completion_tokens_details?: {
+        reasoning_tokens?: number | null;
+      } | null;
+    }
+  | undefined
+  | null;
+
+function convertGoogleVertexXaiUsage(
+  usage: GoogleVertexXaiUsage,
+): LanguageModelV4Usage {
+  if (usage == null) {
+    return {
+      inputTokens: {
+        total: undefined,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: undefined,
+        text: undefined,
+        reasoning: undefined,
+      },
+      raw: undefined,
+    };
+  }
+
+  const promptTokens = usage.prompt_tokens ?? 0;
+  const completionTokens = usage.completion_tokens ?? 0;
+  const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens ?? 0;
+  const reasoningTokens =
+    usage.completion_tokens_details?.reasoning_tokens ?? 0;
+
+  return {
+    inputTokens: {
+      total: promptTokens,
+      noCache: promptTokens - cacheReadTokens,
+      cacheRead: cacheReadTokens,
+      cacheWrite: undefined,
+    },
+    outputTokens: {
+      total: completionTokens + reasoningTokens,
+      text: completionTokens,
+      reasoning: reasoningTokens,
+    },
+    raw: usage,
+  };
+}
+
+function transformGoogleVertexXaiRequestBody(args: Record<string, any>) {
+  const { reasoning_effort: _reasoningEffort, ...rest } = args;
+  return rest;
+}
+
+/**
+ * Create a Google Vertex AI xAI provider instance.
+ * Uses the OpenAI-compatible Chat Completions API for Grok partner models.
+ *
+ * @see https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok
+ */
+export function createGoogleVertexXai(
+  options: GoogleVertexXaiProviderSettings = {},
+): GoogleVertexXaiProvider {
+  const loadLocation = () =>
+    loadOptionalSetting({
+      settingValue: options.location,
+      environmentVariableName: 'GOOGLE_VERTEX_LOCATION',
+    });
+
+  const loadProject = () =>
+    loadSetting({
+      settingValue: options.project,
+      settingName: 'project',
+      environmentVariableName: 'GOOGLE_VERTEX_PROJECT',
+      description: 'Google Vertex project',
+    });
+
+  const constructBaseURL = () => {
+    const projectId = loadProject();
+    const location = loadLocation() ?? 'global';
+
+    return `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/${location}/endpoints/openapi`;
+  };
+
+  const loadBaseURL = () =>
+    withoutTrailingSlash(options.baseURL ?? '') || constructBaseURL();
+
+  let cachedProvider:
+    | OpenAICompatibleProvider<GoogleVertexXaiModelId, string, string, string>
+    | undefined;
+  const getProvider = () =>
+    (cachedProvider ??= createOpenAICompatible({
+      name: 'googleVertex.xai',
+      baseURL: loadBaseURL(),
+      fetch: options.fetch,
+      includeUsage: true,
+      supportsStructuredOutputs: true,
+      supportedUrls: () => ({
+        'image/*': [/^https?:\/\/.*$/],
+      }),
+      transformRequestBody: transformGoogleVertexXaiRequestBody,
+      convertUsage: convertGoogleVertexXaiUsage,
+    }));
+
+  const createChatModel = (modelId: GoogleVertexXaiModelId) =>
+    getProvider().languageModel(modelId);
+
+  const provider = function (modelId: GoogleVertexXaiModelId) {
+    if (new.target) {
+      throw new Error(
+        'The Google Vertex xAI model function cannot be called with the new keyword.',
+      );
+    }
+
+    return createChatModel(modelId);
+  };
+
+  provider.specificationVersion = 'v4' as const;
+  provider.languageModel = createChatModel;
+  provider.chatModel = (modelId: GoogleVertexXaiModelId) =>
+    getProvider().chatModel(modelId);
+  provider.embeddingModel = (modelId: string): never => {
+    throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
+  };
+  provider.textEmbeddingModel = provider.embeddingModel;
+  provider.imageModel = (modelId: string): never => {
+    throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+  };
+
+  return provider;
+}

--- a/packages/google-vertex/src/xai/index.ts
+++ b/packages/google-vertex/src/xai/index.ts
@@ -1,0 +1,9 @@
+export {
+  createGoogleVertexXai,
+  googleVertexXai,
+} from './google-vertex-xai-provider-node';
+export type {
+  GoogleVertexXaiProvider,
+  GoogleVertexXaiProviderSettings,
+} from './google-vertex-xai-provider-node';
+export type { GoogleVertexXaiModelId } from './google-vertex-xai-options';

--- a/packages/google-vertex/tsconfig.json
+++ b/packages/google-vertex/tsconfig.json
@@ -14,7 +14,9 @@
     "anthropic/edge.d.ts",
     "anthropic/index.d.ts",
     "maas/edge.d.ts",
-    "maas/index.d.ts"
+    "maas/index.d.ts",
+    "xai/edge.d.ts",
+    "xai/index.d.ts"
   ],
   "references": [
     {

--- a/packages/google-vertex/tsup.config.ts
+++ b/packages/google-vertex/tsup.config.ts
@@ -79,4 +79,30 @@ export default defineConfig([
     },
     outDir: 'dist/maas/edge',
   },
+  {
+    entry: ['src/xai/index.ts'],
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+    outDir: 'dist/xai',
+  },
+  {
+    entry: ['src/xai/edge/index.ts'],
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+    outDir: 'dist/xai/edge',
+  },
 ]);

--- a/packages/google-vertex/xai/edge.d.ts
+++ b/packages/google-vertex/xai/edge.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/xai/edge';

--- a/packages/google-vertex/xai/index.d.ts
+++ b/packages/google-vertex/xai/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/xai/index';

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -7,6 +7,7 @@ import type {
   LanguageModelV4GenerateResult,
   LanguageModelV4StreamPart,
   LanguageModelV4StreamResult,
+  LanguageModelV4Usage,
   SharedV4ProviderMetadata,
   SharedV4Warning,
 } from '@ai-sdk/provider';
@@ -82,6 +83,14 @@ export type OpenAICompatibleChatConfig = {
    * than the official OpenAI API.
    */
   transformRequestBody?: (args: Record<string, any>) => Record<string, any>;
+
+  /**
+   * Optional usage converter for OpenAI-compatible providers with different
+   * token accounting semantics.
+   */
+  convertUsage?: (
+    usage: z.infer<typeof openaiCompatibleTokenUsageSchema>,
+  ) => LanguageModelV4Usage;
 };
 
 type PendingToolCall = {
@@ -149,6 +158,15 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
 
   private transformRequestBody(args: Record<string, any>): Record<string, any> {
     return this.config.transformRequestBody?.(args) ?? args;
+  }
+
+  private convertUsage(
+    usage: z.infer<typeof openaiCompatibleTokenUsageSchema>,
+  ): LanguageModelV4Usage {
+    return (
+      this.config.convertUsage?.(usage) ??
+      convertOpenAICompatibleChatUsage(usage)
+    );
   }
 
   private async getArgs({
@@ -397,7 +415,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
         unified: mapOpenAICompatibleFinishReason(choice.finish_reason),
         raw: choice.finish_reason ?? undefined,
       },
-      usage: convertOpenAICompatibleChatUsage(responseBody.usage),
+      usage: this.convertUsage(responseBody.usage),
       providerMetadata,
       request: { body },
       response: {
@@ -514,6 +532,9 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
     let isFirstChunk = true;
     let isActiveReasoning = false;
     let isActiveText = false;
+    const convertUsage = (
+      usage: z.infer<typeof openaiCompatibleTokenUsageSchema>,
+    ) => this.convertUsage(usage);
 
     return {
       stream: response.pipeThrough(
@@ -699,7 +720,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
             controller.enqueue({
               type: 'finish',
               finishReason,
-              usage: convertOpenAICompatibleChatUsage(usage),
+              usage: convertUsage(usage),
               providerMetadata,
             });
           },

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -104,6 +104,17 @@ export interface OpenAICompatibleProviderSettings {
    * or provider-specific metrics from both streaming and non-streaming responses.
    */
   metadataExtractor?: MetadataExtractor;
+
+  /**
+   * The supported URLs for chat models.
+   */
+  supportedUrls?: OpenAICompatibleChatConfig['supportedUrls'];
+
+  /**
+   * Optional usage converter for providers with token accounting semantics that
+   * differ from the default OpenAI-compatible shape.
+   */
+  convertUsage?: OpenAICompatibleChatConfig['convertUsage'];
 }
 
 /**
@@ -161,8 +172,10 @@ export function createOpenAICompatible<
       ...getCommonModelConfig('chat'),
       includeUsage: options.includeUsage,
       supportsStructuredOutputs: options.supportsStructuredOutputs,
+      supportedUrls: options.supportedUrls,
       transformRequestBody: options.transformRequestBody,
       metadataExtractor: options.metadataExtractor,
+      convertUsage: options.convertUsage,
     });
 
   const createCompletionModel = (modelId: COMPLETION_MODEL_IDS) =>


### PR DESCRIPTION
## Background

Vertex supports xAI's Grok models https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok

The AI SDK didn't support those models yet

## Summary

added a new provider within google vertex provider specific for XAI. Grok models couldn't be appended to just the MaaS provider since Grok models on vertex support structured outputs.

## Manual Verification

- `examples/ai-functions/src/generate-text/google/vertex-xai-image-url.ts`
- `examples/ai-functions/src/generate-text/google/vertex-xai-output-object.ts`
- `examples/ai-functions/src/generate-text/google/vertex-xai-tool-call.ts`
- `examples/ai-functions/src/generate-text/google/vertex-xai.ts`
- `examples/ai-functions/src/stream-text/google/vertex-xai-output-object.ts`
- `examples/ai-functions/src/stream-text/google/vertex-xai-tool-call.ts`
- `examples/ai-functions/src/stream-text/google/vertex-xai.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)