### PR TITLE
feat(ai): add experimental_onLanguageModelCallStart/End to AgentCallParameters

### DIFF
--- a/.changeset/feat-agent-language-model-callbacks.md
+++ b/.changeset/feat-agent-language-model-callbacks.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Add `experimental_onLanguageModelCallStart` and `experimental_onLanguageModelCallEnd` callbacks to `AgentCallParameters`, `AgentStreamParameters`, and `ToolLoopAgentSettings`. These callbacks fire immediately before and after each provider model call within an agent loop, enabling fine-grained observability (e.g. per-call latency tracking, logging) without needing to use `onStepFinish`.

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -15,6 +15,10 @@ import type { Output } from '../generate-text/output';
 import type { StreamTextTransform } from '../generate-text/stream-text';
 import type { StreamTextResult } from '../generate-text/stream-text-result';
 import type {
+  OnLanguageModelCallEndCallback,
+  OnLanguageModelCallStartCallback,
+} from '../generate-text/language-model-events';
+import type {
   OnToolExecutionEndCallback,
   OnToolExecutionStartCallback,
 } from '../generate-text/tool-execution-events';
@@ -84,6 +88,17 @@ export type AgentCallParameters<
       TOOLS,
       RUNTIME_CONTEXT
     >;
+
+    /**
+     * Callback that is called immediately before the provider model call begins.
+     */
+    experimental_onLanguageModelCallStart?: OnLanguageModelCallStartCallback;
+
+    /**
+     * Callback that is called after the model response has been normalized and
+     * parsed, but before any client-side tool execution begins.
+     */
+    experimental_onLanguageModelCallEnd?: OnLanguageModelCallEndCallback<TOOLS>;
 
     /**
      * Callback that is called before each tool execution begins.

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -23,6 +23,10 @@ import type { StopCondition } from '../generate-text/stop-condition';
 import type { ToolApprovalConfiguration } from '../generate-text/tool-approval-configuration';
 import type { ToolCallRepairFunction } from '../generate-text/tool-call-repair-function';
 import type {
+  OnLanguageModelCallEndCallback,
+  OnLanguageModelCallStartCallback,
+} from '../generate-text/language-model-events';
+import type {
   OnToolExecutionEndCallback,
   OnToolExecutionStartCallback,
 } from '../generate-text/tool-execution-events';
@@ -144,6 +148,19 @@ export type ToolLoopAgentSettings<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>,
       NoInfer<OUTPUT>
+    >;
+
+    /**
+     * Callback that is called immediately before the provider model call begins.
+     */
+    experimental_onLanguageModelCallStart?: OnLanguageModelCallStartCallback;
+
+    /**
+     * Callback that is called after the model response has been normalized and
+     * parsed, but before any client-side tool execution begins.
+     */
+    experimental_onLanguageModelCallEnd?: OnLanguageModelCallEndCallback<
+      NoInfer<TOOLS>
     >;
 
     /**

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -6,6 +6,10 @@ import {
   type GenerateTextOnFinishCallback,
   type ToolApprovalConfiguration,
 } from '../generate-text';
+import type {
+  OnLanguageModelCallEndCallback,
+  OnLanguageModelCallStartCallback,
+} from '../generate-text/language-model-events';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
 import type { AsyncIterableStream } from '../util/async-iterable-stream';
 import type { DeepPartial } from '../util/deep-partial';
@@ -37,6 +41,70 @@ describe('ToolLoopAgent', () => {
       expectTypeOf(agentCallback).toMatchTypeOf<
         GenerateTextOnFinishCallback<{}, {}>
       >();
+    });
+  });
+
+  describe('language model call callbacks', () => {
+    it('should accept experimental_onLanguageModelCallStart in generate', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+      });
+
+      expectTypeOf<
+        Parameters<
+          typeof agent.generate
+        >[0]['experimental_onLanguageModelCallStart']
+      >().toEqualTypeOf<OnLanguageModelCallStartCallback | undefined>();
+    });
+
+    it('should accept experimental_onLanguageModelCallEnd in generate', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+      });
+
+      expectTypeOf<
+        Parameters<
+          typeof agent.generate
+        >[0]['experimental_onLanguageModelCallEnd']
+      >().toEqualTypeOf<OnLanguageModelCallEndCallback<{}> | undefined>();
+    });
+
+    it('should accept experimental_onLanguageModelCallStart in stream', () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+      });
+
+      expectTypeOf<
+        Parameters<
+          typeof agent.stream
+        >[0]['experimental_onLanguageModelCallStart']
+      >().toEqualTypeOf<OnLanguageModelCallStartCallback | undefined>();
+    });
+
+    it('should accept experimental_onLanguageModelCallEnd in stream', () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+      });
+
+      expectTypeOf<
+        Parameters<
+          typeof agent.stream
+        >[0]['experimental_onLanguageModelCallEnd']
+      >().toEqualTypeOf<OnLanguageModelCallEndCallback<{}> | undefined>();
+    });
+
+    it('should allow setting experimental_onLanguageModelCallStart in constructor', () => {
+      new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+        experimental_onLanguageModelCallStart: () => {},
+      });
+    });
+
+    it('should allow setting experimental_onLanguageModelCallEnd in constructor', () => {
+      new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+        experimental_onLanguageModelCallEnd: () => {},
+      });
     });
   });
 

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -10,6 +10,10 @@ import type {
   GenerateTextOnStepStartCallback,
 } from '../generate-text/generate-text-events';
 import type { GenerateTextResult } from '../generate-text/generate-text-result';
+import type {
+  OnLanguageModelCallEndCallback,
+  OnLanguageModelCallStartCallback,
+} from '../generate-text/language-model-events';
 import type { Output } from '../generate-text/output';
 import { isStepCount } from '../generate-text/stop-condition';
 import { streamText } from '../generate-text/stream-text';
@@ -85,6 +89,8 @@ export class ToolLoopAgent<
       | 'instructions'
       | 'experimental_onStart'
       | 'experimental_onStepStart'
+      | 'experimental_onLanguageModelCallStart'
+      | 'experimental_onLanguageModelCallEnd'
       | 'experimental_onToolExecutionStart'
       | 'experimental_onToolExecutionEnd'
       | 'onStepFinish'
@@ -107,6 +113,8 @@ export class ToolLoopAgent<
     const {
       experimental_onStart: _settingsOnStart,
       experimental_onStepStart: _settingsOnStepStart,
+      experimental_onLanguageModelCallStart: _settingsOnLanguageModelCallStart,
+      experimental_onLanguageModelCallEnd: _settingsOnLanguageModelCallEnd,
       experimental_onToolExecutionStart: _settingsOnToolExecutionStart,
       experimental_onToolExecutionEnd: _settingsOnToolExecutionEnd,
       onStepFinish: _settingsOnStepFinish,
@@ -161,6 +169,8 @@ export class ToolLoopAgent<
     timeout,
     experimental_onStart,
     experimental_onStepStart,
+    experimental_onLanguageModelCallStart,
+    experimental_onLanguageModelCallEnd,
     experimental_onToolExecutionStart,
     experimental_onToolExecutionEnd,
     onStepFinish,
@@ -184,6 +194,18 @@ export class ToolLoopAgent<
         this.settings.experimental_onStepStart,
         experimental_onStepStart as
           | GenerateTextOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
+          | undefined,
+      ),
+      experimental_onLanguageModelCallStart: mergeCallbacks(
+        this.settings.experimental_onLanguageModelCallStart,
+        experimental_onLanguageModelCallStart as
+          | OnLanguageModelCallStartCallback
+          | undefined,
+      ),
+      experimental_onLanguageModelCallEnd: mergeCallbacks(
+        this.settings.experimental_onLanguageModelCallEnd,
+        experimental_onLanguageModelCallEnd as
+          | OnLanguageModelCallEndCallback<TOOLS>
           | undefined,
       ),
       experimental_onToolExecutionStart: mergeCallbacks(
@@ -213,6 +235,8 @@ export class ToolLoopAgent<
     experimental_transform,
     experimental_onStart,
     experimental_onStepStart,
+    experimental_onLanguageModelCallStart,
+    experimental_onLanguageModelCallEnd,
     experimental_onToolExecutionStart,
     experimental_onToolExecutionEnd,
     onStepFinish,
@@ -237,6 +261,18 @@ export class ToolLoopAgent<
         this.settings.experimental_onStepStart,
         experimental_onStepStart as
           | GenerateTextOnStepStartCallback<TOOLS, RUNTIME_CONTEXT, OUTPUT>
+          | undefined,
+      ),
+      experimental_onLanguageModelCallStart: mergeCallbacks(
+        this.settings.experimental_onLanguageModelCallStart,
+        experimental_onLanguageModelCallStart as
+          | OnLanguageModelCallStartCallback
+          | undefined,
+      ),
+      experimental_onLanguageModelCallEnd: mergeCallbacks(
+        this.settings.experimental_onLanguageModelCallEnd,
+        experimental_onLanguageModelCallEnd as
+          | OnLanguageModelCallEndCallback<TOOLS>
           | undefined,
       ),
       experimental_onToolExecutionStart: mergeCallbacks(


### PR DESCRIPTION
## Background

`generateText` and `streamText` support `experimental_onLanguageModelCallStart/End` for per-LLM-call observability (latency, logging). These callbacks worked at runtime through `ToolLoopAgent` because unrecognised fields in `...options` flow through `prepareCall` into the underlying call. However, `AgentCallParameters` did not declare them, forcing users to use `as any`.

## Summary

- Add `experimental_onLanguageModelCallStart` and `experimental_onLanguageModelCallEnd` to `AgentCallParameters` and `AgentStreamParameters`
- Add the same callbacks to `ToolLoopAgentSettings` so they can be set once at construction time
- Explicitly handle them in `ToolLoopAgent.generate()` and `ToolLoopAgent.stream()`, merging settings-level and call-level callbacks (same pattern as `experimental_onToolExecutionStart/End`)
- Add type-level tests in `tool-loop-agent.test-d.ts`

## Manual Verification

- `pnpm tsc --noEmit` passes in `packages/ai`
- `pnpm vitest run src/agent/` — 91/91 pass
- New type tests confirm both callbacks appear in `AgentCallParameters` and `ToolLoopAgentSettings` with the correct types

## Checklist
- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #14278