### PR TITLE
feat(@ai-sdk/elevenlabs): add scribe_v2 transcription model ID

### DIFF
--- a/.changeset/feat-elevenlabs-scribe-v2.md
+++ b/.changeset/feat-elevenlabs-scribe-v2.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/elevenlabs': patch
+---
+
+Add `scribe_v2` to `ElevenLabsTranscriptionModelId` type for autocompletion support

--- a/packages/elevenlabs/src/elevenlabs-provider.ts
+++ b/packages/elevenlabs/src/elevenlabs-provider.ts
@@ -17,7 +17,7 @@ import { VERSION } from './version';
 
 export interface ElevenLabsProvider extends ProviderV4 {
   (
-    modelId: 'scribe_v1',
+    modelId: ElevenLabsTranscriptionModelId,
     settings?: {},
   ): {
     transcription: ElevenLabsTranscriptionModel;

--- a/packages/elevenlabs/src/elevenlabs-transcription-options.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-options.ts
@@ -1,4 +1,5 @@
 export type ElevenLabsTranscriptionModelId =
   | 'scribe_v1'
   | 'scribe_v1_experimental'
+  | 'scribe_v2'
   | (string & {});


### PR DESCRIPTION
## Background

ElevenLabs released `scribe_v2` as their latest speech-to-text model, but the SDK only listed `scribe_v1` and `scribe_v1_experimental` in `ElevenLabsTranscriptionModelId`. Users who want `scribe_v2` had to rely on the `(string & {})` escape hatch and lose IDE autocompletion.

## Summary

- Add `'scribe_v2'` to the `ElevenLabsTranscriptionModelId` type union
- Update the `ElevenLabsProvider` interface call signature to use the full `ElevenLabsTranscriptionModelId` union instead of the hardcoded `'scribe_v1'` literal

## Manual Verification

- `pnpm --filter @ai-sdk/elevenlabs build` — builds cleanly
- TypeScript type check passes with `tsc --noEmit`
- Existing model IDs (`scribe_v1`, `scribe_v1_experimental`) still autocomplete correctly
- `scribe_v2` now autocompletes as a valid model ID

## Checklist
- [x] All commits are signed
- [ ] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #13556