### PR TITLE
feat(mistral): add Voxtral speech model support

### DIFF
--- a/.changeset/feat-mistral-speech-model.md
+++ b/.changeset/feat-mistral-speech-model.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': minor
+---
+
+Add Voxtral speech model support to `@ai-sdk/mistral`. The new `MistralSpeechModel` implements `SpeechModelV4` and calls the `/v1/audio/speech` endpoint. Supports output formats `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`. Accessible via `mistral.speech(modelId)` and `mistral.speechModel(modelId)`.

--- a/packages/mistral/src/index.ts
+++ b/packages/mistral/src/index.ts
@@ -8,4 +8,6 @@ export type {
   /** @deprecated Use `MistralLanguageModelChatOptions` instead. */
   MistralLanguageModelChatOptions as MistralLanguageModelOptions,
 } from './mistral-chat-language-model-options';
+export type { MistralSpeechModelOptions } from './mistral-speech-model-options';
+export type { MistralSpeechModelId } from './mistral-speech-options';
 export { VERSION } from './version';

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -3,6 +3,7 @@ import {
   type EmbeddingModelV4,
   type LanguageModelV4,
   type ProviderV4,
+  type SpeechModelV4,
 } from '@ai-sdk/provider';
 import {
   loadApiKey,
@@ -14,6 +15,8 @@ import { MistralChatLanguageModel } from './mistral-chat-language-model';
 import type { MistralChatModelId } from './mistral-chat-language-model-options';
 import { MistralEmbeddingModel } from './mistral-embedding-model';
 import type { MistralEmbeddingModelId } from './mistral-embedding-options';
+import { MistralSpeechModel } from './mistral-speech-model';
+import type { MistralSpeechModelId } from './mistral-speech-options';
 import { VERSION } from './version';
 
 export interface MistralProvider extends ProviderV4 {
@@ -48,6 +51,16 @@ export interface MistralProvider extends ProviderV4 {
    * @deprecated Use `embeddingModel` instead.
    */
   textEmbeddingModel(modelId: MistralEmbeddingModelId): EmbeddingModelV4;
+
+  /**
+   * Creates a model for speech synthesis (text-to-speech).
+   */
+  speech(modelId: MistralSpeechModelId): SpeechModelV4;
+
+  /**
+   * Creates a model for speech synthesis (text-to-speech).
+   */
+  speechModel(modelId: MistralSpeechModelId): SpeechModelV4;
 }
 
 export interface MistralProviderSettings {
@@ -116,6 +129,14 @@ export function createMistral(
       fetch: options.fetch,
     });
 
+  const createSpeechModel = (modelId: MistralSpeechModelId) =>
+    new MistralSpeechModel(modelId, {
+      provider: 'mistral.speech',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
   const provider = function (modelId: MistralChatModelId) {
     if (new.target) {
       throw new Error(
@@ -133,6 +154,8 @@ export function createMistral(
   provider.embeddingModel = createEmbeddingModel;
   provider.textEmbedding = createEmbeddingModel;
   provider.textEmbeddingModel = createEmbeddingModel;
+  provider.speech = createSpeechModel;
+  provider.speechModel = createSpeechModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });

--- a/packages/mistral/src/mistral-speech-model-options.ts
+++ b/packages/mistral/src/mistral-speech-model-options.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod/v4';
+
+export const mistralSpeechModelOptions = z.object({});
+
+export type MistralSpeechModelOptions = z.infer<
+  typeof mistralSpeechModelOptions
+>;

--- a/packages/mistral/src/mistral-speech-model.test.ts
+++ b/packages/mistral/src/mistral-speech-model.test.ts
@@ -1,0 +1,142 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createMistral } from './mistral-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const provider = createMistral({ apiKey: 'test-api-key' });
+const model = provider.speech('voxtral-mini-tts-2506');
+
+const server = createTestServer({
+  'https://api.mistral.ai/v1/audio/speech': {},
+});
+
+describe('doGenerate', () => {
+  function prepareAudioResponse({
+    headers,
+    format = 'mp3',
+  }: {
+    headers?: Record<string, string>;
+    format?: 'mp3' | 'opus' | 'aac' | 'flac' | 'wav' | 'pcm';
+  } = {}) {
+    const audioBuffer = new Uint8Array(100);
+    server.urls['https://api.mistral.ai/v1/audio/speech'].response = {
+      type: 'binary',
+      headers: {
+        'content-type': `audio/${format}`,
+        ...headers,
+      },
+      body: Buffer.from(audioBuffer),
+    };
+    return audioBuffer;
+  }
+
+  it('should pass the model and text', async () => {
+    prepareAudioResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      model: 'voxtral-mini-tts-2506',
+      input: 'Hello from the AI SDK!',
+    });
+  });
+
+  it('should pass voice and format', async () => {
+    prepareAudioResponse({ format: 'mp3' });
+
+    await model.doGenerate({
+      text: 'Hello!',
+      voice: 'coeur_de_lion',
+      outputFormat: 'mp3',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      model: 'voxtral-mini-tts-2506',
+      input: 'Hello!',
+      voice: 'coeur_de_lion',
+      response_format: 'mp3',
+    });
+  });
+
+  it('should warn on unsupported output format', async () => {
+    prepareAudioResponse();
+
+    const { warnings } = await model.doGenerate({
+      text: 'Hello!',
+      outputFormat: 'hex',
+    });
+
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'outputFormat',
+      }),
+    );
+  });
+
+  it('should warn on unsupported speed', async () => {
+    prepareAudioResponse();
+
+    const { warnings } = await model.doGenerate({
+      text: 'Hello!',
+      speed: 1.5,
+    });
+
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'speed',
+      }),
+    );
+  });
+
+  it('should warn on unsupported language', async () => {
+    prepareAudioResponse();
+
+    const { warnings } = await model.doGenerate({
+      text: 'Hello!',
+      language: 'fr',
+    });
+
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'language',
+      }),
+    );
+  });
+
+  it('should return audio data', async () => {
+    const audio = prepareAudioResponse({ format: 'mp3' });
+
+    const result = await model.doGenerate({ text: 'Hello!' });
+
+    expect(result.audio).toBeInstanceOf(Uint8Array);
+    expect(result.audio).toEqual(audio);
+  });
+
+  it('should pass headers', async () => {
+    prepareAudioResponse();
+
+    const customProvider = createMistral({
+      apiKey: 'test-api-key',
+      headers: { 'Custom-Provider-Header': 'provider-value' },
+    });
+
+    await customProvider.speech('voxtral-mini-tts-2506').doGenerate({
+      text: 'Hello!',
+      headers: { 'Custom-Request-Header': 'request-value' },
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      authorization: 'Bearer test-api-key',
+      'custom-provider-header': 'provider-value',
+      'custom-request-header': 'request-value',
+    });
+  });
+});

