### PR TITLE
fix(voyage): correct canary version to 2.0.0 to avoid collision with v6 stable

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -84,7 +84,7 @@
     "@ai-sdk/otel": "0.0.0",
     "@example/next-workflow": "0.0.0",
     "@ai-sdk/workflow": "0.0.0",
-    "@ai-sdk/voyage": "0.0.0"
+    "@ai-sdk/voyage": "1.0.0"
   },
   "changesets": [
     "add-resource-link-content",

--- a/packages/voyage/package.json
+++ b/packages/voyage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-sdk/voyage",
-  "version": "1.0.0-canary.7",
+  "version": "2.0.0-canary.7",
   "type": "module",
   "license": "Apache-2.0",
   "sideEffects": false,


### PR DESCRIPTION
## background

`@ai-sdk/voyage` on v6 (`release-v6.0`) is at `1.0.3` stable. on main (v7 canary) the version was `1.0.0-canary.7`, which looks like a pre-release of the same major as v6 stable

this happened because `pre.json` recorded voyage's initial version as `0.0.0` (the package didn't exist when pre-release mode was entered), so the pending major changeset produced `1.0.0-canary.N` instead of `2.0.0-canary.N`

## summary

- bump `packages/voyage/package.json` version to `2.0.0-canary.7`
- update `.changeset/pre.json` initial version from `0.0.0` to `1.0.0` so future canary releases stay in the `2.0.0` range