### PR TITLE
fix(codemod): harden scaffold script

### DIFF
--- a/.changeset/cool-lamps-build.md
+++ b/.changeset/cool-lamps-build.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/codemod": patch
+---
+
+Harden the scaffold-codemod script for nested transforms.

--- a/packages/codemod/scripts/scaffold-codemod.test.ts
+++ b/packages/codemod/scripts/scaffold-codemod.test.ts
@@ -1,0 +1,83 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { scaffoldCodemod, validateCodemodName } from './scaffold-codemod';
+
+const tempDirs: string[] = [];
+
+function createTempCodemodPackage() {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'codemod-scaffold-'));
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, 'src', 'lib'), { recursive: true });
+  fs.writeFileSync(
+    path.join(cwd, 'src', 'lib', 'upgrade.ts'),
+    `const bundle = [
+  'v4/existing-transform',
+];
+`,
+  );
+
+  return cwd;
+}
+
+function readFile(cwd: string, filePath: string) {
+  return fs.readFileSync(path.join(cwd, filePath), 'utf8');
+}
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe('scaffoldCodemod', () => {
+  it('creates nested codemod files and parent directories', () => {
+    const cwd = createTempCodemodPackage();
+
+    scaffoldCodemod('v6/add-new-helper', cwd);
+
+    expect(
+      fs.existsSync(path.join(cwd, 'src/codemods/v6/add-new-helper.ts')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(cwd, 'src/test/v6/add-new-helper.test.ts')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(cwd, 'src/test/__testfixtures__/v6/add-new-helper.input.ts'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(cwd, 'src/test/__testfixtures__/v6/add-new-helper.output.ts'),
+      ),
+    ).toBe(true);
+
+    expect(readFile(cwd, 'src/test/v6/add-new-helper.test.ts')).toContain(
+      "import transformer from '../../codemods/v6/add-new-helper';",
+    );
+    expect(readFile(cwd, 'src/test/v6/add-new-helper.test.ts')).toContain(
+      "import { testTransform } from '../test-utils';",
+    );
+  });
+
+  it('keeps the bundle unique when rerun for an existing codemod', () => {
+    const cwd = createTempCodemodPackage();
+
+    scaffoldCodemod('v5/repeated-transform', cwd);
+    scaffoldCodemod('v5/repeated-transform', cwd);
+
+    const upgrade = readFile(cwd, 'src/lib/upgrade.ts');
+
+    expect(upgrade.match(/v5\/repeated-transform/g)).toHaveLength(1);
+  });
+
+  it('rejects unsafe codemod names', () => {
+    expect(() => validateCodemodName('../escape')).toThrow();
+    expect(() => validateCodemodName('/absolute')).toThrow();
+    expect(() => validateCodemodName('v6/../escape')).toThrow();
+    expect(() => validateCodemodName('bad\\path')).toThrow();
+  });
+});

--- a/packages/codemod/scripts/scaffold-codemod.ts
+++ b/packages/codemod/scripts/scaffold-codemod.ts
@@ -1,14 +1,59 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
-const codemodName = process.argv[2];
-if (!codemodName) {
-  console.error('Please provide a codemod name');
-  process.exit(1);
+const codemodNamePattern = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*$/;
+
+function ensureParentDirectory(filePath: string) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
 }
 
-// Templates
-const codemodTemplate = `import { API, FileInfo } from 'jscodeshift';
+function toImportPath(fromFile: string, toFileWithoutExtension: string) {
+  let importPath = path
+    .relative(path.dirname(fromFile), toFileWithoutExtension)
+    .split(path.sep)
+    .join('/');
+
+  if (!importPath.startsWith('.')) {
+    importPath = `./${importPath}`;
+  }
+
+  return importPath;
+}
+
+export function validateCodemodName(codemodName: string) {
+  const segments = codemodName.split('/');
+  if (
+    !codemodNamePattern.test(codemodName) ||
+    segments.some(segment => segment === '.' || segment === '..')
+  ) {
+    throw new Error(
+      'Codemod name must use path-safe segments containing only letters, numbers, ".", "_", or "-".',
+    );
+  }
+}
+
+export function scaffoldCodemod(codemodName: string, cwd = process.cwd()) {
+  validateCodemodName(codemodName);
+
+  // File paths
+  const paths = {
+    codemod: path.join(cwd, 'src', 'codemods', `${codemodName}.ts`),
+    test: path.join(cwd, 'src', 'test', `${codemodName}.test.ts`),
+    fixtures: path.join(cwd, 'src', 'test', '__testfixtures__'),
+  };
+
+  const codemodImportPath = toImportPath(
+    paths.test,
+    path.join(cwd, 'src', 'codemods', codemodName),
+  );
+  const testUtilsImportPath = toImportPath(
+    paths.test,
+    path.join(cwd, 'src', 'test', 'test-utils'),
+  );
+
+  // Templates
+  const codemodTemplate = `import { API, FileInfo } from 'jscodeshift';
 
 export default function transformer(file: FileInfo, api: API) {
   const j = api.jscodeshift;
@@ -20,9 +65,9 @@ export default function transformer(file: FileInfo, api: API) {
 }
 `;
 
-const testTemplate = `import { describe, it } from 'vitest';
-import transformer from '../codemods/${codemodName}';
-import { testTransform } from './test-utils';
+  const testTemplate = `import { describe, it } from 'vitest';
+import transformer from '${codemodImportPath}';
+import { testTransform } from '${testUtilsImportPath}';
 
 describe('${codemodName}', () => {
   it('transforms correctly', () => {
@@ -31,55 +76,68 @@ describe('${codemodName}', () => {
 });
 `;
 
-const inputTemplate = `// @ts-nocheck
+  const inputTemplate = `// @ts-nocheck
 // TODO: Add input code
 `;
 
-const outputTemplate = `// @ts-nocheck
+  const outputTemplate = `// @ts-nocheck
 // TODO: Add expected output code
 `;
 
-// File paths
-const paths = {
-  codemod: path.join(process.cwd(), 'src', 'codemods', `${codemodName}.ts`),
-  test: path.join(process.cwd(), 'src', 'test', `${codemodName}.test.ts`),
-  fixtures: path.join(process.cwd(), 'src', 'test', '__testfixtures__'),
-};
+  // Create files
+  ensureParentDirectory(paths.codemod);
+  ensureParentDirectory(paths.test);
+  ensureParentDirectory(path.join(paths.fixtures, `${codemodName}.input.ts`));
+  ensureParentDirectory(path.join(paths.fixtures, `${codemodName}.output.ts`));
 
-// Create files
-fs.writeFileSync(paths.codemod, codemodTemplate);
-fs.writeFileSync(paths.test, testTemplate);
-fs.writeFileSync(
-  path.join(paths.fixtures, `${codemodName}.input.ts`),
-  inputTemplate,
-);
-fs.writeFileSync(
-  path.join(paths.fixtures, `${codemodName}.output.ts`),
-  outputTemplate,
-);
-
-// Update bundle array
-const upgradePath = path.join(process.cwd(), 'src', 'lib', 'upgrade.ts');
-const upgradeContent = fs.readFileSync(upgradePath, 'utf8');
-
-const bundleMatch = upgradeContent.match(/const bundle = \[([\s\S]*?)\];/);
-if (bundleMatch) {
-  const currentBundle = bundleMatch[1]
-    .split('\n')
-    .filter(line => line.trim())
-    .map(line => line.trim().replace(/[',]/g, ''));
-
-  const newBundle = [...currentBundle, codemodName]
-    .sort()
-    .map(name => `  '${name}',`)
-    .join('\n');
-
-  const newContent = upgradeContent.replace(
-    /const bundle = \[([\s\S]*?)\];/,
-    `const bundle = [\n${newBundle}\n];`,
+  fs.writeFileSync(paths.codemod, codemodTemplate);
+  fs.writeFileSync(paths.test, testTemplate);
+  fs.writeFileSync(
+    path.join(paths.fixtures, `${codemodName}.input.ts`),
+    inputTemplate,
+  );
+  fs.writeFileSync(
+    path.join(paths.fixtures, `${codemodName}.output.ts`),
+    outputTemplate,
   );
 
-  fs.writeFileSync(upgradePath, newContent);
+  // Update bundle array
+  const upgradePath = path.join(cwd, 'src', 'lib', 'upgrade.ts');
+  const upgradeContent = fs.readFileSync(upgradePath, 'utf8');
+
+  const bundleMatch = upgradeContent.match(/const bundle = \[([\s\S]*?)\];/);
+  if (bundleMatch) {
+    const currentBundle = bundleMatch[1]
+      .split('\n')
+      .filter(line => line.trim())
+      .map(line => line.trim().replace(/[',]/g, ''));
+
+    const newBundle = [...new Set([...currentBundle, codemodName])]
+      .sort()
+      .map(name => `  '${name}',`)
+      .join('\n');
+
+    const newContent = upgradeContent.replace(
+      /const bundle = \[([\s\S]*?)\];/,
+      `const bundle = [\n${newBundle}\n];`,
+    );
+
+    fs.writeFileSync(upgradePath, newContent);
+  }
 }
 
-console.log(`Created codemod files for '${codemodName}'`);
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const codemodName = process.argv[2];
+  if (!codemodName) {
+    console.error('Please provide a codemod name');
+    process.exit(1);
+  }
+
+  try {
+    scaffoldCodemod(codemodName);
+    console.log(`Created codemod files for '${codemodName}'`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- create parent directories before scaffolded codemod, test, and fixture files are written
- validate codemod names so scaffold input cannot escape the codemod tree
- generate correct relative imports for nested codemods and keep the upgrade bundle unique
- add focused script tests plus a codemod package changeset

Fixes #14856.

## Tests
- pnpm --dir packages/codemod exec vitest --config vitest.config.ts --run scripts/scaffold-codemod.test.ts
- pnpm --filter @ai-sdk/codemod test
- pnpm exec ultracite check packages/codemod/scripts/scaffold-codemod.ts packages/codemod/scripts/scaffold-codemod.test.ts
- git diff --check
