### PR TITLE
fix(anthropic): order provider tool results before tool_use

### DIFF
--- a/.changeset/fix-anthropic-tool-use-order.md
+++ b/.changeset/fix-anthropic-tool-use-order.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Place regular Anthropic tool_use blocks after provider-executed tool results.

--- a/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
@@ -1682,6 +1682,102 @@ describe('assistant messages', () => {
     expect(warnings).toMatchInlineSnapshot(`[]`);
   });
 
+  it('should place regular tool_use blocks after provider-executed tool results', async () => {
+    const warnings: SharedV4Warning[] = [];
+    const result = await convertToAnthropicPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'I will search and then use the local tool.',
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'toolu_01Regular',
+              toolName: 'save_note',
+              input: { note: 'summary' },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'srvtoolu_01Web',
+              toolName: 'web_search',
+              input: { query: 'latest news' },
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'srvtoolu_01Web',
+              toolName: 'web_search',
+              output: {
+                type: 'json',
+                value: [
+                  {
+                    url: 'https://example.com/news',
+                    title: 'News',
+                    pageAge: '1h',
+                    encryptedContent: 'encrypted-content',
+                    type: 'web_search_result',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      sendReasoning: false,
+      warnings,
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    expect(result.prompt.messages[0]).toMatchInlineSnapshot(`
+      {
+        "content": [
+          {
+            "cache_control": undefined,
+            "text": "I will search and then use the local tool.",
+            "type": "text",
+          },
+          {
+            "cache_control": undefined,
+            "id": "srvtoolu_01Web",
+            "input": {
+              "query": "latest news",
+            },
+            "name": "web_search",
+            "type": "server_tool_use",
+          },
+          {
+            "cache_control": undefined,
+            "content": [
+              {
+                "encrypted_content": "encrypted-content",
+                "page_age": "1h",
+                "title": "News",
+                "type": "web_search_result",
+                "url": "https://example.com/news",
+              },
+            ],
+            "tool_use_id": "srvtoolu_01Web",
+            "type": "web_search_tool_result",
+          },
+          {
+            "cache_control": undefined,
+            "id": "toolu_01Regular",
+            "input": {
+              "note": "summary",
+            },
+            "name": "save_note",
+            "type": "tool_use",
+          },
+        ],
+        "role": "assistant",
+      }
+    `);
+    expect(warnings).toMatchInlineSnapshot(`[]`);
+  });
+
   it('should convert anthropic web_fetch tool call and result parts', async () => {
     const warnings: SharedV4Warning[] = [];
     const result = await convertToAnthropicPrompt({

--- a/packages/anthropic/src/convert-to-anthropic-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.ts
@@ -1072,7 +1072,10 @@ export async function convertToAnthropicPrompt({
           }
         }
 
-        messages.push({ role: 'assistant', content: anthropicContent });
+        messages.push({
+          role: 'assistant',
+          content: moveRegularToolUseBlocksToEnd(anthropicContent),
+        });
 
         break;
       }
@@ -1157,4 +1160,19 @@ function groupIntoBlocks(
   }
 
   return blocks;
+}
+
+function moveRegularToolUseBlocksToEnd(
+  content: AnthropicAssistantMessage['content'],
+): AnthropicAssistantMessage['content'] {
+  const regularToolUseBlocks = content.filter(part => part.type === 'tool_use');
+
+  if (regularToolUseBlocks.length === 0) {
+    return content;
+  }
+
+  return [
+    ...content.filter(part => part.type !== 'tool_use'),
+    ...regularToolUseBlocks,
+  ];
 }


### PR DESCRIPTION
## Summary

Fixes #13013.

- Reorder converted Anthropic assistant content so regular `tool_use` blocks are emitted after non-regular content.
- Preserve provider-executed `server_tool_use` + result adjacency for tools such as `web_search` and `tool_search`.
- Add regression coverage for a mixed regular tool call + provider-executed web search result in the same assistant turn.

This keeps regular Anthropic tool calls last in the assistant message, avoiding the API pairing failure when a provider-executed tool result would otherwise appear after a regular `tool_use`.

## Tests

- `pnpm --filter @ai-sdk/anthropic test:node -- src/convert-to-anthropic-prompt.test.ts`
- `pnpm --filter @ai-sdk/anthropic type-check`
- `pnpm exec ultracite check packages/anthropic/src/convert-to-anthropic-prompt.ts packages/anthropic/src/convert-to-anthropic-prompt.test.ts`
- `pnpm changeset status --since origin/main`
- `git diff --check HEAD~1 HEAD`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (not needed for this provider bug fix)
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request (self-review)
- [ ] Signed commits (local signing is not configured in this environment)