### PR TITLE
feat(@ai-sdk/anthropic): support advisor tool (advisor_20260301)

### DIFF
--- a/.changeset/feat-anthropic-advisor-tool.md
+++ b/.changeset/feat-anthropic-advisor-tool.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': minor
+---
+
+Add support for the Anthropic advisor tool (`advisor_20260301`). The advisor tool lets a cheaper executor model (Sonnet/Haiku) consult a more capable advisor model (Opus) mid-generation within a single request — no orchestration code needed. Use via `anthropic.tools.advisor_20260301({ model: 'claude-opus-4-6', maxUses: 3 })`.

--- a/packages/anthropic/src/__fixtures__/anthropic-advisor-20260301.1.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-advisor-20260301.1.json
@@ -1,0 +1,38 @@
+{
+  "model": "claude-sonnet-4-6-20251020",
+  "id": "msg_01ABCDef1234567890ABCDEF",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "Let me consult the advisor for guidance on this complex question."
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01XYZadvisor0000000000001",
+      "name": "advisor",
+      "input": {}
+    },
+    {
+      "type": "advisor_tool_result",
+      "tool_use_id": "srvtoolu_01XYZadvisor0000000000001",
+      "content": {
+        "type": "advisor_result",
+        "text": "Based on my analysis, the recommended approach is to use a recursive algorithm with memoization to achieve O(n) time complexity."
+      }
+    },
+    {
+      "type": "text",
+      "text": "Following the advisor's recommendation, I'll implement the solution with memoization."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 412,
+    "output_tokens": 531,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0
+  }
+}

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -155,7 +155,9 @@ export interface AnthropicServerToolUseContent {
     | 'text_editor_code_execution'
     // tool search:
     | 'tool_search_tool_regex'
-    | 'tool_search_tool_bm25';
+    | 'tool_search_tool_bm25'
+    // advisor:
+    | 'advisor';
   input: unknown;
   cache_control: AnthropicCacheControl | undefined;
 }
@@ -337,6 +339,17 @@ export interface AnthropicWebFetchToolResultContent {
       };
   cache_control: AnthropicCacheControl | undefined;
 }
+
+export interface AnthropicAdvisorToolResultContent {
+  type: 'advisor_tool_result';
+  tool_use_id: string;
+  content:
+    | { type: 'advisor_result'; text: string }
+    | { type: 'advisor_redacted_result'; encrypted_content: string }
+    | { type: 'advisor_tool_result_error'; error_code: string };
+  cache_control: AnthropicCacheControl | undefined;
+}
+
 export interface AnthropicMcpToolUseContent {
   type: 'mcp_tool_use';
   id: string;
@@ -463,6 +476,13 @@ export type AnthropicTool =
   | {
       type: 'tool_search_tool_bm25_20251119';
       name: string;
+    }
+  | {
+      type: 'advisor_20260301';
+      name: string;
+      model: string;
+      max_uses?: number;
+      caching?: { type: 'ephemeral'; ttl?: '5m' | '1h' } | null;
     };
 
 export type AnthropicSpeed = 'fast' | 'standard';
@@ -836,6 +856,25 @@ export const anthropicResponseSchema = lazySchema(() =>
               }),
             ]),
           }),
+          // advisor tool results for advisor_20260301:
+          z.object({
+            type: z.literal('advisor_tool_result'),
+            tool_use_id: z.string(),
+            content: z.discriminatedUnion('type', [
+              z.object({
+                type: z.literal('advisor_result'),
+                text: z.string(),
+              }),
+              z.object({
+                type: z.literal('advisor_redacted_result'),
+                encrypted_content: z.string(),
+              }),
+              z.object({
+                type: z.literal('advisor_tool_result_error'),
+                error_code: z.string(),
+              }),
+            ]),
+          }),
         ]),
       ),
       stop_reason: z.string().nullish(),
