### PR TITLE
feat: introduce include.requestMessage option for step request message storage opt-in

### DIFF
--- a/.changeset/wild-bananas-drop.md
+++ b/.changeset/wild-bananas-drop.md
@@ -2,4 +2,4 @@
 "ai": patch
 ---
 
-feat: introduce include.requestMessage option for opting out of storing request messages
+feat: introduce include.requestMessage option for step request message storage opt-in

--- a/.changeset/wild-bananas-drop.md
+++ b/.changeset/wild-bananas-drop.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat: introduce include.requestMessage option for opting out of storing request messages

--- a/content/docs/03-ai-sdk-core/20-prompt-engineering.mdx
+++ b/content/docs/03-ai-sdk-core/20-prompt-engineering.mdx
@@ -132,12 +132,13 @@ console.log(result.warnings);
 ### Request Messages
 
 You can inspect the input messages that were sent to the model for the final step using `request.messages`.
-Set `experimental_include.requestMessages` to `false` to omit these messages from step results.
+Set `experimental_include.requestMessages` to `true` to include these messages in step results.
 
 ```ts highlight="6"
 const result = await generateText({
   model: __MODEL__,
   prompt: 'Hello, world!',
+  experimental_include: { requestMessages: true },
 });
 
 console.log(result.request.messages);

--- a/content/docs/03-ai-sdk-core/20-prompt-engineering.mdx
+++ b/content/docs/03-ai-sdk-core/20-prompt-engineering.mdx
@@ -132,6 +132,7 @@ console.log(result.warnings);
 ### Request Messages
 
 You can inspect the input messages that were sent to the model for the final step using `request.messages`.
+Set `experimental_include.requestMessages` to `false` to omit these messages from step results.
 
 ```ts highlight="6"
 const result = await generateText({

--- a/content/docs/03-ai-sdk-core/65-event-listeners.mdx
+++ b/content/docs/03-ai-sdk-core/65-event-listeners.mdx
@@ -249,7 +249,7 @@ const result = await generateText({
     },
     {
       name: 'include',
-      type: '{ requestBody?: boolean; responseBody?: boolean } | undefined',
+      type: '{ requestBody?: boolean; requestMessages?: boolean; responseBody?: boolean } | undefined',
       description:
         'Settings for controlling what data is included in step results.',
     },
@@ -363,7 +363,7 @@ const result = await generateText({
     },
     {
       name: 'include',
-      type: '{ requestBody?: boolean; responseBody?: boolean } | undefined',
+      type: '{ requestBody?: boolean; requestMessages?: boolean; responseBody?: boolean } | undefined',
       description:
         'Settings for controlling what data is included in step results.',
     },

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -733,7 +733,7 @@ To see `generateText` in action, check out [these examples](#examples).
       type: '{ requestBody?: boolean; requestMessages?: boolean; responseBody?: boolean }',
       isOptional: true,
       description:
-        'Controls inclusion of request bodies, request messages, and response bodies in step results. By default, all data is included. When processing many large payloads (e.g., images), set requestBody, requestMessages, and/or responseBody to false to reduce memory usage. Experimental feature.',
+        'Controls inclusion of request bodies, request messages, and response bodies in step results. By default, request and response bodies are included, and request messages are excluded. When processing many large payloads (e.g., images), set requestBody and/or responseBody to false to reduce memory usage. Set requestMessages to true when you need access to the messages sent to the model. Experimental feature.',
       properties: [
         {
           type: 'Object',
@@ -750,7 +750,7 @@ To see `generateText` in action, check out [these examples](#examples).
               type: 'boolean',
               isOptional: true,
               description:
-                'Whether to include the request messages in step results. The request messages can be large when sending images or files. Default: true.',
+                'Whether to include the request messages in step results. The request messages can be large when sending images or files. Default: false.',
             },
             {
               name: 'responseBody',
@@ -1597,7 +1597,7 @@ To see `generateText` in action, check out [these examples](#examples).
                       type: 'Array<ModelMessage>',
                       isOptional: true,
                       description:
-                        'The input messages that were sent to the model for this step. Undefined when requestMessages is set to false.',
+                        'The input messages that were sent to the model for this step. Undefined by default unless requestMessages is set to true.',
                     },
                     {
                       name: 'body',
@@ -2015,7 +2015,7 @@ To see `generateText` in action, check out [these examples](#examples).
                       type: 'Array<ModelMessage>',
                       isOptional: true,
                       description:
-                        'The input messages that were sent to the model for this step. Undefined when requestMessages is set to false.',
+                        'The input messages that were sent to the model for this step. Undefined by default unless requestMessages is set to true.',
                     },
                     {
                       name: 'body',
@@ -2430,7 +2430,7 @@ To see `generateText` in action, check out [these examples](#examples).
               type: 'Array<ModelMessage>',
               isOptional: true,
               description:
-                'The input messages that were sent to the model for this step. Undefined when requestMessages is set to false.',
+                'The input messages that were sent to the model for this step. Undefined by default unless requestMessages is set to true.',
             },
             {
               name: 'body',
@@ -2803,7 +2803,7 @@ To see `generateText` in action, check out [these examples](#examples).
                       type: 'Array<ModelMessage>',
                       isOptional: true,
                       description:
-                        'The input messages that were sent to the model for this step. Undefined when requestMessages is set to false.',
+                        'The input messages that were sent to the model for this step. Undefined by default unless requestMessages is set to true.',
                     },
                     {
                       name: 'body',

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -730,10 +730,10 @@ To see `generateText` in action, check out [these examples](#examples).
     },
     {
       name: 'experimental_include',
-      type: '{ requestBody?: boolean; responseBody?: boolean }',
+      type: '{ requestBody?: boolean; requestMessages?: boolean; responseBody?: boolean }',
       isOptional: true,
       description:
-        'Controls inclusion of request and response bodies in step results. By default, bodies are included. When processing many large payloads (e.g., images), set requestBody and/or responseBody to false to reduce memory usage. Experimental feature.',
+        'Controls inclusion of request bodies, request messages, and response bodies in step results. By default, all data is included. When processing many large payloads (e.g., images), set requestBody, requestMessages, and/or responseBody to false to reduce memory usage. Experimental feature.',
       properties: [
         {
           type: 'Object',
@@ -744,6 +744,13 @@ To see `generateText` in action, check out [these examples](#examples).
               isOptional: true,
               description:
                 'Whether to include the request body in step results. The request body can be large when sending images or files. Default: true.',
+            },
+            {
+              name: 'requestMessages',
+              type: 'boolean',
+              isOptional: true,
+              description:
+                'Whether to include the request messages in step results. The request messages can be large when sending images or files. Default: true.',
             },
             {
               name: 'responseBody',
@@ -1066,7 +1073,7 @@ To see `generateText` in action, check out [these examples](#examples).
             },
             {
               name: 'include',
-              type: '{ requestBody?: boolean; responseBody?: boolean } | undefined',
+              type: '{ requestBody?: boolean; requestMessages?: boolean; responseBody?: boolean } | undefined',
               description:
                 'Settings for controlling what data is included in step results.',
             },
@@ -1179,7 +1186,7 @@ To see `generateText` in action, check out [these examples](#examples).
             },
             {
               name: 'include',
-              type: '{ requestBody?: boolean; responseBody?: boolean } | undefined',
+              type: '{ requestBody?: boolean; requestMessages?: boolean; responseBody?: boolean } | undefined',
               description:
                 'Settings for controlling what data is included in step results.',
             },
@@ -1588,8 +1595,9 @@ To see `generateText` in action, check out [these examples](#examples).
                     {
                       name: 'messages',
                       type: 'Array<ModelMessage>',
+                      isOptional: true,
                       description:
-                        'The input messages that were sent to the model for this step.',
+                        'The input messages that were sent to the model for this step. Undefined when requestMessages is set to false.',
                     },
                     {
                       name: 'body',
@@ -2005,8 +2013,9 @@ To see `generateText` in action, check out [these examples](#examples).
                     {
                       name: 'messages',
                       type: 'Array<ModelMessage>',
+                      isOptional: true,
                       description:
-                        'The input messages that were sent to the model for this step.',
+                        'The input messages that were sent to the model for this step. Undefined when requestMessages is set to false.',
                     },
                     {
                       name: 'body',
@@ -2419,8 +2428,9 @@ To see `generateText` in action, check out [these examples](#examples).
             {
               name: 'messages',
               type: 'Array<ModelMessage>',
+              isOptional: true,
               description:
-                'The input messages that were sent to the model for this step.',
+                'The input messages that were sent to the model for this step. Undefined when requestMessages is set to false.',
             },
             {
               name: 'body',
@@ -2791,8 +2801,9 @@ To see `generateText` in action, check out [these examples](#examples).
                     {
                       name: 'messages',
                       type: 'Array<ModelMessage>',
+                      isOptional: true,
                       description:
-                        'The input messages that were sent to the model for this step.',
+                        'The input messages that were sent to the model for this step. Undefined when requestMessages is set to false.',
                     },
                     {
                       name: 'body',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -774,10 +774,10 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'experimental_include',
-      type: '{ requestBody?: boolean }',
+      type: '{ requestBody?: boolean; requestMessages?: boolean }',
       isOptional: true,
       description:
-        'Controls inclusion of request body in step results. By default, the body is included. When processing many large payloads (e.g., images), set requestBody to false to reduce memory usage. Experimental feature.',
+        'Controls inclusion of request body and request messages in step results. By default, both are included. When processing many large payloads (e.g., images), set requestBody and/or requestMessages to false to reduce memory usage. Experimental feature.',
       properties: [
         {
           type: 'Object',
@@ -788,6 +788,13 @@ To see `streamText` in action, check out [these examples](#examples).
               isOptional: true,
               description:
                 'Whether to include the request body in step results. The request body can be large when sending images or files. Default: true.',
+            },
+            {
+              name: 'requestMessages',
+              type: 'boolean',
+              isOptional: true,
+              description:
+                'Whether to include the request messages in step results. The request messages can be large when sending images or files. Default: true.',
             },
           ],
         },
@@ -1973,7 +1980,7 @@ To see `streamText` in action, check out [these examples](#examples).
             },
             {
               name: 'include',
-              type: '{ requestBody?: boolean } | undefined',
+              type: '{ requestBody?: boolean; requestMessages?: boolean } | undefined',
               description:
                 'Settings for controlling what data is included in step results.',
             },
@@ -2084,7 +2091,7 @@ To see `streamText` in action, check out [these examples](#examples).
             },
             {
               name: 'include',
-              type: '{ requestBody?: boolean } | undefined',
+              type: '{ requestBody?: boolean; requestMessages?: boolean } | undefined',
               description:
                 'Settings for controlling what data is included in step results.',
             },
@@ -2606,8 +2613,9 @@ To see `streamText` in action, check out [these examples](#examples).
             {
               name: 'messages',
               type: 'Array<ModelMessage>',
+              isOptional: true,
               description:
-                'The input messages that were sent to the model for this step.',
+                'The input messages that were sent to the model for this step. Undefined when requestMessages is set to false.',
             },
             {
               name: 'body',
@@ -2890,8 +2898,9 @@ To see `streamText` in action, check out [these examples](#examples).
                     {
                       name: 'messages',
                       type: 'Array<ModelMessage>',
+                      isOptional: true,
                       description:
-                        'The input messages that were sent to the model for this step.',
+                        'The input messages that were sent to the model for this step. Undefined when requestMessages is set to false.',
                     },
                     {
                       name: 'body',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -777,7 +777,7 @@ To see `streamText` in action, check out [these examples](#examples).
       type: '{ requestBody?: boolean; requestMessages?: boolean }',
       isOptional: true,
       description:
-        'Controls inclusion of request body and request messages in step results. By default, both are included. When processing many large payloads (e.g., images), set requestBody and/or requestMessages to false to reduce memory usage. Experimental feature.',
+        'Controls inclusion of request body and request messages in step results. By default, request body is included and request messages are excluded. When processing many large payloads (e.g., images), set requestBody to false to reduce memory usage. Set requestMessages to true when you need access to the messages sent to the model. Experimental feature.',
       properties: [
         {
           type: 'Object',
@@ -794,7 +794,7 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'boolean',
               isOptional: true,
               description:
-                'Whether to include the request messages in step results. The request messages can be large when sending images or files. Default: true.',
+                'Whether to include the request messages in step results. The request messages can be large when sending images or files. Default: false.',
             },
           ],
         },
@@ -2615,7 +2615,7 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'Array<ModelMessage>',
               isOptional: true,
               description:
-                'The input messages that were sent to the model for this step. Undefined when requestMessages is set to false.',
+                'The input messages that were sent to the model for this step. Undefined by default unless requestMessages is set to true.',
             },
             {
               name: 'body',
@@ -2900,7 +2900,7 @@ To see `streamText` in action, check out [these examples](#examples).
                       type: 'Array<ModelMessage>',
                       isOptional: true,
                       description:
-                        'The input messages that were sent to the model for this step. Undefined when requestMessages is set to false.',
+                        'The input messages that were sent to the model for this step. Undefined by default unless requestMessages is set to true.',
                     },
                     {
                       name: 'body',

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -242,7 +242,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
             },
             {
               name: 'include',
-              type: '{ requestBody?: boolean; responseBody?: boolean } | undefined',
+              type: '{ requestBody?: boolean; requestMessages?: boolean; responseBody?: boolean } | undefined',
               description:
                 'Settings for controlling what data is included in step results.',
             },
@@ -348,7 +348,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
             },
             {
               name: 'include',
-              type: '{ requestBody?: boolean; responseBody?: boolean } | undefined',
+              type: '{ requestBody?: boolean; requestMessages?: boolean; responseBody?: boolean } | undefined',
               description:
                 'Settings for controlling what data is included in step results.',
             },

--- a/content/docs/09-troubleshooting/70-high-memory-usage-with-images.mdx
+++ b/content/docs/09-troubleshooting/70-high-memory-usage-with-images.mdx
@@ -17,13 +17,13 @@ This is especially noticeable when using `experimental_download` to process imag
 
 ## Background
 
-By default, the AI SDK includes the full request and response bodies in the step results. When processing images, the request body contains the base64-encoded image data, which can be very large (a single image can be 1MB+ when base64 encoded). If you process many images and keep references to the results, this data accumulates in memory.
+By default, the AI SDK includes the full request messages plus request and response bodies in the step results. When processing images, the request messages and request body can contain base64-encoded image data, which can be very large (a single image can be 1MB+ when base64 encoded). If you process many images and keep references to the results, this data accumulates in memory.
 
 For example, processing 100 images of 500KB each would include ~50MB+ of request body data in memory.
 
 ## Solution
 
-Use the `experimental_include` option to disable inclusion of request and/or response bodies:
+Use the `experimental_include` option to disable inclusion of request messages and/or request and response bodies:
 
 ```ts
 import { generateText } from 'ai';
@@ -40,9 +40,10 @@ const result = await generateText({
       ],
     },
   ],
-  // Disable inclusion of request body to reduce memory usage
+  // Disable inclusion of large request data to reduce memory usage
   experimental_include: {
     requestBody: false,
+    requestMessages: false,
     responseBody: false,
   },
 });
@@ -52,7 +53,8 @@ const result = await generateText({
 
 The `experimental_include` option accepts:
 
-- `requestBody`: Set to `false` to exclude the request body from step results. This is where base64-encoded images are stored. Default: `true`. Available in both `generateText` and `streamText`.
+- `requestBody`: Set to `false` to exclude the request body from step results. This is where base64-encoded images are often stored. Default: `true`. Available in both `generateText` and `streamText`.
+- `requestMessages`: Set to `false` to exclude the request messages from step results. This can exclude large message content such as images and files. Default: `true`. Available in both `generateText` and `streamText`.
 - `responseBody`: Set to `false` to exclude the response body from step results. Default: `true`. Only available in `generateText`.
 
 ### When to use
@@ -66,6 +68,7 @@ The `experimental_include` option accepts:
 When you disable body inclusion:
 
 - You won't have access to `result.request.body` or `result.response.body`
+- You won't have access to `result.request.messages` when `requestMessages` is disabled
 - Debugging may be harder since you can't inspect the raw request/response
 - If you need the bodies for logging or debugging, consider extracting the data you need before the next iteration
 
@@ -94,6 +97,7 @@ for (const imageUrl of imageUrls) {
     ],
     experimental_include: {
       requestBody: false,
+      requestMessages: false,
     },
   });
 

--- a/content/docs/09-troubleshooting/70-high-memory-usage-with-images.mdx
+++ b/content/docs/09-troubleshooting/70-high-memory-usage-with-images.mdx
@@ -43,7 +43,6 @@ const result = await generateText({
   // Disable inclusion of large request data to reduce memory usage
   experimental_include: {
     requestBody: false,
-    requestMessages: false,
     responseBody: false,
   },
 });
@@ -54,7 +53,7 @@ const result = await generateText({
 The `experimental_include` option accepts:
 
 - `requestBody`: Set to `false` to exclude the request body from step results. This is where base64-encoded images are often stored. Default: `true`. Available in both `generateText` and `streamText`.
-- `requestMessages`: Set to `false` to exclude the request messages from step results. This can exclude large message content such as images and files. Default: `true`. Available in both `generateText` and `streamText`.
+- `requestMessages`: Set to `true` to include the request messages in step results. The request messages can contain large message content such as images and files. Default: `false`. Available in both `generateText` and `streamText`.
 - `responseBody`: Set to `false` to exclude the response body from step results. Default: `true`. Only available in `generateText`.
 
 ### When to use
@@ -68,7 +67,7 @@ The `experimental_include` option accepts:
 When you disable body inclusion:
 
 - You won't have access to `result.request.body` or `result.response.body`
-- You won't have access to `result.request.messages` when `requestMessages` is disabled
+- You won't have access to `result.request.messages` unless `requestMessages` is enabled
 - Debugging may be harder since you can't inspect the raw request/response
 - If you need the bodies for logging or debugging, consider extracting the data you need before the next iteration
 
@@ -97,7 +96,6 @@ for (const imageUrl of imageUrls) {
     ],
     experimental_include: {
       requestBody: false,
-      requestMessages: false,
     },
   });
 

--- a/examples/ai-functions/src/generate-text/openai/include-request-messages.ts
+++ b/examples/ai-functions/src/generate-text/openai/include-request-messages.ts
@@ -1,0 +1,17 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: openai('gpt-5-nano'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+    experimental_include: {
+      requestMessages: false,
+    },
+  });
+
+  console.log(result.text);
+  print('Request metadata:', result.request);
+});

--- a/examples/ai-functions/src/generate-text/openai/include-request-messages.ts
+++ b/examples/ai-functions/src/generate-text/openai/include-request-messages.ts
@@ -8,7 +8,7 @@ run(async () => {
     model: openai('gpt-5-nano'),
     prompt: 'Invent a new holiday and describe its traditions.',
     experimental_include: {
-      requestMessages: false,
+      requestMessages: true,
     },
   });
 

--- a/examples/ai-functions/src/stream-text/openai/include-request-messages.ts
+++ b/examples/ai-functions/src/stream-text/openai/include-request-messages.ts
@@ -1,0 +1,21 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: openai('gpt-5-nano'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+    experimental_include: {
+      requestMessages: false,
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  print('Request metadata:', await result.request);
+});

--- a/examples/ai-functions/src/stream-text/openai/include-request-messages.ts
+++ b/examples/ai-functions/src/stream-text/openai/include-request-messages.ts
@@ -8,7 +8,7 @@ run(async () => {
     model: openai('gpt-5-nano'),
     prompt: 'Invent a new holiday and describe its traditions.',
     experimental_include: {
-      requestMessages: false,
+      requestMessages: true,
     },
   });
 

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -60,41 +60,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
   "reasoningText": undefined,
   "request": {
     "body": undefined,
-    "messages": [
-      {
-        "content": "test-input",
-        "role": "user",
-      },
-      {
-        "content": [
-          {
-            "input": {
-              "value": "value",
-            },
-            "providerExecuted": undefined,
-            "providerOptions": undefined,
-            "toolCallId": "call-1",
-            "toolName": "tool1",
-            "type": "tool-call",
-          },
-        ],
-        "role": "assistant",
-      },
-      {
-        "content": [
-          {
-            "output": {
-              "type": "text",
-              "value": "result1",
-            },
-            "toolCallId": "call-1",
-            "toolName": "tool1",
-            "type": "tool-result",
-          },
-        ],
-        "role": "tool",
-      },
-    ],
+    "messages": undefined,
   },
   "response": {
     "body": undefined,
@@ -186,12 +152,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       "rawFinishReason": undefined,
       "request": {
         "body": undefined,
-        "messages": [
-          {
-            "content": "test-input",
-            "role": "user",
-          },
-        ],
+        "messages": undefined,
       },
       "response": {
         "body": undefined,
@@ -270,41 +231,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       "rawFinishReason": "stop",
       "request": {
         "body": undefined,
-        "messages": [
-          {
-            "content": "test-input",
-            "role": "user",
-          },
-          {
-            "content": [
-              {
-                "input": {
-                  "value": "value",
-                },
-                "providerExecuted": undefined,
-                "providerOptions": undefined,
-                "toolCallId": "call-1",
-                "toolName": "tool1",
-                "type": "tool-call",
-              },
-            ],
-            "role": "assistant",
-          },
-          {
-            "content": [
-              {
-                "output": {
-                  "type": "text",
-                  "value": "result1",
-                },
-                "toolCallId": "call-1",
-                "toolName": "tool1",
-                "type": "tool-result",
-              },
-            ],
-            "role": "tool",
-          },
-        ],
+        "messages": undefined,
       },
       "response": {
         "body": undefined,
@@ -456,12 +383,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
     "rawFinishReason": undefined,
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "test-input",
-          "role": "user",
-        },
-      ],
+      "messages": undefined,
     },
     "response": {
       "body": undefined,
@@ -540,41 +462,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
     "rawFinishReason": "stop",
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "test-input",
-          "role": "user",
-        },
-        {
-          "content": [
-            {
-              "input": {
-                "value": "value",
-              },
-              "providerExecuted": undefined,
-              "providerOptions": undefined,
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-call",
-            },
-          ],
-          "role": "assistant",
-        },
-        {
-          "content": [
-            {
-              "output": {
-                "type": "text",
-                "value": "result1",
-              },
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-result",
-            },
-          ],
-          "role": "tool",
-        },
-      ],
+      "messages": undefined,
     },
     "response": {
       "body": undefined,
@@ -731,12 +619,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
     "rawFinishReason": undefined,
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "test-input",
-          "role": "user",
-        },
-      ],
+      "messages": undefined,
     },
     "response": {
       "body": undefined,
@@ -815,41 +698,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
     "rawFinishReason": "stop",
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "test-input",
-          "role": "user",
-        },
-        {
-          "content": [
-            {
-              "input": {
-                "value": "value",
-              },
-              "providerExecuted": undefined,
-              "providerOptions": undefined,
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-call",
-            },
-          ],
-          "role": "assistant",
-        },
-        {
-          "content": [
-            {
-              "output": {
-                "type": "text",
-                "value": "result1",
-              },
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-result",
-            },
-          ],
-          "role": "tool",
-        },
-      ],
+      "messages": undefined,
     },
     "response": {
       "body": undefined,
@@ -962,12 +811,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     "rawFinishReason": undefined,
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "new input from prepareStep",
-          "role": "user",
-        },
-      ],
+      "messages": undefined,
     },
     "response": {
       "body": undefined,
@@ -1048,41 +892,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     "rawFinishReason": "stop",
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "test-input",
-          "role": "user",
-        },
-        {
-          "content": [
-            {
-              "input": {
-                "value": "value",
-              },
-              "providerExecuted": undefined,
-              "providerOptions": undefined,
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-call",
-            },
-          ],
-          "role": "assistant",
-        },
-        {
-          "content": [
-            {
-              "output": {
-                "type": "text",
-                "value": "result1",
-              },
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-result",
-            },
-          ],
-          "role": "tool",
-        },
-      ],
+      "messages": undefined,
     },
     "response": {
       "body": undefined,
@@ -1241,12 +1051,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     "rawFinishReason": undefined,
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "new input from prepareStep",
-          "role": "user",
-        },
-      ],
+      "messages": undefined,
     },
     "response": {
       "body": undefined,
@@ -1327,41 +1132,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     "rawFinishReason": "stop",
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "test-input",
-          "role": "user",
-        },
-        {
-          "content": [
-            {
-              "input": {
-                "value": "value",
-              },
-              "providerExecuted": undefined,
-              "providerOptions": undefined,
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-call",
-            },
-          ],
-          "role": "assistant",
-        },
-        {
-          "content": [
-            {
-              "output": {
-                "type": "text",
-                "value": "result1",
-              },
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-result",
-            },
-          ],
-          "role": "tool",
-        },
-      ],
+      "messages": undefined,
     },
     "response": {
       "body": undefined,
@@ -1898,12 +1669,7 @@ exports[`generateText > result.steps > should add the reasoning from the model r
     "rawFinishReason": "stop",
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "prompt",
-          "role": "user",
-        },
-      ],
+      "messages": undefined,
     },
     "response": {
       "body": undefined,
@@ -2006,12 +1772,7 @@ exports[`generateText > result.steps > should contain files 1`] = `
     "rawFinishReason": "stop",
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "prompt",
-          "role": "user",
-        },
-      ],
+      "messages": undefined,
     },
     "response": {
       "body": undefined,
@@ -2112,12 +1873,7 @@ exports[`generateText > result.steps > should contain sources 1`] = `
     "rawFinishReason": "stop",
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "prompt",
-          "role": "user",
-        },
-      ],
+      "messages": undefined,
     },
     "response": {
       "body": undefined,

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -220,12 +220,7 @@ exports[`streamText > result.fullStream > should send delayed asynchronous tool 
   {
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "test-input",
-          "role": "user",
-        },
-      ],
+      "messages": undefined,
     },
     "type": "start-step",
     "warnings": [],
@@ -312,12 +307,7 @@ exports[`streamText > result.fullStream > should send tool calls 1`] = `
   {
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "test-input",
-          "role": "user",
-        },
-      ],
+      "messages": undefined,
     },
     "type": "start-step",
     "warnings": [],
@@ -398,12 +388,7 @@ exports[`streamText > result.fullStream > should send tool results 1`] = `
   {
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "test-input",
-          "role": "user",
-        },
-      ],
+      "messages": undefined,
     },
     "type": "start-step",
     "warnings": [],
@@ -770,12 +755,7 @@ exports[`streamText > tools with custom schema > should send tool calls 1`] = `
   {
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "test-input",
-          "role": "user",
-        },
-      ],
+      "messages": undefined,
     },
     "type": "start-step",
     "warnings": [],

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -815,7 +815,7 @@ describe('generateText', () => {
   });
 
   describe('result.request', () => {
-    it('should contain request body by default', async () => {
+    it('should contain request body but not request messages by default', async () => {
       const result = await generateText({
         model: new MockLanguageModelV4({
           doGenerate: async ({}) => ({
@@ -831,7 +831,7 @@ describe('generateText', () => {
 
       expect(result.request).toStrictEqual({
         body: 'test body',
-        messages: [{ role: 'user', content: 'prompt' }],
+        messages: undefined,
       });
     });
 
@@ -852,11 +852,11 @@ describe('generateText', () => {
 
       expect(result.request).toStrictEqual({
         body: undefined,
-        messages: [{ role: 'user', content: 'prompt' }],
+        messages: undefined,
       });
     });
 
-    it('should exclude request messages when retention.requestMessages is false', async () => {
+    it('should include request messages when retention.requestMessages is true', async () => {
       const result = await generateText({
         model: new MockLanguageModelV4({
           doGenerate: async ({}) => ({
@@ -868,14 +868,16 @@ describe('generateText', () => {
           }),
         }),
         prompt: 'prompt',
-        experimental_include: { requestMessages: false },
+        experimental_include: { requestMessages: true },
       });
 
       expect(result.request).toStrictEqual({
         body: 'test body',
-        messages: undefined,
+        messages: [{ role: 'user', content: 'prompt' }],
       });
-      expect(result.steps[0].request.messages).toBeUndefined();
+      expect(result.steps[0].request.messages).toStrictEqual([
+        { role: 'user', content: 'prompt' },
+      ]);
     });
 
     it('should contain messages from after prepareStep', async () => {
@@ -894,6 +896,7 @@ describe('generateText', () => {
         prepareStep: async () => ({
           messages: preparedMessages,
         }),
+        experimental_include: { requestMessages: true },
       });
 
       expect(result.request.messages).toStrictEqual(preparedMessages);
@@ -3084,12 +3087,7 @@ describe('generateText', () => {
           "reasoningText": undefined,
           "request": {
             "body": undefined,
-            "messages": [
-              {
-                "content": "irrelevant",
-                "role": "user",
-              },
-            ],
+            "messages": undefined,
           },
           "response": {
             "body": undefined,
@@ -3203,12 +3201,7 @@ describe('generateText', () => {
               "rawFinishReason": "stop",
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "irrelevant",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "response": {
                 "body": undefined,
@@ -3739,12 +3732,7 @@ describe('generateText', () => {
                   "rawFinishReason": undefined,
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "new input from prepareStep",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "body": undefined,
@@ -3825,41 +3813,7 @@ describe('generateText', () => {
                   "rawFinishReason": "stop",
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                      {
-                        "content": [
-                          {
-                            "input": {
-                              "value": "value",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "text",
-                              "value": "result1",
-                            },
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "body": undefined,
@@ -4013,12 +3967,7 @@ describe('generateText', () => {
                   "rawFinishReason": undefined,
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "new input from prepareStep",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "body": undefined,
@@ -4099,41 +4048,7 @@ describe('generateText', () => {
                   "rawFinishReason": "stop",
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                      {
-                        "content": [
-                          {
-                            "input": {
-                              "value": "value",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "text",
-                              "value": "result1",
-                            },
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "body": undefined,
@@ -4526,12 +4441,7 @@ describe('generateText', () => {
                   "rawFinishReason": undefined,
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "body": undefined,
@@ -4632,12 +4542,7 @@ describe('generateText', () => {
                   "rawFinishReason": undefined,
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "body": undefined,
@@ -8091,12 +7996,7 @@ describe('generateText', () => {
               "rawFinishReason": undefined,
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "test-input",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "response": {
                 "body": undefined,

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -856,6 +856,28 @@ describe('generateText', () => {
       });
     });
 
+    it('should exclude request messages when retention.requestMessages is false', async () => {
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async ({}) => ({
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: 'Hello, world!' }],
+            request: {
+              body: 'test body',
+            },
+          }),
+        }),
+        prompt: 'prompt',
+        experimental_include: { requestMessages: false },
+      });
+
+      expect(result.request).toStrictEqual({
+        body: 'test body',
+        messages: undefined,
+      });
+      expect(result.steps[0].request.messages).toBeUndefined();
+    });
+
     it('should contain messages from after prepareStep', async () => {
       const preparedMessages: Array<ModelMessage> = [
         { role: 'user', content: 'prepared prompt' },

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -123,7 +123,7 @@ export type GenerateTextInclude = {
   /**
    * Whether to retain the request messages in step results.
    * The request messages can be large when sending images or files.
-   * @default true
+   * @default false
    */
   requestMessages?: boolean;
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -390,7 +390,8 @@ export async function generateText<
      * Disabling inclusion can help reduce memory usage when processing
      * large payloads like images.
      *
-     * By default, all data is included for backwards compatibility.
+     * By default, request and response bodies are included, and request
+     * messages are excluded.
      */
     experimental_include?: GenerateTextInclude;
 
@@ -972,7 +973,7 @@ export async function generateText<
               ? currentModelResponse.request?.body
               : undefined,
           messages:
-            (include?.requestMessages ?? true)
+            (include?.requestMessages ?? false)
               ? cloneModelMessages(stepMessages)
               : undefined,
         };

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -111,6 +111,28 @@ const originalGenerateCallId = createIdGenerator({
   prefix: 'call',
   size: 24,
 });
+
+export type GenerateTextInclude = {
+  /**
+   * Whether to retain the request body in step results.
+   * The request body can be large when sending images or files.
+   * @default true
+   */
+  requestBody?: boolean;
+
+  /**
+   * Whether to retain the request messages in step results.
+   * The request messages can be large when sending images or files.
+   * @default true
+   */
+  requestMessages?: boolean;
+
+  /**
+   * Whether to retain the response body in step results.
+   * @default true
+   */
+  responseBody?: boolean;
+};
 /**
  * Generate a text and call tools for a given prompt using a language model.
  *
@@ -370,20 +392,7 @@ export async function generateText<
      *
      * By default, all data is included for backwards compatibility.
      */
-    experimental_include?: {
-      /**
-       * Whether to retain the request body in step results.
-       * The request body can be large when sending images or files.
-       * @default true
-       */
-      requestBody?: boolean;
-
-      /**
-       * Whether to retain the response body in step results.
-       * @default true
-       */
-      responseBody?: boolean;
-    };
+    experimental_include?: GenerateTextInclude;
 
     /**
      * Internal. For test use only. May change without notice.
@@ -962,7 +971,10 @@ export async function generateText<
             (include?.requestBody ?? true)
               ? currentModelResponse.request?.body
               : undefined,
-          messages: cloneModelMessages(stepMessages),
+          messages:
+            (include?.requestMessages ?? true)
+              ? cloneModelMessages(stepMessages)
+              : undefined,
         };
 
         const stepResponse = {

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -1,7 +1,7 @@
 export type { ActiveTools } from './active-tools';
 export type { ContentPart } from './content-part';
 export { filterActiveTools as experimental_filterActiveTools } from './filter-active-tools';
-export { generateText } from './generate-text';
+export { generateText, type GenerateTextInclude } from './generate-text';
 export type {
   GenerateTextEndEvent,
   GenerateTextOnFinishCallback,
@@ -59,6 +59,7 @@ export {
 } from './stream-language-model-call';
 export {
   streamText,
+  type StreamTextInclude,
   type StreamTextOnChunkCallback,
   type StreamTextOnErrorCallback,
   type StreamTextTransform,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -588,12 +588,7 @@ describe('streamText', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "test-input",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -693,12 +688,7 @@ describe('streamText', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "prompt",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -931,12 +921,7 @@ describe('streamText', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "prompt",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -1048,12 +1033,7 @@ describe('streamText', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "prompt",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -1150,12 +1130,7 @@ describe('streamText', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "prompt",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -1302,12 +1277,7 @@ describe('streamText', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "prompt",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -1462,12 +1432,7 @@ describe('streamText', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "test-input",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -1783,12 +1748,7 @@ describe('streamText', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "test-input",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -2087,12 +2047,7 @@ describe('streamText', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "test-input",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -4793,12 +4748,7 @@ describe('streamText', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "test-input",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -5106,7 +5056,7 @@ describe('streamText', () => {
   });
 
   describe('result.request', () => {
-    it('should resolve with request information by default', async () => {
+    it('should resolve with request body but not request messages by default', async () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
@@ -5132,7 +5082,7 @@ describe('streamText', () => {
 
       expect(await result.request).toStrictEqual({
         body: 'test body',
-        messages: [{ role: 'user', content: 'test-input' }],
+        messages: undefined,
       });
     });
 
@@ -5163,11 +5113,11 @@ describe('streamText', () => {
 
       expect(await result.request).toStrictEqual({
         body: undefined,
-        messages: [{ role: 'user', content: 'test-input' }],
+        messages: undefined,
       });
     });
 
-    it('should exclude request messages when retention.requestMessages is false', async () => {
+    it('should include request messages when retention.requestMessages is true', async () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
@@ -5189,14 +5139,16 @@ describe('streamText', () => {
           request: { body: 'test body' },
         }),
         prompt: 'test-input',
-        experimental_include: { requestMessages: false },
+        experimental_include: { requestMessages: true },
       });
 
       expect(await result.request).toStrictEqual({
         body: 'test body',
-        messages: undefined,
+        messages: [{ role: 'user', content: 'test-input' }],
       });
-      expect((await result.steps)[0].request.messages).toBeUndefined();
+      expect((await result.steps)[0].request.messages).toStrictEqual([
+        { role: 'user', content: 'test-input' },
+      ]);
     });
 
     it('should resolve with messages from after prepareStep', async () => {
@@ -5227,6 +5179,7 @@ describe('streamText', () => {
         prepareStep: async () => ({
           messages: preparedMessages,
         }),
+        experimental_include: { requestMessages: true },
       });
 
       expect((await result.request).messages).toStrictEqual(preparedMessages);
@@ -5417,12 +5370,7 @@ describe('streamText', () => {
             "rawFinishReason": "stop",
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "prompt",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "response": {
               "headers": undefined,
@@ -5567,12 +5515,7 @@ describe('streamText', () => {
             "rawFinishReason": "stop",
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "prompt",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "response": {
               "headers": undefined,
@@ -5662,12 +5605,7 @@ describe('streamText', () => {
             "rawFinishReason": "stop",
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "prompt",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "response": {
               "headers": undefined,
@@ -5779,12 +5717,7 @@ describe('streamText', () => {
             "rawFinishReason": "stop",
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "prompt",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "response": {
               "headers": undefined,
@@ -8116,12 +8049,7 @@ describe('streamText', () => {
           "reasoningText": undefined,
           "request": {
             "body": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
+            "messages": undefined,
           },
           "response": {
             "headers": {
@@ -8239,12 +8167,7 @@ describe('streamText', () => {
               "rawFinishReason": "stop",
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "prompt",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "response": {
                 "headers": {
@@ -8441,12 +8364,7 @@ describe('streamText', () => {
           "reasoningText": undefined,
           "request": {
             "body": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
+            "messages": undefined,
           },
           "response": {
             "headers": undefined,
@@ -8539,12 +8457,7 @@ describe('streamText', () => {
               "rawFinishReason": "stop",
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "prompt",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "response": {
                 "headers": undefined,
@@ -8730,12 +8643,7 @@ describe('streamText', () => {
           "reasoningText": undefined,
           "request": {
             "body": undefined,
-            "messages": [
-              {
-                "content": "prompt",
-                "role": "user",
-              },
-            ],
+            "messages": undefined,
           },
           "response": {
             "headers": undefined,
@@ -8809,12 +8717,7 @@ describe('streamText', () => {
               "rawFinishReason": "stop",
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "prompt",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "response": {
                 "headers": undefined,
@@ -9276,12 +9179,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -9355,46 +9253,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                    {
-                      "content": [
-                        {
-                          "providerOptions": undefined,
-                          "text": "thinking",
-                          "type": "reasoning",
-                        },
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "result1",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -9505,46 +9364,7 @@ describe('streamText', () => {
               "reasoningText": undefined,
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "test-input",
-                    "role": "user",
-                  },
-                  {
-                    "content": [
-                      {
-                        "providerOptions": undefined,
-                        "text": "thinking",
-                        "type": "reasoning",
-                      },
-                      {
-                        "input": {
-                          "value": "value",
-                        },
-                        "providerExecuted": undefined,
-                        "providerOptions": undefined,
-                        "toolCallId": "call-1",
-                        "toolName": "tool1",
-                        "type": "tool-call",
-                      },
-                    ],
-                    "role": "assistant",
-                  },
-                  {
-                    "content": [
-                      {
-                        "output": {
-                          "type": "text",
-                          "value": "result1",
-                        },
-                        "toolCallId": "call-1",
-                        "toolName": "tool1",
-                        "type": "tool-result",
-                      },
-                    ],
-                    "role": "tool",
-                  },
-                ],
+                "messages": undefined,
               },
               "response": {
                 "headers": {
@@ -9645,12 +9465,7 @@ describe('streamText', () => {
                   "rawFinishReason": undefined,
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "headers": {
@@ -9736,46 +9551,7 @@ describe('streamText', () => {
                   "rawFinishReason": "stop",
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                      {
-                        "content": [
-                          {
-                            "providerOptions": undefined,
-                            "text": "thinking",
-                            "type": "reasoning",
-                          },
-                          {
-                            "input": {
-                              "value": "value",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "text",
-                              "value": "result1",
-                            },
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "headers": {
@@ -9938,12 +9714,7 @@ describe('streamText', () => {
                 "rawFinishReason": undefined,
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "response": {
                   "headers": {
@@ -10029,46 +9800,7 @@ describe('streamText', () => {
                 "rawFinishReason": "stop",
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                    {
-                      "content": [
-                        {
-                          "providerOptions": undefined,
-                          "text": "thinking",
-                          "type": "reasoning",
-                        },
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "result1",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "response": {
                   "headers": {
@@ -10248,12 +9980,7 @@ describe('streamText', () => {
                 "rawFinishReason": undefined,
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "response": {
                   "headers": {
@@ -10339,46 +10066,7 @@ describe('streamText', () => {
                 "rawFinishReason": "stop",
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                    {
-                      "content": [
-                        {
-                          "providerOptions": undefined,
-                          "text": "thinking",
-                          "type": "reasoning",
-                        },
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "result1",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "response": {
                   "headers": {
@@ -10894,12 +10582,7 @@ describe('streamText', () => {
                   "rawFinishReason": undefined,
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "new input from prepareStep",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "headers": {
@@ -10982,41 +10665,7 @@ describe('streamText', () => {
                   "rawFinishReason": "stop",
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                      {
-                        "content": [
-                          {
-                            "input": {
-                              "value": "value",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "text",
-                              "value": "result1",
-                            },
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "headers": {
@@ -11169,12 +10818,7 @@ describe('streamText', () => {
                   "rawFinishReason": undefined,
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "new input from prepareStep",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "headers": {
@@ -11257,41 +10901,7 @@ describe('streamText', () => {
                   "rawFinishReason": "stop",
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                      {
-                        "content": [
-                          {
-                            "input": {
-                              "value": "value",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "text",
-                              "value": "result1",
-                            },
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "headers": {
@@ -11492,12 +11102,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -11571,46 +11176,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                    {
-                      "content": [
-                        {
-                          "providerOptions": undefined,
-                          "text": "thinking",
-                          "type": "reasoning",
-                        },
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "RESULT1",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -11721,46 +11287,7 @@ describe('streamText', () => {
               "reasoningText": undefined,
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "test-input",
-                    "role": "user",
-                  },
-                  {
-                    "content": [
-                      {
-                        "providerOptions": undefined,
-                        "text": "thinking",
-                        "type": "reasoning",
-                      },
-                      {
-                        "input": {
-                          "value": "value",
-                        },
-                        "providerExecuted": undefined,
-                        "providerOptions": undefined,
-                        "toolCallId": "call-1",
-                        "toolName": "tool1",
-                        "type": "tool-call",
-                      },
-                    ],
-                    "role": "assistant",
-                  },
-                  {
-                    "content": [
-                      {
-                        "output": {
-                          "type": "text",
-                          "value": "RESULT1",
-                        },
-                        "toolCallId": "call-1",
-                        "toolName": "tool1",
-                        "type": "tool-result",
-                      },
-                    ],
-                    "role": "tool",
-                  },
-                ],
+                "messages": undefined,
               },
               "response": {
                 "headers": {
@@ -11861,12 +11388,7 @@ describe('streamText', () => {
                   "rawFinishReason": undefined,
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "headers": {
@@ -11952,46 +11474,7 @@ describe('streamText', () => {
                   "rawFinishReason": "stop",
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                      {
-                        "content": [
-                          {
-                            "providerOptions": undefined,
-                            "text": "thinking",
-                            "type": "reasoning",
-                          },
-                          {
-                            "input": {
-                              "value": "value",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "text",
-                              "value": "RESULT1",
-                            },
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "headers": {
@@ -12154,12 +11637,7 @@ describe('streamText', () => {
                 "rawFinishReason": undefined,
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "response": {
                   "headers": {
@@ -12245,46 +11723,7 @@ describe('streamText', () => {
                 "rawFinishReason": "stop",
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                    {
-                      "content": [
-                        {
-                          "providerOptions": undefined,
-                          "text": "thinking",
-                          "type": "reasoning",
-                        },
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "RESULT1",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "response": {
                   "headers": {
@@ -12460,12 +11899,7 @@ describe('streamText', () => {
                 "rawFinishReason": undefined,
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "response": {
                   "headers": {
@@ -12551,46 +11985,7 @@ describe('streamText', () => {
                 "rawFinishReason": "stop",
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                    {
-                      "content": [
-                        {
-                          "providerOptions": undefined,
-                          "text": "thinking",
-                          "type": "reasoning",
-                        },
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "RESULT1",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "response": {
                   "headers": {
@@ -12930,12 +12325,7 @@ describe('streamText', () => {
                   "rawFinishReason": undefined,
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "headers": {
@@ -13047,12 +12437,7 @@ describe('streamText', () => {
                   "rawFinishReason": undefined,
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "headers": {
@@ -13390,12 +12775,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "prompt",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -13969,12 +13349,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "prompt",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -15198,12 +14573,7 @@ describe('streamText', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "prompt",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -15320,12 +14690,7 @@ describe('streamText', () => {
             "rawFinishReason": "stop",
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "prompt",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "response": {
               "headers": undefined,
@@ -15824,12 +15189,7 @@ describe('streamText', () => {
               "rawFinishReason": "stop",
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "test-input",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "response": {
                 "headers": undefined,
@@ -16042,12 +15402,7 @@ describe('streamText', () => {
             "reasoningText": undefined,
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "test-input",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "response": {
               "headers": {
@@ -16165,12 +15520,7 @@ describe('streamText', () => {
                 "rawFinishReason": "stop",
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "response": {
                   "headers": {
@@ -16403,12 +15753,7 @@ describe('streamText', () => {
             "rawFinishReason": "stop",
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "test-input",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "response": {
               "headers": {
@@ -16746,12 +16091,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -16868,12 +16208,7 @@ describe('streamText', () => {
             "rawFinishReason": undefined,
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "test-input",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "response": {
               "id": "response-id",
@@ -17367,12 +16702,7 @@ describe('streamText', () => {
             "reasoningText": undefined,
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "prompt",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "response": {
               "headers": undefined,
@@ -17416,12 +16746,7 @@ describe('streamText', () => {
                 "rawFinishReason": "stop",
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "prompt",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "response": {
                   "headers": undefined,
@@ -18309,12 +17634,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -18528,12 +17848,7 @@ describe('streamText', () => {
               "rawFinishReason": "stop",
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "test-input",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "response": {
                 "headers": undefined,
@@ -18940,12 +18255,7 @@ describe('streamText', () => {
                   "rawFinishReason": undefined,
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "prompt",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "response": {
                     "headers": undefined,
@@ -19022,12 +18332,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "prompt",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -19263,12 +18568,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "prompt",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -19535,12 +18835,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -19785,12 +19080,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -20037,12 +19327,7 @@ describe('streamText', () => {
               "rawFinishReason": "stop",
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "test-input",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "response": {
                 "headers": undefined,
@@ -20198,12 +19483,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -21534,12 +20814,7 @@ describe('streamText', () => {
                 {
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "Play a dice game between two players.",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "type": "start-step",
                   "warnings": [],
@@ -21630,56 +20905,7 @@ describe('streamText', () => {
                 {
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "Play a dice game between two players.",
-                        "role": "user",
-                      },
-                      {
-                        "content": [
-                          {
-                            "providerOptions": undefined,
-                            "text": "I'll help you simulate this game between two players where one is using a loaded die.",
-                            "type": "text",
-                          },
-                          {
-                            "input": {
-                              "code": "game_loop()",
-                            },
-                            "providerExecuted": true,
-                            "providerOptions": undefined,
-                            "toolCallId": "srvtoolu_01MzSrFWsmzBdcoQkGWLyRjK",
-                            "toolName": "code_execution",
-                            "type": "tool-call",
-                          },
-                          {
-                            "input": {
-                              "player": "player1",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "toolu_019jKkXz4jAdwHweHBw92CVY",
-                            "toolName": "rollDie",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "json",
-                              "value": 6,
-                            },
-                            "toolCallId": "toolu_019jKkXz4jAdwHweHBw92CVY",
-                            "toolName": "rollDie",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "type": "start-step",
                   "warnings": [],
@@ -21745,85 +20971,7 @@ describe('streamText', () => {
                 {
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "Play a dice game between two players.",
-                        "role": "user",
-                      },
-                      {
-                        "content": [
-                          {
-                            "providerOptions": undefined,
-                            "text": "I'll help you simulate this game between two players where one is using a loaded die.",
-                            "type": "text",
-                          },
-                          {
-                            "input": {
-                              "code": "game_loop()",
-                            },
-                            "providerExecuted": true,
-                            "providerOptions": undefined,
-                            "toolCallId": "srvtoolu_01MzSrFWsmzBdcoQkGWLyRjK",
-                            "toolName": "code_execution",
-                            "type": "tool-call",
-                          },
-                          {
-                            "input": {
-                              "player": "player1",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "toolu_019jKkXz4jAdwHweHBw92CVY",
-                            "toolName": "rollDie",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "json",
-                              "value": 6,
-                            },
-                            "toolCallId": "toolu_019jKkXz4jAdwHweHBw92CVY",
-                            "toolName": "rollDie",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                      {
-                        "content": [
-                          {
-                            "input": {
-                              "player": "player2",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "toolu_015dGLMbwBKv1ZRQr6KdJzeH",
-                            "toolName": "rollDie",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "json",
-                              "value": 3,
-                            },
-                            "toolCallId": "toolu_015dGLMbwBKv1ZRQr6KdJzeH",
-                            "toolName": "rollDie",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "type": "start-step",
                   "warnings": [],
@@ -21889,114 +21037,7 @@ describe('streamText', () => {
                 {
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "Play a dice game between two players.",
-                        "role": "user",
-                      },
-                      {
-                        "content": [
-                          {
-                            "providerOptions": undefined,
-                            "text": "I'll help you simulate this game between two players where one is using a loaded die.",
-                            "type": "text",
-                          },
-                          {
-                            "input": {
-                              "code": "game_loop()",
-                            },
-                            "providerExecuted": true,
-                            "providerOptions": undefined,
-                            "toolCallId": "srvtoolu_01MzSrFWsmzBdcoQkGWLyRjK",
-                            "toolName": "code_execution",
-                            "type": "tool-call",
-                          },
-                          {
-                            "input": {
-                              "player": "player1",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "toolu_019jKkXz4jAdwHweHBw92CVY",
-                            "toolName": "rollDie",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "json",
-                              "value": 6,
-                            },
-                            "toolCallId": "toolu_019jKkXz4jAdwHweHBw92CVY",
-                            "toolName": "rollDie",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                      {
-                        "content": [
-                          {
-                            "input": {
-                              "player": "player2",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "toolu_015dGLMbwBKv1ZRQr6KdJzeH",
-                            "toolName": "rollDie",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "json",
-                              "value": 3,
-                            },
-                            "toolCallId": "toolu_015dGLMbwBKv1ZRQr6KdJzeH",
-                            "toolName": "rollDie",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                      {
-                        "content": [
-                          {
-                            "input": {
-                              "player": "player1",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "toolu_01YYqBNq5mk1wMtv3PAqY44m",
-                            "toolName": "rollDie",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "json",
-                              "value": 6,
-                            },
-                            "toolCallId": "toolu_01YYqBNq5mk1wMtv3PAqY44m",
-                            "toolName": "rollDie",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "type": "start-step",
                   "warnings": [],
@@ -22062,143 +21103,7 @@ describe('streamText', () => {
                 {
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "Play a dice game between two players.",
-                        "role": "user",
-                      },
-                      {
-                        "content": [
-                          {
-                            "providerOptions": undefined,
-                            "text": "I'll help you simulate this game between two players where one is using a loaded die.",
-                            "type": "text",
-                          },
-                          {
-                            "input": {
-                              "code": "game_loop()",
-                            },
-                            "providerExecuted": true,
-                            "providerOptions": undefined,
-                            "toolCallId": "srvtoolu_01MzSrFWsmzBdcoQkGWLyRjK",
-                            "toolName": "code_execution",
-                            "type": "tool-call",
-                          },
-                          {
-                            "input": {
-                              "player": "player1",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "toolu_019jKkXz4jAdwHweHBw92CVY",
-                            "toolName": "rollDie",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "json",
-                              "value": 6,
-                            },
-                            "toolCallId": "toolu_019jKkXz4jAdwHweHBw92CVY",
-                            "toolName": "rollDie",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                      {
-                        "content": [
-                          {
-                            "input": {
-                              "player": "player2",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "toolu_015dGLMbwBKv1ZRQr6KdJzeH",
-                            "toolName": "rollDie",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "json",
-                              "value": 3,
-                            },
-                            "toolCallId": "toolu_015dGLMbwBKv1ZRQr6KdJzeH",
-                            "toolName": "rollDie",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                      {
-                        "content": [
-                          {
-                            "input": {
-                              "player": "player1",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "toolu_01YYqBNq5mk1wMtv3PAqY44m",
-                            "toolName": "rollDie",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "json",
-                              "value": 6,
-                            },
-                            "toolCallId": "toolu_01YYqBNq5mk1wMtv3PAqY44m",
-                            "toolName": "rollDie",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                      {
-                        "content": [
-                          {
-                            "input": {
-                              "player": "player2",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "toolu_018WxjDkQG8h7i63poySGT2x",
-                            "toolName": "rollDie",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "json",
-                              "value": 3,
-                            },
-                            "toolCallId": "toolu_018WxjDkQG8h7i63poySGT2x",
-                            "toolName": "rollDie",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "type": "start-step",
                   "warnings": [],
@@ -22778,12 +21683,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -23574,12 +22474,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -24084,56 +22979,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                    {
-                      "content": [
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                        {
-                          "approvalId": "id-1",
-                          "toolCallId": "call-1",
-                          "type": "tool-approval-request",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "approvalId": "id-1",
-                          "approved": true,
-                          "type": "tool-approval-response",
-                        },
-                      ],
-                      "role": "tool",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "result1",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -24581,56 +23427,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                    {
-                      "content": [
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                        {
-                          "approvalId": "id-1",
-                          "toolCallId": "call-1",
-                          "type": "tool-approval-request",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "approvalId": "id-1",
-                          "approved": true,
-                          "type": "tool-approval-response",
-                        },
-                      ],
-                      "role": "tool",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "final-result",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -24939,56 +23736,7 @@ describe('streamText', () => {
               {
                 "request": {
                   "body": undefined,
-                  "messages": [
-                    {
-                      "content": "test-input",
-                      "role": "user",
-                    },
-                    {
-                      "content": [
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                        {
-                          "approvalId": "id-1",
-                          "toolCallId": "call-1",
-                          "type": "tool-approval-request",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "approvalId": "id-1",
-                          "approved": false,
-                          "type": "tool-approval-response",
-                        },
-                      ],
-                      "role": "tool",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "reason": undefined,
-                            "type": "execution-denied",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
-                  ],
+                  "messages": undefined,
                 },
                 "type": "start-step",
                 "warnings": [],
@@ -25155,12 +23903,7 @@ describe('streamText', () => {
                 {
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "type": "start-step",
                   "warnings": [],

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -18002,12 +18002,7 @@ describe('streamText', () => {
                 {
                   "request": {
                     "body": undefined,
-                    "messages": [
-                      {
-                        "content": "test-input",
-                        "role": "user",
-                      },
-                    ],
+                    "messages": undefined,
                   },
                   "type": "start-step",
                   "warnings": [],

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -5167,6 +5167,38 @@ describe('streamText', () => {
       });
     });
 
+    it('should exclude request messages when retention.requestMessages is false', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'response-metadata',
+              id: 'id-0',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Hello' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+            },
+          ]),
+          request: { body: 'test body' },
+        }),
+        prompt: 'test-input',
+        experimental_include: { requestMessages: false },
+      });
+
+      expect(await result.request).toStrictEqual({
+        body: 'test body',
+        messages: undefined,
+      });
+      expect((await result.steps)[0].request.messages).toBeUndefined();
+    });
+
     it('should resolve with messages from after prepareStep', async () => {
       const preparedMessages: Array<ModelMessage> = [
         { role: 'user', content: 'prepared prompt' },

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -527,7 +527,8 @@ export function streamText<
      * Disabling inclusion can help reduce memory usage when processing
      * large payloads like images.
      *
-     * By default, all data is included for backwards compatibility.
+     * By default, request bodies are included and request messages are
+     * excluded.
      */
     experimental_include?: StreamTextInclude;
 
@@ -1098,7 +1099,7 @@ class DefaultStreamTextResult<
               request: {
                 ...recordedRequest,
                 messages:
-                  (include?.requestMessages ?? true)
+                  (include?.requestMessages ?? false)
                     ? cloneModelMessages(recordedRequestMessages)
                     : undefined,
               },
@@ -1662,7 +1663,7 @@ class DefaultStreamTextResult<
             ...request,
             body: (include?.requestBody ?? true) ? request?.body : undefined,
             messages:
-              (include?.requestMessages ?? true)
+              (include?.requestMessages ?? false)
                 ? cloneModelMessages(stepMessages)
                 : undefined,
           };

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -161,7 +161,7 @@ export type StreamTextInclude = {
   /**
    * Whether to retain the request messages in step results.
    * The request messages can be large when sending images or files.
-   * @default true
+   * @default false
    */
   requestMessages?: boolean;
 };

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -150,6 +150,22 @@ const originalGenerateCallId = createIdGenerator({
   size: 24,
 });
 
+export type StreamTextInclude = {
+  /**
+   * Whether to retain the request body in step results.
+   * The request body can be large when sending images or files.
+   * @default true
+   */
+  requestBody?: boolean;
+
+  /**
+   * Whether to retain the request messages in step results.
+   * The request messages can be large when sending images or files.
+   * @default true
+   */
+  requestMessages?: boolean;
+};
+
 /**
  * A transformation that is applied to the stream.
  *
@@ -513,14 +529,7 @@ export function streamText<
      *
      * By default, all data is included for backwards compatibility.
      */
-    experimental_include?: {
-      /**
-       * Whether to retain the request body in step results.
-       * The request body can be large when sending images or files.
-       * @default true
-       */
-      requestBody?: boolean;
-    };
+    experimental_include?: StreamTextInclude;
 
     /**
      * Internal. For test use only. May change without notice.
@@ -816,7 +825,7 @@ class DefaultStreamTextResult<
     generateCallId: () => string;
     timeout: TimeoutConfiguration<TOOLS> | undefined;
     download: DownloadFunction | undefined;
-    include: { requestBody?: boolean } | undefined;
+    include: StreamTextInclude | undefined;
 
     // callbacks:
     onChunk: undefined | StreamTextOnChunkCallback<TOOLS>;
@@ -1088,7 +1097,10 @@ class DefaultStreamTextResult<
               warnings: recordedWarnings,
               request: {
                 ...recordedRequest,
-                messages: cloneModelMessages(recordedRequestMessages),
+                messages:
+                  (include?.requestMessages ?? true)
+                    ? cloneModelMessages(recordedRequestMessages)
+                    : undefined,
               },
               response: {
                 ...part.response,
@@ -1649,9 +1661,12 @@ class DefaultStreamTextResult<
           const stepRequest: LanguageModelRequestMetadata = {
             ...request,
             body: (include?.requestBody ?? true) ? request?.body : undefined,
-            messages: cloneModelMessages(stepMessages),
+            messages:
+              (include?.requestMessages ?? true)
+                ? cloneModelMessages(stepMessages)
+                : undefined,
           };
-          recordedRequestMessages = stepRequest.messages;
+          recordedRequestMessages = stepRequest.messages ?? [];
 
           const stepToolCalls: TypedToolCall<TOOLS>[] = [];
           const stepToolOutputs: ToolOutput<TOOLS>[] = [];

--- a/packages/ai/src/middleware/__snapshots__/simulate-streaming-middleware.test.ts.snap
+++ b/packages/ai/src/middleware/__snapshots__/simulate-streaming-middleware.test.ts.snap
@@ -8,12 +8,7 @@ exports[`simulateStreamingMiddleware > should handle empty text response 1`] = `
   {
     "request": {
       "body": undefined,
-      "messages": [
-        {
-          "content": "Test prompt",
-          "role": "user",
-        },
-      ],
+      "messages": undefined,
     },
     "type": "start-step",
     "warnings": [],

--- a/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
@@ -294,12 +294,7 @@ describe('extractReasoningMiddleware', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "Hello, how can I help?",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -444,12 +439,7 @@ describe('extractReasoningMiddleware', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "Hello, how can I help?",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -602,12 +592,7 @@ describe('extractReasoningMiddleware', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "Hello, how can I help?",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -750,12 +735,7 @@ describe('extractReasoningMiddleware', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "Hello, how can I help?",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -857,12 +837,7 @@ describe('extractReasoningMiddleware', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "Hello, how can I help?",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],
@@ -995,12 +970,7 @@ describe('extractReasoningMiddleware', () => {
             {
               "request": {
                 "body": undefined,
-                "messages": [
-                  {
-                    "content": "Hello, how can I help?",
-                    "role": "user",
-                  },
-                ],
+                "messages": undefined,
               },
               "type": "start-step",
               "warnings": [],

--- a/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
+++ b/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
@@ -86,12 +86,7 @@ describe('simulateStreamingMiddleware', () => {
           {
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "Test prompt",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "type": "start-step",
             "warnings": [],
@@ -200,12 +195,7 @@ describe('simulateStreamingMiddleware', () => {
           {
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "Test prompt",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "type": "start-step",
             "warnings": [],
@@ -341,12 +331,7 @@ describe('simulateStreamingMiddleware', () => {
           {
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "Test prompt",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "type": "start-step",
             "warnings": [],
@@ -513,12 +498,7 @@ describe('simulateStreamingMiddleware', () => {
           {
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "Test prompt",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "type": "start-step",
             "warnings": [],
@@ -685,12 +665,7 @@ describe('simulateStreamingMiddleware', () => {
           {
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "Test prompt",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "type": "start-step",
             "warnings": [],
@@ -815,12 +790,7 @@ describe('simulateStreamingMiddleware', () => {
           {
             "request": {
               "body": undefined,
-              "messages": [
-                {
-                  "content": "Test prompt",
-                  "role": "user",
-                },
-              ],
+              "messages": undefined,
             },
             "type": "start-step",
             "warnings": [],

--- a/packages/ai/src/types/language-model-request-metadata.ts
+++ b/packages/ai/src/types/language-model-request-metadata.ts
@@ -7,7 +7,7 @@ export type LanguageModelRequestMetadata = {
   /**
    * The input messages that were sent to the model for this step.
    */
-  readonly messages: Array<ModelMessage>;
+  readonly messages?: Array<ModelMessage>;
 
   /**
    * Request HTTP body that was sent to the provider API.


### PR DESCRIPTION
## Background

Storing the request messages on each step can lead to memory issues, similar to storing the request and response body. See #12126

## Summary

* make `request.messages` optional
* add an `include.requestMessages` option for opting into keeping them for each step (default false)

## Related Issues
Similar to #12126
Builds on #15052