### PR TITLE
feat(mcp): deprecate name and use clientName for MCPClient

### DIFF
--- a/.changeset/purple-chefs-jog.md
+++ b/.changeset/purple-chefs-jog.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+feat(mcp): deprecate name and use clientName for MCPClient

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -120,10 +120,18 @@ It currently does not support accepting notifications from an MCP server, and cu
               ],
             },
             {
+              name: 'clientName',
+              type: 'string',
+              isOptional: true,
+              description:
+                'Client name. Defaults to "ai-sdk-mcp-client".',
+            },
+            {
               name: 'name',
               type: 'string',
               isOptional: true,
-              description: 'Client name. Defaults to "ai-sdk-mcp-client"',
+              description:
+                'Deprecated. Use `clientName` instead. Defaults to "ai-sdk-mcp-client".',
             },
             {
               name: 'version',

--- a/examples/ai-e2e-next/app/chat/mcp/chat/route.ts
+++ b/examples/ai-e2e-next/app/chat/mcp/chat/route.ts
@@ -11,7 +11,7 @@ export async function POST(req: Request) {
   const [client, { messages }] = await Promise.all([
     createMCPClient({
       transport,
-      name: 'local-calculator-mcp',
+      clientName: 'local-calculator-mcp',
     }),
     req.json(),
   ]);

--- a/examples/ai-e2e-next/app/chat/mcp/page.tsx
+++ b/examples/ai-e2e-next/app/chat/mcp/page.tsx
@@ -65,10 +65,11 @@ export default function Chat() {
                         )}
                         {part.type === 'dynamic-tool' &&
                           'callProviderMetadata' in part &&
-                          typeof part.callProviderMetadata?.mcp?.name ===
+                          typeof part.callProviderMetadata?.mcp?.clientName ===
                             'string' && (
                             <div className="text-xs text-gray-500">
-                              MCP server: {part.callProviderMetadata.mcp.name}
+                              MCP server:{' '}
+                              {part.callProviderMetadata.mcp.clientName}
                             </div>
                           )}
                       </div>

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -580,7 +580,7 @@ describe('parseToolCall', () => {
         tools: {
           weather: dynamicTool({
             description: 'Get weather',
-            providerMetadata: { mcp: { name: 'MyMCPServer' } },
+            providerMetadata: { mcp: { clientName: 'MyMCPClient' } },
             inputSchema: jsonSchema({
               type: 'object',
               properties: { location: { type: 'string' } },
@@ -595,7 +595,7 @@ describe('parseToolCall', () => {
       });
 
       expect(result.providerMetadata).toEqual({
-        mcp: { name: 'MyMCPServer' },
+        mcp: { clientName: 'MyMCPClient' },
       });
     });
 
@@ -610,7 +610,7 @@ describe('parseToolCall', () => {
         tools: {
           calculator: tool({
             description: 'Calculate',
-            providerMetadata: { mcp: { name: 'MyMCPServer' } },
+            providerMetadata: { mcp: { clientName: 'MyMCPClient' } },
             inputSchema: z.object({ a: z.number(), b: z.number() }),
             execute: async ({ a, b }) => a + b,
           }),
@@ -621,7 +621,7 @@ describe('parseToolCall', () => {
       });
 
       expect(result.providerMetadata).toEqual({
-        mcp: { name: 'MyMCPServer' },
+        mcp: { clientName: 'MyMCPClient' },
       });
     });
 
@@ -633,14 +633,14 @@ describe('parseToolCall', () => {
           toolName: 'weather',
           input: '{"location":"Paris"}',
           providerMetadata: {
-            mcp: { name: 'OverriddenByModel' },
+            mcp: { clientName: 'OverriddenByModel' },
             anthropic: { cacheControl: { type: 'ephemeral' } },
           },
         },
         tools: {
           weather: dynamicTool({
             description: 'Get weather',
-            providerMetadata: { mcp: { name: 'MyMCPServer' } },
+            providerMetadata: { mcp: { clientName: 'MyMCPClient' } },
             inputSchema: jsonSchema({
               type: 'object',
               properties: { location: { type: 'string' } },
@@ -655,7 +655,7 @@ describe('parseToolCall', () => {
       });
 
       expect(result.providerMetadata).toEqual({
-        mcp: { name: 'OverriddenByModel' },
+        mcp: { clientName: 'OverriddenByModel' },
         anthropic: { cacheControl: { type: 'ephemeral' } },
       });
     });
@@ -671,7 +671,7 @@ describe('parseToolCall', () => {
         tools: {
           weather: dynamicTool({
             description: 'Get weather',
-            providerMetadata: { mcp: { name: 'MyMCPServer' } },
+            providerMetadata: { mcp: { clientName: 'MyMCPClient' } },
             inputSchema: jsonSchema({
               type: 'object',
               properties: { location: { type: 'string' } },
@@ -688,7 +688,7 @@ describe('parseToolCall', () => {
 
       expect(result.invalid).toBe(true);
       expect(result.providerMetadata).toEqual({
-        mcp: { name: 'MyMCPServer' },
+        mcp: { clientName: 'MyMCPClient' },
       });
     });
   });

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -93,16 +93,33 @@ describe('MCPClient', () => {
     `);
   });
 
-  it('should expose the configured client name on dynamic tools via providerMetadata', async () => {
+  it('should expose MCP tool metadata on dynamic tools via providerMetadata', async () => {
     client = await createMCPClient({
       transport: { type: 'sse', url: 'https://example.com/sse' },
-      name: 'MyMCPServer',
+      clientName: 'MyMCPClient',
     });
 
     const tools = await client.tools();
 
     expect(tools['mock-tool'].providerMetadata).toEqual({
-      mcp: { name: 'MyMCPServer' },
+      mcp: {
+        clientName: 'MyMCPClient',
+      },
+    });
+  });
+
+  it('should support deprecated name for MCP tool providerMetadata', async () => {
+    client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+      name: 'DeprecatedMCPServer',
+    });
+
+    const tools = await client.tools();
+
+    expect(tools['mock-tool'].providerMetadata).toEqual({
+      mcp: {
+        clientName: 'DeprecatedMCPServer',
+      },
     });
   });
 
@@ -1229,6 +1246,49 @@ describe('MCPClient', () => {
 
     expect(capturedClientInfo).toBeDefined();
     expect(capturedClientInfo?.version).toBe('2.5.0');
+  });
+
+  it('should use clientName for client info when provided', async () => {
+    const mockTransport = new MockMCPTransport();
+    let capturedClientInfo: { name: string; version: string } | undefined;
+
+    const originalSend = mockTransport.send.bind(mockTransport);
+    mockTransport.send = vi.fn(async (message: JSONRPCRequest) => {
+      if (message.method === 'initialize' && message.params) {
+        capturedClientInfo = message.params.clientInfo as Configuration;
+      }
+      return originalSend(message);
+    });
+
+    client = await createMCPClient({
+      transport: mockTransport,
+      clientName: 'CustomMCPClient',
+    });
+
+    expect(capturedClientInfo).toBeDefined();
+    expect(capturedClientInfo?.name).toBe('CustomMCPClient');
+  });
+
+  it('should prefer clientName over deprecated name for client info', async () => {
+    const mockTransport = new MockMCPTransport();
+    let capturedClientInfo: { name: string; version: string } | undefined;
+
+    const originalSend = mockTransport.send.bind(mockTransport);
+    mockTransport.send = vi.fn(async (message: JSONRPCRequest) => {
+      if (message.method === 'initialize' && message.params) {
+        capturedClientInfo = message.params.clientInfo as Configuration;
+      }
+      return originalSend(message);
+    });
+
+    client = await createMCPClient({
+      transport: mockTransport,
+      clientName: 'CustomMCPClient',
+      name: 'DeprecatedMCPServer',
+    });
+
+    expect(capturedClientInfo).toBeDefined();
+    expect(capturedClientInfo?.name).toBe('CustomMCPClient');
   });
 
   it('should use default version when not provided', async () => {

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -99,6 +99,12 @@ export interface MCPClientConfig {
   /** Optional callback for uncaught errors */
   onUncaughtError?: (error: unknown) => void;
   /** Optional client name, defaults to 'ai-sdk-mcp-client' */
+  clientName?: string;
+  /**
+   * Optional client name, defaults to 'ai-sdk-mcp-client'
+   *
+   * @deprecated Use `clientName` instead.
+   */
   name?: string;
   /** Optional client version, defaults to '1.0.0' */
   version?: string;
@@ -226,7 +232,8 @@ class DefaultMCPClient implements MCPClient {
 
   constructor({
     transport: transportConfig,
-    name = 'ai-sdk-mcp-client',
+    name,
+    clientName = name ?? 'ai-sdk-mcp-client',
     version = CLIENT_VERSION,
     onUncaughtError,
     capabilities,
@@ -260,7 +267,7 @@ class DefaultMCPClient implements MCPClient {
     };
 
     this.clientInfo = {
-      name,
+      name: clientName,
       version,
     };
   }
@@ -629,7 +636,7 @@ class DefaultMCPClient implements MCPClient {
               description,
               title: resolvedTitle,
               providerMetadata: {
-                mcp: { name: this.clientInfo.name },
+                mcp: { clientName: this.clientInfo.name },
               },
               inputSchema: jsonSchema({
                 ...inputSchema,
@@ -643,7 +650,7 @@ class DefaultMCPClient implements MCPClient {
               description,
               title: resolvedTitle,
               providerMetadata: {
-                mcp: { name: this.clientInfo.name },
+                mcp: { clientName: this.clientInfo.name },
               },
               inputSchema: schemas[name].inputSchema,
               ...(outputSchema != null ? { outputSchema } : {}),


### PR DESCRIPTION
## Background

as a follow up to https://github.com/vercel/ai/pull/14813, we needed to align the variables with proper naming so as to not create any confusion

## Summary

deprecated the `name` property and renamed to `clientName` since it's just defined in `createMCPClient()`

## Manual Verification

verified by running the example `http://localhost:3000/chat/mcp`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

compile the providerMetadata properties available for MCP tools into separate type