### PR TITLE
fix(ai): remove deprecated LanguageModelUsage properties

### DIFF
--- a/.changeset/hungry-foxes-approve.md
+++ b/.changeset/hungry-foxes-approve.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): remove deprecated LanguageModelUsage properties

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -2440,18 +2440,6 @@ To see `generateText` in action, check out [these examples](#examples).
               description:
                 'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
             },
-            {
-              name: 'reasoningTokens',
-              type: 'number | undefined',
-              isOptional: true,
-              description: 'The number of reasoning tokens used.',
-            },
-            {
-              name: 'cachedInputTokens',
-              type: 'number | undefined',
-              isOptional: true,
-              description: 'The number of cached input tokens.',
-            },
           ],
         },
       ],

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1640,18 +1640,6 @@ To see `streamText` in action, check out [these examples](#examples).
                       description:
                         'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
                     },
-                    {
-                      name: 'reasoningTokens',
-                      type: 'number | undefined',
-                      isOptional: true,
-                      description: 'The number of reasoning tokens used.',
-                    },
-                    {
-                      name: 'cachedInputTokens',
-                      type: 'number | undefined',
-                      isOptional: true,
-                      description: 'The number of cached input tokens.',
-                    },
                   ],
                 },
               ],
@@ -2369,18 +2357,6 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'number | undefined',
               description:
                 'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
-            },
-            {
-              name: 'reasoningTokens',
-              type: 'number | undefined',
-              isOptional: true,
-              description: 'The number of reasoning tokens used.',
-            },
-            {
-              name: 'cachedInputTokens',
-              type: 'number | undefined',
-              isOptional: true,
-              description: 'The number of cached input tokens.',
             },
           ],
         },

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -114,6 +114,32 @@ const result = await generateText({
 
 This applies to AI SDK functions that accept `prompt` or `messages`, including `generateText`, `streamText`, `generateObject`, `streamObject`, and `streamUI`.
 
+### `cachedInputTokens` and `reasoningTokens` Removed from `LanguageModelUsage`
+
+The deprecated top-level `cachedInputTokens` and `reasoningTokens` fields have been removed from `LanguageModelUsage`.
+
+Use `inputTokenDetails.cacheReadTokens` and `outputTokenDetails.reasoningTokens` instead:
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello!',
+});
+
+console.log(result.usage.cachedInputTokens);
+console.log(result.usage.reasoningTokens);
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Hello!',
+});
+
+console.log(result.usage.inputTokenDetails.cacheReadTokens);
+console.log(result.usage.outputTokenDetails.reasoningTokens);
+```
+
 ### Telemetry: OpenTelemetry Moved to `@ai-sdk/otel` — Explicit Registration Required
 
 OpenTelemetry span collection is no longer built into the `ai` package. To continue receiving OpenTelemetry traces, you must install the new `@ai-sdk/otel` package and register the `OpenTelemetry` instance globally.

--- a/examples/ai-functions/src/generate-text/google/thinking.ts
+++ b/examples/ai-functions/src/generate-text/google/thinking.ts
@@ -29,6 +29,9 @@ run(async () => {
   console.log('\n=== USAGE ===');
   console.log('Input tokens:', result.usage.inputTokens);
   console.log('Output tokens:', result.usage.outputTokens);
-  console.log('Reasoning tokens:', result.usage.reasoningTokens || 0);
+  console.log(
+    'Reasoning tokens:',
+    result.usage.outputTokenDetails.reasoningTokens || 0,
+  );
   console.log('Total tokens:', result.usage.totalTokens);
 });

--- a/examples/ai-functions/src/stream-text/openai/output-object-token-usage.ts
+++ b/examples/ai-functions/src/stream-text/openai/output-object-token-usage.ts
@@ -20,8 +20,11 @@ run(async () => {
 
   function recordUsage(usage: LanguageModelUsage) {
     console.log('Input tokens:', usage.inputTokens);
-    console.log('Cached input tokens:', usage.cachedInputTokens);
-    console.log('Reasoning tokens:', usage.reasoningTokens);
+    console.log(
+      'Cached input tokens:',
+      usage.inputTokenDetails.cacheReadTokens,
+    );
+    console.log('Reasoning tokens:', usage.outputTokenDetails.reasoningTokens);
     console.log('Output tokens:', usage.outputTokens);
     console.log('Total tokens:', usage.totalTokens);
   }

--- a/packages/ai/src/generate-object/__snapshots__/stream-object.test.ts.snap
+++ b/packages/ai/src/generate-object/__snapshots__/stream-object.test.ts.snap
@@ -60,7 +60,6 @@ exports[`streamObject > output = "object" > options.onFinish > should be called 
     "timestamp": 1970-01-01T00:00:00.000Z,
   },
   "usage": {
-    "cachedInputTokens": undefined,
     "inputTokenDetails": {
       "cacheReadTokens": undefined,
       "cacheWriteTokens": undefined,
@@ -73,7 +72,6 @@ exports[`streamObject > output = "object" > options.onFinish > should be called 
     },
     "outputTokens": 10,
     "raw": undefined,
-    "reasoningTokens": undefined,
     "totalTokens": 13,
   },
   "warnings": undefined,
@@ -96,7 +94,6 @@ exports[`streamObject > output = "object" > options.onFinish > should be called 
     "timestamp": 1970-01-01T00:00:00.000Z,
   },
   "usage": {
-    "cachedInputTokens": undefined,
     "inputTokenDetails": {
       "cacheReadTokens": undefined,
       "cacheWriteTokens": undefined,
@@ -109,7 +106,6 @@ exports[`streamObject > output = "object" > options.onFinish > should be called 
     },
     "outputTokens": 10,
     "raw": undefined,
-    "reasoningTokens": undefined,
     "totalTokens": 13,
   },
   "warnings": undefined,
@@ -174,7 +170,6 @@ exports[`streamObject > output = "object" > result.fullStream > should send full
     },
     "type": "finish",
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -187,7 +182,6 @@ exports[`streamObject > output = "object" > result.fullStream > should send full
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
   },

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -726,8 +726,6 @@ describe('generateObject', () => {
               reasoningTokens: undefined,
             },
             totalTokens: 30,
-            reasoningTokens: undefined,
-            cachedInputTokens: undefined,
           },
           finishReason: 'stop',
         });

--- a/packages/ai/src/generate-object/stream-object.test.ts
+++ b/packages/ai/src/generate-object/stream-object.test.ts
@@ -360,7 +360,6 @@ describe('streamObject', () => {
 
         expect(await result.usage).toMatchInlineSnapshot(`
           {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -373,7 +372,6 @@ describe('streamObject', () => {
             },
             "outputTokens": 10,
             "raw": undefined,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           }
         `);

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -237,7 +237,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       "stepNumber": 0,
       "toolsContext": {},
       "usage": {
-        "cachedInputTokens": undefined,
         "inputTokenDetails": {
           "cacheReadTokens": undefined,
           "cacheWriteTokens": undefined,
@@ -250,7 +249,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
         },
         "outputTokens": 5,
         "raw": undefined,
-        "reasoningTokens": undefined,
         "totalTokens": 15,
       },
       "warnings": [],
@@ -328,7 +326,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       "stepNumber": 1,
       "toolsContext": {},
       "usage": {
-        "cachedInputTokens": undefined,
         "inputTokenDetails": {
           "cacheReadTokens": undefined,
           "cacheWriteTokens": undefined,
@@ -341,7 +338,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
         },
         "outputTokens": 10,
         "raw": undefined,
-        "reasoningTokens": undefined,
         "totalTokens": 13,
       },
       "warnings": [],
@@ -352,7 +348,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
   "toolResults": [],
   "toolsContext": {},
   "totalUsage": {
-    "cachedInputTokens": undefined,
     "inputTokenDetails": {
       "cacheReadTokens": undefined,
       "cacheWriteTokens": undefined,
@@ -364,11 +359,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       "textTokens": 15,
     },
     "outputTokens": 15,
-    "reasoningTokens": undefined,
     "totalTokens": 28,
   },
   "usage": {
-    "cachedInputTokens": undefined,
     "inputTokenDetails": {
       "cacheReadTokens": undefined,
       "cacheWriteTokens": undefined,
@@ -381,7 +374,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
     },
     "outputTokens": 10,
     "raw": undefined,
-    "reasoningTokens": undefined,
     "totalTokens": 13,
   },
   "warnings": [],
@@ -468,7 +460,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
     "stepNumber": 0,
     "toolsContext": {},
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -481,7 +472,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       },
       "outputTokens": 5,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 15,
     },
     "warnings": [],
@@ -559,7 +549,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
     "stepNumber": 1,
     "toolsContext": {},
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -572,7 +561,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
     "warnings": [],
@@ -704,7 +692,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
     "stepNumber": 0,
     "toolsContext": {},
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -717,7 +704,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
       },
       "outputTokens": 5,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 15,
     },
     "warnings": [],
@@ -795,7 +781,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
     "stepNumber": 1,
     "toolsContext": {},
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -808,7 +793,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
     "warnings": [],
@@ -898,7 +882,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     "stepNumber": 0,
     "toolsContext": {},
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -911,7 +894,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
       },
       "outputTokens": 5,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 15,
     },
     "warnings": [],
@@ -991,7 +973,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     "stepNumber": 1,
     "toolsContext": {},
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -1004,7 +985,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
     "warnings": [],
@@ -1138,7 +1118,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     "stepNumber": 0,
     "toolsContext": {},
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -1151,7 +1130,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
       },
       "outputTokens": 5,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 15,
     },
     "warnings": [],
@@ -1231,7 +1209,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
     "stepNumber": 1,
     "toolsContext": {},
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -1244,7 +1221,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
     "warnings": [],
@@ -1753,7 +1729,6 @@ exports[`generateText > result.steps > should add the reasoning from the model r
     "stepNumber": 0,
     "toolsContext": {},
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -1766,7 +1741,6 @@ exports[`generateText > result.steps > should add the reasoning from the model r
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
     "warnings": [],
@@ -1850,7 +1824,6 @@ exports[`generateText > result.steps > should contain files 1`] = `
     "stepNumber": 0,
     "toolsContext": {},
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -1863,7 +1836,6 @@ exports[`generateText > result.steps > should contain files 1`] = `
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
     "warnings": [],
@@ -1939,7 +1911,6 @@ exports[`generateText > result.steps > should contain sources 1`] = `
     "stepNumber": 0,
     "toolsContext": {},
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -1952,7 +1923,6 @@ exports[`generateText > result.steps > should contain sources 1`] = `
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
     "warnings": [],

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -258,7 +258,6 @@ exports[`streamText > result.fullStream > should send delayed asynchronous tool 
     },
     "type": "finish-step",
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -271,7 +270,6 @@ exports[`streamText > result.fullStream > should send delayed asynchronous tool 
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
   },
@@ -279,7 +277,6 @@ exports[`streamText > result.fullStream > should send delayed asynchronous tool 
     "finishReason": "stop",
     "rawFinishReason": "stop",
     "totalUsage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -291,7 +288,6 @@ exports[`streamText > result.fullStream > should send delayed asynchronous tool 
         "textTokens": 10,
       },
       "outputTokens": 10,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
     "type": "finish",
@@ -339,7 +335,6 @@ exports[`streamText > result.fullStream > should send tool calls 1`] = `
     },
     "type": "finish-step",
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -352,7 +347,6 @@ exports[`streamText > result.fullStream > should send tool calls 1`] = `
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
   },
@@ -360,7 +354,6 @@ exports[`streamText > result.fullStream > should send tool calls 1`] = `
     "finishReason": "stop",
     "rawFinishReason": "stop",
     "totalUsage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -372,7 +365,6 @@ exports[`streamText > result.fullStream > should send tool calls 1`] = `
         "textTokens": 10,
       },
       "outputTokens": 10,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
     "type": "finish",
@@ -426,7 +418,6 @@ exports[`streamText > result.fullStream > should send tool results 1`] = `
     },
     "type": "finish-step",
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -439,7 +430,6 @@ exports[`streamText > result.fullStream > should send tool results 1`] = `
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
   },
@@ -447,7 +437,6 @@ exports[`streamText > result.fullStream > should send tool results 1`] = `
     "finishReason": "stop",
     "rawFinishReason": "stop",
     "totalUsage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -459,7 +448,6 @@ exports[`streamText > result.fullStream > should send tool results 1`] = `
         "textTokens": 10,
       },
       "outputTokens": 10,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
     "type": "finish",
@@ -783,7 +771,6 @@ exports[`streamText > tools with custom schema > should send tool calls 1`] = `
     },
     "type": "finish-step",
     "usage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -796,7 +783,6 @@ exports[`streamText > tools with custom schema > should send tool calls 1`] = `
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
   },
@@ -804,7 +790,6 @@ exports[`streamText > tools with custom schema > should send tool calls 1`] = `
     "finishReason": "stop",
     "rawFinishReason": "stop",
     "totalUsage": {
-      "cachedInputTokens": undefined,
       "inputTokenDetails": {
         "cacheReadTokens": undefined,
         "cacheWriteTokens": undefined,
@@ -816,7 +801,6 @@ exports[`streamText > tools with custom schema > should send tool calls 1`] = `
         "textTokens": 10,
       },
       "outputTokens": 10,
