### PR TITLE
fix(ai): preserve providerMetadata on all smoothStream word-boundary chunks

### DIFF
--- a/.changeset/fix-smooth-stream-preserve-provider-metadata.md
+++ b/.changeset/fix-smooth-stream-preserve-provider-metadata.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Preserve `providerMetadata` on every chunk emitted by `smoothStream` — previously only the first chunk of a word-boundary burst carried the metadata (e.g. Anthropic thinking signatures), causing downstream consumers to lose it.

--- a/packages/ai/src/generate-text/smooth-stream.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test.ts
@@ -1577,6 +1577,44 @@ describe('smoothStream', () => {
         anthropic: { redactedData: 'redacted-thinking-data' },
       });
     });
+
+    it('should preserve providerMetadata on all word-boundary chunks emitted from the while loop', async () => {
+      // When smoothStream detects word boundaries, it emits multiple chunks
+      // from the while loop. Each of those must carry the providerMetadata
+      // from the original delta — not just the final flushed remainder.
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'reasoning-start', id: '1' },
+        {
+          text: 'one two three ',
+          type: 'reasoning-delta',
+          id: '1',
+          providerMetadata: {
+            anthropic: { signature: 'sig_xyz' },
+          },
+        },
+        { type: 'reasoning-end', id: '1' },
+      ]).pipeThrough(
+        smoothStream({
+          chunking: 'word',
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      const reasoningDeltas = events.filter(
+        (e: any) => e.type === 'reasoning-delta',
+      );
+
+      // All three word chunks should carry providerMetadata
+      expect(reasoningDeltas.length).toBeGreaterThanOrEqual(3);
+      for (const chunk of reasoningDeltas) {
+        expect(chunk.providerMetadata).toEqual({
+          anthropic: { signature: 'sig_xyz' },
+        });
+      }
+    });
   });
 
   describe('Intl.Segmenter chunking', () => {

--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -152,7 +152,12 @@ export function smoothStream<TOOLS extends ToolSet>({
         let match;
 
         while ((match = detectChunk(buffer)) != null) {
-          controller.enqueue({ type, text: match, id });
+          controller.enqueue({
+            type,
+            text: match,
+            id,
+            ...(providerMetadata != null ? { providerMetadata } : {}),
+          });
           buffer = buffer.slice(match.length);
 
           await delay(delayInMs);


### PR DESCRIPTION
## Background

\`smoothStream\` buffers text and emits multiple chunks from a single input chunk when a word boundary is detected (the \`while\` loop). The \`providerMetadata\` from the input chunk (e.g. Anthropic thinking signatures) was only forwarded on the first chunk — subsequent chunks emitted from the same burst lost the metadata entirely.

## Summary

Spread \`providerMetadata\` onto every chunk emitted inside the \`while\` loop, not just the first. Chunks without metadata are unaffected (the spread is conditional on \`providerMetadata != null\`).

## Manual Verification

Verified via unit test: all three word-boundary chunks emitted from a single input carry the original \`providerMetadata\`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run \`pnpm changeset\` in the project root)
- [x] I have reviewed this pull request (self-review)