### PR TITLE
Backport to v5: chore(provider/openai): add type for image model options for type-safe processing

### DIFF
--- a/.changeset/quiet-ties-hide.md
+++ b/.changeset/quiet-ties-hide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+chore(provider/openai): add type for image model options for type-safe processing

--- a/examples/ai-core/src/generate-image/openai-dall-e-3-style.ts
+++ b/examples/ai-core/src/generate-image/openai-dall-e-3-style.ts
@@ -1,0 +1,23 @@
+import { openai, type OpenAIImageModelGenerationOptions } from '@ai-sdk/openai';
+import { experimental_generateImage as generateImage } from 'ai';
+import { presentImages } from '../lib/present-image';
+import 'dotenv/config';
+
+async function main() {
+  const { image } = await generateImage({
+    model: openai.image('dall-e-3'),
+    prompt:
+      'A neon-lit cyberpunk alley in Osaka at night, with rain reflections',
+    size: '1024x1792',
+    providerOptions: {
+      openai: {
+        style: 'vivid',
+        quality: 'hd',
+      } satisfies OpenAIImageModelGenerationOptions,
+    },
+  });
+
+  await presentImages([image]);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-image/openai-gpt-image-2-output.ts
+++ b/examples/ai-core/src/generate-image/openai-gpt-image-2-output.ts
@@ -1,0 +1,22 @@
+import { openai, type OpenAIImageModelGenerationOptions } from '@ai-sdk/openai';
+import { experimental_generateImage as generateImage } from 'ai';
+import { presentImages } from '../lib/present-image';
+import 'dotenv/config';
+
+async function main() {
+  const { image } = await generateImage({
+    model: openai.image('gpt-image-2'),
+    prompt: 'A red panda barista pouring latte art in a cozy Tokyo cafe',
+    providerOptions: {
+      openai: {
+        outputFormat: 'webp',
+        outputCompression: 75,
+        moderation: 'low',
+      } satisfies OpenAIImageModelGenerationOptions,
+    },
+  });
+
+  await presentImages([image]);
+}
+
+main().catch(console.error);

--- a/packages/openai/src/image/openai-image-model.test.ts
+++ b/packages/openai/src/image/openai-image-model.test.ts
@@ -63,6 +63,41 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should map provider options to snake_case for /images/generations', async () => {
+    prepareJsonResponse();
+
+    await provider.image('gpt-image-1').doGenerate({
+      prompt,
+      n: 1,
+      size: '1024x1024',
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {
+        openai: {
+          quality: 'high',
+          background: 'transparent',
+          moderation: 'low',
+          outputFormat: 'webp',
+          outputCompression: 80,
+          user: 'user-123',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gpt-image-1',
+      prompt,
+      n: 1,
+      size: '1024x1024',
+      quality: 'high',
+      background: 'transparent',
+      moderation: 'low',
+      output_format: 'webp',
+      output_compression: 80,
+      user: 'user-123',
+    });
+  });
+
   it('should pass headers', async () => {
     prepareJsonResponse();
 

--- a/packages/openai/src/image/openai-image-model.ts
+++ b/packages/openai/src/image/openai-image-model.ts
@@ -2,6 +2,7 @@ import type { ImageModelV2, ImageModelV2CallWarning } from '@ai-sdk/provider';
 import {
   combineHeaders,
   createJsonResponseHandler,
+  parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
 import type { OpenAIConfig } from '../openai-config';
@@ -11,6 +12,7 @@ import {
   type OpenAIImageModelId,
   hasDefaultResponseFormat,
   modelMaxImagesPerCall,
+  openaiImageModelGenerationOptions,
 } from './openai-image-options';
 
 interface OpenAIImageModelConfig extends OpenAIConfig {
@@ -63,6 +65,14 @@ export class OpenAIImageModel implements ImageModelV2 {
     }
 
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+
+    const openaiOptions =
+      (await parseProviderOptions({
+        provider: 'openai',
+        providerOptions,
+        schema: openaiImageModelGenerationOptions,
+      })) ?? {};
+
     const { value: response, responseHeaders } = await postJsonToApi({
       url: this.config.url({
         path: '/images/generations',
@@ -74,7 +84,13 @@ export class OpenAIImageModel implements ImageModelV2 {
         prompt,
         n,
         size,
-        ...(providerOptions.openai ?? {}),
+        quality: openaiOptions.quality,
+        style: openaiOptions.style,
+        background: openaiOptions.background,
+        moderation: openaiOptions.moderation,
+        output_format: openaiOptions.outputFormat,
+        output_compression: openaiOptions.outputCompression,
+        user: openaiOptions.user,
         ...(!hasDefaultResponseFormat.has(this.modelId)
           ? { response_format: 'b64_json' }
           : {}),

--- a/packages/openai/src/image/openai-image-options.ts
+++ b/packages/openai/src/image/openai-image-options.ts
@@ -1,3 +1,10 @@
+import {
+  type InferValidator,
+  lazyValidator,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
 export type OpenAIImageModelId =
   | 'dall-e-3'
   | 'dall-e-2'
@@ -23,3 +30,70 @@ export const hasDefaultResponseFormat = new Set([
   'gpt-image-1.5',
   'gpt-image-2',
 ]);
+
+const baseImageModelOptionsObject = z.object({
+  /**
+   * Quality of the generated image(s).
+   *
+   * Valid values: `standard`, `hd`, `low`, `medium`, `high`, `auto`.
+   */
+  quality: z
+    .enum(['standard', 'hd', 'low', 'medium', 'high', 'auto'])
+    .optional(),
+
+  /**
+   * Background behavior for the generated image(s).
+   *
+   * If `transparent`, the output format must support transparency
+   * (i.e. `png` or `webp`).
+   */
+  background: z.enum(['transparent', 'opaque', 'auto']).optional(),
+
+  /**
+   * Format in which the generated image(s) are returned.
+   */
+  outputFormat: z.enum(['png', 'jpeg', 'webp']).optional(),
+
+  /**
+   * Compression level (0-100) for the generated image(s). Applies to the
+   * `jpeg` and `webp` output formats.
+   */
+  outputCompression: z.number().int().min(0).max(100).optional(),
+
+  /**
+   * A unique identifier representing your end-user, which can help OpenAI
+   * to monitor and detect abuse.
+   */
+  user: z.string().optional(),
+});
+
+export const openaiImageModelOptions = lazyValidator(() =>
+  zodSchema(baseImageModelOptionsObject),
+);
+
+export type OpenAIImageModelOptions = InferValidator<
+  typeof openaiImageModelOptions
+>;
+
+export const openaiImageModelGenerationOptions = lazyValidator(() =>
+  zodSchema(
+    baseImageModelOptionsObject.extend({
+      /**
+       * Style of the generated image. `vivid` produces hyper-real and
+       * dramatic images; `natural` produces more subdued, less hyper-real
+       * looking images.
+       */
+      style: z.enum(['vivid', 'natural']).optional(),
+
+      /**
+       * Content moderation level for the generated image(s). `low` applies
+       * less restrictive filtering.
+       */
+      moderation: z.enum(['auto', 'low']).optional(),
+    }),
+  ),
+);
+
+export type OpenAIImageModelGenerationOptions = InferValidator<
+  typeof openaiImageModelGenerationOptions
+>;

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -2,4 +2,8 @@ export { createOpenAI, openai } from './openai-provider';
 export type { OpenAIProvider, OpenAIProviderSettings } from './openai-provider';
 export type { OpenAIResponsesProviderOptions } from './responses/openai-responses-options';
 export type { OpenAIChatLanguageModelOptions } from './chat/openai-chat-options';
+export type {
+  OpenAIImageModelOptions,
+  OpenAIImageModelGenerationOptions,
+} from './image/openai-image-options';
 export { VERSION } from './version';


### PR DESCRIPTION
## Summary

Manual backport of #14863 / #14880 to v5 branch.

The image editing part was not backported because image editing for OpenAI is generally not supported in v5.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
