### PR TITLE
docs(content): add MongoDB memory provider to agents memory page

### DIFF
--- a/content/docs/03-agents/06-memory.mdx
+++ b/content/docs/03-agents/06-memory.mdx
@@ -207,6 +207,55 @@ The `bankId` identifies the memory store and is typically a user ID. In multi-us
 
 See the [Hindsight provider documentation](/providers/community-providers/hindsight) for full setup and configuration.
 
+### MongoDB
+
+[`@mongodb-developer/vercel-ai-memory`](https://www.npmjs.com/package/@mongodb-developer/vercel-ai-memory) provides MongoDB Atlas-backed persistent memory with five structured tiers: **Session**, **Semantic**, **Procedural**, **Episodic**, and **Scratchpad**. Retrieval is powered by Atlas Vector Search using any AI SDK embedding model, with automatic index creation and per-type retention policies.
+
+```bash
+pnpm add @mongodb-developer/vercel-ai-memory
+```
+
+This integration targets AI SDK v6 because it relies on v6 APIs such as `ModelMessage`, `ToolLoopAgent`, and `isLoopFinished()`:
+
+```json
+{
+  "peerDependencies": {
+    "ai": "^6.0.0",
+    "mongodb": "^6.0.0",
+    "zod": "^3.0.0"
+  }
+}
+```
+
+```ts
+import { createMongoDBMemory } from '@mongodb-developer/vercel-ai-memory';
+import { openai } from '@ai-sdk/openai';
+import { ToolLoopAgent, isLoopFinished } from 'ai';
+
+// Create the memory instance once at module/server level
+const mongodbMemory = createMongoDBMemory({
+  uri: process.env.MONGODB_URI!,
+  embedder: openai.embedding('text-embedding-3-small'),
+});
+
+// Scope to a user and session per request
+const agent = new ToolLoopAgent({
+  model: openai('gpt-4.1'),
+  tools: mongodbMemory({ userId: 'alice', sessionId: 'sess-001' }),
+  stopWhen: isLoopFinished(),
+});
+
+const result = await agent.generate({
+  prompt: 'My name is Alice and I love hiking. Remember that.',
+});
+```
+
+`isLoopFinished()` lets the agent keep running until the tool loop naturally finishes, which is useful when memory tools need to read and write before the final response.
+
+Session memory supports two modes: **tool-driven** (the LLM decides when to read/write — good for prototypes) and **hook-driven** (the runtime persists every turn via `prepareCall` + `onFinish` hooks — recommended for production). The other memory tiers (semantic, procedural, episodic, scratchpad) are always LLM-controlled and selective by design.
+
+MongoDB memory works with any AI SDK model and embedding provider, with no vendor lock-in beyond MongoDB Atlas.
+
 **When to use memory providers**: these providers are a good fit when you want memory without building any storage infrastructure. The tradeoff is that the provider controls memory behavior, so you have less visibility into what gets stored and how it is retrieved. You also take on a dependency on an external service.
 
 ## Custom Tool


### PR DESCRIPTION
## Background

The agents memory documentation page lists several memory provider options (Letta, Mem0, Supermemory, Hindsight) but is missing the [`@mongodb-developer/vercel-ai-memory`](https://www.npmjs.com/package/@mongodb-developer/vercel-ai-memory) package, which is a production-ready MongoDB Atlas-backed memory provider for the AI SDK. Adding it gives users another well-supported option before resorting to building a fully custom tool.

## Summary

Added a new **### MongoDB** subsection under **## Memory Providers** in `content/docs/03-agents/06-memory.mdx`, placed before the **Custom Tool** section. The section includes:

- A brief description of the package and its five memory tiers (Session, Semantic, Procedural, Episodic, Scratchpad) with Atlas Vector Search
- Install snippet (`pnpm add @mongodb-developer/vercel-ai-memory`)
- Quick Start code example using `createMongoDBMemory` + `ToolLoopAgent`
- Brief explanation of tool-driven vs hook-driven session modes
- Note that the package works with any AI SDK model and embedding provider

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)