### PR TITLE
fix(mistral): skip empty choices chunks to prevent crash on Azure AI Services

### DIFF
--- a/.changeset/fix-mistral-empty-choices-crash.md
+++ b/.changeset/fix-mistral-empty-choices-crash.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': patch
+---
+
+Fix crash when streaming from Azure AI Services endpoints that inject content-filter chunks with an empty `choices` array. The streaming transform now skips chunks where `choices[0]` is absent instead of throwing `TypeError: Cannot read properties of undefined (reading 'delta')`.

--- a/packages/mistral/src/__fixtures__/mistral-empty-choices.chunks.txt
+++ b/packages/mistral/src/__fixtures__/mistral-empty-choices.chunks.txt
@@ -1,0 +1,4 @@
+{"id":"abc123","object":"chat.completion.chunk","created":1769088720,"model":"mistral-small-latest","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null,"logprobs":null}]}
+{"id":"abc123","object":"chat.completion.chunk","created":1769088720,"model":"mistral-small-latest","choices":[],"usage":null}
+{"id":"abc123","object":"chat.completion.chunk","created":1769088720,"model":"mistral-small-latest","choices":[{"index":0,"delta":{"content":"Hello!"},"finish_reason":null,"logprobs":null}]}
+{"id":"abc123","object":"chat.completion.chunk","created":1769088720,"model":"mistral-small-latest","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop","logprobs":null}],"usage":{"prompt_tokens":5,"total_tokens":8,"completion_tokens":3}}

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -879,6 +879,72 @@ describe('doStream', () => {
     });
   });
 
+  describe('empty choices (Azure AI Services content-filter chunks)', () => {
+    beforeEach(() => {
+      prepareChunksFixtureResponse('mistral-empty-choices');
+    });
+
+    it('should skip chunks with empty choices array and still stream text', async () => {
+      const result = await model.doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      const parts = await convertReadableStreamToArray(result.stream);
+      expect(parts).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
+          },
+          {
+            "id": "abc123",
+            "modelId": "mistral-small-latest",
+            "timestamp": 2026-01-22T13:32:00.000Z,
+            "type": "response-metadata",
+          },
+          {
+            "id": "0",
+            "type": "text-start",
+          },
+          {
+            "delta": "Hello!",
+            "id": "0",
+            "type": "text-delta",
+          },
+          {
+            "id": "0",
+            "type": "text-end",
+          },
+          {
+            "finishReason": {
+              "raw": "stop",
+              "unified": "stop",
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": {
+                "cacheRead": undefined,
+                "cacheWrite": undefined,
+                "noCache": 5,
+                "total": 5,
+              },
+              "outputTokens": {
+                "reasoning": undefined,
+                "text": 3,
+                "total": 3,
+              },
+              "raw": {
+                "completion_tokens": 3,
+                "prompt_tokens": 5,
+                "total_tokens": 8,
+              },
+            },
+          },
+        ]
+      `);
+    });
+  });
+
   it('should pass the messages', async () => {
     prepareChunksFixtureResponse('mistral-text');
 

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -378,6 +378,11 @@ export class MistralChatLanguageModel implements LanguageModelV4 {
             }
 
             const choice = value.choices[0];
+
+            if (choice == null) {
+              return;
+            }
+
             const delta = choice.delta;
 
             const textContent = extractTextContent(delta.content);


### PR DESCRIPTION
## Background

Azure AI Services (Mistral MaaS) injects content-filter SSE chunks with an empty `choices` array mid-stream, causing `TypeError: Cannot read properties of undefined (reading 'delta')` in the Mistral streaming transform.

## Summary

- Add a `choice == null` early-return guard in `transform()` when `choices[0]` is undefined, matching the defensive pattern already used in the OpenAI provider
- Add a regression test fixture (`mistral-empty-choices.chunks.txt`) with an empty-choices chunk sandwiched between normal text chunks

## Manual Verification

- New test: `doStream > empty choices (Azure AI Services) > should skip empty-choices chunks and still stream text` — verifies no crash and correct `Hello!` text-delta output
- `pnpm vitest run` in `packages/mistral` — 72/72 pass

## Checklist
- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #12501