### PR TITLE
backport v6: fix(openai, openai-compatible): only send null content for assistant messages with tool calls

### DIFF
--- a/.changeset/selfish-rockets-cross.md
+++ b/.changeset/selfish-rockets-cross.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/openai-compatible": patch
+"@ai-sdk/openai": patch
+---
+
+fix(openai, openai-compatible): only send null content for assistant messages with tool calls

--- a/examples/ai-functions/src/generate-text/openai/empty-assistant-content.ts
+++ b/examples/ai-functions/src/generate-text/openai/empty-assistant-content.ts
@@ -1,0 +1,18 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: openai.chat('gpt-4o-mini'),
+    messages: [
+      { role: 'user', content: 'say hi' },
+      { role: 'assistant', content: '' },
+      { role: 'user', content: 'say hi again' },
+    ],
+  });
+
+  print('Response:', result.text);
+  print('Request:', result.request.body);
+});

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -477,6 +477,25 @@ describe('tool calls', () => {
     ]);
   });
 
+  it('should send empty string content for assistant messages with no tool calls', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: '' }],
+      },
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "",
+          "role": "assistant",
+          "tool_calls": undefined,
+        },
+      ]
+    `);
+  });
+
   it('should handle text output type in tool results', () => {
     const result = convertToOpenAICompatibleChatMessages([
       {

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -202,7 +202,7 @@ export function convertToOpenAICompatibleChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text || null,
+          content: toolCalls.length > 0 ? text || null : text,
           ...(reasoning.length > 0 ? { reasoning_content: reasoning } : {}),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           ...metadata,

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
@@ -475,6 +475,27 @@ describe('tool calls', () => {
     ]);
   });
 
+  it('should send empty string content for assistant messages with no tool calls', () => {
+    const result = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: '' }],
+        },
+      ],
+    });
+
+    expect(result.messages).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "",
+          "role": "assistant",
+          "tool_calls": undefined,
+        },
+      ]
+    `);
+  });
+
   it('should default missing tool call input to an empty object', () => {
     const result = convertToOpenAIChatMessages({
       prompt: [

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -179,7 +179,7 @@ export function convertToOpenAIChatMessages({
 
         messages.push({
           role: 'assistant',
-          content: text || null,
+          content: toolCalls.length > 0 ? text || null : text,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 


### PR DESCRIPTION
## background

backport of #14950 from main to release-v6.0

## related issues

backport of #14950
follow-up to #13744