### PR TITLE
fix(provider-utils): correct audio/mp4 detection — ftyp is at offset 4, not 0

### DIFF
--- a/.changeset/fix-audio-mp4-ftyp-offset-detection.md
+++ b/.changeset/fix-audio-mp4-ftyp-offset-detection.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Fix `audio/mp4` (m4a) detection: the `ftyp` signature was checked at byte offset 0, but ISO Base Media File Format boxes prefix `ftyp` with a 4-byte size field, placing `ftyp` at offset 4. Corrected to match the `M4A ` and `M4B ` brands at their actual offset — fixes `experimental_transcribe` mis-tagging iOS/Android/ffmpeg m4a recordings as `audio/wav` and getting rejected by OpenAI with HTTP 400.

--- a/packages/provider-utils/src/detect-media-type.test.ts
+++ b/packages/provider-utils/src/detect-media-type.test.ts
@@ -543,8 +543,26 @@ describe('detectMediaType signature matching', () => {
   });
 
   describe('MP4', () => {
-    it('should detect MP4 from bytes', () => {
-      const mp4Bytes = new Uint8Array([0x66, 0x74, 0x79, 0x70]);
+    // Real m4a/mp4 files use ISO Base Media File Format box structure:
+    // [4-byte box size][4-byte 'ftyp'...]. The 'ftyp' marker is at offset 4,
+    // not offset 0. Files from iOS AVAudioRecorder, Android AAC encoder,
+    // ffmpeg -c:a aac, and ElevenLabs TTS all follow this layout.
+    it('should detect MP4 from real-world bytes (ftyp at offset 4)', () => {
+      // Matches bytes 0..7 of a real m4a: 00 00 00 1c 66 74 79 70
+      const mp4Bytes = new Uint8Array([
+        0x00,
+        0x00,
+        0x00,
+        0x1c, // box size (28 bytes)
+        0x66,
+        0x74,
+        0x79,
+        0x70, // 'ftyp'
+        0x4d,
+        0x34,
+        0x41,
+        0x20, // 'M4A '
+      ]);
       expect(
         detectMediaType({
           data: mp4Bytes,
@@ -553,11 +571,47 @@ describe('detectMediaType signature matching', () => {
       ).toBe('audio/mp4');
     });
 
-    it('should detect MP4 from base64', () => {
-      const mp4Base64 = 'ZnR5cA'; // Base64 string starting with MP4 signature
+    it('should detect MP4 from base64 (real-world ftyp at offset 4)', () => {
+      const mp4Bytes = new Uint8Array([
+        0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41, 0x20,
+      ]);
+      const mp4Base64 = convertUint8ArrayToBase64(mp4Bytes);
       expect(
         detectMediaType({
           data: mp4Base64,
+          topLevelType: 'audio',
+        }),
+      ).toBe('audio/mp4');
+    });
+
+    it('should not detect MP4 when ftyp is at offset 0 (malformed structure)', () => {
+      const malformedBytes = new Uint8Array([0x66, 0x74, 0x79, 0x70]);
+      expect(
+        detectMediaType({
+          data: malformedBytes,
+          topLevelType: 'audio',
+        }),
+      ).toBeUndefined();
+    });
+
+    it('should detect M4B audiobook from bytes', () => {
+      const m4bBytes = new Uint8Array([
+        0x00,
+        0x00,
+        0x00,
+        0x20, // box size
+        0x66,
+        0x74,
+        0x79,
+        0x70, // 'ftyp'
+        0x4d,
+        0x34,
+        0x42,
+        0x20, // 'M4B '
+      ]);
+      expect(
+        detectMediaType({
+          data: m4bBytes,
           topLevelType: 'audio',
         }),
       ).toBe('audio/mp4');

--- a/packages/provider-utils/src/detect-media-type.ts
+++ b/packages/provider-utils/src/detect-media-type.ts
@@ -118,8 +118,42 @@ const audioMediaTypeSignatures = [
     bytesPrefix: [0x40, 0x15, 0x00, 0x00],
   },
   {
+    // M4A audio files: ftyp box with 'M4A ' brand at bytes 8-11.
+    // ISO BMFF layout: [4-byte size][ftyp][M4A ][...]. The size bytes 0-2
+    // are 0x00, byte 3 is the low size byte (wildcard).
     mediaType: 'audio/mp4' as const,
-    bytesPrefix: [0x66, 0x74, 0x79, 0x70],
+    bytesPrefix: [
+      0x00,
+      0x00,
+      0x00,
+      null,
+      0x66,
+      0x74,
+      0x79,
+      0x70, // 'ftyp'
+      0x4d,
+      0x34,
+      0x41,
+      0x20, // 'M4A '
+    ],
+  },
+  {
+    // M4B audiobook files: same layout with 'M4B ' brand.
+    mediaType: 'audio/mp4' as const,
+    bytesPrefix: [
+      0x00,
+      0x00,
+      0x00,
+      null,
+      0x66,
+      0x74,
+      0x79,
+      0x70, // 'ftyp'
+      0x4d,
+      0x34,
+      0x42,
+      0x20, // 'M4B '
+    ],
   },
   {
     mediaType: 'audio/webm',


### PR DESCRIPTION
## Background

\`experimental_transcribe()\` sniffs audio buffers to detect the media type before uploading to the provider. The \`audio/mp4\` (m4a) signature was matching \`ftyp\` at byte offset 0, but ISO Base Media File Format (ISO BMFF) files always prefix the \`ftyp\` box with a 4-byte box-length header:

\`\`\`
bytes 0..15 of a real m4a:  00 00 00 1c  66 74 79 70  4d 34 41 20  ...
                             └── size ──┘ └── ftyp ──┘ └── M4A  ──┘
\"ftyp\" at offset 0:  false  ← old check
\"ftyp\" at offset 4:  true   ← actual position
\`\`\`

The mismatch caused \`detectMediaType\` to fall back to \`audio/wav\`, and OpenAI rejected the upload with HTTP 400 \`unsupported_format\`. Affects audio recorded by iOS \`AVAudioRecorder\`, Android AAC encoder, \`ffmpeg -c:a aac\`, and ElevenLabs TTS m4a export.

Fixes #14721.

## Summary

Replace the \`audio/mp4\` signature \`[0x66, 0x74, 0x79, 0x70]\` (ftyp at offset 0) with brand-specific signatures that check bytes 0–11:

- \`[0x00, 0x00, 0x00, null, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41, 0x20]\` — \`M4A \` brand (iOS, Android, ffmpeg, ElevenLabs)
- \`[0x00, 0x00, 0x00, null, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x42, 0x20]\` — \`M4B \` brand (audiobooks)

The brand check also prevents false-positive collisions with \`video/mp4\`: a generic 8-byte ftyp box (no brand bytes) does not match the 12-byte audio signatures, so the existing \`video/mp4\` detection is unaffected.

## Manual Verification

The signature match is byte-level logic fully covered by the test suite. Verified by inspecting the detection results in tests:

- M4A bytes from the issue reporter (\`00 00 00 1c 66 74 79 70 4d 34 41 20\`) → \`audio/mp4\` ✓
- Same bytes as base64 → \`audio/mp4\` ✓
- M4B brand → \`audio/mp4\` ✓
- Old malformed signature (ftyp at offset 0) → \`undefined\` ✓
- Generic ftyp box without brand (video/mp4 test) → \`video/mp4\` ✓ (unaffected)

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run \`pnpm changeset\` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14721