### PR TITLE
fix(workflow): preserve provider-executed tool-approval-response on resume

### DIFF
--- a/.changeset/preserve-provider-executed-tool-approvals.md
+++ b/.changeset/preserve-provider-executed-tool-approvals.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/workflow": patch
+---
+
+fix (workflow): preserve `tool-approval-request` and `tool-approval-response` parts for provider-executed tools so the provider receives the approval on resume
+
+`WorkflowAgent` previously stripped all approval parts from messages when handling tool-approval responses, regardless of whether the approved tool was locally or provider-executed. For provider-executed tools (e.g. MCP via the Responses API) this silently dropped the approval, leaving the provider to never receive it and the tool to never execute. The fix mirrors the inverse of #14289: locally-executed approvals are still executed and stripped here, while provider-executed approvals are left intact in the messages so the next provider call can process them.

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -3037,5 +3037,103 @@ describe('WorkflowAgent', () => {
       // Should proceed normally without any approval processing
       expect(mockIterator.next).toHaveBeenCalled();
     });
+
+    it('should preserve provider-executed tool-approval-response across resume', async () => {
+      // Inverse of #14289: provider-executed approvals must reach the
+      // provider on resume rather than being silently dropped. The agent
+      // must NOT strip the `tool-approval-response` part whose
+      // `providerExecuted` flag is true, and must NOT synthesize a local
+      // tool-result for it. `convertToLanguageModelPrompt` then forwards
+      // the response to the provider on the next call.
+      const tools: ToolSet = {
+        web_search: {
+          type: 'provider' as const,
+          id: 'test.web_search',
+          args: {},
+          isProviderExecuted: true,
+          inputSchema: z.object({ query: z.string() }),
+        } as ToolSet[string],
+      };
+
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: mockModel,
+        tools,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockClear();
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [
+          { role: 'user', content: 'Search for X' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'web_search',
+                input: { query: 'X' },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-call-1',
+                toolCallId: 'call-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: true,
+                providerExecuted: true,
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      const calls = vi.mocked(streamTextIterator).mock.calls;
+      const lastCall = calls[calls.length - 1][0];
+      const sentPrompt = lastCall.prompt;
+
+      // The provider-executed tool-approval-response must reach the provider.
+      const toolMessage = sentPrompt.find(m => m.role === 'tool');
+      expect(toolMessage).toBeDefined();
+      expect(toolMessage!.content).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'tool-approval-response',
+            approvalId: 'approval-call-1',
+          }),
+        ]),
+      );
+
+      // No synthetic local tool-result should have been injected for the
+      // provider-executed approval — the provider produces the result.
+      const syntheticToolResult = sentPrompt
+        .filter(m => m.role === 'tool')
+        .flatMap(m => m.content as any[])
+        .find(p => p.type === 'tool-result' && p.toolCallId === 'call-1');
+      expect(syntheticToolResult).toBeUndefined();
+    });
   });
 });

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -3038,21 +3038,20 @@ describe('WorkflowAgent', () => {
       expect(mockIterator.next).toHaveBeenCalled();
     });
 
