### PR TITLE
feat: introduce responseMessages on GenerateTextResult and StreamTextResult

### DIFF
--- a/.changeset/rich-moles-double.md
+++ b/.changeset/rich-moles-double.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat: introduce responseMessages on GenerateTextResult and StreamTextResult

--- a/content/cookbook/01-next/11-generate-text-with-chat-prompt.mdx
+++ b/content/cookbook/01-next/11-generate-text-with-chat-prompt.mdx
@@ -95,13 +95,13 @@ import { generateText, type ModelMessage } from 'ai';
 export async function POST(req: Request) {
   const { messages }: { messages: ModelMessage[] } = await req.json();
 
-  const { response } = await generateText({
+  const { responseMessages } = await generateText({
     model: 'openai/gpt-4o',
     system: 'You are a helpful assistant.',
     messages,
   });
 
-  return Response.json({ messages: response.messages });
+  return Response.json({ messages: responseMessages });
 }
 ```
 

--- a/content/cookbook/05-node/55-manual-agent-loop.mdx
+++ b/content/cookbook/05-node/55-manual-agent-loop.mdx
@@ -62,7 +62,7 @@ async function main() {
     }
 
     // Add LLM generated messages to the message history
-    const responseMessages = (await result.response).messages;
+    const responseMessages = await result.responseMessages;
     messages.push(...responseMessages);
 
     const finishReason = await result.finishReason;
@@ -107,7 +107,7 @@ main().catch(console.error);
 The example maintains a `messages` array that tracks the entire conversation history. After each model response, the generated messages are added to this history:
 
 ```ts
-const responseMessages = (await result.response).messages;
+const responseMessages = await result.responseMessages;
 messages.push(...responseMessages);
 ```
 

--- a/content/docs/03-agents/04-loop-control.mdx
+++ b/content/docs/03-agents/04-loop-control.mdx
@@ -406,7 +406,7 @@ while (step < maxSteps) {
     },
   });
 
-  messages.push(...result.response.messages);
+  messages.push(...result.responseMessages);
 
   if (result.text) {
     break; // Stop when model generates text

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -97,10 +97,10 @@ __PROVIDER_IMPORT__;
 const result = await generateText({
   model: __MODEL__,
   prompt: 'Invent a new holiday and describe its traditions.',
-  onFinish({ text, finishReason, usage, response, steps, totalUsage }) {
+  onFinish({ text, finishReason, usage, responseMessages, steps, totalUsage }) {
     // your own logic, e.g. for saving the chat history or recording usage
 
-    const messages = response.messages; // messages that were generated
+    const messages = responseMessages; // messages that were generated
   },
 });
 ```
@@ -305,10 +305,10 @@ __PROVIDER_IMPORT__;
 const result = streamText({
   model: __MODEL__,
   prompt: 'Invent a new holiday and describe its traditions.',
-  onFinish({ text, finishReason, usage, response, steps, totalUsage }) {
+  onFinish({ text, finishReason, usage, responseMessages, steps, totalUsage }) {
     // your own logic, e.g. for saving the chat history or recording usage
 
-    const messages = response.messages; // messages that were generated
+    const messages = responseMessages; // messages that were generated
   },
 });
 ```

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -222,7 +222,7 @@ const result = await generateText({
   messages,
 });
 
-messages.push(...result.response.messages);
+messages.push(...result.responseMessages);
 
 for (const part of result.content) {
   if (part.type === 'tool-approval-request' && !part.isAutomatic) {
@@ -537,11 +537,11 @@ prepareStep: forwardAnthropicContainerIdFromLastStep,
 Adding the generated assistant and tool messages to your conversation history is a common task,
 especially if you are using multi-step tool calls.
 
-Both `generateText` and `streamText` have a `response.messages` property that you can use to
+Both `generateText` and `streamText` have a `responseMessages` property that you can use to
 add the assistant and tool messages to your conversation history.
 It is also available in the `onFinish` callback of `streamText`.
 
-The `response.messages` property contains an array of `ModelMessage` objects that you can add to your conversation history:
+The `responseMessages` property contains an array of `ModelMessage` objects that you can add to your conversation history:
 
 ```ts
 import { generateText, ModelMessage } from 'ai';
@@ -550,13 +550,13 @@ const messages: ModelMessage[] = [
   // ...
 ];
 
-const { response } = await generateText({
+const { responseMessages } = await generateText({
   // ...
   messages,
 });
 
 // add the response messages to your conversation history:
-messages.push(...response.messages); // streamText: ...((await response).messages)
+messages.push(...responseMessages); // streamText: ...(await result.responseMessages)
 ```
 
 ## Dynamic Tools

--- a/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
+++ b/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
@@ -493,11 +493,11 @@ export async function POST(request) {
     model: __MODEL__,
     system: 'you are a friendly assistant!',
     messages: coreMessages,
-    onFinish: async ({ response }) => {
+    onFinish: async ({ responseMessages }) => {
       try {
         await saveChat({
           id,
-          messages: [...coreMessages, ...response.messages],
+          messages: [...coreMessages, ...responseMessages],
         });
       } catch (error) {
         console.error('Failed to save chat');

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -1679,6 +1679,12 @@ To see `generateText` in action, check out [these examples](#examples).
               description:
                 'Additional provider-specific metadata. They are passed through from the provider to the AI SDK and enable provider-specific results that can be fully encapsulated in the provider.',
             },
+            {
+              name: 'responseMessages',
+              type: 'Array<ResponseMessage>',
+              description:
+                'The response messages that were generated during the call.',
+            },
           ],
         },
       ],
@@ -2099,6 +2105,12 @@ To see `generateText` in action, check out [these examples](#examples).
                 'Response information for every step. You can use this to get information about intermediate steps, such as the tool calls or the response headers.',
             },
             {
+              name: 'responseMessages',
+              type: 'Array<ResponseMessage>',
+              description:
+                'The response messages that were generated during the call.',
+            },
+            {
               name: 'runtimeContext',
               type: 'CONTEXT',
               description:
@@ -2511,6 +2523,12 @@ To see `generateText` in action, check out [these examples](#examples).
       type: 'Warning[] | undefined',
       description:
         'Warnings from the model provider (e.g. unsupported settings).',
+    },
+    {
+      name: 'responseMessages',
+      type: 'Array<ResponseMessage>',
+      description:
+        'The response messages that were generated during the call.',
     },
     {
       name: 'providerMetadata',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -2710,6 +2710,12 @@ To see `streamText` in action, check out [these examples](#examples).
         'Warnings from the model provider (e.g. unsupported settings) for the first step.',
     },
     {
+      name: 'responseMessages',
+      type: 'Promise<Array<ResponseMessage>>',
+      description:
+        'The response messages that were generated during the call.',
+    },
+    {
       name: 'steps',
       type: 'Promise<Array<StepResult>>',
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -998,7 +998,7 @@ for (const part of result.content) {
   }
 }
 
-messages.push(...result.response.messages);
+messages.push(...result.responseMessages);
 messages.push({ role: 'tool', content: approvals });
 
 const approvedResult = await agent.generate({ messages });

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1275,7 +1275,7 @@ const turn1 = await generateText({
   providerOptions: { google: { store: false } },
 });
 
-messages.push(...turn1.response.messages);
+messages.push(...turn1.responseMessages);
 messages.push({
   role: 'user',
   content: 'What is the most famous landmark in the second one?',

--- a/examples/ai-functions/src/agent/openai/generate-tool-approval-generic.ts
+++ b/examples/ai-functions/src/agent/openai/generate-tool-approval-generic.ts
@@ -112,6 +112,6 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...result.response.messages);
+    messages.push(...result.responseMessages);
   }
 });

--- a/examples/ai-functions/src/agent/openai/generate-tool-approval.ts
+++ b/examples/ai-functions/src/agent/openai/generate-tool-approval.ts
@@ -108,6 +108,6 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...result.response.messages);
+    messages.push(...result.responseMessages);
   }
 });

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/chatbot.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/chatbot.ts
@@ -20,12 +20,13 @@ run(async () => {
       messages.push({ role: 'user', content: userInput });
     }
 
-    const { text, toolCalls, toolResults, response } = await generateText({
-      model: amazonBedrock('anthropic.claude-3-haiku-20240307-v1:0'),
-      tools: { weatherTool },
-      system: `You are a helpful, respectful and honest assistant. If the weather is requested use the `,
-      messages,
-    });
+    const { text, toolCalls, toolResults, responseMessages } =
+      await generateText({
+        model: amazonBedrock('anthropic.claude-3-haiku-20240307-v1:0'),
+        tools: { weatherTool },
+        system: `You are a helpful, respectful and honest assistant. If the weather is requested use the `,
+        messages,
+      });
 
     toolResponseAvailable = false;
 
@@ -47,7 +48,7 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...response.messages);
+    messages.push(...responseMessages);
 
     toolResponseAvailable = toolCalls.length > 0;
   }

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/reasoning-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/reasoning-chatbot.ts
@@ -16,7 +16,7 @@ run(async () => {
     const userInput = await terminal.question('You: ');
     messages.push({ role: 'user', content: userInput });
 
-    const { steps, response } = await generateText({
+    const { steps, responseMessages } = await generateText({
       model: amazonBedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
       tools: { weatherTool },
       system: `You are a helpful, respectful and honest assistant.`,
@@ -47,6 +47,6 @@ run(async () => {
 
     console.log('\n');
 
-    messages.push(...response.messages);
+    messages.push(...responseMessages);
   }
 });

--- a/examples/ai-functions/src/generate-text/anthropic/chatbot-websearch.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/chatbot-websearch.ts
@@ -25,7 +25,7 @@ run(async () => {
     const userInput = await terminal.question('You: ');
     messages.push({ role: 'user', content: userInput });
 
-    const { content, response } = await generateText({
+    const { content, responseMessages } = await generateText({
       model: anthropic('claude-3-5-sonnet-latest'),
       tools: {
         web_search: anthropic.tools.webSearch_20250305({
@@ -51,6 +51,6 @@ run(async () => {
     console.log();
     console.log();
 
-    messages.push(...response.messages);
+    messages.push(...responseMessages);
   }
 });

--- a/examples/ai-functions/src/generate-text/anthropic/chatbot.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/chatbot.ts
@@ -20,12 +20,13 @@ run(async () => {
       messages.push({ role: 'user', content: userInput });
     }
 
-    const { text, toolCalls, toolResults, response } = await generateText({
-      model: anthropic('claude-3-5-sonnet-20240620'),
-      tools: { weatherTool },
-      system: `You are a helpful, respectful and honest assistant.`,
-      messages,
-    });
+    const { text, toolCalls, toolResults, responseMessages } =
+      await generateText({
+        model: anthropic('claude-3-5-sonnet-20240620'),
+        tools: { weatherTool },
+        system: `You are a helpful, respectful and honest assistant.`,
+        messages,
+      });
 
     toolResponseAvailable = false;
 
@@ -47,7 +48,7 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...response.messages);
+    messages.push(...responseMessages);
 
     toolResponseAvailable = toolCalls.length > 0;
   }

--- a/examples/ai-functions/src/generate-text/anthropic/compaction-pause.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/compaction-pause.ts
@@ -280,7 +280,7 @@ run(async () => {
     if (hasCompaction) {
       console.log('\n[Compaction detected - response paused]');
 
-      messages.push(...result.response.messages);
+      messages.push(...result.responseMessages);
       console.log('Continuing with compacted context...\n');
 
       result = await generateText({

--- a/examples/ai-functions/src/generate-text/anthropic/reasoning-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/reasoning-chatbot.ts
@@ -28,7 +28,7 @@ run(async () => {
     const userInput = await terminal.question('You: ');
     messages.push({ role: 'user', content: userInput });
 
-    const { steps, response } = await generateText({
+    const { steps, responseMessages } = await generateText({
       model: anthropic('claude-sonnet-4-5-20250929'),
       tools: { weatherTool },
       system: `You are a helpful, respectful and honest assistant.`,
@@ -60,6 +60,6 @@ run(async () => {
 
     console.log('\n');
 
-    messages.push(...response.messages);
+    messages.push(...responseMessages);
   }
 });

--- a/examples/ai-functions/src/generate-text/cohere/chatbot.ts
+++ b/examples/ai-functions/src/generate-text/cohere/chatbot.ts
@@ -20,12 +20,13 @@ run(async () => {
       messages.push({ role: 'user', content: userInput });
     }
 
-    const { text, toolCalls, toolResults, response } = await generateText({
-      model: cohere('command-r-plus'),
-      tools: { weatherTool },
-      system: `You are a helpful, respectful and honest assistant. If the weather is requested use the `,
-      messages,
-    });
+    const { text, toolCalls, toolResults, responseMessages } =
+      await generateText({
+        model: cohere('command-r-plus'),
+        tools: { weatherTool },
+        system: `You are a helpful, respectful and honest assistant. If the weather is requested use the `,
+        messages,
+      });
 
     toolResponseAvailable = false;
 
@@ -47,7 +48,7 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...response.messages);
+    messages.push(...responseMessages);
 
     toolResponseAvailable = toolCalls.length > 0;
   }

--- a/examples/ai-functions/src/generate-text/google/chatbot-image-output.ts
+++ b/examples/ai-functions/src/generate-text/google/chatbot-image-output.ts
@@ -37,6 +37,6 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...result.response.messages);
+    messages.push(...result.responseMessages);
   }
 });

--- a/examples/ai-functions/src/generate-text/google/image-multi-step.ts
+++ b/examples/ai-functions/src/generate-text/google/image-multi-step.ts
@@ -16,7 +16,7 @@ run(async () => {
   const step2 = await generateText({
     model: google('gemini-3-pro-image-preview'),
     messages: [
-      ...step1.response.messages,
+      ...step1.responseMessages,
       {
         role: 'user',
         content:

--- a/examples/ai-functions/src/generate-text/google/image-thinking-multi-step.ts
+++ b/examples/ai-functions/src/generate-text/google/image-thinking-multi-step.ts
@@ -33,7 +33,7 @@ run(async () => {
   const step2 = await generateText({
     model: google('gemini-3-pro-image-preview'),
     messages: [
-      ...step1.response.messages,
+      ...step1.responseMessages,
       {
         role: 'user',
         content: "Change it so that it's on Saturn.",

--- a/examples/ai-functions/src/generate-text/google/interactions-multi-turn-stateless.ts
+++ b/examples/ai-functions/src/generate-text/google/interactions-multi-turn-stateless.ts
@@ -35,7 +35,7 @@ run(async () => {
   // send a follow-up that depends on turn 1's context. With `store: false`, the
   // server has no prior state to fall back on — the model must reconstruct the
   // context from the messages we re-send.
-  messages.push(...turn1.response.messages);
+  messages.push(...turn1.responseMessages);
   messages.push({
     role: 'user',
     content: 'What is the most famous landmark in the second one?',

--- a/examples/ai-functions/src/generate-text/google/interactions-reasoning-multiturn.ts
+++ b/examples/ai-functions/src/generate-text/google/interactions-reasoning-multiturn.ts
@@ -37,7 +37,7 @@ run(async () => {
   console.log(turn1.text);
   console.log();
 
-  messages.push(...turn1.response.messages);
+  messages.push(...turn1.responseMessages);
   messages.push({
     role: 'user',
     content:

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-chatbot.ts
@@ -20,12 +20,13 @@ run(async () => {
       messages.push({ role: 'user', content: userInput });
     }
 
-    const { text, toolCalls, toolResults, response } = await generateText({
-      model: vertexAnthropic('claude-3-5-sonnet-v2@20241022'),
-      tools: { weatherTool },
-      system: `You are a helpful, respectful and honest assistant.`,
-      messages,
-    });
+    const { text, toolCalls, toolResults, responseMessages } =
+      await generateText({
+        model: vertexAnthropic('claude-3-5-sonnet-v2@20241022'),
+        tools: { weatherTool },
+        system: `You are a helpful, respectful and honest assistant.`,
+        messages,
+      });
 
     toolResponseAvailable = false;
 
@@ -47,7 +48,7 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...response.messages);
+    messages.push(...responseMessages);
 
     toolResponseAvailable = toolCalls.length > 0;
   }

--- a/examples/ai-functions/src/generate-text/mistral/chatbot.ts
+++ b/examples/ai-functions/src/generate-text/mistral/chatbot.ts
@@ -20,12 +20,13 @@ run(async () => {
       messages.push({ role: 'user', content: userInput });
     }
 
-    const { text, toolCalls, toolResults, response } = await generateText({
-      model: mistral('mistral-large-latest'),
-      tools: { weatherTool },
-      system: `You are a helpful, respectful and honest assistant.`,
-      messages,
-    });
+    const { text, toolCalls, toolResults, responseMessages } =
+      await generateText({
+        model: mistral('mistral-large-latest'),
+        tools: { weatherTool },
+        system: `You are a helpful, respectful and honest assistant.`,
+        messages,
+      });
 
     toolResponseAvailable = false;
 
@@ -47,7 +48,7 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...response.messages);
+    messages.push(...responseMessages);
 
     toolResponseAvailable = toolCalls.length > 0;
   }

--- a/examples/ai-functions/src/generate-text/mock/invalid-tool-call.ts
+++ b/examples/ai-functions/src/generate-text/mock/invalid-tool-call.ts
@@ -62,5 +62,5 @@ run(async () => {
   console.log(JSON.stringify(result.content, null, 2));
 
   console.log('Response messages:');
-  console.log(JSON.stringify(result.response.messages, null, 2));
+  console.log(JSON.stringify(result.responseMessages, null, 2));
 });

--- a/examples/ai-functions/src/generate-text/open-responses/lmstudio-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/open-responses/lmstudio-chatbot.ts
@@ -25,12 +25,13 @@ run(async () => {
       messages.push({ role: 'user', content: userInput });
     }
 
-    const { text, toolCalls, toolResults, response } = await generateText({
-      model: lmstudio('zai-org/glm-4.7-flash'),
-      tools: { weatherTool },
-      system: `You are a helpful, respectful and honest assistant. If the weather is requested use the `,
-      messages,
-    });
+    const { text, toolCalls, toolResults, responseMessages } =
+      await generateText({
+        model: lmstudio('zai-org/glm-4.7-flash'),
+        tools: { weatherTool },
+        system: `You are a helpful, respectful and honest assistant. If the weather is requested use the `,
+        messages,
+      });
 
     toolResponseAvailable = false;
 
@@ -52,7 +53,7 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...response.messages);
+    messages.push(...responseMessages);
 
     toolResponseAvailable = toolCalls.length > 0;
   }

--- a/examples/ai-functions/src/generate-text/openai/compatible-google-thought-signatures.ts
+++ b/examples/ai-functions/src/generate-text/openai/compatible-google-thought-signatures.ts
@@ -80,7 +80,7 @@ run(async () => {
   console.log('\nFinal response:');
   console.log(result1.text);
 
-  result1.response.messages.forEach((msg, i) => {
+  result1.responseMessages.forEach((msg, i) => {
     if (msg.role === 'assistant' && typeof msg.content !== 'string') {
       console.log(`Message ${i} (assistant):`);
       msg.content.forEach(part => {
@@ -102,7 +102,7 @@ run(async () => {
       content:
         'Check flight status for AA100 and book a taxi 2 hours before if delayed.',
     },
-    ...result1.response.messages,
+    ...result1.responseMessages,
     {
       role: 'user',
       content: 'Summarize what you did.',

--- a/examples/ai-functions/src/generate-text/openai/responses-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-chatbot.ts
@@ -20,12 +20,13 @@ run(async () => {
       messages.push({ role: 'user', content: userInput });
     }
 
-    const { text, toolCalls, toolResults, response } = await generateText({
-      model: openai.responses('o3'),
-      tools: { weatherTool },
-      system: `You are a helpful, respectful and honest assistant.`,
-      messages,
-    });
+    const { text, toolCalls, toolResults, responseMessages } =
+      await generateText({
+        model: openai.responses('o3'),
+        tools: { weatherTool },
+        system: `You are a helpful, respectful and honest assistant.`,
+        messages,
+      });
 
     toolResponseAvailable = false;
 
@@ -47,7 +48,7 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...response.messages);
+    messages.push(...responseMessages);
 
     toolResponseAvailable = toolCalls.length > 0;
   }

--- a/examples/ai-functions/src/generate-text/openai/responses-mcp-tool-approval.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-mcp-tool-approval.ts
@@ -97,6 +97,6 @@ run(async () => {
       }
     }
 
-    messages.push(...result.response.messages);
+    messages.push(...result.responseMessages);
   }
 });

--- a/examples/ai-functions/src/generate-text/openai/responses-shell-container-multiturn.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-shell-container-multiturn.ts
@@ -28,7 +28,7 @@ run(async () => {
     },
     messages: [
       { role: 'user', content: 'Run uname -a' },
-      ...result1.response.messages,
+      ...result1.responseMessages,
       { role: 'user', content: 'What architecture do you run in?' },
     ],
   });

--- a/examples/ai-functions/src/generate-text/openai/responses-shell-local-multiturn.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-shell-local-multiturn.ts
@@ -40,7 +40,7 @@ run(async () => {
     },
     messages: [
       { role: 'user', content: 'Run uname -a' },
-      ...result1.response.messages,
+      ...result1.responseMessages,
       { role: 'user', content: 'What architecture do you run in?' },
     ],
     stopWhen: isStepCount(5),

--- a/examples/ai-functions/src/generate-text/openai/responses-shell-tool-with-approval.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-shell-tool-with-approval.ts
@@ -89,7 +89,7 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...result.response.messages);
+    messages.push(...result.responseMessages);
 
     if (approvals.length === 0 && result.finishReason !== 'tool-calls') {
       break;

--- a/examples/ai-functions/src/generate-text/openai/tool-approval-generic.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-approval-generic.ts
@@ -124,6 +124,6 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...result.response.messages);
+    messages.push(...result.responseMessages);
   }
 });

--- a/examples/ai-functions/src/generate-text/openai/tool-approval.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-approval.ts
@@ -124,6 +124,6 @@ run(async () => {
 
     process.stdout.write('\n\n');
 
-    messages.push(...result.response.messages);
+    messages.push(...result.responseMessages);
   }
 });

--- a/examples/ai-functions/src/generate-text/openai/tool-execution-error.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-execution-error.ts
@@ -22,5 +22,5 @@ run(async () => {
 
   console.log(JSON.stringify(result.content, null, 2));
 
-  console.log(JSON.stringify(result.response.messages, null, 2));
+  console.log(JSON.stringify(result.responseMessages, null, 2));
 });

--- a/examples/ai-functions/src/stream-text/openai/on-finish-response-messages.ts
+++ b/examples/ai-functions/src/stream-text/openai/on-finish-response-messages.ts
@@ -16,8 +16,8 @@ run(async () => {
       }),
     },
     stopWhen: isStepCount(5),
-    onFinish({ response }) {
-      console.log(JSON.stringify(response.messages, null, 2));
+    onFinish({ responseMessages }) {
+      console.log(JSON.stringify(responseMessages, null, 2));
     },
     prompt: 'What is the current weather in San Francisco?',
   });

--- a/examples/ai-functions/src/stream-text/openai/responses-mcp-tool-approval.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-mcp-tool-approval.ts
@@ -68,7 +68,6 @@ run(async () => {
 
     // Get final results
     const content = await result.content;
-    const response = await result.response;
 
     for (const part of content) {
       if (part.type === 'tool-approval-request') {
@@ -84,6 +83,6 @@ run(async () => {
       }
     }
 
-    messages.push(...responseMessages);
+    messages.push(...(await result.responseMessages));
   }
 });

--- a/examples/ai-functions/src/stream-text/openai/responses-mcp-tool-approval.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-mcp-tool-approval.ts
@@ -84,6 +84,6 @@ run(async () => {
       }
     }
 
-    messages.push(...response.messages);
+    messages.push(...responseMessages);
   }
 });

--- a/examples/ai-functions/src/stream-text/openai/responses-shell-container-multiturn.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-shell-container-multiturn.ts
@@ -28,7 +28,7 @@ run(async () => {
     },
     messages: [
       { role: 'user', content: 'Run uname -a' },
-      ...result1.response.messages,
+      ...result1.responseMessages,
       { role: 'user', content: 'What architecture do you run in?' },
     ],
   });

--- a/examples/ai-functions/src/stream-text/openai/responses-shell-local-multiturn.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-shell-local-multiturn.ts
@@ -40,7 +40,7 @@ run(async () => {
     },
     messages: [
       { role: 'user', content: 'Run uname -a' },
-      ...result1.response.messages,
+      ...result1.responseMessages,
       { role: 'user', content: 'What architecture do you run in?' },
     ],
     stopWhen: isStepCount(5),

--- a/examples/next-openai-pages/app/api/generate-chat/route.ts
+++ b/examples/next-openai-pages/app/api/generate-chat/route.ts
@@ -4,11 +4,11 @@ import { openai } from '@ai-sdk/openai';
 export async function POST(req: Request) {
   const { messages }: { messages: ModelMessage[] } = await req.json();
 
-  const { response } = await generateText({
+  const { responseMessages } = await generateText({
     model: openai('gpt-5'),
     system: 'You are a helpful assistant.',
     messages,
   });
 
-  return Response.json({ messages: response.messages });
+  return Response.json({ messages: responseMessages });
 }

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -112,6 +112,47 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
     "modelId": "test-response-model-id",
     "timestamp": 1970-01-01T00:00:10.000Z,
   },
+  "responseMessages": [
+    {
+      "content": [
+        {
+          "input": {
+            "value": "value",
+          },
+          "providerExecuted": undefined,
+          "providerOptions": undefined,
+          "toolCallId": "call-1",
+          "toolName": "tool1",
+          "type": "tool-call",
+        },
+      ],
+      "role": "assistant",
+    },
+    {
+      "content": [
+        {
+          "output": {
+            "type": "text",
+            "value": "result1",
+          },
+          "toolCallId": "call-1",
+          "toolName": "tool1",
+          "type": "tool-result",
+        },
+      ],
+      "role": "tool",
+    },
+    {
+      "content": [
+        {
+          "providerOptions": undefined,
+          "text": "Hello, world!",
+          "type": "text",
+        },
+      ],
+      "role": "assistant",
+    },
+  ],
   "runtimeContext": {},
   "sources": [],
   "staticToolCalls": [],
@@ -539,7 +580,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
 ]
 `;
 
-exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > result.response.messages should contain response messages from all steps 1`] = `
+exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > result.responseMessages should contain response messages from all steps 1`] = `
 [
   {
     "content": [
@@ -971,7 +1012,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
 ]
 `;
 
-exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with prepareStep > result.response.messages should contain response messages from all steps 1`] = `
+exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with prepareStep > result.responseMessages should contain response messages from all steps 1`] = `
 [
   {
     "content": [
@@ -1516,7 +1557,7 @@ exports[`generateText > result.response > should contain response body and heade
 }
 `;
 
-exports[`generateText > result.response.messages > should contain assistant response message and tool message when there are tool calls with results 1`] = `
+exports[`generateText > result.responseMessages > should contain assistant response message and tool message when there are tool calls with results 1`] = `
 [
   {
     "content": [
@@ -1555,7 +1596,7 @@ exports[`generateText > result.response.messages > should contain assistant resp
 ]
 `;
 
-exports[`generateText > result.response.messages > should contain assistant response message when there are no tool calls 1`] = `
+exports[`generateText > result.responseMessages > should contain assistant response message when there are no tool calls 1`] = `
 [
   {
     "content": [
@@ -1570,7 +1611,7 @@ exports[`generateText > result.response.messages > should contain assistant resp
 ]
 `;
 
-exports[`generateText > result.response.messages > should contain reasoning 1`] = `
+exports[`generateText > result.responseMessages > should contain reasoning 1`] = `
 [
   {
     "content": [

--- a/packages/ai/src/generate-text/generate-text-events.ts
+++ b/packages/ai/src/generate-text/generate-text-events.ts
@@ -12,6 +12,7 @@ import type { LanguageModelUsage } from '../types/usage';
 import type { Callback } from '../util/callback';
 import type { ActiveTools } from './active-tools';
 import type { Output } from './output';
+import type { ResponseMessage } from './response-message';
 import type { StepResult } from './step-result';
 import type { TextStreamPart } from './stream-text-result';
 
@@ -168,6 +169,9 @@ export type GenerateTextEndEvent<
   TOOLS extends ToolSet = ToolSet,
   RUNTIME_CONTEXT extends Context = Context,
 > = StepResult<TOOLS, RUNTIME_CONTEXT> & {
+  /** The response messages that were generated during the call. */
+  readonly responseMessages: ResponseMessage[];
+
   /** Array containing results from all steps in the generation. */
   readonly steps: StepResult<TOOLS, RUNTIME_CONTEXT>[];
 

--- a/packages/ai/src/generate-text/generate-text-result.ts
+++ b/packages/ai/src/generate-text/generate-text-result.ts
@@ -12,6 +12,7 @@ import type { GeneratedFile } from './generated-file';
 import type { Output } from './output';
 import type { InferCompleteOutput } from './output-utils';
 import type { ReasoningFileOutput, ReasoningOutput } from './reasoning-output';
+import type { ResponseMessage } from './response-message';
 import type { StepResult } from './step-result';
 import type {
   DynamicToolCall,
@@ -130,6 +131,11 @@ export interface GenerateTextResult<
    * Additional response information.
    */
   readonly response: LanguageModelResponseMetadata;
+
+  /**
+   * The response messages that were generated during the call.
+   */
+  readonly responseMessages: Array<ResponseMessage>;
 
   /**
    * Additional provider-specific metadata. They are passed through

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -754,7 +754,7 @@ describe('generateText', () => {
     });
   });
 
-  describe('result.response.messages', () => {
+  describe('result.responseMessages', () => {
     it('should contain assistant response message when there are no tool calls', async () => {
       const result = await generateText({
         model: new MockLanguageModelV4({
@@ -766,7 +766,7 @@ describe('generateText', () => {
         prompt: 'test-input',
       });
 
-      expect(result.response.messages).toMatchSnapshot();
+      expect(result.responseMessages).toMatchSnapshot();
     });
 
     it('should contain assistant response message and tool message when there are tool calls with results', async () => {
@@ -801,7 +801,7 @@ describe('generateText', () => {
         prompt: 'test-input',
       });
 
-      expect(result.response.messages).toMatchSnapshot();
+      expect(result.responseMessages).toMatchSnapshot();
     });
 
     it('should contain reasoning', async () => {
@@ -810,7 +810,7 @@ describe('generateText', () => {
         prompt: 'test-input',
       });
 
-      expect(result.response.messages).toMatchSnapshot();
+      expect(result.responseMessages).toMatchSnapshot();
     });
   });
 
@@ -3319,6 +3319,42 @@ describe('generateText', () => {
             "modelId": "mock-model-id",
             "timestamp": 1970-01-01T00:00:00.000Z,
           },
+          "responseMessages": [
+            {
+              "content": [
+                {
+                  "providerOptions": undefined,
+                  "text": "Hello, World!",
+                  "type": "text",
+                },
+                {
+                  "input": {
+                    "value": "value",
+                  },
+                  "providerExecuted": undefined,
+                  "providerOptions": undefined,
+                  "toolCallId": "call-1",
+                  "toolName": "tool1",
+                  "type": "tool-call",
+                },
+              ],
+              "role": "assistant",
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "value-result",
+                  },
+                  "toolCallId": "call-1",
+                  "toolName": "tool1",
+                  "type": "tool-result",
+                },
+              ],
+              "role": "tool",
+            },
+          ],
           "runtimeContext": {},
           "sources": [],
           "staticToolCalls": [
@@ -3658,8 +3694,8 @@ describe('generateText', () => {
         assert.deepStrictEqual(result.toolResults, []);
       });
 
-      it('result.response.messages should contain response messages from all steps', () => {
-        expect(result.response.messages).toMatchSnapshot();
+      it('result.responseMessages should contain response messages from all steps', () => {
+        expect(result.responseMessages).toMatchSnapshot();
       });
 
       it('result.totalUsage should sum token usage', () => {
@@ -4431,8 +4467,8 @@ describe('generateText', () => {
         expect(result.toolResults).toStrictEqual([]);
       });
 
-      it('result.response.messages should contain response messages from all steps', () => {
-        expect(result.response.messages).toMatchSnapshot();
+      it('result.responseMessages should contain response messages from all steps', () => {
+        expect(result.responseMessages).toMatchSnapshot();
       });
 
       it('result.totalUsage should sum token usage', () => {
@@ -6185,7 +6221,7 @@ describe('generateText', () => {
     });
 
     it('should include error result in response messages', async () => {
-      expect(result.response.messages).toMatchInlineSnapshot(`
+      expect(result.responseMessages).toMatchInlineSnapshot(`
         [
           {
             "content": [
@@ -6953,9 +6989,9 @@ describe('generateText', () => {
         });
       });
 
-      describe('result.response.messages', () => {
+      describe('result.responseMessages', () => {
         it('should contain all response messages from all steps', () => {
-          expect(result.response.messages).toMatchInlineSnapshot(`
+          expect(result.responseMessages).toMatchInlineSnapshot(`
             [
               {
                 "content": [
@@ -7493,7 +7529,7 @@ describe('generateText', () => {
         });
 
         it('should contain all response messages', () => {
-          expect(onFinishResult.response.messages.length).toBe(9);
+          expect(onFinishResult.responseMessages.length).toBe(9);
         });
       });
     });
@@ -8002,7 +8038,7 @@ describe('generateText', () => {
       });
 
       it('should include error result in response messages', async () => {
-        expect(result.response.messages).toMatchInlineSnapshot(`
+        expect(result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -8453,7 +8489,7 @@ describe('generateText', () => {
       });
 
       it('should include tool approval request in response messages', async () => {
-        expect(result.response.messages).toMatchInlineSnapshot(`
+        expect(result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -8559,7 +8595,7 @@ describe('generateText', () => {
       });
 
       it('should include tool approval request in response messages', async () => {
-        expect(result.response.messages).toMatchInlineSnapshot(`
+        expect(result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -8702,7 +8738,7 @@ describe('generateText', () => {
       });
 
       it('should include tool approval request in response messages', async () => {
-        expect(result.response.messages).toMatchInlineSnapshot(`
+        expect(result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -8930,7 +8966,7 @@ describe('generateText', () => {
       });
 
       it('should include the tool result in the response messages', async () => {
-        expect(result.response.messages).toMatchInlineSnapshot(`
+        expect(result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -9207,7 +9243,7 @@ describe('generateText', () => {
       });
 
       it('should include the tool error in the response messages', async () => {
-        expect(result.response.messages).toMatchInlineSnapshot(`
+        expect(result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -9373,7 +9409,7 @@ describe('generateText', () => {
       });
 
       it('should produce response messages', async () => {
-        expect(result.response.messages).toMatchInlineSnapshot(`
+        expect(result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -9574,7 +9610,7 @@ describe('generateText', () => {
       });
 
       it('should produce response messages with automatic approval metadata', async () => {
-        expect(result.response.messages).toMatchInlineSnapshot(`
+        expect(result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -9799,7 +9835,7 @@ describe('generateText', () => {
       });
 
       it('should include the tool results in the response messages', async () => {
-        expect(result.response.messages).toMatchInlineSnapshot(`
+        expect(result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -9925,7 +9961,7 @@ describe('generateText', () => {
         });
 
         it('should include tool approval request in response messages', async () => {
-          expect(result.response.messages).toMatchInlineSnapshot(`
+          expect(result.responseMessages).toMatchInlineSnapshot(`
             [
               {
                 "content": [

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1105,6 +1105,7 @@ export async function generateText<
       dynamicToolResults: lastStep.dynamicToolResults,
       request: lastStep.request,
       response: lastStep.response,
+      responseMessages: lastStep.response.messages,
       warnings: lastStep.warnings,
       providerMetadata: lastStep.providerMetadata,
       steps,
@@ -1277,6 +1278,10 @@ class DefaultGenerateTextResult<
 
   get response() {
     return this.finalStep.response;
+  }
+
+  get responseMessages() {
+    return this.finalStep.response.messages;
   }
 
   get request() {

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -25,6 +25,7 @@ import type {
   InferPartialOutput,
 } from './output-utils';
 import type { ReasoningFileOutput, ReasoningOutput } from './reasoning-output';
+import type { ResponseMessage } from './response-message';
 import type { StepResult } from './step-result';
 import type { ToolApprovalRequestOutput } from './tool-approval-request-output';
 import type { ToolApprovalResponseOutput } from './tool-approval-response-output';
@@ -257,6 +258,13 @@ export interface StreamTextResult<
    * Automatically consumes the stream.
    */
   readonly response: PromiseLike<LanguageModelResponseMetadata>;
+
+  /**
+   * The response messages that were generated during the call.
+   *
+   * Automatically consumes the stream.
+   */
+  readonly responseMessages: PromiseLike<Array<ResponseMessage>>;
 
   /**
    * Additional provider-specific metadata from the last step.

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -4982,14 +4982,14 @@ describe('streamText', () => {
     });
   });
 
-  describe('result.response.messages', () => {
+  describe('result.responseMessages', () => {
     it('should contain reasoning', async () => {
       const result = streamText({
         model: modelWithReasoning,
         ...defaultSettings(),
       });
 
-      expect((await result.response).messages).toMatchInlineSnapshot(`
+      expect(await result.responseMessages).toMatchInlineSnapshot(`
         [
           {
             "content": [
@@ -8340,6 +8340,42 @@ describe('streamText', () => {
             "modelId": "mock-model-id",
             "timestamp": 1970-01-01T00:00:00.000Z,
           },
+          "responseMessages": [
+            {
+              "content": [
+                {
+                  "providerOptions": undefined,
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+                {
+                  "input": {
+                    "value": "value",
+                  },
+                  "providerExecuted": undefined,
+                  "providerOptions": undefined,
+                  "toolCallId": "call-1",
+                  "toolName": "tool1",
+                  "type": "tool-call",
+                },
+              ],
+              "role": "assistant",
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "value-result",
+                  },
+                  "toolCallId": "call-1",
+                  "toolName": "tool1",
+                  "type": "tool-result",
+                },
+              ],
+              "role": "tool",
+            },
+          ],
           "runtimeContext": {},
           "sources": [],
           "staticToolCalls": [
@@ -8629,6 +8665,18 @@ describe('streamText', () => {
             "modelId": "mock-model-id",
             "timestamp": 1970-01-01T00:00:00.000Z,
           },
+          "responseMessages": [
+            {
+              "content": [
+                {
+                  "providerOptions": undefined,
+                  "text": "Hello!",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
           "runtimeContext": {},
           "sources": [
             {
@@ -8920,6 +8968,30 @@ describe('streamText', () => {
             "modelId": "mock-model-id",
             "timestamp": 1970-01-01T00:00:00.000Z,
           },
+          "responseMessages": [
+            {
+              "content": [
+                {
+                  "data": "Hello World",
+                  "mediaType": "text/plain",
+                  "providerOptions": undefined,
+                  "type": "file",
+                },
+                {
+                  "providerOptions": undefined,
+                  "text": "Hello!",
+                  "type": "text",
+                },
+                {
+                  "data": "QkFVRw==",
+                  "mediaType": "image/jpeg",
+                  "providerOptions": undefined,
+                  "type": "file",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
           "runtimeContext": {},
           "sources": [],
           "staticToolCalls": [],
@@ -9104,7 +9176,7 @@ describe('streamText', () => {
         prompt: 'test-input',
       });
 
-      expect((await result.response).messages).toMatchInlineSnapshot(`
+      expect(await result.responseMessages).toMatchInlineSnapshot(`
         [
           {
             "content": [
@@ -9150,7 +9222,7 @@ describe('streamText', () => {
         prompt: 'test-input',
       });
 
-      expect((await result.response).messages).toMatchInlineSnapshot(`
+      expect(await result.responseMessages).toMatchInlineSnapshot(`
         [
           {
             "content": [
@@ -9665,6 +9737,52 @@ describe('streamText', () => {
                 "modelId": "mock-model-id",
                 "timestamp": 1970-01-01T00:00:01.000Z,
               },
+              "responseMessages": [
+                {
+                  "content": [
+                    {
+                      "providerOptions": undefined,
+                      "text": "thinking",
+                      "type": "reasoning",
+                    },
+                    {
+                      "input": {
+                        "value": "value",
+                      },
+                      "providerExecuted": undefined,
+                      "providerOptions": undefined,
+                      "toolCallId": "call-1",
+                      "toolName": "tool1",
+                      "type": "tool-call",
+                    },
+                  ],
+                  "role": "assistant",
+                },
+                {
+                  "content": [
+                    {
+                      "output": {
+                        "type": "text",
+                        "value": "result1",
+                      },
+                      "toolCallId": "call-1",
+                      "toolName": "tool1",
+                      "type": "tool-result",
+                    },
+                  ],
+                  "role": "tool",
+                },
+                {
+                  "content": [
+                    {
+                      "providerOptions": undefined,
+                      "text": "Hello, world!",
+                      "type": "text",
+                    },
+                  ],
+                  "role": "assistant",
+                },
+              ],
               "runtimeContext": {},
               "sources": [],
               "staticToolCalls": [],
@@ -10393,8 +10511,8 @@ describe('streamText', () => {
           `);
         });
 
-        it('result.response.messages should contain response messages from all steps', async () => {
-          expect((await result.response).messages).toMatchInlineSnapshot(`
+        it('result.responseMessages should contain response messages from all steps', async () => {
+          expect(await result.responseMessages).toMatchInlineSnapshot(`
             [
               {
                 "content": [
@@ -11588,6 +11706,52 @@ describe('streamText', () => {
                 "modelId": "mock-model-id",
                 "timestamp": 1970-01-01T00:00:01.000Z,
               },
+              "responseMessages": [
+                {
+                  "content": [
+                    {
+                      "providerOptions": undefined,
+                      "text": "thinking",
+                      "type": "reasoning",
+                    },
+                    {
+                      "input": {
+                        "value": "value",
+                      },
+                      "providerExecuted": undefined,
+                      "providerOptions": undefined,
+                      "toolCallId": "call-1",
+                      "toolName": "tool1",
+                      "type": "tool-call",
+                    },
+                  ],
+                  "role": "assistant",
+                },
+                {
+                  "content": [
+                    {
+                      "output": {
+                        "type": "text",
+                        "value": "RESULT1",
+                      },
+                      "toolCallId": "call-1",
+                      "toolName": "tool1",
+                      "type": "tool-result",
+                    },
+                  ],
+                  "role": "tool",
+                },
+                {
+                  "content": [
+                    {
+                      "providerOptions": undefined,
+                      "text": "Hello, world!",
+                      "type": "text",
+                    },
+                  ],
+                  "role": "assistant",
+                },
+              ],
               "runtimeContext": {},
               "sources": [],
               "staticToolCalls": [],
@@ -12312,8 +12476,8 @@ describe('streamText', () => {
           `);
         });
 
-        it('result.response.messages should contain response messages from all steps', async () => {
-          expect((await result.response).messages).toMatchInlineSnapshot(`
+        it('result.responseMessages should contain response messages from all steps', async () => {
+          expect(await result.responseMessages).toMatchInlineSnapshot(`
             [
               {
                 "content": [
@@ -15001,7 +15165,7 @@ describe('streamText', () => {
     });
 
     it('should include error result in response messages', async () => {
-      expect((await result.response).messages).toMatchInlineSnapshot(`
+      expect(await result.responseMessages).toMatchInlineSnapshot(`
         [
           {
             "content": [
@@ -15140,7 +15304,7 @@ describe('streamText', () => {
         expect(await result.text).toStrictEqual('HELLO, WORLD!');
       });
 
-      it('result.response.messages should be transformed', async () => {
+      it('result.responseMessages should be transformed', async () => {
         const result = streamText({
           model: createTestModel(),
           experimental_transform: upperCaseTransform,
@@ -15693,6 +15857,42 @@ describe('streamText', () => {
               "modelId": "mock-model-id",
               "timestamp": 1970-01-01T00:00:00.000Z,
             },
+            "responseMessages": [
+              {
+                "content": [
+                  {
+                    "providerOptions": undefined,
+                    "text": "HELLO, WORLD!",
+                    "type": "text",
+                  },
+                  {
+                    "input": {
+                      "value": "VALUE",
+                    },
+                    "providerExecuted": undefined,
+                    "providerOptions": undefined,
+                    "toolCallId": "call-1",
+                    "toolName": "tool1",
+                    "type": "tool-call",
+                  },
+                ],
+                "role": "assistant",
+              },
+              {
+                "content": [
+                  {
+                    "output": {
+                      "type": "text",
+                      "value": "VALUE-RESULT",
+                    },
+                    "toolCallId": "call-1",
+                    "toolName": "tool1",
+                    "type": "tool-result",
+                  },
+                ],
+                "role": "tool",
+              },
+            ],
             "runtimeContext": {},
             "sources": [],
             "staticToolCalls": [
@@ -16967,6 +17167,18 @@ describe('streamText', () => {
               "modelId": "mock-model-id",
               "timestamp": 1970-01-01T00:00:00.000Z,
             },
+            "responseMessages": [
+              {
+                "content": [
+                  {
+                    "providerOptions": undefined,
+                    "text": "{ "value": "Hello, world!" }",
+                    "type": "text",
+                  },
+                ],
+                "role": "assistant",
+              },
+            ],
             "runtimeContext": {},
             "sources": [],
             "staticToolCalls": [],
@@ -20671,10 +20883,10 @@ describe('streamText', () => {
         });
       });
 
-      describe('result.response.messages', () => {
+      describe('result.responseMessages', () => {
         it('should contain all response messages from all steps', async () => {
           await result.consumeStream();
-          expect((await result.response).messages).toMatchInlineSnapshot(`
+          expect(await result.responseMessages).toMatchInlineSnapshot(`
             [
               {
                 "content": [
@@ -21173,7 +21385,7 @@ describe('streamText', () => {
 
         it('should contain all response messages', async () => {
           await result.consumeStream();
-          expect(onFinishResult.response.messages.length).toBe(9);
+          expect(onFinishResult.responseMessages.length).toBe(9);
         });
       });
 
@@ -22210,7 +22422,7 @@ describe('streamText', () => {
       });
 
       it('should add tool approval requests to the response messages', async () => {
-        expect((await result.response).messages).toMatchInlineSnapshot(`
+        expect(await result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -22386,7 +22598,7 @@ describe('streamText', () => {
       });
 
       it('should produce response messages', async () => {
-        expect((await result.response).messages).toMatchInlineSnapshot(`
+        expect(await result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -22660,7 +22872,7 @@ describe('streamText', () => {
       });
 
       it('should produce response messages with automatic approval metadata', async () => {
-        expect((await result.response).messages).toMatchInlineSnapshot(`
+        expect(await result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -23064,7 +23276,7 @@ describe('streamText', () => {
       });
 
       it('should add tool approval requests to the response messages', async () => {
-        expect((await result.response).messages).toMatchInlineSnapshot(`
+        expect(await result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -23303,7 +23515,7 @@ describe('streamText', () => {
       });
 
       it('should include the tool result in the response messages', async () => {
-        expect((await result.response).messages).toMatchInlineSnapshot(`
+        expect(await result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -23727,7 +23939,7 @@ describe('streamText', () => {
       });
 
       it('should include the tool result in the response messages', async () => {
-        expect((await result.response).messages).toMatchInlineSnapshot(`
+        expect(await result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -24065,7 +24277,7 @@ describe('streamText', () => {
       });
 
       it('should include the tool error in the response messages', async () => {
-        expect((await result.response).messages).toMatchInlineSnapshot(`
+        expect(await result.responseMessages).toMatchInlineSnapshot(`
           [
             {
               "content": [
@@ -24431,7 +24643,7 @@ describe('streamText', () => {
         });
 
         it('should add provider-executed tool approval request to response messages', async () => {
-          expect((await result.response).messages).toMatchInlineSnapshot(`
+          expect(await result.responseMessages).toMatchInlineSnapshot(`
             [
               {
                 "content": [

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1245,6 +1245,7 @@ class DefaultStreamTextResult<
               dynamicToolResults: finalStep.dynamicToolResults,
               request: finalStep.request,
               response: finalStep.response,
+              responseMessages: finalStep.response.messages,
               warnings: finalStep.warnings,
               providerMetadata: finalStep.providerMetadata,
               steps: recordedSteps,
@@ -2119,6 +2120,10 @@ class DefaultStreamTextResult<
 
   get response() {
     return this.finalStep.then(step => step.response);
+  }
+
+  get responseMessages() {
+    return this.finalStep.then(step => step.response.messages);
   }
 
   get totalUsage() {

--- a/packages/otel/src/legacy-open-telemetry.test.ts
+++ b/packages/otel/src/legacy-open-telemetry.test.ts
@@ -271,6 +271,7 @@ function makeStepFinishEvent(overrides?: Record<string, unknown>) {
 function makeFinishEvent(overrides?: Record<string, unknown>) {
   return {
     ...makeStepFinishEvent(),
+    responseMessages: [],
     steps: [],
     totalUsage: {
       inputTokens: 10,

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -299,6 +299,7 @@ function makeStepFinishEvent(overrides?: Record<string, unknown>) {
 function makeFinishEvent(overrides?: Record<string, unknown>) {
   return {
     ...makeStepFinishEvent(),
+    responseMessages: [],
     steps: [],
     totalUsage: {
       inputTokens: 10,


### PR DESCRIPTION
## Background

Steps currently aggregate the response messages from prior steps as well. We want to change this so it is clear which step generated which response messages. However, we still need the overall response messages from a streamText or generateText call.

## Summary

Introduce `responseMessages` on `StreamTextResult` and on `GenerateTextResult`.

## Future Work

* limit `response.messages` on `StepResult` to the messages from that step