### PR TITLE
test(ai): add multi-step tool-call coverage for pipeTextStreamToResponse and toTextStreamResponse

### DIFF
--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -2921,6 +2921,73 @@ describe('streamText', () => {
         'world!',
       ]);
     });
+
+    it('should write text from all steps when using multi-step tool calls', async () => {
+      const mockResponse = createMockServerResponse();
+
+      let responseCount = 0;
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            switch (responseCount++) {
+              case 0:
+                return {
+                  stream: convertArrayToReadableStream([
+                    {
+                      type: 'tool-call',
+                      id: 'call-1',
+                      toolCallId: 'call-1',
+                      toolName: 'tool1',
+                      input: `{ "value": "test" }`,
+                    },
+                    {
+                      type: 'finish',
+                      finishReason: {
+                        unified: 'tool-calls',
+                        raw: 'tool_calls',
+                      },
+                      usage: { inputTokens: 10, outputTokens: 5 },
+                    },
+                  ]),
+                };
+              case 1:
+                return {
+                  stream: convertArrayToReadableStream([
+                    { type: 'text-start', id: '1' },
+                    { type: 'text-delta', id: '1', delta: 'Tool result: ' },
+                    { type: 'text-delta', id: '1', delta: 'success' },
+                    { type: 'text-end', id: '1' },
+                    {
+                      type: 'finish',
+                      finishReason: { unified: 'stop', raw: 'stop' },
+                      usage: { inputTokens: 20, outputTokens: 10 },
+                    },
+                  ]),
+                };
+              default:
+                throw new Error(`Unexpected response count: ${responseCount}`);
+            }
+          },
+        }),
+        tools: {
+          tool1: {
+            inputSchema: z.object({ value: z.string() }),
+            execute: async () => 'result1',
+          },
+        },
+        prompt: 'test-input',
+        stopWhen: isStepCount(3),
+      });
+
+      result.pipeTextStreamToResponse(mockResponse);
+
+      await mockResponse.waitForEnd();
+
+      expect(mockResponse.getDecodedChunks()).toEqual([
+        'Tool result: ',
+        'success',
+      ]);
+    });
   });
 
   describe('result.toUIMessageStream', () => {
@@ -4593,6 +4660,69 @@ describe('streamText', () => {
         'Hello',
         ', ',
         'world!',
+      ]);
+    });
+
+    it('should stream text from all steps when using multi-step tool calls', async () => {
+      let responseCount = 0;
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            switch (responseCount++) {
+              case 0:
+                return {
+                  stream: convertArrayToReadableStream([
+                    {
+                      type: 'tool-call',
+                      id: 'call-1',
+                      toolCallId: 'call-1',
+                      toolName: 'tool1',
+                      input: `{ "value": "test" }`,
+                    },
+                    {
+                      type: 'finish',
+                      finishReason: {
+                        unified: 'tool-calls',
+                        raw: 'tool_calls',
+                      },
+                      usage: { inputTokens: 10, outputTokens: 5 },
+                    },
+                  ]),
+                };
+              case 1:
+                return {
+                  stream: convertArrayToReadableStream([
+                    { type: 'text-start', id: '1' },
+                    { type: 'text-delta', id: '1', delta: 'Tool result: ' },
+                    { type: 'text-delta', id: '1', delta: 'success' },
+                    { type: 'text-end', id: '1' },
+                    {
+                      type: 'finish',
+                      finishReason: { unified: 'stop', raw: 'stop' },
+                      usage: { inputTokens: 20, outputTokens: 10 },
+                    },
+                  ]),
+                };
+              default:
+                throw new Error(`Unexpected response count: ${responseCount}`);
+            }
+          },
+        }),
+        tools: {
+          tool1: {
+            inputSchema: z.object({ value: z.string() }),
+            execute: async () => 'result1',
+          },
+        },
+        prompt: 'test-input',
+        stopWhen: isStepCount(3),
+      });
+
+      const response = result.toTextStreamResponse();
+
+      expect(await convertResponseStreamToArray(response)).toStrictEqual([
+        'Tool result: ',
+        'success',
       ]);
     });
   });


### PR DESCRIPTION
## Background

Issue #14521 reports that `streamText` stops mid-generation after the first tool step when `maxSteps > 1` is used in a Node.js streaming context.

The multi-step pipeline works correctly in the current codebase. The report was filed against ai@4.3.15 (v4 API), where the option was `maxSteps: N`. In v5+, that became `stopWhen: isStepCount(N)`. Without the migration, `stopWhen` defaults to `isStepCount(1)`, so the stream stops after step 0 — which is exactly what the reporter observed.

## Summary

`pipeTextStreamToResponse` and `toTextStreamResponse` were only tested for single-step scenarios. These two tests cover a two-step case: step 0 triggers a tool call, step 1 returns text after the tool executes. Both confirm that text from step 1 reaches the response.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14521