### PR TITLE
fix(ai): omit empty assistant message for data-only blocks in convertToModelMessages

### DIFF
--- a/.changeset/fix-convert-to-model-messages-empty-assistant.md
+++ b/.changeset/fix-convert-to-model-messages-empty-assistant.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix: `convertToModelMessages` no longer emits an empty assistant message when a block contains only unknown data parts (e.g. a data part before `step-start` with no `convertDataPart` provided)

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -1,7 +1,40 @@
+import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
 import type { ModelMessage } from '@ai-sdk/provider-utils';
 import { describe, expect, it } from 'vitest';
+import type { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
+import { consumeStream } from '../util/consume-stream';
 import { convertToModelMessages } from './convert-to-model-messages';
+import {
+  createStreamingUIMessageState,
+  processUIMessageStream,
+} from './process-ui-message-stream';
 import type { UIMessage } from './ui-messages';
+
+async function recordAssistantMessageFromChunks<
+  UI_MESSAGE extends UIMessage = UIMessage,
+>(chunks: UIMessageChunk[]): Promise<UI_MESSAGE> {
+  const state = createStreamingUIMessageState<UI_MESSAGE>({
+    messageId: 'msg-123',
+    lastMessage: undefined,
+  });
+
+  await consumeStream({
+    stream: processUIMessageStream<UI_MESSAGE>({
+      stream: convertArrayToReadableStream(chunks),
+      runUpdateMessageJob: async job => {
+        await job({
+          state,
+          write: () => {},
+        });
+      },
+      onError: error => {
+        throw error;
+      },
+    }),
+  });
+
+  return state.message;
+}
 
 describe('convertToModelMessages', () => {
   describe('system message', () => {
@@ -3131,6 +3164,78 @@ describe('convertToModelMessages', () => {
               "content": [
                 {
                   "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ]
+        `);
+      });
+
+      it('should not emit empty assistant message for persistent data written before model stream starts', async () => {
+        type WeatherUIMessage = UIMessage<
+          unknown,
+          {
+            weather: {
+              city: string;
+              status: 'loading' | 'success';
+              weather?: string;
+            };
+          }
+        >;
+
+        const recordedMessage =
+          await recordAssistantMessageFromChunks<WeatherUIMessage>([
+            { type: 'start', messageId: 'msg-123' },
+            {
+              type: 'data-weather',
+              id: 'weather-1',
+              data: { city: 'San Francisco', status: 'loading' },
+            },
+            { type: 'start-step' },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'It is sunny.' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish-step' },
+            { type: 'finish' },
+          ]);
+
+        expect(recordedMessage).toMatchInlineSnapshot(`
+          {
+            "id": "msg-123",
+            "metadata": undefined,
+            "parts": [
+              {
+                "data": {
+                  "city": "San Francisco",
+                  "status": "loading",
+                },
+                "id": "weather-1",
+                "type": "data-weather",
+              },
+              {
+                "type": "step-start",
+              },
+              {
+                "providerMetadata": undefined,
+                "state": "done",
+                "text": "It is sunny.",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          }
+        `);
+
+        const result = await convertToModelMessages([recordedMessage]);
+
+        expect(result).toMatchInlineSnapshot(`
+          [
+            {
+              "content": [
+                {
+                  "text": "It is sunny.",
                   "type": "text",
                 },
               ],

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -280,10 +280,12 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
               }
             }
 
-            modelMessages.push({
-              role: 'assistant',
-              content,
-            });
+            if (content.length > 0) {
+              modelMessages.push({
+                role: 'assistant',
+                content,
+              });
+            }
 
             // check if there are tool invocations with results in the block
             // Include non-provider-executed tools, OR provider-executed tools with approval responses


### PR DESCRIPTION
## Background

`convertToModelMessages` was emitting `{ role: 'assistant', content: [] }` when a block contained only unknown data parts (i.e. a data part appears before `step-start` with no `convertDataPart` provided, or `convertDataPart` returns `null`). LLMs reject empty assistant messages, causing downstream failures.

## Summary

- Guard `content.length > 0` before pushing the assistant message in `processBlock()` in `convert-to-model-messages.ts`
- Add regression test for the data-part-before-step-start scenario

## Manual Verification

Verified that this can happen through the public UI stream helpers with `streamText`, not only from a hand-written message fixture.

The real route pattern from `content/docs/04-ai-sdk-ui/20-streaming-data.mdx` writes a persistent data part before merging the model stream:

```ts
writer.write({
  type: 'data-weather',
  id: 'weather-1',
  data: { city: 'San Francisco', status: 'loading' },
});

const result = streamText({
  model,
  prompt: 'What is the weather in San Francisco?',
});

writer.merge(result.toUIMessageStream());
```

That ordering is valid because `createUIMessageStream` enqueues `writer.write()` immediately, while `writer.merge()` forwards chunks from the merged stream later. The merged `streamText` UI stream is what emits `start-step`.

I reproduced the route shape end-to-end with `streamText` and `MockLanguageModelV4`:

```ts
function createWeatherModel() {
  return new MockLanguageModelV4({
    doStream: async () => ({
      stream: convertArrayToReadableStream([
        { type: 'stream-start', warnings: [] },
        {
          type: 'response-metadata',
          id: 'response-1',
          modelId: 'mock-model-id',
          timestamp: new Date(0),
        },
        { type: 'text-start', id: 'text-1' },
        { type: 'text-delta', id: 'text-1', delta: 'It is sunny.' },
        { type: 'text-end', id: 'text-1' },
        {
          type: 'finish',
          finishReason: { unified: 'stop', raw: 'stop' },
          usage: {
            inputTokens: {
              total: 3,
              noCache: 3,
              cacheRead: undefined,
              cacheWrite: undefined,
            },
            outputTokens: {
              total: 4,
              text: 4,
              reasoning: undefined,
            },
          },
        },
      ]),
    }),
  });
}
```

The test route writes the data part first, then merges `streamText(...).toUIMessageStream()`:

```ts
const chunks = await convertReadableStreamToArray(
  createUIMessageStream<WeatherUIMessage>({
    generateId: () => 'msg-123',
    onEnd({ responseMessage }) {
      persistedMessage = responseMessage;
    },
    execute({ writer }) {
      writer.write({
        type: 'data-weather',
        id: 'weather-1',
        data: { city: 'San Francisco', status: 'loading' },
      });

      const result = streamText({
        model: createWeatherModel(),
        prompt: 'What is the weather in San Francisco?',
      });

      writer.merge(result.toUIMessageStream());
    },
  }),
);
```

The recorded UI chunk order was:

```ts
[
  'data-weather',
  'start',
  'start-step',
  'text-start',
  'text-delta',
  'text-end',
  'finish-step',
  'finish',
]
```

The persisted assistant message had `data-weather` before `step-start`:

```ts
[
  {
    type: 'data-weather',
    id: 'weather-1',
    data: { city: 'San Francisco', status: 'loading' },
  },
  { type: 'step-start' },
  {
    type: 'text',
    text: 'It is sunny.',
    state: 'done',
    providerMetadata: undefined,
  },
]
```

Against the test-only commit (`6fa891d8b6`), the repro failed because `convertToModelMessages([persistedMessage])` returned an extra empty assistant message:

```ts
[
  { role: 'assistant', content: [] },
  { role: 'assistant', content: [{ type: 'text', text: 'It is sunny.' }] },
]
```

Against the fixed commit (`872f91b540`), the same repro passed and returned only the valid assistant message:

```ts
[
  { role: 'assistant', content: [{ type: 'text', text: 'It is sunny.' }] },
]
```

Focused test on the fixed head:

```sh
vitest --config packages/ai/vitest.node.config.js --run packages/ai/src/ui/convert-to-model-messages.test.ts
```

Result: 64 tests passed, no type errors.

## Checklist
- [x] All commits are signed
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request

## Related Issues
Fixes #13513
