### PR TITLE
fix(ai): emit DeprecationWarning with stable AISDK_DEP_* code in logWarnings

### DIFF
--- a/.changeset/feat-deprecation-warning-codes.md
+++ b/.changeset/feat-deprecation-warning-codes.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+`logWarnings` now emits `process.emitWarning()` with `type: 'DeprecationWarning'` and a stable `code` (`AISDK_DEP_*`) for deprecated warnings, enabling `--no-deprecation` / `--throw-deprecation` filtering on a per-code basis.

--- a/packages/ai/src/logger/log-warnings.test.ts
+++ b/packages/ai/src/logger/log-warnings.test.ts
@@ -262,7 +262,10 @@ describe('logWarnings', () => {
       expect(mockProcessEmitWarning).toHaveBeenNthCalledWith(
         3,
         `AI SDK Warning (zzz / MMM): Deprecated: "providerOptions key 'old-key'". Use 'oldKey' instead.`,
-        { type: 'DeprecationWarning' },
+        {
+          type: 'DeprecationWarning',
+          code: 'AISDK_DEP_PROVIDEROPTIONS_KEY_OLD_KEY',
+        },
       );
       expect(mockProcessEmitWarning).toHaveBeenNthCalledWith(
         4,

--- a/packages/ai/src/logger/log-warnings.ts
+++ b/packages/ai/src/logger/log-warnings.ts
@@ -86,6 +86,22 @@ function formatWarning({
 export const FIRST_WARNING_INFO_MESSAGE =
   'AI SDK Warning System: To turn off warning logging, set the AI_SDK_LOG_WARNINGS global to false.';
 
+/**
+ * Converts a deprecated setting name to a stable `AISDK_DEP_*` code for
+ * `process.emitWarning`, so callers can filter with `--no-deprecation` or
+ * `--throw-deprecation` on a per-code basis.
+ */
+export function toDeprecationCode(setting: string): string {
+  return (
+    'AISDK_DEP_' +
+    setting
+      .toUpperCase()
+      .replace(/[^A-Z0-9]+/g, '_')
+      .replace(/^_+/, '')
+      .replace(/_+$/, '')
+  );
+}
+
 let hasLoggedBefore = false;
 
 /**
@@ -137,9 +153,15 @@ export const logWarnings: LogWarningsFunction = options => {
       typeof process !== 'undefined' &&
       typeof process.emitWarning === 'function'
     ) {
-      process.emitWarning(message, {
-        type: warning.type === 'deprecated' ? 'DeprecationWarning' : 'Warning',
-      });
+      process.emitWarning(
+        message,
+        warning.type === 'deprecated'
+          ? {
+              type: 'DeprecationWarning',
+              code: toDeprecationCode(warning.setting),
+            }
+          : { type: 'Warning' },
+      );
     } else {
       console.warn(message);
     }

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -2105,7 +2105,10 @@ describe('convertToLanguageModelMessage', () => {
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
           'AI SDK Warning: Deprecated: ""tool-result" content of type "file-data"". The "file-data" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'data\', data } instead.',
-          { type: 'DeprecationWarning' },
+          {
+            type: 'DeprecationWarning',
+            code: 'AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_FILE_DATA',
+          },
         );
         expect(
           (
@@ -2155,7 +2158,10 @@ describe('convertToLanguageModelMessage', () => {
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
           'AI SDK Warning: Deprecated: ""tool-result" content of type "file-reference"". The "file-reference" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'reference\', reference } instead.',
-          { type: 'DeprecationWarning' },
+          {
+            type: 'DeprecationWarning',
+            code: 'AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_FILE_REFERENCE',
+          },
         );
         expect(
           (
@@ -2208,7 +2214,10 @@ describe('convertToLanguageModelMessage', () => {
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
           'AI SDK Warning: Deprecated: ""tool-result" content of type "image-data"". The "image-data" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'data\', data } instead.',
-          { type: 'DeprecationWarning' },
+          {
+            type: 'DeprecationWarning',
+            code: 'AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_IMAGE_DATA',
+          },
         );
         expect(
           (
@@ -2254,7 +2263,10 @@ describe('convertToLanguageModelMessage', () => {
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
           'AI SDK Warning: Deprecated: ""tool-result" content of type "image-url"". The "image-url" type for tool result content is deprecated. Use the "file" type with mediaType \'image\' (or a specific image/* subtype) and { type: \'url\', url } instead.',
-          { type: 'DeprecationWarning' },
+          {
+            type: 'DeprecationWarning',
+            code: 'AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_IMAGE_URL',
+          },
         );
         expect(
           (
@@ -2306,7 +2318,10 @@ describe('convertToLanguageModelMessage', () => {
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
           'AI SDK Warning: Deprecated: ""tool-result" content of type "image-file-reference"". The "image-file-reference" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'reference\', reference } instead.',
-          { type: 'DeprecationWarning' },
+          {
+            type: 'DeprecationWarning',
+            code: 'AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_IMAGE_FILE_REFERENCE',
+          },
         );
         expect(
           (
@@ -2358,7 +2373,10 @@ describe('convertToLanguageModelMessage', () => {
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
           'AI SDK Warning: Deprecated: ""tool-result" content of type "image-file-id"". The "image-file-id" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'reference\', reference } instead.',
-          { type: 'DeprecationWarning' },
+          {
+            type: 'DeprecationWarning',
+            code: 'AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_IMAGE_FILE_ID',
+          },
         );
         expect(
           (
@@ -2410,7 +2428,10 @@ describe('convertToLanguageModelMessage', () => {
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
           'AI SDK Warning: Deprecated: ""tool-result" content of type "file-id"". The "file-id" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'reference\', reference } instead.',
-          { type: 'DeprecationWarning' },
+          {
+            type: 'DeprecationWarning',
+            code: 'AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_FILE_ID',
+          },
         );
         expect(
           (
@@ -2463,7 +2484,10 @@ describe('convertToLanguageModelMessage', () => {
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
           `AI SDK Warning: Deprecated: ""tool-result" content of type "file-url"". The "file-url" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'url', url } instead.`,
-          { type: 'DeprecationWarning' },
+          {
+            type: 'DeprecationWarning',
+            code: 'AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_FILE_URL',
+          },
         );
       });
 
@@ -2494,7 +2518,10 @@ describe('convertToLanguageModelMessage', () => {
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
           `AI SDK Warning: Deprecated: ""tool-result" content of type "file-url"". The "file-url" tool result content part with URL "https://example.com/image.png" is missing a "mediaType". Inferred media type 'image/png' from URL. The "file-url" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'url', url } instead.`,
-          { type: 'DeprecationWarning' },
+          {
+            type: 'DeprecationWarning',
+            code: 'AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_FILE_URL',
+          },
         );
       });
 
@@ -2525,7 +2552,10 @@ describe('convertToLanguageModelMessage', () => {
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
           `AI SDK Warning: Deprecated: ""tool-result" content of type "file-url"". The "file-url" tool result content part with URL "https://example.com/file" is missing a "mediaType". Unable to infer media type from URL. Defaulting to 'application/octet-stream'. The "file-url" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'url', url } instead.`,
-          { type: 'DeprecationWarning' },
+          {
+            type: 'DeprecationWarning',
+            code: 'AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_FILE_URL',
+          },
         );
       });
 
@@ -2560,7 +2590,10 @@ describe('convertToLanguageModelMessage', () => {
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
           `AI SDK Warning: Deprecated: ""tool-result" content of type "file-url"". The "file-url" tool result content part with URL "https://example.com/foo.constructor" is missing a "mediaType". Unable to infer media type from URL. Defaulting to 'application/octet-stream'. The "file-url" type for tool result content is deprecated. Use the "file" type with mediaType and { type: 'url', url } instead.`,
-          { type: 'DeprecationWarning' },
+          {
+            type: 'DeprecationWarning',
+            code: 'AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_FILE_URL',
+          },
         );
       });
 
@@ -2592,7 +2625,10 @@ describe('convertToLanguageModelMessage', () => {
         expect(mockProcessEmitWarning).toHaveBeenCalledOnce();
         expect(mockProcessEmitWarning).toHaveBeenCalledWith(
           'AI SDK Warning: Deprecated: ""tool-result" content of type "image-data"". The "image-data" type for tool result content is deprecated. Use the "file" type with mediaType and { type: \'data\', data } instead.',
-          { type: 'DeprecationWarning' },
+          {
+            type: 'DeprecationWarning',
+            code: 'AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_IMAGE_DATA',
+          },
         );
       });
 


### PR DESCRIPTION
## Background

`logWarnings` was emitting deprecation warnings as generic Node.js warnings without a stable code. This made it impossible for consumers to programmatically filter or escalate specific deprecations using standard Node.js flags like `--no-deprecation` or `--throw-deprecation`.

## Summary

- `logWarnings` now calls `process.emitWarning(msg, { type: 'DeprecationWarning', code: 'AISDK_DEP_...' })` for `deprecated`-type warnings
- New `toDeprecationCode(setting)` helper derives a stable machine-friendly code from the warning's `setting` field (e.g. `"tool-result" content of type "file-data"` → `AISDK_DEP_TOOL_RESULT_CONTENT_OF_TYPE_FILE_DATA`)
- All other warning types continue to use `{ type: 'Warning' }` with no `code`

## Manual Verification

- `log-warnings.test.ts` — covers `toDeprecationCode` output and that `deprecated` warnings emit with `type: 'DeprecationWarning'` + correct `code`
- `convert-to-language-model-prompt.test.ts` — all 12 existing `DeprecationWarning` assertions updated to include the expected `code`
- `pnpm --filter ai test` — 2546 tests pass, 0 failures

## Checklist
- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #14187