### PR TITLE
fix(mistral): account for cached prompt tokens

### DIFF
--- a/.changeset/fix-mistral-cache-usage.md
+++ b/.changeset/fix-mistral-cache-usage.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': patch
+---
+
+Report Mistral prompt cache tokens in usage input token details.

--- a/packages/mistral/src/convert-mistral-usage.test.ts
+++ b/packages/mistral/src/convert-mistral-usage.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { convertMistralUsage } from './convert-mistral-usage';
+
+describe('convertMistralUsage', () => {
+  it('should account for num_cached_tokens', () => {
+    const usage = {
+      prompt_tokens: 100,
+      completion_tokens: 25,
+      total_tokens: 125,
+      num_cached_tokens: 30,
+    };
+
+    const result = convertMistralUsage(usage);
+
+    expect(result.inputTokens.total).toBe(100);
+    expect(result.inputTokens.cacheRead).toBe(30);
+    expect(result.inputTokens.noCache).toBe(70);
+    expect(result.raw).toBe(usage);
+  });
+
+  it('should read singular prompt token details', () => {
+    const result = convertMistralUsage({
+      prompt_tokens: 100,
+      completion_tokens: 25,
+      total_tokens: 125,
+      prompt_token_details: {
+        cached_tokens: 45,
+      },
+    });
+
+    expect(result.inputTokens.cacheRead).toBe(45);
+    expect(result.inputTokens.noCache).toBe(55);
+  });
+
+  it('should read plural prompt token details', () => {
+    const result = convertMistralUsage({
+      prompt_tokens: 100,
+      completion_tokens: 25,
+      total_tokens: 125,
+      prompt_tokens_details: {
+        cached_tokens: 80,
+      },
+    });
+
+    expect(result.inputTokens.cacheRead).toBe(80);
+    expect(result.inputTokens.noCache).toBe(20);
+  });
+
+  it('should prefer num_cached_tokens when multiple cache fields are present', () => {
+    const result = convertMistralUsage({
+      prompt_tokens: 100,
+      completion_tokens: 25,
+      total_tokens: 125,
+      num_cached_tokens: 30,
+      prompt_token_details: {
+        cached_tokens: 45,
+      },
+      prompt_tokens_details: {
+        cached_tokens: 80,
+      },
+    });
+
+    expect(result.inputTokens.cacheRead).toBe(30);
+    expect(result.inputTokens.noCache).toBe(70);
+  });
+
+  it('should preserve existing usage behavior when cache fields are absent', () => {
+    const result = convertMistralUsage({
+      prompt_tokens: 100,
+      completion_tokens: 25,
+      total_tokens: 125,
+    });
+
+    expect(result.inputTokens.cacheRead).toBeUndefined();
+    expect(result.inputTokens.noCache).toBe(100);
+  });
+
+  it('should clamp cached tokens to avoid negative no-cache counts', () => {
+    const result = convertMistralUsage({
+      prompt_tokens: 100,
+      completion_tokens: 25,
+      total_tokens: 125,
+      num_cached_tokens: 120,
+    });
+
+    expect(result.inputTokens.cacheRead).toBe(100);
+    expect(result.inputTokens.noCache).toBe(0);
+  });
+});

