### PR TITLE
feat(ai): expose initial and response messages in prepareStep

### DIFF
--- a/.changeset/tender-pandas-sip.md
+++ b/.changeset/tender-pandas-sip.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): expose initial and response messages in prepareStep

--- a/content/docs/03-agents/04-loop-control.mdx
+++ b/content/docs/03-agents/04-loop-control.mdx
@@ -148,6 +148,8 @@ const budgetExceeded: StopCondition<typeof tools> = ({ steps }) => {
 
 The `prepareStep` callback runs before each step in the loop and defaults to the initial settings if you don't return any changes. Use it to modify settings, manage context, or implement dynamic behavior based on execution history.
 
+It receives `messages` for the current step, plus `initialMessages` and `responseMessages` when you need to distinguish the original input from assistant/tool messages accumulated in earlier steps.
+
 ### Dynamic Model Selection
 
 Switch models based on step requirements:
@@ -191,13 +193,13 @@ const agent = new ToolLoopAgent({
   tools: {
     // your tools
   },
-  prepareStep: async ({ messages }) => {
+  prepareStep: async ({ initialMessages, responseMessages, messages }) => {
     // Keep only recent messages to stay within context limits
     if (messages.length > 20) {
       return {
         messages: [
-          messages[0], // Keep system instructions
-          ...messages.slice(-10), // Keep last 10 messages
+          ...initialMessages, // Keep the original user-provided prompt
+          ...responseMessages.slice(-10), // Keep recent assistant/tool messages
         ],
       };
     }

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -477,6 +477,8 @@ It is called with the following parameters:
 - `stepNumber`: The number of the step that is being executed.
 - `steps`: The steps that have been executed so far.
 - `messages`: The messages that will be sent to the model for the current step.
+- `initialMessages`: The messages that were passed into `generateText` or `streamText`.
+- `responseMessages`: The response messages that have been accumulated from previous steps.
 - `runtimeContext`: The runtime context passed via the `runtimeContext` setting.
 - `toolsContext`: The per-tool context map passed via the `toolsContext` setting.
 - `sandbox`: The sandbox passed via the `sandbox` setting.
@@ -507,7 +509,10 @@ const result = await generateText({
 
 #### Message Modification for Longer Agentic Loops
 
-In longer agentic loops, you can use the `messages` parameter to modify the input messages for each step. This is particularly useful for prompt compression:
+In longer agentic loops, you can use the `messages` parameter to modify the input messages for each step. This is particularly useful for prompt compression.
+
+The `messages` parameter contains `initialMessages` followed by the accumulated `responseMessages`.
+Use `initialMessages` when you need to preserve the original user-provided prompt and `responseMessages` when you only need the assistant/tool messages from previous steps.
 
 ```tsx
 prepareStep: async ({ stepNumber, steps, messages }) => {

--- a/packages/ai/src/generate-text/generate-text.test-d.ts
+++ b/packages/ai/src/generate-text/generate-text.test-d.ts
@@ -1,9 +1,10 @@
 import type { JSONValue } from '@ai-sdk/provider';
-import { tool, type Context } from '@ai-sdk/provider-utils';
+import { tool, type Context, type ModelMessage } from '@ai-sdk/provider-utils';
 import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
 import { generateText, Output } from '../generate-text';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import type { ResponseMessage } from './response-message';
 
 describe('generateText types', () => {
   describe('output', () => {
@@ -284,7 +285,16 @@ describe('generateText types', () => {
         generateText({
           model: new MockLanguageModelV4(),
           prompt: 'Hello',
-          prepareStep: ({ runtimeContext, toolsContext }) => {
+          prepareStep: ({
+            initialMessages,
+            responseMessages,
+            runtimeContext,
+            toolsContext,
+          }) => {
+            expectTypeOf(initialMessages).toEqualTypeOf<Array<ModelMessage>>();
+            expectTypeOf(responseMessages).toEqualTypeOf<
+              Array<ResponseMessage>
+            >();
             expectTypeOf(runtimeContext).toEqualTypeOf<Context>();
             expectTypeOf(toolsContext).toEqualTypeOf<{}>();
 

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1593,6 +1593,114 @@ describe('generateText', () => {
       });
     });
 
+    it('should pass initialMessages and responseMessages to prepareStep', async () => {
+      const prepareStepCalls: Array<{
+        initialMessages: Array<ModelMessage>;
+        responseMessages: Array<ModelMessage>;
+        messages: Array<ModelMessage>;
+      }> = [];
+      let responseCount = 0;
+
+      await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            switch (responseCount++) {
+              case 0:
+                return {
+                  ...dummyResponseValues,
+                  content: [
+                    {
+                      type: 'tool-call',
+                      toolCallType: 'function',
+                      toolCallId: 'call-1',
+                      toolName: 'tool1',
+                      input: '{ "value": "test" }',
+                    },
+                  ],
+                  finishReason: { unified: 'tool-calls', raw: undefined },
+                };
+              case 1:
+              default:
+                return {
+                  ...dummyResponseValues,
+                  content: [{ type: 'text', text: 'Done.' }],
+                };
+            }
+          },
+        }),
+        tools: {
+          tool1: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        messages: [{ role: 'user', content: 'test-input' }],
+        stopWhen: isStepCount(3),
+        prepareStep: async ({
+          initialMessages,
+          responseMessages,
+          messages,
+        }) => {
+          prepareStepCalls.push({
+            initialMessages: [...initialMessages],
+            responseMessages: [...responseMessages],
+            messages: [...messages],
+          });
+          return undefined;
+        },
+      });
+
+      expect(prepareStepCalls).toHaveLength(2);
+      expect(prepareStepCalls[0].initialMessages).toEqual([
+        { role: 'user', content: 'test-input' },
+      ]);
+      expect(prepareStepCalls[0].responseMessages).toEqual([]);
+      expect(prepareStepCalls[0].messages).toEqual([
+        { role: 'user', content: 'test-input' },
+      ]);
+
+      expect(prepareStepCalls[1].initialMessages).toEqual([
+        { role: 'user', content: 'test-input' },
+      ]);
+      expect(prepareStepCalls[1].responseMessages).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "input": {
+                  "value": "test",
+                },
+                "providerExecuted": undefined,
+                "providerOptions": undefined,
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "text",
+                  "value": "test-result",
+                },
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ]
+      `);
+      expect(prepareStepCalls[1].messages).toEqual([
+        ...prepareStepCalls[1].initialMessages,
+        ...prepareStepCalls[1].responseMessages,
+      ]);
+    });
+
     it('should pass updated toolsContext from prepareStep', async () => {
       const prepareStepToolsContexts: Array<unknown> = [];
       const stepStartEvents: Parameters<

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -649,6 +649,8 @@ export async function generateText<
           steps,
           stepNumber: steps.length,
           messages: stepInputMessages,
+          initialMessages,
+          responseMessages,
           runtimeContext,
           toolsContext,
           sandbox,

--- a/packages/ai/src/generate-text/prepare-step.ts
+++ b/packages/ai/src/generate-text/prepare-step.ts
@@ -9,6 +9,7 @@ import type {
 } from '@ai-sdk/provider-utils';
 import type { LanguageModel, ToolChoice } from '../types/language-model';
 import type { ActiveTools } from './active-tools';
+import type { ResponseMessage } from './response-message';
 import type { StepResult } from './step-result';
 
 /**
@@ -19,6 +20,8 @@ import type { StepResult } from './step-result';
  * @param options.stepNumber - The number of the step that is being executed.
  * @param options.model - The model that is being used.
  * @param options.messages - The messages that will be sent to the model for the current step.
+ * @param options.initialMessages - The initial messages that were passed into generateText or streamText.
+ * @param options.responseMessages - The response messages that have been accumulated from previous steps.
  * @param options.runtimeContext - The user-defined runtime context.
  *
  * @returns An object that contains the settings for the step.
@@ -47,6 +50,16 @@ export type PrepareStepFunction<
    * The messages that will be sent to the model for the current step.
    */
   messages: Array<ModelMessage>;
+
+  /**
+   * The initial messages that were passed into generateText or streamText.
+   */
+  initialMessages: Array<ModelMessage>;
+
+  /**
+   * The response messages that have been accumulated from all previous steps.
+   */
+  responseMessages: Array<ResponseMessage>;
 
   /**
    * Tool context.

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -1,11 +1,12 @@
 import type { JSONValue } from '@ai-sdk/provider';
-import { tool, type Context } from '@ai-sdk/provider-utils';
+import { tool, type Context, type ModelMessage } from '@ai-sdk/provider-utils';
 import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
 import { Output, streamText } from '../generate-text';
 import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
 import type { AsyncIterableStream } from '../util';
 import type { DeepPartial } from '../util/deep-partial';
+import type { ResponseMessage } from './response-message';
 
 describe('streamText types', () => {
   describe('output', () => {
@@ -416,7 +417,16 @@ describe('streamText types', () => {
         streamText({
           model: new MockLanguageModelV4(),
           prompt: 'Hello',
-          prepareStep: ({ runtimeContext, toolsContext }) => {
+          prepareStep: ({
+            initialMessages,
+            responseMessages,
+            runtimeContext,
+            toolsContext,
+          }) => {
+            expectTypeOf(initialMessages).toEqualTypeOf<Array<ModelMessage>>();
+            expectTypeOf(responseMessages).toEqualTypeOf<
+              Array<ResponseMessage>
+            >();
             expectTypeOf(runtimeContext).toEqualTypeOf<Context>();
             expectTypeOf(toolsContext).toEqualTypeOf<{}>();
 

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -6650,6 +6650,143 @@ describe('streamText', () => {
       expect(stepStartEvent).not.toHaveProperty('functionId');
     });
 
+    it('should pass initialMessages and responseMessages to prepareStep', async () => {
+      const prepareStepCalls: Array<{
+        initialMessages: Array<ModelMessage>;
+        responseMessages: Array<ModelMessage>;
+        messages: Array<ModelMessage>;
+      }> = [];
+      let responseCount = 0;
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            switch (responseCount++) {
+              case 0:
+                return {
+                  stream: convertArrayToReadableStream([
+                    {
+                      type: 'response-metadata' as const,
+                      id: 'id-0',
+                      modelId: 'mock-model-id',
+                      timestamp: new Date(0),
+                    },
+                    {
+                      type: 'tool-call' as const,
+                      id: 'call-1',
+                      toolCallId: 'call-1',
+                      toolName: 'tool1',
+                      input: '{ "value": "test" }',
+                    },
+                    {
+                      type: 'finish' as const,
+                      finishReason: {
+                        unified: 'tool-calls' as const,
+                        raw: undefined,
+                      },
+                      usage: testUsage,
+                    },
+                  ]),
+                };
+              case 1:
+              default:
+                return {
+                  stream: convertArrayToReadableStream([
+                    {
+                      type: 'response-metadata' as const,
+                      id: 'id-1',
+                      modelId: 'mock-model-id',
+                      timestamp: new Date(1000),
+                    },
+                    { type: 'text-start' as const, id: '1' },
+                    { type: 'text-delta' as const, id: '1', delta: 'Done.' },
+                    { type: 'text-end' as const, id: '1' },
+                    {
+                      type: 'finish' as const,
+                      finishReason: { unified: 'stop' as const, raw: 'stop' },
+                      usage: testUsage,
+                    },
+                  ]),
+                };
+            }
+          },
+        }),
+        tools: {
+          tool1: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        messages: [{ role: 'user', content: 'test-input' }],
+        stopWhen: isStepCount(3),
+        prepareStep: async ({
+          initialMessages,
+          responseMessages,
+          messages,
+        }) => {
+          prepareStepCalls.push({
+            initialMessages: [...initialMessages],
+            responseMessages: [...responseMessages],
+            messages: [...messages],
+          });
+          return undefined;
+        },
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      expect(prepareStepCalls).toHaveLength(2);
+      expect(prepareStepCalls[0].initialMessages).toEqual([
+        { role: 'user', content: 'test-input' },
+      ]);
+      expect(prepareStepCalls[0].responseMessages).toEqual([]);
+      expect(prepareStepCalls[0].messages).toEqual([
+        { role: 'user', content: 'test-input' },
+      ]);
+
+      expect(prepareStepCalls[1].initialMessages).toEqual([
+        { role: 'user', content: 'test-input' },
+      ]);
+      expect(prepareStepCalls[1].responseMessages).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "input": {
+                  "value": "test",
+                },
+                "providerExecuted": undefined,
+                "providerOptions": undefined,
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "text",
+                  "value": "test-result",
+                },
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ]
+      `);
+      expect(prepareStepCalls[1].messages).toEqual([
+        ...prepareStepCalls[1].initialMessages,
+        ...prepareStepCalls[1].responseMessages,
+      ]);
+    });
+
     it('should pass updated toolsContext from prepareStep', async () => {
       const prepareStepToolsContexts: Array<unknown> = [];
       const stepStartEvents: Parameters<

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1583,6 +1583,8 @@ class DefaultStreamTextResult<
             steps: recordedSteps,
             stepNumber: recordedSteps.length,
             messages: stepInputMessages,
+            initialMessages,
+            responseMessages,
             toolsContext,
             runtimeContext,
             sandbox,


### PR DESCRIPTION
## Background

We plan to change `messages` on `prepareStep` to be the input messages plus the response messages from the last step. In order to still allow implementing the current behavior (which resets messages based on input messages and accumulated response messages), we need to pass `initialMessages` and `responseMessages` into `prepareStep`.

## Summary

Expose initial and response messages in prepareStep.

## Future Work

* change behavior of `messages` in `prepareStep`