### PR TITLE
feat(alibaba): add embedding model support

### DIFF
--- a/.changeset/feat-alibaba-embedding-model.md
+++ b/.changeset/feat-alibaba-embedding-model.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/alibaba': minor
+---
+
+Add embedding model support to `@ai-sdk/alibaba`. The new `AlibabaEmbeddingModel` supports Alibaba DashScope's OpenAI-compatible `/v1/embeddings` endpoint with models `text-embedding-v4` and `text-embedding-v3`. Provider-specific options (`dimensions`, `text_type`, `output_type`) are available via `providerOptions.alibaba`.

--- a/packages/alibaba/src/alibaba-embedding-model-options.ts
+++ b/packages/alibaba/src/alibaba-embedding-model-options.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod/v4';
+
+export const alibabaEmbeddingModelOptions = z.object({
+  /**
+   * The number of dimensions for the output embeddings.
+   * Available values depend on the model.
+   *
+   * For `text-embedding-v4`: 2048, 1536, 1024 (default), 768, 512, 256, 128, 64.
+   * For `text-embedding-v3`: 1024 (default), 768, 512.
+   */
+  dimensions: z.number().optional(),
+
+  /**
+   * Specifies whether the input is a search query or a document to embed.
+   * Use `query` for search queries and `document` for texts to be stored and searched.
+   */
+  text_type: z.enum(['query', 'document']).optional(),
+
+  /**
+   * The type of output vectors to return.
+   * Only available for `text-embedding-v4`.
+   *
+   * - `dense`: returns only dense vectors (default)
+   * - `sparse`: returns only sparse vectors
+   * - `dense&sparse`: returns both dense and sparse vectors
+   */
+  output_type: z.enum(['dense', 'sparse', 'dense&sparse']).optional(),
+});
+
+export type AlibabaEmbeddingModelOptions = z.infer<
+  typeof alibabaEmbeddingModelOptions
+>;

--- a/packages/alibaba/src/alibaba-embedding-model.test.ts
+++ b/packages/alibaba/src/alibaba-embedding-model.test.ts
@@ -1,0 +1,115 @@
+import type { EmbeddingModelV4Embedding } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createAlibaba } from './alibaba-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const dummyEmbeddings = [
+  [0.1, 0.2, 0.3, 0.4, 0.5],
+  [0.6, 0.7, 0.8, 0.9, 1.0],
+];
+const testValues = ['sunny day at the beach', 'rainy day in the city'];
+
+const provider = createAlibaba({ apiKey: 'test-api-key' });
+const model = provider.embeddingModel('text-embedding-v3');
+
+const server = createTestServer({
+  'https://dashscope-intl.aliyuncs.com/compatible-mode/v1/embeddings': {},
+});
+
+describe('doEmbed', () => {
+  function prepareJsonResponse({
+    embeddings = dummyEmbeddings,
+    usage = { prompt_tokens: 8, total_tokens: 8 },
+    headers,
+  }: {
+    embeddings?: EmbeddingModelV4Embedding[];
+    usage?: { prompt_tokens: number; total_tokens: number };
+    headers?: Record<string, string>;
+  } = {}) {
+    server.urls[
+      'https://dashscope-intl.aliyuncs.com/compatible-mode/v1/embeddings'
+    ].response = {
+      type: 'json-value',
+      headers,
+      body: {
+        object: 'list',
+        data: embeddings.map((embedding, i) => ({
+          object: 'embedding',
+          embedding,
+          index: i,
+        })),
+        model: 'text-embedding-v3',
+        usage,
+      },
+    };
+  }
+
+  it('should extract embedding', async () => {
+    prepareJsonResponse();
+
+    const { embeddings } = await model.doEmbed({ values: testValues });
+
+    expect(embeddings).toStrictEqual(dummyEmbeddings);
+  });
+
+  it('should extract usage', async () => {
+    prepareJsonResponse({
+      usage: { prompt_tokens: 20, total_tokens: 20 },
+    });
+
+    const { usage } = await model.doEmbed({ values: testValues });
+
+    expect(usage).toStrictEqual({ tokens: 20 });
+  });
+
+  it('should pass correct request body', async () => {
+    prepareJsonResponse();
+
+    await model.doEmbed({ values: testValues });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'text-embedding-v3',
+      input: testValues,
+      encoding_format: 'float',
+    });
+  });
+
+  it('should pass provider options', async () => {
+    prepareJsonResponse();
+
+    await model.doEmbed({
+      values: testValues,
+      providerOptions: {
+        alibaba: {
+          dimensions: 512,
+          text_type: 'query',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      dimensions: 512,
+      text_type: 'query',
+    });
+  });
+
+  it('should throw when too many values are provided', async () => {
+    const manyValues = Array.from({ length: 51 }, (_, i) => `text ${i}`);
+
+    await expect(model.doEmbed({ values: manyValues })).rejects.toThrowError(
+      /Too many values/,
+    );
+  });
+
+  it('should respect per-model maxEmbeddingsPerCall', () => {
+    const v4Model = provider.embeddingModel('text-embedding-v4');
+    expect(v4Model.maxEmbeddingsPerCall).toBe(10);
+
+    const v3Model = provider.embeddingModel('text-embedding-v3');
+    expect(v3Model.maxEmbeddingsPerCall).toBe(50);
+  });
+});

