### PR TITLE
chore(voyage): trigger canary release at 2.0.0

### DIFF
--- a/.changeset/thin-chicken-listen.md
+++ b/.changeset/thin-chicken-listen.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/voyage": patch
+---
+
+chore(voyage): trigger canary release at 2.0.0


### PR DESCRIPTION
## background

#15060 corrected the voyage canary version from `1.0.0-canary.7` to `2.0.0-canary.7` in package.json and pre.json, but the original voyage changeset was already consumed by a previous version-packages cycle. without a new changeset, the corrected version won't publish to npm

## summary

- add a no-op patch changeset for `@ai-sdk/voyage` to trigger a canary release at `2.0.0-canary.X`