### PR TITLE
chore: add .pnpm-store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .env
 .envrc
 .next
+.pnpm-store
 .turbo
 .well-known
 .workflow-vitest


### PR DESCRIPTION
## Background

pnpm 10 stores transient files in `.pnpm-store`. This adds many unwanted files to git changes.

## Summary

Add `.pnpm-store` to `.gitignore`