--- a/packages/alibaba/src/alibaba-embedding-model.ts
+++ b/packages/alibaba/src/alibaba-embedding-model.ts
@@ -1,0 +1,138 @@
+import {
+  TooManyEmbeddingValuesForCallError,
+  type EmbeddingModelV4,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postJsonToApi,
+  serializeModelOptions,
+  WORKFLOW_SERIALIZE,
+  WORKFLOW_DESERIALIZE,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import {
+  alibabaEmbeddingModelOptions,
+  type AlibabaEmbeddingModelOptions,
+} from './alibaba-embedding-model-options';
+import {
+  modelMaxEmbeddingsPerCall,
+  type AlibabaEmbeddingModelId,
+} from './alibaba-embedding-settings';
+import { alibabaFailedResponseHandler } from './alibaba-error';
+
+type AlibabaEmbeddingConfig = {
+  provider: string;
+  baseURL: string;
+  headers?: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+};
+
+export class AlibabaEmbeddingModel implements EmbeddingModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly modelId: AlibabaEmbeddingModelId;
+
+  private readonly config: AlibabaEmbeddingConfig;
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  get maxEmbeddingsPerCall(): number {
+    return modelMaxEmbeddingsPerCall[this.modelId] ?? 10;
+  }
+
+  get supportsParallelCalls(): boolean {
+    return false;
+  }
+
+  static [WORKFLOW_SERIALIZE](model: AlibabaEmbeddingModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: AlibabaEmbeddingModelId;
+    config: AlibabaEmbeddingConfig;
+  }) {
+    return new AlibabaEmbeddingModel(options.modelId, options.config);
+  }
+
+  constructor(
+    modelId: AlibabaEmbeddingModelId,
+    config: AlibabaEmbeddingConfig,
+  ) {
+    this.modelId = modelId;
+    this.config = config;
+  }
+
+  async doEmbed({
+    values,
+    headers,
+    abortSignal,
+    providerOptions,
+  }: Parameters<EmbeddingModelV4['doEmbed']>[0]): Promise<
+    Awaited<ReturnType<EmbeddingModelV4['doEmbed']>>
+  > {
+    if (values.length > this.maxEmbeddingsPerCall) {
+      throw new TooManyEmbeddingValuesForCallError({
+        provider: this.provider,
+        modelId: this.modelId,
+        maxEmbeddingsPerCall: this.maxEmbeddingsPerCall,
+        values,
+      });
+    }
+
+    const options =
+      (await parseProviderOptions({
+        provider: 'alibaba',
+        providerOptions,
+        schema: alibabaEmbeddingModelOptions,
+      })) ?? ({} as AlibabaEmbeddingModelOptions);
+
+    const {
+      responseHeaders,
+      value: response,
+      rawValue,
+    } = await postJsonToApi({
+      url: `${this.config.baseURL}/embeddings`,
+      headers: combineHeaders(this.config.headers?.(), headers),
+      body: {
+        model: this.modelId,
+        input: values,
+        encoding_format: 'float',
+        ...(options.dimensions != null
+          ? { dimensions: options.dimensions }
+          : {}),
+        ...(options.text_type != null ? { text_type: options.text_type } : {}),
+        ...(options.output_type != null
+          ? { output_type: options.output_type }
+          : {}),
+      },
+      failedResponseHandler: alibabaFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        alibabaTextEmbeddingResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      warnings: [],
+      embeddings: response.data.map(item => item.embedding),
+      usage: response.usage
+        ? { tokens: response.usage.prompt_tokens }
+        : undefined,
+      response: { headers: responseHeaders, body: rawValue },
+    };
+  }
+}
+
+const alibabaTextEmbeddingResponseSchema = z.object({
+  data: z.array(z.object({ embedding: z.array(z.number()) })),
+  usage: z.object({ prompt_tokens: z.number() }).nullish(),
+});

--- a/packages/alibaba/src/alibaba-embedding-settings.ts
+++ b/packages/alibaba/src/alibaba-embedding-settings.ts
@@ -1,0 +1,9 @@
+export type AlibabaEmbeddingModelId =
+  | 'text-embedding-v4'
+  | 'text-embedding-v3'
+  | (string & {});
+
+export const modelMaxEmbeddingsPerCall: Record<string, number> = {
+  'text-embedding-v4': 10,
+  'text-embedding-v3': 50,
+};

