### PR TITLE
feat(openai-compatible): add OpenAICompatibleImageModelOptions type

### DIFF
--- a/.changeset/feat-openai-compatible-image-model-options.md
+++ b/.changeset/feat-openai-compatible-image-model-options.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Add `OpenAICompatibleImageModelOptions` type documenting common OpenAI-compatible image generation options (`quality`, `style`, `user`).

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -205,7 +205,6 @@
             "packages/gateway/src/gateway-language-model.ts",
             "packages/gateway/src/gateway-reranking-model.ts",
             "packages/mistral/src/mistral-embedding-model.ts",
-            "packages/openai-compatible/src/image/openai-compatible-image-model.ts",
             "packages/perplexity/src/perplexity-language-model.ts"
           ]
         },

--- a/packages/openai-compatible/src/image/openai-compatible-image-model-options.ts
+++ b/packages/openai-compatible/src/image/openai-compatible-image-model-options.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod/v4';
+
+export const openaiCompatibleImageModelOptions = z.object({
+  /**
+   * Quality of the generated image(s).
+   *
+   * Common values: `"standard"`, `"hd"` (DALL-E 3), `"low"`, `"medium"`,
+   * `"high"`, `"auto"` (gpt-image models).
+   */
+  quality: z.string().optional(),
+
+  /**
+   * Style of the generated image (DALL-E 3 only).
+   *
+   * - `"vivid"`: produces hyper-real and dramatic images.
+   * - `"natural"`: produces more subdued, less hyper-real looking images.
+   */
+  style: z.enum(['vivid', 'natural']).optional(),
+
+  /**
+   * A unique identifier representing your end-user, which can help
+   * providers monitor and detect abuse.
+   */
+  user: z.string().optional(),
+});
+
+export type OpenAICompatibleImageModelOptions = z.infer<
+  typeof openaiCompatibleImageModelOptions
+>;

--- a/packages/openai-compatible/src/index.ts
+++ b/packages/openai-compatible/src/index.ts
@@ -20,6 +20,7 @@ export type {
   OpenAICompatibleEmbeddingModelOptions as OpenAICompatibleEmbeddingProviderOptions,
 } from './embedding/openai-compatible-embedding-model-options';
 export { OpenAICompatibleImageModel } from './image/openai-compatible-image-model';
+export type { OpenAICompatibleImageModelOptions } from './image/openai-compatible-image-model-options';
 export type {
   OpenAICompatibleErrorData,
   ProviderErrorStructure,


### PR DESCRIPTION
## Background

The konsistent convention requires every model file to have a matching options companion file. `openai-compatible-image-model.ts` was excluded from this check because it lacked an `openai-compatible-image-model-options.ts` file.

## Summary

- Add `openai-compatible-image-model-options.ts` exporting `OpenAICompatibleImageModelOptions`, documenting the common options (`quality`, `style`, `user`) callers pass via `experimental_providerOptions`
- Remove `packages/openai-compatible/src/image/openai-compatible-image-model.ts` from the konsistent exclusion list
- No runtime change; strict schema validation intentionally omitted since valid options vary by provider

## Manual Verification

- TypeScript compiles cleanly (`pnpm tsc --noEmit` in `packages/openai-compatible`)
- Existing image model tests continue to pass
- konsistent lint passes with the exclusion removed

## Checklist
- [x] All commits are signed
- [ ] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes part of #14859