### PR TITLE
feat(bytedance): extract ByteDanceVideoModelOptions into dedicated options file

### DIFF
--- a/.changeset/feat-bytedance-video-model-options.md
+++ b/.changeset/feat-bytedance-video-model-options.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/bytedance': patch
+---
+
+Extract `ByteDanceVideoModelOptions` into a dedicated `bytedance-video-model-options.ts` file. The existing `ByteDanceVideoProviderOptions` type is preserved as a deprecated alias for backward compatibility.

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -263,7 +263,6 @@
             "haveFiles": ["${providerId}-video-model-options.ts"]
           },
           "excludeFiles": [
-            "packages/bytedance/src/bytedance-video-model.ts",
             "packages/gateway/src/gateway-video-model.ts"
           ]
         },

--- a/packages/bytedance/src/bytedance-video-model-options.ts
+++ b/packages/bytedance/src/bytedance-video-model-options.ts
@@ -1,0 +1,103 @@
+import { z } from 'zod/v4';
+import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
+
+export type ByteDanceVideoModelOptions = {
+  /**
+   * Whether to add a watermark to the generated video.
+   */
+  watermark?: boolean | null;
+
+  /**
+   * Whether to generate audio for the video.
+   */
+  generateAudio?: boolean | null;
+
+  /**
+   * Whether to keep the camera fixed (no camera movement).
+   */
+  cameraFixed?: boolean | null;
+
+  /**
+   * Whether to return the last frame of the generated video.
+   */
+  returnLastFrame?: boolean | null;
+
+  /**
+   * Service tier to use for generation.
+   *
+   * - `"default"`: Standard generation tier.
+   * - `"flex"`: Flexible (lower-priority) tier with potentially reduced cost.
+   */
+  serviceTier?: 'default' | 'flex' | null;
+
+  /**
+   * Whether to generate in draft mode (faster, lower quality preview).
+   */
+  draft?: boolean | null;
+
+  /**
+   * URL of an image to use as the last frame of the generated video.
+   */
+  lastFrameImage?: string | null;
+
+  /**
+   * URLs of reference images to guide the generated video style.
+   */
+  referenceImages?: string[] | null;
+
+  /**
+   * URLs of reference videos to guide the generated video style.
+   */
+  referenceVideos?: string[] | null;
+
+  /**
+   * URLs of reference audio to use in the generated video.
+   */
+  referenceAudio?: string[] | null;
+
+  /**
+   * Polling interval in milliseconds for checking generation status.
+   * Defaults to 3000 (3 seconds).
+   */
+  pollIntervalMs?: number | null;
+
+  /**
+   * Maximum time in milliseconds to wait for generation to complete.
+   * Defaults to 300000 (5 minutes).
+   */
+  pollTimeoutMs?: number | null;
+
+  [key: string]: unknown;
+};
+
+export const byteDanceVideoModelOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z
+      .object({
+        watermark: z.boolean().nullish(),
+        generateAudio: z.boolean().nullish(),
+        cameraFixed: z.boolean().nullish(),
+        returnLastFrame: z.boolean().nullish(),
+        serviceTier: z.enum(['default', 'flex']).nullish(),
+        draft: z.boolean().nullish(),
+        lastFrameImage: z.string().nullish(),
+        referenceImages: z.array(z.string()).nullish(),
+        referenceVideos: z.array(z.string()).nullish(),
+        referenceAudio: z.array(z.string()).nullish(),
+        pollIntervalMs: z.number().positive().nullish(),
+        pollTimeoutMs: z.number().positive().nullish(),
+      })
+      .passthrough(),
+  ),
+);
+
+/**
+ * @deprecated Use {@link ByteDanceVideoModelOptions} instead.
+ */
+export type ByteDanceVideoProviderOptions = ByteDanceVideoModelOptions;
+
+/**
+ * @deprecated Use {@link byteDanceVideoModelOptionsSchema} instead.
+ */
+export const byteDanceVideoProviderOptionsSchema =
+  byteDanceVideoModelOptionsSchema;

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -10,31 +10,17 @@ import {
   createJsonResponseHandler,
   delay,
   getFromApi,
-  lazySchema,
   parseProviderOptions,
   postJsonToApi,
   resolve,
-  zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import type { ByteDanceConfig } from './bytedance-config';
+import {
+  byteDanceVideoModelOptionsSchema,
+  type ByteDanceVideoModelOptions,
+} from './bytedance-video-model-options';
 import type { ByteDanceVideoModelId } from './bytedance-video-settings';
-
-export type ByteDanceVideoProviderOptions = {
-  watermark?: boolean | null;
-  generateAudio?: boolean | null;
-  cameraFixed?: boolean | null;
-  returnLastFrame?: boolean | null;
-  serviceTier?: 'default' | 'flex' | null;
-  draft?: boolean | null;
-  lastFrameImage?: string | null;
-  referenceImages?: string[] | null;
-  referenceVideos?: string[] | null;
-  referenceAudio?: string[] | null;
-  pollIntervalMs?: number | null;
-  pollTimeoutMs?: number | null;
-  [key: string]: unknown;
-};
 
 const HANDLED_PROVIDER_OPTIONS = new Set([
   'watermark',
@@ -50,27 +36,6 @@ const HANDLED_PROVIDER_OPTIONS = new Set([
   'pollIntervalMs',
   'pollTimeoutMs',
 ]);
-
-export const byteDanceVideoProviderOptionsSchema = lazySchema(() =>
-  zodSchema(
-    z
-      .object({
-        watermark: z.boolean().nullish(),
-        generateAudio: z.boolean().nullish(),
-        cameraFixed: z.boolean().nullish(),
-        returnLastFrame: z.boolean().nullish(),
-        serviceTier: z.enum(['default', 'flex']).nullish(),
-        draft: z.boolean().nullish(),
-        lastFrameImage: z.string().nullish(),
-        referenceImages: z.array(z.string()).nullish(),
-        referenceVideos: z.array(z.string()).nullish(),
-        referenceAudio: z.array(z.string()).nullish(),
-        pollIntervalMs: z.number().positive().nullish(),
-        pollTimeoutMs: z.number().positive().nullish(),
-      })
-      .passthrough(),
-  ),
-);
 
 const RESOLUTION_MAP: Record<string, string> = {
   '864x496': '480p',
@@ -143,8 +108,8 @@ export class ByteDanceVideoModel implements Experimental_VideoModelV4 {
     const byteDanceOptions = (await parseProviderOptions({
       provider: 'bytedance',
       providerOptions: options.providerOptions,
-      schema: byteDanceVideoProviderOptionsSchema,
-    })) as ByteDanceVideoProviderOptions | undefined;
+      schema: byteDanceVideoModelOptionsSchema,
+    })) as ByteDanceVideoModelOptions | undefined;
 
     // Warn about unsupported standard options
     if (options.fps) {

--- a/packages/bytedance/src/index.ts
+++ b/packages/bytedance/src/index.ts
@@ -3,6 +3,10 @@ export type {
   ByteDanceProviderSettings,
 } from './bytedance-provider';
 export { byteDance, createByteDance } from './bytedance-provider';
-export type { ByteDanceVideoProviderOptions } from './bytedance-video-model';
+export type {
+  ByteDanceVideoModelOptions,
+  /** @deprecated Use {@link ByteDanceVideoModelOptions} instead. */
+  ByteDanceVideoProviderOptions,
+} from './bytedance-video-model-options';
 export type { ByteDanceVideoModelId } from './bytedance-video-settings';
 export { VERSION } from './version';


### PR DESCRIPTION
## Background

The konsistent convention requires every `*-video-model.ts` file to have a matching `*-video-model-options.ts` companion file. `bytedance-video-model.ts` had its options type defined inline and was excluded from this check.

## Summary

- Move `ByteDanceVideoProviderOptions` type and `byteDanceVideoProviderOptionsSchema` out of `bytedance-video-model.ts` into a new `bytedance-video-model-options.ts` companion file
- Export `ByteDanceVideoModelOptions` as the canonical type name (matches the `${providerId.toPascalCase()}VideoModelOptions` convention)
- Preserve `ByteDanceVideoProviderOptions` and `byteDanceVideoProviderOptionsSchema` as deprecated aliases for backward compatibility
- Remove `packages/bytedance/src/bytedance-video-model.ts` from the konsistent exclusion list

## Manual Verification

- TypeScript compiles cleanly (`pnpm tsc --noEmit` in `packages/bytedance`)
- Existing bytedance video model tests continue to pass
- konsistent lint passes with the exclusion removed
- `ByteDanceVideoProviderOptions` still importable from `@ai-sdk/bytedance` (backward compat preserved via deprecated alias)

## Checklist
- [x] All commits are signed
- [ ] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes part of #14859