### PR TITLE
fix(providers): send null content for tool-only messages

### DIFF
--- a/.changeset/fix-tool-only-assistant-content.md
+++ b/.changeset/fix-tool-only-assistant-content.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/xai': patch
+'@ai-sdk/deepseek': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/mistral': patch
+---
+
+Send `null` content for tool-only assistant messages in chat prompt converters.

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
@@ -131,7 +131,7 @@ describe('convertToDeepSeekChatMessages', () => {
         {
           "messages": [
             {
-              "content": "",
+              "content": null,
               "reasoning_content": undefined,
               "role": "assistant",
               "tool_calls": [
@@ -190,7 +190,7 @@ describe('convertToDeepSeekChatMessages', () => {
         {
           "messages": [
             {
-              "content": "",
+              "content": null,
               "reasoning_content": undefined,
               "role": "assistant",
               "tool_calls": [
@@ -261,7 +261,7 @@ describe('convertToDeepSeekChatMessages', () => {
               "role": "user",
             },
             {
-              "content": "",
+              "content": null,
               "reasoning_content": "I think the tool will return the correct value.",
               "role": "assistant",
               "tool_calls": [
@@ -336,7 +336,7 @@ describe('convertToDeepSeekChatMessages', () => {
               "role": "user",
             },
             {
-              "content": "",
+              "content": null,
               "reasoning_content": undefined,
               "role": "assistant",
               "tool_calls": [
@@ -421,7 +421,7 @@ describe('convertToDeepSeekChatMessages', () => {
               "role": "user",
             },
             {
-              "content": "",
+              "content": null,
               "reasoning_content": "I think the tool will return the correct value.",
               "role": "assistant",
               "tool_calls": [

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -129,7 +129,7 @@ export function convertToDeepSeekChatMessages({
         // string when the source message had no reasoning part at all.
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text.length > 0 || toolCalls.length === 0 ? text : null,
           reasoning_content: reasoning ?? (isDeepSeekV4 ? '' : undefined),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/groq/src/convert-to-groq-chat-messages.test.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.test.ts
@@ -123,7 +123,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "role": "assistant",
           "tool_calls": [
             {
@@ -167,7 +167,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "reasoning": "I think the tool will return the correct value.",
           "role": "assistant",
           "tool_calls": [

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -112,7 +112,7 @@ export function convertToGroqChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text.length > 0 || toolCalls.length === 0 ? text : null,
           ...(reasoning.length > 0 ? { reasoning } : null),
           ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : null),
         });

--- a/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
@@ -163,7 +163,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -216,7 +216,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -279,7 +279,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -332,7 +332,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [

--- a/packages/mistral/src/convert-to-mistral-chat-messages.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.ts
@@ -138,7 +138,7 @@ export function convertToMistralChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text.length > 0 || toolCalls.length === 0 ? text : null,
           prefix: isLastMessage ? true : undefined,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/mistral/src/mistral-chat-prompt.ts
+++ b/packages/mistral/src/mistral-chat-prompt.ts
@@ -23,7 +23,7 @@ export type MistralUserMessageContent =
 
 export interface MistralAssistantMessage {
   role: 'assistant';
-  content: string;
+  content: string | null;
   prefix?: boolean;
   tool_calls?: Array<{
     id: string;

--- a/packages/xai/src/convert-to-xai-chat-messages.test.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.test.ts
@@ -225,7 +225,7 @@ describe('convertToXaiChatMessages', () => {
     expect(messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call_123',
@@ -270,7 +270,7 @@ describe('convertToXaiChatMessages', () => {
     expect(messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call_123',

--- a/packages/xai/src/convert-to-xai-chat-messages.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.ts
@@ -113,7 +113,7 @@ export function convertToXaiChatMessages(prompt: LanguageModelV4Prompt): {
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: text.length > 0 || toolCalls.length === 0 ? text : null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 

--- a/packages/xai/src/xai-chat-prompt.ts
+++ b/packages/xai/src/xai-chat-prompt.ts
@@ -23,7 +23,7 @@ export type XaiUserMessageContent =
 
 export interface XaiAssistantMessage {
   role: 'assistant';
-  content: string;
+  content?: string | null;
   tool_calls?: Array<{
     id: string;
     type: 'function';


### PR DESCRIPTION
## Summary

Fixes #14612.

The xAI, DeepSeek, Groq, and Mistral chat converters were serializing assistant messages that only contain tool calls as `content: ""`. Bedrock-backed/OpenAI-compatible endpoints reject empty text content blocks in that shape. This sends `content: null` only when the assistant message has tool calls and no text content, while preserving existing string content for normal assistant turns.

I also updated the xAI and Mistral prompt types to allow nullable assistant content. For Mistral, I checked the current official OpenAPI schema, where `AssistantMessage.content` is `string | null | ContentChunk[]`.

## Tests

- `pnpm exec vitest --config vitest.node.config.js --run src/convert-to-xai-chat-messages.test.ts`
- `pnpm exec vitest --config vitest.edge.config.js --run src/convert-to-xai-chat-messages.test.ts`
- `pnpm exec vitest --config vitest.node.config.js --run src/chat/convert-to-deepseek-chat-messages.test.ts`
- `pnpm exec vitest --config vitest.edge.config.js --run src/chat/convert-to-deepseek-chat-messages.test.ts`
- `pnpm exec vitest --config vitest.node.config.js --run src/convert-to-groq-chat-messages.test.ts`
- `pnpm exec vitest --config vitest.edge.config.js --run src/convert-to-groq-chat-messages.test.ts`
- `pnpm exec vitest --config vitest.node.config.js --run src/convert-to-mistral-chat-messages.test.ts`
- `pnpm exec vitest --config vitest.edge.config.js --run src/convert-to-mistral-chat-messages.test.ts`
- `pnpm --filter @ai-sdk/xai type-check`
- `pnpm --filter @ai-sdk/deepseek type-check`
- `pnpm --filter @ai-sdk/groq type-check`
- `pnpm --filter @ai-sdk/mistral type-check`
- `pnpm exec ultracite check packages/xai/src/convert-to-xai-chat-messages.ts packages/xai/src/xai-chat-prompt.ts packages/xai/src/convert-to-xai-chat-messages.test.ts packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts packages/groq/src/convert-to-groq-chat-messages.ts packages/groq/src/convert-to-groq-chat-messages.test.ts packages/mistral/src/convert-to-mistral-chat-messages.ts packages/mistral/src/mistral-chat-prompt.ts packages/mistral/src/convert-to-mistral-chat-messages.test.ts .changeset/fix-tool-only-assistant-content.md`
- `git diff --check`
