### PR TITLE
fix(xai, deepseek, groq, mistral): send null content for tool-only assistant messages

### DIFF
--- a/.changeset/fix-tool-only-assistant-content-null.md
+++ b/.changeset/fix-tool-only-assistant-content-null.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/xai': patch
+'@ai-sdk/deepseek': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/mistral': patch
+---
+
+Send `null` content (instead of empty string) for tool-only assistant messages — fixes strict API validation errors from xAI, DeepSeek, Groq, and Mistral when an assistant turn contains only tool calls.

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
@@ -131,7 +131,7 @@ describe('convertToDeepSeekChatMessages', () => {
         {
           "messages": [
             {
-              "content": "",
+              "content": null,
               "reasoning_content": undefined,
               "role": "assistant",
               "tool_calls": [
@@ -190,7 +190,7 @@ describe('convertToDeepSeekChatMessages', () => {
         {
           "messages": [
             {
-              "content": "",
+              "content": null,
               "reasoning_content": undefined,
               "role": "assistant",
               "tool_calls": [
@@ -261,7 +261,7 @@ describe('convertToDeepSeekChatMessages', () => {
               "role": "user",
             },
             {
-              "content": "",
+              "content": null,
               "reasoning_content": "I think the tool will return the correct value.",
               "role": "assistant",
               "tool_calls": [
@@ -336,7 +336,7 @@ describe('convertToDeepSeekChatMessages', () => {
               "role": "user",
             },
             {
-              "content": "",
+              "content": null,
               "reasoning_content": undefined,
               "role": "assistant",
               "tool_calls": [
@@ -421,7 +421,7 @@ describe('convertToDeepSeekChatMessages', () => {
               "role": "user",
             },
             {
-              "content": "",
+              "content": null,
               "reasoning_content": "I think the tool will return the correct value.",
               "role": "assistant",
               "tool_calls": [

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -129,7 +129,7 @@ export function convertToDeepSeekChatMessages({
         // string when the source message had no reasoning part at all.
         messages.push({
           role: 'assistant',
-          content: text,
+          content: toolCalls.length > 0 ? text || null : text,
           reasoning_content: reasoning ?? (isDeepSeekV4 ? '' : undefined),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/groq/src/convert-to-groq-chat-messages.test.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.test.ts
@@ -123,7 +123,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "role": "assistant",
           "tool_calls": [
             {
@@ -167,7 +167,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "reasoning": "I think the tool will return the correct value.",
           "role": "assistant",
           "tool_calls": [

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -112,7 +112,7 @@ export function convertToGroqChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: toolCalls.length > 0 ? text || null : text,
           ...(reasoning.length > 0 ? { reasoning } : null),
           ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : null),
         });

--- a/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
@@ -163,7 +163,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -216,7 +216,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -279,7 +279,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -332,7 +332,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [

--- a/packages/mistral/src/convert-to-mistral-chat-messages.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.ts
@@ -138,7 +138,7 @@ export function convertToMistralChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: toolCalls.length > 0 ? text || null : text,
           prefix: isLastMessage ? true : undefined,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/mistral/src/mistral-chat-prompt.ts
+++ b/packages/mistral/src/mistral-chat-prompt.ts
@@ -23,7 +23,7 @@ export type MistralUserMessageContent =
 
 export interface MistralAssistantMessage {
   role: 'assistant';
-  content: string;
+  content: string | null;
   prefix?: boolean;
   tool_calls?: Array<{
     id: string;

--- a/packages/xai/src/convert-to-xai-chat-messages.test.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.test.ts
@@ -225,7 +225,7 @@ describe('convertToXaiChatMessages', () => {
     expect(messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call_123',
@@ -270,7 +270,7 @@ describe('convertToXaiChatMessages', () => {
     expect(messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call_123',

--- a/packages/xai/src/convert-to-xai-chat-messages.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.ts
@@ -113,7 +113,7 @@ export function convertToXaiChatMessages(prompt: LanguageModelV4Prompt): {
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: toolCalls.length > 0 ? text || null : text,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 

--- a/packages/xai/src/xai-chat-prompt.ts
+++ b/packages/xai/src/xai-chat-prompt.ts
@@ -23,7 +23,7 @@ export type XaiUserMessageContent =
 
 export interface XaiAssistantMessage {
   role: 'assistant';
-  content: string;
+  content: string | null;
   tool_calls?: Array<{
     id: string;
     type: 'function';


### PR DESCRIPTION
## Background

xAI, DeepSeek, Groq, and Mistral strictly validate the \`content\` field on assistant messages. When an assistant turn contains only tool calls (no text), their message converters were setting \`content: ''\` (empty string). Several of these APIs reject an empty string and expect \`null\` or the field to be omitted.

## Summary

In each converter, set \`content: null\` when there are tool calls and no text content, matching the behavior of the OpenAI converter and the expectations of these providers.

## Manual Verification

Verified by inspecting serialized messages in unit tests: tool-only assistant turns now carry \`content: null\`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run \`pnpm changeset\` in the project root)
- [x] I have reviewed this pull request (self-review)