--- a/packages/mistral/src/convert-mistral-usage.ts
+++ b/packages/mistral/src/convert-mistral-usage.ts
@@ -4,6 +4,13 @@ export type MistralUsage = {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  num_cached_tokens?: number | null;
+  prompt_token_details?: {
+    cached_tokens?: number | null;
+  } | null;
+  prompt_tokens_details?: {
+    cached_tokens?: number | null;
+  } | null;
 };
 
 export function convertMistralUsage(
@@ -28,12 +35,16 @@ export function convertMistralUsage(
 
   const promptTokens = usage.prompt_tokens;
   const completionTokens = usage.completion_tokens;
+  const cachedPromptTokens = getCachedPromptTokens(usage, promptTokens);
 
   return {
     inputTokens: {
       total: promptTokens,
-      noCache: promptTokens,
-      cacheRead: undefined,
+      noCache:
+        cachedPromptTokens == null
+          ? promptTokens
+          : promptTokens - cachedPromptTokens,
+      cacheRead: cachedPromptTokens,
       cacheWrite: undefined,
     },
     outputTokens: {
@@ -43,4 +54,20 @@ export function convertMistralUsage(
     },
     raw: usage,
   };
+}
+
+function getCachedPromptTokens(
+  usage: MistralUsage,
+  promptTokens: number,
+): number | undefined {
+  const cachedTokens =
+    usage.num_cached_tokens ??
+    usage.prompt_token_details?.cached_tokens ??
+    usage.prompt_tokens_details?.cached_tokens;
+
+  if (cachedTokens == null) {
+    return undefined;
+  }
+
+  return Math.min(Math.max(cachedTokens, 0), promptTokens);
 }

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -230,6 +230,68 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should extract cached prompt token usage', async () => {
+    server.urls[CHAT_COMPLETIONS_URL].response = {
+      type: 'json-value',
+      body: {
+        object: 'chat.completion',
+        id: 'cached-token-test',
+        created: 1711113008,
+        model: 'mistral-small-latest',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: 'Hello',
+              tool_calls: null,
+            },
+            finish_reason: 'stop',
+            logprobs: null,
+          },
+        ],
+        usage: {
+          prompt_tokens: 127,
+          completion_tokens: 11,
+          total_tokens: 138,
+          num_cached_tokens: 125,
+          prompt_tokens_details: {
+            cached_tokens: 123,
+          },
+        },
+      },
+    };
+
+    const { usage } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(usage).toMatchInlineSnapshot(`
+      {
+        "inputTokens": {
+          "cacheRead": 125,
+          "cacheWrite": undefined,
+          "noCache": 2,
+          "total": 127,
+        },
+        "outputTokens": {
+          "reasoning": undefined,
+          "text": 11,
+          "total": 11,
+        },
+        "raw": {
+          "completion_tokens": 11,
+          "num_cached_tokens": 125,
+          "prompt_tokens": 127,
+          "prompt_tokens_details": {
+            "cached_tokens": 123,
+          },
+          "total_tokens": 138,
+        },
+      }
+    `);
+  });
+
   it('should send additional response information', async () => {
     prepareJsonFixtureResponse('mistral-text');
 

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -577,6 +577,17 @@ const mistralUsageSchema = z.object({
   prompt_tokens: z.number(),
   completion_tokens: z.number(),
   total_tokens: z.number(),
+  num_cached_tokens: z.number().nullish(),
+  prompt_token_details: z
+    .object({
+      cached_tokens: z.number().nullish(),
+    })
+    .nullish(),
+  prompt_tokens_details: z
+    .object({
+      cached_tokens: z.number().nullish(),
+    })
+    .nullish(),
 });
 
 // limited version of the schema, focussed on what is needed for the implementation


### PR DESCRIPTION
## Background

Mistral usage responses can report prompt cache hits via `num_cached_tokens`, `prompt_token_details.cached_tokens`, or `prompt_tokens_details.cached_tokens`. The provider currently treats every prompt token as uncached, so `usage.inputTokens.noCache` is inflated and `usage.inputTokens.cacheRead` is never populated.

## Summary

- Preserve Mistral cached-token fields in the chat completion and streaming usage schemas.
- Convert cached prompt tokens into `inputTokens.cacheRead` and subtract them from `inputTokens.noCache`.
- Support the top-level and singular/plural nested field shapes, preferring `num_cached_tokens` when multiple are present.
- Clamp cache-read tokens to the prompt-token total to avoid negative no-cache counts.
- Add focused converter coverage plus an end-to-end chat model usage test so schema stripping is covered.
- Add a patch changeset for `@ai-sdk/mistral`.

## Manual Verification

- `pnpm --filter @ai-sdk/mistral test:node -- src/convert-mistral-usage.test.ts src/mistral-chat-language-model.test.ts`
- `pnpm --filter @ai-sdk/mistral type-check`
- `pnpm exec ultracite check packages/mistral/src/convert-mistral-usage.ts packages/mistral/src/convert-mistral-usage.test.ts packages/mistral/src/mistral-chat-language-model.ts packages/mistral/src/mistral-chat-language-model.test.ts`
- `pnpm changeset status --since origin/main`
- `git diff --check HEAD~1 HEAD`

## Checklist

- [ ] All commits are signed (local signing is not configured on this machine, so leaving this unchecked)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (not needed for this provider usage accounting fix)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14382
