### PR TITLE
fix(mcp): use negotiated protocol version in mcp-protocol-version header

### DIFF
--- a/.changeset/fix-mcp-use-negotiated-protocol-version.md
+++ b/.changeset/fix-mcp-use-negotiated-protocol-version.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+Use the server-negotiated protocol version in the `mcp-protocol-version` header for all subsequent requests — previously the SDK always sent `LATEST_PROTOCOL_VERSION`, causing handshake mismatches with servers that negotiate an older version (e.g. Figma MCP).

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -306,6 +306,10 @@ class DefaultMCPClient implements MCPClient {
       this._serverInfo = result.serverInfo;
       this._serverInstructions = result.instructions;
 
+      // Store the negotiated version so subsequent requests use the correct
+      // mcp-protocol-version header (spec: SHOULD reflect negotiated version).
+      this.transport.setNegotiatedProtocolVersion?.(result.protocolVersion);
+
       // Complete initialization handshake:
       await this.notification({
         method: 'notifications/initialized',

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -482,4 +482,65 @@ describe('HttpMCPTransport', () => {
       );
     });
   });
+
+  describe('setNegotiatedProtocolVersion', () => {
+    it('should use the negotiated protocol version in subsequent requests', async () => {
+      const negotiatedVersion = '2025-06-18';
+
+      server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+        switch (callNumber) {
+          case 0:
+            // GET SSE returns 405 (server doesn't support inbound SSE)
+            return { type: 'error', status: 405 };
+          default:
+            return {
+              type: 'json-value',
+              body: { jsonrpc: '2.0', id: 1, result: { ok: true } },
+            };
+        }
+      };
+
+      await transport.start();
+      transport.setNegotiatedProtocolVersion(negotiatedVersion);
+
+      await transport.send({
+        jsonrpc: '2.0' as const,
+        method: 'notifications/initialized',
+        params: {},
+      });
+
+      const postCall = server.calls.find(c => c.requestMethod === 'POST');
+      expect(postCall?.requestHeaders['mcp-protocol-version']).toBe(
+        negotiatedVersion,
+      );
+    });
+
+    it('should use LATEST_PROTOCOL_VERSION before negotiation', async () => {
+      server.urls['http://localhost:4000/mcp'].response = ({ callNumber }) => {
+        switch (callNumber) {
+          case 0:
+            return { type: 'error', status: 405 };
+          default:
+            return {
+              type: 'json-value',
+              body: { jsonrpc: '2.0', id: 1, result: { ok: true } },
+            };
+        }
+      };
+
+      await transport.start();
+
+      await transport.send({
+        jsonrpc: '2.0' as const,
+        method: 'initialize',
+        id: 1,
+        params: {},
+      });
+
+      const postCall = server.calls.find(c => c.requestMethod === 'POST');
+      expect(postCall?.requestHeaders['mcp-protocol-version']).toBe(
+        LATEST_PROTOCOL_VERSION,
+      );
+    });
+  });
 });

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -38,6 +38,9 @@ export class HttpMCPTransport implements MCPTransport {
   private redirectMode: RequestRedirect;
   private fetchFn: FetchFunction;
 
+  // Protocol version negotiated during initialize handshake (MCP spec §4.1.1)
+  private negotiatedProtocolVersion?: string;
+
   // Inbound SSE resumption and reconnection state
   private lastInboundEventId?: string;
   private inboundReconnectAttempts = 0;
@@ -78,7 +81,8 @@ export class HttpMCPTransport implements MCPTransport {
     const headers: Record<string, string> = {
       ...this.headers,
       ...base,
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version':
+        this.negotiatedProtocolVersion ?? LATEST_PROTOCOL_VERSION,
     };
 
     if (this.sessionId) {
@@ -97,6 +101,10 @@ export class HttpMCPTransport implements MCPTransport {
       `ai-sdk/${VERSION}`,
       getRuntimeEnvironmentUserAgent(),
     );
+  }
+
+  setNegotiatedProtocolVersion(version: string): void {
+    this.negotiatedProtocolVersion = version;
   }
 
   async start(): Promise<void> {

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -29,6 +29,7 @@ export class SseMCPTransport implements MCPTransport {
   private resourceMetadataUrl?: URL;
   private redirectMode: RequestRedirect;
   private fetchFn: FetchFunction;
+  private negotiatedProtocolVersion?: string;
 
   onclose?: () => void;
   onerror?: (error: unknown) => void;
@@ -60,7 +61,8 @@ export class SseMCPTransport implements MCPTransport {
     const headers: Record<string, string> = {
       ...this.headers,
       ...base,
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version':
+        this.negotiatedProtocolVersion ?? LATEST_PROTOCOL_VERSION,
     };
 
     if (this.authProvider) {
@@ -75,6 +77,10 @@ export class SseMCPTransport implements MCPTransport {
       `ai-sdk/${VERSION}`,
       getRuntimeEnvironmentUserAgent(),
     );
+  }
+
+  setNegotiatedProtocolVersion(version: string): void {
+    this.negotiatedProtocolVersion = version;
   }
 
   async start(): Promise<void> {

--- a/packages/mcp/src/tool/mcp-transport.ts
+++ b/packages/mcp/src/tool/mcp-transport.ts
@@ -27,6 +27,15 @@ export interface MCPTransport {
   close(): Promise<void>;
 
   /**
+   * Called by the client after a successful initialize handshake to store the
+   * protocol version that the server actually negotiated. HTTP/SSE transports
+   * use this value for the `mcp-protocol-version` header on subsequent requests
+   * so they conform to the MCP spec (the header SHOULD reflect the negotiated
+   * version, not always the client's latest).
+   */
+  setNegotiatedProtocolVersion?(version: string): void;
+
+  /**
    * Event handler for transport closure
    */
   onclose?: () => void;


### PR DESCRIPTION
## Background

During the MCP \`initialize\` handshake the server responds with the protocol version it has negotiated. The SDK stored this value but continued to send \`LATEST_PROTOCOL_VERSION\` in the \`mcp-protocol-version\` header for all subsequent requests. Servers that negotiate an older version (such as Figma MCP on \`2024-11-05\`) see a mismatched header and reject requests — breaking the connection entirely.

Fixes #14413.

## Summary

Add an optional \`setNegotiatedProtocolVersion(version: string)\` method to the \`MCPTransport\` interface and implement it on both \`HttpMCPTransport\` and \`SseMCPTransport\`. After the initialize handshake, \`MCPClient\` calls this method with the server's negotiated version. Subsequent requests use that version in the header instead of the SDK's latest.

Custom transports that don't implement the method are unaffected (the call is optional-chained).

## Manual Verification

Verified via two new unit tests on \`HttpMCPTransport\`: one confirms the negotiated version is used in POST headers after calling \`setNegotiatedProtocolVersion\`, the other confirms \`LATEST_PROTOCOL_VERSION\` is still used as a fallback when the method has not been called.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run \`pnpm changeset\` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14413