--- a/packages/alibaba/src/alibaba-provider.ts
+++ b/packages/alibaba/src/alibaba-provider.ts
@@ -1,5 +1,6 @@
 import {
   NoSuchModelError,
+  type EmbeddingModelV4,
   type Experimental_VideoModelV4,
   type LanguageModelV4,
   type ProviderV4,
@@ -12,6 +13,8 @@ import {
 } from '@ai-sdk/provider-utils';
 import { AlibabaChatLanguageModel } from './alibaba-chat-language-model';
 import type { AlibabaChatModelId } from './alibaba-chat-language-model-options';
+import { AlibabaEmbeddingModel } from './alibaba-embedding-model';
+import type { AlibabaEmbeddingModelId } from './alibaba-embedding-settings';
 import { AlibabaVideoModel } from './alibaba-video-model';
 import type { AlibabaVideoModelId } from './alibaba-video-settings';
 import { VERSION } from './version';
@@ -41,6 +44,26 @@ export interface AlibabaProvider extends ProviderV4 {
    * Creates a model for video generation.
    */
   videoModel(modelId: AlibabaVideoModelId): Experimental_VideoModelV4;
+
+  /**
+   * Creates a model for text embeddings.
+   */
+  embedding(modelId: AlibabaEmbeddingModelId): EmbeddingModelV4;
+
+  /**
+   * Creates a model for text embeddings.
+   */
+  embeddingModel(modelId: AlibabaEmbeddingModelId): EmbeddingModelV4;
+
+  /**
+   * @deprecated Use `embedding` instead.
+   */
+  textEmbedding(modelId: AlibabaEmbeddingModelId): EmbeddingModelV4;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: AlibabaEmbeddingModelId): EmbeddingModelV4;
 }
 
 export interface AlibabaProviderSettings {
@@ -119,6 +142,14 @@ export function createAlibaba(
       includeUsage: options.includeUsage ?? true,
     });
 
+  const createEmbeddingModel = (modelId: AlibabaEmbeddingModelId) =>
+    new AlibabaEmbeddingModel(modelId, {
+      provider: 'alibaba.embedding',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
   const createVideoModel = (modelId: AlibabaVideoModelId) =>
     new AlibabaVideoModel(modelId, {
       provider: 'alibaba.video',
@@ -142,13 +173,13 @@ export function createAlibaba(
   provider.chatModel = createLanguageModel;
   provider.video = createVideoModel;
   provider.videoModel = createVideoModel;
+  provider.embedding = createEmbeddingModel;
+  provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbedding = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
-  };
-
-  provider.embeddingModel = (modelId: string) => {
-    throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
 
   return provider;

--- a/packages/alibaba/src/index.ts
+++ b/packages/alibaba/src/index.ts
@@ -6,6 +6,8 @@ export type {
   /** @deprecated Use `AlibabaLanguageModelChatOptions` instead. */
   AlibabaLanguageModelChatOptions as AlibabaProviderOptions,
 } from './alibaba-chat-language-model-options';
+export type { AlibabaEmbeddingModelOptions } from './alibaba-embedding-model-options';
+export type { AlibabaEmbeddingModelId } from './alibaba-embedding-settings';
 export type { AlibabaCacheControl } from './alibaba-chat-prompt';
 export {
   type AlibabaProvider,


### PR DESCRIPTION
## Background

`@ai-sdk/alibaba` had a placeholder `throw new NoSuchModelError` for embedding models. DashScope's OpenAI-compatible `/v1/embeddings` endpoint supports several embedding models and provider-specific parameters that were not exposed.

## Summary

- New `AlibabaEmbeddingModel` implementing `EmbeddingModelV4` for DashScope's `/v1/embeddings` endpoint
- Supports `text-embedding-v4` (max 10 embeddings/call) and `text-embedding-v3` (max 50 embeddings/call)
- New `AlibabaEmbeddingModelOptions` exposes three Alibaba-specific parameters: `dimensions`, `text_type` (`"query"` | `"document"`), and `output_type` (`"dense"` | `"sparse"` | `"dense&sparse"`, v4 only)
- Adds `embedding()`, `embeddingModel()`, `textEmbedding()`, `textEmbeddingModel()` methods to `AlibabaProvider`
- Replaces the placeholder `throw new NoSuchModelError` for `embeddingModel`

## Manual Verification

- `pnpm --filter @ai-sdk/alibaba test` — all 93 tests pass (7 new embedding model tests added)
- TypeScript build succeeds: `pnpm --filter @ai-sdk/alibaba build`

## Checklist
- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #14644