### PR TITLE
feat(tools-registry): add Nitrosend

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -551,4 +551,37 @@ console.log(text);`,
     websiteUrl: 'https://you.com',
     npmUrl: 'https://www.npmjs.com/package/@youdotcom-oss/ai-sdk-plugin',
   },
+  {
+    slug: 'nitrosend',
+    name: 'Nitrosend',
+    description:
+      'Nitrosend tools for Vercel AI SDK agents — send email and SMS, manage contacts and segments, build flows, run campaigns. Backed by the Nitrosend remote MCP server.',
+    packageName: '@nitrosend/ai-sdk',
+    tags: ['email', 'sms', 'marketing', 'mcp', 'automation', 'crm'],
+    apiKeyEnvName: 'NITROSEND_API_KEY',
+    installCommand: {
+      pnpm: 'pnpm add @nitrosend/ai-sdk ai @ai-sdk/mcp zod @ai-sdk/openai',
+      npm: 'npm install @nitrosend/ai-sdk ai @ai-sdk/mcp zod @ai-sdk/openai',
+      yarn: 'yarn add @nitrosend/ai-sdk ai @ai-sdk/mcp zod @ai-sdk/openai',
+      bun: 'bun add @nitrosend/ai-sdk ai @ai-sdk/mcp zod @ai-sdk/openai',
+    },
+    codeExample: `import { generateText, stepCountIs } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { withNitrosendTools } from '@nitrosend/ai-sdk';
+
+const result = await withNitrosendTools({}, async ({ tools }) => {
+  return generateText({
+    model: openai('gpt-4o'),
+    tools,
+    stopWhen: stepCountIs(5),
+    prompt: 'Send a welcome email to founder@acme.com from our team.',
+  });
+});
+
+console.log(result.text);`,
+    docsUrl: 'https://docs.nitrosend.com/integrations/vercel-ai-sdk',
+    apiKeyUrl: 'https://app.nitrosend.com/settings/api-keys',
+    websiteUrl: 'https://nitrosend.com',
+    npmUrl: 'https://www.npmjs.com/package/@nitrosend/ai-sdk',
+  },
 ];

--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -565,7 +565,7 @@ console.log(text);`,
       yarn: 'yarn add @nitrosend/ai-sdk ai @ai-sdk/mcp zod @ai-sdk/openai',
       bun: 'bun add @nitrosend/ai-sdk ai @ai-sdk/mcp zod @ai-sdk/openai',
     },
-    codeExample: `import { generateText, stepCountIs } from 'ai';
+    codeExample: `import { generateText, isStepCount } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { withNitrosendTools } from '@nitrosend/ai-sdk';
 
@@ -573,7 +573,7 @@ const result = await withNitrosendTools({}, async ({ tools }) => {
   return generateText({
     model: openai('gpt-4o'),
     tools,
-    stopWhen: stepCountIs(5),
+    stopWhen: isStepCount(5),
     prompt: 'Send a welcome email to founder@acme.com from our team.',
   });
 });


### PR DESCRIPTION
Adds Nitrosend to the AI SDK Tools Registry.

## Summary

- **Package**: [`@nitrosend/ai-sdk`](https://www.npmjs.com/package/@nitrosend/ai-sdk) — published v0.1.0
- **Source**: https://github.com/nitrosend/ai-sdk
- **Docs**: https://docs.nitrosend.com/integrations/vercel-ai-sdk

Nitrosend is a multi-channel marketing platform (email, SMS, flows, campaigns). `@nitrosend/ai-sdk` wraps Nitrosend's remote MCP server as Vercel AI SDK tools so agents can send email, manage contacts, build automation flows, and run campaigns from `generateText` / `streamText` / agent loops.

## Positioning

This is a tool surface, not a model provider. The package wraps `@ai-sdk/mcp` defaults, generates typed Zod schemas from the Nitrosend MCP manifest, and exposes a small typed API (`nitrosend`, `withNitrosendTools`, `pickNitrosendToolSchemas`).

## Verification

- [x] `@nitrosend/ai-sdk@0.1.0` is publicly installable on npm
- [x] All required `Tool` interface fields populated (slug, name, description, packageName, tags, apiKeyEnvName, installCommand, codeExample, docsUrl, apiKeyUrl, websiteUrl, npmUrl)
- [x] Code example imports from `ai` and `@nitrosend/ai-sdk` only; uses `stopWhen: stepCountIs(N)` so the model can take a follow-up step after a tool call
- [x] Code example uses `withNitrosendTools` to guarantee the MCP transport closes in a `finally` block
- [x] `installCommand` provided for pnpm / npm / yarn / bun
- [x] No claims of Vercel Marketplace availability (separate listing track)

## Notes for reviewers

The package wraps a remote MCP server, so the toolset is async-loaded behind a lifecycle helper rather than synchronous-factory style like `webSearch()` / `executeCode()`. This is intentional — MCP tool discovery happens at runtime against the live server, which keeps the registry submission decoupled from server-side schema changes.