### PR TITLE
fix(ai): tag step/chunk timeout aborts with TimeoutError reason

### DIFF
--- a/.changeset/timeout-abort-reason.md
+++ b/.changeset/timeout-abort-reason.md
@@ -2,10 +2,6 @@
 "ai": patch
 ---
 
-fix(ai): tag step/chunk timeout aborts with TimeoutError reason
+fix(ai): tag step/chunk timeout aborts with `TimeoutError` reason
 
-When `timeout: { stepMs }` or `timeout: { chunkMs }` fires, the abort
-reason is now a `TimeoutError` `DOMException`, matching what
-`AbortSignal.timeout()` produces natively. Consumers can distinguish a
-framework timeout from a user-initiated cancel via
-`signal.reason.name === 'TimeoutError'`.
+When `timeout: { stepMs }` or `timeout: { chunkMs }` fires, the abort reason is now a `TimeoutError` `DOMException`, matching what `AbortSignal.timeout()` produces natively. Consumers can distinguish a framework timeout from a user-initiated cancel via `signal.reason.name === 'TimeoutError'`.

--- a/.changeset/timeout-abort-reason.md
+++ b/.changeset/timeout-abort-reason.md
@@ -1,0 +1,11 @@
+---
+"ai": patch
+---
+
+fix(ai): tag step/chunk timeout aborts with TimeoutError reason
+
+When `timeout: { stepMs }` or `timeout: { chunkMs }` fires, the abort
+reason is now a `TimeoutError` `DOMException`, matching what
+`AbortSignal.timeout()` produces natively. Consumers can distinguish a
+framework timeout from a user-initiated cancel via
+`signal.reason.name === 'TimeoutError'`.

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -7,6 +7,7 @@ import {
   type LanguageModelV4Usage,
 } from '@ai-sdk/provider';
 import {
+  DelayedPromise,
   dynamicTool,
   jsonSchema,
   tool,
@@ -4949,6 +4950,38 @@ describe('generateText', () => {
       });
 
       expect(receivedAbortSignal).toBeDefined();
+    });
+
+    it('should abort when step timeout expires', async () => {
+      let receivedAbortSignal: AbortSignal | undefined;
+      const delayedPromise = new DelayedPromise<void>();
+
+      const generatePromise = generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async ({ abortSignal }) => {
+            receivedAbortSignal = abortSignal;
+            await delayedPromise.promise;
+            return {
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: 'Hello, world!' }],
+            };
+          },
+        }),
+        prompt: 'test-input',
+        timeout: { stepMs: 50 },
+        maxRetries: 0,
+      });
+
+      // Advance time past the step timeout — fires stepAbortController.abort(...)
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Allow doGenerate to complete so the test cleans up
+      delayedPromise.resolve(undefined);
+
+      await generatePromise.catch(() => {});
+
+      expect(receivedAbortSignal?.aborted).toBe(true);
+      expect((receivedAbortSignal?.reason as Error)?.name).toBe('TimeoutError');
     });
   });
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -53,6 +53,7 @@ import { mergeAbortSignals } from '../util/merge-abort-signals';
 import { mergeObjects } from '../util/merge-objects';
 import { notify } from '../util/notify';
 import { prepareRetries } from '../util/prepare-retries';
+import { setAbortTimeout } from '../util/set-abort-timeout';
 import { VERSION } from '../version';
 import type { ActiveTools } from './active-tools';
 import { collectToolApprovals } from './collect-tool-approvals';
@@ -578,16 +579,7 @@ export async function generateText<
       // Set up step timeout if configured
       const stepTimeoutId =
         stepTimeoutMs != null
