### PR TITLE
chore(ci): add context to gateway model settings workflow PRs

### DIFF
--- a/.github/workflows/update-model-settings.yml
+++ b/.github/workflows/update-model-settings.yml
@@ -1,3 +1,15 @@
+# Update Gateway Model Settings
+#
+# Regenerates the gateway model settings files
+# (packages/gateway/src/gateway-*-model-settings.ts) from the upstream
+# gateway model list and opens a PR for review on each release branch
+# (main, release-v6.0, release-v5.0). Runs on weekdays at 8am PT.
+#
+# The generated PRs are how new models become available in
+# `@ai-sdk/gateway` — without a merge here, the package keeps shipping the
+# previous snapshot of the model list. If this workflow breaks, gateway
+# users stop seeing new models.
+
 name: Update Gateway Model Settings
 
 on:
@@ -181,13 +193,24 @@ jobs:
             PR_TITLE="chore(provider/gateway): update gateway model settings files"
           fi
 
+          WORKFLOW_FILE_URL="${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/update-model-settings.yml"
+          WORKFLOW_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          PR_BODY=$(cat <<EOF
+          Automated update of the gateway model settings files.
+
+          Regenerated from the upstream gateway model list by [\`update-model-settings.yml\`]($WORKFLOW_FILE_URL) ([this run]($WORKFLOW_RUN_URL)). Merging this PR is what makes newly-released gateway models visible in \`@ai-sdk/gateway\`.
+
+          See the workflow file for details on cadence and scope.
+          EOF
+          )
+
           PR_URL=$(gh pr create \
             --title "$PR_TITLE" \
-            --body "This is an automated update of the gateway model settings files." \
+            --body "$PR_BODY" \
             --base "${{ matrix.target-branch }}" \
             --head "${{ steps.create-branch.outputs.branch-name }}" \
-            --reviewer R-Taneja \
-            --reviewer sylviezhang37)
+            --reviewer R-Taneja)
 
           PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
           echo "pr-url=$PR_URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-model-settings.yml
+++ b/.github/workflows/update-model-settings.yml
@@ -3,12 +3,11 @@
 # Regenerates the gateway model settings files
 # (packages/gateway/src/gateway-*-model-settings.ts) from the upstream
 # gateway model list and opens a PR for review on each release branch
-# (main, release-v6.0, release-v5.0). Runs on weekdays at 8am PT.
+# (main, release-v6.0, release-v5.0).
 #
 # The generated PRs are how new models become available in
-# `@ai-sdk/gateway` — without a merge here, the package keeps shipping the
-# previous snapshot of the model list. If this workflow breaks, gateway
-# users stop seeing new models.
+# `@ai-sdk/gateway`. They surface as IDE autocomplete
+# suggestions when users type a model string.
 
 name: Update Gateway Model Settings
 
@@ -199,7 +198,7 @@ jobs:
           PR_BODY=$(cat <<EOF
           Automated update of the gateway model settings files.
 
-          Regenerated from the upstream gateway model list by [\`update-model-settings.yml\`]($WORKFLOW_FILE_URL) ([this run]($WORKFLOW_RUN_URL)). Merging this PR is what makes newly-released gateway models visible in \`@ai-sdk/gateway\`.
+          Regenerated from the upstream gateway model list by [\`update-model-settings.yml\`]($WORKFLOW_FILE_URL) ([this run]($WORKFLOW_RUN_URL)). Merging this PR is what surfaces newly-released gateway models as IDE autocomplete suggestions when users type a model string with \`@ai-sdk/gateway\`.
 
           See the workflow file for details on cadence and scope.
           EOF


### PR DESCRIPTION
## Summary

The `Update Gateway Model Settings` workflow opens automated PRs (e.g. #14956) with a one-line body and no link back to its source, making them hard to interpret cold. This adds context in two places.

- **Header comment in `update-model-settings.yml`** — explains what the workflow does, when it runs, and why merging the generated PRs matters (without a merge here, `@ai-sdk/gateway` keeps shipping a stale model list).
- **Workflow + run links in the generated PR body** — so a reviewer landing on one of these PRs can immediately find the workflow file and the specific run that produced it.
- **Reviewer cleanup** — drops `sylviezhang37` from the auto-requested reviewers; only `R-Taneja` is requested now.

Workflow-only change, no production code touched, so no changeset.