### PR TITLE
fix(xai): remove unsupported schema property flags

### DIFF
--- a/.changeset/fix-xai-additional-properties.md
+++ b/.changeset/fix-xai-additional-properties.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Remove unsupported `additionalProperties: false` entries from xAI schemas.

--- a/packages/xai/src/remove-unsupported-xai-schema-properties.test.ts
+++ b/packages/xai/src/remove-unsupported-xai-schema-properties.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { removeUnsupportedXaiSchemaProperties } from './remove-unsupported-xai-schema-properties';
+
+describe('removeUnsupportedXaiSchemaProperties', () => {
+  it('should remove additionalProperties false recursively', () => {
+    expect(
+      removeUnsupportedXaiSchemaProperties({
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          nested: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              value: { type: 'string' },
+            },
+          },
+          items: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                label: { type: 'string' },
+              },
+            },
+          },
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "properties": {
+          "items": {
+            "items": {
+              "properties": {
+                "label": {
+                  "type": "string",
+                },
+              },
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "nested": {
+            "properties": {
+              "value": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "type": "object",
+      }
+    `);
+  });
+
+  it('should preserve non-boolean additionalProperties schemas', () => {
+    const schema = {
+      type: 'object',
+      additionalProperties: {
+        type: 'string',
+      },
+    };
+
+    expect(removeUnsupportedXaiSchemaProperties(schema)).toEqual(schema);
+  });
+});

--- a/packages/xai/src/remove-unsupported-xai-schema-properties.ts
+++ b/packages/xai/src/remove-unsupported-xai-schema-properties.ts
@@ -1,0 +1,21 @@
+export function removeUnsupportedXaiSchemaProperties(schema: unknown): unknown {
+  if (schema == null || typeof schema !== 'object') {
+    return schema;
+  }
+
+  if (Array.isArray(schema)) {
+    return schema.map(removeUnsupportedXaiSchemaProperties);
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === 'additionalProperties' && value === false) {
+      continue;
+    }
+
+    result[key] = removeUnsupportedXaiSchemaProperties(value);
+  }
+
+  return result;
+}

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -881,7 +881,6 @@ describe('XaiResponsesLanguageModel', () => {
                   "description": "A recipe object",
                   "name": "recipe",
                   "schema": {
-                    "additionalProperties": false,
                     "properties": {
                       "ingredients": {
                         "items": {

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -25,6 +25,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import type { z } from 'zod/v4';
 import { getResponseMetadata } from '../get-response-metadata';
+import { removeUnsupportedXaiSchemaProperties } from '../remove-unsupported-xai-schema-properties';
 import { xaiFailedResponseHandler } from '../xai-error';
 import { convertToXaiResponsesInput } from './convert-to-xai-responses-input';
 import { convertXaiResponsesUsage } from './convert-xai-responses-usage';
@@ -203,7 +204,9 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
                   strict: true,
                   name: responseFormat.name ?? 'response',
                   description: responseFormat.description,
-                  schema: responseFormat.schema,
+                  schema: removeUnsupportedXaiSchemaProperties(
+                    responseFormat.schema,
+                  ),
                 }
               : { type: 'json_object' },
         },

--- a/packages/xai/src/responses/xai-responses-prepare-tools.test.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.test.ts
@@ -572,6 +572,51 @@ describe('prepareResponsesTools', () => {
         }
       `);
     });
+
+    it('should remove additionalProperties false from function tool parameters', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'weather',
+            inputSchema: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                location: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: {
+                    city: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+
+      expect(result.tools?.[0]).toMatchInlineSnapshot(`
+        {
+          "description": undefined,
+          "name": "weather",
+          "parameters": {
+            "properties": {
+              "location": {
+                "properties": {
+                  "city": {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "type": "function",
+        }
+      `);
+    });
   });
 
   describe('tool choice', () => {

--- a/packages/xai/src/responses/xai-responses-prepare-tools.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.ts
@@ -5,6 +5,7 @@ import {
 } from '@ai-sdk/provider';
 import { validateTypes } from '@ai-sdk/provider-utils';
 import { fileSearchArgsSchema } from '../tool/file-search';
+import { removeUnsupportedXaiSchemaProperties } from '../remove-unsupported-xai-schema-properties';
 import { mcpServerArgsSchema } from '../tool/mcp-server';
 import { webSearchArgsSchema } from '../tool/web-search';
 import { xSearchArgsSchema } from '../tool/x-search';
@@ -142,7 +143,7 @@ export async function prepareResponsesTools({
         type: 'function',
         name: tool.name,
         description: tool.description,
-        parameters: tool.inputSchema,
+        parameters: removeUnsupportedXaiSchemaProperties(tool.inputSchema),
         ...(tool.strict != null ? { strict: tool.strict } : {}),
       });
     }

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -263,7 +263,6 @@ describe('XaiChatLanguageModel', () => {
                 "name": "test-tool",
                 "parameters": {
                   "$schema": "http://json-schema.org/draft-07/schema#",
-                  "additionalProperties": false,
                   "properties": {
                     "value": {
                       "type": "string",
@@ -832,11 +831,14 @@ describe('XaiChatLanguageModel', () => {
               name: { type: 'string' },
             },
             required: ['name'],
+            additionalProperties: false,
           },
         },
       });
 
-      expect(await server.calls[0].requestBodyJson).toMatchObject({
+      const requestBody = await server.calls[0].requestBodyJson;
+
+      expect(requestBody).toMatchObject({
         model: 'grok-3',
         response_format: {
           type: 'json_schema',
@@ -853,6 +855,9 @@ describe('XaiChatLanguageModel', () => {
           },
         },
       });
+      expect(requestBody.response_format.json_schema.schema).not.toHaveProperty(
+        'additionalProperties',
+      );
     });
 
     it('should handle missing usage in response', async () => {

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -31,6 +31,7 @@ import { convertToXaiChatMessages } from './convert-to-xai-chat-messages';
 import { convertXaiChatUsage } from './convert-xai-chat-usage';
 import { getResponseMetadata } from './get-response-metadata';
 import { mapXaiFinishReason } from './map-xai-finish-reason';
+import { removeUnsupportedXaiSchemaProperties } from './remove-unsupported-xai-schema-properties';
 import {
   xaiLanguageModelChatOptions,
   type XaiChatModelId,
@@ -182,7 +183,9 @@ export class XaiChatLanguageModel implements LanguageModelV4 {
                 type: 'json_schema',
                 json_schema: {
                   name: responseFormat.name ?? 'response',
-                  schema: responseFormat.schema,
+                  schema: removeUnsupportedXaiSchemaProperties(
+                    responseFormat.schema,
+                  ),
                   strict: true,
                 },
               }

--- a/packages/xai/src/xai-prepare-tools.test.ts
+++ b/packages/xai/src/xai-prepare-tools.test.ts
@@ -59,6 +59,46 @@ describe('prepareTools', () => {
     `);
   });
 
+  it('should remove additionalProperties false from function tool parameters', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          inputSchema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              value: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  label: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result.tools?.[0].function.parameters).toMatchInlineSnapshot(`
+      {
+        "properties": {
+          "value": {
+            "properties": {
+              "label": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "type": "object",
+      }
+    `);
+  });
+
   it('should add warnings for provider-defined tools', () => {
     const result = prepareTools({
       tools: [

--- a/packages/xai/src/xai-prepare-tools.ts
+++ b/packages/xai/src/xai-prepare-tools.ts
@@ -4,6 +4,7 @@ import {
   type SharedV4Warning,
 } from '@ai-sdk/provider';
 import type { XaiToolChoice } from './xai-chat-prompt';
+import { removeUnsupportedXaiSchemaProperties } from './remove-unsupported-xai-schema-properties';
 
 export function prepareTools({
   tools,
@@ -58,7 +59,7 @@ export function prepareTools({
         function: {
           name: tool.name,
           description: tool.description,
-          parameters: tool.inputSchema,
+          parameters: removeUnsupportedXaiSchemaProperties(tool.inputSchema),
           ...(tool.strict != null ? { strict: tool.strict } : {}),
         },
       });


### PR DESCRIPTION
## Background

xAI rejects JSON schema `additionalProperties: false` entries in tool schemas, while treating object schemas as closed by default. The SDK currently forwards those flags to xAI function tools, and response-format schemas can carry the same unsupported flag.

## Summary

- Add an xAI-scoped schema sanitizer that removes `additionalProperties: false` recursively while leaving non-boolean `additionalProperties` schemas intact.
- Apply the sanitizer to xAI Chat Completions function tools and JSON schema response formats.
- Apply the same sanitizer to xAI Responses function tools and JSON schema response formats.
- Add focused helper, tool-preparation, and request-shape tests for both xAI model surfaces.
- Add a patch changeset for `@ai-sdk/xai`.

## Manual Verification

- `pnpm --filter @ai-sdk/xai test:node -- src/remove-unsupported-xai-schema-properties.test.ts src/xai-prepare-tools.test.ts src/xai-chat-language-model.test.ts src/responses/xai-responses-prepare-tools.test.ts src/responses/xai-responses-language-model.test.ts`
- `pnpm --filter @ai-sdk/xai type-check`
- `pnpm exec ultracite check packages/xai/src/remove-unsupported-xai-schema-properties.ts packages/xai/src/remove-unsupported-xai-schema-properties.test.ts packages/xai/src/xai-prepare-tools.ts packages/xai/src/xai-prepare-tools.test.ts packages/xai/src/xai-chat-language-model.ts packages/xai/src/xai-chat-language-model.test.ts packages/xai/src/responses/xai-responses-prepare-tools.ts packages/xai/src/responses/xai-responses-prepare-tools.test.ts packages/xai/src/responses/xai-responses-language-model.ts packages/xai/src/responses/xai-responses-language-model.test.ts`
- `pnpm changeset status --since origin/main`
- `git diff --check HEAD~1 HEAD`

## Checklist

- [ ] All commits are signed (local signing is not configured on this machine, so leaving this unchecked)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (not needed for this provider request-shape fix)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14678
