### PR TITLE
feat(provider/openai): forward imageDetail providerOptions on tool-result image content

### DIFF
--- a/.changeset/openai-tool-result-image-detail.md
+++ b/.changeset/openai-tool-result-image-detail.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(provider/openai): forward imageDetail providerOptions on tool-result image content

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -2522,7 +2522,111 @@ describe('convertToOpenAIResponsesInput', () => {
             "call_id": "call_123",
             "output": [
               {
+                "detail": undefined,
                 "image_url": "data:image/png;base64,base64_data",
+                "type": "input_image",
+              },
+            ],
+            "type": "function_call_output",
+          },
+        ]
+      `);
+    });
+
+    it('should forward openai.imageDetail providerOptions on tool-result image (data)', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_123',
+                toolName: 'view_image',
+                output: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'file',
+                      mediaType: 'image/png',
+                      data: { type: 'data', data: 'base64_data' },
+                      providerOptions: {
+                        openai: { imageDetail: 'original' },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      expect(result.input).toMatchInlineSnapshot(`
+        [
+          {
+            "call_id": "call_123",
+            "output": [
+              {
+                "detail": "original",
+                "image_url": "data:image/png;base64,base64_data",
+                "type": "input_image",
+              },
+            ],
+            "type": "function_call_output",
+          },
+        ]
+      `);
+    });
+
+    it('should forward openai.imageDetail providerOptions on tool-result image (url)', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_123',
+                toolName: 'view_image',
+                output: {
+                  type: 'content',
+                  value: [
+                    {
+                      type: 'file',
+                      mediaType: 'image/png',
+                      data: {
+                        type: 'url',
+                        url: new URL('https://example.com/x.png'),
+                      },
+                      providerOptions: {
+                        openai: { imageDetail: 'high' },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      expect(result.input).toMatchInlineSnapshot(`
+        [
+          {
+            "call_id": "call_123",
+            "output": [
+              {
+                "detail": "high",
+                "image_url": "https://example.com/x.png",
                 "type": "input_image",
               },
             ],
@@ -2571,6 +2675,7 @@ describe('convertToOpenAIResponsesInput', () => {
             "call_id": "call_123",
             "output": [
               {
+                "detail": undefined,
                 "image_url": "https://example.com/screenshot.png",
                 "type": "input_image",
               },
@@ -2788,6 +2893,7 @@ describe('convertToOpenAIResponsesInput', () => {
                 "type": "input_text",
               },
               {
+                "detail": undefined,
                 "image_url": "data:image/png;base64,base64_data",
                 "type": "input_image",
               },

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -769,6 +769,9 @@ export async function convertToOpenAIResponsesInput({
                         return { type: 'input_text' as const, text: item.text };
                       case 'file': {
                         const topLevel = getTopLevelMediaType(item.mediaType);
+                        const imageDetail =
+                          item.providerOptions?.[providerOptionsName]
+                            ?.imageDetail;
 
                         if (item.data.type === 'data') {
                           const fullMediaType = resolveFullMediaType({
@@ -778,6 +781,7 @@ export async function convertToOpenAIResponsesInput({
                             return {
                               type: 'input_image' as const,
                               image_url: `data:${fullMediaType};base64,${convertToBase64(item.data.data)}`,
+                              detail: imageDetail,
                             };
                           }
                           return {
@@ -792,6 +796,7 @@ export async function convertToOpenAIResponsesInput({
                             return {
                               type: 'input_image' as const,
                               image_url: item.data.url.toString(),
+                              detail: imageDetail,
                             };
                           }
                           return {
@@ -850,6 +855,9 @@ export async function convertToOpenAIResponsesInput({
 
                     case 'file': {
                       const topLevel = getTopLevelMediaType(item.mediaType);
+                      const imageDetail =
+                        item.providerOptions?.[providerOptionsName]
+                          ?.imageDetail;
 
                       if (item.data.type === 'data') {
                         const fullMediaType = resolveFullMediaType({
@@ -859,6 +867,7 @@ export async function convertToOpenAIResponsesInput({
                           return {
                             type: 'input_image' as const,
                             image_url: `data:${fullMediaType};base64,${convertToBase64(item.data.data)}`,
+                            detail: imageDetail,
                           };
                         }
                         return {
@@ -873,6 +882,7 @@ export async function convertToOpenAIResponsesInput({
                           return {
                             type: 'input_image' as const,
                             image_url: item.data.url.toString(),
+                            detail: imageDetail,
                           };
                         }
                         return {


### PR DESCRIPTION
## Summary

When a tool returns an image content part (`type: 'file'` with `image/*` media type) and the part carries `providerOptions.openai.imageDetail`, forward the value as `detail` on the resulting `input_image` inside `function_call_output` / `custom_tool_call_output`. Previously this was only honored on user-message images.

This unblocks Codex SDK 0.125.0's built-in `view_image` tool, whose tool result includes `detail: "original"` on the returned image — currently dropped on the way to OpenAI.

## Test plan

- [x] Two new tests in `convert-to-openai-responses-input.test.ts` covering tool-result image with `imageDetail` providerOptions (data URL and HTTP URL forms)
- [x] Three existing snapshots updated to include the now-always-emitted `detail` field, matching the existing user-message convention
- [x] `pnpm test:node convert-to-openai-responses-input` — 109/109 pass