### PR TITLE
fix(@ai-sdk/togetherai): omit seed from request body when undefined

### DIFF
--- a/.changeset/fix-togetherai-seed-unsupported-params.md
+++ b/.changeset/fix-togetherai-seed-unsupported-params.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/togetherai': patch
+---
+
+Fix: omit `seed` from request body when undefined to avoid "Unsupported use of 'seed' parameter" errors from non-diffusion models (e.g. google/gemini-3-pro-image)

--- a/packages/togetherai/src/togetherai-image-model.test.ts
+++ b/packages/togetherai/src/togetherai-image-model.test.ts
@@ -65,6 +65,29 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should omit seed from request body when seed is undefined', async () => {
+    const model = createBasicModel();
+
+    await model.doGenerate({
+      prompt,
+      files: undefined,
+      mask: undefined,
+      n: 1,
+      size: undefined,
+      seed: undefined,
+      providerOptions: {},
+      aspectRatio: undefined,
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody).not.toHaveProperty('seed');
+    expect(requestBody).toStrictEqual({
+      model: 'stabilityai/stable-diffusion-xl',
+      prompt,
+      response_format: 'base64',
+    });
+  });
+
   it('should include n parameter when requesting multiple images', async () => {
     const model = createBasicModel();
 

--- a/packages/togetherai/src/togetherai-image-model.ts
+++ b/packages/togetherai/src/togetherai-image-model.ts
@@ -114,7 +114,7 @@ export class TogetherAIImageModel implements ImageModelV4 {
       body: {
         model: this.modelId,
         prompt,
-        seed,
+        ...(seed != null ? { seed } : {}),
         ...(n > 1 ? { n } : {}),
         ...(splitSize && {
           width: parseInt(splitSize[0]),


### PR DESCRIPTION
## Background

Together AI returns `"Unsupported use of 'seed' parameter"` when `seed` is sent to models that don't support it (e.g. non-diffusion models like `google/gemini-3-pro-image`). The `seed` was previously always included in the request body even when `undefined`.

## Summary

Changed the request body construction to only include `seed` when it is explicitly provided:

```ts
// Before
seed,

// After
...(seed != null ? { seed } : {}),
```

## Manual Verification

Tested by calling `doGenerate` without a `seed` parameter against a TogetherAI model — the field is no longer present in the serialized request body. Automated test added to assert the same.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)