### PR TITLE
fix(google): emit streaming no-args tool calls

### DIFF
--- a/packages/google/src/__fixtures__/google-stream-no-args-tool-call.chunks.txt
+++ b/packages/google/src/__fixtures__/google-stream-no-args-tool-call.chunks.txt
@@ -1,0 +1,4 @@
+{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_theme"},"thoughtSignature":"test-thought-signature"}]}}]}
+{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_screen","willContinue":true}}]}}]}
+{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"partialArgs":[{"jsonPath":"$.id","stringValue":"A","willContinue":true}],"willContinue":true}}]}}]}
+{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{}}]},"finishReason":"STOP"}]}

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -4069,6 +4069,72 @@ describe('doStream', () => {
     });
   });
 
+  describe('streaming no-args tool call', () => {
+    beforeEach(() => {
+      prepareChunksFixtureResponse('google-stream-no-args-tool-call');
+    });
+
+    it('should emit single-chunk no-args tool calls with thoughtSignature', async () => {
+      const vertexModel = new GoogleLanguageModel('gemini-pro', {
+        provider: 'google.vertex.chat',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        headers: { 'x-goog-api-key': 'test-api-key' },
+        generateId: () => 'test-id',
+      });
+
+      const { stream } = await vertexModel.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+        tools: [
+          {
+            type: 'function',
+            name: 'read_theme',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+          {
+            type: 'function',
+            name: 'read_screen',
+            inputSchema: {
+              type: 'object',
+              properties: { id: { type: 'string' } },
+              required: ['id'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+      const toolCalls = chunks.filter(chunk => chunk.type === 'tool-call');
+
+      expect(toolCalls).toEqual([
+        {
+          type: 'tool-call',
+          toolCallId: 'test-id',
+          toolName: 'read_theme',
+          input: '{}',
+          providerMetadata: {
+            googleVertex: { thoughtSignature: 'test-thought-signature' },
+            vertex: { thoughtSignature: 'test-thought-signature' },
+          },
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'test-id',
+          toolName: 'read_screen',
+          input: '{"id":"A"}',
+          providerMetadata: undefined,
+        },
+      ]);
+    });
+  });
+
   describe('streaming-tool-call-arguments-nested', () => {
     beforeEach(() => {
       prepareChunksFixtureResponse(

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -829,6 +829,11 @@ export class GoogleLanguageModel implements LanguageModelV4 {
                   part.functionCall.name != null &&
                   part.functionCall.args != null &&
                   part.functionCall.partialArgs == null;
+                const isCompleteNoArgsCall =
+                  part.functionCall.name != null &&
+                  part.functionCall.args == null &&
+                  part.functionCall.partialArgs == null &&
+                  part.functionCall.willContinue !== true;
 
                 if (isStreamingChunk) {
                   if (
@@ -935,6 +940,33 @@ export class GoogleLanguageModel implements LanguageModelV4 {
                     type: 'tool-input-delta',
                     id: toolCallId,
                     delta: args,
+                    providerMetadata: providerMeta,
+                  });
+
+                  controller.enqueue({
+                    type: 'tool-input-end',
+                    id: toolCallId,
+                    providerMetadata: providerMeta,
+                  });
+
+                  controller.enqueue({
+                    type: 'tool-call',
+                    toolCallId,
+                    toolName,
+                    input: args,
+                    providerMetadata: providerMeta,
+                  });
+
+                  hasToolCalls = true;
+                } else if (isCompleteNoArgsCall) {
+                  const toolCallId = generateId();
+                  const toolName = part.functionCall.name!;
+                  const args = '{}';
+
+                  controller.enqueue({
+                    type: 'tool-input-start',
+                    id: toolCallId,
+                    toolName,
                     providerMetadata: providerMeta,
                   });
 


### PR DESCRIPTION
## Summary
- handle Vertex streaming function-call chunks that contain only a tool name as complete no-args calls
- preserve provider metadata, including vertex thoughtSignature, on those emitted tool calls
- add a fixture-driven regression test for the wire shape from #14847

## Tests
- pnpm vitest --config vitest.node.config.js --run src/google-language-model.test.ts -t "streaming no-args tool call"
- pnpm test:node
- pnpm test:edge
- pnpm type-check

Fixes #14847