-    it('should preserve provider-executed tool-approval-response across resume', async () => {
+    it('should forward provider-executed tool-approval-response to the provider', async () => {
       // Inverse of #14289: provider-executed approvals must reach the
       // provider on resume rather than being silently dropped. The agent
-      // must NOT strip the `tool-approval-response` part whose
-      // `providerExecuted` flag is true, and must NOT synthesize a local
-      // tool-result for it. `convertToLanguageModelPrompt` then forwards
-      // the response to the provider on the next call.
+      // must NOT execute provider-executed approvals locally and must
+      // preserve their `tool-approval-response` so
+      // `convertToLanguageModelPrompt` forwards them to the provider.
       const tools: ToolSet = {
         web_search: {
-          type: 'provider' as const,
+          type: 'provider',
           id: 'test.web_search',
           args: {},
           isProviderExecuted: true,
           inputSchema: z.object({ query: z.string() }),
-        } as ToolSet[string],
+        },
       };
 
       const mockModel = createMockModel();
@@ -3115,7 +3114,6 @@ describe('WorkflowAgent', () => {
       const lastCall = calls[calls.length - 1][0];
       const sentPrompt = lastCall.prompt;
 
-      // The provider-executed tool-approval-response must reach the provider.
       const toolMessage = sentPrompt.find(m => m.role === 'tool');
       expect(toolMessage).toBeDefined();
       expect(toolMessage!.content).toEqual(
@@ -3123,17 +3121,248 @@ describe('WorkflowAgent', () => {
           expect.objectContaining({
             type: 'tool-approval-response',
             approvalId: 'approval-call-1',
+            approved: true,
           }),
         ]),
       );
 
-      // No synthetic local tool-result should have been injected for the
-      // provider-executed approval — the provider produces the result.
       const syntheticToolResult = sentPrompt
         .filter(m => m.role === 'tool')
         .flatMap(m => m.content as any[])
         .find(p => p.type === 'tool-result' && p.toolCallId === 'call-1');
       expect(syntheticToolResult).toBeUndefined();
+    });
+
+    it('should preserve denied provider-executed tool-approval-response', async () => {
+      // Symmetric to the approved-provider-executed test above: a denied
+      // approval for a provider-executed tool must also reach the provider
+      // (no synthetic local denial result, no part stripping).
+      const tools: ToolSet = {
+        web_search: {
+          type: 'provider',
+          id: 'test.web_search',
+          args: {},
+          isProviderExecuted: true,
+          inputSchema: z.object({ query: z.string() }),
+        },
+      };
+
+      const agent = new WorkflowAgent({
+        model: createMockModel(),
+        tools,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockClear();
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [
+          { role: 'user', content: 'Search for X' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'web_search',
+                input: { query: 'X' },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-call-1',
+                toolCallId: 'call-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-call-1',
+                approved: false,
+                reason: 'denied by user',
+                providerExecuted: true,
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      const calls = vi.mocked(streamTextIterator).mock.calls;
+      const lastCall = calls[calls.length - 1][0];
+      const sentPrompt = lastCall.prompt;
+
+      const toolMessage = sentPrompt.find(m => m.role === 'tool');
+      expect(toolMessage).toBeDefined();
+      expect(toolMessage!.content).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'tool-approval-response',
+            approvalId: 'approval-call-1',
+            approved: false,
+          }),
+        ]),
+      );
+
+      const syntheticDenialResult = sentPrompt
+        .filter(m => m.role === 'tool')
+        .flatMap(m => m.content as any[])
+        .find(p => p.type === 'tool-result' && p.toolCallId === 'call-1');
+      expect(syntheticDenialResult).toBeUndefined();
+    });
+
+    it('should partition mixed local and provider-executed approvals correctly', async () => {
+      // Exercises the per-approvalId Set: in a single resume turn one tool
+      // is locally executed (its approval parts must be stripped, a synthetic
+      // tool-result injected) and another is provider-executed (its approval
+      // response must survive into the prompt unchanged).
+      const localExecuteFn = vi
+        .fn()
+        .mockResolvedValue({ city: 'London', temperature: 72 });
+      const tools: ToolSet = {
+        getWeather: {
+          description: 'Get weather',
+          inputSchema: z.object({ city: z.string() }),
+          execute: localExecuteFn,
+          needsApproval: true as const,
+        },
+        web_search: {
+          type: 'provider',
+          id: 'test.web_search',
+          args: {},
+          isProviderExecuted: true,
+          inputSchema: z.object({ query: z.string() }),
+        },
+      };
+
+      const agent = new WorkflowAgent({
+        model: createMockModel(),
+        tools,
+      });
+
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockClear();
+      const mockIterator = {
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      await agent.stream({
+        messages: [
+          { role: 'user', content: 'Plan my trip' },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'local-1',
+                toolName: 'getWeather',
+                input: { city: 'London' },
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-local-1',
+                toolCallId: 'local-1',
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'provider-1',
+                toolName: 'web_search',
+                input: { query: 'London attractions' },
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-approval-request',
+                approvalId: 'approval-provider-1',
+                toolCallId: 'provider-1',
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-local-1',
+                approved: true,
+              },
+              {
+                type: 'tool-approval-response',
+                approvalId: 'approval-provider-1',
+                approved: true,
+                providerExecuted: true,
+              },
+            ],
+          },
+        ] as any,
+        writable: mockWritable,
+      });
+
+      // Local tool was executed.
+      expect(localExecuteFn).toHaveBeenCalledWith(
+        { city: 'London' },
+        expect.objectContaining({ toolCallId: 'local-1' }),
+      );
+
+      const calls = vi.mocked(streamTextIterator).mock.calls;
+      const lastCall = calls[calls.length - 1][0];
+      const sentPrompt = lastCall.prompt;
+      const toolParts = sentPrompt
+        .filter(m => m.role === 'tool')
+        .flatMap(m => m.content as any[]);
+
+      // Local approval response is stripped.
+      expect(
+        toolParts.find(
+          p =>
+            p.type === 'tool-approval-response' &&
+            p.approvalId === 'approval-local-1',
+        ),
+      ).toBeUndefined();
+
+      // Provider-executed approval response is preserved for the provider.
+      expect(toolParts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'tool-approval-response',
+            approvalId: 'approval-provider-1',
+            approved: true,
+          }),
+        ]),
+      );
+
+      // Local tool produced a synthetic tool-result; provider tool did not.
+      expect(
+        toolParts.find(
+          p => p.type === 'tool-result' && p.toolCallId === 'local-1',
+        ),
+      ).toBeDefined();
+      expect(
+        toolParts.find(
+          p => p.type === 'tool-result' && p.toolCallId === 'provider-1',
+        ),
+      ).toBeUndefined();
     });
   });
 });

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1256,9 +1256,10 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
         });
       }
 
