### PR TITLE
feat(provider): align tool result output content file part types with top-level message file part types

### DIFF
--- a/.changeset/strange-penguins-drive.md
+++ b/.changeset/strange-penguins-drive.md
@@ -1,0 +1,14 @@
+---
+"@ai-sdk/provider-utils": major
+"@ai-sdk/provider": major
+"ai": major
+"@ai-sdk/amazon-bedrock": patch
+"@ai-sdk/open-responses": patch
+"@ai-sdk/anthropic": patch
+"@ai-sdk/mistral": patch
+"@ai-sdk/google": patch
+"@ai-sdk/openai": patch
+"@ai-sdk/mcp": patch
+---
+
+feat(provider): align tool result output content file part types with top-level message file part types

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -1186,9 +1186,11 @@ const { text } = await generateText({
   and Google (Gemini 3 models).
 </Note>
 
-For Google, use base64 media parts (`file-data`) or base64
-`data:` URLs in URL-style parts. Remote HTTP(S) URLs in tool-result URL parts
-are not supported.
+For Google, use base64 inline-data file parts
+(`{ type: 'file', mediaType, data: { type: 'data', data } }`) or base64
+`data:` URLs in URL-style file parts
+(`{ type: 'file', mediaType, data: { type: 'url', url: new URL('data:...') } }`).
+Remote HTTP(S) URLs in tool-result URL parts are not supported.
 
 In order to send multi-modal tool results, e.g. screenshots, back to the model,
 they need to be converted into a specific format.
@@ -1228,7 +1230,13 @@ const result = await generateText({
           value:
             typeof output === 'string'
               ? [{ type: 'text', text: output }]
-              : [{ type: 'media', data: output.data, mediaType: 'image/png' }],
+              : [
+                  {
+                    type: 'file',
+                    mediaType: 'image/png',
+                    data: { type: 'data', data: output.data },
+                  },
+                ],
         };
       },
     }),

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -554,26 +554,28 @@ The deprecated tool result content part of `{ type: 'media' }` has been removed 
 
 Use `{ type: 'file-data' }` for all inline file content, including images.
 
-### Tool Result Content: Migrate Away From `image-*` and `*-id` Variants
+### Tool Result Content: Migrate Away From `image-*` and `file-*` variants to `file`
 
-The `image-*` content part types and the `file-id` / `image-file-id` types are deprecated in AI SDK 7. Auto-migration is applied at runtime, so existing tool outputs continue to work without code changes. However, updating to the new types is recommended.
+All `image-*` and legacy `file-*` content part types for `toModelOutput` results are deprecated in AI SDK 7 in favor of a single canonical `file` variant that mirrors the top-level `FilePart` shape. Auto-migration is applied at runtime, so existing tool outputs continue to work without code changes. However, updating to the new shape is recommended.
 
-Images are just files with an image media type, so the general `file-*` types cover all cases:
+The new shape carries a tagged `data` discriminated union, and it always has `mediaType`:
 
-- `{ type: 'image-data', data, mediaType }` → `{ type: 'file-data', data, mediaType }` (same fields)
-- `{ type: 'image-url', url }` → `{ type: 'file-url', url, mediaType: 'image/jpeg' }` (add the appropriate `mediaType`)
-- `{ type: 'image-file-reference', providerReference }` → `{ type: 'file-reference', providerReference }`
+- `{ type: 'file-data', data, mediaType, filename? }` → `{ type: 'file', mediaType, filename, data: { type: 'data', data } }`
+- `{ type: 'file-url', url, mediaType }` → `{ type: 'file', mediaType, data: { type: 'url', url: new URL(url) } }`
+- `{ type: 'file-reference', providerReference }` → `{ type: 'file', mediaType, data: { type: 'reference', reference: providerReference } }`
 
-`ProviderReference` is a provider-to-file-ID map (for example `{ openai: 'file_123', anthropic: 'file_abc' }`) that lets the same logical file be reused across providers. Where supported, upload files to the provider first and reference them for inference. The `file-id` / `image-file-id` types, which held a single ID, are replaced by `file-reference`:
+Images are just files with an image media type, so the `image-*` aliases collapse into the same shape — pass `mediaType: 'image'` (or a more specific `image/*` subtype) instead:
 
-- `{ type: 'file-id', fileId }` → `{ type: 'file-reference', providerReference }`
-- `{ type: 'image-file-id', fileId }` → `{ type: 'file-reference', providerReference }` (skip the intermediate step)
+- `{ type: 'image-data', data, mediaType }` → `{ type: 'file', mediaType, data: { type: 'data', data } }`
+- `{ type: 'image-url', url }` → `{ type: 'file', mediaType: 'image', data: { type: 'url', url: new URL(url) } }`
+- `{ type: 'image-file-reference', providerReference }` → `{ type: 'file', mediaType: 'image', data: { type: 'reference', reference: providerReference } }`
 
-Note that `file-url` now requires a `mediaType` field so providers can correctly determine how to handle the file. Update parsing/validation and discriminated unions to use the replacement types:
+The `-id` content part types (`file-id` and `image-file-id`) are also generally deprecated in favor of the `reference` data shape, which carries a full `ProviderReference` (a provider-to-file-ID map like `{ openai: 'file_123', anthropic: 'file_abc' }`) that lets the same logical file be reused across providers. The single-ID `-id` variants required the runtime to know which provider the ID belonged to; the explicit reference shape removes that ambiguity:
 
-- `file-data` (replaces `image-data`)
-- `file-url` (replaces `image-url`) — now requires `mediaType`
-- `file-reference` (replaces `image-file-reference`, `file-id`, `image-file-id`)
+- `{ type: 'file-id', fileId }` → `{ type: 'file', mediaType, data: { type: 'reference', reference: { [provider]: fileId } } }`
+- `{ type: 'image-file-id', fileId }` → `{ type: 'file', mediaType: 'image', data: { type: 'reference', reference: { [provider]: fileId } } }`
+
+`mediaType` on the new `file` variant accepts either a full IANA type (e.g. `'image/png'`) or just a top-level segment (e.g. `'image'`, `'audio'`, `'video'`, `'text'`). When only a top-level segment is provided, the subtype is auto-detected from inline bytes where possible. Update parsing/validation and discriminated unions to handle the single canonical `file` variant.
 
 ### Message Parts: Migrate Away From Deprecated `image` Part
 

--- a/examples/ai-e2e-next/tool/fetch-pdf-tool.ts
+++ b/examples/ai-e2e-next/tool/fetch-pdf-tool.ts
@@ -22,7 +22,7 @@ export const fetchPdfTool = tool({
   },
   toModelOutput: ({ output: { mediaType, base64 } }) => ({
     type: 'content',
-    value: [{ type: 'file-data', data: base64, mediaType }],
+    value: [{ type: 'file', mediaType, data: { type: 'data', data: base64 } }],
   }),
 });
 

--- a/examples/ai-e2e-next/tool/generate-image-tool.ts
+++ b/examples/ai-e2e-next/tool/generate-image-tool.ts
@@ -18,7 +18,7 @@ export const generateImageTool = tool({
   },
   toModelOutput: ({ output: { mediaType, base64 } }) => ({
     type: 'content',
-    value: [{ type: 'file-data', data: base64, mediaType }],
+    value: [{ type: 'file', mediaType, data: { type: 'data', data: base64 } }],
   }),
 });
 

--- a/examples/ai-functions/src/e2e/amazon-bedrock-anthropic.test.ts
+++ b/examples/ai-functions/src/e2e/amazon-bedrock-anthropic.test.ts
@@ -149,9 +149,9 @@ const toolTests = (model: LanguageModelV4) => {
                   typeof output === 'string'
                     ? { type: 'text', text: output }
                     : {
-                        type: 'file-data',
-                        data: output.data,
+                        type: 'file',
                         mediaType: 'image/png',
+                        data: { type: 'data', data: output.data },
                       },
                 ],
               };

--- a/examples/ai-functions/src/e2e/google-vertex-anthropic.test.ts
+++ b/examples/ai-functions/src/e2e/google-vertex-anthropic.test.ts
@@ -145,9 +145,9 @@ const toolTests = (model: LanguageModelV4) => {
                   typeof output === 'string'
                     ? { type: 'text', text: output }
                     : {
-                        type: 'file-data',
-                        data: output.data,
+                        type: 'file',
                         mediaType: 'image/png',
+                        data: { type: 'data', data: output.data },
                       },
                 ],
               };

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/anthropic-computer-use-computer.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/anthropic-computer-use-computer.ts
@@ -35,9 +35,9 @@ run(async () => {
               typeof output === 'string'
                 ? { type: 'text', text: output }
                 : {
-                    type: 'file-data',
-                    data: output.data,
+                    type: 'file',
                     mediaType: 'image/png',
+                    data: { type: 'data', data: output.data },
                   },
             ],
           };

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/tool-call-image-result.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/tool-call-image-result.ts
@@ -34,9 +34,12 @@ run(async () => {
             type: 'content',
             value: [
               {
-                type: 'file-data',
-                data: Buffer.from(output.bytes).toString('base64'),
+                type: 'file',
                 mediaType: 'image/jpeg',
+                data: {
+                  type: 'data',
+                  data: Buffer.from(output.bytes).toString('base64'),
+                },
               },
             ],
           };

--- a/examples/ai-functions/src/generate-text/anthropic/computer-use-computer.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/computer-use-computer.ts
@@ -41,9 +41,9 @@ run(async () => {
               typeof output === 'string'
                 ? { type: 'text', text: output }
                 : {
-                    type: 'file-data',
-                    data: output.data,
+                    type: 'file',
                     mediaType: 'image/png',
+                    data: { type: 'data', data: output.data },
                   },
             ],
           };

--- a/examples/ai-functions/src/generate-text/anthropic/computer-use-zoom.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/computer-use-zoom.ts
@@ -51,9 +51,9 @@ run(async () => {
               typeof output === 'string'
                 ? { type: 'text', text: output }
                 : {
-                    type: 'file-data',
-                    data: output.data,
+                    type: 'file',
                     mediaType: 'image/png',
+                    data: { type: 'data', data: output.data },
                   },
             ],
           };

--- a/examples/ai-functions/src/generate-text/anthropic/image-tool-result-url.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/image-tool-result-url.ts
@@ -28,9 +28,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-url',
-            url: output.imageUrl,
+            type: 'file',
             mediaType: 'image/png',
+            data: { type: 'url', url: new URL(output.imageUrl) },
           },
         ],
       };

--- a/examples/ai-functions/src/generate-text/anthropic/pdf-tool-results-base64.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/pdf-tool-results-base64.ts
@@ -36,10 +36,10 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-data',
-            data: output.pdfData,
+            type: 'file',
             mediaType: 'application/pdf',
             filename: 'ai.pdf',
+            data: { type: 'data', data: output.pdfData },
           },
         ],
       };

