### PR TITLE
fix(ai): make input optional on input-streaming UIMessagePart variants

### DIFF
--- a/.changeset/fix-ui-messages-exact-optional-property-types.md
+++ b/.changeset/fix-ui-messages-exact-optional-property-types.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Mark `input` as optional (`input?`) on input-streaming `UIToolInvocation` and `DynamicToolUIPart` variants — aligns TypeScript types with the Zod runtime schema and fixes errors under `exactOptionalPropertyTypes: true`.

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -289,7 +289,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
 } & (
   | {
       state: 'input-streaming';
-      input: DeepPartial<asUITool<TOOL>['input']> | undefined;
+      input?: DeepPartial<asUITool<TOOL>['input']> | undefined;
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;
@@ -401,7 +401,7 @@ export type DynamicToolUIPart = {
 } & (
   | {
       state: 'input-streaming';
-      input: unknown | undefined;
+      input?: unknown;
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;


### PR DESCRIPTION
## Background

Under \`exactOptionalPropertyTypes: true\` (strict TypeScript mode), \`input: T | undefined\` and \`input?: T\` are not equivalent — the former requires the key to be present (even if \`undefined\`), while the latter allows it to be absent entirely. The input-streaming variants of \`UIToolInvocation\` and \`DynamicToolUIPart\` used the former, causing type errors when constructing these objects without an \`input\` key.

Fixes #14703.

## Summary

Change \`input: DeepPartial<...> | undefined\` to \`input?: DeepPartial<...>\` and \`input: unknown | undefined\` to \`input?: unknown\` on the streaming variants. The Zod runtime schema in \`validate-ui-messages.ts\` already used \`z.unknown().optional()\`, so this aligns the TypeScript types with the runtime validator.

## Manual Verification

The fix is purely a type-level change with no runtime behaviour difference. Verified by confirming the Zod schema already matches the corrected types.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run \`pnpm changeset\` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14703