### PR TITLE
docs: add README.md for @ai-sdk/mcp, @ai-sdk/otel, and @ai-sdk/voyage

### DIFF
--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -19,7 +19,7 @@
               "tsconfig.json"
             ]
           },
-          "excludeFiles": ["packages/mcp", "packages/otel", "packages/voyage"]
+          "excludeFiles": []
         },
         {
           "name": "package-dir-must-have-index",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,48 @@
+# AI SDK - MCP Client
+
+The **[@ai-sdk/mcp](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#mcp-tools)** package provides a client for connecting to [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers and using their tools with the [AI SDK](https://ai-sdk.dev/docs).
+
+## Setup
+
+The MCP client is available in the `@ai-sdk/mcp` module. You can install it with
+
+```bash
+npm i @ai-sdk/mcp
+```
+
+## Skill for Coding Agents
+
+If you use coding agents such as Claude Code or Cursor, we highly recommend adding the AI SDK skill to your repository:
+
+```shell
+npx skills add vercel/ai
+```
+
+## Example
+
+```ts
+import { createMCPClient } from '@ai-sdk/mcp';
+import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const client = await createMCPClient({
+  transport: {
+    type: 'sse',
+    url: 'https://your-mcp-server.example.com/sse',
+  },
+});
+
+const tools = await client.tools();
+
+const { text } = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'What tools do you have available?',
+});
+
+await client.close();
+```
+
+## Documentation
+
+Please check out the **[MCP tools documentation](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#mcp-tools)** for more information.

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -1,0 +1,49 @@
+# AI SDK - OpenTelemetry
+
+The **[@ai-sdk/otel](https://ai-sdk.dev/docs/ai-sdk-core/telemetry)** package provides [OpenTelemetry](https://opentelemetry.io/) telemetry support for the [AI SDK](https://ai-sdk.dev/docs), enabling distributed tracing of AI SDK operations.
+
+## Setup
+
+The OpenTelemetry package is available in the `@ai-sdk/otel` module. You can install it with
+
+```bash
+npm i @ai-sdk/otel
+```
+
+## Skill for Coding Agents
+
+If you use coding agents such as Claude Code or Cursor, we highly recommend adding the AI SDK skill to your repository:
+
+```shell
+npx skills add vercel/ai
+```
+
+## Example
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { generateText, registerTelemetry } from 'ai';
+import { OpenTelemetry } from '@ai-sdk/otel';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node';
+
+registerTelemetry(new OpenTelemetry());
+
+const sdk = new NodeSDK({
+  traceExporter: new ConsoleSpanExporter(),
+});
+
+sdk.start();
+
+const { text } = await generateText({
+  model: openai('gpt-4o'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+  telemetry: { functionId: 'lasagna-recipe' },
+});
+
+await sdk.shutdown();
+```
+
+## Documentation
+
+Please check out the **[AI SDK telemetry documentation](https://ai-sdk.dev/docs/ai-sdk-core/telemetry)** for more information.

--- a/packages/voyage/README.md
+++ b/packages/voyage/README.md
@@ -1,0 +1,46 @@
+# AI SDK - Voyage AI Provider
+
+The **[Voyage AI provider](https://ai-sdk.dev/providers/ai-sdk-providers/voyage)** for the [AI SDK](https://ai-sdk.dev/docs) contains embedding and reranking model support for the [Voyage AI](https://voyageai.com/) APIs.
+
+## Setup
+
+The Voyage AI provider is available in the `@ai-sdk/voyage` module. You can install it with
+
+```bash
+npm i @ai-sdk/voyage
+```
+
+## Skill for Coding Agents
+
+If you use coding agents such as Claude Code or Cursor, we highly recommend adding the AI SDK skill to your repository:
+
+```shell
+npx skills add vercel/ai
+```
+
+## Provider Instance
+
+You can import the default provider instance `voyage` from `@ai-sdk/voyage`:
+
+```ts
+import { voyage } from '@ai-sdk/voyage';
+```
+
+## Example
+
+```ts
+import { voyage } from '@ai-sdk/voyage';
+import { embedMany } from 'ai';
+
+const { embeddings } = await embedMany({
+  model: voyage.textEmbedding('voyage-3'),
+  values: [
+    'Sunny days are great for hiking',
+    'Machine learning is a subset of AI',
+  ],
+});
+```
+
+## Documentation
+
+Please check out the **[Voyage AI provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/voyage)** for more information.


### PR DESCRIPTION
## Background

Three packages — `@ai-sdk/mcp`, `@ai-sdk/otel`, and `@ai-sdk/voyage` — were missing `README.md` files and were excluded from the `konsistent` convention check that requires every package to have a README.

## Summary

- Added `README.md` for `packages/mcp` with MCP client usage example
- Added `README.md` for `packages/otel` with OpenTelemetry usage example
- Added `README.md` for `packages/voyage` with embedding usage example
- Removed the three packages from the `excludeFiles` list in `.github/konsistent.json` so the README convention is now enforced for all packages

## Manual Verification

- `packages/mcp/README.md` exists ✓
- `packages/otel/README.md` exists ✓
- `packages/voyage/README.md` exists ✓
- `.github/konsistent.json` exclusion list no longer contains these packages ✓

## Checklist

- [x] Documentation has been added / updated
- [x] I have reviewed this pull request (self-review)

## Related Issues

Closes #14859 (README.md portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)