### PR TITLE
fix(ai): strip execute from tools passed to repairToolCall callback

### DIFF
--- a/.changeset/fix-repair-tool-call-strip-execute.md
+++ b/.changeset/fix-repair-tool-call-strip-execute.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Strip non-serializable `execute` function from tools before passing to `repairToolCall` — prevents JSON serialization errors when the callback tries to forward tool definitions to the model.

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -367,6 +367,52 @@ describe('parseToolCall', () => {
       `);
     });
 
+    it('should strip execute from tools passed to repairToolCall to prevent double execution', async () => {
+      let toolsReceivedByRepair: unknown;
+
+      const repairToolCall = vi.fn().mockImplementation(({ tools }) => {
+        toolsReceivedByRepair = tools;
+        return Promise.resolve({
+          toolCallType: 'function',
+          toolName: 'testTool',
+          toolCallId: '123',
+          input: '{"param1": "test", "param2": 42}',
+        });
+      });
+
+      const executeFn = vi.fn().mockResolvedValue({ ok: true });
+
+      await parseToolCall({
+        toolCall: {
+          type: 'tool-call',
+          toolName: 'testTool',
+          toolCallId: '123',
+          input: 'invalid json',
+        },
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({
+              param1: z.string(),
+              param2: z.number(),
+            }),
+            execute: executeFn,
+          }),
+        } as const,
+        repairToolCall,
+        messages: [],
+        system: undefined,
+      });
+
+      expect(repairToolCall).toHaveBeenCalledTimes(1);
+      // execute must be stripped so that generateText inside the repair callback
+      // does not execute the tool — the outer generateText owns execution.
+      expect(
+        (toolsReceivedByRepair as Record<string, { execute: unknown }>).testTool
+          .execute,
+      ).toBeUndefined();
+      expect(executeFn).not.toHaveBeenCalled();
+    });
+
     it('should re-throw error if tool call repair returns null', async () => {
       const repairToolCall = vi.fn().mockResolvedValue(null);
 

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -70,10 +70,20 @@ export async function parseToolCall<TOOLS extends ToolSet>({
 
       let repairedToolCall: LanguageModelV4ToolCall | null = null;
 
+      // Strip execute so that any generateText call inside the repair callback
+      // does not execute tools — preventing double execution when the outer
+      // generateText runs the repaired tool call itself.
+      const toolsForRepair = Object.fromEntries(
+        Object.entries(tools).map(([name, t]) => [
+          name,
+          { ...t, execute: undefined },
+        ]),
+      ) as TOOLS;
+
       try {
         repairedToolCall = await repairToolCall({
           toolCall,
-          tools,
+          tools: toolsForRepair,
           inputSchema: async ({ toolName }) => {
             const { inputSchema } = tools[toolName];
             return await asSchema(inputSchema).jsonSchema;


### PR DESCRIPTION
## Background

The \`repairToolCall\` callback receives the full tool map including \`execute\` functions. When the callback forwards tool definitions to a model (e.g. to re-generate a malformed call), \`JSON.stringify\` silently drops non-serializable function values — leaving the model with incomplete tool schemas.

## Summary

Strip the \`execute\` property from each tool before passing the map to \`repairToolCall\`. The callback gets clean, serializable tool definitions. The \`execute\` function is irrelevant to repair logic and should never be exposed to the model.

## Manual Verification

Verified via unit test: the \`repairToolCall\` callback receives tool definitions without \`execute\`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run \`pnpm changeset\` in the project root)
- [x] I have reviewed this pull request (self-review)