### PR TITLE
fix(ui): skip validation for failed tool inputs

### DIFF
--- a/.changeset/fix-ui-output-error-validation.md
+++ b/.changeset/fix-ui-output-error-validation.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Do not revalidate failed tool inputs when validating historical UI message `output-error` parts.

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -1153,6 +1153,51 @@ describe('validateUIMessages', () => {
       `);
     });
 
+    it('should not revalidate tool input when state is output-error and there is invalid input', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-foo',
+                toolCallId: '1',
+                state: 'output-error',
+                input: { foo: 123 },
+                errorText: 'Tool input validation failed',
+                providerExecuted: false,
+              },
+            ],
+          },
+        ],
+        tools: {
+          foo: testTool,
+        },
+      });
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "errorText": "Tool input validation failed",
+                "input": {
+                  "foo": 123,
+                },
+                "providerExecuted": false,
+                "state": "output-error",
+                "toolCallId": "1",
+                "type": "tool-foo",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
     it('should preserve result provider metadata when state is output-error', async () => {
       const messages = await validateUIMessages<TestMessage>({
         messages: [

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -453,9 +453,7 @@ export async function safeValidateUIMessages<UI_MESSAGE extends UIMessage>({
             // Tool input validation
             if (
               toolPart.state === 'input-available' ||
-              toolPart.state === 'output-available' ||
-              (toolPart.state === 'output-error' &&
-                toolPart.input !== undefined)
+              toolPart.state === 'output-available'
             ) {
               await validateTypes({
                 value: toolPart.input,


### PR DESCRIPTION
## Summary

Fixes #13591.

`validateUIMessages` was revalidating tool inputs even after a tool part had already moved into `output-error`. That makes persisted failed tool calls impossible to reload when the original input was invalid, even though the error state is the record of that failed validation/execution.

This keeps input validation for `input-available` and `output-available`, but skips revalidating `output-error` inputs. A regression test covers a historical `tool-foo` part whose failed input no longer matches the tool schema.

## Tests

- `pnpm --dir packages/ai test:node -- validate-ui-messages.test.ts`
- `pnpm --dir packages/ai test:edge -- validate-ui-messages.test.ts`
- `pnpm --dir packages/ai type-check`
- `pnpm exec ultracite check packages/ai/src/ui/validate-ui-messages.ts packages/ai/src/ui/validate-ui-messages.test.ts .changeset/fix-ui-output-error-validation.md`
- `git diff --check`
