### PR TITLE
fix(ai): guard against undefined warnings from EmbeddingModelV2 providers

### DIFF
--- a/.changeset/fix-embed-warnings-undefined.md
+++ b/.changeset/fix-embed-warnings-undefined.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Normalize `undefined` warnings from `EmbeddingModelV2` providers to `[]` — prevents `onFinish` callbacks from receiving `undefined` where `Array<Warning>` is expected.

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -423,6 +423,50 @@ describe('result.warnings', () => {
     expect(result.warnings).toStrictEqual(expectedWarnings);
   });
 
+  it('should not crash when doEmbed returns undefined warnings (v2 provider, single call)', async () => {
+    const result = await embedMany({
+      model: new MockEmbeddingModelV4({
+        maxEmbeddingsPerCall: null,
+        doEmbed: async () => ({
+          embeddings: dummyEmbeddings,
+          warnings: undefined as unknown as [],
+        }),
+      }),
+      values: testValues,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it('should not crash when doEmbed returns undefined warnings (v2 provider, chunked calls)', async () => {
+    let callCount = 0;
+
+    const result = await embedMany({
+      model: new MockEmbeddingModelV4({
+        maxEmbeddingsPerCall: 2,
+        doEmbed: async () => {
+          switch (callCount++) {
+            case 0:
+              return {
+                embeddings: dummyEmbeddings.slice(0, 2),
+                warnings: undefined as unknown as [],
+              };
+            case 1:
+              return {
+                embeddings: dummyEmbeddings.slice(2),
+                warnings: undefined as unknown as [],
+              };
+            default:
+              throw new Error('Unexpected call');
+          }
+        },
+      }),
+      values: testValues,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+  });
+
   it('should aggregate warnings from multiple calls', async () => {
     const warning1: Warning = {
       type: 'other',

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -222,7 +222,7 @@ export async function embedMany({
         });
 
       logWarnings({
-        warnings,
+        warnings: warnings ?? [],
         provider: model.provider,
         model: model.modelId,
       });
@@ -247,7 +247,7 @@ export async function embedMany({
         values,
         embeddings,
         usage,
-        warnings,
+        warnings: warnings ?? [],
         providerMetadata,
         responses: [response],
       });
@@ -327,7 +327,7 @@ export async function embedMany({
 
       for (const result of results) {
         embeddings.push(...result.embeddings);
-        warnings.push(...result.warnings);
+        warnings.push(...(result.warnings ?? []));
         responses.push(result.response);
         tokens += result.usage.tokens;
         if (result.providerMetadata) {

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -215,7 +215,7 @@ export async function embedMany({
           return {
             embeddings,
             usage,
-            warnings: modelResponse.warnings,
+            warnings: modelResponse.warnings ?? [],
             providerMetadata: modelResponse.providerMetadata,
             response: modelResponse.response,
           };

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -183,6 +183,23 @@ describe('result.warnings', () => {
   });
 });
 
+describe('result.warnings - undefined from v2 provider', () => {
+  it('should not crash when doEmbed returns undefined warnings', async () => {
+    const result = await embed({
+      model: new MockEmbeddingModelV4({
+        doEmbed: async () => ({
+          embeddings: [dummyEmbedding],
+          // v2 providers do not include warnings in their doEmbed response
+          warnings: undefined as unknown as [],
+        }),
+      }),
+      value: testValue,
+    });
+
+    expect(result.embedding).toStrictEqual(dummyEmbedding);
+  });
+});
+
 describe('logWarnings', () => {
   let logWarningsSpy: ReturnType<typeof vitest.spyOn>;
 

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -193,7 +193,7 @@ export async function embed({
         return {
           embedding,
           usage,
-          warnings: modelResponse.warnings,
+          warnings: modelResponse.warnings ?? [],
           providerMetadata: modelResponse.providerMetadata,
           response: modelResponse.response,
         };

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -199,7 +199,11 @@ export async function embed({
         };
       });
 
-    logWarnings({ warnings, provider: model.provider, model: model.modelId });
+    logWarnings({
+      warnings: warnings ?? [],
+      provider: model.provider,
+      model: model.modelId,
+    });
 
     await notify({
       event: {
@@ -221,7 +225,7 @@ export async function embed({
       value,
       embedding,
       usage,
-      warnings,
+      warnings: warnings ?? [],
       providerMetadata,
       response,
     });


### PR DESCRIPTION
## Background

\`EmbeddingModelV2.doEmbed()\` returns \`warnings?: Array<Warning>\` — the field is optional and can be \`undefined\`. The \`embed\` and \`embedMany\` functions forward this value directly to \`onFinish\` callbacks and to \`notify()\`, which both expect \`Array<Warning>\`.

## Summary

Normalize \`modelResponse.warnings\` to \`[]\` at the point of destructuring in both \`embed.ts\` and \`embed-many.ts\`. All downstream consumers (return value, \`onFinish\`, \`notify()\`) receive an empty array instead of \`undefined\`.

## Manual Verification

Verified via unit test: \`onFinish\` is called with \`warnings: []\` when the provider returns \`undefined\` for warnings.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run \`pnpm changeset\` in the project root)
- [x] I have reviewed this pull request (self-review)