### PR TITLE
fix(google): include customMetadata from grounding chunks in source providerMetadata

### DIFF
--- a/.changeset/fix-google-grounding-custom-metadata.md
+++ b/.changeset/fix-google-grounding-custom-metadata.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Include `customMetadata` from `retrievedContext` grounding chunks in the `providerMetadata.google` of returned sources. This surfaces file-search custom metadata (e.g. tags, categories) to consumers of the SDK's grounding results.

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -1419,6 +1419,76 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should include customMetadata in source providerMetadata when present', async () => {
+    prepareJsonResponse({
+      content: 'test response with custom metadata',
+      groundingMetadata: {
+        groundingChunks: [
+          {
+            retrievedContext: {
+              fileSearchStore: 'fileSearchStores/store-xyz',
+              title: 'Document with Metadata',
+              customMetadata: {
+                category: 'technical',
+                year: 2024,
+                tags: ['ai', 'sdk'],
+              },
+            },
+          },
+          {
+            retrievedContext: {
+              fileSearchStore: 'fileSearchStores/store-abc',
+              title: 'Document without Metadata',
+              // no customMetadata
+            },
+          },
+        ],
+      },
+    });
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "providerMetadata": undefined,
+          "text": "test response with custom metadata",
+          "type": "text",
+        },
+        {
+          "filename": "store-xyz",
+          "id": "test-id",
+          "mediaType": "application/octet-stream",
+          "providerMetadata": {
+            "google": {
+              "customMetadata": {
+                "category": "technical",
+                "tags": [
+                  "ai",
+                  "sdk",
+                ],
+                "year": 2024,
+              },
+            },
+          },
+          "sourceType": "document",
+          "title": "Document with Metadata",
+          "type": "source",
+        },
+        {
+          "filename": "store-abc",
+          "id": "test-id",
+          "mediaType": "application/octet-stream",
+          "sourceType": "document",
+          "title": "Document without Metadata",
+          "type": "source",
+        },
+      ]
+    `);
+  });
+
   it('should handle URL sources with undefined title correctly', async () => {
     prepareJsonResponse({
       content: 'test response with URLs',

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -1177,6 +1177,13 @@ function extractSources({
       // Handle retrievedContext chunks from RAG operations
       const uri = chunk.retrievedContext.uri;
       const fileSearchStore = chunk.retrievedContext.fileSearchStore;
+      const customMetadata = chunk.retrievedContext.customMetadata ?? undefined;
+      const customMetadataProviderMetadata =
+        customMetadata != null
+          ? ({
+              google: { customMetadata: customMetadata as JSONObject },
+            } as SharedV4ProviderMetadata)
+          : undefined;
 
       if (uri && (uri.startsWith('http://') || uri.startsWith('https://'))) {
         // Old format: Google Search with HTTP/HTTPS URL
@@ -1186,6 +1193,9 @@ function extractSources({
           id: generateId(),
           url: uri,
           title: chunk.retrievedContext.title ?? undefined,
+          ...(customMetadataProviderMetadata != null
+            ? { providerMetadata: customMetadataProviderMetadata }
+            : {}),
         });
       } else if (uri) {
         // Old format: Document with file path (gs://, etc.)
@@ -1220,6 +1230,9 @@ function extractSources({
           mediaType,
           title,
           filename,
+          ...(customMetadataProviderMetadata != null
+            ? { providerMetadata: customMetadataProviderMetadata }
+            : {}),
         });
       } else if (fileSearchStore) {
         // New format: File Search with fileSearchStore (no uri)
@@ -1231,6 +1244,9 @@ function extractSources({
           mediaType: 'application/octet-stream',
           title,
           filename: fileSearchStore.split('/').pop(),
+          ...(customMetadataProviderMetadata != null
+            ? { providerMetadata: customMetadataProviderMetadata }
+            : {}),
         });
       }
     } else if (chunk.maps != null) {
@@ -1275,6 +1291,7 @@ export const getGroundingMetadataSchema = () =>
               title: z.string().nullish(),
               text: z.string().nullish(),
               fileSearchStore: z.string().nullish(),
+              customMetadata: z.record(z.string(), z.unknown()).nullish(),
             })
             .nullish(),
           maps: z


### PR DESCRIPTION
## Background

When using Google's file-search grounding, `retrievedContext` chunks can include a `customMetadata` field with arbitrary key-value metadata. Previously this field was silently dropped, losing potentially useful information for callers.

## Summary

- Add `customMetadata: z.record(z.string(), z.unknown()).nullish()` to the `retrievedContext` Zod schema
- When `customMetadata` is present, include it in `providerMetadata.google.customMetadata` on the returned `LanguageModelV4Source` object
- When absent, no `providerMetadata` key is added — no breaking change to existing consumers

## Manual Verification

- New inline snapshot test: `should include customMetadata in source providerMetadata when present`
- All 402 existing tests still pass: `pnpm --filter @ai-sdk/google test`

## Checklist
- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #14195