### PR TITLE
feat(ai): add object generation auto repair

### DIFF
--- a/.changeset/repair-on-validation-error.md
+++ b/.changeset/repair-on-validation-error.md
@@ -5,3 +5,5 @@
 feat(ai): add experimental_repairOnValidationError option to generateText and generateObject
 
 When schema validation fails, setting `experimental_repairOnValidationError: true` (or a number for multiple attempts) automatically retries generation with the Zod validation error appended to the conversation. This is particularly useful in production when working with smaller models that are prone to hallucinating incorrect field types, as it increases reliability without requiring manual retry logic. Token usage from repair calls is accumulated in the result's `totalUsage`.
+
+The result also exposes `experimental_repairHistory`: an array of `{ text, error }` pairs for every failed attempt, making it easy to collect high-quality training data to fine-tune models to produce correct schemas out of the gate.

--- a/.changeset/repair-on-validation-error.md
+++ b/.changeset/repair-on-validation-error.md
@@ -1,0 +1,7 @@
+---
+"ai": patch
+---
+
+feat(ai): add experimental_repairOnValidationError option to generateText and generateObject
+
+When schema validation fails, setting `experimental_repairOnValidationError: true` (or a number for multiple attempts) automatically retries generation with the Zod validation error appended to the conversation. This is particularly useful in production when working with smaller models that are prone to hallucinating incorrect field types, as it increases reliability without requiring manual retry logic. Token usage from repair calls is accumulated in the result's `totalUsage`.

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -451,6 +451,39 @@ try {
 }
 ```
 
+## Automatic Repair on Validation Error
+
+When schema validation fails, you can automatically retry generation with the validation error appended to the conversation using `experimental_repairOnValidationError`. The model sees its own failed response alongside the exact Zod error, which usually produces a valid object on the next attempt.
+
+```ts
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
+
+const result = await generateText({
+  model,
+  output: Output.object({
+    schema: z.object({
+      name: z.string(),
+      age: z.number(),
+    }),
+  }),
+  prompt: 'Generate a user profile.',
+  experimental_repairOnValidationError: true, // 1 repair attempt
+});
+```
+
+Pass a number to allow multiple attempts:
+
+```ts
+experimental_repairOnValidationError: 3, // up to 3 repair attempts
+```
+
+Each repair attempt makes an additional LLM call with the failed response and validation error included in the conversation. Token usage from repair calls is accumulated in the result's `totalUsage`.
+
+If all repair attempts fail, a `NoObjectGeneratedError` is thrown.
+
+This option is also available on the deprecated `generateObject` function.
+
 ## More Examples
 
 You can see structured output generation in action using various frameworks in the following examples:

--- a/packages/ai/src/generate-object/generate-object-result.ts
+++ b/packages/ai/src/generate-object/generate-object-result.ts
@@ -60,6 +60,20 @@ export interface GenerateObjectResult<OBJECT> {
   readonly providerMetadata: ProviderMetadata | undefined;
 
   /**
+   * History of schema validation repair attempts made during the call.
+   * Each entry is a failed attempt: the text the model produced and the
+   * validation error that caused the retry.
+   *
+   * Empty when `experimental_repairOnValidationError` is not set or the
+   * first attempt succeeded. Useful for collecting (bad output, error)
+   * pairs to fine-tune models.
+   */
+  readonly experimental_repairHistory: ReadonlyArray<{
+    readonly text: string;
+    readonly error: unknown;
+  }>;
+
+  /**
    * Converts the object to a JSON response.
    * The response will have a status code of 200 and a content type of `application/json; charset=utf-8`.
    */

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -817,6 +817,103 @@ describe('generateObject', () => {
         expect(callCount).toBe(2);
         expect(result.object).toStrictEqual({ content: 'llm-repaired' });
       });
+
+      it('should have empty repairHistory when option is not set', async () => {
+        const result = await generateObject({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => ({
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: '{ "content": "ok" }' }],
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+        });
+
+        expect(result.experimental_repairHistory).toEqual([]);
+      });
+
+      it('should have empty repairHistory when first attempt succeeds', async () => {
+        const result = await generateObject({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => ({
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: '{ "content": "ok" }' }],
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+          experimental_repairOnValidationError: true,
+        });
+
+        expect(result.experimental_repairHistory).toEqual([]);
+      });
+
+      it('should record one repairHistory entry on first-attempt failure', async () => {
+        let callCount = 0;
+        const result = await generateObject({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => {
+              callCount++;
+              return {
+                ...dummyResponseValues,
+                content: [
+                  {
+                    type: 'text',
+                    text:
+                      callCount === 1
+                        ? '{ "content": 42 }'
+                        : '{ "content": "ok" }',
+                  },
+                ],
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+          experimental_repairOnValidationError: true,
+        });
+
+        expect(result.experimental_repairHistory).toHaveLength(1);
+        expect(result.experimental_repairHistory[0].text).toBe(
+          '{ "content": 42 }',
+        );
+        expect(result.experimental_repairHistory[0].error).toBeDefined();
+      });
+
+      it('should record N repairHistory entries after N failures', async () => {
+        let callCount = 0;
+        const result = await generateObject({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => {
+              callCount++;
+              return {
+                ...dummyResponseValues,
+                content: [
+                  {
+                    type: 'text',
+                    text:
+                      callCount <= 2
+                        ? `{ "content": ${callCount} }` // fails for first 2
+                        : '{ "content": "ok" }',
+                  },
+                ],
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+          experimental_repairOnValidationError: 3,
+        });
+
+        expect(result.experimental_repairHistory).toHaveLength(2);
+        expect(result.experimental_repairHistory[0].text).toBe(
+          '{ "content": 1 }',
+        );
+        expect(result.experimental_repairHistory[1].text).toBe(
+          '{ "content": 2 }',
+        );
+      });
     });
 
     describe('options.providerOptions', () => {

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -668,6 +668,157 @@ describe('generateObject', () => {
       });
     });
 
+    describe('options.experimental_repairOnValidationError', () => {
+      it('should repair on first attempt when schema validation fails', async () => {
+        let callCount = 0;
+        const result = await generateObject({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => {
+              callCount++;
+              return {
+                ...dummyResponseValues,
+                content: [
+                  {
+                    type: 'text',
+                    text:
+                      callCount === 1
+                        ? '{ "content": 42 }' // fails: number not string
+                        : '{ "content": "repaired" }',
+                  },
+                ],
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+          experimental_repairOnValidationError: true,
+        });
+
+        expect(callCount).toBe(2);
+        expect(result.object).toStrictEqual({ content: 'repaired' });
+      });
+
+      it('should retry up to N times when configured as a number', async () => {
+        let callCount = 0;
+        const result = await generateObject({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => {
+              callCount++;
+              return {
+                ...dummyResponseValues,
+                content: [
+                  {
+                    type: 'text',
+                    text:
+                      callCount <= 2
+                        ? '{ "content": 42 }'
+                        : '{ "content": "repaired" }',
+                  },
+                ],
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+          experimental_repairOnValidationError: 3,
+        });
+
+        expect(callCount).toBe(3);
+        expect(result.object).toStrictEqual({ content: 'repaired' });
+      });
+
+      it('should throw NoObjectGeneratedError when all repair attempts fail', async () => {
+        await expect(
+          generateObject({
+            model: new MockLanguageModelV4({
+              doGenerate: async () => ({
+                ...dummyResponseValues,
+                content: [{ type: 'text', text: '{ "content": 42 }' }],
+              }),
+            }),
+            schema: z.object({ content: z.string() }),
+            prompt: 'prompt',
+            experimental_repairOnValidationError: 1,
+          }),
+        ).rejects.toThrow('No object generated');
+      });
+
+      it('should accumulate usage across repair calls', async () => {
+        let callCount = 0;
+        const result = await generateObject({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => {
+              callCount++;
+              return {
+                finishReason: { unified: 'stop', raw: 'stop' } as const,
+                usage: {
+                  inputTokens: {
+                    total: 10,
+                    noCache: 10,
+                    cacheRead: undefined,
+                    cacheWrite: undefined,
+                  },
+                  outputTokens: { total: 5, text: 5, reasoning: undefined },
+                },
+                response: {
+                  id: 'id-1',
+                  timestamp: new Date(123),
+                  modelId: 'm-1',
+                },
+                warnings: [],
+                content: [
+                  {
+                    type: 'text',
+                    text:
+                      callCount === 1
+                        ? '{ "content": 42 }'
+                        : '{ "content": "ok" }',
+                  },
+                ],
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+          experimental_repairOnValidationError: true,
+        });
+
+        expect(callCount).toBe(2);
+        expect(result.usage.inputTokens).toBe(20);
+        expect(result.usage.outputTokens).toBe(10);
+      });
+
+      it('should compose with experimental_repairText: string repair fails, LLM repair succeeds', async () => {
+        let callCount = 0;
+        const result = await generateObject({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => {
+              callCount++;
+              return {
+                ...dummyResponseValues,
+                content: [
+                  {
+                    type: 'text',
+                    text:
+                      callCount === 1
+                        ? '{ "content": 42 }'
+                        : '{ "content": "llm-repaired" }',
+                  },
+                ],
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+          experimental_repairText: async () => null, // string repair gives up
+          experimental_repairOnValidationError: true,
+        });
+
+        expect(callCount).toBe(2);
+        expect(result.object).toStrictEqual({ content: 'llm-repaired' });
+      });
+    });
+
     describe('options.providerOptions', () => {
       it('should pass provider options to model', async () => {
         const result = await generateObject({

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -440,6 +440,7 @@ export async function generateObject<
       callbacks: [onStepFinish, telemetryDispatcher.onObjectStepFinish],
     });
 
+    const repairHistory: Array<{ text: string; error: unknown }> = [];
     let object: RESULT;
     {
       let repairAttempt = 0;
@@ -468,6 +469,7 @@ export async function generateObject<
             NoObjectGeneratedError.isInstance(error) &&
             TypeValidationError.isInstance(error.cause)
           ) {
+            repairHistory.push({ text: repairText_, error: error.cause });
             repairAttempt++;
             repairPromptMessages = [
               ...repairPromptMessages,
@@ -543,6 +545,7 @@ export async function generateObject<
       request,
       response,
       providerMetadata: resultProviderMetadata,
+      repairHistory,
     });
   } catch (error) {
     await telemetryDispatcher.onError?.({ callId, error });
@@ -559,6 +562,7 @@ class DefaultGenerateObjectResult<T> implements GenerateObjectResult<T> {
   readonly response: GenerateObjectResult<T>['response'];
   readonly request: GenerateObjectResult<T>['request'];
   readonly reasoning: GenerateObjectResult<T>['reasoning'];
+  readonly experimental_repairHistory: GenerateObjectResult<T>['experimental_repairHistory'];
 
   constructor(options: {
     object: GenerateObjectResult<T>['object'];
@@ -569,6 +573,7 @@ class DefaultGenerateObjectResult<T> implements GenerateObjectResult<T> {
     response: GenerateObjectResult<T>['response'];
     request: GenerateObjectResult<T>['request'];
     reasoning: GenerateObjectResult<T>['reasoning'];
+    repairHistory: GenerateObjectResult<T>['experimental_repairHistory'];
   }) {
     this.object = options.object;
     this.finishReason = options.finishReason;
@@ -578,6 +583,7 @@ class DefaultGenerateObjectResult<T> implements GenerateObjectResult<T> {
     this.response = options.response;
     this.request = options.request;
     this.reasoning = options.reasoning;
+    this.experimental_repairHistory = options.repairHistory;
   }
 
   toJsonResponse(init?: ResponseInit): Response {

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -1,4 +1,8 @@
-import type { JSONValue } from '@ai-sdk/provider';
+import {
+  TypeValidationError,
+  type JSONValue,
+  type LanguageModelV4Prompt,
+} from '@ai-sdk/provider';
 import {
   createIdGenerator,
   withUserAgentSuffix,
@@ -23,7 +27,7 @@ import type { TelemetryOptions } from '../telemetry/telemetry-options';
 import type { LanguageModel } from '../types/language-model';
 import type { LanguageModelRequestMetadata } from '../types/language-model-request-metadata';
 import type { LanguageModelResponseMetadata } from '../types/language-model-response-metadata';
-import { asLanguageModelUsage } from '../types/usage';
+import { addLanguageModelUsage, asLanguageModelUsage } from '../types/usage';
 import type { Callback } from '../util/callback';
 import type { DownloadFunction } from '../util/download/download-function';
 import { notify } from '../util/notify';
@@ -169,6 +173,14 @@ export async function generateObject<
       experimental_repairText?: RepairTextFunction;
 
       /**
+       * When the output schema validation fails, automatically retry generation
+       * with the validation error appended to the conversation.
+       * `true` = 1 repair attempt, `number` = up to N repair attempts.
+       * @default false
+       */
+      experimental_repairOnValidationError?: boolean | number;
+
+      /**
        * Optional telemetry configuration.
        */
       telemetry?: TelemetryOptions;
@@ -238,6 +250,7 @@ export async function generateObject<
     abortSignal,
     headers,
     experimental_repairText: repairText,
+    experimental_repairOnValidationError: repairOnValidationError,
     experimental_telemetry,
     telemetry = experimental_telemetry,
     experimental_download: download,
@@ -274,6 +287,13 @@ export async function generateObject<
     maxRetries: maxRetriesArg,
     abortSignal,
   });
+
+  const maxRepairAttempts =
+    repairOnValidationError === true
+      ? 1
+      : typeof repairOnValidationError === 'number'
+        ? repairOnValidationError
+        : 0;
 
   const outputStrategy = getOutputStrategy({
     output,
@@ -387,7 +407,7 @@ export async function generateObject<
     }
 
     const finishReason = generateResult.finishReason.unified;
-    const usage = asLanguageModelUsage(generateResult.usage);
+    let usage = asLanguageModelUsage(generateResult.usage);
     const warnings = generateResult.warnings;
     const resultProviderMetadata = generateResult.providerMetadata;
     const request: LanguageModelRequestMetadata = generateResult.request ?? {};
@@ -420,16 +440,83 @@ export async function generateObject<
       callbacks: [onStepFinish, telemetryDispatcher.onObjectStepFinish],
     });
 
-    const object = await parseAndValidateObjectResultWithRepair(
-      text,
-      outputStrategy,
-      repairText,
-      {
-        response,
-        usage,
-        finishReason,
-      },
-    );
+    let object: RESULT;
+    {
+      let repairAttempt = 0;
+      let repairText_ = text;
+      let repairResponse = response;
+      let repairUsage = usage;
+      let repairPromptMessages: LanguageModelV4Prompt = promptMessages;
+
+      while (true) {
+        try {
+          object = await parseAndValidateObjectResultWithRepair(
+            repairText_,
+            outputStrategy,
+            repairText,
+            {
+              response: repairResponse,
+              usage: repairUsage,
+              finishReason,
+            },
+          );
+          usage = repairUsage;
+          break;
+        } catch (error) {
+          if (
+            repairAttempt < maxRepairAttempts &&
+            NoObjectGeneratedError.isInstance(error) &&
+            TypeValidationError.isInstance(error.cause)
+          ) {
+            repairAttempt++;
+            repairPromptMessages = [
+              ...repairPromptMessages,
+              {
+                role: 'assistant' as const,
+                content: [{ type: 'text' as const, text: repairText_ }],
+              },
+              {
+                role: 'user' as const,
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: `The response failed schema validation:\n\n${error.cause.message}\n\nPlease provide a corrected response.`,
+                  },
+                ],
+              },
+            ];
+
+            const repairResult = await retry(() =>
+              model.doGenerate({
+                responseFormat: {
+                  type: 'json',
+                  schema: jsonSchema,
+                  name: schemaName,
+                  description: schemaDescription,
+                },
+                ...prepareLanguageModelCallOptions(settings),
+                prompt: repairPromptMessages,
+                providerOptions,
+                abortSignal,
+                headers: headersWithUserAgent,
+              }),
+            );
+
+            repairText_ = extractTextContent(repairResult.content) ?? '';
+            repairResponse = {
+              id: repairResult.response?.id ?? generateId(),
+              timestamp: repairResult.response?.timestamp ?? currentDate(),
+              modelId: repairResult.response?.modelId ?? model.modelId,
+              headers: repairResult.response?.headers,
+            };
+            const repairCallUsage = asLanguageModelUsage(repairResult.usage);
+            repairUsage = addLanguageModelUsage(repairUsage, repairCallUsage);
+          } else {
+            throw error;
+          }
+        }
+      }
+    }
 
     await notify({
       event: {

--- a/packages/ai/src/generate-text/generate-text-result.ts
+++ b/packages/ai/src/generate-text/generate-text-result.ts
@@ -163,4 +163,18 @@ export interface GenerateTextResult<
    *
    */
   readonly output: InferCompleteOutput<OUTPUT>;
+
+  /**
+   * History of schema validation repair attempts made during the call.
+   * Each entry is a failed attempt: the text the model produced and the
+   * validation error that caused the retry.
+   *
+   * Empty when `experimental_repairOnValidationError` is not set or the
+   * first attempt succeeded. Useful for collecting (bad output, error)
+   * pairs to fine-tune models.
+   */
+  readonly experimental_repairHistory: ReadonlyArray<{
+    readonly text: string;
+    readonly error: unknown;
+  }>;
 }

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -5986,6 +5986,95 @@ describe('generateText', () => {
         .text as string;
       expect(repairMessageText).toContain('schema validation');
     });
+
+    it('should have empty repairHistory when option is not set', async () => {
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: `{ "value": "ok" }` }],
+          }),
+        }),
+        prompt: 'prompt',
+        output: Output.object({ schema: z.object({ value: z.string() }) }),
+      });
+
+      expect(result.experimental_repairHistory).toEqual([]);
+    });
+
+    it('should have empty repairHistory when first attempt succeeds', async () => {
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: `{ "value": "ok" }` }],
+          }),
+        }),
+        prompt: 'prompt',
+        output: Output.object({ schema: z.object({ value: z.string() }) }),
+        experimental_repairOnValidationError: true,
+      });
+
+      expect(result.experimental_repairHistory).toEqual([]);
+    });
+
+    it('should record one repairHistory entry on first-attempt failure', async () => {
+      let callCount = 0;
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            callCount++;
+            return {
+              ...dummyResponseValues,
+              content: [
+                {
+                  type: 'text',
+                  text:
+                    callCount === 1 ? `{ "value": 42 }` : `{ "value": "ok" }`,
+                },
+              ],
+            };
+          },
+        }),
+        prompt: 'prompt',
+        output: Output.object({ schema: z.object({ value: z.string() }) }),
+        experimental_repairOnValidationError: true,
+      });
+
+      expect(result.experimental_repairHistory).toHaveLength(1);
+      expect(result.experimental_repairHistory[0].text).toBe('{ "value": 42 }');
+      expect(result.experimental_repairHistory[0].error).toBeDefined();
+    });
+
+    it('should record N repairHistory entries after N failures', async () => {
+      let callCount = 0;
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            callCount++;
+            return {
+              ...dummyResponseValues,
+              content: [
+                {
+                  type: 'text',
+                  text:
+                    callCount <= 2
+                      ? `{ "value": ${callCount} }` // fails for first 2
+                      : `{ "value": "ok" }`,
+                },
+              ],
+            };
+          },
+        }),
+        prompt: 'prompt',
+        output: Output.object({ schema: z.object({ value: z.string() }) }),
+        experimental_repairOnValidationError: 3,
+      });
+
+      expect(result.experimental_repairHistory).toHaveLength(2);
+      expect(result.experimental_repairHistory[0].text).toBe('{ "value": 1 }');
+      expect(result.experimental_repairHistory[1].text).toBe('{ "value": 2 }');
+    });
   });
 
   describe('tool execution errors', () => {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -5815,6 +5815,179 @@ describe('generateText', () => {
     });
   });
 
+  describe('experimental_repairOnValidationError', () => {
+    it('should repair on first attempt when schema validation fails', async () => {
+      let callCount = 0;
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            callCount++;
+            return {
+              ...dummyResponseValues,
+              content: [
+                {
+                  type: 'text',
+                  text:
+                    callCount === 1
+                      ? `{ "value": 42 }` // fails: number instead of string
+                      : `{ "value": "repaired" }`,
+                },
+              ],
+            };
+          },
+        }),
+        prompt: 'prompt',
+        output: Output.object({ schema: z.object({ value: z.string() }) }),
+        experimental_repairOnValidationError: true,
+      });
+
+      expect(callCount).toBe(2);
+      expect(result.output).toEqual({ value: 'repaired' });
+    });
+
+    it('should retry up to N times when configured as a number', async () => {
+      let callCount = 0;
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            callCount++;
+            return {
+              ...dummyResponseValues,
+              content: [
+                {
+                  type: 'text',
+                  text:
+                    callCount <= 2
+                      ? `{ "value": 42 }` // fails for first 2 calls
+                      : `{ "value": "repaired" }`,
+                },
+              ],
+            };
+          },
+        }),
+        prompt: 'prompt',
+        output: Output.object({ schema: z.object({ value: z.string() }) }),
+        experimental_repairOnValidationError: 3,
+      });
+
+      expect(callCount).toBe(3);
+      expect(result.output).toEqual({ value: 'repaired' });
+    });
+
+    it('should throw NoObjectGeneratedError when all repair attempts fail', async () => {
+      await expect(
+        generateText({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => ({
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: `{ "value": 42 }` }],
+            }),
+          }),
+          prompt: 'prompt',
+          output: Output.object({ schema: z.object({ value: z.string() }) }),
+          experimental_repairOnValidationError: 1,
+        }),
+      ).rejects.toThrow('No object generated');
+    });
+
+    it('should not trigger repair when output is text()', async () => {
+      let callCount = 0;
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            callCount++;
+            return {
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: 'hello' }],
+            };
+          },
+        }),
+        prompt: 'prompt',
+        experimental_repairOnValidationError: true,
+      });
+
+      expect(callCount).toBe(1);
+      expect(result.text).toBe('hello');
+    });
+
+    it('should accumulate usage tokens across repair calls', async () => {
+      let callCount = 0;
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            callCount++;
+            return {
+              finishReason: { unified: 'stop', raw: 'stop' } as const,
+              usage: {
+                inputTokens: {
+                  total: 10,
+                  noCache: 10,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: { total: 5, text: 5, reasoning: undefined },
+              },
+              warnings: [],
+              content: [
+                {
+                  type: 'text',
+                  text:
+                    callCount === 1 ? `{ "value": 42 }` : `{ "value": "ok" }`,
+                },
+              ],
+            };
+          },
+        }),
+        prompt: 'prompt',
+        output: Output.object({ schema: z.object({ value: z.string() }) }),
+        experimental_repairOnValidationError: true,
+      });
+
+      expect(callCount).toBe(2);
+      expect(result.totalUsage.inputTokens).toBe(20);
+      expect(result.totalUsage.outputTokens).toBe(10);
+    });
+
+    it('should append failed response and error to conversation before repair call', async () => {
+      const callPrompts: Array<LanguageModelV4Prompt> = [];
+      await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async args => {
+            callPrompts.push(args.prompt);
+            const callCount = callPrompts.length;
+            return {
+              ...dummyResponseValues,
+              content: [
+                {
+                  type: 'text',
+                  text:
+                    callCount === 1 ? `{ "value": 42 }` : `{ "value": "ok" }`,
+                },
+              ],
+            };
+          },
+        }),
+        prompt: 'prompt',
+        output: Output.object({ schema: z.object({ value: z.string() }) }),
+        experimental_repairOnValidationError: true,
+      });
+
+      expect(callPrompts).toHaveLength(2);
+      // repair call should have original prompt + failed response + error message
+      const repairPrompt = callPrompts[1];
+      expect(repairPrompt).toHaveLength(3);
+      expect(repairPrompt[0]).toMatchObject({ role: 'user' });
+      expect(repairPrompt[1]).toMatchObject({
+        role: 'assistant',
+        content: [{ type: 'text', text: '{ "value": 42 }' }],
+      });
+      expect(repairPrompt[2]).toMatchObject({ role: 'user' });
+      const repairMessageText = (repairPrompt[2] as any).content[0]
+        .text as string;
+      expect(repairMessageText).toContain('schema validation');
+    });
+  });
+
   describe('tool execution errors', () => {
     let result: GenerateTextResult<any, any, any>;
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1088,6 +1088,7 @@ export async function generateText<
 
     // parse output only if the last step was finished with "stop":
     let resolvedOutput;
+    const repairHistory: Array<{ text: string; error: unknown }> = [];
     if (lastStep.finishReason === 'stop') {
       const outputSpecification = output ?? text();
 
@@ -1115,6 +1116,7 @@ export async function generateText<
             NoObjectGeneratedError.isInstance(error) &&
             TypeValidationError.isInstance(error.cause)
           ) {
+            repairHistory.push({ text: repairText, error: error.cause });
             repairAttempt++;
             repairPromptMessages = [
               ...repairPromptMessages,
@@ -1172,6 +1174,7 @@ export async function generateText<
       steps,
       totalUsage,
       output: resolvedOutput,
+      repairHistory,
     });
   } catch (error) {
     await telemetryDispatcher.onError?.({ callId, error });
@@ -1232,16 +1235,27 @@ class DefaultGenerateTextResult<
 > implements GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT> {
   readonly steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['steps'];
   readonly totalUsage: LanguageModelUsage;
+  readonly experimental_repairHistory: GenerateTextResult<
+    TOOLS,
+    RUNTIME_CONTEXT,
+    OUTPUT
+  >['experimental_repairHistory'];
   private readonly _output: InferCompleteOutput<OUTPUT> | undefined;
 
   constructor(options: {
     steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['steps'];
     output: InferCompleteOutput<OUTPUT> | undefined;
     totalUsage: LanguageModelUsage;
+    repairHistory: GenerateTextResult<
+      TOOLS,
+      RUNTIME_CONTEXT,
+      OUTPUT
+    >['experimental_repairHistory'];
   }) {
     this.steps = options.steps;
     this._output = options.output;
     this.totalUsage = options.totalUsage;
+    this.experimental_repairHistory = options.repairHistory;
   }
 
   private get finalStep() {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1,7 +1,9 @@
-import type {
-  LanguageModelV4Content,
-  LanguageModelV4GenerateResult,
-  LanguageModelV4ToolCall,
+import {
+  TypeValidationError,
+  type LanguageModelV4Content,
+  type LanguageModelV4GenerateResult,
+  type LanguageModelV4Prompt,
+  type LanguageModelV4ToolCall,
 } from '@ai-sdk/provider';
 import {
   asArray,
@@ -16,6 +18,7 @@ import {
   type ProviderOptions,
 } from '@ai-sdk/provider-utils';
 import { NoOutputGeneratedError } from '../error';
+import { NoObjectGeneratedError } from '../error/no-object-generated-error';
 import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
@@ -38,6 +41,7 @@ import { wrapGatewayError } from '../prompt/wrap-gateway-error';
 import type { Telemetry } from '../telemetry/telemetry';
 import type { TelemetryOptions } from '../telemetry/telemetry-options';
 import type {
+  FinishReason,
   LanguageModel,
   LanguageModelRequestMetadata,
   ToolChoice,
@@ -55,6 +59,7 @@ import { prepareRetries } from '../util/prepare-retries';
 import { setAbortTimeout } from '../util/set-abort-timeout';
 import { VERSION } from '../version';
 import type { ActiveTools } from './active-tools';
+import { extractTextContent } from './extract-text-content';
 import { collectToolApprovals } from './collect-tool-approvals';
 import type { ContentPart } from './content-part';
 import { executeToolCall } from './execute-tool-call';
@@ -189,6 +194,7 @@ export async function generateText<
   activeTools,
   prepareStep,
   experimental_repairToolCall: repairToolCall,
+  experimental_repairOnValidationError: repairOnValidationError,
   experimental_download: download,
   runtimeContext = {} as RUNTIME_CONTEXT,
   toolsContext = {} as InferToolSetContext<TOOLS>,
@@ -287,6 +293,15 @@ export async function generateText<
      * A function that attempts to repair a tool call that failed to parse.
      */
     experimental_repairToolCall?: ToolCallRepairFunction<NoInfer<TOOLS>>;
+
+    /**
+     * When the output schema validation fails, automatically retry generation
+     * with the validation error appended to the conversation.
+     * `true` = 1 repair attempt, `number` = up to N repair attempts.
+     * Only applies when `output` is set to a schema-based Output specification.
+     * @default false
+     */
+    experimental_repairOnValidationError?: boolean | number;
 
     /**
      * Callback that is called when the generateText operation begins,
@@ -393,6 +408,13 @@ export async function generateText<
     totalTimeoutMs,
     stepAbortController?.signal,
   );
+
+  const maxRepairAttempts =
+    repairOnValidationError === true
+      ? 1
+      : typeof repairOnValidationError === 'number'
+        ? repairOnValidationError
+        : 0;
 
   const { maxRetries, retry } = prepareRetries({
     maxRetries: maxRetriesArg,
@@ -560,6 +582,10 @@ export async function generateText<
     const steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['steps'] =
       [];
 
+    let lastStepModel = model;
+    let lastStepPromptMessages: LanguageModelV4Prompt = [];
+    let lastStepProviderOptions = providerOptions;
+
     // Track provider-executed tool calls that support deferred results
     // (e.g., code_execution in programmatic tool calling scenarios).
     // These tools may not return their results in the same turn as their call.
@@ -623,6 +649,11 @@ export async function generateText<
           providerOptions,
           prepareStepResult?.providerOptions,
         );
+
+        lastStepModel = stepModel;
+        lastStepPromptMessages = promptMessages;
+        lastStepProviderOptions = stepProviderOptions;
+
         const stepNumber = steps.length;
 
         await notify({
@@ -1008,7 +1039,7 @@ export async function generateText<
 
     const lastStep = steps[steps.length - 1];
 
-    const totalUsage = steps.reduce(
+    let totalUsage = steps.reduce(
       (totalUsage, step) => {
         return addLanguageModelUsage(totalUsage, step.usage);
       },
@@ -1059,14 +1090,82 @@ export async function generateText<
     let resolvedOutput;
     if (lastStep.finishReason === 'stop') {
       const outputSpecification = output ?? text();
-      resolvedOutput = await outputSpecification.parseCompleteOutput(
-        { text: lastStep.text },
-        {
-          response: lastStep.response,
-          usage: lastStep.usage,
-          finishReason: lastStep.finishReason,
-        },
-      );
+
+      let repairAttempt = 0;
+      let repairText = lastStep.text;
+      let repairResponse: typeof lastStep.response = lastStep.response;
+      let repairUsage = lastStep.usage;
+      let repairFinishReason: FinishReason = lastStep.finishReason;
+      let repairPromptMessages = lastStepPromptMessages;
+
+      while (true) {
+        try {
+          resolvedOutput = await outputSpecification.parseCompleteOutput(
+            { text: repairText },
+            {
+              response: repairResponse,
+              usage: repairUsage,
+              finishReason: repairFinishReason,
+            },
+          );
+          break;
+        } catch (error) {
+          if (
+            repairAttempt < maxRepairAttempts &&
+            NoObjectGeneratedError.isInstance(error) &&
+            TypeValidationError.isInstance(error.cause)
+          ) {
+            repairAttempt++;
+            repairPromptMessages = [
+              ...repairPromptMessages,
+              {
+                role: 'assistant' as const,
+                content: [{ type: 'text' as const, text: repairText }],
+              },
+              {
+                role: 'user' as const,
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: `The response failed schema validation:\n\n${error.cause.message}\n\nPlease provide a corrected response.`,
+                  },
+                ],
+              },
+            ];
+
+            const repairResult = await retry(async () => {
+              const result = await lastStepModel.doGenerate({
+                ...callSettings,
+                responseFormat: await output?.responseFormat,
+                prompt: repairPromptMessages,
+                providerOptions: lastStepProviderOptions,
+                abortSignal: mergedAbortSignal,
+                headers: headersWithUserAgent,
+              });
+
+              return {
+                ...result,
+                response: {
+                  id: result.response?.id ?? generateId(),
+                  timestamp: result.response?.timestamp ?? new Date(),
+                  modelId: result.response?.modelId ?? lastStepModel.modelId,
+                  headers: result.response?.headers,
+                  body: result.response?.body,
+                  messages: [],
+                },
+              };
+            });
+
+            repairText = extractTextContent(repairResult.content) ?? '';
+            repairResponse = repairResult.response;
+            repairUsage = asLanguageModelUsage(repairResult.usage);
+            repairFinishReason = repairResult.finishReason.unified;
+            totalUsage = addLanguageModelUsage(totalUsage, repairUsage);
+          } else {
+            throw error;
+          }
+        }
+      }
     }
 
     return new DefaultGenerateTextResult({


### PR DESCRIPTION
## Background

When using `generateText` (with `Output.object()`) or the deprecated `generateObject`, models sometimes return output that fails schema validation. This happens in three broad categories:

**Simple type mismatches** — the model returns the wrong base type, e.g. a number where a string was expected. Common with smaller models.

**Constraint violations** — the model returns the right type but violates a `.refine()` constraint. For example, a schema might enforce a maximum word count on a summary field:

```ts
const schema = z.object({
  title: z
    .string()
    .refine(
      val => val.trim().split(/\s+/).length <= 5,
      val => ({
        message: `title must be at most 5 words (was ${val.trim().split(/\s+/).length}).`,
      }),
    )
    .describe('A short title. At most 5 words.'),
});
```

When the model returns `"The Quick Brown Fox Jumped Over"`, the base type is correct but the `.refine()` fails with a descriptive message. In production this kind of violation is more common than simple type mismatches, especially as schemas grow to encode business rules about length, format, or enumerated values.

**Structural errors** — the model misreads the nesting depth of the schema and flattens or over-nests properties. For example, given a schema that expects `{ metadata: { author: string } }`, the model might return `{ author: string }` (one level too shallow) or `{ metadata: { info: { author: string } } }` (one level too deep). These errors are more subtle and harder to prompt-engineer away upfront, but the validation error message precisely identifies the mismatched path, giving the model exactly what it needs to self-correct.

In all three cases, simply appending the failed output and the Zod validation error to the conversation and asking the model to try again is generally enough to produce a valid result on the next attempt.

Currently there is no built-in way to do this: the call throws `NoObjectGeneratedError` and the caller must implement their own retry logic from scratch.

Additionally, teams that want to fine-tune smaller models need a way to collect (bad output, validation error) pairs from production calls. Without access to that data, improving model reliability over time requires significant custom instrumentation.

## Summary

**`experimental_repairOnValidationError`** — new option on `generateText` and `generateObject`

When schema validation fails, the SDK automatically retries by appending the model's failed response and the exact Zod validation error to the conversation, then making a new LLM call. The model sees its own output alongside the precise error message (e.g. `"title must be at most 5 words (was 6)."`) and typically produces a valid object on the next attempt.

```ts
// One repair attempt
const result = await generateText({
  model,
  output: Output.object({ schema }),
  prompt: 'Generate a blog post header.',
  experimental_repairOnValidationError: true,
});