--- a/examples/ai-functions/src/generate-text/anthropic/pdf-tool-results-url.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/pdf-tool-results-url.ts
@@ -28,8 +28,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-url',
-            url: output.pdfUrl,
+            type: 'file',
+            mediaType: 'application/pdf',
+            data: { type: 'url', url: new URL(output.pdfUrl) },
           },
         ],
       };

--- a/examples/ai-functions/src/generate-text/google/image-tool-result-base64.ts
+++ b/examples/ai-functions/src/generate-text/google/image-tool-result-base64.ts
@@ -32,9 +32,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-data',
+            type: 'file',
             mediaType: 'image/png',
-            data: output.imageData,
+            data: { type: 'data', data: output.imageData },
           },
         ],
       };

--- a/examples/ai-functions/src/generate-text/google/image-tool-result-data-url.ts
+++ b/examples/ai-functions/src/generate-text/google/image-tool-result-data-url.ts
@@ -33,9 +33,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-url',
-            url: output.imageUrl,
+            type: 'file',
             mediaType: 'image/png',
+            data: { type: 'url', url: new URL(output.imageUrl) },
           },
         ],
       };

--- a/examples/ai-functions/src/generate-text/google/image-tool-result-old.ts
+++ b/examples/ai-functions/src/generate-text/google/image-tool-result-old.ts
@@ -36,9 +36,9 @@ const imageAnalysisTool = tool({
       type: 'content',
       value: [
         {
-          type: 'file-data',
+          type: 'file',
           mediaType: 'image/png',
-          data: output.base64Image!,
+          data: { type: 'data', data: output.base64Image! },
         },
       ],
     };

--- a/examples/ai-functions/src/generate-text/google/image-tool-result-url.ts
+++ b/examples/ai-functions/src/generate-text/google/image-tool-result-url.ts
@@ -26,9 +26,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-url',
-            url: output.imageUrl,
+            type: 'file',
             mediaType: 'image/png',
+            data: { type: 'url', url: new URL(output.imageUrl) },
           },
         ],
       };

--- a/examples/ai-functions/src/generate-text/google/pdf-tool-results-base64.ts
+++ b/examples/ai-functions/src/generate-text/google/pdf-tool-results-base64.ts
@@ -32,10 +32,10 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-data',
-            data: output.pdfData,
+            type: 'file',
             mediaType: 'application/pdf',
             filename: 'ai.pdf',
+            data: { type: 'data', data: output.pdfData },
           },
         ],
       };

--- a/examples/ai-functions/src/generate-text/google/pdf-tool-results-data-url.ts
+++ b/examples/ai-functions/src/generate-text/google/pdf-tool-results-data-url.ts
@@ -33,8 +33,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-url',
-            url: output.pdfUrl,
+            type: 'file',
+            mediaType: 'application/pdf',
+            data: { type: 'url', url: new URL(output.pdfUrl) },
           },
         ],
       };

--- a/examples/ai-functions/src/generate-text/google/pdf-tool-results-url.ts
+++ b/examples/ai-functions/src/generate-text/google/pdf-tool-results-url.ts
@@ -26,8 +26,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-url',
-            url: output.pdfUrl,
+            type: 'file',
+            mediaType: 'application/pdf',
+            data: { type: 'url', url: new URL(output.pdfUrl) },
           },
         ],
       };

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-computer-use-computer.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-computer-use-computer.ts
@@ -41,9 +41,9 @@ run(async () => {
               typeof output === 'string'
                 ? { type: 'text', text: output }
                 : {
-                    type: 'file-data',
-                    data: output.data,
+                    type: 'file',
                     mediaType: 'image/png',
+                    data: { type: 'data', data: output.data },
                   },
             ],
           };

--- a/examples/ai-functions/src/generate-text/openai/responses-file-url-tool-result.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-file-url-tool-result.ts
@@ -21,8 +21,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-url',
-            url: output.pdfUrl,
+            type: 'file',
+            mediaType: 'application/pdf',
+            data: { type: 'url', url: new URL(output.pdfUrl) },
           },
         ],
       };

--- a/examples/ai-functions/src/generate-text/openai/responses-image-tool-result-url.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-image-tool-result-url.ts
@@ -28,9 +28,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-url',
-            url: output.imageUrl,
+            type: 'file',
             mediaType: 'image/png',
+            data: { type: 'url', url: new URL(output.imageUrl) },
           },
         ],
       };

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-computer-use-computer.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-computer-use-computer.ts
@@ -33,9 +33,9 @@ run(async () => {
               typeof output === 'string'
                 ? { type: 'text', text: output }
                 : {
-                    type: 'file-data',
-                    data: output.data,
+                    type: 'file',
                     mediaType: 'image/png',
+                    data: { type: 'data', data: output.data },
                   },
             ],
           };

--- a/examples/ai-functions/src/stream-text/anthropic/computer-use-zoom.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/computer-use-zoom.ts
@@ -51,9 +51,9 @@ run(async () => {
               typeof output === 'string'
                 ? { type: 'text', text: output }
                 : {
-                    type: 'file-data',
-                    data: output.data,
+                    type: 'file',
                     mediaType: 'image/png',
+                    data: { type: 'data', data: output.data },
                   },
             ],
           };

--- a/examples/ai-functions/src/stream-text/google/image-tool-result-base64.ts
+++ b/examples/ai-functions/src/stream-text/google/image-tool-result-base64.ts
@@ -32,9 +32,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-data',
+            type: 'file',
             mediaType: 'image/png',
-            data: output.imageData,
+            data: { type: 'data', data: output.imageData },
           },
         ],
       };

--- a/examples/ai-functions/src/stream-text/google/image-tool-result-data-url.ts
+++ b/examples/ai-functions/src/stream-text/google/image-tool-result-data-url.ts
@@ -33,9 +33,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-url',
-            url: output.imageUrl,
+            type: 'file',
             mediaType: 'image/png',
+            data: { type: 'url', url: new URL(output.imageUrl) },
           },
         ],
       };

--- a/examples/ai-functions/src/stream-text/google/image-tool-result-old.ts
+++ b/examples/ai-functions/src/stream-text/google/image-tool-result-old.ts
@@ -36,9 +36,9 @@ const imageAnalysisTool = tool({
       type: 'content',
       value: [
         {
-          type: 'file-data',
+          type: 'file',
           mediaType: 'image/png',
-          data: output.base64Image!,
+          data: { type: 'data', data: output.base64Image! },
         },
       ],
     };

--- a/examples/ai-functions/src/stream-text/google/image-tool-result-url.ts
+++ b/examples/ai-functions/src/stream-text/google/image-tool-result-url.ts
@@ -26,9 +26,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-url',
-            url: output.imageUrl,
+            type: 'file',
             mediaType: 'image/png',
+            data: { type: 'url', url: new URL(output.imageUrl) },
           },
         ],
       };

--- a/examples/ai-functions/src/stream-text/google/pdf-tool-results-url.ts
+++ b/examples/ai-functions/src/stream-text/google/pdf-tool-results-url.ts
@@ -26,8 +26,9 @@ run(async () => {
             text: output.description,
           },
           {
-            type: 'file-url',
-            url: output.pdfUrl,
+            type: 'file',
+            mediaType: 'application/pdf',
+            data: { type: 'url', url: new URL(output.pdfUrl) },
           },
         ],
       };

