### PR TITLE
feat(ai): add experimental_refineToolInput option to ToolLoopAgent, generateText, streamText

### DIFF
--- a/.changeset/nine-insects-double.md
+++ b/.changeset/nine-insects-double.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): add experimental_refineToolInput option to ToolLoopAgent, generateText, streamText

--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -166,6 +166,48 @@ The AI SDK supports the following schemas:
   setting.
 </Note>
 
+## Refining Tool Inputs
+
+Different LLM providers can generate slightly different tool inputs for the same
+tool input type. For example, one provider might produce `null` for an optional
+field while another produces an empty string.
+
+When you do not own the tool, such as with tools from a third-party package, you
+may not be able to change the tool's `inputSchema` to accept both shapes. In
+these cases, you can use the experimental `experimental_refineToolInput` option
+to normalize a parsed tool input before it is executed and before it appears in
+outputs, lifecycle callbacks, and telemetry.
+
+```ts
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+const result = await generateText({
+  model: 'openai/gpt-5-mini',
+  tools: {
+    search: tool({
+      inputSchema: z.object({
+        query: z.string(),
+        category: z.string().nullable(),
+      }),
+      execute: async ({ query, category }) => {
+        return search({ query, category });
+      },
+    }),
+  },
+  experimental_refineToolInput: {
+    search: input => ({
+      ...input,
+      category: input.category === '' ? null : input.category,
+    }),
+  },
+  prompt: 'Search for ski jackets with no category.',
+});
+```
+
+Refinement functions are typed per tool. Each function receives the typed input
+for its tool and must return an input with the same type shape.
+
 ## Tool Packages
 
 Given tools are JavaScript objects, they can be packaged and distributed through npm like any other library. This makes it easy to share reusable tools across projects and with the community.

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -572,6 +572,13 @@ To see `generateText` in action, check out [these examples](#examples).
         "Approval configuration for this call. Pass a `GenericToolApprovalFunction` to handle all tool calls in one callback with `toolCall`, `tools`, `toolsContext`, `messages`, and `runtimeContext`, or pass a per-tool object where each key can be a status (`'not-applicable'`, `'approved'`, `'denied'`, or `'user-approval'`), an object form such as `{ type: 'denied', reason: 'blocked by policy' }`, or a `SingleToolApprovalFunction` that receives the tool input and options `toolCallId`, `messages`, `toolContext`, and `runtimeContext` (same shape as tool execution options without `abortSignal`, with `context` renamed to `toolContext`). The `RUNTIME_CONTEXT` type parameter matches the call's `runtimeContext`. A `GenericToolApprovalFunction` or `SingleToolApprovalFunction` may return `undefined` for the same effect as `'not-applicable'`. `'not-applicable'` is the default execution path and runs the tool without approval metadata. Use `'approved'`, `'denied'`, or their object forms when you want explicit automatic approval request/response parts in the output. Automatic approvals and denials can include a `reason`, which is forwarded to the emitted approval response. This setting takes precedence over a tool's `needsApproval` default.",
     },
     {
+      name: 'experimental_refineToolInput',
+      type: 'ToolInputRefinement<TOOLS>',
+      isOptional: true,
+      description:
+        'Optional mapping of tool names to functions that refine parsed tool inputs. Each function receives the typed input for its tool and must return the same input type shape. The refined input is used for tool execution, output parts, lifecycle callbacks, and telemetry.',
+    },
+    {
       name: 'stopWhen',
       type: 'StopCondition<TOOLS> | Array<StopCondition<TOOLS>>',
       isOptional: true,

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -616,6 +616,13 @@ To see `streamText` in action, check out [these examples](#examples).
         "Approval configuration for this call. Pass a `GenericToolApprovalFunction` to handle all tool calls in one callback with `toolCall`, `tools`, `toolsContext`, `messages`, and `runtimeContext`, or pass a per-tool object where each key can be a status (`'not-applicable'`, `'approved'`, `'denied'`, or `'user-approval'`), an object form such as `{ type: 'denied', reason: 'blocked by policy' }`, or a `SingleToolApprovalFunction` that receives the tool input and options `toolCallId`, `messages`, `toolContext`, and `runtimeContext` (same shape as tool execution options without `abortSignal`, with `context` renamed to `toolContext`). The `RUNTIME_CONTEXT` type parameter matches the call's `runtimeContext`. A `GenericToolApprovalFunction` or `SingleToolApprovalFunction` may return `undefined` for the same effect as `'not-applicable'`. `'not-applicable'` is the default execution path and runs the tool without approval metadata. Use `'approved'`, `'denied'`, or their object forms when you want explicit automatic approval request/response parts in the output. Automatic approvals and denials can include a `reason`, which is forwarded to the emitted approval response. This setting takes precedence over a tool's `needsApproval` default.",
     },
     {
+      name: 'experimental_refineToolInput',
+      type: 'ToolInputRefinement<TOOLS>',
+      isOptional: true,
+      description:
+        'Optional mapping of tool names to functions that refine parsed tool inputs. Each function receives the typed input for its tool and must return the same input type shape. The refined input is used for tool execution, stream parts, lifecycle callbacks, and telemetry.',
+    },
+    {
       name: 'stopWhen',
       type: 'StopCondition<TOOLS> | Array<StopCondition<TOOLS>>',
       isOptional: true,

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -117,6 +117,13 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
         'Optional callback to attempt automatic recovery when a tool call cannot be parsed.',
     },
     {
+      name: 'experimental_refineToolInput',
+      type: 'ToolInputRefinement<TOOLS>',
+      isOptional: true,
+      description:
+        'Optional mapping of tool names to functions that refine parsed tool inputs. Each function receives the typed input for its tool and must return the same input type shape. The refined input is used for tool execution, output parts, lifecycle callbacks, and telemetry in both `generate()` and `stream()`.',
+    },
+    {
       name: 'experimental_onStart',
       type: 'GenerateTextOnStartCallback',
       isOptional: true,

--- a/examples/ai-functions/src/agent/openai/generate-refine-tool-input.ts
+++ b/examples/ai-functions/src/agent/openai/generate-refine-tool-input.ts
@@ -1,0 +1,35 @@
+import { openai } from '@ai-sdk/openai';
+import { isStepCount, tool, ToolLoopAgent } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+const agent = new ToolLoopAgent({
+  model: openai('gpt-5-mini'),
+  instructions:
+    'Use the weather tool when a user asks about weather. Then summarize the result.',
+  stopWhen: isStepCount(2),
+  tools: {
+    weather: tool({
+      description: 'Get the weather for a city.',
+      inputSchema: z.object({
+        city: z.string(),
+      }),
+      execute: async ({ city }) => {
+        return { city, weather: 'sunny' };
+      },
+    }),
+  },
+  experimental_refineToolInput: {
+    weather: input => ({
+      city: input.city.trim().toLowerCase(),
+    }),
+  },
+});
+
+run(async () => {
+  const result = await agent.generate({
+    prompt: 'What is the weather in "  San Francisco  "?',
+  });
+
+  console.log(JSON.stringify(result.steps, null, 2));
+});

--- a/examples/ai-functions/src/generate-text/openai/refine-tool-input.ts
+++ b/examples/ai-functions/src/generate-text/openai/refine-tool-input.ts
@@ -1,0 +1,31 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: openai('gpt-5-mini'),
+    toolChoice: { type: 'tool', toolName: 'weather' },
+    tools: {
+      weather: tool({
+        description: 'Get the weather for a city.',
+        inputSchema: z.object({
+          city: z.string(),
+        }),
+        execute: async ({ city }) => {
+          return { city, weather: 'sunny' };
+        },
+      }),
+    },
+    experimental_refineToolInput: {
+      weather: input => ({
+        city: input.city.trim().toLowerCase(),
+      }),
+    },
+    prompt: 'Get the weather for "  San Francisco  ".',
+  });
+
+  console.log(JSON.stringify(result.toolCalls, null, 2));
+  console.log(JSON.stringify(result.toolResults, null, 2));
+});

