### PR TITLE
feat(deepinfra, moonshotai): add chat language model options companion files

### DIFF
--- a/.changeset/fix-deepinfra-moonshotai-chat-language-model-options.md
+++ b/.changeset/fix-deepinfra-moonshotai-chat-language-model-options.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/deepinfra': patch
+'@ai-sdk/moonshotai': patch
+---
+
+Add companion `*-chat-language-model-options.ts` files for `DeepInfraChatLanguageModel` and `MoonshotAIChatLanguageModel`, and add explicit `implements LanguageModelV4` declarations, satisfying the `konsistent` code-consistency convention. Exports `DeepInfraLanguageModelChatOptions` and `MoonshotAILanguageModelChatOptions`.

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -233,10 +233,7 @@
             ],
             "haveFiles": ["${providerId}-${modelKind}-model-options.ts"]
           },
-          "excludeFiles": [
-            "packages/deepinfra/src/deepinfra-chat-language-model.ts",
-            "packages/moonshotai/src/moonshotai-chat-language-model.ts"
-          ]
+          "excludeFiles": []
         },
         {
           "name": "provider-video-model-file-must-export-model-class",

--- a/packages/deepinfra/src/deepinfra-chat-language-model-options.ts
+++ b/packages/deepinfra/src/deepinfra-chat-language-model-options.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod/v4';
+
+export const deepinfraLanguageModelChatOptions = z.object({});
+
+export type DeepInfraLanguageModelChatOptions = z.infer<
+  typeof deepinfraLanguageModelChatOptions
+>;

--- a/packages/deepinfra/src/deepinfra-chat-language-model.ts
+++ b/packages/deepinfra/src/deepinfra-chat-language-model.ts
@@ -1,4 +1,5 @@
 import type {
+  LanguageModelV4,
   LanguageModelV4CallOptions,
   LanguageModelV4GenerateResult,
   LanguageModelV4StreamResult,
@@ -17,7 +18,10 @@ type DeepInfraChatConfig = {
   fetch?: FetchFunction;
 };
 
-export class DeepInfraChatLanguageModel extends OpenAICompatibleChatLanguageModel {
+export class DeepInfraChatLanguageModel
+  extends OpenAICompatibleChatLanguageModel
+  implements LanguageModelV4
+{
   static [WORKFLOW_SERIALIZE](model: DeepInfraChatLanguageModel) {
     return serializeModelOptions({
       modelId: model.modelId,

--- a/packages/moonshotai/src/index.ts
+++ b/packages/moonshotai/src/index.ts
@@ -9,4 +9,5 @@ export type {
   /** @deprecated Use `MoonshotAILanguageModelOptions` instead. */
   MoonshotAILanguageModelOptions as MoonshotAIProviderOptions,
 } from './moonshotai-chat-options';
+export type { MoonshotAILanguageModelChatOptions } from './moonshotai-chat-language-model-options';
 export { VERSION } from './version';

--- a/packages/moonshotai/src/moonshotai-chat-language-model-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model-options.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod/v4';
+
+export const moonshotaiLanguageModelChatOptions = z.object({
+  thinking: z
+    .object({
+      type: z.enum(['enabled', 'disabled']).optional(),
+      budgetTokens: z.number().int().min(1024).optional(),
+    })
+    .optional(),
+
+  reasoningHistory: z.enum(['disabled', 'interleaved', 'preserved']).optional(),
+});
+
+export type MoonshotAILanguageModelChatOptions = z.infer<
+  typeof moonshotaiLanguageModelChatOptions
+>;

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -6,6 +6,7 @@ import {
   WORKFLOW_DESERIALIZE,
 } from '@ai-sdk/provider-utils';
 import type {
+  LanguageModelV4,
   LanguageModelV4CallOptions,
   LanguageModelV4GenerateResult,
   LanguageModelV4StreamPart,
@@ -14,7 +15,10 @@ import type {
 import { convertMoonshotAIChatUsage } from './convert-moonshotai-chat-usage';
 import type { MoonshotAIChatModelId } from './moonshotai-chat-options';
 
-export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageModel {
+export class MoonshotAIChatLanguageModel
+  extends OpenAICompatibleChatLanguageModel
+  implements LanguageModelV4
+{
   static [WORKFLOW_SERIALIZE](model: MoonshotAIChatLanguageModel) {
     return serializeModelOptions({
       modelId: model.modelId,

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -1,5 +1,3 @@
-import { z } from 'zod/v4';
-
 export type MoonshotAIChatModelId =
   | 'moonshot-v1-8k'
   | 'moonshot-v1-32k'
@@ -12,17 +10,5 @@ export type MoonshotAIChatModelId =
   | 'kimi-k2.5'
   | (string & {});
 
-export const moonshotaiLanguageModelOptions = z.object({
-  thinking: z
-    .object({
-      type: z.enum(['enabled', 'disabled']).optional(),
-      budgetTokens: z.number().int().min(1024).optional(),
-    })
-    .optional(),
-
-  reasoningHistory: z.enum(['disabled', 'interleaved', 'preserved']).optional(),
-});
-
-export type MoonshotAILanguageModelOptions = z.infer<
-  typeof moonshotaiLanguageModelOptions
->;
+export { moonshotaiLanguageModelChatOptions as moonshotaiLanguageModelOptions } from './moonshotai-chat-language-model-options';
+export type { MoonshotAILanguageModelChatOptions as MoonshotAILanguageModelOptions } from './moonshotai-chat-language-model-options';


### PR DESCRIPTION
## Background

`DeepInfraChatLanguageModel` and `MoonshotAIChatLanguageModel` were excluded from the konsistent `provider-model-file-with-subtype-must-export-model-class` convention because they lacked companion `*-chat-language-model-options.ts` files and explicit `implements LanguageModelV4` declarations.

## Summary

**`packages/deepinfra`**
- Add `deepinfra-chat-language-model-options.ts` exporting `DeepInfraLanguageModelChatOptions` (empty schema; no provider-specific options beyond the OpenAI-compatible base)
- Add `implements LanguageModelV4` to `DeepInfraChatLanguageModel`

**`packages/moonshotai`**
- Add `moonshotai-chat-language-model-options.ts` exporting `moonshotaiLanguageModelChatOptions` schema and `MoonshotAILanguageModelChatOptions` type
- Refactor `moonshotai-chat-options.ts` to re-export from the new file, preserving existing aliases for backward compatibility
- Export `MoonshotAILanguageModelChatOptions` from `index.ts`
- Add `implements LanguageModelV4` to `MoonshotAIChatLanguageModel`

**`.github/konsistent.json`** — remove both entries from `excludeFiles`

## Manual Verification

- `pnpm --filter @ai-sdk/deepinfra test` — all tests pass
- `pnpm --filter @ai-sdk/moonshotai test` — all tests pass
- `pnpm konsistent` — no violations

## Checklist
- [x] All commits are signed
- [ ] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes part of #14859