### PR TITLE
feat(mistral): add MistralEmbeddingModelOptions with encodingFormat provider option

### DIFF
--- a/.changeset/feat-mistral-embedding-model-options.md
+++ b/.changeset/feat-mistral-embedding-model-options.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': patch
+---
+
+Add `MistralEmbeddingModelOptions` type with `encodingFormat` provider option, enabling callers to request `"base64"` encoding instead of the default `"float"`.

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -204,7 +204,6 @@
             "packages/gateway/src/gateway-image-model.ts",
             "packages/gateway/src/gateway-language-model.ts",
             "packages/gateway/src/gateway-reranking-model.ts",
-            "packages/mistral/src/mistral-embedding-model.ts",
             "packages/openai-compatible/src/image/openai-compatible-image-model.ts",
             "packages/perplexity/src/perplexity-language-model.ts"
           ]

--- a/packages/mistral/src/index.ts
+++ b/packages/mistral/src/index.ts
@@ -8,4 +8,5 @@ export type {
   /** @deprecated Use `MistralLanguageModelChatOptions` instead. */
   MistralLanguageModelChatOptions as MistralLanguageModelOptions,
 } from './mistral-chat-language-model-options';
+export type { MistralEmbeddingModelOptions } from './mistral-embedding-model-options';
 export { VERSION } from './version';

--- a/packages/mistral/src/mistral-embedding-model-options.ts
+++ b/packages/mistral/src/mistral-embedding-model-options.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod/v4';
+
+export const mistralEmbeddingModelOptions = z.object({
+  /**
+   * The format to return the embeddings in.
+   * Defaults to `"float"`.
+   *
+   * - `"float"`: Returns embeddings as an array of 32-bit floating-point numbers.
+   * - `"base64"`: Returns embeddings as a base64-encoded string, which can
+   *   reduce bandwidth for large batches.
+   */
+  encodingFormat: z.enum(['float', 'base64']).optional(),
+});
+
+export type MistralEmbeddingModelOptions = z.infer<
+  typeof mistralEmbeddingModelOptions
+>;

--- a/packages/mistral/src/mistral-embedding-model.ts
+++ b/packages/mistral/src/mistral-embedding-model.ts
@@ -5,6 +5,7 @@ import {
 import {
   combineHeaders,
   createJsonResponseHandler,
+  parseProviderOptions,
   postJsonToApi,
   serializeModelOptions,
   WORKFLOW_SERIALIZE,
@@ -13,6 +14,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import type { MistralEmbeddingModelId } from './mistral-embedding-options';
+import { mistralEmbeddingModelOptions } from './mistral-embedding-model-options';
 import { mistralFailedResponseHandler } from './mistral-error';
 
 type MistralEmbeddingConfig = {
@@ -60,9 +62,16 @@ export class MistralEmbeddingModel implements EmbeddingModelV4 {
     values,
     abortSignal,
     headers,
+    providerOptions,
   }: Parameters<EmbeddingModelV4['doEmbed']>[0]): Promise<
     Awaited<ReturnType<EmbeddingModelV4['doEmbed']>>
   > {
+    const embeddingOptions = await parseProviderOptions({
+      provider: 'mistral',
+      providerOptions,
+      schema: mistralEmbeddingModelOptions,
+    });
+
     if (values.length > this.maxEmbeddingsPerCall) {
       throw new TooManyEmbeddingValuesForCallError({
         provider: this.provider,
@@ -82,7 +91,7 @@ export class MistralEmbeddingModel implements EmbeddingModelV4 {
       body: {
         model: this.modelId,
         input: values,
-        encoding_format: 'float',
+        encoding_format: embeddingOptions?.encodingFormat ?? 'float',
       },
       failedResponseHandler: mistralFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(

--- a/packages/mistral/src/mistral-embedding-model.ts
+++ b/packages/mistral/src/mistral-embedding-model.ts
@@ -4,6 +4,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
+  convertBase64ToUint8Array,
   createJsonResponseHandler,
   parseProviderOptions,
   postJsonToApi,
@@ -103,7 +104,11 @@ export class MistralEmbeddingModel implements EmbeddingModelV4 {
 
     return {
       warnings: [],
-      embeddings: response.data.map(item => item.embedding),
+      embeddings: response.data.map(item =>
+        typeof item.embedding === 'string'
+          ? decodeBase64Embedding(item.embedding)
+          : item.embedding,
+      ),
       usage: response.usage
         ? { tokens: response.usage.prompt_tokens }
         : undefined,
@@ -112,9 +117,21 @@ export class MistralEmbeddingModel implements EmbeddingModelV4 {
   }
 }
 
+function decodeBase64Embedding(base64: string): number[] {
+  const bytes = convertBase64ToUint8Array(base64);
+  const floats = new Float32Array(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength / 4,
+  );
+  return Array.from(floats);
+}
+
 // minimal version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
 const MistralTextEmbeddingResponseSchema = z.object({
-  data: z.array(z.object({ embedding: z.array(z.number()) })),
+  data: z.array(
+    z.object({ embedding: z.union([z.array(z.number()), z.string()]) }),
+  ),
   usage: z.object({ prompt_tokens: z.number() }).nullish(),
 });


### PR DESCRIPTION
## Background

The konsistent convention requires every `*-model.ts` file to have a matching `*-model-options.ts` companion file. `mistral-embedding-model.ts` was excluded from this check and also hardcoded `encoding_format: 'float'` with no way for callers to override it.

## Summary

- Add `mistral-embedding-model-options.ts` exporting `MistralEmbeddingModelOptions`, satisfying the konsistent convention
- Expose `encodingFormat` (`"float"` | `"base64"`) as a provider option, replacing the previous hardcoded `"float"`. Default remains `"float"` — no breaking change
- Export `MistralEmbeddingModelOptions` from the package root
- Remove `packages/mistral/src/mistral-embedding-model.ts` from the konsistent exclusion list

## Manual Verification

- TypeScript compiles cleanly (`pnpm tsc --noEmit` in `packages/mistral`)
- Existing embedding tests continue to pass (default `encoding_format: 'float'` preserved when no option is passed)
- konsistent lint passes with the exclusion removed

## Checklist
- [x] All commits are signed
- [ ] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request