--- a/examples/ai-functions/src/stream-text/openai/refine-tool-input.ts
+++ b/examples/ai-functions/src/stream-text/openai/refine-tool-input.ts
@@ -1,0 +1,31 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+import { printFullStream } from '../../lib/print-full-stream';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: openai('gpt-5-mini'),
+    toolChoice: { type: 'tool', toolName: 'weather' },
+    tools: {
+      weather: tool({
+        description: 'Get the weather for a city.',
+        inputSchema: z.object({
+          city: z.string(),
+        }),
+        execute: async ({ city }) => {
+          return { city, weather: 'sunny' };
+        },
+      }),
+    },
+    experimental_refineToolInput: {
+      weather: input => ({
+        city: input.city.trim().toLowerCase(),
+      }),
+    },
+    prompt: 'Get the weather for "  San Francisco  ".',
+  });
+
+  await printFullStream({ result });
+});

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -9,13 +9,13 @@ import type {
   SystemModelMessage,
   ToolSet,
 } from '@ai-sdk/provider-utils';
+import type { ActiveTools } from '../generate-text/active-tools';
 import type {
   GenerateTextOnFinishCallback,
   GenerateTextOnStartCallback,
   GenerateTextOnStepFinishCallback,
   GenerateTextOnStepStartCallback,
 } from '../generate-text/generate-text-events';
-import type { ActiveTools } from '../generate-text/active-tools';
 import type { Output } from '../generate-text/output';
 import type { PrepareStepFunction } from '../generate-text/prepare-step';
 import type { StopCondition } from '../generate-text/stop-condition';
@@ -25,6 +25,7 @@ import type {
   OnToolExecutionEndCallback,
   OnToolExecutionStartCallback,
 } from '../generate-text/tool-execution-events';
+import type { ToolInputRefinement } from '../generate-text/tool-input-refinement';
 import type { ToolsContextParameter } from '../generate-text/tools-context-parameter';
 import type { LanguageModelCallOptions } from '../prompt/language-model-call-options';
 import type { Prompt } from '../prompt/prompt';
@@ -120,6 +121,14 @@ export type ToolLoopAgentSettings<
      * A function that attempts to repair a tool call that failed to parse.
      */
     experimental_repairToolCall?: ToolCallRepairFunction<NoInfer<TOOLS>>;
