### PR TITLE
fix(ai): default warnings to [] for v2 embedding providers

### DIFF
--- a/.changeset/fix-embed-v2-warnings.md
+++ b/.changeset/fix-embed-v2-warnings.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(embed): default `warnings` to `[]` when an `EmbeddingModelV2` provider omits the field. Previously `embed()` and `embedMany()` crashed with `TypeError: Cannot read properties of undefined (reading 'length')` (and `result.warnings is not iterable` on the chunked path) when used with v2 embedding providers, because the v2 spec's `doEmbed` return type does not include `warnings`.

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -10,6 +10,7 @@ import {
   vitest,
 } from 'vitest';
 import * as logWarningsModule from '../logger/log-warnings';
+import { MockEmbeddingModelV2 } from '../test/mock-embedding-model-v2';
 import { MockEmbeddingModelV4 } from '../test/mock-embedding-model-v4';
 import type { Embedding, EmbeddingModelUsage, Warning } from '../types';
 import { createResolvablePromise } from '../util/create-resolvable-promise';
@@ -459,6 +460,49 @@ describe('result.warnings', () => {
     });
 
     expect(result.warnings).toStrictEqual([warning1, warning2]);
+  });
+
+  it('should default to empty array when v2 model omits warnings (single call path)', async () => {
+    const result = await embedMany({
+      model: new MockEmbeddingModelV2<string>({
+        maxEmbeddingsPerCall: null,
+        doEmbed: async () => ({
+          embeddings: dummyEmbeddings,
+          usage: { tokens: 3 },
+        }),
+      }),
+      values: testValues,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it('should default to empty array when v2 model omits warnings (chunked path)', async () => {
+    let callCount = 0;
+    const result = await embedMany({
+      model: new MockEmbeddingModelV2<string>({
+        maxEmbeddingsPerCall: 2,
+        doEmbed: async () => {
+          switch (callCount++) {
+            case 0:
+              return {
+                embeddings: dummyEmbeddings.slice(0, 2),
+                usage: { tokens: 2 },
+              };
+            case 1:
+              return {
+                embeddings: dummyEmbeddings.slice(2),
+                usage: { tokens: 1 },
+              };
+            default:
+              throw new Error('Unexpected call');
+          }
+        },
+      }),
+      values: testValues,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
   });
 });
 

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -215,7 +215,7 @@ export async function embedMany({
           return {
             embeddings,
             usage,
-            warnings: modelResponse.warnings,
+            warnings: modelResponse.warnings ?? [],
             providerMetadata: modelResponse.providerMetadata,
             response: modelResponse.response,
           };
@@ -317,7 +317,7 @@ export async function embedMany({
             return {
               embeddings: chunkEmbeddings,
               usage,
-              warnings: modelResponse.warnings,
+              warnings: modelResponse.warnings ?? [],
               providerMetadata: modelResponse.providerMetadata,
               response: modelResponse.response,
             };

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -2,6 +2,7 @@ import type { EmbeddingModelV4 } from '@ai-sdk/provider';
 import assert from 'node:assert';
 import { beforeEach, describe, expect, it, vi, vitest } from 'vitest';
 import * as logWarningsModule from '../logger/log-warnings';
+import { MockEmbeddingModelV2 } from '../test/mock-embedding-model-v2';
 import { MockEmbeddingModelV4 } from '../test/mock-embedding-model-v4';
 import type { Embedding, EmbeddingModelUsage, Warning } from '../types';
 import { embed } from './embed';
@@ -180,6 +181,20 @@ describe('result.warnings', () => {
     });
 
     expect(result.warnings).toStrictEqual(expectedWarnings);
+  });
+
+  it('should default to empty array when v2 model omits warnings', async () => {
+    const result = await embed({
+      model: new MockEmbeddingModelV2<string>({
+        doEmbed: async () => ({
+          embeddings: [dummyEmbedding],
+          usage: { tokens: 1 },
+        }),
+      }),
+      value: testValue,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
   });
 });
 

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -193,7 +193,7 @@ export async function embed({
         return {
           embedding,
           usage,
-          warnings: modelResponse.warnings,
+          warnings: modelResponse.warnings ?? [],
           providerMetadata: modelResponse.providerMetadata,
           response: modelResponse.response,
         };


### PR DESCRIPTION
## Summary

- `embed()` and `embedMany()` crashed at runtime when used with an `EmbeddingModelV2` provider, because the v2 `doEmbed` return type does not include a `warnings` field. `EmbeddingModel` still accepts v2 models, so the SDK was violating its own type contract.
- Coerces `modelResponse.warnings ?? []` at the three boundary sites in `embed.ts` and `embed-many.ts` (single-call + chunked paths). This honors the typed `Warning[]` result shape and is a no-op for v3/v4 providers.
- Adds three regression tests using `MockEmbeddingModelV2` covering both `embed()`, `embedMany()` single-call, and `embedMany()` chunked paths.

Closes #14926.

## Reproduction

Before the fix:

```ts
import { embed } from 'ai';
import { MockEmbeddingModelV2 } from 'ai/test';

const model = new MockEmbeddingModelV2<string>({
  doEmbed: async () => ({ embeddings: [[0.1, 0.2, 0.3]], usage: { tokens: 1 } }),
});

await embed({ model, value: 'hello' });
// TypeError: Cannot read properties of undefined (reading 'length')
//   at logWarnings (packages/ai/src/logger/log-warnings.ts:106)
```

The chunked `embedMany()` path failed earlier with `TypeError: result.warnings is not iterable` at `embed-many.ts:330`.

## Test plan

- [x] `pnpm vitest run src/embed/embed.test.ts src/embed/embed-many.test.ts` — 61 pass (3 new + 58 existing)
- [x] `pnpm vitest run src/logger/log-warnings.test.ts` — 16/16 pass
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm check` (oxlint + oxfmt) — clean
- [x] Three new regression tests fail before the fix with the exact `TypeError`s from the issue, and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)