-      // Strip approval parts for local approvals only; preserve approval
-      // parts whose `approvalId` belongs to a provider-executed tool so the
-      // provider can process them on the next call.
+      // Strip approval parts that we processed locally; preserve everything
+      // else (provider-executed approvals, plus any unmatched/orphan request
+      // parts) so the next call to `convertToLanguageModelPrompt` can forward
+      // them to the provider.
       const cleanedMessages: ModelMessage[] = [];
       for (const msg of prompt.messages) {
         if (msg.role === 'assistant' && Array.isArray(msg.content)) {
@@ -2196,11 +2197,13 @@ interface CollectedApproval {
   approvalId: string;
   reason?: string;
   /**
-   * Whether the approval response is for a provider-executed tool call.
-   * Provider-executed approvals must be forwarded to the provider on resume
-   * rather than executed locally and stripped from the messages.
-   * `convertToLanguageModelPrompt` uses the same flag on the response part
-   * to decide which approval responses to forward to the model.
+   * Whether the original tool call is provider-executed.
+   *
+   * Sourced from the `tool-call` part rather than the `tool-approval-response`
+   * part: the tool-call's flag is what the provider declared, while the
+   * response part's `providerExecuted` is metadata the UI carries and may
+   * disagree. Matches the discriminator used by `stream-text.ts`
+   * (`packages/ai/src/generate-text/stream-text.ts:1335`).
    */
   providerExecuted: boolean;
 }
@@ -2227,7 +2230,7 @@ function collectToolApprovalsFromMessages(messages: ModelMessage[]): {
   // Gather tool calls from assistant messages
   const toolCallsByToolCallId: Record<
     string,
-    { toolName: string; input: unknown }
+    { toolName: string; input: unknown; providerExecuted: boolean }
   > = {};
   for (const message of messages) {
     if (message.role === 'assistant' && Array.isArray(message.content)) {
@@ -2236,6 +2239,7 @@ function collectToolApprovalsFromMessages(messages: ModelMessage[]): {
           toolCallsByToolCallId[part.toolCallId] = {
             toolName: part.toolName,
             input: part.input ?? part.args,
+            providerExecuted: part.providerExecuted === true,
           };
         }
       }
@@ -2292,7 +2296,7 @@ function collectToolApprovalsFromMessages(messages: ModelMessage[]): {
       input: toolCall.input,
       approvalId: response.approvalId,
       reason: response.reason,
-      providerExecuted: response.providerExecuted === true,
+      providerExecuted: toolCall.providerExecuted,
     };
 
     if (response.approved) {

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1174,10 +1174,30 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
     // This mirrors how stream-text.ts handles tool-approval-response parts:
     // approved tools are executed, denied tools get denial results, and
     // approval parts are stripped from the messages.
+    //
+    // Provider-executed tool approvals (e.g. MCP via Responses API) cannot
+    // be resolved locally — the provider owns execution. For those we keep
+    // both the `tool-approval-request` and `tool-approval-response` parts in
+    // the messages so the provider sees the approval on the next call. Only
+    // local approvals are executed and stripped here.
     const { approvedToolApprovals, deniedToolApprovals } =
       collectToolApprovalsFromMessages(prompt.messages);
 
-    if (approvedToolApprovals.length > 0 || deniedToolApprovals.length > 0) {
+    const localApprovedToolApprovals = approvedToolApprovals.filter(
+      a => !a.providerExecuted,
+    );
+    const localDeniedToolApprovals = deniedToolApprovals.filter(
+      a => !a.providerExecuted,
+    );
+    const localApprovalIds = new Set<string>([
+      ...localApprovedToolApprovals.map(a => a.approvalId),
+      ...localDeniedToolApprovals.map(a => a.approvalId),
+    ]);
+
+    if (
+      localApprovedToolApprovals.length > 0 ||
+      localDeniedToolApprovals.length > 0
+    ) {
       const _toolResultMessages: ModelMessage[] = [];
       const toolResultContent: Array<{
         type: 'tool-result';
@@ -1190,7 +1210,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       }> = [];
 
       // Execute approved tools
-      for (const approval of approvedToolApprovals) {
+      for (const approval of localApprovedToolApprovals) {
         const tool = (this.tools as ToolSet)[approval.toolName];
         if (tool && typeof tool.execute === 'function') {
           try {
@@ -1224,7 +1244,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
       }
 
       // Create denial results for denied tools
-      for (const denial of deniedToolApprovals) {
+      for (const denial of localDeniedToolApprovals) {
         toolResultContent.push({
           type: 'tool-result' as const,
           toolCallId: denial.toolCallId,
@@ -1236,19 +1256,25 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
         });
       }
 
-      // Strip approval parts from messages and inject tool results
+      // Strip approval parts for local approvals only; preserve approval
+      // parts whose `approvalId` belongs to a provider-executed tool so the
+      // provider can process them on the next call.
       const cleanedMessages: ModelMessage[] = [];
       for (const msg of prompt.messages) {
         if (msg.role === 'assistant' && Array.isArray(msg.content)) {
           const filtered = (msg.content as any[]).filter(
-            (p: any) => p.type !== 'tool-approval-request',
+            (p: any) =>
+              p.type !== 'tool-approval-request' ||
+              !localApprovalIds.has(p.approvalId),
           );
           if (filtered.length > 0) {
             cleanedMessages.push({ ...msg, content: filtered });
           }
         } else if (msg.role === 'tool') {
           const filtered = (msg.content as any[]).filter(
-            (p: any) => p.type !== 'tool-approval-response',
+            (p: any) =>
+              p.type !== 'tool-approval-response' ||
+              !localApprovalIds.has(p.approvalId),
           );
           if (filtered.length > 0) {
             cleanedMessages.push({ ...msg, content: filtered });
@@ -1277,7 +1303,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
           .map(r => ({
             toolCallId: r.toolCallId,
             toolName: r.toolName,
-            input: approvedToolApprovals.find(
+            input: localApprovedToolApprovals.find(
               a => a.toolCallId === r.toolCallId,
             )?.input,
             output: 'value' in r.output ? r.output.value : undefined,
@@ -2169,6 +2195,14 @@ interface CollectedApproval {
   input: unknown;
   approvalId: string;
   reason?: string;
+  /**
+   * Whether the approval response is for a provider-executed tool call.
+   * Provider-executed approvals must be forwarded to the provider on resume
+   * rather than executed locally and stripped from the messages.
+   * `convertToLanguageModelPrompt` uses the same flag on the response part
+   * to decide which approval responses to forward to the model.
+   */
+  providerExecuted: boolean;
 }
 
 /**
@@ -2258,6 +2292,7 @@ function collectToolApprovalsFromMessages(messages: ModelMessage[]): {
       input: toolCall.input,
       approvalId: response.approvalId,
       reason: response.reason,
+      providerExecuted: response.providerExecuted === true,
     };
 
     if (response.approved) {


### PR DESCRIPTION
Closes #14292.

## Summary

`WorkflowAgent` previously stripped every `tool-approval-response` part from messages when handling approval resumption, regardless of whether the underlying tool was locally or provider-executed. For provider-executed tools (e.g. MCP via the OpenAI Responses API) this silently dropped the approval before `convertToLanguageModelPrompt` could forward it, so the provider never learned of the approval and the tool was never executed.

This is the inverse of #14289, which fixed the symmetric bug where local approvals were being forwarded twice.

## Fix

In `packages/workflow/src/workflow-agent.ts`:

- `collectToolApprovalsFromMessages` now tracks `providerExecuted` from the `tool-approval-response` part itself. This is the same flag `convertToLanguageModelPrompt` already uses (line 360-361 of `convert-to-language-model-prompt.ts`) to decide which approval responses to forward to the model.
- The caller derives `localApprovedToolApprovals` and `localDeniedToolApprovals` subsets and a `localApprovalIds` `Set`. Local approvals retain the existing behavior (executed locally, results synthesized, parts stripped). Provider-executed approvals are skipped from local execution and their `tool-approval-request` and `tool-approval-response` parts are preserved in the messages so the next conversion forwards the response to the provider.

The fix is intentionally narrow: no change to the public API, no new dependencies, mirrors the discriminator the conversion layer already uses.

## Test plan

- [x] Added `should preserve provider-executed tool-approval-response across resume` to `tool approval resumption` describe block in `workflow-agent.test.ts`. The test constructs a provider-executed tool, resumes with an approved approval whose response carries `providerExecuted: true`, then asserts the response reaches the iterator and that no synthetic local tool-result was injected for it.
- [x] All existing tests in `tool approval resumption` (3) still pass.
- [x] Full workflow node test suite passes: 108 tests, 5 expected fails (pre-existing).
- [x] `pnpm check` (oxlint + oxfmt) clean.
- [x] `pnpm type-check:full` exit 0.

## Follow-ups out of scope

- The inverse-of-#14289 framing is consistent with this fix being a `patch` changeset. No `Experimental_*` API change.
- Behavioral parity with the core path (`convertToLanguageModelPrompt`) is now restored — both layers use the response's `providerExecuted` flag as the discriminator.