+
+    /**
+     * Optional mapping of tool names to functions that refine parsed tool inputs.
+     *
+     * The refined input must have the same type shape as the tool input. Refined
+     * inputs are used for tool execution, outputs, callbacks, and telemetry.
+     */
+    experimental_refineToolInput?: ToolInputRefinement<NoInfer<TOOLS>>;
 
     /**
      * Callback that is called when the agent operation begins, before any LLM calls.
@@ -236,6 +245,7 @@ export type ToolLoopAgentSettings<
           | 'toolApproval'
           | 'providerOptions'
           | 'experimental_download'
+          | 'experimental_refineToolInput'
           | 'runtimeContext'
           | '_internal'
         > & { toolsContext: InferToolSetContext<TOOLS> },
@@ -266,6 +276,7 @@ export type ToolLoopAgentSettings<
         | 'toolApproval'
         | 'providerOptions'
         | 'experimental_download'
+        | 'experimental_refineToolInput'
         | 'runtimeContext'
         | '_internal'
       > &

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -5,6 +5,7 @@ import {
   Output,
   type GenerateTextOnFinishCallback,
   type ToolApprovalConfiguration,
+  type ToolInputRefinement,
 } from '../generate-text';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
 import type { AsyncIterableStream } from '../util/async-iterable-stream';
@@ -110,9 +111,18 @@ describe('ToolLoopAgent', () => {
             return 'user-approval';
           },
         },
+        experimental_refineToolInput: {
+          testTool: input => {
+            expectTypeOf(input).toEqualTypeOf<{ value: string }>();
+            return { value: input.value.trim() };
+          },
+        },
         prepareCall: options => {
           expectTypeOf(options.toolApproval).toEqualTypeOf<
             ToolApprovalConfiguration<typeof tools, Context> | undefined
+          >();
+          expectTypeOf(options.experimental_refineToolInput).toEqualTypeOf<
+            ToolInputRefinement<typeof tools> | undefined
           >();
 
           return {

--- a/packages/ai/src/generate-text/generate-text.test-d.ts
+++ b/packages/ai/src/generate-text/generate-text.test-d.ts
@@ -105,6 +105,55 @@ describe('generateText types', () => {
     }),
   };
 
+  describe('experimental_refineToolInput', () => {
+    it('should infer input and return types for each tool', async () => {
+      generateText({
+        model: new MockLanguageModelV4(),
+        prompt: 'Hello',
+        tools: mixedTools,
+        toolsContext: { weather: { weatherApiKey: 'key' } },
+        experimental_refineToolInput: {
+          weather: input => {
+            expectTypeOf(input).toEqualTypeOf<{ location: string }>();
+            return { location: input.location.trim() };
+          },
+          calculator: input => {
+            expectTypeOf(input).toEqualTypeOf<{ expression: string }>();
+            return { expression: input.expression.trim() };
+          },
+        },
+      });
+    });
+
+    it('should reject refinements that return a different shape', async () => {
+      generateText({
+        model: new MockLanguageModelV4(),
+        prompt: 'Hello',
+        tools: mixedTools,
+        toolsContext: { weather: { weatherApiKey: 'key' } },
+        experimental_refineToolInput: {
+          // @ts-expect-error refinement must return the same tool input type
+          weather: _input => ({
+            location: 123,
+          }),
+        },
+      });
+    });
+
+    it('should reject refinements for unknown tools', async () => {
+      generateText({
+        model: new MockLanguageModelV4(),
+        prompt: 'Hello',
+        tools: mixedTools,
+        toolsContext: { weather: { weatherApiKey: 'key' } },
+        experimental_refineToolInput: {
+          // @ts-expect-error unknown tool names are not accepted
+          unknown: input => input,
+        },
+      });
+    });
+  });
+
   describe('runtimeContext', () => {
     it('should accept no runtimeContext', async () => {
       generateText({

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -591,6 +591,58 @@ describe('generateText', () => {
         ]
       `);
     });
+
+    it('should refine tool input before tool execution, outputs, and callbacks', async () => {
+      const modelCallEndEvents: LanguageModelCallEndEvent<any>[] = [];
+      const toolExecutionStartEvents: ToolExecutionStartEvent<any>[] = [];
+
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            content: [
+              {
+                type: 'tool-call',
+                toolCallType: 'function',
+                toolCallId: 'call-1',
+                toolName: 'tool1',
+                input: `{ "value": " raw " }`,
+              },
+            ],
+            finishReason: { unified: 'tool-calls', raw: undefined },
+          }),
+        }),
+        tools: {
+          tool1: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async input => {
+              expect(input).toStrictEqual({ value: 'raw' });
+              return `result:${input.value}`;
+            },
+          }),
+        },
+        experimental_refineToolInput: {
+          tool1: input => ({ value: input.value.trim() }),
+        },
+        experimental_onLanguageModelCallEnd: event => {
+          modelCallEndEvents.push(event);
+        },
+        experimental_onToolExecutionStart: event => {
+          toolExecutionStartEvents.push(event);
+        },
+        prompt: 'test-input',
+      });
+
+      expect(result.toolCalls[0].input).toStrictEqual({ value: 'raw' });
+      expect(result.toolResults[0].input).toStrictEqual({ value: 'raw' });
+      expect(modelCallEndEvents[0].content[0]).toMatchObject({
+        type: 'tool-call',
+        input: { value: 'raw' },
+      });
+      expect(toolExecutionStartEvents[0].toolCall.input).toStrictEqual({
+        value: 'raw',
+      });
+    });
   });
 
   describe('result.toolResults', () => {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -10,10 +10,10 @@ import {
   withUserAgentSuffix,
   type Arrayable,
   type Context,
-  type InferToolSetContext,
-  type ToolSet,
   type IdGenerator,
+  type InferToolSetContext,
   type ProviderOptions,
+  type ToolSet,
 } from '@ai-sdk/provider-utils';
 import { NoOutputGeneratedError } from '../error';
 import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
@@ -76,9 +76,9 @@ import type { InferCompleteOutput } from './output-utils';
 import { parseToolCall } from './parse-tool-call';
 import type { PrepareStepFunction } from './prepare-step';
 import { convertToReasoningOutputs } from './reasoning-output';
-import { createRestrictedTelemetryDispatcher } from './restricted-telemetry-dispatcher';
 import { resolveToolApproval } from './resolve-tool-approval';
 import type { ResponseMessage } from './response-message';
+import { createRestrictedTelemetryDispatcher } from './restricted-telemetry-dispatcher';
 import { DefaultStepResult, type StepResult } from './step-result';
 import {
   isStepCount,
@@ -96,6 +96,7 @@ import type {
   OnToolExecutionEndCallback,
   OnToolExecutionStartCallback,
 } from './tool-execution-events';
+import type { ToolInputRefinement } from './tool-input-refinement';
 import type { ToolOutput } from './tool-output';
 import type { TypedToolResult } from './tool-result';
 import type { ToolsContextParameter } from './tools-context-parameter';
@@ -151,6 +152,7 @@ const originalGenerateCallId = createIdGenerator({
  * @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
  *
  * @param runtimeContext - User-defined runtime context that flows through the entire generation lifecycle.
+ * @param experimental_refineToolInput - Optional mapping of tool names to functions that refine parsed tool inputs before tools are executed and before outputs, callbacks, and telemetry are recorded.
  * @param experimental_onStart - Callback invoked when generation begins, before any LLM calls.
  * @param experimental_onStepStart - Callback invoked when each step begins, before the provider is called.
  * Receives step number, messages (in ModelMessage format), tools, and runtimeContext.
@@ -189,6 +191,7 @@ export async function generateText<
   activeTools,
   prepareStep,
   experimental_repairToolCall: repairToolCall,
+  experimental_refineToolInput: refineToolInput,
   experimental_download: download,
   runtimeContext = {} as RUNTIME_CONTEXT,
   toolsContext = {} as InferToolSetContext<TOOLS>,
@@ -287,6 +290,14 @@ export async function generateText<
      * A function that attempts to repair a tool call that failed to parse.
      */
     experimental_repairToolCall?: ToolCallRepairFunction<NoInfer<TOOLS>>;
