### PR TITLE
feat(provider/anthropic): automatically use sandbox in bash tool

### DIFF
--- a/.changeset/forty-melons-fry.md
+++ b/.changeset/forty-melons-fry.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+feat(provider/anthropic): automatically use sandbox in bash tool

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -723,14 +723,31 @@ For more on prompt caching with Anthropic, see [Anthropic's Cache Control docume
 
 ### Bash Tool
 
-The Bash Tool allows running bash commands. Here's how to create and use it:
+The Bash Tool allows running bash commands. By default, the tool executes
+commands through the `sandbox` that you pass to `generateText` or `streamText`:
 
 ```ts
-const bashTool = anthropic.tools.bash_20250124({
-  execute: async ({ command, restart }) => {
-    // Implement your bash command execution logic here
-    // Return the result of the command execution
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText, isStepCount } from 'ai';
+
+const result = await generateText({
+  model: anthropic('claude-opus-4-7'),
+  tools: {
+    bash: anthropic.tools.bash_20250124(),
   },
+  sandbox: {
+    description: 'A sandboxed shell environment.',
+    executeCommand: async ({ command }) => {
+      // Run the command in your sandbox and return the result.
+      return {
+        exitCode: 0,
+        stdout: `Executed: ${command}`,
+        stderr: '',
+      };
+    },
+  },
+  stopWhen: isStepCount(2),
+  prompt: 'List the files in the current directory.',
 });
 ```
 
@@ -743,6 +760,9 @@ Parameters:
   Two versions are available: `bash_20250124` (recommended) and `bash_20241022`.
   Only certain Claude versions are supported.
 </Note>
+
+You can also provide a custom `execute` function when you want to handle bash
+execution directly instead of using the request sandbox.
 
 ### Memory Tool
 

--- a/examples/ai-functions/src/generate-text/anthropic/bash-tool.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/bash-tool.ts
@@ -1,28 +1,19 @@
 import { anthropic } from '@ai-sdk/anthropic';
 import { generateText, isStepCount } from 'ai';
 import { run } from '../../lib/run';
+import { LocalSandbox } from '../../sandbox/local-sandbox';
 
 run(async () => {
   const result = await generateText({
-    model: anthropic('claude-3-5-sonnet-20241022'),
+    model: anthropic('claude-opus-4-7'),
     tools: {
-      bash: anthropic.tools.bash_20241022({
-        async execute({ command }) {
-          console.log('COMMAND', command);
-          return [
-            {
-              type: 'text',
-              text: `
-          ❯ ls
-          README.md     build         data          node_modules  package.json  src           tsconfig.json
-          `,
-            },
-          ];
-        },
-      }),
+      bash: anthropic.tools.bash_20250124(),
     },
-    prompt: 'List the files in my home directory.',
+    sandbox: new LocalSandbox({
+      rootDirectory: `${process.env.HOME}/Downloads`,
+    }),
     stopWhen: isStepCount(2),
+    prompt: 'List the files in my home directory.',
   });
 
   console.log(result.text);

--- a/packages/anthropic/src/tool/bash_20241022.test-d.ts
+++ b/packages/anthropic/src/tool/bash_20241022.test-d.ts
@@ -1,0 +1,61 @@
+import type {
+  InferToolOutput,
+  ProviderDefinedTool,
+} from '@ai-sdk/provider-utils';
+import { describe, expectTypeOf, it } from 'vitest';
+import { bash_20241022 } from './bash_20241022';
+
+type BashInput = {
+  command: string;
+  restart?: boolean;
+};
+
+type BashDefaultOutput = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+describe('bash_20241022 tool type', () => {
+  it('uses the sandbox command result output by default', () => {
+    const bashTool = bash_20241022();
+
+    expectTypeOf(bashTool).toExtend<
+      ProviderDefinedTool<BashInput, BashDefaultOutput, {}>
+    >();
+    expectTypeOf<
+      InferToolOutput<typeof bashTool>
+    >().toEqualTypeOf<BashDefaultOutput>();
+  });
+
+  it('allows disabling the default execute function', () => {
+    const bashTool = bash_20241022({
+      execute: null,
+    });
+
+    expectTypeOf(bashTool).toExtend<
+      ProviderDefinedTool<BashInput, never, {}>
+    >();
+    expectTypeOf(bashTool.execute).toEqualTypeOf<undefined>();
+  });
+
+  it('infers custom execute output', () => {
+    const bashTool = bash_20241022({
+      execute: async ({ command, restart }, { sandbox }) => {
+        expectTypeOf(command).toEqualTypeOf<string>();
+        expectTypeOf(restart).toEqualTypeOf<boolean | undefined>();
+        expectTypeOf(sandbox).not.toEqualTypeOf<undefined>();
+
+        return {
+          command,
+          restarted: restart ?? false,
+        };
+      },
+    });
+
+    expectTypeOf<InferToolOutput<typeof bashTool>>().toEqualTypeOf<{
+      command: string;
+      restarted: boolean;
+    }>();
+  });
+});

--- a/packages/anthropic/src/tool/bash_20241022.ts
+++ b/packages/anthropic/src/tool/bash_20241022.ts
@@ -1,6 +1,7 @@
 import {
   createProviderDefinedToolFactory,
   lazySchema,
+  type Sandbox,
   zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
@@ -14,7 +15,7 @@ const bash_20241022InputSchema = lazySchema(() =>
   ),
 );
 
-export const bash_20241022 = createProviderDefinedToolFactory<
+export const bash_20241022_internal = createProviderDefinedToolFactory<
   {
     /**
      * The bash command to run. Required unless the tool is being restarted.
@@ -31,3 +32,57 @@ export const bash_20241022 = createProviderDefinedToolFactory<
   id: 'anthropic.bash_20241022',
   inputSchema: bash_20241022InputSchema,
 });
+
+type Bash20241022Options<OUTPUT> = Parameters<
+  typeof bash_20241022_internal<OUTPUT>
+>[0];
+
+type Bash20241022OptionsWithNullableExecute<OUTPUT> = Omit<
+  Bash20241022Options<OUTPUT>,
+  'execute'
+> & {
+  execute?: Bash20241022Options<OUTPUT>['execute'] | null;
+};
+
+type Bash20241022DefaultOutput = Awaited<ReturnType<Sandbox['executeCommand']>>;
+
+export function bash_20241022(
+  options?: Omit<Bash20241022Options<Bash20241022DefaultOutput>, 'execute'> & {
+    execute?: undefined;
+  },
+): ReturnType<typeof bash_20241022_internal<Bash20241022DefaultOutput>>;
+export function bash_20241022<OUTPUT = never>(
+  options: Omit<Bash20241022Options<OUTPUT>, 'execute'> & {
+    execute: null;
+  },
+): ReturnType<typeof bash_20241022_internal<OUTPUT>>;
+export function bash_20241022<OUTPUT>(
+  options: Omit<Bash20241022Options<OUTPUT>, 'execute'> & {
+    execute: Bash20241022Options<OUTPUT>['execute'];
+  },
+): ReturnType<typeof bash_20241022_internal<OUTPUT>>;
+export function bash_20241022<OUTPUT>(
+  options: Bash20241022OptionsWithNullableExecute<OUTPUT> = {},
+): ReturnType<typeof bash_20241022_internal<OUTPUT>> {
+  const { execute, ...rest } = options;
+
+  if (execute === undefined) {
+    return bash_20241022_internal({
+      ...rest,
+      execute: async ({ command }, { sandbox }) => {
+        if (!sandbox) {
+          throw new Error('Sandbox is not available');
+        }
+
+        return await sandbox.executeCommand({ command });
+      },
+    } as Bash20241022Options<Bash20241022DefaultOutput>) as ReturnType<
+      typeof bash_20241022_internal<OUTPUT>
+    >;
+  }
+
+  return bash_20241022_internal({
+    ...rest,
+    ...(execute === null ? {} : { execute }),
+  } as Bash20241022Options<OUTPUT>);
+}

--- a/packages/anthropic/src/tool/bash_20241022.ts
+++ b/packages/anthropic/src/tool/bash_20241022.ts
@@ -1,10 +1,25 @@
 import {
   createProviderDefinedToolFactory,
   lazySchema,
+  type ProviderDefinedTool,
   type Sandbox,
+  type Tool,
+  type ToolExecuteFunction,
   zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
+
+type Bash20241022Input = {
+  /**
+   * The bash command to run. Required unless the tool is being restarted.
+   */
+  command: string;
+
+  /**
+   * Specifying true will restart this tool. Otherwise, leave this unspecified.
+   */
+  restart?: boolean;
+};
 
 const bash_20241022InputSchema = lazySchema(() =>
   zodSchema(
@@ -16,26 +31,21 @@ const bash_20241022InputSchema = lazySchema(() =>
 );
 
 export const bash_20241022_internal = createProviderDefinedToolFactory<
-  {
-    /**
-     * The bash command to run. Required unless the tool is being restarted.
-     */
-    command: string;
-
-    /**
-     * Specifying true will restart this tool. Otherwise, leave this unspecified.
-     */
-    restart?: boolean;
-  },
+  Bash20241022Input,
   {}
 >({
   id: 'anthropic.bash_20241022',
   inputSchema: bash_20241022InputSchema,
 });
 
-type Bash20241022Options<OUTPUT> = Parameters<
-  typeof bash_20241022_internal<OUTPUT>
->[0];
+type Bash20241022Options<OUTPUT> = {
+  execute?: ToolExecuteFunction<Bash20241022Input, OUTPUT, {}>;
+  needsApproval?: Tool<Bash20241022Input, OUTPUT, {}>['needsApproval'];
+  toModelOutput?: Tool<Bash20241022Input, OUTPUT, {}>['toModelOutput'];
+  onInputStart?: Tool<Bash20241022Input, OUTPUT, {}>['onInputStart'];
+  onInputDelta?: Tool<Bash20241022Input, OUTPUT, {}>['onInputDelta'];
+  onInputAvailable?: Tool<Bash20241022Input, OUTPUT, {}>['onInputAvailable'];
+};
 
 type Bash20241022OptionsWithNullableExecute<OUTPUT> = Omit<
   Bash20241022Options<OUTPUT>,
@@ -50,20 +60,20 @@ export function bash_20241022(
   options?: Omit<Bash20241022Options<Bash20241022DefaultOutput>, 'execute'> & {
     execute?: undefined;
   },
-): ReturnType<typeof bash_20241022_internal<Bash20241022DefaultOutput>>;
+): ProviderDefinedTool<Bash20241022Input, Bash20241022DefaultOutput, {}>;
 export function bash_20241022<OUTPUT = never>(
   options: Omit<Bash20241022Options<OUTPUT>, 'execute'> & {
     execute: null;
   },
-): ReturnType<typeof bash_20241022_internal<OUTPUT>>;
+): ProviderDefinedTool<Bash20241022Input, OUTPUT, {}>;
 export function bash_20241022<OUTPUT>(
   options: Omit<Bash20241022Options<OUTPUT>, 'execute'> & {
     execute: Bash20241022Options<OUTPUT>['execute'];
   },
-): ReturnType<typeof bash_20241022_internal<OUTPUT>>;
+): ProviderDefinedTool<Bash20241022Input, OUTPUT, {}>;
 export function bash_20241022<OUTPUT>(
   options: Bash20241022OptionsWithNullableExecute<OUTPUT> = {},
-): ReturnType<typeof bash_20241022_internal<OUTPUT>> {
+): ProviderDefinedTool<Bash20241022Input, OUTPUT, {}> {
   const { execute, ...rest } = options;
 
   if (execute === undefined) {

--- a/packages/anthropic/src/tool/bash_20250124.test-d.ts
+++ b/packages/anthropic/src/tool/bash_20250124.test-d.ts
@@ -1,0 +1,61 @@
+import type {
+  InferToolOutput,
+  ProviderDefinedTool,
+} from '@ai-sdk/provider-utils';
+import { describe, expectTypeOf, it } from 'vitest';
+import { bash_20250124 } from './bash_20250124';
+
+type BashInput = {
+  command: string;
+  restart?: boolean;
+};
+
+type BashDefaultOutput = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+describe('bash_20250124 tool type', () => {
+  it('uses the sandbox command result output by default', () => {
+    const bashTool = bash_20250124();
+
+    expectTypeOf(bashTool).toExtend<
+      ProviderDefinedTool<BashInput, BashDefaultOutput, {}>
+    >();
+    expectTypeOf<
+      InferToolOutput<typeof bashTool>
+    >().toEqualTypeOf<BashDefaultOutput>();
+  });
+
+  it('allows disabling the default execute function', () => {
+    const bashTool = bash_20250124({
+      execute: null,
+    });
+
+    expectTypeOf(bashTool).toExtend<
+      ProviderDefinedTool<BashInput, never, {}>
+    >();
+    expectTypeOf(bashTool.execute).toEqualTypeOf<undefined>();
+  });
+
+  it('infers custom execute output', () => {
+    const bashTool = bash_20250124({
+      execute: async ({ command, restart }, { sandbox }) => {
+        expectTypeOf(command).toEqualTypeOf<string>();
+        expectTypeOf(restart).toEqualTypeOf<boolean | undefined>();
+        expectTypeOf(sandbox).not.toEqualTypeOf<undefined>();
+
+        return {
+          command,
+          restarted: restart ?? false,
+        };
+      },
+    });
+
+    expectTypeOf<InferToolOutput<typeof bashTool>>().toEqualTypeOf<{
+      command: string;
+      restarted: boolean;
+    }>();
+  });
+});

--- a/packages/anthropic/src/tool/bash_20250124.ts
+++ b/packages/anthropic/src/tool/bash_20250124.ts
@@ -1,6 +1,7 @@
 import {
   createProviderDefinedToolFactory,
   lazySchema,
+  type Sandbox,
   zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
@@ -14,7 +15,7 @@ const bash_20250124InputSchema = lazySchema(() =>
   ),
 );
 
-export const bash_20250124 = createProviderDefinedToolFactory<
+export const bash_20250124_internal = createProviderDefinedToolFactory<
   {
     /**
      * The bash command to run. Required unless the tool is being restarted.
@@ -31,3 +32,57 @@ export const bash_20250124 = createProviderDefinedToolFactory<
   id: 'anthropic.bash_20250124',
   inputSchema: bash_20250124InputSchema,
 });
+
+type Bash20250124Options<OUTPUT> = Parameters<
+  typeof bash_20250124_internal<OUTPUT>
+>[0];
+
+type Bash20250124OptionsWithNullableExecute<OUTPUT> = Omit<
+  Bash20250124Options<OUTPUT>,
+  'execute'
+> & {
+  execute?: Bash20250124Options<OUTPUT>['execute'] | null;
+};
+
+type Bash20250124DefaultOutput = Awaited<ReturnType<Sandbox['executeCommand']>>;
+
+export function bash_20250124(
+  options?: Omit<Bash20250124Options<Bash20250124DefaultOutput>, 'execute'> & {
+    execute?: undefined;
+  },
+): ReturnType<typeof bash_20250124_internal<Bash20250124DefaultOutput>>;
+export function bash_20250124<OUTPUT = never>(
+  options: Omit<Bash20250124Options<OUTPUT>, 'execute'> & {
+    execute: null;
+  },
+): ReturnType<typeof bash_20250124_internal<OUTPUT>>;
+export function bash_20250124<OUTPUT>(
+  options: Omit<Bash20250124Options<OUTPUT>, 'execute'> & {
+    execute: Bash20250124Options<OUTPUT>['execute'];
+  },
+): ReturnType<typeof bash_20250124_internal<OUTPUT>>;
+export function bash_20250124<OUTPUT>(
+  options: Bash20250124OptionsWithNullableExecute<OUTPUT> = {},
+): ReturnType<typeof bash_20250124_internal<OUTPUT>> {
+  const { execute, ...rest } = options;
+
+  if (execute === undefined) {
+    return bash_20250124_internal({
+      ...rest,
+      execute: async ({ command }, { sandbox }) => {
+        if (!sandbox) {
+          throw new Error('Sandbox is not available');
+        }
+
+        return await sandbox.executeCommand({ command });
+      },
+    } as Bash20250124Options<Bash20250124DefaultOutput>) as ReturnType<
+      typeof bash_20250124_internal<OUTPUT>
+    >;
+  }
+
+  return bash_20250124_internal({
+    ...rest,
+    ...(execute === null ? {} : { execute }),
+  } as Bash20250124Options<OUTPUT>);
+}

--- a/packages/anthropic/src/tool/bash_20250124.ts
+++ b/packages/anthropic/src/tool/bash_20250124.ts
@@ -1,10 +1,25 @@
 import {
   createProviderDefinedToolFactory,
   lazySchema,
+  type ProviderDefinedTool,
   type Sandbox,
+  type Tool,
+  type ToolExecuteFunction,
   zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
+
+type Bash20250124Input = {
+  /**
+   * The bash command to run. Required unless the tool is being restarted.
+   */
+  command: string;
+
+  /**
+   * Specifying true will restart this tool. Otherwise, leave this unspecified.
+   */
+  restart?: boolean;
+};
 
 const bash_20250124InputSchema = lazySchema(() =>
   zodSchema(
@@ -16,26 +31,21 @@ const bash_20250124InputSchema = lazySchema(() =>
 );
 
 export const bash_20250124_internal = createProviderDefinedToolFactory<
-  {
-    /**
-     * The bash command to run. Required unless the tool is being restarted.
-     */
-    command: string;
-
-    /**
-     * Specifying true will restart this tool. Otherwise, leave this unspecified.
-     */
-    restart?: boolean;
-  },
+  Bash20250124Input,
   {}
 >({
   id: 'anthropic.bash_20250124',
   inputSchema: bash_20250124InputSchema,
 });
 
-type Bash20250124Options<OUTPUT> = Parameters<
-  typeof bash_20250124_internal<OUTPUT>
->[0];
+type Bash20250124Options<OUTPUT> = {
+  execute?: ToolExecuteFunction<Bash20250124Input, OUTPUT, {}>;
+  needsApproval?: Tool<Bash20250124Input, OUTPUT, {}>['needsApproval'];
+  toModelOutput?: Tool<Bash20250124Input, OUTPUT, {}>['toModelOutput'];
+  onInputStart?: Tool<Bash20250124Input, OUTPUT, {}>['onInputStart'];
+  onInputDelta?: Tool<Bash20250124Input, OUTPUT, {}>['onInputDelta'];
+  onInputAvailable?: Tool<Bash20250124Input, OUTPUT, {}>['onInputAvailable'];
+};
 
 type Bash20250124OptionsWithNullableExecute<OUTPUT> = Omit<
   Bash20250124Options<OUTPUT>,
@@ -50,20 +60,20 @@ export function bash_20250124(
   options?: Omit<Bash20250124Options<Bash20250124DefaultOutput>, 'execute'> & {
     execute?: undefined;
   },
-): ReturnType<typeof bash_20250124_internal<Bash20250124DefaultOutput>>;
+): ProviderDefinedTool<Bash20250124Input, Bash20250124DefaultOutput, {}>;
 export function bash_20250124<OUTPUT = never>(
   options: Omit<Bash20250124Options<OUTPUT>, 'execute'> & {
     execute: null;
   },
-): ReturnType<typeof bash_20250124_internal<OUTPUT>>;
+): ProviderDefinedTool<Bash20250124Input, OUTPUT, {}>;
 export function bash_20250124<OUTPUT>(
   options: Omit<Bash20250124Options<OUTPUT>, 'execute'> & {
     execute: Bash20250124Options<OUTPUT>['execute'];
   },
-): ReturnType<typeof bash_20250124_internal<OUTPUT>>;
+): ProviderDefinedTool<Bash20250124Input, OUTPUT, {}>;
 export function bash_20250124<OUTPUT>(
   options: Bash20250124OptionsWithNullableExecute<OUTPUT> = {},
-): ReturnType<typeof bash_20250124_internal<OUTPUT>> {
+): ProviderDefinedTool<Bash20250124Input, OUTPUT, {}> {
   const { execute, ...rest } = options;
 
   if (execute === undefined) {

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -15,11 +15,25 @@ import {
 } from '@ai-sdk/anthropic/internal';
 import type { GoogleVertexAnthropicModelId } from './google-vertex-anthropic-options';
 
+type GoogleVertexAnthropicTools = Pick<
+  typeof anthropicTools,
+  | 'bash_20241022'
+  | 'bash_20250124'
+  | 'textEditor_20241022'
+  | 'textEditor_20250124'
+  | 'textEditor_20250429'
+  | 'textEditor_20250728'
+  | 'computer_20241022'
+  | 'webSearch_20250305'
+  | 'toolSearchRegex_20251119'
+  | 'toolSearchBm25_20251119'
+>;
+
 /**
  * Tools supported by Google Vertex Anthropic.
  * This is a subset of the full Anthropic tools - only these are recognized by the Vertex API.
  */
-export const googleVertexAnthropicTools = {
+export const googleVertexAnthropicTools: GoogleVertexAnthropicTools = {
   /**
    * The bash tool enables Claude to execute shell commands in a persistent bash session,
    * allowing system operations, script execution, and command-line automation.


### PR DESCRIPTION
## Background

We introduced a sandbox abstraction in #14949

When possible, provider defined tools should automatically leverage it unless the users provide custom execution functions.

## Summary

Automatically use sandbox by default in Anthropic bash tools.

## Example

```ts
const result = await generateText({
  model: anthropic('claude-opus-4-7'),
  tools: {
    bash: anthropic.tools.bash_20250124(),
  },
  sandbox: new LocalSandbox({
    rootDirectory: `${process.env.HOME}/Downloads`,
  }),
  stopWhen: isStepCount(2),
  prompt: 'List the files in my home directory.',
});
```

## Manual Verification

- [x] run and verify `examples/ai-functions/src/generate-text/anthropic/bash-tool.ts`

## Future Work

- sandbox type safety
- apply to bash tools from other providers

## Related Issues

Builds upon #14949