### PR TITLE
fix(openai, openai-compatible): only send null content for assistant messages with tool calls

### DIFF
--- a/.changeset/selfish-rockets-cross.md
+++ b/.changeset/selfish-rockets-cross.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/openai-compatible": patch
+"@ai-sdk/openai": patch
+---
+
+fix(openai, openai-compatible): only send null content for assistant messages with tool calls

--- a/examples/ai-functions/src/generate-text/openai/empty-assistant-content.ts
+++ b/examples/ai-functions/src/generate-text/openai/empty-assistant-content.ts
@@ -1,0 +1,18 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: openai.chat('gpt-4o-mini'),
+    messages: [
+      { role: 'user', content: 'say hi' },
+      { role: 'assistant', content: '' },
+      { role: 'user', content: 'say hi again' },
+    ],
+  });
+
+  print('Response:', result.text);
+  print('Request:', result.request.body);
+});

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -532,6 +532,25 @@ describe('tool calls', () => {
     ]);
   });
 
+  it('should send empty string content for assistant messages with no tool calls', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: '' }],
+      },
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "",
+          "role": "assistant",
+          "tool_calls": undefined,
+        },
+      ]
+    `);
+  });
+
   it('should handle text output type in tool results', () => {
     const result = convertToOpenAICompatibleChatMessages([
       {

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -223,7 +223,7 @@ export function convertToOpenAICompatibleChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text || null,
+          content: toolCalls.length > 0 ? text || null : text,
           ...(reasoning.length > 0 ? { reasoning_content: reasoning } : {}),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           ...metadata,

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
@@ -673,6 +673,27 @@ describe('tool calls', () => {
     ]);
   });
 
+  it('should send empty string content for assistant messages with no tool calls', () => {
+    const result = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: '' }],
+        },
+      ],
+    });
+
+    expect(result.messages).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "",
+          "role": "assistant",
+          "tool_calls": undefined,
+        },
+      ]
+    `);
+  });
+
   it('should default missing tool call input to an empty object', () => {
     const result = convertToOpenAIChatMessages({
       prompt: [

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -203,7 +203,7 @@ export function convertToOpenAIChatMessages({
 
         messages.push({
           role: 'assistant',
-          content: text || null,
+          content: toolCalls.length > 0 ? text || null : text,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 


### PR DESCRIPTION
## background

#13744 changed `content: text` to `content: text || null` for assistant messages. this correctly fixed tool-only messages (openai requires `content: null` when `tool_calls` is present), but also broke the case where an assistant message has empty text and no tool calls - openai rejects `content: null` when `tool_calls` is absent with "Invalid value for 'content': expected a string, got null"

per the [openai api spec](https://developers.openai.com/api/reference/go/resources/chat/subresources/completions), content is "required unless `tool_calls` or `function_call` is specified"

## summary

- only send `null` when `toolCalls.length > 0`, otherwise preserve the text string
- add regression tests for both `@ai-sdk/openai` and `@ai-sdk/openai-compatible`

## verification

verified against live openai chat completions api with `openai.chat('gpt-4o-mini')` - empty assistant content now sends `content: ""` and returns a valid response

## related issues

follow-up to #13744