--- a/packages/ai/src/prompt/content-part.ts
+++ b/packages/ai/src/prompt/content-part.ts
@@ -196,6 +196,14 @@ export const outputSchema: z.ZodType<ToolResultOutput> = z.discriminatedUnion(
             providerOptions: providerMetadataSchema.optional(),
           }),
           z.object({
+            type: z.literal('file'),
+            data: taggedFileDataSchema,
+            mediaType: z.string(),
+            filename: z.string().optional(),
+            providerOptions: providerMetadataSchema.optional(),
+          }),
+          z.object({
+            // Deprecated.
             type: z.literal('file-data'),
             data: z.string(),
             mediaType: z.string(),
@@ -203,39 +211,45 @@ export const outputSchema: z.ZodType<ToolResultOutput> = z.discriminatedUnion(
             providerOptions: providerMetadataSchema.optional(),
           }),
           z.object({
+            // Deprecated.
             type: z.literal('file-url'),
             url: z.string(),
-            // Temporarily optional. TODO: make required in v8, after migration period.
             mediaType: z.string().optional(),
             providerOptions: providerMetadataSchema.optional(),
           }),
           z.object({
+            // Deprecated.
             type: z.literal('file-id'),
             fileId: z.union([z.string(), z.record(z.string(), z.string())]),
             providerOptions: providerMetadataSchema.optional(),
           }),
           z.object({
+            // Deprecated.
             type: z.literal('file-reference'),
             providerReference: z.record(z.string(), z.string()),
             providerOptions: providerMetadataSchema.optional(),
           }),
           z.object({
+            // Deprecated.
             type: z.literal('image-data'),
             data: z.string(),
             mediaType: z.string(),
             providerOptions: providerMetadataSchema.optional(),
           }),
           z.object({
+            // Deprecated.
             type: z.literal('image-url'),
             url: z.string(),
             providerOptions: providerMetadataSchema.optional(),
           }),
           z.object({
+            // Deprecated.
             type: z.literal('image-file-id'),
             fileId: z.union([z.string(), z.record(z.string(), z.string())]),
             providerOptions: providerMetadataSchema.optional(),
           }),
           z.object({
+            // Deprecated.
             type: z.literal('image-file-reference'),
             providerReference: z.record(z.string(), z.string()),
             providerOptions: providerMetadataSchema.optional(),

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -2077,8 +2077,111 @@ describe('convertToLanguageModelMessage', () => {
         mockProcessEmitWarning.mockRestore();
       });
 
-      it('should emit DeprecationWarning for image-data', () => {
-        convertToLanguageModelMessage({
+      it('should emit DeprecationWarning for file-data and emit type: "file"', () => {
+        const result = convertToLanguageModelMessage({
+          message: {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'toolName',
+                toolCallId: 'toolCallId',
+                output: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'file-data',
+                      data: 'dGVzdA==',
+                      mediaType: 'image/png',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          downloadedAssets: {},
+        });
+
+        expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
+        expect(mockProcessEmitWarning).toHaveBeenCalledWith(
+          'AI SDK Warning: Deprecated: ""tool-result" content of type "file-data"". The "file-data" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'data\', data } instead.',
+          { type: 'DeprecationWarning' },
+        );
+        expect(
+          (
+            result.content[0] as Extract<
+              (typeof result.content)[number],
+              { type: 'tool-result' }
+            >
+          ).output,
+        ).toEqual({
+          type: 'content',
+          value: [
+            {
+              type: 'file',
+              data: { type: 'data', data: 'dGVzdA==' },
+              filename: undefined,
+              mediaType: 'image/png',
+              providerOptions: undefined,
+            },
+          ],
+        });
+      });
+
+      it('should emit DeprecationWarning for file-reference and emit type: "file" with application default', () => {
+        const result = convertToLanguageModelMessage({
+          message: {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'toolName',
+                toolCallId: 'toolCallId',
+                output: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'file-reference',
+                      providerReference: { 'test-provider': 'fileId' },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          downloadedAssets: {},
+        });
+
+        expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
+        expect(mockProcessEmitWarning).toHaveBeenCalledWith(
+          'AI SDK Warning: Deprecated: ""tool-result" content of type "file-reference"". The "file-reference" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'reference\', reference } instead.',
+          { type: 'DeprecationWarning' },
+        );
+        expect(
+          (
+            result.content[0] as Extract<
+              (typeof result.content)[number],
+              { type: 'tool-result' }
+            >
+          ).output,
+        ).toEqual({
+          type: 'content',
+          value: [
+            {
+              type: 'file',
+              data: {
+                type: 'reference',
+                reference: { 'test-provider': 'fileId' },
+              },
+              mediaType: 'application',
+              providerOptions: undefined,
+            },
+          ],
+        });
+      });
+
+      it('should emit DeprecationWarning for image-data and emit type: "file"', () => {
+        const result = convertToLanguageModelMessage({
           message: {
             role: 'tool',
             content: [
@@ -2104,13 +2207,31 @@ describe('convertToLanguageModelMessage', () => {
 
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
-          'AI SDK Warning: Deprecated: ""tool-result" content of type "image-data"". The "image-data" type for tool result content is deprecated. Use the "file-data" type instead.',
+          'AI SDK Warning: Deprecated: ""tool-result" content of type "image-data"". The "image-data" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'data\', data } instead.',
           { type: 'DeprecationWarning' },
         );
+        expect(
+          (
+            result.content[0] as Extract<
+              (typeof result.content)[number],
+              { type: 'tool-result' }
+            >
+          ).output,
+        ).toEqual({
+          type: 'content',
+          value: [
+            {
+              type: 'file',
+              data: { type: 'data', data: 'dGVzdA==' },
+              mediaType: 'image/png',
+              providerOptions: undefined,
+            },
+          ],
+        });
       });
 
-      it('should emit DeprecationWarning for image-url', () => {
-        convertToLanguageModelMessage({
+      it('should emit DeprecationWarning for image-url and emit type: "file" with mediaType "image"', () => {
+        const result = convertToLanguageModelMessage({
           message: {
             role: 'tool',
             content: [
@@ -2132,13 +2253,34 @@ describe('convertToLanguageModelMessage', () => {
 
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
-          'AI SDK Warning: Deprecated: ""tool-result" content of type "image-url"". The "image-url" type for tool result content is deprecated. Use the "file-url" type instead.',
+          'AI SDK Warning: Deprecated: ""tool-result" content of type "image-url"". The "image-url" type for tool result content is deprecated. Use the "file" type with mediaType \'image\' (or a specific image/* subtype) and { type: \'url\', url } instead.',
           { type: 'DeprecationWarning' },
         );
+        expect(
+          (
+            result.content[0] as Extract<
+              (typeof result.content)[number],
+              { type: 'tool-result' }
+            >
+          ).output,
+        ).toEqual({
+          type: 'content',
+          value: [
+            {
+              type: 'file',
+              data: {
+                type: 'url',
+                url: new URL('https://example.com/image.png'),
+              },
+              mediaType: 'image',
+              providerOptions: undefined,
+            },
+          ],
+        });
       });
 
-      it('should emit DeprecationWarning for image-file-reference', () => {
-        convertToLanguageModelMessage({
+      it('should emit DeprecationWarning for image-file-reference and emit type: "file" with mediaType "image"', () => {
+        const result = convertToLanguageModelMessage({
           message: {
             role: 'tool',
             content: [
@@ -2163,13 +2305,34 @@ describe('convertToLanguageModelMessage', () => {
 
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
-          'AI SDK Warning: Deprecated: ""tool-result" content of type "image-file-reference"". The "image-file-reference" type for tool result content is deprecated. Use the "file-reference" type instead.',
+          'AI SDK Warning: Deprecated: ""tool-result" content of type "image-file-reference"". The "image-file-reference" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'reference\', reference } instead.',
           { type: 'DeprecationWarning' },
         );
+        expect(
+          (
+            result.content[0] as Extract<
+              (typeof result.content)[number],
+              { type: 'tool-result' }
+            >
+          ).output,
+        ).toEqual({
+          type: 'content',
+          value: [
+            {
+              type: 'file',
+              data: {
+                type: 'reference',
+                reference: { 'test-provider': 'fileId' },
+              },
+              mediaType: 'image',
+              providerOptions: undefined,
+            },
+          ],
+        });
       });
 
-      it('should emit DeprecationWarning for image-file-id with object fileId', () => {
-        convertToLanguageModelMessage({
+      it('should emit DeprecationWarning for image-file-id with object fileId and emit type: "file" with mediaType "image"', () => {
+        const result = convertToLanguageModelMessage({
           message: {
             role: 'tool',
             content: [
@@ -2194,13 +2357,34 @@ describe('convertToLanguageModelMessage', () => {
 
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
-          'AI SDK Warning: Deprecated: ""tool-result" content of type "image-file-id"". The "image-file-id" type for tool result content is deprecated. Use the "file-reference" type instead.',
+          'AI SDK Warning: Deprecated: ""tool-result" content of type "image-file-id"". The "image-file-id" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'reference\', reference } instead.',
           { type: 'DeprecationWarning' },
         );
+        expect(
+          (
+            result.content[0] as Extract<
+              (typeof result.content)[number],
+              { type: 'tool-result' }
+            >
+          ).output,
+        ).toEqual({
+          type: 'content',
+          value: [
+            {
+              type: 'file',
+              data: {
+                type: 'reference',
+                reference: { 'test-provider': 'fileId' },
+              },
+              mediaType: 'image',
+              providerOptions: undefined,
+            },
+          ],
+        });
       });
 
-      it('should emit DeprecationWarning for file-id with object fileId', () => {
-        convertToLanguageModelMessage({
+      it('should emit DeprecationWarning for file-id with object fileId and emit type: "file" with application default', () => {
+        const result = convertToLanguageModelMessage({
           message: {
             role: 'tool',
             content: [
@@ -2225,7 +2409,60 @@ describe('convertToLanguageModelMessage', () => {
 
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
-          'AI SDK Warning: Deprecated: ""tool-result" content of type "file-id"". The "file-id" type for tool result content is deprecated. Use the "file-reference" type instead.',
+          'AI SDK Warning: Deprecated: ""tool-result" content of type "file-id"". The "file-id" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'reference\', reference } instead.',
+          { type: 'DeprecationWarning' },
+        );
+        expect(
+          (
+            result.content[0] as Extract<
+              (typeof result.content)[number],
+              { type: 'tool-result' }
+            >
+          ).output,
+        ).toEqual({
+          type: 'content',
+          value: [
+            {
+              type: 'file',
+              data: {
+                type: 'reference',
+                reference: { 'test-provider': 'fileId' },
+              },
+              mediaType: 'application',
+              providerOptions: undefined,
+            },
+          ],
+        });
+      });
+
+      it('should emit DeprecationWarning for file-url with mediaType', () => {
+        convertToLanguageModelMessage({
+          message: {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'toolName',
+                toolCallId: 'toolCallId',
+                output: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'file-url',
+                      url: 'https://example.com/image.png',
+                      mediaType: 'image/png',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          downloadedAssets: {},
+        });
+
+        expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
+        expect(mockProcessEmitWarning).toHaveBeenCalledWith(
+          `AI SDK Warning: Deprecated: ""tool-result" content of type "file-url"". The "file-url" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'url', url } instead.`,
           { type: 'DeprecationWarning' },
         );
       });
@@ -2242,7 +2479,10 @@ describe('convertToLanguageModelMessage', () => {
                 output: {
                   type: 'content',
                   value: [
-                    { type: 'file-url', url: 'https://example.com/image.png' },
+                    {
+                      type: 'file-url',
+                      url: 'https://example.com/image.png',
+                    },
                   ],
                 },
               },
@@ -2253,7 +2493,7 @@ describe('convertToLanguageModelMessage', () => {
 
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
-          `AI SDK Warning: Deprecated: ""tool-result" content of type "file-url" without mediaType". The "file-url" tool result content part with URL "https://example.com/image.png" is missing a "mediaType". Inferred media type 'image/png' from URL.`,
+          `AI SDK Warning: Deprecated: ""tool-result" content of type "file-url"". The "file-url" tool result content part with URL "https://example.com/image.png" is missing a "mediaType". Inferred media type 'image/png' from URL. The "file-url" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'url', url } instead.`,
           { type: 'DeprecationWarning' },
         );
       });
@@ -2270,7 +2510,10 @@ describe('convertToLanguageModelMessage', () => {
                 output: {
                   type: 'content',
                   value: [
-                    { type: 'file-url', url: 'https://example.com/file' },
+                    {
+                      type: 'file-url',
+                      url: 'https://example.com/file',
+                    },
                   ],
                 },
               },
@@ -2281,7 +2524,7 @@ describe('convertToLanguageModelMessage', () => {
 
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
-          `AI SDK Warning: Deprecated: ""tool-result" content of type "file-url" without mediaType". The "file-url" tool result content part with URL "https://example.com/file" is missing a "mediaType". Unable to infer media type from URL. Defaulting to 'application/octet-stream'.`,
+          `AI SDK Warning: Deprecated: ""tool-result" content of type "file-url"". The "file-url" tool result content part with URL "https://example.com/file" is missing a "mediaType". Unable to infer media type from URL. Defaulting to 'application/octet-stream'. The "file-url" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'url', url } instead.`,
           { type: 'DeprecationWarning' },
         );
       });
@@ -2316,7 +2559,7 @@ describe('convertToLanguageModelMessage', () => {
 
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
-          `AI SDK Warning: Deprecated: ""tool-result" content of type "file-url" without mediaType". The "file-url" tool result content part with URL "https://example.com/foo.constructor" is missing a "mediaType". Unable to infer media type from URL. Defaulting to 'application/octet-stream'.`,
+          `AI SDK Warning: Deprecated: ""tool-result" content of type "file-url"". The "file-url" tool result content part with URL "https://example.com/foo.constructor" is missing a "mediaType". Unable to infer media type from URL. Defaulting to 'application/octet-stream'. The "file-url" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'url', url } instead.`,
           { type: 'DeprecationWarning' },
         );
       });
@@ -2348,7 +2591,7 @@ describe('convertToLanguageModelMessage', () => {
 
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
-          'AI SDK Warning: Deprecated: ""tool-result" content of type "image-data"". The "image-data" type for tool result content is deprecated. Use the "file-data" type instead.',
+          'AI SDK Warning: Deprecated: ""tool-result" content of type "image-data"". The "image-data" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'data\', data } instead.',
           { type: 'DeprecationWarning' },
         );
       });
@@ -2395,18 +2638,25 @@ describe('convertToLanguageModelMessage', () => {
                   type: 'content',
                   value: [
                     {
-                      type: 'file-data',
-                      data: 'dGVzdA==',
+                      type: 'file',
+                      data: { type: 'data', data: 'dGVzdA==' },
                       mediaType: 'image/png',
                     },
                     {
-                      type: 'file-url',
-                      url: 'https://example.com/image.png',
+                      type: 'file',
+                      data: {
+                        type: 'url',
+                        url: new URL('https://example.com/image.png'),
+                      },
                       mediaType: 'image/png',
                     },
                     {
-                      type: 'file-reference',
-                      providerReference: { 'test-provider': 'fileId' },
+                      type: 'file',
+                      data: {
+                        type: 'reference',
+                        reference: { 'test-provider': 'fileId' },
+                      },
+                      mediaType: 'application/octet-stream',
                     },
                   ],
                 },
@@ -2417,6 +2667,102 @@ describe('convertToLanguageModelMessage', () => {
         });
 
         expect(mockProcessEmitWarning).not.toHaveBeenCalled();
+      });
+
+      it('should pass the new "file" shape through unchanged', () => {
+        const result = convertToLanguageModelMessage({
+          message: {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'toolName',
+                toolCallId: 'toolCallId',
+                output: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'file',
+                      data: { type: 'data', data: 'dGVzdA==' },
+                      mediaType: 'image/png',
+                      filename: 'image.png',
+                    },
+                    {
+                      type: 'file',
+                      data: {
+                        type: 'url',
+                        url: new URL('https://example.com/image.png'),
+                      },
+                      mediaType: 'image/png',
+                    },
+                    {
+                      type: 'file',
+                      data: {
+                        type: 'reference',
+                        reference: { 'test-provider': 'fileId' },
+                      },
+                      mediaType: 'application/pdf',
+                    },
+                    {
+                      type: 'file',
+                      data: { type: 'text', text: 'inline text' },
+                      mediaType: 'text/plain',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          downloadedAssets: {},
+        });
+
+        expect(mockProcessEmitWarning).not.toHaveBeenCalled();
+        expect(
+          (
+            result.content[0] as Extract<
+              (typeof result.content)[number],
+              { type: 'tool-result' }
+            >
+          ).output,
+        ).toEqual({
+          type: 'content',
+          value: [
+            {
+              type: 'file',
+              data: { type: 'data', data: 'dGVzdA==' },
+              mediaType: 'image/png',
+              filename: 'image.png',
+              providerOptions: undefined,
+            },
+            {
+              type: 'file',
+              data: {
+                type: 'url',
+                url: new URL('https://example.com/image.png'),
+              },
+              mediaType: 'image/png',
+              filename: undefined,
+              providerOptions: undefined,
+            },
+            {
+              type: 'file',
+              data: {
+                type: 'reference',
+                reference: { 'test-provider': 'fileId' },
+              },
+              mediaType: 'application/pdf',
+              filename: undefined,
+              providerOptions: undefined,
+            },
+            {
+              type: 'file',
+              data: { type: 'text', text: 'inline text' },
+              mediaType: 'text/plain',
+              filename: undefined,
+              providerOptions: undefined,
+            },
+          ],
+        });
       });
     });
 
@@ -2481,40 +2827,63 @@ describe('convertToLanguageModelMessage', () => {
                 "type": "content",
                 "value": [
                   {
-                    "mediaType": "image/png",
-                    "providerOptions": undefined,
-                    "type": "file-url",
-                    "url": "https://example.com/image.png",
-                  },
-                  {
-                    "data": "dGVzdA==",
-                    "mediaType": "image/png",
-                    "type": "file-data",
-                  },
-                  {
-                    "providerReference": {
-                      "test-provider": "fileId",
+                    "data": {
+                      "type": "url",
+                      "url": "https://example.com/image.png",
                     },
-                    "type": "file-reference",
-                  },
-                  {
-                    "data": "dGVzdA==",
                     "mediaType": "image/png",
                     "providerOptions": undefined,
-                    "type": "file-data",
+                    "type": "file",
                   },
                   {
-                    "mediaType": "image/png",
-                    "providerOptions": undefined,
-                    "type": "file-url",
-                    "url": "https://example.com/image.png",
-                  },
-                  {
-                    "providerOptions": undefined,
-                    "providerReference": {
-                      "test-provider": "fileId",
+                    "data": {
+                      "data": "dGVzdA==",
+                      "type": "data",
                     },
-                    "type": "file-reference",
+                    "filename": undefined,
+                    "mediaType": "image/png",
+                    "providerOptions": undefined,
+                    "type": "file",
+                  },
+                  {
+                    "data": {
+                      "reference": {
+                        "test-provider": "fileId",
+                      },
+                      "type": "reference",
+                    },
+                    "mediaType": "application",
+                    "providerOptions": undefined,
+                    "type": "file",
+                  },
+                  {
+                    "data": {
+                      "data": "dGVzdA==",
+                      "type": "data",
+                    },
+                    "mediaType": "image/png",
+                    "providerOptions": undefined,
+                    "type": "file",
+                  },
+                  {
+                    "data": {
+                      "type": "url",
+                      "url": "https://example.com/image.png",
+                    },
+                    "mediaType": "image",
+                    "providerOptions": undefined,
+                    "type": "file",
+                  },
+                  {
+                    "data": {
+                      "reference": {
+                        "test-provider": "fileId",
+                      },
+                      "type": "reference",
+                    },
+                    "mediaType": "image",
+                    "providerOptions": undefined,
+                    "type": "file",
                   },
                   {
                     "providerOptions": {

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -570,17 +570,100 @@ function mapToolResultOutput({
     type: 'content',
     value: output.value.map(item => {
       switch (item.type) {
+        case 'file': {
+          const { data, mediaType } = convertToLanguageModelV4FilePart(
+            item.data,
+          );
+          return {
+            type: 'file' as const,
+            data,
+            filename: item.filename,
+            mediaType: mediaType ?? item.mediaType,
+            providerOptions: item.providerOptions,
+          };
+        }
+        case 'file-data': {
+          warnings.push({
+            type: 'deprecated',
+            setting: '"tool-result" content of type "file-data"',
+            message: `The "file-data" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'data', data } instead.`,
+          });
+          return {
+            type: 'file' as const,
+            data: { type: 'data' as const, data: item.data },
+            filename: item.filename,
+            mediaType: item.mediaType,
+            providerOptions: item.providerOptions,
+          };
+        }
+        case 'file-url': {
+          const mediaType = item.mediaType ?? getMediaTypeFromUrl(item.url);
+          let message = `The "file-url" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'url', url } instead.`;
+          if (!item.mediaType) {
+            const inferenceSuffix =
+              mediaType === 'application/octet-stream'
+                ? `Unable to infer media type from URL. Defaulting to 'application/octet-stream'.`
+                : `Inferred media type '${mediaType}' from URL.`;
+            message = `The "file-url" tool result content part with URL "${item.url}" is missing a "mediaType". ${inferenceSuffix} ${message}`;
+          }
+          warnings.push({
+            type: 'deprecated',
+            setting: '"tool-result" content of type "file-url"',
+            message,
+          });
+          return {
+            type: 'file' as const,
+            data: { type: 'url' as const, url: new URL(item.url) },
+            mediaType,
+            providerOptions: item.providerOptions,
+          };
+        }
+        case 'file-id': {
+          warnings.push({
+            type: 'deprecated',
+            setting: '"tool-result" content of type "file-id"',
+            message: `The "file-id" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'reference', reference } instead.`,
+          });
+          return {
+            type: 'file' as const,
+            data: {
+              type: 'reference' as const,
+              reference: convertFileIdToProviderReference({
+                fileId: item.fileId,
+                provider,
+              }),
+            },
+            mediaType: 'application',
+            providerOptions: item.providerOptions,
+          };
+        }
+        case 'file-reference': {
+          warnings.push({
+            type: 'deprecated',
+            setting: '"tool-result" content of type "file-reference"',
+            message: `The "file-reference" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'reference', reference } instead.`,
+          });
+          return {
+            type: 'file' as const,
+            data: {
+              type: 'reference' as const,
+              reference: item.providerReference,
+            },
+            mediaType: 'application',
+            providerOptions: item.providerOptions,
+          };
+        }
         // The "image-*" types are legacy and deprecated.
         // TODO: remove migration in v8 in combination with the removal of these types from the provider utils.
         case 'image-data': {
           warnings.push({
             type: 'deprecated',
             setting: '"tool-result" content of type "image-data"',
-            message: `The "image-data" type for tool result content is deprecated. Use the "file-data" type instead.`,
+            message: `The "image-data" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'data', data } instead.`,
           });
           return {
-            type: 'file-data' as const,
-            data: item.data,
+            type: 'file' as const,
+            data: { type: 'data' as const, data: item.data },
             mediaType: item.mediaType,
             providerOptions: item.providerOptions,
           };
@@ -589,12 +672,12 @@ function mapToolResultOutput({
           warnings.push({
             type: 'deprecated',
             setting: '"tool-result" content of type "image-url"',
-            message: `The "image-url" type for tool result content is deprecated. Use the "file-url" type instead.`,
+            message: `The "image-url" type for tool result content is deprecated. Use the "file" type with mediaType 'image' (or a specific image/* subtype) and { type: 'url', url } instead.`,
           });
           return {
-            type: 'file-url' as const,
-            url: item.url,
-            mediaType: getMediaTypeFromUrl(item.url, 'image/*'),
+            type: 'file' as const,
+            data: { type: 'url' as const, url: new URL(item.url) },
+            mediaType: 'image',
             providerOptions: item.providerOptions,
           };
         }
@@ -602,14 +685,18 @@ function mapToolResultOutput({
           warnings.push({
             type: 'deprecated',
             setting: '"tool-result" content of type "image-file-id"',
-            message: `The "image-file-id" type for tool result content is deprecated. Use the "file-reference" type instead.`,
+            message: `The "image-file-id" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'reference', reference } instead.`,
           });
           return {
-            type: 'file-reference' as const,
-            providerReference: convertFileIdToProviderReference({
-              fileId: item.fileId,
-              provider,
-            }),
+            type: 'file' as const,
+            data: {
+              type: 'reference' as const,
+              reference: convertFileIdToProviderReference({
+                fileId: item.fileId,
+                provider,
+              }),
+            },
+            mediaType: 'image',
             providerOptions: item.providerOptions,
           };
         }
@@ -617,49 +704,15 @@ function mapToolResultOutput({
           warnings.push({
             type: 'deprecated',
             setting: '"tool-result" content of type "image-file-reference"',
-            message: `The "image-file-reference" type for tool result content is deprecated. Use the "file-reference" type instead.`,
+            message: `The "image-file-reference" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'reference', reference } instead.`,
           });
           return {
-            type: 'file-reference' as const,
-            providerReference: item.providerReference,
-            providerOptions: item.providerOptions,
-          };
-        }
-        case 'file-id': {
-          warnings.push({
-            type: 'deprecated',
-            setting: '"tool-result" content of type "file-id"',
-            message: `The "file-id" type for tool result content is deprecated. Use the "file-reference" type instead.`,
-          });
-          return {
-            type: 'file-reference' as const,
-            providerReference: convertFileIdToProviderReference({
-              fileId: item.fileId,
-              provider,
-            }),
-            providerOptions: item.providerOptions,
-          };
-        }
-        case 'file-url': {
-          const mediaType = item.mediaType ?? getMediaTypeFromUrl(item.url);
-          if (!item.mediaType) {
-            const messageSuffix =
-              mediaType === 'application/octet-stream'
-                ? `Unable to infer media type from URL. Defaulting to 'application/octet-stream'.`
-                : `Inferred media type '${mediaType}' from URL.`;
-            warnings.push({
-              type: 'deprecated',
-              setting:
-                '"tool-result" content of type "file-url" without mediaType',
-              message:
-                `The "file-url" tool result content part with URL "${item.url}" is missing a "mediaType". ` +
-                messageSuffix,
-            });
-          }
-          return {
-            type: 'file-url' as const,
-            url: item.url,
-            mediaType,
+            type: 'file' as const,
+            data: {
+              type: 'reference' as const,
+              reference: item.providerReference,
+            },
+            mediaType: 'image',
             providerOptions: item.providerOptions,
           };
         }
@@ -692,7 +745,6 @@ function convertFileIdToProviderReference({
 }
 
 // Temporary private helper (see below).
-// TODO: remove in v8
 const URL_EXTENSION_TO_MEDIA_TYPE: Record<string, string> = {
   jpg: 'image/jpeg',
   jpeg: 'image/jpeg',
@@ -719,7 +771,6 @@ const URL_EXTENSION_TO_MEDIA_TYPE: Record<string, string> = {
  * unrecognized, or the URL cannot be parsed.
  *
  * Temporary private helper as a best-effort solution for missing media types on "file-url" content parts.
- * TODO: remove in v8 when "file-url" content parts are required to have media types, after a migration period.
  */
 function getMediaTypeFromUrl(
   url: string,

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -1273,8 +1273,8 @@ describe('tool messages', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-data',
-                  data: 'base64data',
+                  type: 'file',
+                  data: { type: 'data', data: 'base64data' },
                   mediaType: 'image/jpeg',
                 },
               ],
@@ -1318,8 +1318,8 @@ describe('tool messages', () => {
                 type: 'content',
                 value: [
                   {
-                    type: 'file-data',
-                    data: 'base64data',
+                    type: 'file',
+                    data: { type: 'data', data: 'base64data' },
                     mediaType: 'image/avif', // unsupported format
                   },
                 ],
@@ -1347,8 +1347,8 @@ describe('tool messages', () => {
                 type: 'content',
                 value: [
                   {
-                    type: 'file-data',
-                    data: 'base64data',
+                    type: 'file',
+                    data: { type: 'data', data: 'base64data' },
                     mediaType: 'unsupported/mime-type',
                   },
                 ],

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -219,23 +219,37 @@ export async function convertToAmazonBedrockChatMessages(
                       switch (contentPart.type) {
                         case 'text':
                           return { text: contentPart.text };
-                        case 'file-data':
-                          if (!contentPart.mediaType.startsWith('image/')) {
+                        case 'file': {
+                          if (
+                            getTopLevelMediaType(contentPart.mediaType) !==
+                            'image'
+                          ) {
                             throw new UnsupportedFunctionalityError({
                               functionality: `media type: ${contentPart.mediaType}`,
                             });
                           }
 
-                          const format = getAmazonBedrockImageFormat(
-                            contentPart.mediaType,
-                          );
+                          if (contentPart.data.type !== 'data') {
+                            throw new UnsupportedFunctionalityError({
+                              functionality: `tool result file data of type "${contentPart.data.type}"`,
+                            });
+                          }
+
+                          const fullMediaType = resolveFullMediaType({
+                            part: contentPart,
+                          });
+                          const format =
+                            getAmazonBedrockImageFormat(fullMediaType);
 
                           return {
                             image: {
                               format,
-                              source: { bytes: contentPart.data },
+                              source: {
+                                bytes: convertToBase64(contentPart.data.data),
+                              },
                             },
                           };
+                        }
                         default: {
                           throw new UnsupportedFunctionalityError({
                             functionality: `unsupported tool content part type: ${contentPart.type}`,

--- a/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
@@ -925,8 +925,8 @@ describe('tool messages', () => {
                     text: 'Image generated successfully',
                   },
                   {
-                    type: 'file-data',
-                    data: 'AAECAw==',
+                    type: 'file',
+                    data: { type: 'data', data: 'AAECAw==' },
                     mediaType: 'image/png',
                   },
                 ],
@@ -995,8 +995,11 @@ describe('tool messages', () => {
                     text: 'PDF generated successfully',
                   },
                   {
-                    type: 'file-data',
-                    data: 'JVBERi0xLjQKJeLjz9MKNCAwIG9iago=', // Sample PDF base64
+                    type: 'file',
+                    data: {
+                      type: 'data',
+                      data: 'JVBERi0xLjQKJeLjz9MKNCAwIG9iago=', // Sample PDF base64
+                    },
                     mediaType: 'application/pdf',
                   },
                 ],
@@ -1138,8 +1141,11 @@ describe('tool messages', () => {
                 type: 'content',
                 value: [
                   {
-                    type: 'file-url',
-                    url: 'https://example.com/document.pdf',
+                    type: 'file',
+                    data: {
+                      type: 'url',
+                      url: new URL('https://example.com/document.pdf'),
+                    },
                     mediaType: 'application/pdf',
                   },
                 ],
@@ -1199,8 +1205,11 @@ describe('tool messages', () => {
                 type: 'content',
                 value: [
                   {
-                    type: 'file-url',
-                    url: 'https://example.com/image.png',
+                    type: 'file',
+                    data: {
+                      type: 'url',
+                      url: new URL('https://example.com/image.png'),
+                    },
                     mediaType: 'image/png',
                   },
                 ],

--- a/packages/anthropic/src/convert-to-anthropic-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.ts
@@ -349,50 +349,73 @@ export async function convertToAnthropicPrompt({
                               type: 'text' as const,
                               text: contentPart.text,
                             };
-                          case 'file-url': {
-                            if (contentPart.mediaType.startsWith('image/')) {
-                              return {
-                                type: 'image' as const,
-                                source: {
-                                  type: 'url' as const,
-                                  url: contentPart.url,
-                                },
-                              };
-                            }
-                            return {
-                              type: 'document' as const,
-                              source: {
-                                type: 'url' as const,
-                                url: contentPart.url,
-                              },
-                            };
-                          }
-                          case 'file-data': {
-                            if (contentPart.mediaType.startsWith('image/')) {
-                              return {
-                                type: 'image' as const,
-                                source: {
-                                  type: 'base64' as const,
-                                  media_type: contentPart.mediaType,
-                                  data: contentPart.data,
-                                },
-                              };
-                            }
-                            if (contentPart.mediaType === 'application/pdf') {
-                              betas.add('pdfs-2024-09-25');
+                          case 'file': {
+                            const topLevel = getTopLevelMediaType(
+                              contentPart.mediaType,
+                            );
+
+                            if (contentPart.data.type === 'url') {
+                              if (topLevel === 'image') {
+                                return {
+                                  type: 'image' as const,
+                                  source: {
+                                    type: 'url' as const,
+                                    url: contentPart.data.url.toString(),
+                                  },
+                                };
+                              }
                               return {
                                 type: 'document' as const,
                                 source: {
-                                  type: 'base64' as const,
-                                  media_type: contentPart.mediaType,
-                                  data: contentPart.data,
+                                  type: 'url' as const,
+                                  url: contentPart.data.url.toString(),
                                 },
                               };
                             }
 
+                            if (contentPart.data.type === 'data') {
+                              if (topLevel === 'image') {
+                                return {
+                                  type: 'image' as const,
+                                  source: {
+                                    type: 'base64' as const,
+                                    media_type: resolveFullMediaType({
+                                      part: contentPart,
+                                    }),
+                                    data: convertToBase64(
+                                      contentPart.data.data,
+                                    ),
+                                  },
+                                };
+                              }
+                              if (
+                                resolveFullMediaType({ part: contentPart }) ===
+                                'application/pdf'
+                              ) {
+                                betas.add('pdfs-2024-09-25');
+                                return {
+                                  type: 'document' as const,
+                                  source: {
+                                    type: 'base64' as const,
+                                    media_type: 'application/pdf',
+                                    data: convertToBase64(
+                                      contentPart.data.data,
+                                    ),
+                                  },
+                                };
+                              }
+
+                              warnings.push({
+                                type: 'other',
+                                message: `unsupported tool content part type: ${contentPart.type} with media type: ${contentPart.mediaType}`,
+                              });
+
+                              return undefined;
+                            }
+
                             warnings.push({
                               type: 'other',
-                              message: `unsupported tool content part type: ${contentPart.type} with media type: ${contentPart.mediaType}`,
+                              message: `unsupported tool content part type: ${contentPart.type} with data type: ${contentPart.data.type}`,
                             });
 
                             return undefined;
@@ -417,7 +440,7 @@ export async function convertToAnthropicPrompt({
                           default: {
                             warnings.push({
                               type: 'other',
-                              message: `unsupported tool content part type: ${contentPart.type}`,
+                              message: `unsupported tool content part type: ${(contentPart as { type: string }).type}`,
                             });
 
                             return undefined;

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -664,8 +664,8 @@ describe('tool messages', () => {
                   text: 'Here is the generated image:',
                 },
                 {
-                  type: 'file-data',
-                  data: 'base64encodedimagedata',
+                  type: 'file',
+                  data: { type: 'data', data: 'base64encodedimagedata' },
                   mediaType: 'image/jpeg',
                 },
               ],
@@ -717,8 +717,8 @@ describe('tool messages', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-data',
-                  data: 'base64pdfdata',
+                  type: 'file',
+                  data: { type: 'data', data: 'base64pdfdata' },
                   mediaType: 'application/pdf',
                   filename: 'report.pdf',
                 },
@@ -761,8 +761,11 @@ describe('tool messages', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-url',
-                  url: 'data:image/png;base64,base64pngdata',
+                  type: 'file',
+                  data: {
+                    type: 'url',
+                    url: new URL('data:image/png;base64,base64pngdata'),
+                  },
                   mediaType: 'image/png',
                 },
               ],
@@ -804,8 +807,11 @@ describe('tool messages', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-url',
-                  url: 'https://example.com/image.png',
+                  type: 'file',
+                  data: {
+                    type: 'url',
+                    url: new URL('https://example.com/image.png'),
+                  },
                   mediaType: 'image/png',
                 },
               ],
@@ -820,8 +826,7 @@ describe('tool messages', () => {
         name: 'imageGenerator',
         response: {
           name: 'imageGenerator',
-          content:
-            '{"type":"file-url","url":"https://example.com/image.png","mediaType":"image/png"}',
+          content: `{"type":"file","data":{"type":"url","url":"https://example.com/image.png"},"mediaType":"image/png"}`,
         },
       },
     });
@@ -840,8 +845,11 @@ describe('tool messages', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file-url',
-                  url: 'https://example.com/report.pdf',
+                  type: 'file',
+                  data: {
+                    type: 'url',
+                    url: new URL('https://example.com/report.pdf'),
+                  },
                   mediaType: 'application/pdf',
                 },
               ],
@@ -856,8 +864,7 @@ describe('tool messages', () => {
         name: 'documentReader',
         response: {
           name: 'documentReader',
-          content:
-            '{"type":"file-url","url":"https://example.com/report.pdf","mediaType":"application/pdf"}',
+          content: `{"type":"file","data":{"type":"url","url":"https://example.com/report.pdf"},"mediaType":"application/pdf"}`,
         },
       },
     });
@@ -881,13 +888,13 @@ describe('tool messages', () => {
                     text: 'Here is the generated image:',
                   },
                   {
-                    type: 'file-data',
-                    data: 'base64encodedimagedata',
+                    type: 'file',
+                    data: { type: 'data', data: 'base64encodedimagedata' },
                     mediaType: 'image/jpeg',
                   },
                   {
-                    type: 'file-data',
-                    data: 'base64pdfdata',
+                    type: 'file',
+                    data: { type: 'data', data: 'base64pdfdata' },
                     mediaType: 'application/pdf',
                     filename: 'report.pdf',
                   },
@@ -920,7 +927,7 @@ describe('tool messages', () => {
         text: 'Tool executed successfully and returned this image as a response',
       },
       {
-        text: '{"type":"file-data","data":"base64pdfdata","mediaType":"application/pdf","filename":"report.pdf"}',
+        text: `{"type":"file","data":{"type":"data","data":"base64pdfdata"},"mediaType":"application/pdf","filename":"report.pdf"}`,
       },
     ]);
   });
@@ -939,13 +946,19 @@ describe('tool messages', () => {
                 type: 'content',
                 value: [
                   {
-                    type: 'file-url',
-                    url: 'https://example.com/image.png',
+                    type: 'file',
+                    data: {
+                      type: 'url',
+                      url: new URL('https://example.com/image.png'),
+                    },
                     mediaType: 'image/png',
                   },
                   {
-                    type: 'file-url',
-                    url: 'https://example.com/report.pdf',
+                    type: 'file',
+                    data: {
+                      type: 'url',
+                      url: new URL('https://example.com/report.pdf'),
+                    },
                     mediaType: 'application/pdf',
                   },
                 ],
@@ -959,10 +972,10 @@ describe('tool messages', () => {
 
     expect(result.contents[0].parts).toEqual([
       {
-        text: '{"type":"file-url","url":"https://example.com/image.png","mediaType":"image/png"}',
+        text: `{"type":"file","data":{"type":"url","url":"https://example.com/image.png"},"mediaType":"image/png"}`,
       },
       {
-        text: '{"type":"file-url","url":"https://example.com/report.pdf","mediaType":"application/pdf"}',
+        text: `{"type":"file","data":{"type":"url","url":"https://example.com/report.pdf"},"mediaType":"application/pdf"}`,
       },
     ]);
   });

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -1,9 +1,11 @@
 import {
   UnsupportedFunctionalityError,
   type LanguageModelV4Prompt,
+  type LanguageModelV4ToolResultOutput,
 } from '@ai-sdk/provider';
 import {
   convertToBase64,
+  getTopLevelMediaType,
   isFullMediaType,
   resolveFullMediaType,
   resolveProviderReference,
@@ -58,10 +60,10 @@ function convertUrlToolResultPart(
 function appendToolResultParts(
   parts: GoogleContentPart[],
   toolName: string,
-  outputValue: Array<{
-    type: string;
-    [key: string]: unknown;
-  }>,
+  outputValue: Extract<
+    LanguageModelV4ToolResultOutput,
+    { type: 'content' }
+  >['value'],
 ): void {
   const functionResponseParts: GoogleFunctionResponsePart[] = [];
   const responseTextParts: string[] = [];
@@ -69,25 +71,27 @@ function appendToolResultParts(
   for (const contentPart of outputValue) {
     switch (contentPart.type) {
       case 'text': {
-        responseTextParts.push(contentPart.text as string);
+        responseTextParts.push(contentPart.text);
         break;
       }
-      case 'file-data': {
-        functionResponseParts.push({
-          inlineData: {
-            mimeType: contentPart.mediaType as string,
-            data: contentPart.data as string,
-          },
-        });
-        break;
-      }
-      case 'file-url': {
-        const functionResponsePart = convertUrlToolResultPart(
-          contentPart.url as string,
-        );
+      case 'file': {
+        if (contentPart.data.type === 'data') {
+          functionResponseParts.push({
+            inlineData: {
+              mimeType: resolveFullMediaType({ part: contentPart }),
+              data: convertToBase64(contentPart.data.data),
+            },
+          });
+        } else if (contentPart.data.type === 'url') {
+          const functionResponsePart = convertUrlToolResultPart(
+            contentPart.data.url.toString(),
+          );
 
-        if (functionResponsePart != null) {
-          functionResponseParts.push(functionResponsePart);
+          if (functionResponsePart != null) {
+            functionResponseParts.push(functionResponsePart);
+          } else {
+            responseTextParts.push(JSON.stringify(contentPart));
+          }
         } else {
           responseTextParts.push(JSON.stringify(contentPart));
         }
@@ -125,10 +129,10 @@ function appendToolResultParts(
 function appendLegacyToolResultParts(
   parts: GoogleContentPart[],
   toolName: string,
-  outputValue: Array<{
-    type: string;
-    [key: string]: unknown;
-  }>,
+  outputValue: Extract<
+    LanguageModelV4ToolResultOutput,
+    { type: 'content' }
+  >['value'],
 ): void {
   for (const contentPart of outputValue) {
     switch (contentPart.type) {
@@ -143,13 +147,16 @@ function appendLegacyToolResultParts(
           },
         });
         break;
-      case 'file-data':
-        if ((contentPart.mediaType as string).startsWith('image/')) {
+      case 'file': {
+        if (
+          contentPart.data.type === 'data' &&
+          getTopLevelMediaType(contentPart.mediaType) === 'image'
+        ) {
           parts.push(
             {
               inlineData: {
-                mimeType: contentPart.mediaType as string,
-                data: contentPart.data as string,
+                mimeType: resolveFullMediaType({ part: contentPart }),
+                data: convertToBase64(contentPart.data.data),
               },
             },
             {
@@ -160,6 +167,7 @@ function appendLegacyToolResultParts(
           parts.push({ text: JSON.stringify(contentPart) });
         }
         break;
+      }
       default:
         parts.push({ text: JSON.stringify(contentPart) });
         break;

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -243,9 +243,12 @@ describe('MCPClient', () => {
         "type": "content",
         "value": [
           {
-            "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+            "data": {
+              "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+              "type": "data",
+            },
             "mediaType": "image/png",
-            "type": "file-data",
+            "type": "file",
           },
         ],
       }
@@ -393,9 +396,12 @@ describe('MCPClient', () => {
             "type": "text",
           },
           {
-            "data": "base64data",
+            "data": {
+              "data": "base64data",
+              "type": "data",
+            },
             "mediaType": "image/png",
-            "type": "file-data",
+            "type": "file",
           },
         ],
       }

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -81,9 +81,9 @@ function mcpToModelOutput({
       }
       if (part.type === 'image' && 'data' in part && 'mimeType' in part) {
         return {
-          type: 'file-data' as const,
-          data: part.data as string,
+          type: 'file' as const,
           mediaType: part.mimeType as string,
+          data: { type: 'data' as const, data: part.data as string },
         };
       }
       return { type: 'text' as const, text: JSON.stringify(part) };

--- a/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
@@ -265,8 +265,8 @@ describe('tool calls', () => {
               value: [
                 { type: 'text', text: 'Here is the result:' },
                 {
-                  type: 'file-data',
-                  data: 'base64data',
+                  type: 'file',
+                  data: { type: 'data', data: 'base64data' },
                   mediaType: 'image/png',
                 },
               ],
@@ -294,7 +294,7 @@ describe('tool calls', () => {
           ],
         },
         {
-          "content": "[{"type":"text","text":"Here is the result:"},{"type":"file-data","data":"base64data","mediaType":"image/png"}]",
+          "content": "[{"type":"text","text":"Here is the result:"},{"type":"file","data":{"type":"data","data":"base64data"},"mediaType":"image/png"}]",
           "name": "image-tool",
           "role": "tool",
           "tool_call_id": "tool-call-id-3",

--- a/packages/open-responses/src/responses/convert-to-open-responses-input.test.ts
+++ b/packages/open-responses/src/responses/convert-to-open-responses-input.test.ts
@@ -614,8 +614,11 @@ describe('convertToOpenResponsesInput', () => {
                   type: 'content',
                   value: [
                     {
-                      type: 'file-url',
-                      url: 'https://example.com/image.png',
+                      type: 'file',
+                      data: {
+                        type: 'url',
+                        url: new URL('https://example.com/image.png'),
+                      },
                       mediaType: 'image/png',
                     },
                   ],

--- a/packages/open-responses/src/responses/convert-to-open-responses-input.ts
+++ b/packages/open-responses/src/responses/convert-to-open-responses-input.ts
@@ -170,31 +170,41 @@ export async function convertToOpenResponsesInput({
                       });
                       break;
                     }
-                    case 'file-data': {
-                      if (item.mediaType.startsWith('image/')) {
-                        contentParts.push({
-                          type: 'input_image',
-                          image_url: `data:${item.mediaType};base64,${item.data}`,
+                    case 'file': {
+                      const topLevel = getTopLevelMediaType(item.mediaType);
+
+                      if (item.data.type === 'data') {
+                        const fullMediaType = resolveFullMediaType({
+                          part: item,
                         });
+                        if (topLevel === 'image') {
+                          contentParts.push({
+                            type: 'input_image',
+                            image_url: `data:${fullMediaType};base64,${convertToBase64(item.data.data)}`,
+                          });
+                        } else {
+                          contentParts.push({
+                            type: 'input_file',
+                            filename: item.filename ?? 'data',
+                            file_data: `data:${fullMediaType};base64,${convertToBase64(item.data.data)}`,
+                          });
+                        }
+                      } else if (item.data.type === 'url') {
+                        if (topLevel === 'image') {
+                          contentParts.push({
+                            type: 'input_image',
+                            image_url: item.data.url.toString(),
+                          });
+                        } else {
+                          contentParts.push({
+                            type: 'input_file',
+                            file_url: item.data.url.toString(),
+                          });
+                        }
                       } else {
-                        contentParts.push({
-                          type: 'input_file',
-                          filename: item.filename ?? 'data',
-                          file_data: `data:${item.mediaType};base64,${item.data}`,
-                        });
-                      }
-                      break;
-                    }
-                    case 'file-url': {
-                      if (item.mediaType.startsWith('image/')) {
-                        contentParts.push({
-                          type: 'input_image',
-                          image_url: item.url,
-                        });
-                      } else {
-                        contentParts.push({
-                          type: 'input_file',
-                          file_url: item.url,
+                        warnings.push({
+                          type: 'other',
+                          message: `unsupported tool content part type: ${item.type} with data type: ${item.data.type}`,
                         });
                       }
                       break;

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -2501,9 +2501,9 @@ describe('convertToOpenAIResponsesInput', () => {
                   type: 'content',
                   value: [
                     {
-                      type: 'file-data',
+                      type: 'file',
                       mediaType: 'image/png',
-                      data: 'base64_data',
+                      data: { type: 'data', data: 'base64_data' },
                     },
                   ],
                 },
@@ -2547,8 +2547,11 @@ describe('convertToOpenAIResponsesInput', () => {
                   type: 'content',
                   value: [
                     {
-                      type: 'file-url',
-                      url: 'https://example.com/screenshot.png',
+                      type: 'file',
+                      data: {
+                        type: 'url',
+                        url: new URL('https://example.com/screenshot.png'),
+                      },
                       mediaType: 'image/png',
                     },
                   ],
@@ -2594,9 +2597,9 @@ describe('convertToOpenAIResponsesInput', () => {
                   type: 'content',
                   value: [
                     {
-                      type: 'file-data',
+                      type: 'file',
                       mediaType: 'application/pdf',
-                      data: base64Data,
+                      data: { type: 'data', data: base64Data },
                       filename: 'document.pdf',
                     },
                   ],
@@ -2642,8 +2645,11 @@ describe('convertToOpenAIResponsesInput', () => {
                   type: 'content',
                   value: [
                     {
-                      type: 'file-url',
-                      url: 'https://example.com/document.pdf',
+                      type: 'file',
+                      data: {
+                        type: 'url',
+                        url: new URL('https://example.com/document.pdf'),
+                      },
                       mediaType: 'application/pdf',
                     },
                   ],
@@ -2693,8 +2699,11 @@ describe('convertToOpenAIResponsesInput', () => {
                       text: 'Here is the file you asked for:',
                     },
                     {
-                      type: 'file-url',
-                      url: 'https://example.com/test.pdf',
+                      type: 'file',
+                      data: {
+                        type: 'url',
+                        url: new URL('https://example.com/test.pdf'),
+                      },
                       mediaType: 'application/pdf',
                     },
                   ],
@@ -2749,14 +2758,14 @@ describe('convertToOpenAIResponsesInput', () => {
                       text: 'The weather in San Francisco is 72°F',
                     },
                     {
-                      type: 'file-data',
+                      type: 'file',
                       mediaType: 'image/png',
-                      data: 'base64_data',
+                      data: { type: 'data', data: 'base64_data' },
                     },
                     {
-                      type: 'file-data',
+                      type: 'file',
                       mediaType: 'application/pdf',
-                      data: base64Data,
+                      data: { type: 'data', data: base64Data },
                     },
                   ],
                 },
@@ -4895,8 +4904,11 @@ describe('convertToOpenAIResponsesInput', () => {
                   value: [
                     { type: 'text', text: 'Here is the file:' },
                     {
-                      type: 'file-url',
-                      url: 'https://example.com/test.pdf',
+                      type: 'file',
+                      data: {
+                        type: 'url',
+                        url: new URL('https://example.com/test.pdf'),
+                      },
                       mediaType: 'application/pdf',
                     },
                   ],

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -767,29 +767,45 @@ export async function convertToOpenAIResponsesInput({
                     switch (item.type) {
                       case 'text':
                         return { type: 'input_text' as const, text: item.text };
-                      case 'file-data':
-                        if (item.mediaType.startsWith('image/')) {
+                      case 'file': {
+                        const topLevel = getTopLevelMediaType(item.mediaType);
+
+                        if (item.data.type === 'data') {
+                          const fullMediaType = resolveFullMediaType({
+                            part: item,
+                          });
+                          if (topLevel === 'image') {
+                            return {
+                              type: 'input_image' as const,
+                              image_url: `data:${fullMediaType};base64,${convertToBase64(item.data.data)}`,
+                            };
+                          }
                           return {
-                            type: 'input_image' as const,
-                            image_url: `data:${item.mediaType};base64,${item.data}`,
+                            type: 'input_file' as const,
+                            filename: item.filename ?? 'data',
+                            file_data: `data:${fullMediaType};base64,${convertToBase64(item.data.data)}`,
                           };
                         }
-                        return {
-                          type: 'input_file' as const,
-                          filename: item.filename ?? 'data',
-                          file_data: `data:${item.mediaType};base64,${item.data}`,
-                        };
-                      case 'file-url':
-                        if (item.mediaType.startsWith('image/')) {
+
+                        if (item.data.type === 'url') {
+                          if (topLevel === 'image') {
+                            return {
+                              type: 'input_image' as const,
+                              image_url: item.data.url.toString(),
+                            };
+                          }
                           return {
-                            type: 'input_image' as const,
-                            image_url: item.url,
+                            type: 'input_file' as const,
+                            file_url: item.data.url.toString(),
                           };
                         }
-                        return {
-                          type: 'input_file' as const,
-                          file_url: item.url,
-                        };
+
+                        warnings.push({
+                          type: 'other',
+                          message: `unsupported custom tool content part type: ${item.type} with data type: ${item.data.type}`,
+                        });
+                        return undefined;
+                      }
                       default:
                         warnings.push({
                           type: 'other',
@@ -832,31 +848,44 @@ export async function convertToOpenAIResponsesInput({
                       return { type: 'input_text' as const, text: item.text };
                     }
 
-                    case 'file-data': {
-                      if (item.mediaType.startsWith('image/')) {
-                        return {
-                          type: 'input_image' as const,
-                          image_url: `data:${item.mediaType};base64,${item.data}`,
-                        };
-                      }
-                      return {
-                        type: 'input_file' as const,
-                        filename: item.filename ?? 'data',
-                        file_data: `data:${item.mediaType};base64,${item.data}`,
-                      };
-                    }
+                    case 'file': {
+                      const topLevel = getTopLevelMediaType(item.mediaType);
 
-                    case 'file-url': {
-                      if (item.mediaType.startsWith('image/')) {
+                      if (item.data.type === 'data') {
+                        const fullMediaType = resolveFullMediaType({
+                          part: item,
+                        });
+                        if (topLevel === 'image') {
+                          return {
+                            type: 'input_image' as const,
+                            image_url: `data:${fullMediaType};base64,${convertToBase64(item.data.data)}`,
+                          };
+                        }
                         return {
-                          type: 'input_image' as const,
-                          image_url: item.url,
+                          type: 'input_file' as const,
+                          filename: item.filename ?? 'data',
+                          file_data: `data:${fullMediaType};base64,${convertToBase64(item.data.data)}`,
                         };
                       }
-                      return {
-                        type: 'input_file' as const,
-                        file_url: item.url,
-                      };
+
+                      if (item.data.type === 'url') {
+                        if (topLevel === 'image') {
+                          return {
+                            type: 'input_image' as const,
+                            image_url: item.data.url.toString(),
+                          };
+                        }
+                        return {
+                          type: 'input_file' as const,
+                          file_url: item.data.url.toString(),
+                        };
+                      }
+
+                      warnings.push({
+                        type: 'other',
+                        message: `unsupported tool content part type: ${item.type} with data type: ${item.data.type}`,
+                      });
+                      return undefined;
                     }
 
                     default: {

--- a/packages/provider-utils/src/types/content-part.test-d.ts
+++ b/packages/provider-utils/src/types/content-part.test-d.ts
@@ -1,7 +1,37 @@
 import { describe, expectTypeOf, it } from 'vitest';
 import type { DataContent } from './data-content';
-import type { FilePart, ReasoningFilePart } from './content-part';
+import type {
+  FilePart,
+  ReasoningFilePart,
+  ToolResultOutput,
+} from './content-part';
 import type { ProviderReference } from './provider-reference';
+
+type ToolResultContentItem = Extract<
+  ToolResultOutput,
+  { type: 'content' }
+>['value'][number];
+type ToolResultFilePart = Extract<ToolResultContentItem, { type: 'file' }>;
+type ToolResultFileUrlPart = Extract<
+  ToolResultContentItem,
+  { type: 'file-url' }
+>;
+type ToolResultFileDataPart = Extract<
+  ToolResultContentItem,
+  { type: 'file-data' }
+>;
+type ToolResultFileReferencePart = Extract<
+  ToolResultContentItem,
+  { type: 'file-reference' }
+>;
+type ToolResultImageDataPart = Extract<
+  ToolResultContentItem,
+  { type: 'image-data' }
+>;
+type ToolResultImageUrlPart = Extract<
+  ToolResultContentItem,
+  { type: 'image-url' }
+>;
 
 type TaggedFileData = Extract<FilePart['data'], { type: string }>;
 type TaggedReasoningFileData = Extract<
@@ -156,6 +186,105 @@ describe('ReasoningFilePart.data', () => {
       data: URL;
       mediaType: string;
     }>().toMatchTypeOf<ReasoningFilePart>();
+  });
+});
+
+describe('ToolResultOutput content "file" variant', () => {
+  it('accepts the tagged `data` arm with a full mediaType', () => {
+    expectTypeOf<{
+      type: 'file';
+      data: { type: 'data'; data: Uint8Array };
+      mediaType: 'image/png';
+    }>().toMatchTypeOf<ToolResultFilePart>();
+  });
+
+  it('accepts the tagged `url` arm with a top-level mediaType', () => {
+    expectTypeOf<{
+      type: 'file';
+      data: { type: 'url'; url: URL };
+      mediaType: 'image';
+    }>().toMatchTypeOf<ToolResultFilePart>();
+  });
+
+  it('accepts the tagged `reference` arm', () => {
+    expectTypeOf<{
+      type: 'file';
+      data: { type: 'reference'; reference: ProviderReference };
+      mediaType: 'application/octet-stream';
+    }>().toMatchTypeOf<ToolResultFilePart>();
+  });
+
+  it('accepts the tagged `text` arm', () => {
+    expectTypeOf<{
+      type: 'file';
+      data: { type: 'text'; text: string };
+      mediaType: 'text/plain';
+    }>().toMatchTypeOf<ToolResultFilePart>();
+  });
+
+  it('rejects bare data shorthands (tagged-only on tool-result)', () => {
+    expectTypeOf<{
+      type: 'file';
+      data: Uint8Array;
+      mediaType: string;
+    }>().not.toMatchTypeOf<ToolResultFilePart>();
+
+    expectTypeOf<{
+      type: 'file';
+      data: URL;
+      mediaType: string;
+    }>().not.toMatchTypeOf<ToolResultFilePart>();
+  });
+
+  it('exposes the four tagged `data.type` discriminants', () => {
+    expectTypeOf<ToolResultFilePart['data']['type']>().toEqualTypeOf<
+      'data' | 'url' | 'reference' | 'text'
+    >();
+  });
+});
+
+describe('ToolResultOutput content legacy variants', () => {
+  it('still type-checks "file-data"', () => {
+    expectTypeOf<{
+      type: 'file-data';
+      data: string;
+      mediaType: string;
+    }>().toMatchTypeOf<ToolResultFileDataPart>();
+  });
+
+  it('still type-checks "file-url" with mediaType', () => {
+    expectTypeOf<{
+      type: 'file-url';
+      url: string;
+      mediaType: string;
+    }>().toMatchTypeOf<ToolResultFileUrlPart>();
+  });
+
+  it('still type-checks "file-url" without mediaType', () => {
+    expectTypeOf<{
+      type: 'file-url';
+      url: string;
+    }>().toMatchTypeOf<ToolResultFileUrlPart>();
+  });
+
+  it('still type-checks "file-reference"', () => {
+    expectTypeOf<{
+      type: 'file-reference';
+      providerReference: ProviderReference;
+    }>().toMatchTypeOf<ToolResultFileReferencePart>();
+  });
+
+  it('still type-checks legacy "image-*" variants', () => {
+    expectTypeOf<{
+      type: 'image-data';
+      data: string;
+      mediaType: string;
+    }>().toMatchTypeOf<ToolResultImageDataPart>();
+
+    expectTypeOf<{
+      type: 'image-url';
+      url: string;
+    }>().toMatchTypeOf<ToolResultImageUrlPart>();
   });
 });
 

--- a/packages/provider-utils/src/types/content-part.ts
+++ b/packages/provider-utils/src/types/content-part.ts
@@ -317,6 +317,50 @@ export type ToolResultOutput =
             providerOptions?: ProviderOptions;
           }
         | {
+            type: 'file';
+
+            /**
+             * File data as a tagged discriminated union:
+             *
+             * - `{ type: 'data', data }`: raw bytes
+             *   (base64 string, Uint8Array, ArrayBuffer, Buffer)
+             * - `{ type: 'url', url }`: a URL that points to the file
+             * - `{ type: 'reference', reference }`: a provider reference
+             *   from `uploadFile`
+             * - `{ type: 'text', text }`: inline text content (e.g. an inline
+             *   text document)
+             */
+            data: FileData;
+
+            /**
+             * Either a full IANA media type (`type/subtype`, e.g. `image/png`) or just
+             * the top-level IANA segment (e.g. `image`, `audio`, `video`, `text`).
+             *
+             * `*`-subtype wildcards (e.g. `image/*`) are normalized as equivalent to the
+             * top-level segment alone (e.g. `image`). Providers can use the helpers in
+             * `@ai-sdk/provider-utils` (`isFullMediaType`, `getTopLevelMediaType`,
+             * `detectMediaType`) to resolve the field according to their API
+             * requirements.
+             *
+             * @see https://www.iana.org/assignments/media-types/media-types.xhtml
+             */
+            mediaType: string;
+
+            /**
+             * Optional filename of the file.
+             */
+            filename?: string;
+
+            /**
+             * Provider-specific options.
+             */
+            providerOptions?: ProviderOptions;
+          }
+        | {
+            /**
+             * @deprecated Use 'file' with mediaType + tagged data instead:
+             * `{ type: 'file', mediaType, data: { type: 'data', data } }`.
+             */
             type: 'file-data';
 
             /**
@@ -341,6 +385,10 @@ export type ToolResultOutput =
             providerOptions?: ProviderOptions;
           }
         | {
+            /**
+             * @deprecated Use 'file' with mediaType and tagged data instead:
+             * `{ type: 'file', mediaType, data: { type: 'url', url: new URL(url) } }`.
+             */
             type: 'file-url';
 
             /**
@@ -352,7 +400,7 @@ export type ToolResultOutput =
              * IANA media type.
              * @see https://www.iana.org/assignments/media-types/media-types.xhtml
              */
-            mediaType?: string; // Temporarily optional. TODO: make required in v8, after migration period.
+            mediaType?: string;
 
             /**
              * Provider-specific options.
@@ -361,7 +409,8 @@ export type ToolResultOutput =
           }
         | {
             /**
-             * @deprecated Use file-reference instead.
+             * @deprecated Use 'file' with tagged data instead:
+             * `{ type: 'file', mediaType, data: { type: 'reference', reference } }`.
              */
             type: 'file-id';
 
@@ -381,6 +430,10 @@ export type ToolResultOutput =
             providerOptions?: ProviderOptions;
           }
         | {
+            /**
+             * @deprecated Use 'file' with tagged data instead:
+             * `{ type: 'file', mediaType, data: { type: 'reference', reference } }`.
+             */
             type: 'file-reference';
 
             /**
@@ -396,7 +449,9 @@ export type ToolResultOutput =
           }
         | {
             /**
-             * @deprecated Use file-data instead.
+             * @deprecated Use 'file' with mediaType (e.g. 'image' or a specific
+             * `image/*` subtype) and tagged data instead:
+             * `{ type: 'file', mediaType: 'image', data: { type: 'data', data } }`.
              */
             type: 'image-data';
 
@@ -418,7 +473,9 @@ export type ToolResultOutput =
           }
         | {
             /**
-             * @deprecated Use file-url instead.
+             * @deprecated Use 'file' with `mediaType: 'image'` (or a specific
+             * `image/*` subtype) and tagged data instead:
+             * `{ type: 'file', mediaType: 'image', data: { type: 'url', url: new URL(url) } }`.
              */
             type: 'image-url';
 
@@ -434,7 +491,9 @@ export type ToolResultOutput =
           }
         | {
             /**
-             * @deprecated Use file-reference instead.
+             * @deprecated Use 'file' with `mediaType: 'image'` (or a specific
+             * `image/*` subtype) and tagged data instead:
+             * `{ type: 'file', mediaType: 'image', data: { type: 'reference', reference } }`.
              */
             type: 'image-file-id';
 
@@ -455,7 +514,9 @@ export type ToolResultOutput =
           }
         | {
             /**
-             * @deprecated Use file-reference instead.
+             * @deprecated Use 'file' with `mediaType: 'image'` (or a specific
+             * `image/*` subtype) and tagged data instead:
+             * `{ type: 'file', mediaType: 'image', data: { type: 'reference', reference } }`.
              */
             type: 'image-file-reference';
 

--- a/packages/provider/src/language-model/v4/language-model-v4-prompt.ts
+++ b/packages/provider/src/language-model/v4/language-model-v4-prompt.ts
@@ -5,7 +5,6 @@ import type {
   SharedV4FileDataUrl,
 } from '../../shared/v4/shared-v4-file-data';
 import type { SharedV4ProviderOptions } from '../../shared/v4/shared-v4-provider-options';
-import type { SharedV4ProviderReference } from '../../shared/v4/shared-v4-provider-reference';
 
 /**
  * A prompt is a list of messages.
@@ -359,15 +358,28 @@ export type LanguageModelV4ToolResultOutput =
             providerOptions?: SharedV4ProviderOptions;
           }
         | {
-            type: 'file-data';
+            type: 'file';
 
             /**
-             * Base-64 encoded media data.
+             * File data as a tagged discriminated union:
+             *
+             * - `{ type: 'data', data }`: raw bytes (Uint8Array) or base64-encoded string.
+             * - `{ type: 'url', url }`: a URL that points to the file.
+             * - `{ type: 'reference', reference }`: a provider reference (`{ [provider]: id }`).
+             * - `{ type: 'text', text }`: inline text content (e.g. an inline text document).
              */
-            data: string;
+            data: SharedV4FileData;
 
             /**
-             * IANA media type.
+             * Either a full IANA media type (`type/subtype`, e.g. `image/png`) or just
+             * the top-level IANA segment (e.g. `image`, `audio`, `video`, `text`).
+             *
+             * `*`-subtype wildcards (e.g. `image/*`) are normalized as equivalent to the
+             * top-level segment alone (e.g. `image`). Providers can use the helpers in
+             * `@ai-sdk/provider-utils` (`isFullMediaType`, `getTopLevelMediaType`,
+             * `detectMediaType`) to resolve the field according to their API
+             * requirements.
+             *
              * @see https://www.iana.org/assignments/media-types/media-types.xhtml
              */
             mediaType: string;
@@ -376,39 +388,6 @@ export type LanguageModelV4ToolResultOutput =
              * Optional filename of the file.
              */
             filename?: string;
-
-            /**
-             * Provider-specific options.
-             */
-            providerOptions?: SharedV4ProviderOptions;
-          }
-        | {
-            type: 'file-url';
-
-            /**
-             * URL of the file.
-             */
-            url: string;
-
-            /**
-             * IANA media type.
-             * @see https://www.iana.org/assignments/media-types/media-types.xhtml
-             */
-            mediaType: string;
-
-            /**
-             * Provider-specific options.
-             */
-            providerOptions?: SharedV4ProviderOptions;
-          }
-        | {
-            type: 'file-reference';
-
-            /**
-             * Provider-specific references for the file.
-             * The key is the provider name, e.g. 'openai' or 'anthropic'.
-             */
-            providerReference: SharedV4ProviderReference;
 
             /**
              * Provider-specific options.


### PR DESCRIPTION
## Background

In #14733, we unified the different ways to pass file content for top-level `type: 'file'` parts. However, for tool result output content parts, the AI SDK has been still using various independent shapes like `file-*`, and `image-*`, the latter of which were already deprecated in #14411.

We should align files being returned as tool result output to work similar to how files are being passed in top-level messages.

## Summary

This PR introduces a single canonical `file` content-part variant for tool-result outputs that mirrors the top-level `FilePart`: `{ type: 'file', mediaType, filename?, data: { type: 'data' | 'url' | 'reference' | 'text', ... } }`.

- **`provider` (v4 spec)**: `LanguageModelV4ToolResultOutput.value` now carries a single tagged `file` variant. Spec break — atomic update across spec + provider adapters.
- **`provider-utils`**: top-level `ToolResultOutput` content array gets the new `file` variant added; every legacy `file-*` and `image-*` variant stays in place and is annotated `@deprecated` with a message pointing at `file`, for back compat.
- **`ai` (`mapToolResultOutput`)**: the conversion seam normalizes every legacy case into the new `type: 'file'` shape and emits exactly one `DeprecationWarning` per legacy item.
- **`mcp`**: client emits the new shape directly.
- **Examples + docs**: every `toModelOutput`-emitting example and the tool-calling guide use the canonical shape.

Top-level `ToolResultOutput` is fully backward compatible (legacy variants still accepted; the seam normalizes them with a deprecation warning). The v4 spec change is a breaking change for direct `LanguageModelV4` consumers.

## Manual Verification

Examples using `toModelOutput` can be run to verify the changes.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Eventually remove the deprecated legacy `file-*`/`image-*`/`*-id` content-part variants from `ToolResultOutput` and remove the auto-migration as part of it.

## Related Issues

Technically a follow-up to #14010.