@@ -1190,6 +1229,25 @@ export const anthropicChunkSchema = lazySchema(() =>
               }),
               z.object({
                 type: z.literal('tool_search_tool_result_error'),
+                error_code: z.string(),
+              }),
+            ]),
+          }),
+          // advisor tool results for advisor_20260301:
+          z.object({
+            type: z.literal('advisor_tool_result'),
+            tool_use_id: z.string(),
+            content: z.discriminatedUnion('type', [
+              z.object({
+                type: z.literal('advisor_result'),
+                text: z.string(),
+              }),
+              z.object({
+                type: z.literal('advisor_redacted_result'),
+                encrypted_content: z.string(),
+              }),
+              z.object({
+                type: z.literal('advisor_tool_result_error'),
                 error_code: z.string(),
               }),
             ]),

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -4317,6 +4317,105 @@ describe('AnthropicLanguageModel', () => {
       });
     });
 
+    describe('advisor 20260301', () => {
+      it('should send correct request body and beta header', async () => {
+        prepareJsonFixtureResponse('anthropic-advisor-20260301.1');
+
+        await model.doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'anthropic.advisor_20260301',
+              name: 'advisor',
+              args: { model: 'claude-opus-4-6', maxUses: 3 },
+            },
+          ],
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "max_tokens": 4096,
+            "messages": [
+              {
+                "content": [
+                  {
+                    "text": "Hello",
+                    "type": "text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "claude-3-haiku-20240307",
+            "tools": [
+              {
+                "max_uses": 3,
+                "model": "claude-opus-4-6",
+                "name": "advisor",
+                "type": "advisor_20260301",
+              },
+            ],
+          }
+        `);
+
+        expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+          {
+            "anthropic-beta": "advisor-tool-2026-03-01",
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+            "x-api-key": "test-api-key",
+          }
+        `);
+      });
+
+      it('should include advisor tool call and result in content', async () => {
+        prepareJsonFixtureResponse('anthropic-advisor-20260301.1');
+
+        const result = await model.doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'anthropic.advisor_20260301',
+              name: 'advisor',
+              args: { model: 'claude-opus-4-6' },
+            },
+          ],
+        });
+
+        expect(result.content).toMatchInlineSnapshot(`
+          [
+            {
+              "text": "Let me consult the advisor for guidance on this complex question.",
+              "type": "text",
+            },
+            {
+              "input": "{}",
+              "providerExecuted": true,
+              "toolCallId": "srvtoolu_01XYZadvisor0000000000001",
+              "toolName": "advisor",
+              "type": "tool-call",
+            },
+            {
+              "isError": false,
+              "result": {
+                "text": "Based on my analysis, the recommended approach is to use a recursive algorithm with memoization to achieve O(n) time complexity.",
+                "type": "advisor_result",
+              },
+              "toolCallId": "srvtoolu_01XYZadvisor0000000000001",
+              "toolName": "advisor",
+              "type": "tool-result",
+            },
+            {
+              "text": "Following the advisor's recommendation, I'll implement the solution with memoization.",
+              "type": "text",
+            },
+          ]
+        `);
+      });
+    });
+
     describe('code execution 20250825', () => {
       it('should send request body with include and tool', async () => {
         prepareJsonFixtureResponse('anthropic-code-execution-20250825.1');

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -1058,6 +1058,15 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
               input: JSON.stringify(part.input),
               providerExecuted: true,
             });
+          } else if (part.name === 'advisor') {
+            serverToolCalls[part.id] = part.name;
+            content.push({
+              type: 'tool-call',
+              toolCallId: part.id,
+              toolName: toolNameMapping.toCustomToolName('advisor'),
+              input: '{}',
+              providerExecuted: true,
+            });
           }
 
           break;
@@ -1276,6 +1285,18 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
           }
           break;
         }
+
+        // advisor tool results:
+        case 'advisor_tool_result': {
+          content.push({
+            type: 'tool-result',
+            toolCallId: part.tool_use_id,
+            toolName: toolNameMapping.toCustomToolName('advisor'),
+            isError: part.content.type === 'advisor_tool_result_error',
+            result: part.content,
+          });
+          break;
+        }
       }
     }
 
@@ -1435,6 +1456,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       | 'text_editor_code_execution_tool_result'
       | 'bash_code_execution_tool_result'
       | 'tool_search_tool_result'
