### PR TITLE
feat(ai): add toolMetadata for tool specific metdata

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
@@ -187,11 +187,11 @@ export const weatherTool = tool({
                 'Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.',
             },
             {
-              name: 'providerMetadata',
+              name: 'metadata',
               isOptional: true,
-              type: 'ProviderMetadata',
+              type: 'JSONObject',
               description:
-                "Optional metadata about the tool itself (e.g. its source). It is propagated onto the resulting tool call's providerMetadata so consumers can read it from tool call/result parts and UI message parts. Useful for sources of dynamic tools (e.g. an MCP server) to identify themselves.",
+                "Optional metadata about the tool itself (e.g. its source). It is propagated onto the resulting tool call's toolMetadata so consumers can read it from tool call/result parts and UI message parts. Useful for sources of dynamic tools (e.g. an MCP server) to identify themselves.",
             },
             {
               name: 'type',

--- a/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
@@ -153,11 +153,11 @@ export const customTool = dynamicTool({
               description: 'Additional provider-specific metadata.'
             },
             {
-              name: 'providerMetadata',
+              name: 'metadata',
               isOptional: true,
-              type: 'ProviderMetadata',
+              type: 'JSONObject',
               description:
-                "Optional metadata about the tool itself (e.g. its source). It is propagated onto the resulting tool call's providerMetadata so consumers can read it from tool call/result parts and UI message parts. Useful for sources of dynamic tools (e.g. an MCP server) to identify themselves."
+                "Optional metadata about the tool itself (e.g. its source). It is propagated onto the resulting tool call's toolMetadata so consumers can read it from tool call/result parts and UI message parts. Useful for sources of dynamic tools (e.g. an MCP server) to identify themselves."
             }
           ]
         }

--- a/examples/ai-e2e-next/app/chat/mcp/page.tsx
+++ b/examples/ai-e2e-next/app/chat/mcp/page.tsx
@@ -64,12 +64,9 @@ export default function Chat() {
                           </div>
                         )}
                         {part.type === 'dynamic-tool' &&
-                          'callProviderMetadata' in part &&
-                          typeof part.callProviderMetadata?.mcp?.clientName ===
-                            'string' && (
+                          typeof part.toolMetadata?.clientName === 'string' && (
                             <div className="text-xs text-gray-500">
-                              MCP server:{' '}
-                              {part.callProviderMetadata.mcp.clientName}
+                              MCP server: {part.toolMetadata.clientName}
                             </div>
                           )}
                       </div>

--- a/packages/ai/src/generate-text/execute-tool-call.test.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.test.ts
@@ -104,6 +104,40 @@ describe('executeToolCall', () => {
       });
     });
 
