### PR TITLE
fix(workflow): preserve provider-executed approval responses

### DIFF
--- a/.changeset/fix-workflow-provider-approvals.md
+++ b/.changeset/fix-workflow-provider-approvals.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Preserve provider-executed tool approval responses when resuming WorkflowAgent streams.

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -2999,6 +2999,172 @@ describe('WorkflowAgent', () => {
       expect(mockIterator.next).toHaveBeenCalled();
     });
 
+    it('should preserve approved provider-executed tool approvals for the provider', async () => {
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: mockModel,
+        tools: {},
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockClear();
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [
+          { role: 'user', content: 'Search for the current release notes' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'web_search',
+                input: { query: 'AI SDK release notes' },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-call-1',
+                toolCallId: 'call-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: true,
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      const iteratorCall = vi.mocked(streamTextIterator).mock.calls.at(-1)?.[0];
+
+      expect(iteratorCall?.prompt).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: 'assistant',
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                providerExecuted: true,
+              }),
+            ]),
+          }),
+          expect.objectContaining({
+            role: 'tool',
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: true,
+              }),
+            ]),
+          }),
+        ]),
+      );
+      expect(JSON.stringify(iteratorCall?.prompt)).not.toContain(
+        '"tool-result"',
+      );
+    });
+
+    it('should preserve denied provider-executed tool approvals for the provider', async () => {
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: mockModel,
+        tools: {},
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockClear();
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [
+          { role: 'user', content: 'Search for private account data' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'web_search',
+                input: { query: 'private account data' },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-call-1',
+                toolCallId: 'call-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: false,
+                reason: 'Policy denied',
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      const iteratorCall = vi.mocked(streamTextIterator).mock.calls.at(-1)?.[0];
+
+      expect(iteratorCall?.prompt).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: 'tool',
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: false,
+                reason: 'Policy denied',
+              }),
+            ]),
+          }),
+        ]),
+      );
+      expect(JSON.stringify(iteratorCall?.prompt)).not.toContain(
+        'execution-denied',
+      );
+    });
+
     it('should pass through messages without approval responses unchanged', async () => {
       const tools: ToolSet = {
         getWeather: {

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1178,6 +1178,11 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       collectToolApprovalsFromMessages(prompt.messages);
 
     if (approvedToolApprovals.length > 0 || deniedToolApprovals.length > 0) {
+      const providerExecutedApprovalIds = new Set(
+        [...approvedToolApprovals, ...deniedToolApprovals]
+          .filter(approval => approval.providerExecuted)
+          .map(approval => approval.approvalId),
+      );
       const _toolResultMessages: ModelMessage[] = [];
       const toolResultContent: Array<{
         type: 'tool-result';
@@ -1191,6 +1196,9 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
 
       // Execute approved tools
       for (const approval of approvedToolApprovals) {
+        if (approval.providerExecuted) {
+          continue;
+        }
         const tool = (this.tools as ToolSet)[approval.toolName];
         if (tool && typeof tool.execute === 'function') {
           try {
@@ -1225,6 +1233,9 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
 
       // Create denial results for denied tools
       for (const denial of deniedToolApprovals) {
+        if (denial.providerExecuted) {
+          continue;
+        }
         toolResultContent.push({
           type: 'tool-result' as const,
           toolCallId: denial.toolCallId,
@@ -1240,16 +1251,19 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       const cleanedMessages: ModelMessage[] = [];
       for (const msg of prompt.messages) {
         if (msg.role === 'assistant' && Array.isArray(msg.content)) {
-          const filtered = (msg.content as any[]).filter(
-            (p: any) => p.type !== 'tool-approval-request',
-          );
+          const filtered = (msg.content as any[]).filter((p: any) => {
+            if (p.type !== 'tool-approval-request') return true;
+            return providerExecutedApprovalIds.has(p.approvalId);
+          });
           if (filtered.length > 0) {
             cleanedMessages.push({ ...msg, content: filtered });
           }
         } else if (msg.role === 'tool') {
-          const filtered = (msg.content as any[]).filter(
-            (p: any) => p.type !== 'tool-approval-response',
-          );
+          const filtered = (msg.content as any[]).flatMap((p: any) => {
+            if (p.type !== 'tool-approval-response') return [p];
+            if (!providerExecutedApprovalIds.has(p.approvalId)) return [];
+            return [{ ...p, providerExecuted: true }];
+          });
           if (filtered.length > 0) {
             cleanedMessages.push({ ...msg, content: filtered });
           }
@@ -2168,6 +2182,7 @@ interface CollectedApproval {
   toolName: string;
   input: unknown;
   approvalId: string;
+  providerExecuted?: boolean;
   reason?: string;
 }
 
@@ -2193,7 +2208,7 @@ function collectToolApprovalsFromMessages(messages: ModelMessage[]): {
   // Gather tool calls from assistant messages
   const toolCallsByToolCallId: Record<
     string,
-    { toolName: string; input: unknown }
+    { toolName: string; input: unknown; providerExecuted?: boolean }
   > = {};
   for (const message of messages) {
     if (message.role === 'assistant' && Array.isArray(message.content)) {
@@ -2202,6 +2217,7 @@ function collectToolApprovalsFromMessages(messages: ModelMessage[]): {
           toolCallsByToolCallId[part.toolCallId] = {
             toolName: part.toolName,
             input: part.input ?? part.args,
+            providerExecuted: part.providerExecuted,
           };
         }
       }
@@ -2257,6 +2273,7 @@ function collectToolApprovalsFromMessages(messages: ModelMessage[]): {
       toolName: toolCall.toolName,
       input: toolCall.input,
       approvalId: response.approvalId,
+      providerExecuted: toolCall.providerExecuted,
       reason: response.reason,
     };
 


### PR DESCRIPTION
## Summary

Closes #14292.

- Track whether collected WorkflowAgent approvals came from provider-executed tool calls.
- Preserve provider-executed approval requests/responses through resume prompt cleanup, while continuing to strip and replace local approval parts with local tool results.
- Avoid creating synthetic local execution or denial results for provider-executed approvals so the provider receives the approval response exactly once.
- Add regression coverage for approved and denied provider-executed approval resumes.

## Tests

- `pnpm --filter @ai-sdk/workflow test:node -- src/workflow-agent.test.ts`
- `pnpm --filter @ai-sdk/workflow type-check`
- `pnpm exec ultracite check packages/workflow/src/workflow-agent.ts packages/workflow/src/workflow-agent.test.ts`
- `pnpm changeset status --since origin/main`
- `git diff --check HEAD~1 HEAD`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (not needed for this bug fix)
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request (self-review)
- [ ] Signed commits (local signing is not configured in this environment)