### PR TITLE
fix(xai,groq,deepseek,mistral): send null content for tool-only assistant messages

### DIFF
--- a/.changeset/fix-tool-only-assistant-null-content.md
+++ b/.changeset/fix-tool-only-assistant-null-content.md
@@ -1,0 +1,13 @@
+---
+'@ai-sdk/xai': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/deepseek': patch
+'@ai-sdk/mistral': patch
+---
+
+fix(xai,groq,deepseek,mistral): send null instead of empty string for content in tool-only assistant messages
+
+When an assistant message contains only tool calls (no text), these providers now
+send `content: null` instead of `content: ""`. Several providers (xAI, DeepSeek,
+Groq, Mistral) reject requests with `content: ""` on tool-call-only turns.
+This matches the fix already applied to the OpenAI provider in #13744.

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
@@ -131,7 +131,7 @@ describe('convertToDeepSeekChatMessages', () => {
         {
           "messages": [
             {
-              "content": "",
+              "content": null,
               "reasoning_content": undefined,
               "role": "assistant",
               "tool_calls": [
@@ -190,7 +190,7 @@ describe('convertToDeepSeekChatMessages', () => {
         {
           "messages": [
             {
-              "content": "",
+              "content": null,
               "reasoning_content": undefined,
               "role": "assistant",
               "tool_calls": [
@@ -261,7 +261,7 @@ describe('convertToDeepSeekChatMessages', () => {
               "role": "user",
             },
             {
-              "content": "",
+              "content": null,
               "reasoning_content": "I think the tool will return the correct value.",
               "role": "assistant",
               "tool_calls": [
@@ -336,7 +336,7 @@ describe('convertToDeepSeekChatMessages', () => {
               "role": "user",
             },
             {
-              "content": "",
+              "content": null,
               "reasoning_content": undefined,
               "role": "assistant",
               "tool_calls": [
@@ -421,7 +421,7 @@ describe('convertToDeepSeekChatMessages', () => {
               "role": "user",
             },
             {
-              "content": "",
+              "content": null,
               "reasoning_content": "I think the tool will return the correct value.",
               "role": "assistant",
               "tool_calls": [

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -129,7 +129,7 @@ export function convertToDeepSeekChatMessages({
         // string when the source message had no reasoning part at all.
         messages.push({
           role: 'assistant',
-          content: text,
+          content: toolCalls.length > 0 ? text || null : text,
           reasoning_content: reasoning ?? (isDeepSeekV4 ? '' : undefined),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/groq/src/convert-to-groq-chat-messages.test.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.test.ts
@@ -123,7 +123,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "role": "assistant",
           "tool_calls": [
             {
@@ -167,7 +167,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "reasoning": "I think the tool will return the correct value.",
           "role": "assistant",
           "tool_calls": [

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -112,7 +112,7 @@ export function convertToGroqChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: toolCalls.length > 0 ? text || null : text,
           ...(reasoning.length > 0 ? { reasoning } : null),
           ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : null),
         });

--- a/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
@@ -163,7 +163,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -216,7 +216,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -279,7 +279,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [
@@ -332,7 +332,7 @@ describe('tool calls', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "",
+          "content": null,
           "prefix": undefined,
           "role": "assistant",
           "tool_calls": [

--- a/packages/mistral/src/convert-to-mistral-chat-messages.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.ts
@@ -138,7 +138,7 @@ export function convertToMistralChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: toolCalls.length > 0 ? text || null : text,
           prefix: isLastMessage ? true : undefined,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/mistral/src/mistral-chat-prompt.ts
+++ b/packages/mistral/src/mistral-chat-prompt.ts
@@ -23,7 +23,7 @@ export type MistralUserMessageContent =
 
 export interface MistralAssistantMessage {
   role: 'assistant';
-  content: string;
+  content: string | null;
   prefix?: boolean;
   tool_calls?: Array<{
     id: string;

--- a/packages/xai/src/convert-to-xai-chat-messages.test.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.test.ts
@@ -225,7 +225,7 @@ describe('convertToXaiChatMessages', () => {
     expect(messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call_123',
@@ -270,7 +270,7 @@ describe('convertToXaiChatMessages', () => {
     expect(messages).toEqual([
       {
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: [
           {
             id: 'call_123',

--- a/packages/xai/src/convert-to-xai-chat-messages.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.ts
@@ -113,7 +113,7 @@ export function convertToXaiChatMessages(prompt: LanguageModelV4Prompt): {
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: toolCalls.length > 0 ? text || null : text,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 

--- a/packages/xai/src/xai-chat-prompt.ts
+++ b/packages/xai/src/xai-chat-prompt.ts
@@ -23,7 +23,7 @@ export type XaiUserMessageContent =
 
 export interface XaiAssistantMessage {
   role: 'assistant';
-  content: string;
+  content: string | null;
   tool_calls?: Array<{
     id: string;
     type: 'function';


### PR DESCRIPTION
## Summary

Fixes #14612

When an assistant message contains only tool calls (no text content), these providers now correctly send `content: null` instead of `content: ""`. Several providers (xAI, DeepSeek, Groq, Mistral) reject requests with `content: ""` on tool-call-only turns, breaking multi-step tool use.

**Changed providers:**
- `@ai-sdk/xai`
- `@ai-sdk/groq`
- `@ai-sdk/deepseek`
- `@ai-sdk/mistral`

**Pattern applied:**
```ts
// Before
content: text,

// After
content: toolCalls.length > 0 ? text || null : text,
```

This is the same fix already applied to the OpenAI provider in #13744. When `text` is empty and tool calls are present, `null` is sent instead of `""`, which is what these providers expect per their API specs.

## Test plan

- [x] All 4 provider converter test suites pass
- [x] Existing tests updated to assert `content: null` (was `content: ""`) for tool-only assistant turns
- [x] Mixed text+tool turns still send the text string (unchanged behavior)
- [x] Text-only turns (no tool calls) continue to send `""` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)