// Up to N repair attempts
experimental_repairOnValidationError: 3,
```

Token usage from repair calls is accumulated into the result's `totalUsage`.

---

**`experimental_repairHistory`** — new field on `GenerateTextResult` and `GenerateObjectResult`

After a call completes (successfully or not), `result.experimental_repairHistory` exposes every failed attempt as an array of `{ text, error }` pairs — the exact invalid output and the `TypeValidationError` that rejected it. Empty array when no repairs were needed.

```ts
console.log(result.experimental_repairHistory);
// [{ text: '{ "title": "The Quick Brown Fox Jumped Over" }', error: TypeValidationError }]
```

This enables teams to collect high-quality training data from production traffic and fine-tune smaller models to produce correct schemas out of the gate, reducing the need for repair retries over time.

---

**Changes by file:**

| File | Change |
|------|--------|
| `packages/ai/src/generate-text/generate-text.ts` | Added repair loop; tracks `lastStepPromptMessages`/`lastStepModel`; accumulates `totalUsage`; collects `repairHistory` |
| `packages/ai/src/generate-text/generate-text-result.ts` | Added `experimental_repairHistory` to `GenerateTextResult` interface |
| `packages/ai/src/generate-object/generate-object.ts` | Same repair loop for the deprecated path |
| `packages/ai/src/generate-object/generate-object-result.ts` | Added `experimental_repairHistory` to `GenerateObjectResult` interface |
| `packages/ai/src/generate-text/generate-text.test.ts` | Tests for repair on first attempt, N attempts, exhaustion, usage accumulation, conversation shape, repair history |
| `packages/ai/src/generate-object/generate-object.test.ts` | Same test coverage for `generateObject` |
| `content/docs/03-ai-sdk-core/10-generating-structured-data.mdx` | Added "Automatic Repair on Validation Error" section |
| `.changeset/repair-on-validation-error.md` | Patch changeset for `ai` |

## Manual Verification

Tested locally with a small Node.js script against a real model (gpt-4o-mini), injecting a schema mismatch on the first attempt by wrapping `doGenerate` to return `{ "age": "thirty" }` on call 1 and a valid response on call 2:

- With `experimental_repairOnValidationError: true`: second call succeeds, `result.output` is valid, `result.totalUsage` reflects tokens from both calls.
- `result.experimental_repairHistory` contains exactly one entry with `text: '{ "age": "thirty" }'` and a `TypeValidationError` as `error`.
- Without the option set: call throws `NoObjectGeneratedError` as before (no regression).
- With `experimental_repairOnValidationError: 1` and the model always returning invalid JSON: `NoObjectGeneratedError` is thrown after 2 total calls (original + 1 repair).

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Expose `experimental_repairHistory` on streaming paths (`streamText`/`streamObject`) — currently repair only applies to non-streaming generation.
- Consider stabilising `experimental_repairOnValidationError` and `experimental_repairHistory` once the API shape is validated in production.
- The repair loop currently only triggers on `TypeValidationError` (schema mismatch). A future extension could also cover `JSONParseError` (unparseable JSON) for models that occasionally return malformed JSON.

## Related Issues

- **#2265** — "Optional type validation in generateObject": requested access to malformed model output for logging and prompt debugging without having to catch and inspect errors. `experimental_repairHistory` directly addresses this by exposing every failed output alongside its validation error on the result object.
- **#4924** — "Option to split validation schema and prompt schema": raised the same underlying problem (models returning slightly wrong values — e.g. wrong enum casing — that fail validation), and proposed a separate `validationSchema` with Zod transforms as the fix. `experimental_repairOnValidationError` is a complementary approach: rather than pre-transforming output, it lets the model self-correct using the exact error it produced.
- **#4446** — "Re-Asks with Repair Tool Call": requested the same re-ask-with-error-feedback mechanism for tool call validation failures. `experimental_repairOnValidationError` brings the equivalent capability to structured output generation.