+    it('should preserve toolMetadata from toolCall', async () => {
+      const result = await executeToolCall({
+        toolCall: createToolCall({
+          toolMetadata: { clientName: 'MyMCPClient' },
+        }),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        callId: 'test-telemetry-call-id',
+        messages: [],
+        abortSignal: undefined,
+        toolsContext: {},
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "dynamic": false,
+          "input": {
+            "value": "test",
+          },
+          "output": "test-result",
+          "toolCallId": "call-1",
+          "toolMetadata": {
+            "clientName": "MyMCPClient",
+          },
+          "toolName": "testTool",
+          "type": "tool-result",
+        }
+      `);
+    });
+
     it('should throw TypeValidationError when tool context fails validation', async () => {
       try {
         await executeToolCall({
@@ -189,6 +223,42 @@ describe('executeToolCall', () => {
         type: 'tool-error',
         providerMetadata: { custom: { key: 'value' } },
       });
+    });
+
+    it('should preserve toolMetadata from toolCall on error', async () => {
+      const result = await executeToolCall({
+        toolCall: createToolCall({
+          toolMetadata: { clientName: 'MyMCPClient' },
+        }),
+        tools: {
+          testTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async (): Promise<string> => {
+              throw new Error('execution failed');
+            },
+          }),
+        },
+        callId: 'test-telemetry-call-id',
+        messages: [],
+        abortSignal: undefined,
+        toolsContext: {},
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "dynamic": false,
+          "error": [Error: execution failed],
+          "input": {
+            "value": "test",
+          },
+          "toolCallId": "call-1",
+          "toolMetadata": {
+            "clientName": "MyMCPClient",
+          },
+          "toolName": "testTool",
+          "type": "tool-error",
+        }
+      `);
     });
   });
 

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -148,6 +148,9 @@ export async function executeToolCall<TOOLS extends ToolSet>({
       ...(toolCall.providerMetadata != null
         ? { providerMetadata: toolCall.providerMetadata }
         : {}),
+      ...(toolCall.toolMetadata != null
+        ? { toolMetadata: toolCall.toolMetadata }
+        : {}),
     } as TypedToolError<TOOLS>;
 
     await notify({
@@ -171,6 +174,9 @@ export async function executeToolCall<TOOLS extends ToolSet>({
     dynamic: tool.type === 'dynamic',
     ...(toolCall.providerMetadata != null
       ? { providerMetadata: toolCall.providerMetadata }
+      : {}),
+    ...(toolCall.toolMetadata != null
+      ? { toolMetadata: toolCall.toolMetadata }
       : {}),
   } as TypedToolResult<TOOLS>;
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1335,6 +1335,9 @@ function asContent<TOOLS extends ToolSet>({
               ...(part.providerMetadata != null
                 ? { providerMetadata: part.providerMetadata }
                 : {}),
+              ...(tool?.metadata != null
+                ? { toolMetadata: tool.metadata }
+                : {}),
             } as TypedToolError<TOOLS>);
           } else {
             contentParts.push({
@@ -1347,6 +1350,9 @@ function asContent<TOOLS extends ToolSet>({
               dynamic: part.dynamic,
               ...(part.providerMetadata != null
                 ? { providerMetadata: part.providerMetadata }
+                : {}),
+              ...(tool?.metadata != null
+                ? { toolMetadata: tool.metadata }
                 : {}),
             } as TypedToolResult<TOOLS>);
           }
@@ -1365,6 +1371,9 @@ function asContent<TOOLS extends ToolSet>({
             ...(part.providerMetadata != null
               ? { providerMetadata: part.providerMetadata }
               : {}),
+            ...(toolCall.toolMetadata != null
+              ? { toolMetadata: toolCall.toolMetadata }
+              : {}),
           } as TypedToolError<TOOLS>);
         } else {
           contentParts.push({
@@ -1377,6 +1386,9 @@ function asContent<TOOLS extends ToolSet>({
             dynamic: toolCall.dynamic,
             ...(part.providerMetadata != null
               ? { providerMetadata: part.providerMetadata }
+              : {}),
+            ...(toolCall.toolMetadata != null
+              ? { toolMetadata: toolCall.toolMetadata }
               : {}),
           } as TypedToolResult<TOOLS>);
         }

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -606,8 +606,8 @@ describe('parseToolCall', () => {
     });
   });
 
-  describe('tool providerMetadata propagation', () => {
-    it('should propagate tool providerMetadata onto a parsed dynamic tool call', async () => {
+  describe('tool metadata propagation', () => {
+    it('should propagate tool metadata onto a parsed dynamic tool call', async () => {
       const result = await parseToolCall({
         toolCall: {
           type: 'tool-call',
@@ -618,7 +618,7 @@ describe('parseToolCall', () => {
         tools: {
           weather: dynamicTool({
             description: 'Get weather',
-            providerMetadata: { mcp: { clientName: 'MyMCPClient' } },
+            metadata: { clientName: 'MyMCPClient' },
             inputSchema: jsonSchema({
               type: 'object',
               properties: { location: { type: 'string' } },
@@ -632,12 +632,26 @@ describe('parseToolCall', () => {
         messages: [],
       });
 
-      expect(result.providerMetadata).toEqual({
-        mcp: { clientName: 'MyMCPClient' },
-      });
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "dynamic": true,
+          "input": {
+            "location": "Paris",
+          },
+          "providerExecuted": undefined,
+          "providerMetadata": undefined,
+          "title": undefined,
+          "toolCallId": "call-1",
+          "toolMetadata": {
+            "clientName": "MyMCPClient",
+          },
+          "toolName": "weather",
+          "type": "tool-call",
+        }
+      `);
     });
 
-    it('should propagate tool providerMetadata onto a parsed static tool call', async () => {
+    it('should propagate tool metadata onto a parsed static tool call', async () => {
       const result = await parseToolCall({
         toolCall: {
           type: 'tool-call',
@@ -648,7 +662,7 @@ describe('parseToolCall', () => {
         tools: {
           calculator: tool({
             description: 'Calculate',
-            providerMetadata: { mcp: { clientName: 'MyMCPClient' } },
+            metadata: { clientName: 'MyMCPClient' },
             inputSchema: z.object({ a: z.number(), b: z.number() }),
             execute: async ({ a, b }) => a + b,
           }),
@@ -658,12 +672,26 @@ describe('parseToolCall', () => {
         messages: [],
       });
 
-      expect(result.providerMetadata).toEqual({
-        mcp: { clientName: 'MyMCPClient' },
-      });
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "input": {
+            "a": 5,
+            "b": 3,
+          },
+          "providerExecuted": undefined,
+          "providerMetadata": undefined,
+          "title": undefined,
+          "toolCallId": "call-2",
+          "toolMetadata": {
+            "clientName": "MyMCPClient",
+          },
+          "toolName": "calculator",
+          "type": "tool-call",
+        }
+      `);
     });
 
-    it('should merge tool providerMetadata with model-supplied providerMetadata (model wins on conflicts)', async () => {
+    it('should keep tool metadata separate from model-supplied providerMetadata', async () => {
       const result = await parseToolCall({
         toolCall: {
           type: 'tool-call',
@@ -671,14 +699,13 @@ describe('parseToolCall', () => {
           toolName: 'weather',
           input: '{"location":"Paris"}',
           providerMetadata: {
-            mcp: { clientName: 'OverriddenByModel' },
             anthropic: { cacheControl: { type: 'ephemeral' } },
           },
         },
         tools: {
           weather: dynamicTool({
             description: 'Get weather',
-            providerMetadata: { mcp: { clientName: 'MyMCPClient' } },
+            metadata: { clientName: 'MyMCPClient' },
             inputSchema: jsonSchema({
               type: 'object',
               properties: { location: { type: 'string' } },
@@ -692,13 +719,26 @@ describe('parseToolCall', () => {
         messages: [],
       });
 
-      expect(result.providerMetadata).toEqual({
-        mcp: { clientName: 'OverriddenByModel' },
-        anthropic: { cacheControl: { type: 'ephemeral' } },
-      });
+      expect({
+        providerMetadata: result.providerMetadata,
+        toolMetadata: result.toolMetadata,
+      }).toMatchInlineSnapshot(`
+        {
+          "providerMetadata": {
+            "anthropic": {
+              "cacheControl": {
+                "type": "ephemeral",
+              },
+            },
+          },
+          "toolMetadata": {
+            "clientName": "MyMCPClient",
+          },
+        }
+      `);
     });
 
-    it('should propagate tool providerMetadata onto an invalid tool call', async () => {
+    it('should propagate tool metadata onto an invalid tool call', async () => {
       const result = await parseToolCall({
         toolCall: {
           type: 'tool-call',
@@ -709,7 +749,7 @@ describe('parseToolCall', () => {
         tools: {
           weather: dynamicTool({
             description: 'Get weather',
-            providerMetadata: { mcp: { clientName: 'MyMCPClient' } },
+            metadata: { clientName: 'MyMCPClient' },
             inputSchema: jsonSchema({
               type: 'object',
               properties: { location: { type: 'string' } },
@@ -724,10 +764,17 @@ describe('parseToolCall', () => {
         messages: [],
       });
 
-      expect(result.invalid).toBe(true);
-      expect(result.providerMetadata).toEqual({
-        mcp: { clientName: 'MyMCPClient' },
-      });
+      expect({
+        invalid: result.invalid,
+        toolMetadata: result.toolMetadata,
+      }).toMatchInlineSnapshot(`
+        {
+          "invalid": true,
+          "toolMetadata": {
+            "clientName": "MyMCPClient",
+          },
+        }
+      `);
     });
   });
 });

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -11,7 +11,6 @@ import {
 import { InvalidToolInputError } from '../error/invalid-tool-input-error';
 import { NoSuchToolError } from '../error/no-such-tool-error';
 import { ToolCallRepairError } from '../error/tool-call-repair-error';
-import type { ProviderMetadata } from '../types';
 import type { DynamicToolCall, TypedToolCall } from './tool-call';
 import type { ToolCallRepairFunction } from './tool-call-repair-function';
 import type { ToolInputRefinement } from './tool-input-refinement';
@@ -95,6 +94,7 @@ export async function parseToolCall<TOOLS extends ToolSet>({
     // use parsed input when possible
     const parsedInput = await safeParseJSON({ text: toolCall.input });
     const input = parsedInput.success ? parsedInput.value : toolCall.input;
+    const tool = tools?.[toolCall.toolName];
 
     // TODO AI SDK 6: special invalid tool call parts
     return {
@@ -105,12 +105,10 @@ export async function parseToolCall<TOOLS extends ToolSet>({
       dynamic: true,
       invalid: true,
       error,
-      title: tools?.[toolCall.toolName]?.title,
+      title: tool?.title,
       providerExecuted: toolCall.providerExecuted,
-      providerMetadata: mergeToolProviderMetadata(
-        tools?.[toolCall.toolName]?.providerMetadata,
-        toolCall.providerMetadata,
-      ),
+      providerMetadata: toolCall.providerMetadata,
+      ...(tool?.metadata != null ? { toolMetadata: tool.metadata } : {}),
     };
   }
 }
@@ -201,11 +199,6 @@ async function doParseToolCall<TOOLS extends ToolSet>({
     });
   }
 
-  const mergedProviderMetadata = mergeToolProviderMetadata(
-    tool.providerMetadata,
-    toolCall.providerMetadata,
-  );
-
   return tool.type === 'dynamic'
     ? {
         type: 'tool-call',
@@ -213,7 +206,8 @@ async function doParseToolCall<TOOLS extends ToolSet>({
         toolName: toolCall.toolName,
         input: parseResult.value,
         providerExecuted: toolCall.providerExecuted,
-        providerMetadata: mergedProviderMetadata,
+        providerMetadata: toolCall.providerMetadata,
+        ...(tool.metadata != null ? { toolMetadata: tool.metadata } : {}),
         dynamic: true,
         title: tool.title,
       }
@@ -223,25 +217,8 @@ async function doParseToolCall<TOOLS extends ToolSet>({
         toolName,
         input: parseResult.value,
         providerExecuted: toolCall.providerExecuted,
-        providerMetadata: mergedProviderMetadata,
+        providerMetadata: toolCall.providerMetadata,
+        ...(tool.metadata != null ? { toolMetadata: tool.metadata } : {}),
         title: tool.title,
       };
-}
-
-/**
- * Merge the tool's static `providerMetadata` (e.g. an MCP server name)
- * with the `providerMetadata` returned by the language model on the tool
- * call. Model-supplied metadata wins on conflicting top-level namespaces.
- */
-function mergeToolProviderMetadata(
-  toolMetadata: ProviderMetadata | undefined,
-  callMetadata: ProviderMetadata | undefined,
-): ProviderMetadata | undefined {
-  if (toolMetadata == null) {
-    return callMetadata;
-  }
-  if (callMetadata == null) {
-    return toolMetadata;
-  }
-  return { ...toolMetadata, ...callMetadata };
 }

--- a/packages/ai/src/generate-text/stream-language-model-call.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.ts
@@ -528,6 +528,9 @@ function createLanguageModelV4StreamPartToLanguageModelStreamPartTransform<
                 error: getErrorMessage(toolCall.error!),
                 dynamic: true,
                 title: toolCall.title,
+                ...(toolCall.toolMetadata != null
+                  ? { toolMetadata: toolCall.toolMetadata }
+                  : {}),
               });
               break;
             }
@@ -565,30 +568,37 @@ function createLanguageModelV4StreamPartToLanguageModelStreamPartTransform<
 
         case 'tool-result': {
           const toolName = chunk.toolName as keyof TOOLS & string;
+          const toolCall = toolCallsByToolCallId.get(chunk.toolCallId);
 
           const toolResultPart = chunk.isError
             ? ({
                 type: 'tool-error',
                 toolCallId: chunk.toolCallId,
                 toolName,
-                input: toolCallsByToolCallId.get(chunk.toolCallId)?.input,
+                input: toolCall?.input,
                 providerExecuted: true,
                 error: chunk.result,
                 dynamic: chunk.dynamic,
                 ...(chunk.providerMetadata != null
                   ? { providerMetadata: chunk.providerMetadata }
                   : {}),
+                ...(toolCall?.toolMetadata != null
+                  ? { toolMetadata: toolCall.toolMetadata }
+                  : {}),
               } as TypedToolError<TOOLS>)
             : ({
                 type: 'tool-result',
                 toolCallId: chunk.toolCallId,
                 toolName,
-                input: toolCallsByToolCallId.get(chunk.toolCallId)?.input,
+                input: toolCall?.input,
                 output: chunk.result,
                 providerExecuted: true,
                 dynamic: chunk.dynamic,
                 ...(chunk.providerMetadata != null
                   ? { providerMetadata: chunk.providerMetadata }
+                  : {}),
+                ...(toolCall?.toolMetadata != null
+                  ? { toolMetadata: toolCall.toolMetadata }
                   : {}),
               } as TypedToolResult<TOOLS>);
 
@@ -605,6 +615,7 @@ function createLanguageModelV4StreamPartToLanguageModelStreamPartTransform<
             ...chunk,
             dynamic: chunk.dynamic ?? tool?.type === 'dynamic',
             title: tool?.title,
+            ...(tool?.metadata != null ? { toolMetadata: tool.metadata } : {}),
           });
           break;
         }

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -1,3 +1,4 @@
+import type { JSONObject } from '@ai-sdk/provider';
 import type { Context, IdGenerator, ToolSet } from '@ai-sdk/provider-utils';
 import type { ServerResponse } from 'node:http';
 import type {
@@ -421,6 +422,7 @@ export type TextStreamToolInputStartPart = {
   id: string;
   toolName: string;
   providerMetadata?: ProviderMetadata;
+  toolMetadata?: JSONObject;
   providerExecuted?: boolean;
   dynamic?: boolean;
   title?: string;

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -2897,6 +2897,54 @@ describe('streamText', () => {
   });
 
   describe('result.toUIMessageStream', () => {
+    it('should include tool metadata in ui message stream chunks', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'test-tool',
+              input: `{ "value": "value" }`,
+            },
+            {
+              type: 'finish',
+              finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+              usage: testUsage,
+            },
+          ]),
+        }),
+        tools: {
+          'test-tool': dynamicTool({
+            metadata: { clientName: 'MyMCPClient' },
+            inputSchema: z.object({ value: z.string() }),
+            execute: async () => 'result',
+          }),
+        },
+        prompt: 'test-input',
+      });
+
+      const chunks = await convertReadableStreamToArray(
+        result.toUIMessageStream(),
+      );
+
+      expect(chunks.find(chunk => chunk.type === 'tool-input-available'))
+        .toMatchInlineSnapshot(`
+        {
+          "dynamic": true,
+          "input": {
+            "value": "value",
+          },
+          "toolCallId": "call-1",
+          "toolMetadata": {
+            "clientName": "MyMCPClient",
+          },
+          "toolName": "test-tool",
+          "type": "tool-input-available",
+        }
+      `);
+    });
+
     it('should create a ui message stream', async () => {
       const result = streamText({
         model: createTestModel(),

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2351,6 +2351,9 @@ class DefaultStreamTextResult<
                 ...(part.providerMetadata != null
                   ? { providerMetadata: part.providerMetadata }
                   : {}),
+                ...(part.toolMetadata != null
+                  ? { toolMetadata: part.toolMetadata }
+                  : {}),
                 ...(dynamic != null ? { dynamic } : {}),
                 ...(part.title != null ? { title: part.title } : {}),
               });
@@ -2381,6 +2384,9 @@ class DefaultStreamTextResult<
                   ...(part.providerMetadata != null
                     ? { providerMetadata: part.providerMetadata }
                     : {}),
+                  ...(part.toolMetadata != null
+                    ? { toolMetadata: part.toolMetadata }
+                    : {}),
                   ...(dynamic != null ? { dynamic } : {}),
                   errorText: onError(part.error),
                   ...(part.title != null ? { title: part.title } : {}),
@@ -2396,6 +2402,9 @@ class DefaultStreamTextResult<
                     : {}),
                   ...(part.providerMetadata != null
                     ? { providerMetadata: part.providerMetadata }
+                    : {}),
+                  ...(part.toolMetadata != null
+                    ? { toolMetadata: part.toolMetadata }
                     : {}),
                   ...(dynamic != null ? { dynamic } : {}),
                   ...(part.title != null ? { title: part.title } : {}),
@@ -2443,6 +2452,9 @@ class DefaultStreamTextResult<
                 ...(part.providerMetadata != null
                   ? { providerMetadata: part.providerMetadata }
                   : {}),
+                ...(part.toolMetadata != null
+                  ? { toolMetadata: part.toolMetadata }
+                  : {}),
                 ...(part.preliminary != null
                   ? { preliminary: part.preliminary }
                   : {}),
@@ -2467,6 +2479,9 @@ class DefaultStreamTextResult<
                   : {}),
                 ...(part.providerMetadata != null
                   ? { providerMetadata: part.providerMetadata }
+                  : {}),
+                ...(part.toolMetadata != null
+                  ? { toolMetadata: part.toolMetadata }
                   : {}),
                 ...(dynamic != null ? { dynamic } : {}),
               });

--- a/packages/ai/src/generate-text/tool-call.ts
+++ b/packages/ai/src/generate-text/tool-call.ts
@@ -1,3 +1,4 @@
+import type { JSONObject } from '@ai-sdk/provider';
 import type { InferToolInput, ToolSet } from '@ai-sdk/provider-utils';
 import type { ProviderMetadata } from '../types';
 import type { ValueOf } from '../util/value-of';
@@ -7,6 +8,7 @@ type BaseToolCall = {
   toolCallId: string;
   providerExecuted?: boolean;
   providerMetadata?: ProviderMetadata;
+  toolMetadata?: JSONObject;
 };
 
 /**

--- a/packages/ai/src/generate-text/tool-error.ts
+++ b/packages/ai/src/generate-text/tool-error.ts
@@ -1,3 +1,4 @@
+import type { JSONObject } from '@ai-sdk/provider';
 import type { InferToolInput, ToolSet } from '@ai-sdk/provider-utils';
 import type { ProviderMetadata } from '../types';
 import type { ValueOf } from '../util/value-of';
@@ -11,6 +12,7 @@ export type StaticToolError<TOOLS extends ToolSet> = ValueOf<{
     error: unknown;
     providerExecuted?: boolean;
     providerMetadata?: ProviderMetadata;
+    toolMetadata?: JSONObject;
     dynamic?: false | undefined;
     title?: string;
   };
@@ -24,6 +26,7 @@ export type DynamicToolError = {
   error: unknown;
   providerExecuted?: boolean;
   providerMetadata?: ProviderMetadata;
+  toolMetadata?: JSONObject;
   dynamic: true;
   title?: string;
 };

--- a/packages/ai/src/generate-text/tool-result.ts
+++ b/packages/ai/src/generate-text/tool-result.ts
@@ -1,3 +1,4 @@
+import type { JSONObject } from '@ai-sdk/provider';
 import type {
   InferToolInput,
   InferToolOutput,
@@ -15,6 +16,7 @@ export type StaticToolResult<TOOLS extends ToolSet> = ValueOf<{
     output: InferToolOutput<TOOLS[NAME]>;
     providerExecuted?: boolean;
     providerMetadata?: ProviderMetadata;
+    toolMetadata?: JSONObject;
     dynamic?: false | undefined;
     preliminary?: boolean;
     title?: string;
@@ -29,6 +31,7 @@ export type DynamicToolResult = {
   output: unknown;
   providerExecuted?: boolean;
   providerMetadata?: ProviderMetadata;
+  toolMetadata?: JSONObject;
   dynamic: true;
   preliminary?: boolean;
   title?: string;

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -1,8 +1,10 @@
+import type { JSONObject } from '@ai-sdk/provider';
 import { z } from 'zod/v4';
 import {
   providerMetadataSchema,
   type ProviderMetadata,
 } from '../types/provider-metadata';
+import { jsonValueSchema } from '../types/json-value';
 import type { FinishReason } from '../types/language-model';
 import type {
   InferUIMessageData,
@@ -12,6 +14,11 @@ import type {
 } from '../ui/ui-messages';
 import type { ValueOf } from '../util/value-of';
 import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
+
+const toolMetadataSchema: z.ZodType<JSONObject> = z.record(
+  z.string(),
+  jsonValueSchema.optional(),
+);
 
 export const uiMessageChunkSchema = lazySchema(() =>
   zodSchema(
@@ -42,6 +49,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
         toolName: z.string(),
         providerExecuted: z.boolean().optional(),
         providerMetadata: providerMetadataSchema.optional(),
+        toolMetadata: toolMetadataSchema.optional(),
         dynamic: z.boolean().optional(),
         title: z.string().optional(),
       }),
@@ -57,6 +65,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
         input: z.unknown(),
         providerExecuted: z.boolean().optional(),
         providerMetadata: providerMetadataSchema.optional(),
+        toolMetadata: toolMetadataSchema.optional(),
         dynamic: z.boolean().optional(),
         title: z.string().optional(),
       }),
@@ -67,6 +76,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
         input: z.unknown(),
         providerExecuted: z.boolean().optional(),
         providerMetadata: providerMetadataSchema.optional(),
+        toolMetadata: toolMetadataSchema.optional(),
         dynamic: z.boolean().optional(),
         errorText: z.string(),
         title: z.string().optional(),
@@ -91,6 +101,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
         output: z.unknown(),
         providerExecuted: z.boolean().optional(),
         providerMetadata: providerMetadataSchema.optional(),
+        toolMetadata: toolMetadataSchema.optional(),
         dynamic: z.boolean().optional(),
         preliminary: z.boolean().optional(),
       }),
@@ -100,6 +111,7 @@ export const uiMessageChunkSchema = lazySchema(() =>
         errorText: z.string(),
         providerExecuted: z.boolean().optional(),
         providerMetadata: providerMetadataSchema.optional(),
+        toolMetadata: toolMetadataSchema.optional(),
         dynamic: z.boolean().optional(),
       }),
       z.strictObject({
@@ -262,6 +274,7 @@ export type UIMessageChunk<
       input: unknown;
       providerExecuted?: boolean;
       providerMetadata?: ProviderMetadata;
+      toolMetadata?: JSONObject;
       dynamic?: boolean;
       title?: string;
     }
@@ -272,6 +285,7 @@ export type UIMessageChunk<
       input: unknown;
       providerExecuted?: boolean;
       providerMetadata?: ProviderMetadata;
+      toolMetadata?: JSONObject;
       dynamic?: boolean;
       errorText: string;
       title?: string;
@@ -296,6 +310,7 @@ export type UIMessageChunk<
       output: unknown;
       providerExecuted?: boolean;
       providerMetadata?: ProviderMetadata;
+      toolMetadata?: JSONObject;
       dynamic?: boolean;
       preliminary?: boolean;
     }
@@ -305,6 +320,7 @@ export type UIMessageChunk<
       errorText: string;
       providerExecuted?: boolean;
       providerMetadata?: ProviderMetadata;
+      toolMetadata?: JSONObject;
       dynamic?: boolean;
     }
   | {
@@ -317,6 +333,7 @@ export type UIMessageChunk<
       toolName: string;
       providerExecuted?: boolean;
       providerMetadata?: ProviderMetadata;
+      toolMetadata?: JSONObject;
       dynamic?: boolean;
       title?: string;
     }

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -5682,6 +5682,71 @@ describe('processUIMessageStream', () => {
         testProvider: { itemId: 'result-item' },
       });
     });
+
+    it('should preserve tool metadata on dynamic tool parts', async () => {
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-123' },
+        { type: 'start-step' },
+        {
+          type: 'tool-input-available',
+          toolCallId: 'tool-call-1',
+          toolName: 'tool-name',
+          input: { query: 'test' },
+          dynamic: true,
+          toolMetadata: { clientName: 'MyMCPClient' },
+        },
+        {
+          type: 'tool-output-available',
+          toolCallId: 'tool-call-1',
+          output: { result: 'provider-result' },
+          dynamic: true,
+        },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+
+      const toolPart = state!.message.parts.find(
+        (part: any) => part.toolCallId === 'tool-call-1',
+      ) as any;
+
+      expect(toolPart).toMatchInlineSnapshot(`
+        {
+          "errorText": undefined,
+          "input": {
+            "query": "test",
+          },
+          "output": {
+            "result": "provider-result",
+          },
+          "preliminary": undefined,
+          "providerExecuted": undefined,
+          "rawInput": undefined,
+          "state": "output-available",
+          "title": undefined,
+          "toolCallId": "tool-call-1",
+          "toolMetadata": {
+            "clientName": "MyMCPClient",
+          },
+          "toolName": "tool-name",
+          "type": "dynamic-tool",
+        }
+      `);
+    });
   });
 
   it('should call onToolCall for client-executed tools', async () => {

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -1,3 +1,4 @@
+import type { JSONObject } from '@ai-sdk/provider';
 import { validateTypes, type FlexibleSchema } from '@ai-sdk/provider-utils';
 import { UIMessageStreamError } from '../error/ui-message-stream-error';
 import type { ProviderMetadata } from '../types';
@@ -41,6 +42,7 @@ export type StreamingUIMessageState<UI_MESSAGE extends UIMessage> = {
       toolName: string;
       dynamic?: boolean;
       title?: string;
+      toolMetadata?: JSONObject;
     }
   >;
   finishReason?: FinishReason;
@@ -143,6 +145,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               toolCallId: string;
               providerExecuted?: boolean;
               title?: string;
+              toolMetadata?: JSONObject;
             } & (
               | {
                   state: 'input-streaming';
@@ -193,6 +196,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               if (options.title !== undefined) {
                 anyPart.title = options.title;
               }
+              if (options.toolMetadata !== undefined) {
+                anyPart.toolMetadata = options.toolMetadata;
+              }
               // once providerExecuted is set, it stays for streaming
               anyPart.providerExecuted =
                 anyOptions.providerExecuted ?? part.providerExecuted;
@@ -220,6 +226,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 toolCallId: options.toolCallId,
                 state: options.state,
                 title: options.title,
+                ...(options.toolMetadata !== undefined
+                  ? { toolMetadata: options.toolMetadata }
+                  : {}),
                 input: anyOptions.input,
                 output: anyOptions.output,
                 rawInput: anyOptions.rawInput,
@@ -248,6 +257,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               toolCallId: string;
               providerExecuted?: boolean;
               title?: string;
+              toolMetadata?: JSONObject;
             } & (
               | {
                   state: 'input-streaming';
@@ -294,6 +304,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               if (options.title !== undefined) {
                 anyPart.title = options.title;
               }
+              if (options.toolMetadata !== undefined) {
+                anyPart.toolMetadata = options.toolMetadata;
+              }
               // once providerExecuted is set, it stays for streaming
               anyPart.providerExecuted =
                 anyOptions.providerExecuted ?? part.providerExecuted;
@@ -327,6 +340,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 preliminary: anyOptions.preliminary,
                 providerExecuted: anyOptions.providerExecuted,
                 title: options.title,
+                ...(options.toolMetadata !== undefined
+                  ? { toolMetadata: options.toolMetadata }
+                  : {}),
                 ...(anyOptions.providerMetadata != null &&
                 (options.state === 'output-available' ||
                   options.state === 'output-error')
@@ -532,6 +548,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 index: toolInvocations.length,
                 dynamic: chunk.dynamic,
                 title: chunk.title,
+                toolMetadata: chunk.toolMetadata,
               };
 
               if (chunk.dynamic) {
@@ -542,6 +559,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   input: undefined,
                   providerExecuted: chunk.providerExecuted,
                   title: chunk.title,
+                  toolMetadata: chunk.toolMetadata,
                   providerMetadata: chunk.providerMetadata,
                 });
               } else {
@@ -552,6 +570,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   input: undefined,
                   providerExecuted: chunk.providerExecuted,
                   title: chunk.title,
+                  toolMetadata: chunk.toolMetadata,
                   providerMetadata: chunk.providerMetadata,
                 });
               }
@@ -585,6 +604,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   state: 'input-streaming',
                   input: partialArgs,
                   title: partialToolCall.title,
+                  toolMetadata: partialToolCall.toolMetadata,
                 });
               } else {
                 updateToolPart({
@@ -593,6 +613,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   state: 'input-streaming',
                   input: partialArgs,
                   title: partialToolCall.title,
+                  toolMetadata: partialToolCall.toolMetadata,
                 });
               }
 
@@ -610,6 +631,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerExecuted: chunk.providerExecuted,
                   providerMetadata: chunk.providerMetadata,
                   title: chunk.title,
+                  toolMetadata: chunk.toolMetadata,
                 });
               } else {
                 updateToolPart({
@@ -620,6 +642,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerExecuted: chunk.providerExecuted,
                   providerMetadata: chunk.providerMetadata,
                   title: chunk.title,
+                  toolMetadata: chunk.toolMetadata,
                 });
               }
 
@@ -658,6 +681,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   errorText: chunk.errorText,
                   providerExecuted: chunk.providerExecuted,
                   providerMetadata: chunk.providerMetadata,
+                  toolMetadata: chunk.toolMetadata,
                 });
               } else {
                 updateToolPart({
@@ -669,6 +693,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   errorText: chunk.errorText,
                   providerExecuted: chunk.providerExecuted,
                   providerMetadata: chunk.providerMetadata,
+                  toolMetadata: chunk.toolMetadata,
                 });
               }
 
@@ -734,6 +759,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerExecuted: chunk.providerExecuted,
                   providerMetadata: chunk.providerMetadata,
                   title: toolInvocation.title,
+                  toolMetadata: toolInvocation.toolMetadata,
                 });
               } else {
                 updateToolPart({
@@ -746,6 +772,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   preliminary: chunk.preliminary,
                   providerMetadata: chunk.providerMetadata,
                   title: toolInvocation.title,
+                  toolMetadata: toolInvocation.toolMetadata,
                 });
               }
 
@@ -766,6 +793,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerExecuted: chunk.providerExecuted,
                   providerMetadata: chunk.providerMetadata,
                   title: toolInvocation.title,
+                  toolMetadata: toolInvocation.toolMetadata,
                 });
               } else {
                 updateToolPart({
@@ -778,6 +806,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   providerExecuted: chunk.providerExecuted,
                   providerMetadata: chunk.providerMetadata,
                   title: toolInvocation.title,
+                  toolMetadata: toolInvocation.toolMetadata,
                 });
               }
 

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -1,3 +1,4 @@
+import type { JSONObject } from '@ai-sdk/provider';
 import type {
   InferToolInput,
   InferToolOutput,
@@ -281,6 +282,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
    */
   toolCallId: string;
   title?: string;
+  toolMetadata?: JSONObject;
 
   /**
    * Whether the tool call was executed by the provider.
@@ -393,6 +395,7 @@ export type DynamicToolUIPart = {
    */
   toolCallId: string;
   title?: string;
+  toolMetadata?: JSONObject;
 
   /**
    * Whether the tool call was executed by the provider.

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -1,4 +1,4 @@
-import { TypeValidationError } from '@ai-sdk/provider';
+import { TypeValidationError, type JSONObject } from '@ai-sdk/provider';
 import {
   lazySchema,
   validateTypes,
@@ -8,6 +8,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { InvalidArgumentError } from '../error';
+import { jsonValueSchema } from '../types/json-value';
 import { providerMetadataSchema } from '../types/provider-metadata';
 import type {
   DataUIPart,
@@ -16,6 +17,11 @@ import type {
   ToolUIPart,
   UIMessage,
 } from './ui-messages';
+
+const toolMetadataSchema: z.ZodType<JSONObject> = z.record(
+  z.string(),
+  jsonValueSchema.optional(),
+);
 
 const uiMessagesSchema = lazySchema(() =>
   zodSchema(
@@ -85,6 +91,7 @@ const uiMessagesSchema = lazySchema(() =>
                   type: z.literal('dynamic-tool'),
                   toolName: z.string(),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('input-streaming'),
                   input: z.unknown().optional(),
                   providerExecuted: z.boolean().optional(),
@@ -97,6 +104,7 @@ const uiMessagesSchema = lazySchema(() =>
                   type: z.literal('dynamic-tool'),
                   toolName: z.string(),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('input-available'),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
@@ -109,6 +117,7 @@ const uiMessagesSchema = lazySchema(() =>
                   type: z.literal('dynamic-tool'),
                   toolName: z.string(),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('approval-requested'),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
@@ -126,6 +135,7 @@ const uiMessagesSchema = lazySchema(() =>
                   type: z.literal('dynamic-tool'),
                   toolName: z.string(),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('approval-responded'),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
@@ -143,6 +153,7 @@ const uiMessagesSchema = lazySchema(() =>
                   type: z.literal('dynamic-tool'),
                   toolName: z.string(),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('output-available'),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
@@ -164,6 +175,7 @@ const uiMessagesSchema = lazySchema(() =>
                   type: z.literal('dynamic-tool'),
                   toolName: z.string(),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('output-error'),
                   input: z.unknown(),
                   rawInput: z.unknown().optional(),
@@ -185,6 +197,7 @@ const uiMessagesSchema = lazySchema(() =>
                   type: z.literal('dynamic-tool'),
                   toolName: z.string(),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('output-denied'),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
@@ -201,6 +214,7 @@ const uiMessagesSchema = lazySchema(() =>
                 z.object({
                   type: z.string().startsWith('tool-'),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('input-streaming'),
                   providerExecuted: z.boolean().optional(),
                   callProviderMetadata: providerMetadataSchema.optional(),
@@ -212,6 +226,7 @@ const uiMessagesSchema = lazySchema(() =>
                 z.object({
                   type: z.string().startsWith('tool-'),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('input-available'),
                   providerExecuted: z.boolean().optional(),
                   input: z.unknown(),
@@ -223,6 +238,7 @@ const uiMessagesSchema = lazySchema(() =>
                 z.object({
                   type: z.string().startsWith('tool-'),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('approval-requested'),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
@@ -239,6 +255,7 @@ const uiMessagesSchema = lazySchema(() =>
                 z.object({
                   type: z.string().startsWith('tool-'),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('approval-responded'),
                   input: z.unknown(),
                   providerExecuted: z.boolean().optional(),
@@ -255,6 +272,7 @@ const uiMessagesSchema = lazySchema(() =>
                 z.object({
                   type: z.string().startsWith('tool-'),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('output-available'),
                   providerExecuted: z.boolean().optional(),
                   input: z.unknown(),
@@ -275,6 +293,7 @@ const uiMessagesSchema = lazySchema(() =>
                 z.object({
                   type: z.string().startsWith('tool-'),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('output-error'),
                   providerExecuted: z.boolean().optional(),
                   input: z.unknown(),
@@ -295,6 +314,7 @@ const uiMessagesSchema = lazySchema(() =>
                 z.object({
                   type: z.string().startsWith('tool-'),
                   toolCallId: z.string(),
+                  toolMetadata: toolMetadataSchema.optional(),
                   state: z.literal('output-denied'),
                   providerExecuted: z.boolean().optional(),
                   input: z.unknown(),

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -93,7 +93,7 @@ describe('MCPClient', () => {
     `);
   });
 
-  it('should expose MCP tool metadata on dynamic tools via providerMetadata', async () => {
+  it('should expose MCP tool metadata on dynamic tools', async () => {
     client = await createMCPClient({
       transport: { type: 'sse', url: 'https://example.com/sse' },
       clientName: 'MyMCPClient',
@@ -101,14 +101,12 @@ describe('MCPClient', () => {
 
     const tools = await client.tools();
 
-    expect(tools['mock-tool'].providerMetadata).toEqual({
-      mcp: {
-        clientName: 'MyMCPClient',
-      },
+    expect(tools['mock-tool'].metadata).toEqual({
+      clientName: 'MyMCPClient',
     });
   });
 
-  it('should support deprecated name for MCP tool providerMetadata', async () => {
+  it('should support deprecated client name for MCP tool metadata', async () => {
     client = await createMCPClient({
       transport: { type: 'sse', url: 'https://example.com/sse' },
       name: 'DeprecatedMCPServer',
@@ -116,10 +114,8 @@ describe('MCPClient', () => {
 
     const tools = await client.tools();
 
-    expect(tools['mock-tool'].providerMetadata).toEqual({
-      mcp: {
-        clientName: 'DeprecatedMCPServer',
-      },
+    expect(tools['mock-tool'].metadata).toEqual({
+      clientName: 'DeprecatedMCPServer',
     });
   });
 

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -635,8 +635,8 @@ class DefaultMCPClient implements MCPClient {
           ? dynamicTool({
               description,
               title: resolvedTitle,
-              providerMetadata: {
-                mcp: { clientName: this.clientInfo.name },
+              metadata: {
+                clientName: this.clientInfo.name,
               },
               inputSchema: jsonSchema({
                 ...inputSchema,
@@ -649,8 +649,8 @@ class DefaultMCPClient implements MCPClient {
           : tool({
               description,
               title: resolvedTitle,
-              providerMetadata: {
-                mcp: { clientName: this.clientInfo.name },
+              metadata: {
+                clientName: this.clientInfo.name,
               },
               inputSchema: schemas[name].inputSchema,
               ...(outputSchema != null ? { outputSchema } : {}),

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -1,4 +1,4 @@
-import type { JSONValue, SharedV4ProviderMetadata } from '@ai-sdk/provider';
+import type { JSONValue, JSONObject } from '@ai-sdk/provider';
 import type { FlexibleSchema } from '../schema';
 import type { ToolResultOutput } from './content-part';
 import type { Context } from './context';
@@ -73,11 +73,11 @@ type BaseTool<
    *
    * Unlike `providerOptions`, this metadata is not sent to the language
    * model. Instead, it is propagated onto the resulting tool call's
-   * `providerMetadata` so consumers can read it from tool call / result
-   * parts and UI message parts. This is useful for sources of dynamic
-   * tools (e.g. an MCP server) to identify themselves.
+   * `toolMetadata` so consumers can read it from tool call / result parts
+   * and UI message parts. This is useful for sources of dynamic tools (e.g.
+   * an MCP server) to identify themselves.
    */
-  providerMetadata?: SharedV4ProviderMetadata;
+  metadata?: JSONObject;
 
   /**
    * The schema of the input that the tool expects.


### PR DESCRIPTION
## Background

in PR https://github.com/vercel/ai/pull/14813, we introduced a merging function that combined tool specific providerMetdata with model call providerMetadata.

a cleaner solution would have been to keep the tool metadata separate than the model's. 

## Summary

- added a new tool-owned metadata path: tools can define `metadata?: JSONObject`, which propagates as `toolMetadata` on parsed tool calls
- existing providerMetadata remains model/provider owned
- MCP tools now expose `metadata: { clientName }`
- remove the merging function (that combined callProviderMetadata with tool providerMetadata)

## Manual Verification

verified by running the example `http://localhost:3000/chat/mcp`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)