### PR TITLE
fix(@ai-sdk/cerebras): use 'reasoning' field name for assistant messages in multi-step runs

### DIFF
--- a/.changeset/cerebras-reasoning-field.md
+++ b/.changeset/cerebras-reasoning-field.md
@@ -1,0 +1,12 @@
+---
+'@ai-sdk/cerebras': patch
+'@ai-sdk/openai-compatible': patch
+---
+
+fix(@ai-sdk/cerebras): use 'reasoning' field name for assistant reasoning in multi-step runs
+
+Cerebras expects `reasoning` instead of `reasoning_content` in assistant message history.
+The openai-compatible provider now supports a configurable `reasoningFieldName` option,
+and the Cerebras provider sets it to `'reasoning'` to match the Cerebras API schema.
+
+Fixes vercel/ai#15042.

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -101,6 +101,7 @@ export function createCerebras(
       fetch: options.fetch,
       errorStructure: cerebrasErrorStructure,
       supportsStructuredOutputs: true,
+      reasoningFieldName: 'reasoning',
     });
   };
 

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -1431,4 +1431,49 @@ describe('top-level-only media type resolution', () => {
       image_url: { url: `data:image/png;base64,${pngBase64}` },
     });
   });
+
+  it('uses reasoning_content by default for assistant reasoning', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'thinking...' },
+          { type: 'text', text: 'answer' },
+        ],
+      },
+    ]);
+
+    expect(result).toStrictEqual([
+      {
+        role: 'assistant',
+        content: 'answer',
+        reasoning_content: 'thinking...',
+        tool_calls: undefined,
+      },
+    ]);
+  });
+
+  it('uses custom reasoningFieldName when provided', () => {
+    const result = convertToOpenAICompatibleChatMessages(
+      [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'thinking...' },
+            { type: 'text', text: 'answer' },
+          ],
+        },
+      ],
+      { reasoningFieldName: 'reasoning' },
+    );
+
+    expect(result).toStrictEqual([
+      {
+        role: 'assistant',
+        content: 'answer',
+        reasoning: 'thinking...',
+        tool_calls: undefined,
+      },
+    ]);
+  });
 });

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -234,8 +234,7 @@ export function convertToOpenAICompatibleChatMessages(
           content: toolCalls.length > 0 ? text || null : text,
           ...(reasoning.length > 0
             ? {
-                [options?.reasoningFieldName ?? 'reasoning_content']:
-                  reasoning,
+                [options?.reasoningFieldName ?? 'reasoning_content']: reasoning,
               }
             : {}),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -31,6 +31,14 @@ function getAudioFormat(mediaType: string): 'wav' | 'mp3' | null {
 
 export function convertToOpenAICompatibleChatMessages(
   prompt: LanguageModelV4Prompt,
+  options?: {
+    /**
+     * The field name to use for reasoning content in assistant messages.
+     * Some providers (e.g. Cerebras) use 'reasoning' instead of 'reasoning_content'.
+     * @default 'reasoning_content'
+     */
+    reasoningFieldName?: string;
+  },
 ): OpenAICompatibleChatPrompt {
   const messages: OpenAICompatibleChatPrompt = [];
   for (const { role, content, ...message } of prompt) {
@@ -224,7 +232,12 @@ export function convertToOpenAICompatibleChatMessages(
         messages.push({
           role: 'assistant',
           content: toolCalls.length > 0 ? text || null : text,
-          ...(reasoning.length > 0 ? { reasoning_content: reasoning } : {}),
+          ...(reasoning.length > 0
+            ? {
+                [options?.reasoningFieldName ?? 'reasoning_content']:
+                  reasoning,
+              }
+            : {}),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           ...metadata,
         });

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -91,6 +91,13 @@ export type OpenAICompatibleChatConfig = {
   convertUsage?: (
     usage: z.infer<typeof openaiCompatibleTokenUsageSchema>,
   ) => LanguageModelV4Usage;
+
+  /**
+   * The field name to use for reasoning content in assistant messages.
+   * Some providers (e.g. Cerebras) use 'reasoning' instead of 'reasoning_content'.
+   * @default 'reasoning_content'
+   */
+  reasoningFieldName?: string;
 };
 
 type PendingToolCall = {
@@ -314,7 +321,9 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
         verbosity: compatibleOptions.textVerbosity,
 
         // messages:
-        messages: convertToOpenAICompatibleChatMessages(prompt),
+        messages: convertToOpenAICompatibleChatMessages(prompt, {
+          reasoningFieldName: this.config.reasoningFieldName,
+        }),
 
         // tools:
         tools: openaiTools,


### PR DESCRIPTION
## Summary

Fixes #15042.

Cerebras's chat-completions API expects `reasoning` (not `reasoning_content`) on assistant messages in multi-turn history. The `@ai-sdk/openai-compatible` package currently hardcodes `reasoning_content` when serializing assistant reasoning back into the prompt, causing a 400 `wrong_api_format` error on any multi-step run with a reasoning model behind Cerebras.

## Changes

- **`@ai-sdk/openai-compatible`**: Add a `reasoningFieldName` option to `OpenAICompatibleChatConfig` and `convertToOpenAICompatibleChatMessages()`. Defaults to `'reasoning_content'` (no change for existing providers).
- **`@ai-sdk/cerebras`**: Set `reasoningFieldName: 'reasoning'` in provider config to match the Cerebras API schema.
- **Tests**: Added tests verifying both the default (`reasoning_content`) and custom (`reasoning`) field name behavior.

## Why this approach

The response parsing side already handles both fields (`choice.message.reasoning_content ?? choice.message.reasoning`). This fix applies the same flexibility to the input serialization side, keeping it configurable per provider rather than hardcoded.

## Changeset

Included — patch for both `@ai-sdk/cerebras` and `@ai-sdk/openai-compatible`.