### PR TITLE
fix(google-vertex): include CJS output for xai sub-module build

### DIFF
--- a/.changeset/fix-vertex-xai-build-format.md
+++ b/.changeset/fix-vertex-xai-build-format.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google-vertex": patch
+---
+
+fix(google-vertex): include CJS output for xai sub-module build

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -69,18 +69,18 @@
     },
     "./maas/edge": {
       "types": "./dist/maas/edge/index.d.ts",
-      "import": "./dist/maas/edge/index.js",
-      "default": "./dist/maas/edge/index.js"
+      "import": "./dist/maas/edge/index.mjs",
+      "require": "./dist/maas/edge/index.js"
     },
     "./xai": {
       "types": "./dist/xai/index.d.ts",
-      "import": "./dist/xai/index.js",
-      "default": "./dist/xai/index.js"
+      "import": "./dist/xai/index.mjs",
+      "require": "./dist/xai/index.js"
     },
     "./xai/edge": {
       "types": "./dist/xai/edge/index.d.ts",
-      "import": "./dist/xai/edge/index.js",
-      "default": "./dist/xai/edge/index.js"
+      "import": "./dist/xai/edge/index.mjs",
+      "require": "./dist/xai/edge/index.js"
     }
   },
   "dependencies": {

--- a/packages/google-vertex/tsup.config.ts
+++ b/packages/google-vertex/tsup.config.ts
@@ -81,7 +81,7 @@ export default defineConfig([
   },
   {
     entry: ['src/xai/index.ts'],
-    format: ['esm'],
+    format: ['cjs', 'esm'],
     dts: true,
     sourcemap: true,
     define: {
@@ -94,7 +94,7 @@ export default defineConfig([
   },
   {
     entry: ['src/xai/edge/index.ts'],
-    format: ['esm'],
+    format: ['cjs', 'esm'],
     dts: true,
     sourcemap: true,
     define: {


### PR DESCRIPTION
## Summary

- The `xai` and `xai/edge` sub-module entries in `packages/google-vertex/tsup.config.ts` use `format: ['esm']`, while all other sub-modules (`anthropic`, `maas`) use `format: ['cjs', 'esm']`.
- In v7 (main), this works because `package.json` has `"type": "module"` — tsup emits `.js`/`.d.ts` for ESM format, which matches the paths in the `exports` field.
- In v5/v6, the package lacks `"type": "module"`, so an ESM-only build produces `.mjs`/`.d.mts`. But the `exports` field still references `.js`/`.d.ts`, causing `MODULE_NOT_FOUND` at runtime for any consumer resolving the `@ai-sdk/google-vertex/xai/edge` import.
- Adding `'cjs'` to the format array matches the other sub-modules and produces the `.js`/`.d.ts` files that `exports` expects.

## Test plan

- [x] Build `packages/google-vertex` and verify `dist/xai/edge/` contains both `index.js` and `index.mjs`
- [x] Verify `node -e "require.resolve('@ai-sdk/google-vertex/xai/edge')"` resolves without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)