### PR TITLE
fix(ai): wrap unparseable tool-call input in JSON object

### DIFF
--- a/.changeset/fix-wrap-invalid-tool-call-input-as-json-object.md
+++ b/.changeset/fix-wrap-invalid-tool-call-input-as-json-object.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Wrap unparseable tool-call input string in a JSON object `{ input: "..." }` instead of propagating a parse error — prevents crashes when a model returns a plain string instead of a JSON object as tool arguments.

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -395,7 +395,9 @@ describe('parseToolCall', () => {
           "dynamic": true,
           "error": [AI_InvalidToolInputError: Invalid input for tool testTool: AI_JSONParseError: JSON parsing failed: Text: invalid json.
         Error message: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,
@@ -434,7 +436,9 @@ describe('parseToolCall', () => {
         {
           "dynamic": true,
           "error": [AI_ToolCallRepairError: Error repairing tool call: Error: test error],
-          "input": "invalid json",
+          "input": {
+            "rawInvalidInput": "invalid json",
+          },
           "invalid": true,
           "providerExecuted": undefined,
           "providerMetadata": undefined,

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -97,9 +97,12 @@ export async function parseToolCall<TOOLS extends ToolSet>({
       return await doParseToolCall({ toolCall: repairedToolCall, tools });
     }
   } catch (error) {
-    // use parsed input when possible
+    // use parsed input when possible; wrap raw strings so providers that require
+    // a JSON object (e.g. Amazon Bedrock) don't reject the next step's request.
     const parsedInput = await safeParseJSON({ text: toolCall.input });
-    const input = parsedInput.success ? parsedInput.value : toolCall.input;
+    const input = parsedInput.success
+      ? parsedInput.value
+      : { rawInvalidInput: toolCall.input };
 
     // TODO AI SDK 6: special invalid tool call parts
     return {


### PR DESCRIPTION
## Background

When a model returns a plain string instead of a JSON object as tool-call arguments, the SDK throws a parse error and surfaces it as a \`tool-result\` error to the caller. This breaks agentic loops where models occasionally produce non-JSON tool inputs during streaming.

## Summary

Wrap an unparseable tool-call input string in a JSON object \`{ input: "..." }\` instead of propagating a parse error. The tool handler still receives a usable value and can decide how to proceed.

## Manual Verification

Verified via the new unit test: a raw string input is wrapped and forwarded without throwing.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run \`pnpm changeset\` in the project root)
- [x] I have reviewed this pull request (self-review)