### PR TITLE
docs(tools): fix double tool execution in re-ask repair example

### DIFF
--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -1111,6 +1111,15 @@ const result = await generateText({
     messages,
     system,
   }) => {
+    // Strip execute functions so the inner generateText only asks the model
+    // for corrected arguments without running the tools a second time.
+    const toolsForRepair = Object.fromEntries(
+      Object.entries(tools).map(([name, { execute: _execute, ...rest }]) => [
+        name,
+        rest,
+      ]),
+    );
+
     const result = await generateText({
       model,
       system,
@@ -1139,7 +1148,7 @@ const result = await generateText({
           ],
         },
       ],
-      tools,
+      tools: toolsForRepair,
     });
 
     const newToolCall = result.toolCalls.find(


### PR DESCRIPTION
## Problem

Fixes #5801.

The re-ask strategy example in the tool call repair docs passes the full `tools` object (including `execute` functions) to the inner `generateText` call. When the model returns a corrected tool call, the inner `generateText` executes it — and then the outer `generateText` executes it again, causing **double tool execution**.

## Fix

Strip `execute` functions before passing `tools` to the inner `generateText`. The inner call only needs the tool schemas so the model can produce a corrected tool call; it should not run the tool itself.

```ts
const toolsForRepair = Object.fromEntries(
  Object.entries(tools).map(([name, { execute: _execute, ...rest }]) => [
    name,
    rest,
  ]),
);
```

## Testing

Run the re-ask strategy example from the docs before and after this change. Before: the tool's `execute` function is called twice. After: it is called exactly once by the outer `generateText`.