-          ? setTimeout(
-              () =>
-                stepAbortController!.abort(
-                  new DOMException(
-                    `Step timeout of ${stepTimeoutMs}ms exceeded`,
-                    'TimeoutError',
-                  ),
-                ),
-              stepTimeoutMs,
-            )
+          ? setAbortTimeout(stepAbortController!, 'Step', stepTimeoutMs)
           : undefined;
 
       try {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -577,14 +577,11 @@ export async function generateText<
 
     do {
       // Set up step timeout if configured
-      const stepTimeoutId =
-        stepTimeoutMs != null
-          ? setAbortTimeout({
-              controller: stepAbortController!,
-              label: 'Step',
-              ms: stepTimeoutMs,
-            })
-          : undefined;
+      const stepTimeoutId = setAbortTimeout({
+        abortController: stepAbortController,
+        label: 'Step',
+        timeoutMs: stepTimeoutMs,
+      });
 
       try {
         const stepInputMessages = [...initialMessages, ...responseMessages];

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -578,7 +578,16 @@ export async function generateText<
       // Set up step timeout if configured
       const stepTimeoutId =
         stepTimeoutMs != null
-          ? setTimeout(() => stepAbortController!.abort(), stepTimeoutMs)
+          ? setTimeout(
+              () =>
+                stepAbortController!.abort(
+                  new DOMException(
+                    `Step timeout of ${stepTimeoutMs}ms exceeded`,
+                    'TimeoutError',
+                  ),
+                ),
+              stepTimeoutMs,
+            )
           : undefined;
 
       try {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -579,7 +579,11 @@ export async function generateText<
       // Set up step timeout if configured
       const stepTimeoutId =
         stepTimeoutMs != null
-          ? setAbortTimeout(stepAbortController!, 'Step', stepTimeoutMs)
+          ? setAbortTimeout({
+              controller: stepAbortController!,
+              label: 'Step',
+              ms: stepTimeoutMs,
+            })
           : undefined;
 
       try {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -13677,6 +13677,7 @@ describe('streamText', () => {
 
       // The abort signal should have been triggered due to chunk timeout
       expect(receivedAbortSignal?.aborted).toBe(true);
+      expect((receivedAbortSignal?.reason as Error)?.name).toBe('TimeoutError');
     });
 
     it('should support chunkMs alongside totalMs and stepMs', async () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1463,7 +1463,11 @@ class DefaultStreamTextResult<
         // Set up step timeout if configured
         const stepTimeoutId =
           stepTimeoutMs != null
-            ? setAbortTimeout(stepAbortController!, 'Step', stepTimeoutMs)
+            ? setAbortTimeout({
+                controller: stepAbortController!,
+                label: 'Step',
+                ms: stepTimeoutMs,
+              })
             : undefined;
 
         // Set up chunk timeout tracking (will be reset on each chunk)
@@ -1475,11 +1479,11 @@ class DefaultStreamTextResult<
             if (chunkTimeoutId != null) {
               clearTimeout(chunkTimeoutId);
             }
-            chunkTimeoutId = setAbortTimeout(
-              chunkAbortController!,
-              'Chunk',
-              chunkTimeoutMs,
-            );
+            chunkTimeoutId = setAbortTimeout({
+              controller: chunkAbortController!,
+              label: 'Chunk',
+              ms: chunkTimeoutMs,
+            });
           }
         }
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1461,30 +1461,25 @@ class DefaultStreamTextResult<
         const includeRawChunks = self.includeRawChunks;
 
         // Set up step timeout if configured
-        const stepTimeoutId =
-          stepTimeoutMs != null
-            ? setAbortTimeout({
-                controller: stepAbortController!,
-                label: 'Step',
-                ms: stepTimeoutMs,
-              })
-            : undefined;
+        const stepTimeoutId = setAbortTimeout({
+          abortController: stepAbortController,
+          label: 'Step',
+          timeoutMs: stepTimeoutMs,
+        });
 
         // Set up chunk timeout tracking (will be reset on each chunk)
         let chunkTimeoutId: ReturnType<typeof setTimeout> | undefined =
           undefined;
 
         function resetChunkTimeout() {
-          if (chunkTimeoutMs != null) {
-            if (chunkTimeoutId != null) {
-              clearTimeout(chunkTimeoutId);
-            }
-            chunkTimeoutId = setAbortTimeout({
-              controller: chunkAbortController!,
-              label: 'Chunk',
-              ms: chunkTimeoutMs,
-            });
+          if (chunkTimeoutId != null) {
+            clearTimeout(chunkTimeoutId);
           }
+          chunkTimeoutId = setAbortTimeout({
+            abortController: chunkAbortController,
+            label: 'Chunk',
+            timeoutMs: chunkTimeoutMs,
+          });
         }
 
         function clearChunkTimeout() {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1462,7 +1462,16 @@ class DefaultStreamTextResult<
         // Set up step timeout if configured
         const stepTimeoutId =
           stepTimeoutMs != null
-            ? setTimeout(() => stepAbortController!.abort(), stepTimeoutMs)
+            ? setTimeout(
+                () =>
+                  stepAbortController!.abort(
+                    new DOMException(
+                      `Step timeout of ${stepTimeoutMs}ms exceeded`,
+                      'TimeoutError',
+                    ),
+                  ),
+                stepTimeoutMs,
+              )
             : undefined;
 
         // Set up chunk timeout tracking (will be reset on each chunk)
@@ -1475,7 +1484,13 @@ class DefaultStreamTextResult<
               clearTimeout(chunkTimeoutId);
             }
             chunkTimeoutId = setTimeout(
-              () => chunkAbortController!.abort(),
+              () =>
+                chunkAbortController!.abort(
+                  new DOMException(
+                    `Chunk timeout of ${chunkTimeoutMs}ms exceeded`,
+                    'TimeoutError',
+                  ),
+                ),
               chunkTimeoutMs,
             );
           }

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -82,6 +82,7 @@ import { mergeObjects } from '../util/merge-objects';
 import { notify } from '../util/notify';
 import { now as originalNow } from '../util/now';
 import { prepareRetries } from '../util/prepare-retries';
+import { setAbortTimeout } from '../util/set-abort-timeout';
 import type { ActiveTools } from './active-tools';
 import { collectToolApprovals } from './collect-tool-approvals';
 import type { ContentPart } from './content-part';
@@ -1462,16 +1463,7 @@ class DefaultStreamTextResult<
         // Set up step timeout if configured
         const stepTimeoutId =
           stepTimeoutMs != null
-            ? setTimeout(
-                () =>
-                  stepAbortController!.abort(
-                    new DOMException(
-                      `Step timeout of ${stepTimeoutMs}ms exceeded`,
-                      'TimeoutError',
-                    ),
-                  ),
-                stepTimeoutMs,
-              )
+            ? setAbortTimeout(stepAbortController!, 'Step', stepTimeoutMs)
             : undefined;
 
         // Set up chunk timeout tracking (will be reset on each chunk)
@@ -1483,14 +1475,9 @@ class DefaultStreamTextResult<
             if (chunkTimeoutId != null) {
               clearTimeout(chunkTimeoutId);
             }
-            chunkTimeoutId = setTimeout(
-              () =>
-                chunkAbortController!.abort(
-                  new DOMException(
-                    `Chunk timeout of ${chunkTimeoutMs}ms exceeded`,
-                    'TimeoutError',
-                  ),
-                ),
+            chunkTimeoutId = setAbortTimeout(
+              chunkAbortController!,
+              'Chunk',
               chunkTimeoutMs,
             );
           }

--- a/packages/ai/src/util/set-abort-timeout.test.ts
+++ b/packages/ai/src/util/set-abort-timeout.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setAbortTimeout } from './set-abort-timeout';
+
+describe('setAbortTimeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should not abort the controller before the timeout elapses', () => {
+    const controller = new AbortController();
+
+    setAbortTimeout({ controller, label: 'Step', ms: 100 });
+    vi.advanceTimersByTime(99);
+
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  it('should abort the controller when the timeout elapses', () => {
+    const controller = new AbortController();
+
+    setAbortTimeout({ controller, label: 'Step', ms: 100 });
+    vi.advanceTimersByTime(100);
+
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it('should abort with a TimeoutError DOMException', () => {
+    const controller = new AbortController();
+
+    setAbortTimeout({ controller, label: 'Step', ms: 100 });
+    vi.advanceTimersByTime(100);
+
+    expect(controller.signal.reason).toBeInstanceOf(DOMException);
+    expect((controller.signal.reason as DOMException).name).toBe(
+      'TimeoutError',
+    );
+  });
+
+  it('should include the label and duration in the abort reason message', () => {
+    const controller = new AbortController();
+
+    setAbortTimeout({ controller, label: 'Chunk', ms: 250 });
+    vi.advanceTimersByTime(250);
+
+    expect((controller.signal.reason as DOMException).message).toBe(
+      'Chunk timeout of 250ms exceeded',
+    );
+  });
+
+  it('should return a timeout id that can be cleared to cancel the abort', () => {
+    const controller = new AbortController();
+
+    const id = setAbortTimeout({ controller, label: 'Step', ms: 100 });
+    clearTimeout(id);
+    vi.advanceTimersByTime(100);
+
+    expect(controller.signal.aborted).toBe(false);
+  });
+});

--- a/packages/ai/src/util/set-abort-timeout.test.ts
+++ b/packages/ai/src/util/set-abort-timeout.test.ts
@@ -11,53 +11,81 @@ describe('setAbortTimeout', () => {
   });
 
   it('should not abort the controller before the timeout elapses', () => {
-    const controller = new AbortController();
+    const abortController = new AbortController();
 
-    setAbortTimeout({ controller, label: 'Step', ms: 100 });
+    setAbortTimeout({ abortController, label: 'Step', timeoutMs: 100 });
     vi.advanceTimersByTime(99);
 
-    expect(controller.signal.aborted).toBe(false);
+    expect(abortController.signal.aborted).toBe(false);
   });
 
   it('should abort the controller when the timeout elapses', () => {
-    const controller = new AbortController();
+    const abortController = new AbortController();
 
-    setAbortTimeout({ controller, label: 'Step', ms: 100 });
+    setAbortTimeout({ abortController, label: 'Step', timeoutMs: 100 });
     vi.advanceTimersByTime(100);
 
-    expect(controller.signal.aborted).toBe(true);
+    expect(abortController.signal.aborted).toBe(true);
   });
 
   it('should abort with a TimeoutError DOMException', () => {
-    const controller = new AbortController();
+    const abortController = new AbortController();
 
-    setAbortTimeout({ controller, label: 'Step', ms: 100 });
+    setAbortTimeout({ abortController, label: 'Step', timeoutMs: 100 });
     vi.advanceTimersByTime(100);
 
-    expect(controller.signal.reason).toBeInstanceOf(DOMException);
-    expect((controller.signal.reason as DOMException).name).toBe(
+    expect(abortController.signal.reason).toBeInstanceOf(DOMException);
+    expect((abortController.signal.reason as DOMException).name).toBe(
       'TimeoutError',
     );
   });
 
   it('should include the label and duration in the abort reason message', () => {
-    const controller = new AbortController();
+    const abortController = new AbortController();
 
-    setAbortTimeout({ controller, label: 'Chunk', ms: 250 });
+    setAbortTimeout({ abortController, label: 'Chunk', timeoutMs: 250 });
     vi.advanceTimersByTime(250);
 
-    expect((controller.signal.reason as DOMException).message).toBe(
+    expect((abortController.signal.reason as DOMException).message).toBe(
       'Chunk timeout of 250ms exceeded',
     );
   });
 
   it('should return a timeout id that can be cleared to cancel the abort', () => {
-    const controller = new AbortController();
+    const abortController = new AbortController();
 
-    const id = setAbortTimeout({ controller, label: 'Step', ms: 100 });
+    const id = setAbortTimeout({
+      abortController,
+      label: 'Step',
+      timeoutMs: 100,
+    });
     clearTimeout(id);
     vi.advanceTimersByTime(100);
 
-    expect(controller.signal.aborted).toBe(false);
+    expect(abortController.signal.aborted).toBe(false);
+  });
+
+  it('should return undefined when abortController is undefined', () => {
+    const id = setAbortTimeout({
+      abortController: undefined,
+      label: 'Step',
+      timeoutMs: 100,
+    });
+
+    expect(id).toBeUndefined();
+  });
+
+  it('should return undefined when timeoutMs is undefined', () => {
+    const abortController = new AbortController();
+
+    const id = setAbortTimeout({
+      abortController,
+      label: 'Step',
+      timeoutMs: undefined,
+    });
+    vi.advanceTimersByTime(1000);
+
+    expect(id).toBeUndefined();
+    expect(abortController.signal.aborted).toBe(false);
   });
 });

--- a/packages/ai/src/util/set-abort-timeout.ts
+++ b/packages/ai/src/util/set-abort-timeout.ts
@@ -1,0 +1,26 @@
+/**
+ * Schedules a timeout that aborts the given controller with a `TimeoutError`
+ * `DOMException`, matching the reason produced by `AbortSignal.timeout(ms)`.
+ *
+ * @param controller - The controller to abort when the timeout elapses.
+ * @param label - Human-readable label included in the error message
+ * (e.g. "Step", "Chunk").
+ * @param ms - Duration in milliseconds before the controller is aborted.
+ * @returns The timeout id, suitable for passing to `clearTimeout`.
+ */
+export function setAbortTimeout(
+  controller: AbortController,
+  label: string,
+  ms: number,
+): ReturnType<typeof setTimeout> {
+  return setTimeout(
+    () =>
+      controller.abort(
+        new DOMException(
+          `${label} timeout of ${ms}ms exceeded`,
+          'TimeoutError',
+        ),
+      ),
+    ms,
+  );
+}

--- a/packages/ai/src/util/set-abort-timeout.ts
+++ b/packages/ai/src/util/set-abort-timeout.ts
@@ -8,11 +8,15 @@
  * @param ms - Duration in milliseconds before the controller is aborted.
  * @returns The timeout id, suitable for passing to `clearTimeout`.
  */
-export function setAbortTimeout(
-  controller: AbortController,
-  label: string,
-  ms: number,
-): ReturnType<typeof setTimeout> {
+export function setAbortTimeout({
+  controller,
+  label,
+  ms,
+}: {
+  controller: AbortController;
+  label: string;
+  ms: number;
+}): ReturnType<typeof setTimeout> {
   return setTimeout(
     () =>
       controller.abort(

--- a/packages/ai/src/util/set-abort-timeout.ts
+++ b/packages/ai/src/util/set-abort-timeout.ts
@@ -2,29 +2,36 @@
  * Schedules a timeout that aborts the given controller with a `TimeoutError`
  * `DOMException`, matching the reason produced by `AbortSignal.timeout(ms)`.
  *
- * @param controller - The controller to abort when the timeout elapses.
+ * @param abortController - The controller to abort when the timeout elapses.
+ * If undefined, no timeout is scheduled.
  * @param label - Human-readable label included in the error message
  * (e.g. "Step", "Chunk").
- * @param ms - Duration in milliseconds before the controller is aborted.
- * @returns The timeout id, suitable for passing to `clearTimeout`.
+ * @param timeoutMs - Duration in milliseconds before the controller is aborted.
+ * If undefined, no timeout is scheduled.
+ * @returns The timeout id (suitable for passing to `clearTimeout`), or
+ * `undefined` if no timeout was scheduled.
  */
 export function setAbortTimeout({
-  controller,
+  abortController,
   label,
-  ms,
+  timeoutMs,
 }: {
-  controller: AbortController;
+  abortController: AbortController | undefined;
   label: string;
-  ms: number;
-}): ReturnType<typeof setTimeout> {
+  timeoutMs: number | undefined;
+}): ReturnType<typeof setTimeout> | undefined {
+  if (abortController == null || timeoutMs == null) {
+    return undefined;
+  }
+
   return setTimeout(
     () =>
-      controller.abort(
+      abortController.abort(
         new DOMException(
-          `${label} timeout of ${ms}ms exceeded`,
+          `${label} timeout of ${timeoutMs}ms exceeded`,
           'TimeoutError',
         ),
       ),
-    ms,
+    timeoutMs,
   );
 }


### PR DESCRIPTION
## Summary

When `timeout: { stepMs }` or `timeout: { chunkMs }` fires, the SDK calls `stepAbortController.abort()` / `chunkAbortController.abort()` with no argument. The resulting `signal.reason` is a generic `AbortError` DOMException indistinguishable from a user-initiated `controller.abort()`.

This PR passes a `TimeoutError` DOMException as the abort reason, mirroring what `AbortSignal.timeout()` produces natively (and what `totalMs` already does, since it goes through `mergeAbortSignals` → `AbortSignal.timeout(n)`).

## Motivation

Consumers currently can't tell apart "user pressed cancel" from "framework step/chunk timeout fired". Both surface as `AbortError`. Tagging the reason makes them distinguishable via `signal.reason.name === 'TimeoutError'`.

This also brings step/chunk timeouts into symmetry with `totalMs` and user-supplied `AbortSignal.timeout()`, which already produce `TimeoutError`.