### PR TITLE
fix(@ai-sdk/openai): omit reasoning item id when store is false

### DIFF
--- a/.changeset/fix-openai-omit-reasoning-id-when-store-false.md
+++ b/.changeset/fix-openai-omit-reasoning-id-when-store-false.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Omit `id` from reasoning items when `store: false` — Azure OpenAI rejects requests where a stateless reasoning item includes an `id` field.

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -1606,7 +1606,6 @@ describe('convertToOpenAIResponsesInput', () => {
             [
               {
                 "encrypted_content": "encrypted_content_001",
-                "id": "reasoning_001",
                 "summary": [
                   {
                     "text": "First reasoning step",
@@ -1914,7 +1913,6 @@ describe('convertToOpenAIResponsesInput', () => {
               },
               {
                 "encrypted_content": "encrypted_content_001",
-                "id": "reasoning_001",
                 "summary": [
                   {
                     "text": "First reasoning step (message 1)",
@@ -1948,7 +1946,6 @@ describe('convertToOpenAIResponsesInput', () => {
               },
               {
                 "encrypted_content": "encrypted_content_002",
-                "id": "reasoning_002",
                 "summary": [
                   {
                     "text": "First reasoning step (message 2)",

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -1339,7 +1339,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [
                 {
@@ -1381,7 +1380,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [
                 {
@@ -1423,7 +1421,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [
                 {
@@ -1467,7 +1464,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [],
             },
@@ -1504,7 +1500,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [],
             },
@@ -1550,7 +1545,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [
                 {
@@ -1714,7 +1708,6 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.input).toEqual([
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [
                 {
@@ -1725,7 +1718,6 @@ describe('convertToOpenAIResponsesInput', () => {
             },
             {
               type: 'reasoning',
-              id: 'reasoning_002',
               encrypted_content: 'encrypted_content_002',
               summary: [
                 {
@@ -2111,7 +2103,6 @@ describe('convertToOpenAIResponsesInput', () => {
             // First reasoning block (2 parts merged)
             {
               type: 'reasoning',
-              id: 'reasoning_001',
               encrypted_content: 'encrypted_content_001',
               summary: [
                 {
@@ -2140,7 +2131,6 @@ describe('convertToOpenAIResponsesInput', () => {
             // Second reasoning block (3 parts merged)
             {
               type: 'reasoning',
-              id: 'reasoning_002',
               encrypted_content: 'encrypted_content_002',
               summary: [
                 {

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -537,7 +537,8 @@ export async function convertToOpenAIResponsesInput({
                   if (reasoningMessage === undefined) {
                     reasoningMessages[reasoningId] = {
                       type: 'reasoning',
-                      id: reasoningId,
+                      // Omit id when store is false — Azure OpenAI rejects
+                      // reasoning items that include id in stateless mode.
                       encrypted_content:
                         providerOptions?.reasoningEncryptedContent,
                       summary: summaryParts,


### PR DESCRIPTION
## Background

When \`store: false\`, the SDK includes \`id\` in reasoning items sent to the API. Azure OpenAI rejects these requests with an error because the \`id\` field is only meaningful in store mode — in stateless mode it is an invalid field.

Fixes #12687.

## Summary

Remove \`id\` from the reasoning object in the \`store: false\` branch of \`convert-to-openai-responses-input.ts\`. The field is already typed as optional (\`id?: string\`), so omitting it is type-safe and has no effect on direct OpenAI.

## Manual Verification

Inspected serialized request body in the test suite: \`id\` is absent from reasoning items in the \`store: false\` path and present as expected in the \`store: true\` path.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run \`pnpm changeset\` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #12687