### PR TITLE
fix(gateway): add automatic caching provider option

### DIFF
--- a/.changeset/few-lemons-drum.md
+++ b/.changeset/few-lemons-drum.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+Add the `caching: 'auto'` gateway provider option to the exported type schema.

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -800,6 +800,12 @@ The following gateway provider options are available:
 
   Example: `models: ['openai/gpt-5.4-nano', 'gemini-3-flash-preview']` will try the fallback models in order if the primary model fails.
 
+- **caching** _'auto'_
+
+  Enables automatic prompt caching for supported models.
+
+  Example: `caching: 'auto'` lets AI Gateway apply automatic prompt caching when the routed model supports it.
+
 - **user** _string_
 
   Optional identifier for the end user on whose behalf the request is being made. This is used for spend tracking and attribution purposes, allowing you to track usage per end-user in your application.

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1544,6 +1544,26 @@ describe('GatewayLanguageModel', () => {
       });
     });
 
+    it('should pass automatic caching option', async () => {
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Test response' },
+      });
+
+      await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          gateway: {
+            caching: 'auto',
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        gateway: { caching: 'auto' },
+      });
+    });
+
     it('should pass providerTimeouts for doGenerate', async () => {
       prepareJsonResponse({
         content: { type: 'text', text: 'Test response' },

--- a/packages/gateway/src/gateway-provider-options.test-d.ts
+++ b/packages/gateway/src/gateway-provider-options.test-d.ts
@@ -1,0 +1,12 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { GatewayProviderOptions } from './gateway-provider-options';
+
+describe('GatewayProviderOptions type', () => {
+  it('should allow automatic caching', () => {
+    const options = {
+      caching: 'auto',
+    } satisfies GatewayProviderOptions;
+
+    expectTypeOf(options).toMatchTypeOf<GatewayProviderOptions>();
+  });
+});

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -50,6 +50,10 @@ const gatewayProviderOptions = lazySchema(() =>
        */
       models: z.array(z.string()).optional(),
       /**
+       * Enable automatic prompt caching for supported models.
+       */
+      caching: z.literal('auto').optional(),
+      /**
        * Request-scoped BYOK credentials to use instead of cached credentials.
        *
        * When provided, cached BYOK credentials are ignored entirely.


### PR DESCRIPTION
Fixes #14595

## Summary
- add `caching: 'auto'` to the Gateway provider options schema/exported type
- add compile-time type coverage for `GatewayProviderOptions`
- add node/edge request passthrough coverage for the gateway language model
- document the option in the AI Gateway provider options list

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @ai-sdk/provider --filter @ai-sdk/provider-utils --filter @ai-sdk/test-server build`
- `corepack pnpm --filter @ai-sdk/gateway exec vitest --config vitest.node.config.js --run src/gateway-language-model.test.ts`
- `corepack pnpm --filter @ai-sdk/gateway exec vitest --config vitest.edge.config.js --run src/gateway-language-model.test.ts`
- `corepack pnpm --filter @ai-sdk/gateway type-check`
- `corepack pnpm exec ultracite check packages/gateway/src/gateway-provider-options.ts packages/gateway/src/gateway-provider-options.test-d.ts packages/gateway/src/gateway-language-model.test.ts content/providers/01-ai-sdk-providers/00-ai-gateway.mdx`
- `corepack pnpm --filter @ai-sdk/gateway build`
- `git diff --check`