### PR TITLE
docs: fix broken example links to renamed/missing directories

### DIFF
--- a/content/docs/04-ai-sdk-ui/01-overview.mdx
+++ b/content/docs/04-ai-sdk-ui/01-overview.mdx
@@ -34,7 +34,7 @@ Here is a comparison of the supported functions across these frameworks:
 
 Explore these example implementations for different frameworks:
 
-- [**Next.js**](https://github.com/vercel/ai/tree/main/examples/next-openai)
+- [**Next.js**](https://github.com/vercel/ai/tree/main/examples/ai-e2e-next)
 - [**Nuxt**](https://github.com/vercel/ai/tree/main/examples/nuxt-openai)
 - [**SvelteKit**](https://github.com/vercel/ai/tree/main/examples/sveltekit-openai)
 - [**Angular**](https://github.com/vercel/ai/tree/main/examples/angular)

--- a/content/providers/05-observability/langfuse.mdx
+++ b/content/providers/05-observability/langfuse.mdx
@@ -154,7 +154,7 @@ Done! All traces that contain AI SDK spans are automatically captured in Langfus
 ## Example Application
 
 Check out the sample repository ([langfuse/langfuse-vercel-ai-nextjs-example](https://github.com/langfuse/langfuse-vercel-ai-nextjs-example)) based
-on the [next-openai](https://github.com/vercel/ai/tree/main/examples/next-openai) template to showcase the integration of Langfuse with Next.js and AI SDK.
+on the [ai-e2e-next](https://github.com/vercel/ai/tree/main/examples/ai-e2e-next) template to showcase the integration of Langfuse with Next.js and AI SDK.
 
 ## Configuration
 

--- a/examples/ai-e2e-next/README.md
+++ b/examples/ai-e2e-next/README.md
@@ -6,7 +6,7 @@ This example shows how to use the [AI SDK](https://ai-sdk.dev/docs) with [Next.j
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=ai-sdk-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-openai&env=OPENAI_API_KEY&project-name=ai-sdk-next-openai&repository-name=ai-sdk-next-openai)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fai-e2e-next&env=OPENAI_API_KEY&project-name=ai-sdk-next-openai&repository-name=ai-sdk-next-openai)
 
 ## How to use
 

--- a/examples/next-openai-upstash-rate-limits/README.md
+++ b/examples/next-openai-upstash-rate-limits/README.md
@@ -8,22 +8,22 @@ This example shows how to use the [AI SDK](https://ai-sdk.dev/docs) with [Next.j
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=ai-sdk-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-openai-rate-limits&env=OPENAI_API_KEY&envDescription=OpenAI%20API%20Key&envLink=https%3A%2F%2Fplatform.openai.com%2Faccount%2Fapi-keys&project-name=vercel-ai-chat-openai&repository-name=vercel-ai-chat-openai)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai%2Ftree%2Fmain%2Fexamples%2Fnext-openai-upstash-rate-limits&env=OPENAI_API_KEY&envDescription=OpenAI%20API%20Key&envLink=https%3A%2F%2Fplatform.openai.com%2Faccount%2Fapi-keys&project-name=vercel-ai-chat-openai&repository-name=vercel-ai-chat-openai)
 
 ## How to use
 
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
 
 ```bash
-npx create-next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-rate-limits next-openai-rate-limits-app
+npx create-next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-upstash-rate-limits next-openai-rate-limits-app
 ```
 
 ```bash
-yarn create next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-rate-limits next-openai-rate-limits-app
+yarn create next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-upstash-rate-limits next-openai-rate-limits-app
 ```
 
 ```bash
-pnpm create next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-rate-limits next-openai-rate-limits-app
+pnpm create next-app --example https://github.com/vercel/ai/tree/main/examples/next-openai-upstash-rate-limits next-openai-rate-limits-app
 ```
 
 To run the example locally you need to:


### PR DESCRIPTION
Issue #14705 reports doc links pointing at `examples/next-openai`, which 404s now that the directory was renamed to `examples/ai-e2e-next`. While checking the repo, also caught a stale path in the rate-limits README that points at `examples/next-openai-rate-limits` (the actual dir is `examples/next-openai-upstash-rate-limits`), and the deploy-button URL on `examples/ai-e2e-next/README.md` itself was missed during the rename.

Changes:
- `content/docs/04-ai-sdk-ui/01-overview.mdx` — Next.js framework example link
- `content/providers/05-observability/langfuse.mdx` — Langfuse template reference
- `examples/ai-e2e-next/README.md` — Vercel deploy-button URL
- `examples/next-openai-upstash-rate-limits/README.md` — deploy-button URL + 3 create-next-app commands

Out of scope (flagged for follow-up):
- `content/cookbook/01-next/75-human-in-the-loop.mdx` references a `/test-tool-approval` page that does not exist in any current example. Will comment on #14705 to ask which example should host this demo before patching the link.

Refs #14705