+      | 'advisor_tool_result'
       | 'mcp_tool_use'
       | 'mcp_tool_result'
       | 'compaction'
@@ -1659,8 +1681,40 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                       toolName: customToolName,
                       providerExecuted: true,
                     });
+                  } else if (part.name === 'advisor') {
+                    serverToolCalls[part.id] = part.name;
+                    const customToolName =
+                      toolNameMapping.toCustomToolName('advisor');
+
+                    contentBlocks[value.index] = {
+                      type: 'tool-call',
+                      toolCallId: part.id,
+                      toolName: customToolName,
+                      input: '{}',
+                      providerExecuted: true,
+                      firstDelta: false,
+                      providerToolName: part.name,
+                    };
+
+                    controller.enqueue({
+                      type: 'tool-input-start',
+                      id: part.id,
+                      toolName: customToolName,
+                      providerExecuted: true,
+                    });
                   }
 
+                  return;
+                }
+
+                case 'advisor_tool_result': {
+                  controller.enqueue({
+                    type: 'tool-result',
+                    toolCallId: part.tool_use_id,
+                    toolName: toolNameMapping.toCustomToolName('advisor'),
+                    isError: part.content.type === 'advisor_tool_result_error',
+                    result: part.content,
+                  });
                   return;
                 }
 

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -5,6 +5,7 @@ import {
 } from '@ai-sdk/provider';
 import type { AnthropicTool, AnthropicToolChoice } from './anthropic-api';
 import { CacheControlValidator } from './get-cache-control';
+import { advisor_20260301ArgsSchema } from './tool/advisor_20260301';
 import { textEditor_20250728ArgsSchema } from './tool/text-editor_20250728';
 import { webSearch_20260209ArgsSchema } from './tool/web-search_20260209';
 import { webSearch_20250305ArgsSchema } from './tool/web-search_20250305';