-      "reasoningTokens": undefined,
       "totalTokens": 13,
     },
     "type": "finish",

--- a/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/create-execute-tools-transformation.test.ts
@@ -101,7 +101,6 @@ describe('createExecuteToolsTransformation', () => {
             "rawFinishReason": "stop",
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -114,7 +113,6 @@ describe('createExecuteToolsTransformation', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -181,7 +179,6 @@ describe('createExecuteToolsTransformation', () => {
           "rawFinishReason": "stop",
           "type": "model-call-end",
           "usage": {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -194,7 +191,6 @@ describe('createExecuteToolsTransformation', () => {
             },
             "outputTokens": 10,
             "raw": undefined,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           },
         },
@@ -400,7 +396,6 @@ describe('createExecuteToolsTransformation', () => {
             "rawFinishReason": "stop",
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -413,7 +408,6 @@ describe('createExecuteToolsTransformation', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -520,7 +514,6 @@ describe('createExecuteToolsTransformation', () => {
             "rawFinishReason": "stop",
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -533,7 +526,6 @@ describe('createExecuteToolsTransformation', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -1186,7 +1178,6 @@ describe('createExecuteToolsTransformation', () => {
             "rawFinishReason": "stop",
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -1199,7 +1190,6 @@ describe('createExecuteToolsTransformation', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -1272,7 +1262,6 @@ describe('createExecuteToolsTransformation', () => {
             "rawFinishReason": "stop",
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -1285,7 +1274,6 @@ describe('createExecuteToolsTransformation', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1990,7 +1990,6 @@ describe('generateText', () => {
             "provider": "mock-provider",
             "responseId": "response-1",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -2003,7 +2002,6 @@ describe('generateText', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -3475,7 +3473,6 @@ describe('generateText', () => {
               "stepNumber": 0,
               "toolsContext": {},
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -3488,7 +3485,6 @@ describe('generateText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "warnings": [],
@@ -3522,7 +3518,6 @@ describe('generateText', () => {
           ],
           "toolsContext": {},
           "totalUsage": {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -3534,11 +3529,9 @@ describe('generateText', () => {
               "textTokens": 10,
             },
             "outputTokens": 10,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           },
           "usage": {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -3551,7 +3544,6 @@ describe('generateText', () => {
             },
             "outputTokens": 10,
             "raw": undefined,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           },
           "warnings": [],
@@ -3703,7 +3695,6 @@ describe('generateText', () => {
       it('result.totalUsage should sum token usage', () => {
         expect(result.totalUsage).toMatchInlineSnapshot(`
           {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -3715,7 +3706,6 @@ describe('generateText', () => {
               "textTokens": 15,
             },
             "outputTokens": 15,
-            "reasoningTokens": undefined,
             "totalTokens": 28,
           }
         `);
@@ -3724,7 +3714,6 @@ describe('generateText', () => {
       it('result.usage should contain token usage from final step', async () => {
         expect(result.usage).toMatchInlineSnapshot(`
           {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -3737,7 +3726,6 @@ describe('generateText', () => {
             },
             "outputTokens": 10,
             "raw": undefined,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           }
         `);
@@ -4001,7 +3989,6 @@ describe('generateText', () => {
                   "stepNumber": 0,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -4014,7 +4001,6 @@ describe('generateText', () => {
                     },
                     "outputTokens": 5,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 15,
                   },
                   "warnings": [],
@@ -4094,7 +4080,6 @@ describe('generateText', () => {
                   "stepNumber": 1,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -4107,7 +4092,6 @@ describe('generateText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -4236,7 +4220,6 @@ describe('generateText', () => {
                   "stepNumber": 0,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -4249,7 +4232,6 @@ describe('generateText', () => {
                     },
                     "outputTokens": 5,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 15,
                   },
                   "warnings": [],
@@ -4329,7 +4311,6 @@ describe('generateText', () => {
                   "stepNumber": 1,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -4342,7 +4323,6 @@ describe('generateText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -4476,7 +4456,6 @@ describe('generateText', () => {
       it('result.totalUsage should sum token usage', () => {
         expect(result.totalUsage).toMatchInlineSnapshot(`
           {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -4488,7 +4467,6 @@ describe('generateText', () => {
               "textTokens": 15,
             },
             "outputTokens": 15,
-            "reasoningTokens": undefined,
             "totalTokens": 28,
           }
         `);
@@ -4497,7 +4475,6 @@ describe('generateText', () => {
       it('result.usage should contain token usage from final step', async () => {
         expect(result.usage).toMatchInlineSnapshot(`
           {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -4510,7 +4487,6 @@ describe('generateText', () => {
             },
             "outputTokens": 10,
             "raw": undefined,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           }
         `);
@@ -4708,7 +4684,6 @@ describe('generateText', () => {
                   "stepNumber": 0,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -4721,7 +4696,6 @@ describe('generateText', () => {
                     },
                     "outputTokens": 5,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 15,
                   },
                   "warnings": [],
@@ -4809,7 +4783,6 @@ describe('generateText', () => {
                   "stepNumber": 0,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -4822,7 +4795,6 @@ describe('generateText', () => {
                     },
                     "outputTokens": 5,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 15,
                   },
                   "warnings": [],
@@ -7401,7 +7373,6 @@ describe('generateText', () => {
         it('should sum token usage across all steps', () => {
           expect(result.totalUsage).toMatchInlineSnapshot(`
             {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -7413,7 +7384,6 @@ describe('generateText', () => {
                 "textTokens": 806,
               },
               "outputTokens": 806,
-              "reasoningTokens": undefined,
               "totalTokens": 8418,
             }
           `);
@@ -7512,7 +7482,6 @@ describe('generateText', () => {
         it('should contain correct totalUsage', () => {
           expect(onFinishResult.totalUsage).toMatchInlineSnapshot(`
             {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -7524,7 +7493,6 @@ describe('generateText', () => {
                 "textTokens": 806,
               },
               "outputTokens": 806,
-              "reasoningTokens": undefined,
               "totalTokens": 8418,
             }
           `);
@@ -8339,7 +8307,6 @@ describe('generateText', () => {
               "stepNumber": 0,
               "toolsContext": {},
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -8352,7 +8319,6 @@ describe('generateText', () => {
                 },
                 "outputTokens": 20,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 30,
               },
               "warnings": [],

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1089,10 +1089,17 @@ export async function generateText<
       },
       {
         inputTokens: undefined,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
         outputTokens: undefined,
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
         totalTokens: undefined,
-        reasoningTokens: undefined,
-        cachedInputTokens: undefined,
       } as LanguageModelUsage,
     );
 

--- a/packages/ai/src/generate-text/stream-language-model-call.test.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.test.ts
@@ -201,7 +201,6 @@ describe('streamLanguageModelCall', () => {
             "provider": "mock-provider",
             "responseId": "aitxt-generated-response-id",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -214,7 +213,6 @@ describe('streamLanguageModelCall', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -309,7 +307,6 @@ describe('streamLanguageModelCall', () => {
             "provider": "mock-provider",
             "responseId": "response-1",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -322,7 +319,6 @@ describe('streamLanguageModelCall', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -367,7 +363,6 @@ describe('streamLanguageModelCall', () => {
           "provider": "mock-provider",
           "responseId": "aitxt-generated-response-id",
           "usage": {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -380,7 +375,6 @@ describe('streamLanguageModelCall', () => {
             },
             "outputTokens": 10,
             "raw": undefined,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           },
         }
@@ -446,7 +440,6 @@ describe('streamLanguageModelCall', () => {
             "rawFinishReason": "stop",
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -459,7 +452,6 @@ describe('streamLanguageModelCall', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -507,7 +499,6 @@ describe('streamLanguageModelCall', () => {
             "rawFinishReason": "stop",
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -520,7 +511,6 @@ describe('streamLanguageModelCall', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -599,7 +589,6 @@ describe('streamLanguageModelCall', () => {
             "rawFinishReason": "stop",
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -612,7 +601,6 @@ describe('streamLanguageModelCall', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -680,7 +668,6 @@ describe('streamLanguageModelCall', () => {
             "rawFinishReason": "stop",
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -693,7 +680,6 @@ describe('streamLanguageModelCall', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -740,7 +726,6 @@ describe('streamLanguageModelCall', () => {
             "rawFinishReason": "stop",
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -753,7 +738,6 @@ describe('streamLanguageModelCall', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -853,43 +837,41 @@ describe('streamLanguageModelCall', () => {
       });
 
       expect(result).toMatchInlineSnapshot(`
-          [
-            {
-              "input": {
-                "value": "test",
-              },
-              "providerExecuted": undefined,
-              "providerMetadata": undefined,
-              "title": undefined,
-              "toolCallId": "call-1",
-              "toolName": "correctTool",
-              "type": "tool-call",
+        [
+          {
+            "input": {
+              "value": "test",
             },
-            {
-              "finishReason": "stop",
-              "providerMetadata": undefined,
-              "rawFinishReason": "stop",
-              "type": "model-call-end",
-              "usage": {
-                "cachedInputTokens": undefined,
-                "inputTokenDetails": {
-                  "cacheReadTokens": undefined,
-                  "cacheWriteTokens": undefined,
-                  "noCacheTokens": 3,
-                },
-                "inputTokens": 3,
-                "outputTokenDetails": {
-                  "reasoningTokens": undefined,
-                  "textTokens": 10,
-                },
-                "outputTokens": 10,
-                "raw": undefined,
+            "providerExecuted": undefined,
+            "providerMetadata": undefined,
+            "title": undefined,
+            "toolCallId": "call-1",
+            "toolName": "correctTool",
+            "type": "tool-call",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": undefined,
+            "rawFinishReason": "stop",
+            "type": "model-call-end",
+            "usage": {
+              "inputTokenDetails": {
+                "cacheReadTokens": undefined,
+                "cacheWriteTokens": undefined,
+                "noCacheTokens": 3,
+              },
+              "inputTokens": 3,
+              "outputTokenDetails": {
                 "reasoningTokens": undefined,
-                "totalTokens": 13,
+                "textTokens": 10,
               },
+              "outputTokens": 10,
+              "raw": undefined,
+              "totalTokens": 13,
             },
-          ]
-        `);
+          },
+        ]
+      `);
     });
   });
 
@@ -925,7 +907,6 @@ describe('streamLanguageModelCall', () => {
             "rawFinishReason": undefined,
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -938,7 +919,6 @@ describe('streamLanguageModelCall', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -1015,7 +995,6 @@ describe('streamLanguageModelCall', () => {
             "rawFinishReason": undefined,
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -1028,7 +1007,6 @@ describe('streamLanguageModelCall', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -1150,7 +1128,6 @@ describe('streamLanguageModelCall', () => {
             "rawFinishReason": undefined,
             "type": "model-call-end",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -1163,7 +1140,6 @@ describe('streamLanguageModelCall', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -632,7 +632,6 @@ describe('streamText', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -645,7 +644,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
             },
@@ -653,7 +651,6 @@ describe('streamText', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -665,7 +662,6 @@ describe('streamText', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "type": "finish",
@@ -865,7 +861,6 @@ describe('streamText', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -878,7 +873,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
             },
@@ -886,7 +880,6 @@ describe('streamText', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -898,7 +891,6 @@ describe('streamText', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "type": "finish",
@@ -977,7 +969,6 @@ describe('streamText', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -990,7 +981,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
             },
@@ -998,7 +988,6 @@ describe('streamText', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -1010,7 +999,6 @@ describe('streamText', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "type": "finish",
@@ -1074,7 +1062,6 @@ describe('streamText', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -1087,7 +1074,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
             },
@@ -1095,7 +1081,6 @@ describe('streamText', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -1107,7 +1092,6 @@ describe('streamText', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "type": "finish",
@@ -1182,7 +1166,6 @@ describe('streamText', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -1195,7 +1178,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
             },
@@ -1203,7 +1185,6 @@ describe('streamText', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -1215,7 +1196,6 @@ describe('streamText', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "type": "finish",
@@ -1347,7 +1327,6 @@ describe('streamText', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -1360,7 +1339,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
             },
@@ -1368,7 +1346,6 @@ describe('streamText', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -1380,7 +1357,6 @@ describe('streamText', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "type": "finish",
@@ -1476,7 +1452,6 @@ describe('streamText', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -1489,7 +1464,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
             },
@@ -1497,7 +1471,6 @@ describe('streamText', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -1509,7 +1482,6 @@ describe('streamText', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "type": "finish",
@@ -1823,7 +1795,6 @@ describe('streamText', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -1836,7 +1807,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": 10,
                 "totalTokens": 13,
               },
             },
@@ -1844,7 +1814,6 @@ describe('streamText', () => {
               "finishReason": "tool-calls",
               "rawFinishReason": undefined,
               "totalUsage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -1856,7 +1825,6 @@ describe('streamText', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": 10,
                 "totalTokens": 13,
               },
               "type": "finish",
@@ -2091,7 +2059,6 @@ describe('streamText', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -2104,7 +2071,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
             },
@@ -2112,7 +2078,6 @@ describe('streamText', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -2124,7 +2089,6 @@ describe('streamText', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "type": "finish",
@@ -4792,7 +4756,6 @@ describe('streamText', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -4805,7 +4768,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
             },
@@ -4813,7 +4775,6 @@ describe('streamText', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -4825,7 +4786,6 @@ describe('streamText', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "type": "finish",
@@ -4914,7 +4874,6 @@ describe('streamText', () => {
 
       expect(await result.usage).toMatchInlineSnapshot(`
         {
-          "cachedInputTokens": undefined,
           "inputTokenDetails": {
             "cacheReadTokens": undefined,
             "cacheWriteTokens": undefined,
@@ -4927,7 +4886,6 @@ describe('streamText', () => {
           },
           "outputTokens": 10,
           "raw": undefined,
-          "reasoningTokens": undefined,
           "totalTokens": 13,
         }
       `);
@@ -5507,7 +5465,6 @@ describe('streamText', () => {
             "stepNumber": 0,
             "toolsContext": {},
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -5520,7 +5477,6 @@ describe('streamText', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
             "warnings": [],
@@ -5603,7 +5559,6 @@ describe('streamText', () => {
             "stepNumber": 0,
             "toolsContext": {},
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -5616,7 +5571,6 @@ describe('streamText', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
             "warnings": [],
@@ -5705,7 +5659,6 @@ describe('streamText', () => {
             "stepNumber": 0,
             "toolsContext": {},
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -5718,7 +5671,6 @@ describe('streamText', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
             "warnings": [],
@@ -5826,7 +5778,6 @@ describe('streamText', () => {
             "stepNumber": 0,
             "toolsContext": {},
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -5839,7 +5790,6 @@ describe('streamText', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
             "warnings": [],
@@ -6859,7 +6809,6 @@ describe('streamText', () => {
             "provider": "mock-provider",
             "responseId": "response-1",
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -6872,7 +6821,6 @@ describe('streamText', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
           },
@@ -8499,7 +8447,6 @@ describe('streamText', () => {
               "stepNumber": 0,
               "toolsContext": {},
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -8512,7 +8459,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "warnings": [],
@@ -8546,7 +8492,6 @@ describe('streamText', () => {
           ],
           "toolsContext": {},
           "totalUsage": {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -8558,11 +8503,9 @@ describe('streamText', () => {
               "textTokens": 10,
             },
             "outputTokens": 10,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           },
           "usage": {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -8575,7 +8518,6 @@ describe('streamText', () => {
             },
             "outputTokens": 10,
             "raw": undefined,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           },
           "warnings": [],
@@ -8775,7 +8717,6 @@ describe('streamText', () => {
               "stepNumber": 0,
               "toolsContext": {},
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -8788,7 +8729,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "warnings": [],
@@ -8799,7 +8739,6 @@ describe('streamText', () => {
           "toolResults": [],
           "toolsContext": {},
           "totalUsage": {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -8811,11 +8750,9 @@ describe('streamText', () => {
               "textTokens": 10,
             },
             "outputTokens": 10,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           },
           "usage": {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -8828,7 +8765,6 @@ describe('streamText', () => {
             },
             "outputTokens": 10,
             "raw": undefined,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           },
           "warnings": [],
@@ -9071,7 +9007,6 @@ describe('streamText', () => {
               "stepNumber": 0,
               "toolsContext": {},
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -9084,7 +9019,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "warnings": [],
@@ -9095,7 +9029,6 @@ describe('streamText', () => {
           "toolResults": [],
           "toolsContext": {},
           "totalUsage": {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -9107,11 +9040,9 @@ describe('streamText', () => {
               "textTokens": 10,
             },
             "outputTokens": 10,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           },
           "usage": {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -9124,7 +9055,6 @@ describe('streamText', () => {
             },
             "outputTokens": 10,
             "raw": undefined,
-            "reasoningTokens": undefined,
             "totalTokens": 13,
           },
           "warnings": [],
@@ -9551,7 +9481,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -9564,7 +9493,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -9610,7 +9538,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "cacheWriteTokens": 0,
@@ -9623,7 +9550,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": 10,
                   "totalTokens": 13,
                 },
               },
@@ -9631,7 +9557,6 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "rawFinishReason": "stop",
                 "totalUsage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "cacheWriteTokens": 0,
@@ -9643,7 +9568,6 @@ describe('streamText', () => {
                     "textTokens": 20,
                   },
                   "outputTokens": 20,
-                  "reasoningTokens": 10,
                   "totalTokens": 26,
                 },
                 "type": "finish",
@@ -9879,7 +9803,6 @@ describe('streamText', () => {
                   "stepNumber": 0,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -9892,7 +9815,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -9975,7 +9897,6 @@ describe('streamText', () => {
                   "stepNumber": 1,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": 0,
                     "inputTokenDetails": {
                       "cacheReadTokens": 0,
                       "cacheWriteTokens": 0,
@@ -9988,7 +9909,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": 10,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -9999,7 +9919,6 @@ describe('streamText', () => {
               "toolResults": [],
               "toolsContext": {},
               "totalUsage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -10011,11 +9930,9 @@ describe('streamText', () => {
                   "textTokens": 20,
                 },
                 "outputTokens": 20,
-                "reasoningTokens": 10,
                 "totalTokens": 26,
               },
               "usage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -10028,7 +9945,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": 10,
                 "totalTokens": 13,
               },
               "warnings": [],
@@ -10128,7 +10044,6 @@ describe('streamText', () => {
                 "stepNumber": 0,
                 "toolsContext": {},
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -10141,7 +10056,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "warnings": [],
@@ -10224,7 +10138,6 @@ describe('streamText', () => {
                 "stepNumber": 1,
                 "toolsContext": {},
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "cacheWriteTokens": 0,
@@ -10237,7 +10150,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": 10,
                   "totalTokens": 13,
                 },
                 "warnings": [],
@@ -10255,7 +10167,6 @@ describe('streamText', () => {
         it('result.totalUsage should contain total token usage', async () => {
           expect(await result.totalUsage).toMatchInlineSnapshot(`
             {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -10267,7 +10178,6 @@ describe('streamText', () => {
                 "textTokens": 20,
               },
               "outputTokens": 20,
-              "reasoningTokens": 10,
               "totalTokens": 26,
             }
           `);
@@ -10276,7 +10186,6 @@ describe('streamText', () => {
         it('result.usage should contain token usage from final step', async () => {
           expect(await result.totalUsage).toMatchInlineSnapshot(`
             {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -10288,7 +10197,6 @@ describe('streamText', () => {
                 "textTokens": 20,
               },
               "outputTokens": 20,
-              "reasoningTokens": 10,
               "totalTokens": 26,
             }
           `);
@@ -10394,7 +10302,6 @@ describe('streamText', () => {
                 "stepNumber": 0,
                 "toolsContext": {},
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -10407,7 +10314,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "warnings": [],
@@ -10490,7 +10396,6 @@ describe('streamText', () => {
                 "stepNumber": 1,
                 "toolsContext": {},
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "cacheWriteTokens": 0,
@@ -10503,7 +10408,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": 10,
                   "totalTokens": 13,
                 },
                 "warnings": [],
@@ -10993,7 +10897,6 @@ describe('streamText', () => {
                   "stepNumber": 0,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -11006,7 +10909,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -11086,7 +10988,6 @@ describe('streamText', () => {
                   "stepNumber": 1,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": 0,
                     "inputTokenDetails": {
                       "cacheReadTokens": 0,
                       "cacheWriteTokens": 0,
@@ -11099,7 +11000,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": 10,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -11229,7 +11129,6 @@ describe('streamText', () => {
                   "stepNumber": 0,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -11242,7 +11141,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -11322,7 +11220,6 @@ describe('streamText', () => {
                   "stepNumber": 1,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": 0,
                     "inputTokenDetails": {
                       "cacheReadTokens": 0,
                       "cacheWriteTokens": 0,
@@ -11335,7 +11232,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": 10,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -11520,7 +11416,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -11533,7 +11428,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -11579,7 +11473,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "cacheWriteTokens": 0,
@@ -11592,7 +11485,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": 10,
                   "totalTokens": 13,
                 },
               },
@@ -11600,7 +11492,6 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "rawFinishReason": "stop",
                 "totalUsage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "cacheWriteTokens": 0,
@@ -11612,7 +11503,6 @@ describe('streamText', () => {
                     "textTokens": 20,
                   },
                   "outputTokens": 20,
-                  "reasoningTokens": 10,
                   "totalTokens": 26,
                 },
                 "type": "finish",
@@ -11848,7 +11738,6 @@ describe('streamText', () => {
                   "stepNumber": 0,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -11861,7 +11750,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -11944,7 +11832,6 @@ describe('streamText', () => {
                   "stepNumber": 1,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": 0,
                     "inputTokenDetails": {
                       "cacheReadTokens": 0,
                       "cacheWriteTokens": 0,
@@ -11957,7 +11844,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": 10,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -11968,7 +11854,6 @@ describe('streamText', () => {
               "toolResults": [],
               "toolsContext": {},
               "totalUsage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -11980,11 +11865,9 @@ describe('streamText', () => {
                   "textTokens": 20,
                 },
                 "outputTokens": 20,
-                "reasoningTokens": 10,
                 "totalTokens": 26,
               },
               "usage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -11997,7 +11880,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": 10,
                 "totalTokens": 13,
               },
               "warnings": [],
@@ -12097,7 +11979,6 @@ describe('streamText', () => {
                 "stepNumber": 0,
                 "toolsContext": {},
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -12110,7 +11991,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "warnings": [],
@@ -12193,7 +12073,6 @@ describe('streamText', () => {
                 "stepNumber": 1,
                 "toolsContext": {},
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "cacheWriteTokens": 0,
@@ -12206,7 +12085,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": 10,
                   "totalTokens": 13,
                 },
                 "warnings": [],
@@ -12220,7 +12098,6 @@ describe('streamText', () => {
         it('result.totalUsage should contain total token usage', async () => {
           expect(await result.totalUsage).toMatchInlineSnapshot(`
             {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -12232,7 +12109,6 @@ describe('streamText', () => {
                 "textTokens": 20,
               },
               "outputTokens": 20,
-              "reasoningTokens": 10,
               "totalTokens": 26,
             }
           `);
@@ -12241,7 +12117,6 @@ describe('streamText', () => {
         it('result.usage should contain token usage from final step', async () => {
           expect(await result.totalUsage).toMatchInlineSnapshot(`
             {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -12253,7 +12128,6 @@ describe('streamText', () => {
                 "textTokens": 20,
               },
               "outputTokens": 20,
-              "reasoningTokens": 10,
               "totalTokens": 26,
             }
           `);
@@ -12359,7 +12233,6 @@ describe('streamText', () => {
                 "stepNumber": 0,
                 "toolsContext": {},
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -12372,7 +12245,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "warnings": [],
@@ -12455,7 +12327,6 @@ describe('streamText', () => {
                 "stepNumber": 1,
                 "toolsContext": {},
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "cacheWriteTokens": 0,
@@ -12468,7 +12339,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": 10,
                   "totalTokens": 13,
                 },
                 "warnings": [],
@@ -12785,7 +12655,6 @@ describe('streamText', () => {
                   "stepNumber": 0,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -12798,7 +12667,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -12897,7 +12765,6 @@ describe('streamText', () => {
                   "stepNumber": 0,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -12910,7 +12777,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -13273,7 +13139,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -13286,7 +13151,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -13294,7 +13158,6 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "rawFinishReason": "stop",
                 "totalUsage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -13306,7 +13169,6 @@ describe('streamText', () => {
                     "textTokens": 10,
                   },
                   "outputTokens": 10,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "type": "finish",
@@ -13816,7 +13678,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -13829,7 +13690,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -13837,7 +13697,6 @@ describe('streamText', () => {
                 "finishReason": "tool-calls",
                 "rawFinishReason": undefined,
                 "totalUsage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -13849,7 +13708,6 @@ describe('streamText', () => {
                     "textTokens": 10,
                   },
                   "outputTokens": 10,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "type": "finish",
@@ -15021,7 +14879,6 @@ describe('streamText', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -15034,7 +14891,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
             },
@@ -15042,7 +14898,6 @@ describe('streamText', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -15054,7 +14909,6 @@ describe('streamText', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "type": "finish",
@@ -15143,7 +14997,6 @@ describe('streamText', () => {
             "stepNumber": 0,
             "toolsContext": {},
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -15156,7 +15009,6 @@ describe('streamText', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
             "warnings": [],
@@ -15363,8 +15215,6 @@ describe('streamText', () => {
                       textTokens: 300,
                     },
                     totalTokens: undefined,
-                    reasoningTokens: undefined,
-                    cachedInputTokens: undefined,
                   };
                 }
                 controller.enqueue(chunk);
@@ -15375,7 +15225,6 @@ describe('streamText', () => {
 
         expect(await result.totalUsage).toMatchInlineSnapshot(`
           {
-            "cachedInputTokens": undefined,
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
               "cacheWriteTokens": undefined,
@@ -15387,7 +15236,6 @@ describe('streamText', () => {
               "textTokens": 300,
             },
             "outputTokens": 300,
-            "reasoningTokens": undefined,
             "totalTokens": undefined,
           }
         `);
@@ -15647,7 +15495,6 @@ describe('streamText', () => {
               "stepNumber": 0,
               "toolsContext": {},
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -15660,7 +15507,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "warnings": [],
@@ -16016,7 +15862,6 @@ describe('streamText', () => {
                 "stepNumber": 0,
                 "toolsContext": {},
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -16029,7 +15874,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "warnings": [],
@@ -16063,7 +15907,6 @@ describe('streamText', () => {
             ],
             "toolsContext": {},
             "totalUsage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -16075,11 +15918,9 @@ describe('streamText', () => {
                 "textTokens": 10,
               },
               "outputTokens": 10,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -16092,7 +15933,6 @@ describe('streamText', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
             "warnings": [],
@@ -16249,7 +16089,6 @@ describe('streamText', () => {
             "stepNumber": 0,
             "toolsContext": {},
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -16262,7 +16101,6 @@ describe('streamText', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
             "warnings": [],
@@ -17228,7 +17066,6 @@ describe('streamText', () => {
                 "stepNumber": 0,
                 "toolsContext": {},
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -17241,7 +17078,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "warnings": [],
@@ -17252,7 +17088,6 @@ describe('streamText', () => {
             "toolResults": [],
             "toolsContext": {},
             "totalUsage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -17264,11 +17099,9 @@ describe('streamText', () => {
                 "textTokens": 10,
               },
               "outputTokens": 10,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
             "usage": {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -17281,7 +17114,6 @@ describe('streamText', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": undefined,
               "totalTokens": 13,
             },
             "warnings": [],
@@ -18335,7 +18167,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -18348,7 +18179,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -18356,7 +18186,6 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "rawFinishReason": "stop",
                 "totalUsage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -18368,7 +18197,6 @@ describe('streamText', () => {
                     "textTokens": 10,
                   },
                   "outputTokens": 10,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "type": "finish",
@@ -18479,7 +18307,6 @@ describe('streamText', () => {
               "stepNumber": 0,
               "toolsContext": {},
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -18492,7 +18319,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "warnings": [],
@@ -18885,7 +18711,6 @@ describe('streamText', () => {
                   "stepNumber": 0,
                   "toolsContext": {},
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -18898,7 +18723,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 13,
                   },
                   "warnings": [],
@@ -18957,7 +18781,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -18970,7 +18793,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -19585,7 +19407,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -19598,7 +19419,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -19606,7 +19426,6 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "rawFinishReason": "stop",
                 "totalUsage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -19618,7 +19437,6 @@ describe('streamText', () => {
                     "textTokens": 10,
                   },
                   "outputTokens": 10,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "type": "finish",
@@ -19827,7 +19645,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -19840,7 +19657,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -19848,7 +19664,6 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "rawFinishReason": "stop",
                 "totalUsage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -19860,7 +19675,6 @@ describe('streamText', () => {
                     "textTokens": 10,
                   },
                   "outputTokens": 10,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "type": "finish",
@@ -20046,7 +19860,6 @@ describe('streamText', () => {
               "stepNumber": 0,
               "toolsContext": {},
               "usage": {
-                "cachedInputTokens": undefined,
                 "inputTokenDetails": {
                   "cacheReadTokens": undefined,
                   "cacheWriteTokens": undefined,
@@ -20059,7 +19872,6 @@ describe('streamText', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": undefined,
                 "totalTokens": 13,
               },
               "warnings": [],
@@ -20228,7 +20040,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -20241,7 +20052,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -20249,7 +20059,6 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "rawFinishReason": "stop",
                 "totalUsage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -20261,7 +20070,6 @@ describe('streamText', () => {
                     "textTokens": 10,
                   },
                   "outputTokens": 10,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "type": "finish",
@@ -21329,7 +21137,6 @@ describe('streamText', () => {
           await result.consumeStream();
           expect(await result.totalUsage).toMatchInlineSnapshot(`
             {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -21341,7 +21148,6 @@ describe('streamText', () => {
                 "textTokens": 922,
               },
               "outputTokens": 922,
-              "reasoningTokens": undefined,
               "totalTokens": 8842,
             }
           `);
@@ -21451,7 +21257,6 @@ describe('streamText', () => {
           await result.consumeStream();
           expect(onFinishResult.totalUsage).toMatchInlineSnapshot(`
             {
-              "cachedInputTokens": undefined,
               "inputTokenDetails": {
                 "cacheReadTokens": undefined,
                 "cacheWriteTokens": undefined,
@@ -21463,7 +21268,6 @@ describe('streamText', () => {
                 "textTokens": 922,
               },
               "outputTokens": 922,
-              "reasoningTokens": undefined,
               "totalTokens": 8842,
             }
           `);
@@ -21557,7 +21361,6 @@ describe('streamText', () => {
                   },
                   "type": "finish-step",
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -21570,7 +21373,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 725,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 4094,
                   },
                 },
@@ -21623,7 +21425,6 @@ describe('streamText', () => {
                   },
                   "type": "finish-step",
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -21636,7 +21437,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 0,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 0,
                   },
                 },
@@ -21689,7 +21489,6 @@ describe('streamText', () => {
                   },
                   "type": "finish-step",
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -21702,7 +21501,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 0,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 0,
                   },
                 },
@@ -21755,7 +21553,6 @@ describe('streamText', () => {
                   },
                   "type": "finish-step",
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -21768,7 +21565,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 0,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 0,
                   },
                 },
@@ -21883,7 +21679,6 @@ describe('streamText', () => {
                   },
                   "type": "finish-step",
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -21896,7 +21691,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 197,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 4748,
                   },
                 },
@@ -21904,7 +21698,6 @@ describe('streamText', () => {
                   "finishReason": "stop",
                   "rawFinishReason": "stop",
                   "totalUsage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -21916,7 +21709,6 @@ describe('streamText', () => {
                       "textTokens": 922,
                     },
                     "outputTokens": 922,
-                    "reasoningTokens": undefined,
                     "totalTokens": 8842,
                   },
                   "type": "finish",
@@ -22398,7 +22190,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -22411,7 +22202,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -22419,7 +22209,6 @@ describe('streamText', () => {
                 "finishReason": "tool-calls",
                 "rawFinishReason": undefined,
                 "totalUsage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -22431,7 +22220,6 @@ describe('streamText', () => {
                     "textTokens": 10,
                   },
                   "outputTokens": 10,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "type": "finish",
@@ -23210,7 +22998,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -23223,7 +23010,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -23231,7 +23017,6 @@ describe('streamText', () => {
                 "finishReason": "tool-calls",
                 "rawFinishReason": undefined,
                 "totalUsage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -23243,7 +23028,6 @@ describe('streamText', () => {
                     "textTokens": 10,
                   },
                   "outputTokens": 10,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "type": "finish",
@@ -23701,7 +23485,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -23714,7 +23497,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -23722,7 +23504,6 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "rawFinishReason": "stop",
                 "totalUsage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -23734,7 +23515,6 @@ describe('streamText', () => {
                     "textTokens": 10,
                   },
                   "outputTokens": 10,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "type": "finish",
@@ -24149,7 +23929,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -24162,7 +23941,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -24170,7 +23948,6 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "rawFinishReason": "stop",
                 "totalUsage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -24182,7 +23959,6 @@ describe('streamText', () => {
                     "textTokens": 10,
                   },
                   "outputTokens": 10,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "type": "finish",
@@ -24458,7 +24234,6 @@ describe('streamText', () => {
                 },
                 "type": "finish-step",
                 "usage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -24471,7 +24246,6 @@ describe('streamText', () => {
                   },
                   "outputTokens": 10,
                   "raw": undefined,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
               },
@@ -24479,7 +24253,6 @@ describe('streamText', () => {
                 "finishReason": "stop",
                 "rawFinishReason": "stop",
                 "totalUsage": {
-                  "cachedInputTokens": undefined,
                   "inputTokenDetails": {
                     "cacheReadTokens": undefined,
                     "cacheWriteTokens": undefined,
@@ -24491,7 +24264,6 @@ describe('streamText', () => {
                     "textTokens": 10,
                   },
                   "outputTokens": 10,
-                  "reasoningTokens": undefined,
                   "totalTokens": 13,
                 },
                 "type": "finish",
@@ -24637,7 +24409,6 @@ describe('streamText', () => {
                   },
                   "type": "finish-step",
                   "usage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -24650,7 +24421,6 @@ describe('streamText', () => {
                     },
                     "outputTokens": 10,
                     "raw": undefined,
-                    "reasoningTokens": undefined,
                     "totalTokens": 13,
                   },
                 },
@@ -24658,7 +24428,6 @@ describe('streamText', () => {
                   "finishReason": "tool-calls",
                   "rawFinishReason": undefined,
                   "totalUsage": {
-                    "cachedInputTokens": undefined,
                     "inputTokenDetails": {
                       "cacheReadTokens": undefined,
                       "cacheWriteTokens": undefined,
@@ -24670,7 +24439,6 @@ describe('streamText', () => {
                       "textTokens": 10,
                     },
                     "outputTokens": 10,
-                    "reasoningTokens": undefined,
                     "totalTokens": 13,
                   },
                   "type": "finish",

--- a/packages/ai/src/middleware/__snapshots__/simulate-streaming-middleware.test.ts.snap
+++ b/packages/ai/src/middleware/__snapshots__/simulate-streaming-middleware.test.ts.snap
@@ -25,7 +25,6 @@ exports[`simulateStreamingMiddleware > should handle empty text response 1`] = `
     },
     "type": "finish-step",
     "usage": {
-      "cachedInputTokens": 0,
       "inputTokenDetails": {
         "cacheReadTokens": 0,
         "cacheWriteTokens": 0,
@@ -38,7 +37,6 @@ exports[`simulateStreamingMiddleware > should handle empty text response 1`] = `
       },
       "outputTokens": 10,
       "raw": undefined,
-      "reasoningTokens": 3,
       "totalTokens": 15,
     },
   },
@@ -46,7 +44,6 @@ exports[`simulateStreamingMiddleware > should handle empty text response 1`] = `
     "finishReason": "stop",
     "rawFinishReason": "stop",
     "totalUsage": {
-      "cachedInputTokens": 0,
       "inputTokenDetails": {
         "cacheReadTokens": 0,
         "cacheWriteTokens": 0,
@@ -58,7 +55,6 @@ exports[`simulateStreamingMiddleware > should handle empty text response 1`] = `
         "textTokens": 10,
       },
       "outputTokens": 10,
-      "reasoningTokens": 3,
       "totalTokens": 15,
     },
     "type": "finish",

--- a/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
@@ -351,7 +351,6 @@ describe('extractReasoningMiddleware', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -364,7 +363,6 @@ describe('extractReasoningMiddleware', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": 3,
                 "totalTokens": 15,
               },
             },
@@ -372,7 +370,6 @@ describe('extractReasoningMiddleware', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -384,7 +381,6 @@ describe('extractReasoningMiddleware', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": 3,
                 "totalTokens": 15,
               },
               "type": "finish",
@@ -506,7 +502,6 @@ describe('extractReasoningMiddleware', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -519,7 +514,6 @@ describe('extractReasoningMiddleware', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": 3,
                 "totalTokens": 15,
               },
             },
@@ -527,7 +521,6 @@ describe('extractReasoningMiddleware', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -539,7 +532,6 @@ describe('extractReasoningMiddleware', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": 3,
                 "totalTokens": 15,
               },
               "type": "finish",
@@ -638,7 +630,6 @@ describe('extractReasoningMiddleware', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -651,7 +642,6 @@ describe('extractReasoningMiddleware', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": 3,
                 "totalTokens": 15,
               },
             },
@@ -659,7 +649,6 @@ describe('extractReasoningMiddleware', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -671,7 +660,6 @@ describe('extractReasoningMiddleware', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": 3,
                 "totalTokens": 15,
               },
               "type": "finish",
@@ -787,7 +775,6 @@ describe('extractReasoningMiddleware', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -800,7 +787,6 @@ describe('extractReasoningMiddleware', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": 3,
                 "totalTokens": 15,
               },
             },
@@ -808,7 +794,6 @@ describe('extractReasoningMiddleware', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -820,7 +805,6 @@ describe('extractReasoningMiddleware', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": 3,
                 "totalTokens": 15,
               },
               "type": "finish",
@@ -887,7 +871,6 @@ describe('extractReasoningMiddleware', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -900,7 +883,6 @@ describe('extractReasoningMiddleware', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": 3,
                 "totalTokens": 15,
               },
             },
@@ -908,7 +890,6 @@ describe('extractReasoningMiddleware', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -920,7 +901,6 @@ describe('extractReasoningMiddleware', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": 3,
                 "totalTokens": 15,
               },
               "type": "finish",
@@ -1001,7 +981,6 @@ describe('extractReasoningMiddleware', () => {
               },
               "type": "finish-step",
               "usage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -1014,7 +993,6 @@ describe('extractReasoningMiddleware', () => {
                 },
                 "outputTokens": 10,
                 "raw": undefined,
-                "reasoningTokens": 3,
                 "totalTokens": 15,
               },
             },
@@ -1022,7 +1000,6 @@ describe('extractReasoningMiddleware', () => {
               "finishReason": "stop",
               "rawFinishReason": "stop",
               "totalUsage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "cacheWriteTokens": 0,
@@ -1034,7 +1011,6 @@ describe('extractReasoningMiddleware', () => {
                   "textTokens": 10,
                 },
                 "outputTokens": 10,
-                "reasoningTokens": 3,
                 "totalTokens": 15,
               },
               "type": "finish",

--- a/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
+++ b/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
@@ -117,7 +117,6 @@ describe('simulateStreamingMiddleware', () => {
             },
             "type": "finish-step",
             "usage": {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -130,7 +129,6 @@ describe('simulateStreamingMiddleware', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": 3,
               "totalTokens": 15,
             },
           },
@@ -138,7 +136,6 @@ describe('simulateStreamingMiddleware', () => {
             "finishReason": "stop",
             "rawFinishReason": "stop",
             "totalUsage": {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -150,7 +147,6 @@ describe('simulateStreamingMiddleware', () => {
                 "textTokens": 10,
               },
               "outputTokens": 10,
-              "reasoningTokens": 3,
               "totalTokens": 15,
             },
             "type": "finish",
@@ -241,7 +237,6 @@ describe('simulateStreamingMiddleware', () => {
             },
             "type": "finish-step",
             "usage": {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -254,7 +249,6 @@ describe('simulateStreamingMiddleware', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": 3,
               "totalTokens": 15,
             },
           },
@@ -262,7 +256,6 @@ describe('simulateStreamingMiddleware', () => {
             "finishReason": "stop",
             "rawFinishReason": "stop",
             "totalUsage": {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -274,7 +267,6 @@ describe('simulateStreamingMiddleware', () => {
                 "textTokens": 10,
               },
               "outputTokens": 10,
-              "reasoningTokens": 3,
               "totalTokens": 15,
             },
             "type": "finish",
@@ -411,7 +403,6 @@ describe('simulateStreamingMiddleware', () => {
             },
             "type": "finish-step",
             "usage": {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -424,7 +415,6 @@ describe('simulateStreamingMiddleware', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": 3,
               "totalTokens": 15,
             },
           },
@@ -432,7 +422,6 @@ describe('simulateStreamingMiddleware', () => {
             "finishReason": "stop",
             "rawFinishReason": "stop",
             "totalUsage": {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -444,7 +433,6 @@ describe('simulateStreamingMiddleware', () => {
                 "textTokens": 10,
               },
               "outputTokens": 10,
-              "reasoningTokens": 3,
               "totalTokens": 15,
             },
             "type": "finish",
@@ -563,7 +551,6 @@ describe('simulateStreamingMiddleware', () => {
             },
             "type": "finish-step",
             "usage": {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -576,7 +563,6 @@ describe('simulateStreamingMiddleware', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": 3,
               "totalTokens": 15,
             },
           },
@@ -584,7 +570,6 @@ describe('simulateStreamingMiddleware', () => {
             "finishReason": "stop",
             "rawFinishReason": "stop",
             "totalUsage": {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -596,7 +581,6 @@ describe('simulateStreamingMiddleware', () => {
                 "textTokens": 10,
               },
               "outputTokens": 10,
-              "reasoningTokens": 3,
               "totalTokens": 15,
             },
             "type": "finish",
@@ -718,7 +702,6 @@ describe('simulateStreamingMiddleware', () => {
             },
             "type": "finish-step",
             "usage": {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -731,7 +714,6 @@ describe('simulateStreamingMiddleware', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": 3,
               "totalTokens": 15,
             },
           },
@@ -739,7 +721,6 @@ describe('simulateStreamingMiddleware', () => {
             "finishReason": "tool-calls",
             "rawFinishReason": undefined,
             "totalUsage": {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -751,7 +732,6 @@ describe('simulateStreamingMiddleware', () => {
                 "textTokens": 10,
               },
               "outputTokens": 10,
-              "reasoningTokens": 3,
               "totalTokens": 15,
             },
             "type": "finish",
@@ -825,7 +805,6 @@ describe('simulateStreamingMiddleware', () => {
             },
             "type": "finish-step",
             "usage": {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -838,7 +817,6 @@ describe('simulateStreamingMiddleware', () => {
               },
               "outputTokens": 10,
               "raw": undefined,
-              "reasoningTokens": 3,
               "totalTokens": 15,
             },
           },
@@ -846,7 +824,6 @@ describe('simulateStreamingMiddleware', () => {
             "finishReason": "stop",
             "rawFinishReason": "stop",
             "totalUsage": {
-              "cachedInputTokens": 0,
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
                 "cacheWriteTokens": 0,
@@ -858,7 +835,6 @@ describe('simulateStreamingMiddleware', () => {
                 "textTokens": 10,
               },
               "outputTokens": 10,
-              "reasoningTokens": 3,
               "totalTokens": 15,
             },
             "type": "finish",

--- a/packages/ai/src/types/usage.ts
+++ b/packages/ai/src/types/usage.ts
@@ -59,16 +59,6 @@ export type LanguageModelUsage = {
   totalTokens: number | undefined;
 
   /**
-   * @deprecated Use outputTokenDetails.reasoningTokens instead.
-   */
-  reasoningTokens?: number | undefined;
-
-  /**
-   * @deprecated Use inputTokenDetails.cacheReadTokens instead.
-   */
-  cachedInputTokens?: number | undefined;
-
-  /**
    * Raw usage information from the provider.
    *
    * This is the usage information in the shape that the provider returns.
@@ -108,8 +98,6 @@ export function asLanguageModelUsage(
       usage.outputTokens.total,
     ),
     raw: usage.raw,
-    reasoningTokens: usage.outputTokens.reasoning,
-    cachedInputTokens: usage.inputTokens.cacheRead,
   };
 }
 
@@ -163,14 +151,6 @@ export function addLanguageModelUsage(
       ),
     },
     totalTokens: addTokenCounts(usage1.totalTokens, usage2.totalTokens),
-    reasoningTokens: addTokenCounts(
-      usage1.reasoningTokens,
-      usage2.reasoningTokens,
-    ),
-    cachedInputTokens: addTokenCounts(
-      usage1.cachedInputTokens,
-      usage2.cachedInputTokens,
-    ),
   };
 }
 

--- a/packages/otel/src/legacy-open-telemetry.test.ts
+++ b/packages/otel/src/legacy-open-telemetry.test.ts
@@ -242,8 +242,6 @@ function makeStepFinishEvent(overrides?: Record<string, unknown>) {
       inputTokens: 10,
       outputTokens: 20,
       totalTokens: 30,
-      reasoningTokens: undefined,
-      cachedInputTokens: undefined,
       inputTokenDetails: {
         noCacheTokens: undefined,
         cacheReadTokens: undefined,
@@ -277,8 +275,6 @@ function makeFinishEvent(overrides?: Record<string, unknown>) {
       inputTokens: 10,
       outputTokens: 20,
       totalTokens: 30,
-      reasoningTokens: undefined,
-      cachedInputTokens: undefined,
       inputTokenDetails: {
         noCacheTokens: undefined,
         cacheReadTokens: undefined,

--- a/packages/otel/src/legacy-open-telemetry.ts
+++ b/packages/otel/src/legacy-open-telemetry.ts
@@ -420,8 +420,10 @@ export class LegacyOpenTelemetry implements Telemetry {
         'ai.usage.inputTokens': event.usage.inputTokens,
         'ai.usage.outputTokens': event.usage.outputTokens,
         'ai.usage.totalTokens': event.usage.totalTokens,
-        'ai.usage.reasoningTokens': event.usage.reasoningTokens,
-        'ai.usage.cachedInputTokens': event.usage.cachedInputTokens,
+        'ai.usage.reasoningTokens':
+          event.usage.outputTokenDetails?.reasoningTokens,
+        'ai.usage.cachedInputTokens':
+          event.usage.inputTokenDetails?.cacheReadTokens,
 
         'gen_ai.response.finish_reasons': [event.finishReason],
         'gen_ai.response.id': event.response.id,
@@ -688,8 +690,10 @@ export class LegacyOpenTelemetry implements Telemetry {
         'ai.usage.inputTokens': event.usage.inputTokens,
         'ai.usage.outputTokens': event.usage.outputTokens,
         'ai.usage.totalTokens': event.usage.totalTokens,
-        'ai.usage.reasoningTokens': event.usage.reasoningTokens,
-        'ai.usage.cachedInputTokens': event.usage.cachedInputTokens,
+        'ai.usage.reasoningTokens':
+          event.usage.outputTokenDetails?.reasoningTokens,
+        'ai.usage.cachedInputTokens':
+          event.usage.inputTokenDetails?.cacheReadTokens,
         'ai.usage.inputTokenDetails.noCacheTokens':
           event.usage.inputTokenDetails?.noCacheTokens,
         'ai.usage.inputTokenDetails.cacheReadTokens':
@@ -800,8 +804,10 @@ export class LegacyOpenTelemetry implements Telemetry {
         'ai.usage.inputTokens': event.totalUsage.inputTokens,
         'ai.usage.outputTokens': event.totalUsage.outputTokens,
         'ai.usage.totalTokens': event.totalUsage.totalTokens,
-        'ai.usage.reasoningTokens': event.totalUsage.reasoningTokens,
-        'ai.usage.cachedInputTokens': event.totalUsage.cachedInputTokens,
+        'ai.usage.reasoningTokens':
+          event.totalUsage.outputTokenDetails?.reasoningTokens,
+        'ai.usage.cachedInputTokens':
+          event.totalUsage.inputTokenDetails?.cacheReadTokens,
         'ai.usage.inputTokenDetails.noCacheTokens':
           event.totalUsage.inputTokenDetails?.noCacheTokens,
         'ai.usage.inputTokenDetails.cacheReadTokens':
@@ -841,8 +847,10 @@ export class LegacyOpenTelemetry implements Telemetry {
         'ai.usage.inputTokens': event.usage.inputTokens,
         'ai.usage.outputTokens': event.usage.outputTokens,
         'ai.usage.totalTokens': event.usage.totalTokens,
-        'ai.usage.reasoningTokens': event.usage.reasoningTokens,
-        'ai.usage.cachedInputTokens': event.usage.cachedInputTokens,
+        'ai.usage.reasoningTokens':
+          event.usage.outputTokenDetails?.reasoningTokens,
+        'ai.usage.cachedInputTokens':
+          event.usage.inputTokenDetails?.cacheReadTokens,
       }),
     );
 

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -227,8 +227,6 @@ function makeLanguageModelCallEndEvent(overrides?: Record<string, unknown>) {
       inputTokens: 10,
       outputTokens: 20,
       totalTokens: 30,
-      reasoningTokens: undefined,
-      cachedInputTokens: undefined,
       inputTokenDetails: {
         noCacheTokens: undefined,
         cacheReadTokens: undefined,
@@ -268,8 +266,6 @@ function makeStepFinishEvent(overrides?: Record<string, unknown>) {
       inputTokens: 10,
       outputTokens: 20,
       totalTokens: 30,
-      reasoningTokens: undefined,
-      cachedInputTokens: undefined,
       inputTokenDetails: {
         noCacheTokens: undefined,
         cacheReadTokens: undefined,
@@ -305,8 +301,6 @@ function makeFinishEvent(overrides?: Record<string, unknown>) {
       inputTokens: 10,
       outputTokens: 20,
       totalTokens: 30,
-      reasoningTokens: undefined,
-      cachedInputTokens: undefined,
       inputTokenDetails: {
         noCacheTokens: undefined,
         cacheReadTokens: undefined,
@@ -670,8 +664,6 @@ describe('OpenTelemetry', () => {
             inputTokens: 100,
             outputTokens: 50,
             totalTokens: 150,
-            reasoningTokens: 10,
-            cachedInputTokens: 30,
             inputTokenDetails: {
               noCacheTokens: 70,
               cacheReadTokens: 20,
@@ -690,8 +682,6 @@ describe('OpenTelemetry', () => {
             inputTokens: 100,
             outputTokens: 50,
             totalTokens: 150,
-            reasoningTokens: 10,
-            cachedInputTokens: 30,
             inputTokenDetails: {
               noCacheTokens: 70,
               cacheReadTokens: 20,
@@ -994,8 +984,6 @@ describe('OpenTelemetry', () => {
         inputTokens: 10,
         outputTokens: 20,
         totalTokens: 30,
-        reasoningTokens: 5,
-        cachedInputTokens: 2,
         inputTokenDetails: {
           noCacheTokens: 7,
           cacheReadTokens: 2,

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -405,7 +405,8 @@ export class OpenTelemetry implements Telemetry {
         'gen_ai.response.model': event.response.modelId,
         'gen_ai.usage.input_tokens': event.usage.inputTokens,
         'gen_ai.usage.output_tokens': event.usage.outputTokens,
-        'gen_ai.usage.cache_read.input_tokens': event.usage.cachedInputTokens,
+        'gen_ai.usage.cache_read.input_tokens':
+          event.usage.inputTokenDetails?.cacheReadTokens,
         'gen_ai.output.messages': {
           output: () => {
             try {
@@ -603,8 +604,7 @@ export class OpenTelemetry implements Telemetry {
         'gen_ai.usage.input_tokens': event.usage.inputTokens,
         'gen_ai.usage.output_tokens': event.usage.outputTokens,
         'gen_ai.usage.cache_read.input_tokens':
-          event.usage.inputTokenDetails?.cacheReadTokens ??
-          event.usage.cachedInputTokens,
+          event.usage.inputTokenDetails?.cacheReadTokens,
         'gen_ai.usage.cache_creation.input_tokens':
           event.usage.inputTokenDetails?.cacheWriteTokens,
         'gen_ai.output.messages': {
@@ -770,8 +770,7 @@ export class OpenTelemetry implements Telemetry {
         'gen_ai.usage.input_tokens': event.totalUsage.inputTokens,
         'gen_ai.usage.output_tokens': event.totalUsage.outputTokens,
         'gen_ai.usage.cache_read.input_tokens':
-          event.totalUsage.inputTokenDetails?.cacheReadTokens ??
-          event.totalUsage.cachedInputTokens,
+          event.totalUsage.inputTokenDetails?.cacheReadTokens,
         'gen_ai.usage.cache_creation.input_tokens':
           event.totalUsage.inputTokenDetails?.cacheWriteTokens,
         'gen_ai.output.messages': {
@@ -818,7 +817,8 @@ export class OpenTelemetry implements Telemetry {
         'gen_ai.response.finish_reasons': [event.finishReason],
         'gen_ai.usage.input_tokens': event.usage.inputTokens,
         'gen_ai.usage.output_tokens': event.usage.outputTokens,
-        'gen_ai.usage.cache_read.input_tokens': event.usage.cachedInputTokens,
+        'gen_ai.usage.cache_read.input_tokens':
+          event.usage.inputTokenDetails?.cacheReadTokens,
         'gen_ai.output.messages': {
           output: () =>
             event.object != null


### PR DESCRIPTION
## Background

The `LanguageModelUsage` `reasoningTokens` and `cachedInputTokens` properties were deprecated in AI SDK 6.

## Summary

Remove the `LanguageModelUsage` `reasoningTokens` and `cachedInputTokens` properties.