### PR TITLE
fix(provider-utils): detect m4a audio media type

### DIFF
--- a/.changeset/transcribe-audio-mp-four-detect.md
+++ b/.changeset/transcribe-audio-mp-four-detect.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+Detect ISO BMFF audio (M4A/MP4) where `ftyp` follows a 4-byte box length, so `transcribe()` no longer falls back to `audio/wav` for valid m4a/mp4 input.

--- a/packages/provider-utils/src/detect-media-type.test.ts
+++ b/packages/provider-utils/src/detect-media-type.test.ts
@@ -543,21 +543,25 @@ describe('detectMediaType signature matching', () => {
   });
 
   describe('MP4', () => {
-    it('should detect MP4 from bytes', () => {
-      const mp4Bytes = new Uint8Array([0x66, 0x74, 0x79, 0x70]);
+    it('should detect MP4 from bytes (M4A brand)', () => {
+      // Real ISO BMFF header (issue #14721): 4-byte box length (0x1c), ftyp, "M4A ".
+      const m4aBytes = new Uint8Array([
+        0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41, 0x20,
+      ]);
       expect(
         detectMediaType({
-          data: mp4Bytes,
+          data: m4aBytes,
           topLevelType: 'audio',
         }),
       ).toBe('audio/mp4');
     });
 
-    it('should detect MP4 from base64', () => {
-      const mp4Base64 = 'ZnR5cA'; // Base64 string starting with MP4 signature
+    it('should detect MP4 from base64 (M4A brand)', () => {
+      // Base64 of 00 00 00 1c 66 74 79 70 4d 34 41 20 (M4A header).
+      const m4aBase64 = 'AAAAHGZ0eXBNNEEg';
       expect(
         detectMediaType({
-          data: mp4Base64,
+          data: m4aBase64,
           topLevelType: 'audio',
         }),
       ).toBe('audio/mp4');

--- a/packages/provider-utils/src/detect-media-type.ts
+++ b/packages/provider-utils/src/detect-media-type.ts
@@ -119,7 +119,21 @@ const audioMediaTypeSignatures = [
   },
   {
     mediaType: 'audio/mp4' as const,
-    bytesPrefix: [0x66, 0x74, 0x79, 0x70],
+    // ISO BMFF M4A audio: 4-byte box length, "ftyp", then the "M4A " brand.
+    bytesPrefix: [
+      null,
+      null,
+      null,
+      null,
+      0x66, // f
+      0x74, // t
+      0x79, // y
+      0x70, // p
+      0x4d, // M
+      0x34, // 4
+      0x41, // A
+      0x20, // (space)
+    ],
   },
   {
     mediaType: 'audio/webm',


### PR DESCRIPTION
## Background

Valid M4A files can use an ISO BMFF header where `ftyp` appears after the 4-byte box length. In [#14721](https://github.com/vercel/ai/issues/14721), that caused `transcribe()` to miss `audio/mp4` detection and fall back to `audio/wav`.

## Summary

- Detect M4A ISO BMFF headers with the `M4A ` brand as `audio/mp4`.
- Keep generic MP4 containers out of audio detection, preserving existing `video/mp4` behavior.

## Manual Verification

Ran a local `transcribe()` call with a mock transcription model and M4A header bytes:

```text
00 00 00 1c 66 74 79 70 4d 34 41 20
```

Confirmed the media type passed to `doGenerate()` was:

```text
audio/mp4
```

## Automated Verification

- `pnpm test` from `packages/provider-utils`
- `pnpm build:packages`
- `pnpm type-check:full`
- `pnpm check`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14721
