### PR TITLE
feat(@ai-sdk/mistral): add built-in web_search and web_search_premium tools

### DIFF
--- a/.changeset/feat-mistral-builtin-web-search.md
+++ b/.changeset/feat-mistral-builtin-web-search.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': minor
+---
+
+Add built-in `web_search` and `web_search_premium` tool support to `@ai-sdk/mistral`. These tools can now be passed via `mistral.tools.webSearch()` / `mistral.tools.webSearchPremium()`, letting Mistral models perform live web searches without any client-side execution handler.

--- a/packages/mistral/src/index.ts
+++ b/packages/mistral/src/index.ts
@@ -8,4 +8,7 @@ export type {
   /** @deprecated Use `MistralLanguageModelChatOptions` instead. */
   MistralLanguageModelChatOptions as MistralLanguageModelOptions,
 } from './mistral-chat-language-model-options';
+export { mistralTools } from './mistral-tools';
+export { webSearch } from './tool/web-search';
+export { webSearchPremium } from './tool/web-search-premium';
 export { VERSION } from './version';

--- a/packages/mistral/src/mistral-prepare-tools.test.ts
+++ b/packages/mistral/src/mistral-prepare-tools.test.ts
@@ -105,6 +105,134 @@ describe('prepareTools', () => {
     `);
   });
 
+  describe('provider-defined tools', () => {
+    it('should convert mistral.web_search to { type: "web_search" }', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'mistral.web_search',
+            name: 'web_search',
+            args: {},
+            inputSchema: { type: 'object', properties: {} },
+            outputSchema: {},
+          },
+        ],
+      });
+
+      expect(result.tools).toEqual([{ type: 'web_search' }]);
+      expect(result.toolWarnings).toHaveLength(0);
+    });
+
+    it('should convert mistral.web_search_premium to { type: "web_search_premium" }', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'mistral.web_search_premium',
+            name: 'web_search_premium',
+            args: {},
+            inputSchema: { type: 'object', properties: {} },
+            outputSchema: {},
+          },
+        ],
+      });
+
+      expect(result.tools).toEqual([{ type: 'web_search_premium' }]);
+      expect(result.toolWarnings).toHaveLength(0);
+    });
+
+    it('should mix function tools and built-in tools', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'myFunc',
+            description: 'A function',
+            inputSchema: { type: 'object', properties: {} },
+          },
+          {
+            type: 'provider',
+            id: 'mistral.web_search',
+            name: 'web_search',
+            args: {},
+            inputSchema: { type: 'object', properties: {} },
+            outputSchema: {},
+          },
+        ],
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'myFunc',
+            description: 'A function',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+        { type: 'web_search' },
+      ]);
+      expect(result.toolWarnings).toHaveLength(0);
+    });
+
+    it('should emit unsupported warning for unknown provider tools', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'unknown.tool',
+            name: 'unknown_tool',
+            args: {},
+            inputSchema: { type: 'object', properties: {} },
+            outputSchema: {},
+          },
+        ],
+      });
+
+      expect(result.tools).toEqual([]);
+      expect(result.toolWarnings).toHaveLength(1);
+      expect(result.toolWarnings[0]).toMatchObject({
+        type: 'unsupported',
+        feature: 'provider-defined tool unknown.tool',
+      });
+    });
+
+    it('should not include built-in tools when filtering by tool choice', () => {
+      const result = prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'myFunc',
+            description: 'A function',
+            inputSchema: { type: 'object', properties: {} },
+          },
+          {
+            type: 'provider',
+            id: 'mistral.web_search',
+            name: 'web_search',
+            args: {},
+            inputSchema: { type: 'object', properties: {} },
+            outputSchema: {},
+          },
+        ],
+        toolChoice: { type: 'tool', toolName: 'myFunc' },
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'myFunc',
+            description: 'A function',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      ]);
+      expect(result.toolChoice).toBe('any');
+    });
+  });
+
   it('should pass through strict mode for multiple tools with different strict settings', () => {
     const result = prepareTools({
       tools: [

--- a/packages/mistral/src/mistral-prepare-tools.ts
+++ b/packages/mistral/src/mistral-prepare-tools.ts
@@ -5,6 +5,22 @@ import {
 } from '@ai-sdk/provider';
 import type { MistralToolChoice } from './mistral-chat-prompt';
 
+type MistralFunctionTool = {
+  type: 'function';
+  function: {
+    name: string;
+    description: string | undefined;
+    parameters: unknown;
+    strict?: boolean;
+  };
+};
+
+type MistralBuiltinTool =
+  | { type: 'web_search' }
+  | { type: 'web_search_premium' };
+
+type MistralTool = MistralFunctionTool | MistralBuiltinTool;
+
 export function prepareTools({
   tools,
   toolChoice,
@@ -12,17 +28,7 @@ export function prepareTools({
   tools: LanguageModelV4CallOptions['tools'];
   toolChoice?: LanguageModelV4CallOptions['toolChoice'];
 }): {
-  tools:
-    | Array<{
-        type: 'function';
-        function: {
-          name: string;
-          description: string | undefined;
-          parameters: unknown;
-          strict?: boolean;
-        };
-      }>
-    | undefined;
+  tools: Array<MistralTool> | undefined;
   toolChoice: MistralToolChoice | undefined;
   toolWarnings: SharedV4Warning[];
 } {
@@ -35,22 +41,23 @@ export function prepareTools({
     return { tools: undefined, toolChoice: undefined, toolWarnings };
   }
 
-  const mistralTools: Array<{
-    type: 'function';
-    function: {
-      name: string;
-      description: string | undefined;
-      parameters: unknown;
-      strict?: boolean;
-    };
-  }> = [];
+  const mistralTools: Array<MistralTool> = [];
 
   for (const tool of tools) {
     if (tool.type === 'provider') {
-      toolWarnings.push({
-        type: 'unsupported',
-        feature: `provider-defined tool ${tool.id}`,
-      });
+      switch (tool.id) {
+        case 'mistral.web_search':
+          mistralTools.push({ type: 'web_search' });
+          break;
+        case 'mistral.web_search_premium':
+          mistralTools.push({ type: 'web_search_premium' });
+          break;
+        default:
+          toolWarnings.push({
+            type: 'unsupported',
+            feature: `provider-defined tool ${tool.id}`,
+          });
+      }
     } else {
       mistralTools.push({
         type: 'function',
@@ -82,7 +89,9 @@ export function prepareTools({
     case 'tool':
       return {
         tools: mistralTools.filter(
-          tool => tool.function.name === toolChoice.toolName,
+          tool =>
+            tool.type === 'function' &&
+            tool.function.name === toolChoice.toolName,
         ),
         toolChoice: 'any',
         toolWarnings,

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -14,10 +14,16 @@ import { MistralChatLanguageModel } from './mistral-chat-language-model';
 import type { MistralChatModelId } from './mistral-chat-language-model-options';
 import { MistralEmbeddingModel } from './mistral-embedding-model';
 import type { MistralEmbeddingModelId } from './mistral-embedding-options';
+import { mistralTools } from './mistral-tools';
 import { VERSION } from './version';
 
 export interface MistralProvider extends ProviderV4 {
   (modelId: MistralChatModelId): LanguageModelV4;
+
+  /**
+   * Built-in Mistral tools (e.g. web_search, web_search_premium).
+   */
+  tools: typeof mistralTools;
 
   /**
    * Creates a model for text generation.
@@ -127,6 +133,7 @@ export function createMistral(
   };
 
   provider.specificationVersion = 'v4' as const;
+  provider.tools = mistralTools;
   provider.languageModel = createChatModel;
   provider.chat = createChatModel;
   provider.embedding = createEmbeddingModel;

--- a/packages/mistral/src/mistral-tools.ts
+++ b/packages/mistral/src/mistral-tools.ts
@@ -1,0 +1,24 @@
+import { webSearch } from './tool/web-search';
+import { webSearchPremium } from './tool/web-search-premium';
+
+export const mistralTools = {
+  /**
+   * Mistral's built-in web search tool.
+   *
+   * When included in the `tools` array, the model can perform live web searches
+   * to answer questions that require up-to-date information.
+   *
+   * @see https://docs.mistral.ai/agents/tools/built-in/websearch
+   */
+  webSearch,
+
+  /**
+   * Mistral's built-in premium web search tool.
+   *
+   * Higher-quality variant of the built-in web search, backed by a premium
+   * search index.
+   *
+   * @see https://docs.mistral.ai/agents/tools/built-in/websearch
+   */
+  webSearchPremium,
+};

--- a/packages/mistral/src/tool/web-search-premium.ts
+++ b/packages/mistral/src/tool/web-search-premium.ts
@@ -1,0 +1,18 @@
+import {
+  createProviderExecutedToolFactory,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+const factory = createProviderExecutedToolFactory<
+  Record<string, never>,
+  unknown,
+  Record<string, never>
+>({
+  id: 'mistral.web_search_premium',
+  inputSchema: zodSchema(z.object({})),
+  outputSchema: zodSchema(z.unknown()),
+});
+
+export const webSearchPremium = (args: Parameters<typeof factory>[0] = {}) =>
+  factory(args);

--- a/packages/mistral/src/tool/web-search.ts
+++ b/packages/mistral/src/tool/web-search.ts
@@ -1,0 +1,18 @@
+import {
+  createProviderExecutedToolFactory,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+const factory = createProviderExecutedToolFactory<
+  Record<string, never>,
+  unknown,
+  Record<string, never>
+>({
+  id: 'mistral.web_search',
+  inputSchema: zodSchema(z.object({})),
+  outputSchema: zodSchema(z.unknown()),
+});
+
+export const webSearch = (args: Parameters<typeof factory>[0] = {}) =>
+  factory(args);


### PR DESCRIPTION
## Background

Mistral's API supports server-side built-in tools (`web_search`, `web_search_premium`) passed in the `tools` array, but `@ai-sdk/mistral` had no way to use them through the standard AI SDK provider-defined tool pattern.

## Summary

- New `packages/mistral/src/tool/web-search.ts` — `mistral.web_search` provider tool factory
- New `packages/mistral/src/tool/web-search-premium.ts` — `mistral.web_search_premium` provider tool factory
- New `packages/mistral/src/mistral-tools.ts` — groups both tools under `mistralTools`
- `mistral-prepare-tools.ts` — converts `mistral.web_search` → `{ type: 'web_search' }` and `mistral.web_search_premium` → `{ type: 'web_search_premium' }` in the API request; unknown provider tools still emit an unsupported warning
- `mistral-provider.ts` — adds `tools` property to `MistralProvider` interface
- `index.ts` — exports `webSearch`, `webSearchPremium`, and `mistralTools`

## Manual Verification

- New tests cover: `web_search` conversion, `web_search_premium` conversion, mixing function tools and built-in tools, unknown provider tool warning, and `tool` choice filtering with built-in tools present
- `pnpm --filter @ai-sdk/mistral test` — 76 tests pass

## Checklist
- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #14312