### PR TITLE
fix(vertex): use correct import for token generator

### DIFF
--- a/.changeset/loud-apes-applaud.md
+++ b/.changeset/loud-apes-applaud.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google-vertex": patch
+---
+
+fix(vertex): use correct import for token generator

--- a/packages/google-vertex/src/xai/google-vertex-xai-provider-node.test.ts
+++ b/packages/google-vertex/src/xai/google-vertex-xai-provider-node.test.ts
@@ -3,10 +3,14 @@ import {
   createGoogleVertexXai,
   googleVertexXai,
 } from './google-vertex-xai-provider-node';
-import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
+import { createAuthTokenGenerator } from '../google-vertex-auth-google-auth-library';
+
+const { generateAuthToken } = vi.hoisted(() => ({
+  generateAuthToken: vi.fn(),
+}));
 
 vi.mock('../google-vertex-auth-google-auth-library', () => ({
-  generateAuthToken: vi.fn(),
+  createAuthTokenGenerator: vi.fn(() => generateAuthToken),
 }));
 
 vi.mock('./google-vertex-xai-provider', () => ({
@@ -28,6 +32,7 @@ vi.mock('@ai-sdk/provider-utils', () => ({
 describe('google-vertex-xai-provider-node', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    generateAuthToken.mockReset();
   });
 
   it('should create provider with auth wrapper', async () => {
@@ -66,13 +71,8 @@ describe('google-vertex-xai-provider-node', () => {
       headers: { 'Content-Type': 'application/json' },
     });
 
-    expect(vi.mocked(generateAuthToken).mock.calls).toMatchInlineSnapshot(`
-      [
-        [
-          undefined,
-        ],
-      ]
-    `);
+    expect(createAuthTokenGenerator).toHaveBeenCalledWith(undefined);
+    expect(generateAuthToken.mock.calls).toEqual([[]]);
 
     expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
       [
@@ -90,7 +90,7 @@ describe('google-vertex-xai-provider-node', () => {
     `);
   });
 
-  it('should pass googleAuthOptions to generateAuthToken', async () => {
+  it('should pass googleAuthOptions to createAuthTokenGenerator', async () => {
     vi.mocked(generateAuthToken).mockResolvedValue('mock-auth-token');
     const mockFetch = vi.fn().mockResolvedValue(new Response('{}'));
     global.fetch = mockFetch;
@@ -104,17 +104,8 @@ describe('google-vertex-xai-provider-node', () => {
     const customFetch = (provider as any).fetch;
     await customFetch('https://example.com/test', {});
 
-    expect(vi.mocked(generateAuthToken).mock.calls).toMatchInlineSnapshot(`
-      [
-        [
-          {
-            "scopes": [
-              "test-scope",
-            ],
-          },
-        ],
-      ]
-    `);
+    expect(createAuthTokenGenerator).toHaveBeenCalledWith(googleAuthOptions);
+    expect(generateAuthToken.mock.calls).toEqual([[]]);
   });
 
   it('should merge custom headers with auth header', async () => {

--- a/packages/google-vertex/src/xai/google-vertex-xai-provider-node.ts
+++ b/packages/google-vertex/src/xai/google-vertex-xai-provider-node.ts
@@ -1,6 +1,6 @@
 import { resolve, type FetchFunction } from '@ai-sdk/provider-utils';
 import type { GoogleAuthOptions } from 'google-auth-library';
-import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
+import { createAuthTokenGenerator } from '../google-vertex-auth-google-auth-library';
 import {
   createGoogleVertexXai as createGoogleVertexXaiOriginal,
   type GoogleVertexXaiProvider,
@@ -28,8 +28,10 @@ export interface GoogleVertexXaiProviderSettings extends GoogleVertexXaiProvider
 export function createGoogleVertexXai(
   options: GoogleVertexXaiProviderSettings = {},
 ): GoogleVertexXaiProvider {
+  const generateAuthToken = createAuthTokenGenerator(options.googleAuthOptions);
+
   const customFetch: FetchFunction = async (url, init) => {
-    const token = await generateAuthToken(options.googleAuthOptions);
+    const token = await generateAuthToken();
     const resolvedHeaders = await resolve(options.headers);
     const authHeaders = {
       ...resolvedHeaders,


### PR DESCRIPTION
## Background

the change in https://github.com/vercel/ai/pull/14102 didn't pull from latest main and didn't account for the latest vertex/xai package created. and thus `main` on that path was using the wrong import

## Summary

use correct import

## Manual Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)