### PR TITLE
fix(workflow): align WorkflowAgent invalid tool-call handling with core

### DIFF
--- a/.changeset/fix-workflow-agent-dynamic-invalid-tool-calls.md
+++ b/.changeset/fix-workflow-agent-dynamic-invalid-tool-calls.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+`WorkflowAgent` now mirrors core (`generateText`/`streamText`) by only feeding back error results for `dynamic` invalid tool calls. Non-dynamic (statically-typed) invalid tool calls are silently dropped, matching the `invalid && dynamic` gate in `generate-text.ts`.

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -639,7 +639,7 @@ describe('WorkflowAgent', () => {
       consoleWarnSpy.mockRestore();
     });
 
-    it('should keep invalid tool calls on the error path without executing them', async () => {
+    it('should silently drop non-dynamic invalid tool calls (no error result fed back)', async () => {
       const execute = vi.fn(async () => 'should-not-run');
       const tools: ToolSet = {
         testTool: {
@@ -673,12 +673,7 @@ describe('WorkflowAgent', () => {
         ...mockMessages,
         {
           role: 'assistant',
-          content: [
-            {
-              type: 'text',
-              text: 'done',
-            },
-          ],
+          content: [{ type: 'text', text: 'done' }],
         },
       ];
       const mockIterator = {
@@ -694,6 +689,99 @@ describe('WorkflowAgent', () => {
                   toolName: 'testTool',
                   input: { cities: 'San Francisco' },
                   invalid: true,
+                  error: invalidError,
+                  // no dynamic flag — matches core behaviour for static tools
+                } satisfies ParsedToolCall,
+              ],
+              messages: mockMessages,
+            },
+          })
+          .mockResolvedValueOnce({
+            done: true,
+            value: finalMessages,
+          }),
+      };
+      vi.mocked(streamTextIterator).mockReturnValue(
+        mockIterator as unknown as MockIterator,
+      );
+
+      const result = await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: mockWritable,
+      });
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(mockIterator.next).toHaveBeenCalledTimes(2);
+      // Non-dynamic invalid tool calls are silently dropped — no error result
+      // fed back to the model, matching core (generate-text) behaviour.
+      expect(mockIterator.next.mock.calls[1][0]).toEqual([]);
+      expect(writes).toEqual([
+        { type: 'finish-step' },
+        { type: 'start-step' },
+        { type: 'finish' },
+      ]);
+      expect(result.toolCalls).toMatchObject([
+        {
+          type: 'tool-call',
+          toolCallId: 'invalid-call-id',
+          toolName: 'testTool',
+          input: { cities: 'San Francisco' },
+        },
+      ]);
+      expect(result.toolResults).toHaveLength(0);
+    });
+
+    it('should feed an error result back for dynamic invalid tool calls', async () => {
+      const execute = vi.fn(async () => 'should-not-run');
+      const tools: ToolSet = {
+        testTool: {
+          description: 'A test tool',
+          inputSchema: z.object({ city: z.string() }),
+          execute,
+        },
+      };
+
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: mockModel,
+        tools,
+      });
+
+      const writes: any[] = [];
+      const mockWritable = new WritableStream({
+        write: chunk => {
+          writes.push(chunk);
+        },
+        close: vi.fn(),
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      const invalidError = new Error('Invalid input for tool testTool');
+      const mockMessages: LanguageModelV4Prompt = [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ];
+      const finalMessages: LanguageModelV4Prompt = [
+        ...mockMessages,
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'done' }],
+        },
+      ];
+      const mockIterator = {
+        next: vi
+          .fn()
+          .mockResolvedValueOnce({
+            done: false,
+            value: {
+              toolCalls: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'dynamic-invalid-call-id',
+                  toolName: 'testTool',
+                  input: { cities: 'San Francisco' },
+                  invalid: true,
+                  dynamic: true,
                   error: invalidError,
                 } satisfies ParsedToolCall,
               ],
@@ -716,6 +804,7 @@ describe('WorkflowAgent', () => {
 
       expect(execute).not.toHaveBeenCalled();
       expect(mockIterator.next).toHaveBeenCalledTimes(2);
+      // Dynamic invalid tool calls get an error-text result fed back, matching core.
       expect(mockIterator.next.mock.calls[1][0]).toMatchInlineSnapshot(`
         [
           {
@@ -723,7 +812,7 @@ describe('WorkflowAgent', () => {
               "type": "error-text",
               "value": "Invalid input for tool testTool",
             },
-            "toolCallId": "invalid-call-id",
+            "toolCallId": "dynamic-invalid-call-id",
             "toolName": "testTool",
             "type": "tool-result",
           },
@@ -733,14 +822,6 @@ describe('WorkflowAgent', () => {
         { type: 'finish-step' },
         { type: 'start-step' },
         { type: 'finish' },
-      ]);
-      expect(result.toolCalls).toMatchObject([
-        {
-          type: 'tool-call',
-          toolCallId: 'invalid-call-id',
-          toolName: 'testTool',
-          input: { cities: 'San Francisco' },
-        },
       ]);
       expect(result.toolResults).toHaveLength(0);
     });

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1546,6 +1546,9 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
         // Only execute tools if there are tool calls
         if (toolCalls.length > 0) {
           const invalidToolCalls = toolCalls.filter(tc => tc.invalid === true);
+          const dynamicInvalidToolCalls = invalidToolCalls.filter(
+            tc => tc.dynamic === true,
+          );
           const validToolCalls = toolCalls.filter(tc => tc.invalid !== true);
 
           // Separate provider-executed tool calls from client-executed ones
@@ -1618,7 +1621,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
                 ),
               );
 
-            const continuationInvalidResults = invalidToolCalls.map(
+            const continuationInvalidResults = dynamicInvalidToolCalls.map(
               createInvalidToolResult,
             );
             const resolvedResults = [
@@ -1723,7 +1726,7 @@ export class WorkflowAgent<TBaseTools extends ToolSet = ToolSet> {
             providerToolCalls.map(toolCall =>
               resolveProviderToolResult(toolCall, providerExecutedToolResults),
             );
-          const continuationInvalidToolResults = invalidToolCalls.map(
+          const continuationInvalidToolResults = dynamicInvalidToolCalls.map(
             createInvalidToolResult,
           );
 


### PR DESCRIPTION
## Background

`generate-text.ts` only generates error output parts for invalid tool calls that also have `dynamic: true`. `WorkflowAgent` was unconditionally generating error results for all invalid tool calls, diverging from core behavior — non-dynamic (statically-typed) invalid tool calls should be silently dropped, not fed back to the model as error results.

## Summary

- Extract `dynamicInvalidToolCalls` from `invalidToolCalls` in `workflow-agent.ts` and use it in both the paused and normal execution paths when calling `createInvalidToolResult`
- Non-dynamic invalid tool calls are still excluded from execution but no longer generate an error-text continuation result
- Update existing test to assert no error result for non-dynamic invalid tool calls; add new test asserting a `dynamic` invalid tool call does produce an error-text result

## Manual Verification

- `pnpm --filter @ai-sdk/workflow test` — all tests pass

## Checklist
- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #14668