### PR TITLE
feat(ai): allow prepareStep to override sandbox per step

### DIFF
--- a/.changeset/wet-geckos-float.md
+++ b/.changeset/wet-geckos-float.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): allow prepareStep to override sandbox per step

--- a/content/docs/03-agents/04-loop-control.mdx
+++ b/content/docs/03-agents/04-loop-control.mdx
@@ -310,6 +310,40 @@ const result = await agent.generate({
 });
 ```
 
+### Sandbox Selection
+
+Switch the sandbox used for tool execution in a single step:
+
+```ts
+import { ToolLoopAgent } from 'ai';
+__PROVIDER_IMPORT__;
+
+const agent = new ToolLoopAgent({
+  model: __MODEL__,
+  tools: {
+    runCommand,
+  },
+  sandbox: defaultSandbox,
+  prepareStep: async ({ stepNumber }) => {
+    if (stepNumber === 0) {
+      return {
+        sandbox: setupSandbox,
+      };
+    }
+
+    return {};
+  },
+});
+
+const result = await agent.generate({
+  prompt: '...',
+});
+```
+
+Unlike `runtimeContext` and `toolsContext`, a sandbox returned from `prepareStep`
+only applies to tool execution in that step. Later steps use the top-level
+`sandbox` unless they return their own sandbox override.
+
 ## Access Step Information
 
 Both `stopWhen` and `prepareStep` receive detailed information about the current execution:

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -590,7 +590,7 @@ To see `generateText` in action, check out [these examples](#examples).
       type: '(options: PrepareStepOptions) => PrepareStepResult<TOOLS> | Promise<PrepareStepResult<TOOLS>>',
       isOptional: true,
       description:
-        'Optional function that you can use to provide different settings for a step. You can modify the model, tool choices, active tools, system prompt, and input messages for each step.',
+        'Optional function that you can use to provide different settings for a step. You can modify the model, tool choices, active tools, system prompt, input messages, and sandbox for each step.',
       properties: [
         {
           type: 'PrepareStepFunction<TOOLS>',
@@ -703,6 +703,13 @@ To see `generateText` in action, check out [these examples](#examples).
               type: 'InferToolSetContext<TOOLS>',
               description:
                 'Per-tool context map. Changing it will affect tool-specific context in this step and all subsequent steps.',
+            },
+            {
+              name: 'sandbox',
+              type: 'Sandbox',
+              isOptional: true,
+              description:
+                'Sandbox environment for this step. Changing it will affect tool execution in this step only.',
             },
             {
               name: 'providerOptions',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -634,7 +634,7 @@ To see `streamText` in action, check out [these examples](#examples).
       type: '(options: PrepareStepOptions) => PrepareStepResult<TOOLS> | Promise<PrepareStepResult<TOOLS>>',
       isOptional: true,
       description:
-        'Optional function that you can use to provide different settings for a step. You can modify the model, tool choices, active tools, system prompt, and input messages for each step.',
+        'Optional function that you can use to provide different settings for a step. You can modify the model, tool choices, active tools, system prompt, input messages, and sandbox for each step.',
       properties: [
         {
           type: 'PrepareStepFunction<TOOLS>',
@@ -747,6 +747,13 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'InferToolSetContext<TOOLS>',
               description:
                 'Per-tool context map. Changing it will affect tool-specific context in this step and all subsequent steps.',
+            },
+            {
+              name: 'sandbox',
+              type: 'Sandbox',
+              isOptional: true,
+              description:
+                'Sandbox environment for this step. Changing it will affect tool execution in this step only.',
             },
             {
               name: 'providerOptions',

--- a/packages/ai/src/generate-text/generate-text.test-d.ts
+++ b/packages/ai/src/generate-text/generate-text.test-d.ts
@@ -338,6 +338,23 @@ describe('generateText types', () => {
           },
         });
       });
+
+      it('should accept sandbox overrides', async () => {
+        generateText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          prepareStep: () => ({
+            sandbox: {
+              description: 'test sandbox',
+              executeCommand: async () => ({
+                exitCode: 0,
+                stdout: 'ok',
+                stderr: '',
+              }),
+            },
+          }),
+        });
+      });
     });
 
     it('should pass the runtimeContext type into toolApproval callbacks', async () => {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -7739,6 +7739,85 @@ describe('generateText', () => {
       expect(capturedSandbox).toBe(sandbox);
     });
 
+    it('should use sandbox returned from prepareStep for that step only', async () => {
+      const sandbox = {
+        description: 'default sandbox',
+        executeCommand: vi.fn(async () => ({
+          exitCode: 0,
+          stdout: 'ok',
+          stderr: '',
+        })),
+      } satisfies Sandbox;
+      const stepSandbox = {
+        description: 'step sandbox',
+        executeCommand: vi.fn(async () => ({
+          exitCode: 0,
+          stdout: 'ok',
+          stderr: '',
+        })),
+      } satisfies Sandbox;
+      const recordedSandboxes: Array<Sandbox | undefined> = [];
+      let responseCount = 0;
+
+      await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            switch (responseCount++) {
+              case 0:
+                return {
+                  ...dummyResponseValues,
+                  content: [
+                    {
+                      type: 'tool-call',
+                      toolCallType: 'function',
+                      toolCallId: 'call-1',
+                      toolName: 't1',
+                      input: `{ "value": "first" }`,
+                    },
+                  ],
+                  finishReason: { unified: 'tool-calls', raw: undefined },
+                };
+              case 1:
+                return {
+                  ...dummyResponseValues,
+                  content: [
+                    {
+                      type: 'tool-call',
+                      toolCallType: 'function',
+                      toolCallId: 'call-2',
+                      toolName: 't1',
+                      input: `{ "value": "second" }`,
+                    },
+                  ],
+                  finishReason: { unified: 'tool-calls', raw: undefined },
+                };
+              default:
+                return {
+                  ...dummyResponseValues,
+                  content: [{ type: 'text', text: 'done' }],
+                };
+            }
+          },
+        }),
+        tools: {
+          t1: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }, { sandbox }) => {
+              recordedSandboxes.push(sandbox);
+              return { value };
+            },
+          }),
+        },
+        sandbox,
+        prepareStep: async ({ stepNumber }) =>
+          stepNumber === 0 ? { sandbox: stepSandbox } : {},
+        prompt: 'test-input',
+        stopWhen: isStepCount(3),
+      });
+
+      expect(recordedSandboxes).toEqual([stepSandbox, sandbox]);
+    });
+
     it('should send runtimeContext in onFinish callback', async () => {
       let recordedContext: unknown | undefined;
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -654,6 +654,8 @@ export async function generateText<
           sandbox,
         });
 
+        const stepSandbox = prepareStepResult?.sandbox ?? sandbox;
+
         const stepModel = resolveLanguageModel(
           prepareStepResult?.model ?? model,
         );
@@ -941,7 +943,7 @@ export async function generateText<
               messages: stepInputMessages,
               abortSignal: mergedAbortSignal,
               timeout,
-              sandbox,
+              sandbox: stepSandbox,
               toolsContext,
               onToolExecutionStart: event =>
                 notify({

--- a/packages/ai/src/generate-text/prepare-step.ts
+++ b/packages/ai/src/generate-text/prepare-step.ts
@@ -121,6 +121,13 @@ export type PrepareStepResult<
       runtimeContext?: RUNTIME_CONTEXT;
 
       /**
+       * The sandbox environment that the step is operating in.
+       *
+       * Changing the sandbox will affect tool execution in this step only.
+       */
+      sandbox?: Sandbox;
+
+      /**
        * Additional provider-specific options for this step.
        *
        * Can be used to pass provider-specific configuration such as

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -470,6 +470,23 @@ describe('streamText types', () => {
           },
         });
       });
+
+      it('should accept sandbox overrides', async () => {
+        streamText({
+          model: new MockLanguageModelV4(),
+          prompt: 'Hello',
+          prepareStep: () => ({
+            sandbox: {
+              description: 'test sandbox',
+              executeCommand: async () => ({
+                exitCode: 0,
+                stdout: 'ok',
+                stderr: '',
+              }),
+            },
+          }),
+        });
+      });
     });
 
     it('should pass the runtimeContext type into toolApproval callbacks', async () => {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -19358,6 +19358,99 @@ describe('streamText', () => {
       expect(capturedSandbox).toBe(sandbox);
     });
 
+    it('should use sandbox returned from prepareStep for that step only', async () => {
+      const sandbox = {
+        description: 'default sandbox',
+        executeCommand: vi.fn(async () => ({
+          exitCode: 0,
+          stdout: 'ok',
+          stderr: '',
+        })),
+      } satisfies Sandbox;
+      const stepSandbox = {
+        description: 'step sandbox',
+        executeCommand: vi.fn(async () => ({
+          exitCode: 0,
+          stdout: 'ok',
+          stderr: '',
+        })),
+      } satisfies Sandbox;
+      const recordedSandboxes: Array<Sandbox | undefined> = [];
+      let responseCount = 0;
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            switch (responseCount++) {
+              case 0:
+                return {
+                  stream: convertArrayToReadableStream([
+                    {
+                      type: 'tool-call',
+                      toolCallId: 'call-1',
+                      toolName: 't1',
+                      input: `{ "value": "first" }`,
+                    },
+                    {
+                      type: 'finish',
+                      finishReason: { unified: 'tool-calls', raw: undefined },
+                      usage: testUsage,
+                    },
+                  ]),
+                };
+              case 1:
+                return {
+                  stream: convertArrayToReadableStream([
+                    {
+                      type: 'tool-call',
+                      toolCallId: 'call-2',
+                      toolName: 't1',
+                      input: `{ "value": "second" }`,
+                    },
+                    {
+                      type: 'finish',
+                      finishReason: { unified: 'tool-calls', raw: undefined },
+                      usage: testUsage,
+                    },
+                  ]),
+                };
+              default:
+                return {
+                  stream: convertArrayToReadableStream([
+                    { type: 'text-start', id: '1' },
+                    { type: 'text-delta', id: '1', delta: 'done' },
+                    { type: 'text-end', id: '1' },
+                    {
+                      type: 'finish',
+                      finishReason: { unified: 'stop', raw: 'stop' },
+                      usage: testUsage,
+                    },
+                  ]),
+                };
+            }
+          },
+        }),
+        tools: {
+          t1: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }, { sandbox }) => {
+              recordedSandboxes.push(sandbox);
+              return { value };
+            },
+          }),
+        },
+        sandbox,
+        prepareStep: async ({ stepNumber }) =>
+          stepNumber === 0 ? { sandbox: stepSandbox } : {},
+        prompt: 'test-input',
+        stopWhen: isStepCount(3),
+      });
+
+      await result.consumeStream();
+
+      expect(recordedSandboxes).toEqual([stepSandbox, sandbox]);
+    });
+
     it('should send runtimeContext in onFinish callback', async () => {
       let recordedContext: unknown | undefined;
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1588,6 +1588,8 @@ class DefaultStreamTextResult<
             sandbox,
           });
 
+          const stepSandbox = prepareStepResult?.sandbox ?? sandbox;
+
           const stepModel = resolveLanguageModel(
             prepareStepResult?.model ?? model,
           );
@@ -1696,7 +1698,7 @@ class DefaultStreamTextResult<
               messages: stepInputMessages,
               abortSignal,
               timeout,
-              sandbox,
+              sandbox: stepSandbox,
               toolsContext,
               toolApproval,
               runtimeContext,


### PR DESCRIPTION
## Background

We introduced a `Sandbox` abstraction in #14949

It should be possible to change/determine the sandbox in `prepareStep`.

## Summary

Allow changing the sandbox in `prepareStep`.

## Related Issues

Follow up from #14949