--- a/packages/mistral/src/mistral-speech-model.ts
+++ b/packages/mistral/src/mistral-speech-model.ts
@@ -1,0 +1,144 @@
+import type { SpeechModelV4, SharedV4Warning } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createBinaryResponseHandler,
+  parseProviderOptions,
+  postJsonToApi,
+  serializeModelOptions,
+  WORKFLOW_SERIALIZE,
+  WORKFLOW_DESERIALIZE,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { mistralSpeechModelOptions } from './mistral-speech-model-options';
+import { mistralFailedResponseHandler } from './mistral-error';
+import type { MistralSpeechModelId } from './mistral-speech-options';
+
+type MistralSpeechConfig = {
+  provider: string;
+  baseURL: string;
+  headers?: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+};
+
+export class MistralSpeechModel implements SpeechModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly modelId: MistralSpeechModelId;
+
+  private readonly config: MistralSpeechConfig;
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  static [WORKFLOW_SERIALIZE](model: MistralSpeechModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: MistralSpeechModelId;
+    config: MistralSpeechConfig;
+  }) {
+    return new MistralSpeechModel(options.modelId, options.config);
+  }
+
+  constructor(modelId: MistralSpeechModelId, config: MistralSpeechConfig) {
+    this.modelId = modelId;
+    this.config = config;
+  }
+
+  private async getArgs({
+    text,
+    voice = 'coeur_de_lion',
+    outputFormat = 'mp3',
+    speed,
+    language,
+    providerOptions,
+  }: Parameters<SpeechModelV4['doGenerate']>[0]) {
+    const warnings: SharedV4Warning[] = [];
+
+    await parseProviderOptions({
+      provider: 'mistral',
+      providerOptions,
+      schema: mistralSpeechModelOptions,
+    });
+
+    const requestBody: Record<string, unknown> = {
+      model: this.modelId,
+      input: text,
+      voice,
+      response_format: 'mp3',
+    };
+
+    if (outputFormat) {
+      if (['mp3', 'opus', 'aac', 'flac', 'wav', 'pcm'].includes(outputFormat)) {
+        requestBody.response_format = outputFormat;
+      } else {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'outputFormat',
+          details: `Unsupported output format: ${outputFormat}. Using mp3 instead.`,
+        });
+      }
+    }
+
+    if (speed != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'speed',
+        details: 'Mistral speech models do not support speed adjustment.',
+      });
+    }
+
+    if (language != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'language',
+        details:
+          'Mistral speech models do not support explicit language selection.',
+      });
+    }
+
+    return { requestBody, warnings };
+  }
+
+  async doGenerate(
+    options: Parameters<SpeechModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<SpeechModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const { requestBody, warnings } = await this.getArgs(options);
+
+    const {
+      value: audio,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: `${this.config.baseURL}/audio/speech`,
+      headers: combineHeaders(this.config.headers?.(), options.headers),
+      body: requestBody,
+      failedResponseHandler: mistralFailedResponseHandler,
+      successfulResponseHandler: createBinaryResponseHandler(),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      audio,
+      warnings,
+      request: {
+        body: JSON.stringify(requestBody),
+      },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+    };
+  }
+}

--- a/packages/mistral/src/mistral-speech-options.ts
+++ b/packages/mistral/src/mistral-speech-options.ts
@@ -1,0 +1,1 @@
+export type MistralSpeechModelId = 'voxtral-mini-tts-2506' | (string & {});


### PR DESCRIPTION
## Background

Mistral released Voxtral, a speech model available via their API, but `@ai-sdk/mistral` had no `SpeechModelV4` implementation for it.

## Summary

- New `MistralSpeechModel` class calling `/v1/audio/speech` (OpenAI-compatible endpoint), implementing `SpeechModelV4`
- Supported output formats: `mp3`, `opus`, `aac`, `flac`, `wav`, `pcm`
- Default voice: `coeur_de_lion`; any Mistral voice ID accepted
- Warnings emitted for unsupported features (`speed`, `language`)
- Accessible via `mistral.speech(modelId)` and `mistral.speechModel(modelId)`
- Exports `MistralSpeechModelId` and `MistralSpeechModelOptions` types

## Manual Verification

- `pnpm --filter @ai-sdk/mistral test` — all 78 tests pass (7 new speech model tests added)
- TypeScript build succeeds: `pnpm --filter @ai-sdk/mistral build`

## Checklist
- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #14245