@@ -342,6 +343,22 @@ export async function prepareTools({
             anthropicTools.push({
               type: 'tool_search_tool_bm25_20251119',
               name: 'tool_search_tool_bm25',
+            });
+            break;
+          }
+
+          case 'anthropic.advisor_20260301': {
+            betas.add('advisor-tool-2026-03-01');
+            const args = await validateTypes({
+              value: tool.args,
+              schema: advisor_20260301ArgsSchema,
+            });
+            anthropicTools.push({
+              type: 'advisor_20260301',
+              name: 'advisor',
+              model: args.model,
+              max_uses: args.maxUses,
+              caching: args.caching ?? undefined,
             });
             break;
           }

--- a/packages/anthropic/src/anthropic-tools.ts
+++ b/packages/anthropic/src/anthropic-tools.ts
@@ -1,3 +1,4 @@
+import { advisor_20260301 } from './tool/advisor_20260301';
 import { bash_20241022 } from './tool/bash_20241022';
 import { bash_20250124 } from './tool/bash_20250124';
 import { codeExecution_20250522 } from './tool/code-execution_20250522';
@@ -19,6 +20,19 @@ import { webSearch_20260209 } from './tool/web-search_20260209';
 import { webSearch_20250305 } from './tool/web-search_20250305';
 
 export const anthropicTools = {
+  /**
+   * The advisor tool enables a cheaper executor model (e.g. claude-sonnet-4-6) to consult
+   * a more capable advisor model (e.g. claude-opus-4-6) mid-generation — all within a
+   * single /v1/messages request. No orchestration code needed.
+   *
+   * @param model - The advisor model ID (e.g. "claude-opus-4-6").
+   * @param maxUses - Per-request cap on advisor calls.
+   * @param caching - Prompt caching for the advisor's transcript.
+   *
+   * Supported executor models: Claude Sonnet 4.6, Claude Haiku 4.5
+   */
+  advisor_20260301,
+
   /**
    * The bash tool enables Claude to execute shell commands in a persistent bash session,
    * allowing system operations, script execution, and command-line automation.

--- a/packages/anthropic/src/tool/advisor_20260301.ts
+++ b/packages/anthropic/src/tool/advisor_20260301.ts
@@ -1,0 +1,91 @@
+import {
+  createProviderExecutedToolFactory,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const advisor_20260301OutputSchema = lazySchema(() =>
+  zodSchema(
+    z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('advisor_result'),
+        text: z.string(),
+      }),
+      z.object({
+        type: z.literal('advisor_redacted_result'),
+        encrypted_content: z.string(),
+      }),
+      z.object({
+        type: z.literal('advisor_tool_result_error'),
+        error_code: z.string(),
+      }),
+    ]),
+  ),
+);
+
+export const advisor_20260301ArgsSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      model: z.string(),
+      maxUses: z.number().optional(),
+      caching: z
+        .object({
+          type: z.literal('ephemeral'),
+          ttl: z.enum(['5m', '1h']).optional(),
+        })
+        .nullish(),
+    }),
+  ),
+);
+
+const advisor_20260301InputSchema = lazySchema(() => zodSchema(z.object({})));
+
+const factory = createProviderExecutedToolFactory<
+  Record<string, never>,
+  | {
+      /**
+       * Plaintext advice from the advisor model.
+       */
+      type: 'advisor_result';
+      text: string;
+    }
+  | {
+      /**
+       * Opaque encrypted advice that must be round-tripped verbatim in multi-turn conversations.
+       */
+      type: 'advisor_redacted_result';
+      encrypted_content: string;
+    }
+  | {
+      /**
+       * Non-fatal error from the advisor (e.g. max_uses_exceeded, overloaded).
+       */
+      type: 'advisor_tool_result_error';
+      error_code: string;
+    },
+  {
+    /**
+     * The advisor model ID (e.g. "claude-opus-4-6").
+     */
+    model: string;
+
+    /**
+     * Per-request cap on advisor calls.
+     */
+    maxUses?: number;
+
+    /**
+     * Prompt caching configuration for the advisor's transcript.
+     */
+    caching?: { type: 'ephemeral'; ttl?: '5m' | '1h' } | null;
+  }
+>({
+  id: 'anthropic.advisor_20260301',
+  inputSchema: advisor_20260301InputSchema,
+  outputSchema: advisor_20260301OutputSchema,
+});
+
+export const advisor_20260301 = (args: Parameters<typeof factory>[0]) => {
+  return factory(args);
+};


### PR DESCRIPTION
## Background

Anthropic's [advisor tool](https://platform.claude.com/docs/en/docs/agents-and-tools/tool-use/advisor-tool) (`advisor_20260301`) lets a cheaper executor model (Sonnet/Haiku) consult a more capable advisor model (Opus) mid-generation — all within a single `/v1/messages` request, no orchestration code needed. The AI SDK had no support for it.

## Summary

- New `packages/anthropic/src/tool/advisor_20260301.ts` — tool factory using `createProviderExecutedToolFactory`; input is empty `{}`, output is `advisor_result | advisor_redacted_result | advisor_tool_result_error`
- `anthropic-prepare-tools.ts` — new case for `anthropic.advisor_20260301`: adds `advisor-tool-2026-03-01` beta header, validates args (`model`, `maxUses`, `caching`), pushes the `advisor_20260301` tool object
- `anthropic-api.ts` — adds `'advisor'` to `AnthropicServerToolUseContent.name`, `AnthropicAdvisorToolResultContent` interface, `advisor_20260301` to the `AnthropicTool` union, and `advisor_tool_result` Zod schemas for streaming and non-streaming
- `anthropic-language-model.ts` — handles `server_tool_use` with `name: 'advisor'` and `advisor_tool_result` in both streaming and non-streaming paths
- `anthropic-tools.ts` — exports `advisor_20260301` from `anthropicTools`

## Manual Verification

- New `describe('advisor 20260301')` tests verify the correct request body and beta header (`advisor-tool-2026-03-01`)
- Inline snapshot verifies `server_tool_use → tool-call` and `advisor_tool_result → tool-result` content mapping
- All 402 existing tests continue to pass

## Checklist
- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #14285