+
+    /**
+     * Optional mapping of tool names to functions that refine parsed tool inputs.
+     *
+     * The refined input must have the same type shape as the tool input. Refined
+     * inputs are used for tool execution, outputs, callbacks, and telemetry.
+     */
+    experimental_refineToolInput?: ToolInputRefinement<NoInfer<TOOLS>>;
 
     /**
      * Callback that is called when the generateText operation begins,
@@ -701,6 +712,7 @@ export async function generateText<
                 toolCall,
                 tools,
                 repairToolCall,
+                refineToolInput,
                 system,
                 messages: stepInputMessages,
               }),

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -1,5 +1,5 @@
-export type { ContentPart } from './content-part';
 export type { ActiveTools } from './active-tools';
+export type { ContentPart } from './content-part';
 export { filterActiveTools as experimental_filterActiveTools } from './filter-active-tools';
 export { generateText } from './generate-text';
 export type {
@@ -95,6 +95,7 @@ export type {
   ToolExecutionEndEvent,
   ToolExecutionStartEvent,
 } from './tool-execution-events';
+export type { ToolInputRefinement } from './tool-input-refinement';
 export type {
   StaticToolOutputDenied,
   TypedToolOutputDenied,

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -42,6 +42,44 @@ describe('parseToolCall', () => {
     `);
   });
 
+  it('should refine input after successfully parsing a valid tool call', async () => {
+    const result = await parseToolCall({
+      toolCall: {
+        type: 'tool-call',
+        toolName: 'testTool',
+        toolCallId: '123',
+        input: '{"value": " raw "}',
+      },
+      tools: {
+        testTool: tool({
+          inputSchema: z.object({
+            value: z.string(),
+          }),
+        }),
+      } as const,
+      repairToolCall: undefined,
+      refineToolInput: {
+        testTool: input => ({ value: input.value.trim() }),
+      },
+      messages: [],
+      system: undefined,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "input": {
+          "value": "raw",
+        },
+        "providerExecuted": undefined,
+        "providerMetadata": undefined,
+        "title": undefined,
+        "toolCallId": "123",
+        "toolName": "testTool",
+        "type": "tool-call",
+      }
+    `);
+  });
+
   it('should successfully parse a valid provider-executed dynamic tool call', async () => {
     const result = await parseToolCall({
       toolCall: {

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -3,9 +3,10 @@ import {
   asSchema,
   safeParseJSON,
   safeValidateTypes,
-  type ToolSet,
+  type InferToolInput,
   type ModelMessage,
   type SystemModelMessage,
+  type ToolSet,
 } from '@ai-sdk/provider-utils';
 import { InvalidToolInputError } from '../error/invalid-tool-input-error';
 import { NoSuchToolError } from '../error/no-such-tool-error';
@@ -13,35 +14,20 @@ import { ToolCallRepairError } from '../error/tool-call-repair-error';
 import type { ProviderMetadata } from '../types';
 import type { DynamicToolCall, TypedToolCall } from './tool-call';
 import type { ToolCallRepairFunction } from './tool-call-repair-function';
-
-/**
- * Merge the tool's static `providerMetadata` (e.g. an MCP server name)
- * with the `providerMetadata` returned by the language model on the tool
- * call. Model-supplied metadata wins on conflicting top-level namespaces.
- */
-function mergeToolProviderMetadata(
-  toolMetadata: ProviderMetadata | undefined,
-  callMetadata: ProviderMetadata | undefined,
-): ProviderMetadata | undefined {
-  if (toolMetadata == null) {
-    return callMetadata;
-  }
-  if (callMetadata == null) {
-    return toolMetadata;
-  }
-  return { ...toolMetadata, ...callMetadata };
-}
+import type { ToolInputRefinement } from './tool-input-refinement';
 
 export async function parseToolCall<TOOLS extends ToolSet>({
   toolCall,
   tools,
   repairToolCall,
+  refineToolInput,
   system,
   messages,
 }: {
   toolCall: LanguageModelV4ToolCall;
   tools: TOOLS | undefined;
   repairToolCall: ToolCallRepairFunction<TOOLS> | undefined;
+  refineToolInput?: ToolInputRefinement<TOOLS> | undefined;
   system: string | SystemModelMessage | Array<SystemModelMessage> | undefined;
   messages: ModelMessage[];
 }): Promise<TypedToolCall<TOOLS>> {
@@ -49,14 +35,20 @@ export async function parseToolCall<TOOLS extends ToolSet>({
     if (tools == null) {
       // provider-executed dynamic tools are not part of our list of tools:
       if (toolCall.providerExecuted && toolCall.dynamic) {
-        return await parseProviderExecutedDynamicToolCall(toolCall);
+        return await refineParsedToolCallInput({
+          toolCall: await parseProviderExecutedDynamicToolCall(toolCall),
+          refineToolInput,
+        });
       }
 
       throw new NoSuchToolError({ toolName: toolCall.toolName });
     }
 
     try {
-      return await doParseToolCall({ toolCall, tools });
+      return await refineParsedToolCallInput({
+        toolCall: await doParseToolCall({ toolCall, tools }),
+        refineToolInput,
+      });
     } catch (error) {
       if (
         repairToolCall == null ||
@@ -94,7 +86,10 @@ export async function parseToolCall<TOOLS extends ToolSet>({
         throw error;
       }
 
-      return await doParseToolCall({ toolCall: repairedToolCall, tools });
+      return await refineParsedToolCallInput({
+        toolCall: await doParseToolCall({ toolCall: repairedToolCall, tools }),
+        refineToolInput,
+      });
     }
   } catch (error) {
     // use parsed input when possible
@@ -118,6 +113,25 @@ export async function parseToolCall<TOOLS extends ToolSet>({
       ),
     };
   }
+}
+
+async function refineParsedToolCallInput<TOOLS extends ToolSet>({
+  toolCall,
+  refineToolInput,
+}: {
+  toolCall: TypedToolCall<TOOLS>;
+  refineToolInput: ToolInputRefinement<TOOLS> | undefined;
+}): Promise<TypedToolCall<TOOLS>> {
+  const refine = refineToolInput?.[toolCall.toolName];
+
+  if (refine == null) {
+    return toolCall;
+  }
+
+  return {
+    ...toolCall,
+    input: await refine(toolCall.input as InferToolInput<TOOLS[keyof TOOLS]>),
+  } as TypedToolCall<TOOLS>;
 }
 
 async function parseProviderExecutedDynamicToolCall(
@@ -212,4 +226,22 @@ async function doParseToolCall<TOOLS extends ToolSet>({
         providerMetadata: mergedProviderMetadata,
         title: tool.title,
       };
+}
+
+/**
+ * Merge the tool's static `providerMetadata` (e.g. an MCP server name)
+ * with the `providerMetadata` returned by the language model on the tool
+ * call. Model-supplied metadata wins on conflicting top-level namespaces.
+ */
+function mergeToolProviderMetadata(
+  toolMetadata: ProviderMetadata | undefined,
+  callMetadata: ProviderMetadata | undefined,
+): ProviderMetadata | undefined {
+  if (toolMetadata == null) {
+    return callMetadata;
+  }
+  if (callMetadata == null) {
+    return toolMetadata;
+  }
+  return { ...toolMetadata, ...callMetadata };
 }

--- a/packages/ai/src/generate-text/stream-language-model-call.test.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.test.ts
@@ -17,6 +17,7 @@ import type {
 } from './language-model-events';
 import { streamLanguageModelCall } from './stream-language-model-call';
 import type { ToolCallRepairFunction } from './tool-call-repair-function';
+import type { ToolInputRefinement } from './tool-input-refinement';
 
 const testUsage: LanguageModelV4Usage = {
   inputTokens: {
@@ -36,10 +37,12 @@ async function streamLanguageModelCallResult<TOOLS extends ToolSet>({
   streamParts,
   tools,
   repairToolCall,
+  refineToolInput,
 }: {
   streamParts: LanguageModelV4StreamPart[];
   tools: TOOLS | undefined;
   repairToolCall?: ToolCallRepairFunction<TOOLS>;
+  refineToolInput?: ToolInputRefinement<TOOLS>;
 }) {
   const model = new MockLanguageModelV4({
     doStream: async () => ({
@@ -53,6 +56,7 @@ async function streamLanguageModelCallResult<TOOLS extends ToolSet>({
     prompt: 'test prompt',
     system: undefined,
     repairToolCall,
+    refineToolInput,
   });
 
   return convertReadableStreamToArray(stream);
@@ -759,6 +763,59 @@ describe('streamLanguageModelCall', () => {
   });
 
   describe('tool-call parts', () => {
+    it('should refine tool call input before emitting tool-call parts and model-call end content', async () => {
+      const tools = {
+        testTool: tool({
+          inputSchema: z.object({ value: z.string() }),
+          execute: async ({ value }) => `${value}-result`,
+        }),
+      };
+      const modelCallEndEvents: LanguageModelCallEndEvent<typeof tools>[] = [];
+
+      const { stream } = await streamLanguageModelCall({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'testTool',
+                input: '{ "value": " raw " }',
+              },
+              {
+                type: 'finish',
+                finishReason: { unified: 'tool-calls', raw: undefined },
+                usage: testUsage,
+              },
+            ]),
+          }),
+        }),
+        tools,
+        prompt: 'test prompt',
+        refineToolInput: {
+          testTool: input => ({ value: input.value.trim() }),
+        },
+        onLanguageModelCallEnd: event => {
+          modelCallEndEvents.push(event);
+        },
+      });
+
+      const result = await convertReadableStreamToArray(stream);
+
+      expect(result[0]).toMatchObject({
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'testTool',
+        input: { value: 'raw' },
+      });
+      expect(modelCallEndEvents[0].content[0]).toMatchObject({
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'testTool',
+        input: { value: 'raw' },
+      });
+    });
+
     it('should try to repair tool call when the tool name is not found', async () => {
       const tools = {
         correctTool: tool({

--- a/packages/ai/src/generate-text/stream-language-model-call.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.ts
@@ -8,16 +8,16 @@ import {
   createIdGenerator,
   type Arrayable,
   type IdGenerator,
-  type ToolSet,
   type ModelMessage,
   type ProviderOptions,
   type SystemModelMessage,
+  type ToolSet,
 } from '@ai-sdk/provider-utils';
 import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
 import { resolveLanguageModel } from '../model/resolve-model';
-import type { LanguageModelCallOptions } from '../prompt/language-model-call-options';
 import type { Prompt } from '../prompt';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
+import type { LanguageModelCallOptions } from '../prompt/language-model-call-options';
 import { prepareToolChoice } from '../prompt/prepare-tool-choice';
 import { prepareTools } from '../prompt/prepare-tools';
 import { standardizePrompt } from '../prompt/standardize-prompt';
@@ -58,6 +58,7 @@ import type {
 import type { TypedToolCall } from './tool-call';
 import type { ToolCallRepairFunction } from './tool-call-repair-function';
 import type { TypedToolError } from './tool-error';
+import type { ToolInputRefinement } from './tool-input-refinement';
 import type { TypedToolResult } from './tool-result';
 
 const originalGenerateId = createIdGenerator({
@@ -167,6 +168,7 @@ export type LanguageModelStreamPart<TOOLS extends ToolSet = ToolSet> =
  * @param includeRawChunks - Whether to include raw provider stream chunks in the model stream.
  * @param providerOptions - Additional provider-specific options.
  * @param repairToolCall - A function that can repair invalid tool calls before they are emitted.
+ * @param refineToolInput - Optional mapping of tool names to functions that refine parsed tool inputs before they are emitted, used for telemetry, or executed.
  * @param onStart - A callback that receives the fully converted prompt before the model call starts.
  *
  * @returns A stream of model call parts together with request and response metadata when available.
@@ -189,6 +191,7 @@ export async function streamLanguageModelCall<
   includeRawChunks,
   providerOptions,
   repairToolCall,
+  refineToolInput,
   callId,
   _internal: {
     generateId = originalGenerateId,
@@ -209,6 +212,7 @@ export async function streamLanguageModelCall<
   includeRawChunks?: boolean;
   providerOptions?: ProviderOptions;
   repairToolCall?: ToolCallRepairFunction<TOOLS> | undefined;
+  refineToolInput?: ToolInputRefinement<TOOLS> | undefined;
   callId?: string;
   _internal?: {
     generateId?: IdGenerator;
@@ -312,6 +316,7 @@ export async function streamLanguageModelCall<
       system: standardizedPrompt.system,
       messages: standardizedPrompt.messages,
       repairToolCall,
+      refineToolInput,
       callId: effectiveCallId,
       provider: resolvedModel.provider,
       modelId: resolvedModel.modelId,
@@ -335,6 +340,7 @@ function createLanguageModelV4StreamPartToLanguageModelStreamPartTransform<
   system,
   messages,
   repairToolCall,
+  refineToolInput,
   callId,
   provider,
   modelId,
@@ -345,6 +351,7 @@ function createLanguageModelV4StreamPartToLanguageModelStreamPartTransform<
   system: string | SystemModelMessage | Array<SystemModelMessage> | undefined;
   messages: ModelMessage[];
   repairToolCall: ToolCallRepairFunction<TOOLS> | undefined;
+  refineToolInput: ToolInputRefinement<TOOLS> | undefined;
   callId: string;
   provider: string;
   modelId: string;
@@ -503,6 +510,7 @@ function createLanguageModelV4StreamPartToLanguageModelStreamPartTransform<
               toolCall: chunk,
               tools,
               repairToolCall,
+              refineToolInput,
               system,
               messages,
             });

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -237,6 +237,55 @@ describe('streamText types', () => {
     }),
   };
 
+  describe('experimental_refineToolInput', () => {
+    it('should infer input and return types for each tool', async () => {
+      streamText({
+        model: new MockLanguageModelV4(),
+        prompt: 'Hello',
+        tools: mixedTools,
+        toolsContext: { weather: { weatherApiKey: 'key' } },
+        experimental_refineToolInput: {
+          weather: input => {
+            expectTypeOf(input).toEqualTypeOf<{ location: string }>();
+            return { location: input.location.trim() };
+          },
+          calculator: input => {
+            expectTypeOf(input).toEqualTypeOf<{ expression: string }>();
+            return { expression: input.expression.trim() };
+          },
+        },
+      });
+    });
+
+    it('should reject refinements that return a different shape', async () => {
+      streamText({
+        model: new MockLanguageModelV4(),
+        prompt: 'Hello',
+        tools: mixedTools,
+        toolsContext: { weather: { weatherApiKey: 'key' } },
+        experimental_refineToolInput: {
+          // @ts-expect-error refinement must return the same tool input type
+          weather: _input => ({
+            location: 123,
+          }),
+        },
+      });
+    });
+
+    it('should reject refinements for unknown tools', async () => {
+      streamText({
+        model: new MockLanguageModelV4(),
+        prompt: 'Hello',
+        tools: mixedTools,
+        toolsContext: { weather: { weatherApiKey: 'key' } },
+        experimental_refineToolInput: {
+          // @ts-expect-error unknown tool names are not accepted
+          unknown: input => input,
+        },
+      });
+    });
+  });
+
   describe('runtimeContext', () => {
     it('should accept no runtimeContext', async () => {
       streamText({

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -1569,6 +1569,79 @@ describe('streamText', () => {
       ).toMatchSnapshot();
     });
 
+    it('should refine tool input before tool execution, stream parts, and callbacks', async () => {
+      const modelCallEndEvents: LanguageModelCallEndEvent<any>[] = [];
+      const toolExecutionStartEvents: Array<{
+        toolCall: { input: unknown };
+      }> = [];
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'tool1',
+                input: `{ "value": " raw " }`,
+              },
+              {
+                type: 'finish',
+                finishReason: { unified: 'tool-calls', raw: undefined },
+                usage: testUsage,
+              },
+            ]),
+          }),
+        }),
+        tools: {
+          tool1: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async input => {
+              expect(input).toStrictEqual({ value: 'raw' });
+              return `result:${input.value}`;
+            },
+          }),
+        },
+        experimental_refineToolInput: {
+          tool1: input => ({ value: input.value.trim() }),
+        },
+        experimental_onLanguageModelCallEnd: event => {
+          modelCallEndEvents.push(event);
+        },
+        experimental_onToolExecutionStart: event => {
+          toolExecutionStartEvents.push(event);
+        },
+        prompt: 'test-input',
+      });
+
+      const fullStream = await convertAsyncIterableToArray(result.fullStream);
+
+      expect(fullStream).toContainEqual(
+        expect.objectContaining({
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'tool1',
+          input: { value: 'raw' },
+        }),
+      );
+      expect(fullStream).toContainEqual(
+        expect.objectContaining({
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'tool1',
+          input: { value: 'raw' },
+          output: 'result:raw',
+        }),
+      );
+      expect(modelCallEndEvents[0].content[0]).toMatchObject({
+        type: 'tool-call',
+        input: { value: 'raw' },
+      });
+      expect(toolExecutionStartEvents[0].toolCall.input).toStrictEqual({
+        value: 'raw',
+      });
+    });
+
     it('should send tool call deltas', async () => {
       const result = streamText({
         model: createTestModel({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -12,12 +12,12 @@ import {
   isAbortError,
   type Arrayable,
   type Context,
-  type InferToolSetContext,
-  type ToolApprovalResponse,
-  type ToolSet,
   type IdGenerator,
+  type InferToolSetContext,
   type ProviderOptions,
+  type ToolApprovalResponse,
   type ToolContent,
+  type ToolSet,
 } from '@ai-sdk/provider-utils';
 import type { ServerResponse } from 'node:http';
 import { NoOutputGeneratedError } from '../error';
@@ -85,14 +85,20 @@ import { setAbortTimeout } from '../util/set-abort-timeout';
 import type { ActiveTools } from './active-tools';
 import { collectToolApprovals } from './collect-tool-approvals';
 import type { ContentPart } from './content-part';
+import { createExecuteToolsTransformation } from './create-execute-tools-transformation';
+import { executeToolCall } from './execute-tool-call';
+import { filterActiveTools } from './filter-active-tools';
+import type {
+  GenerateTextOnFinishCallback,
+  GenerateTextOnStartCallback,
+  GenerateTextOnStepFinishCallback,
+  GenerateTextOnStepStartCallback,
+} from './generate-text-events';
+import { invokeToolCallbacksFromStream } from './invoke-tool-callbacks-from-stream';
 import type {
   OnLanguageModelCallEndCallback,
   OnLanguageModelCallStartCallback,
 } from './language-model-events';
-import { createExecuteToolsTransformation } from './create-execute-tools-transformation';
-import { executeToolCall } from './execute-tool-call';
-import { filterActiveTools } from './filter-active-tools';
-import { invokeToolCallbacksFromStream } from './invoke-tool-callbacks-from-stream';
 import { text, type Output } from './output';
 import type {
   InferCompleteOutput,
@@ -101,8 +107,8 @@ import type {
 } from './output-utils';
 import type { PrepareStepFunction } from './prepare-step';
 import { convertToReasoningOutputs } from './reasoning-output';
-import { createRestrictedTelemetryDispatcher } from './restricted-telemetry-dispatcher';
 import type { ResponseMessage } from './response-message';
+import { createRestrictedTelemetryDispatcher } from './restricted-telemetry-dispatcher';
 import { DefaultStepResult, type StepResult } from './step-result';
 import {
   isStepCount,
@@ -127,15 +133,10 @@ import type {
   OnToolExecutionEndCallback,
   OnToolExecutionStartCallback,
 } from './tool-execution-events';
+import type { ToolInputRefinement } from './tool-input-refinement';
 import type { ToolOutput } from './tool-output';
 import type { StaticToolOutputDenied } from './tool-output-denied';
 import type { ToolsContextParameter } from './tools-context-parameter';
-import type {
-  GenerateTextOnFinishCallback,
-  GenerateTextOnStartCallback,
-  GenerateTextOnStepFinishCallback,
-  GenerateTextOnStepStartCallback,
-} from './generate-text-events';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -245,6 +246,7 @@ export type StreamTextOnAbortCallback<
  * @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
  *
  * @param runtimeContext - User-defined runtime context that flows through the entire generation lifecycle.
+ * @param experimental_refineToolInput - Optional mapping of tool names to functions that refine parsed tool inputs before tools are executed and before outputs, callbacks, and telemetry are recorded.
  *
  * @param onChunk - Callback that is called for each chunk of the stream. The stream processing will pause until the callback promise is resolved.
  * @param onError - Callback that is called when an error occurs during streaming. You can use it to log errors.
@@ -279,6 +281,7 @@ export function streamText<
   providerOptions,
   activeTools,
   experimental_repairToolCall: repairToolCall,
+  experimental_refineToolInput: refineToolInput,
   experimental_transform: transform,
   experimental_download: download,
   includeRawChunks = false,
@@ -386,6 +389,14 @@ export function streamText<
      * A function that attempts to repair a tool call that failed to parse.
      */
     experimental_repairToolCall?: ToolCallRepairFunction<TOOLS>;
+
+    /**
+     * Optional mapping of tool names to functions that refine parsed tool inputs.
+     *
+     * The refined input must have the same type shape as the tool input. Refined
+     * inputs are used for tool execution, stream parts, callbacks, and telemetry.
+     */
+    experimental_refineToolInput?: ToolInputRefinement<NoInfer<TOOLS>>;
 
     /**
      * Optional stream transformations.
@@ -552,6 +563,7 @@ export function streamText<
     transforms: asArray(transform),
     activeTools,
     repairToolCall,
+    refineToolInput,
     stopConditions: asArray(stopWhen),
     output,
     toolApproval,
@@ -738,6 +750,7 @@ class DefaultStreamTextResult<
     transforms,
     activeTools,
     repairToolCall,
+    refineToolInput,
     stopConditions,
     output,
     toolApproval,
@@ -785,6 +798,7 @@ class DefaultStreamTextResult<
     transforms: Array<StreamTextTransform<TOOLS>>;
     activeTools: ActiveTools<TOOLS>;
     repairToolCall: ToolCallRepairFunction<TOOLS> | undefined;
+    refineToolInput: ToolInputRefinement<TOOLS> | undefined;
     stopConditions: Array<
       StopCondition<NoInfer<TOOLS>, NoInfer<RUNTIME_CONTEXT>>
     >;
@@ -1542,6 +1556,7 @@ class DefaultStreamTextResult<
               messages: stepMessages,
               allowSystemInMessages,
               repairToolCall,
+              refineToolInput,
               abortSignal,
               headers,
               includeRawChunks,

--- a/packages/ai/src/generate-text/tool-input-refinement.ts
+++ b/packages/ai/src/generate-text/tool-input-refinement.ts
@@ -1,0 +1,18 @@
+import type {
+  InferToolInput,
+  MaybePromiseLike,
+  ToolSet,
+} from '@ai-sdk/provider-utils';
+
+/**
+ * Mapping of tool names to functions that refine parsed tool inputs.
+ *
+ * Each refinement function receives the typed input for its tool and must return
+ * an input with the same type shape. Refined inputs are used for tool execution,
+ * output parts, lifecycle callbacks, and telemetry.
+ */
+export type ToolInputRefinement<TOOLS extends ToolSet> = {
+  [NAME in keyof TOOLS]?: (
+    input: InferToolInput<TOOLS[NAME]>,
+  ) => MaybePromiseLike<InferToolInput<TOOLS[NAME]>>;
+};


### PR DESCRIPTION
## Background

Different LLM provider might generate slightly different tool inputs for the same tool input type, e.g. using empty string instead of `null`. Tools might come from 3rd party providers, so the input schemas might not support refinement.

## Summary

Add an experimental `refineToolInput` option to `ToolLoopAgent`, `generateText`, `streamText` that can be used to modify the tool inputs as long as the expected type is retained.

## Manual Verification

Execute examples and check tool inputs:

- [x] `examples/ai-functions/src/generate-text/openai/refine-tool-input.ts`
- [x] `examples/ai-functions/src/steam-text/openai/refine-tool-input.ts`
