### PR TITLE
fix(embed): default missing warnings to [] for v2 embedding models

### DIFF
--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -215,7 +215,7 @@ export async function embedMany({
           return {
             embeddings,
             usage,
-            warnings: modelResponse.warnings,
+            warnings: modelResponse.warnings ?? [],
             providerMetadata: modelResponse.providerMetadata,
             response: modelResponse.response,
           };
@@ -317,7 +317,7 @@ export async function embedMany({
             return {
               embeddings: chunkEmbeddings,
               usage,
-              warnings: modelResponse.warnings,
+              warnings: modelResponse.warnings ?? [],
               providerMetadata: modelResponse.providerMetadata,
               response: modelResponse.response,
             };

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -181,6 +181,26 @@ describe('result.warnings', () => {
 
     expect(result.warnings).toStrictEqual(expectedWarnings);
   });
+
+  it('defaults warnings to [] when the model omits them (v2 shape)', async () => {
+    // Regression for #14926: EmbeddingModelV2 implementations may omit
+    // `warnings`; embed() previously propagated `undefined` and crashed
+    // downstream in logWarnings.
+    const { MockEmbeddingModelV2 } = await import(
+      '../test/mock-embedding-model-v2'
+    );
+    const result = await embed({
+      model: new MockEmbeddingModelV2<string>({
+        doEmbed: async () => ({
+          embeddings: [dummyEmbedding],
+          // intentionally no `warnings` field
+        }),
+      }),
+      value: testValue,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+  });
 });
 
 describe('logWarnings', () => {

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -193,7 +193,9 @@ export async function embed({
         return {
           embedding,
           usage,
-          warnings: modelResponse.warnings,
+          // EmbeddingModelV2 implementations may omit `warnings`; default to []
+          // so logWarnings and downstream consumers don't crash on undefined.
+          warnings: modelResponse.warnings ?? [],
           providerMetadata: modelResponse.providerMetadata,
           response: modelResponse.response,
         };


### PR DESCRIPTION
Fixes #14926.

`EmbeddingModelV2` providers may omit `warnings` from `doEmbed`. Three sites in `packages/ai/src/embed` propagated `modelResponse.warnings` directly into the result; downstream `logWarnings` reads `.length` and `embed-many`'s chunked path spreads `...result.warnings`, both crash on undefined. Coerce with `?? []` at each boundary, and add a regression test using `MockEmbeddingModelV2` with no `warnings` field.