### PR TITLE
fix(ai): limit response messages in StepResult to messages created in that step

### DIFF
--- a/.changeset/hot-beds-wink.md
+++ b/.changeset/hot-beds-wink.md
@@ -1,0 +1,5 @@
+---
+"ai": major
+---
+
+fix(ai): limit response messages in StepResult to messages created in that step

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -478,7 +478,7 @@ It is called with the following parameters:
 - `steps`: The steps that have been executed so far.
 - `messages`: The messages that will be sent to the model for the current step.
 - `initialMessages`: The messages that were passed into `generateText` or `streamText`.
-- `responseMessages`: The response messages that have been accumulated from previous steps.
+- `responseMessages`: The accumulated assistant/tool response messages so far, including any tool results generated before the first model step from approved tool calls in the input messages.
 - `runtimeContext`: The runtime context passed via the `runtimeContext` setting.
 - `toolsContext`: The per-tool context map passed via the `toolsContext` setting.
 - `sandbox`: The sandbox passed via the `sandbox` setting.
@@ -512,7 +512,7 @@ const result = await generateText({
 In longer agentic loops, you can use the `messages` parameter to modify the input messages for each step. This is particularly useful for prompt compression.
 
 The `messages` parameter contains `initialMessages` followed by the accumulated `responseMessages`.
-Use `initialMessages` when you need to preserve the original user-provided prompt and `responseMessages` when you only need the assistant/tool messages from previous steps.
+Use `initialMessages` when you need to preserve the original user-provided prompt and `responseMessages` when you only need the accumulated assistant/tool response messages.
 
 ```tsx
 prepareStep: async ({ stepNumber, steps, messages }) => {
@@ -547,7 +547,7 @@ Both `generateText` and `streamText` have a `responseMessages` property that you
 add the assistant and tool messages to your conversation history.
 It is also available in the `onFinish` callback of `streamText`.
 
-The `responseMessages` property contains an array of `ModelMessage` objects that you can add to your conversation history:
+The `responseMessages` property contains the accumulated response messages from the call as an array of `ModelMessage` objects that you can add to your conversation history:
 
 ```ts
 import { generateText, ModelMessage } from 'ai';

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -1673,7 +1673,7 @@ To see `generateText` in action, check out [these examples](#examples).
                       name: 'messages',
                       type: 'Array<ResponseMessage>',
                       description:
-                        'The response messages that were generated during the call.',
+                        'The response messages generated during this step.',
                     },
                     {
                       name: 'body',
@@ -1697,7 +1697,7 @@ To see `generateText` in action, check out [these examples](#examples).
               name: 'responseMessages',
               type: 'Array<ResponseMessage>',
               description:
-                'The response messages that were generated during the call.',
+                'The accumulated response messages that were generated during the call.',
             },
           ],
         },
@@ -2106,7 +2106,7 @@ To see `generateText` in action, check out [these examples](#examples).
                       name: 'messages',
                       type: 'Array<ResponseMessage>',
                       description:
-                        'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
+                        'The response messages generated during this step. It consists of an assistant message, potentially containing tool calls. When there are tool results in this step, there is an additional tool message with the available tool results. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
                     },
                   ],
                 },
@@ -2122,7 +2122,7 @@ To see `generateText` in action, check out [these examples](#examples).
               name: 'responseMessages',
               type: 'Array<ResponseMessage>',
               description:
-                'The response messages that were generated during the call.',
+                'The accumulated response messages that were generated during the call.',
             },
             {
               name: 'runtimeContext',
@@ -2526,7 +2526,7 @@ To see `generateText` in action, check out [these examples](#examples).
               name: 'messages',
               type: 'Array<ResponseMessage>',
               description:
-                'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
+                'The response messages generated during the final step. It consists of an assistant message, potentially containing tool calls. When there are tool results in the final step, there is an additional tool message with the available tool results. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
             },
           ],
         },
@@ -2542,7 +2542,7 @@ To see `generateText` in action, check out [these examples](#examples).
       name: 'responseMessages',
       type: 'Array<ResponseMessage>',
       description:
-        'The response messages that were generated during the call.',
+        'The accumulated response messages that were generated during the call.',
     },
     {
       name: 'providerMetadata',
@@ -2905,7 +2905,7 @@ To see `generateText` in action, check out [these examples](#examples).
                       name: 'messages',
                       type: 'Array<ResponseMessage>',
                       description:
-                        'The response messages that were generated during the call. Response messages can be either assistant messages or tool messages. They contain a generated id.',
+                        'The response messages generated during this step. Response messages can be either assistant messages or tool messages. They contain a generated id.',
                     },
                   ],
                 },

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1840,7 +1840,7 @@ To see `streamText` in action, check out [these examples](#examples).
                       name: 'messages',
                       type: 'Array<ResponseMessage>',
                       description:
-                        'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
+                        'The response messages generated during this step. It consists of an assistant message, potentially containing tool calls. When there are tool results in this step, there is an additional tool message with the available tool results. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
                     },
                   ],
                 },
@@ -2711,7 +2711,7 @@ To see `streamText` in action, check out [these examples](#examples).
               name: 'messages',
               type: 'Array<ResponseMessage>',
               description:
-                'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
+                'The response messages generated during the final step. It consists of an assistant message, potentially containing tool calls. When there are tool results in the final step, there is an additional tool message with the available tool results. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
             },
           ],
         },
@@ -2727,7 +2727,7 @@ To see `streamText` in action, check out [these examples](#examples).
       name: 'responseMessages',
       type: 'Promise<Array<ResponseMessage>>',
       description:
-        'The response messages that were generated during the call.',
+        'The accumulated response messages that were generated during the call.',
     },
     {
       name: 'steps',
@@ -2996,7 +2996,7 @@ To see `streamText` in action, check out [these examples](#examples).
                       name: 'messages',
                       type: 'Array<ResponseMessage>',
                       description:
-                        'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
+                        'The response messages generated during this step. It consists of an assistant message, potentially containing tool calls. When there are tool results in this step, there is an additional tool message with the available tool results. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
                     },
                   ],
                 },

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -402,6 +402,42 @@ const result = streamText({
 });
 ```
 
+### Step Response Messages Are No Longer Accumulated
+
+In AI SDK 7, `step.response.messages` on each `StepResult` only contains the
+response messages produced by that particular step.
+
+In AI SDK 6, `step.response.messages` accumulated response messages from all
+previous steps. If your application reads `step.response.messages` from an
+intermediate or final step and expects the full assistant/tool message history,
+use the top-level `result.responseMessages` instead.
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Use tools if needed',
+  tools,
+  stopWhen: isStepCount(5),
+});
+
+// Accumulated response messages from all steps:
+const responseMessages = result.responseMessages;
+
+// Response messages produced by each individual step:
+const stepMessages = result.steps.map(step => step.response.messages);
+```
+
+If you specifically need to reconstruct response messages from step results,
+flatten the per-step messages:
+
+```tsx filename="AI SDK 7"
+const responseMessages = result.steps.flatMap(step => step.response.messages);
+```
+
+Prefer `result.responseMessages` when you want the full response message history.
+It also includes response messages produced before the first model step, such as
+tool results from approved tool calls in the input messages.
+
 ### Context: `experimental_context` Became Tool `context`, and Shared Runtime Data Moved to `runtimeContext`
 
 In AI SDK 7, the tool callback option previously exposed as `experimental_context` has been renamed to `context` and is now stable.

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -72,35 +72,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       {
         "content": [
           {
-            "input": {
-              "value": "value",
-            },
-            "providerExecuted": undefined,
-            "providerOptions": undefined,
-            "toolCallId": "call-1",
-            "toolName": "tool1",
-            "type": "tool-call",
-          },
-        ],
-        "role": "assistant",
-      },
-      {
-        "content": [
-          {
-            "output": {
-              "type": "text",
-              "value": "result1",
-            },
-            "toolCallId": "call-1",
-            "toolName": "tool1",
-            "type": "tool-result",
-          },
-        ],
-        "role": "tool",
-      },
-      {
-        "content": [
-          {
             "providerOptions": undefined,
             "text": "Hello, world!",
             "type": "text",
@@ -281,35 +252,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
         },
         "id": "test-id-2-from-model",
         "messages": [
-          {
-            "content": [
-              {
-                "input": {
-                  "value": "value",
-                },
-                "providerExecuted": undefined,
-                "providerOptions": undefined,
-                "toolCallId": "call-1",
-                "toolName": "tool1",
-                "type": "tool-call",
-              },
-            ],
-            "role": "assistant",
-          },
-          {
-            "content": [
-              {
-                "output": {
-                  "type": "text",
-                  "value": "result1",
-                },
-                "toolCallId": "call-1",
-                "toolName": "tool1",
-                "type": "tool-result",
-              },
-            ],
-            "role": "tool",
-          },
           {
             "content": [
               {
@@ -512,35 +454,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       },
       "id": "test-id-2-from-model",
       "messages": [
-        {
-          "content": [
-            {
-              "input": {
-                "value": "value",
-              },
-              "providerExecuted": undefined,
-              "providerOptions": undefined,
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-call",
-            },
-          ],
-          "role": "assistant",
-        },
-        {
-          "content": [
-            {
-              "output": {
-                "type": "text",
-                "value": "result1",
-              },
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-result",
-            },
-          ],
-          "role": "tool",
-        },
         {
           "content": [
             {
@@ -751,35 +664,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
         {
           "content": [
             {
-              "input": {
-                "value": "value",
-              },
-              "providerExecuted": undefined,
-              "providerOptions": undefined,
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-call",
-            },
-          ],
-          "role": "assistant",
-        },
-        {
-          "content": [
-            {
-              "output": {
-                "type": "text",
-                "value": "result1",
-              },
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-result",
-            },
-          ],
-          "role": "tool",
-        },
-        {
-          "content": [
-            {
               "providerOptions": undefined,
               "text": "Hello, world!",
               "type": "text",
@@ -942,35 +826,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
       },
       "id": "test-id-2-from-model",
       "messages": [
-        {
-          "content": [
-            {
-              "input": {
-                "value": "value",
-              },
-              "providerExecuted": undefined,
-              "providerOptions": undefined,
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-call",
-            },
-          ],
-          "role": "assistant",
-        },
-        {
-          "content": [
-            {
-              "output": {
-                "type": "text",
-                "value": "result1",
-              },
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-result",
-            },
-          ],
-          "role": "tool",
-        },
         {
           "content": [
             {
@@ -1182,35 +1037,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
       },
       "id": "test-id-2-from-model",
       "messages": [
-        {
-          "content": [
-            {
-              "input": {
-                "value": "value",
-              },
-              "providerExecuted": undefined,
-              "providerOptions": undefined,
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-call",
-            },
-          ],
-          "role": "assistant",
-        },
-        {
-          "content": [
-            {
-              "output": {
-                "type": "text",
-                "value": "result1",
-              },
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-result",
-            },
-          ],
-          "role": "tool",
-        },
         {
           "content": [
             {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -4156,35 +4156,6 @@ describe('generateText', () => {
                       {
                         "content": [
                           {
-                            "input": {
-                              "value": "value",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "text",
-                              "value": "result1",
-                            },
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                      {
-                        "content": [
-                          {
                             "providerOptions": undefined,
                             "text": "Hello, world!",
                             "type": "text",
@@ -4388,35 +4359,6 @@ describe('generateText', () => {
                     },
                     "id": "test-id-2-from-model",
                     "messages": [
-                      {
-                        "content": [
-                          {
-                            "input": {
-                              "value": "value",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "text",
-                              "value": "result1",
-                            },
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
                       {
                         "content": [
                           {
@@ -7100,7 +7042,7 @@ describe('generateText', () => {
       });
 
       describe('result.responseMessages', () => {
-        it('should contain all response messages from all steps', () => {
+        it('should contain response messages from all steps', () => {
           expect(result.responseMessages).toMatchInlineSnapshot(`
             [
               {
@@ -7638,7 +7580,7 @@ describe('generateText', () => {
           `);
         });
 
-        it('should contain all response messages', () => {
+        it('should contain response messages from all steps', () => {
           expect(onFinishResult.responseMessages.length).toBe(9);
         });
       });
@@ -9174,6 +9116,86 @@ describe('generateText', () => {
               ],
               "role": "assistant",
             },
+          ]
+        `);
+      });
+
+      it('should pass the initial tool result in responseMessages to prepareStep', async () => {
+        const prepareStepResponseMessages: Array<ModelMessage[]> = [];
+
+        await generateText({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => ({
+              ...dummyResponseValues,
+              content: [{ type: 'text', text: 'Hello, world!' }],
+              finishReason: { unified: 'stop', raw: 'stop' },
+            }),
+          }),
+          tools: {
+            tool1: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: () => 'result1',
+            }),
+          },
+          toolApproval: {
+            tool1: 'user-approval',
+          },
+          stopWhen: isStepCount(3),
+          messages: [
+            { role: 'user', content: 'test-input' },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  input: { value: 'value' },
+                  providerExecuted: undefined,
+                  providerOptions: undefined,
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  type: 'tool-call',
+                },
+                {
+                  approvalId: 'id-1',
+                  toolCallId: 'call-1',
+                  type: 'tool-approval-request',
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  approvalId: 'id-1',
+                  type: 'tool-approval-response',
+                  approved: true,
+                },
+              ],
+            },
+          ],
+          prepareStep: ({ responseMessages }) => {
+            prepareStepResponseMessages.push([...responseMessages]);
+            return undefined;
+          },
+        });
+
+        expect(prepareStepResponseMessages).toMatchInlineSnapshot(`
+          [
+            [
+              {
+                "content": [
+                  {
+                    "output": {
+                      "type": "text",
+                      "value": "result1",
+                    },
+                    "toolCallId": "call-1",
+                    "toolName": "tool1",
+                    "type": "tool-result",
+                  },
+                ],
+                "role": "tool",
+              },
+            ],
           ]
         `);
       });

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -525,7 +525,7 @@ export async function generateText<
 
   try {
     const initialMessages = initialPrompt.messages;
-    const responseMessages: Array<ResponseMessage> = [];
+    const initialResponseMessages: Array<ResponseMessage> = [];
 
     const { approvedToolApprovals, deniedToolApprovals } =
       collectToolApprovals<TOOLS>({ messages: initialMessages });
@@ -609,7 +609,7 @@ export async function generateText<
         });
       }
 
-      responseMessages.push({
+      initialResponseMessages.push({
         role: 'tool',
         content: toolContent,
       });
@@ -642,7 +642,14 @@ export async function generateText<
       });
 
       try {
-        const stepInputMessages = [...initialMessages, ...responseMessages];
+        const accumulatedResponseMessages = [
+          ...initialResponseMessages,
+          ...steps.flatMap(step => step.response.messages),
+        ];
+        const stepInputMessages = [
+          ...initialMessages,
+          ...accumulatedResponseMessages,
+        ];
 
         const prepareStepResult = await prepareStep?.({
           model,
@@ -650,7 +657,7 @@ export async function generateText<
           stepNumber: steps.length,
           messages: stepInputMessages,
           initialMessages,
-          responseMessages,
+          responseMessages: accumulatedResponseMessages,
           runtimeContext,
           toolsContext,
           sandbox,
@@ -1005,13 +1012,10 @@ export async function generateText<
           tools,
         });
 
-        // append to messages for potential next step:
-        responseMessages.push(
-          ...(await toResponseMessages({
-            content: stepContent,
-            tools,
-          })),
-        );
+        const stepResponseMessages = await toResponseMessages({
+          content: stepContent,
+          tools,
+        });
 
         // Add step information (after response messages are updated):
         // Conditionally include request.body and response.body based on include settings.
@@ -1028,8 +1032,8 @@ export async function generateText<
 
         const stepResponse = {
           ...currentModelResponse.response,
-          // deep clone msgs to avoid mutating past messages in multi-step:
-          messages: cloneModelMessages(responseMessages),
+          // deep clone msgs to avoid mutating step results in multi-step:
+          messages: cloneModelMessages(stepResponseMessages),
           // Conditionally include response body:
           body: include.responseBody
             ? currentModelResponse.response?.body
@@ -1120,7 +1124,10 @@ export async function generateText<
       dynamicToolResults: lastStep.dynamicToolResults,
       request: lastStep.request,
       response: lastStep.response,
-      responseMessages: lastStep.response.messages,
+      responseMessages: [
+        ...initialResponseMessages,
+        ...steps.flatMap(step => step.response.messages),
+      ],
       warnings: lastStep.warnings,
       providerMetadata: lastStep.providerMetadata,
       steps,
@@ -1148,6 +1155,7 @@ export async function generateText<
     }
 
     return new DefaultGenerateTextResult({
+      initialResponseMessages,
       steps,
       totalUsage,
       output: resolvedOutput,
@@ -1217,14 +1225,18 @@ class DefaultGenerateTextResult<
   private readonly _output: InferCompleteOutput<OUTPUT> | undefined;
 
   constructor(options: {
+    initialResponseMessages: Array<ResponseMessage>;
     steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['steps'];
     output: InferCompleteOutput<OUTPUT> | undefined;
     totalUsage: LanguageModelUsage;
   }) {
+    this.initialResponseMessages = options.initialResponseMessages;
     this.steps = options.steps;
     this._output = options.output;
     this.totalUsage = options.totalUsage;
   }
+
+  private readonly initialResponseMessages: Array<ResponseMessage>;
 
   private get finalStep() {
     return this.steps[this.steps.length - 1];
@@ -1299,7 +1311,10 @@ class DefaultGenerateTextResult<
   }
 
   get responseMessages() {
-    return this.finalStep.response.messages;
+    return [
+      ...this.initialResponseMessages,
+      ...this.steps.flatMap(step => step.response.messages),
+    ];
   }
 
   get request() {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -9831,40 +9831,6 @@ describe('streamText', () => {
                     "content": [
                       {
                         "providerOptions": undefined,
-                        "text": "thinking",
-                        "type": "reasoning",
-                      },
-                      {
-                        "input": {
-                          "value": "value",
-                        },
-                        "providerExecuted": undefined,
-                        "providerOptions": undefined,
-                        "toolCallId": "call-1",
-                        "toolName": "tool1",
-                        "type": "tool-call",
-                      },
-                    ],
-                    "role": "assistant",
-                  },
-                  {
-                    "content": [
-                      {
-                        "output": {
-                          "type": "text",
-                          "value": "result1",
-                        },
-                        "toolCallId": "call-1",
-                        "toolName": "tool1",
-                        "type": "tool-result",
-                      },
-                    ],
-                    "role": "tool",
-                  },
-                  {
-                    "content": [
-                      {
-                        "providerOptions": undefined,
                         "text": "Hello, world!",
                         "type": "text",
                       },
@@ -10060,40 +10026,6 @@ describe('streamText', () => {
                     },
                     "id": "id-1",
                     "messages": [
-                      {
-                        "content": [
-                          {
-                            "providerOptions": undefined,
-                            "text": "thinking",
-                            "type": "reasoning",
-                          },
-                          {
-                            "input": {
-                              "value": "value",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "text",
-                              "value": "result1",
-                            },
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
                       {
                         "content": [
                           {
@@ -10309,40 +10241,6 @@ describe('streamText', () => {
                   },
                   "id": "id-1",
                   "messages": [
-                    {
-                      "content": [
-                        {
-                          "providerOptions": undefined,
-                          "text": "thinking",
-                          "type": "reasoning",
-                        },
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "result1",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
                     {
                       "content": [
                         {
@@ -10575,40 +10473,6 @@ describe('streamText', () => {
                   },
                   "id": "id-1",
                   "messages": [
-                    {
-                      "content": [
-                        {
-                          "providerOptions": undefined,
-                          "text": "thinking",
-                          "type": "reasoning",
-                        },
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "result1",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
                     {
                       "content": [
                         {
@@ -11177,35 +11041,6 @@ describe('streamText', () => {
                       {
                         "content": [
                           {
-                            "input": {
-                              "value": "value",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "text",
-                              "value": "result1",
-                            },
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
-                      {
-                        "content": [
-                          {
                             "providerOptions": undefined,
                             "text": "Hello, world!",
                             "type": "text",
@@ -11410,35 +11245,6 @@ describe('streamText', () => {
                     },
                     "id": "id-1",
                     "messages": [
-                      {
-                        "content": [
-                          {
-                            "input": {
-                              "value": "value",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "text",
-                              "value": "result1",
-                            },
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
                       {
                         "content": [
                           {
@@ -11800,40 +11606,6 @@ describe('streamText', () => {
                     "content": [
                       {
                         "providerOptions": undefined,
-                        "text": "thinking",
-                        "type": "reasoning",
-                      },
-                      {
-                        "input": {
-                          "value": "value",
-                        },
-                        "providerExecuted": undefined,
-                        "providerOptions": undefined,
-                        "toolCallId": "call-1",
-                        "toolName": "tool1",
-                        "type": "tool-call",
-                      },
-                    ],
-                    "role": "assistant",
-                  },
-                  {
-                    "content": [
-                      {
-                        "output": {
-                          "type": "text",
-                          "value": "RESULT1",
-                        },
-                        "toolCallId": "call-1",
-                        "toolName": "tool1",
-                        "type": "tool-result",
-                      },
-                    ],
-                    "role": "tool",
-                  },
-                  {
-                    "content": [
-                      {
-                        "providerOptions": undefined,
                         "text": "Hello, world!",
                         "type": "text",
                       },
@@ -12029,40 +11801,6 @@ describe('streamText', () => {
                     },
                     "id": "id-1",
                     "messages": [
-                      {
-                        "content": [
-                          {
-                            "providerOptions": undefined,
-                            "text": "thinking",
-                            "type": "reasoning",
-                          },
-                          {
-                            "input": {
-                              "value": "value",
-                            },
-                            "providerExecuted": undefined,
-                            "providerOptions": undefined,
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-call",
-                          },
-                        ],
-                        "role": "assistant",
-                      },
-                      {
-                        "content": [
-                          {
-                            "output": {
-                              "type": "text",
-                              "value": "RESULT1",
-                            },
-                            "toolCallId": "call-1",
-                            "toolName": "tool1",
-                            "type": "tool-result",
-                          },
-                        ],
-                        "role": "tool",
-                      },
                       {
                         "content": [
                           {
@@ -12278,40 +12016,6 @@ describe('streamText', () => {
                   },
                   "id": "id-1",
                   "messages": [
-                    {
-                      "content": [
-                        {
-                          "providerOptions": undefined,
-                          "text": "thinking",
-                          "type": "reasoning",
-                        },
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "RESULT1",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
                     {
                       "content": [
                         {
@@ -12540,40 +12244,6 @@ describe('streamText', () => {
                   },
                   "id": "id-1",
                   "messages": [
-                    {
-                      "content": [
-                        {
-                          "providerOptions": undefined,
-                          "text": "thinking",
-                          "type": "reasoning",
-                        },
-                        {
-                          "input": {
-                            "value": "value",
-                          },
-                          "providerExecuted": undefined,
-                          "providerOptions": undefined,
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-call",
-                        },
-                      ],
-                      "role": "assistant",
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "RESULT1",
-                          },
-                          "toolCallId": "call-1",
-                          "toolName": "tool1",
-                          "type": "tool-result",
-                        },
-                      ],
-                      "role": "tool",
-                    },
                     {
                       "content": [
                         {
@@ -21107,7 +20777,7 @@ describe('streamText', () => {
       });
 
       describe('result.responseMessages', () => {
-        it('should contain all response messages from all steps', async () => {
+        it('should contain response messages from all steps', async () => {
           await result.consumeStream();
           expect(await result.responseMessages).toMatchInlineSnapshot(`
             [
@@ -21606,7 +21276,7 @@ describe('streamText', () => {
           `);
         });
 
-        it('should contain all response messages', async () => {
+        it('should contain response messages from all steps', async () => {
           await result.consumeStream();
           expect(onFinishResult.responseMessages.length).toBe(9);
         });
@@ -23783,6 +23453,100 @@ describe('streamText', () => {
               ],
               "role": "assistant",
             },
+          ]
+        `);
+      });
+
+      it('should pass the initial tool result in responseMessages to prepareStep', async () => {
+        const prepareStepResponseMessages: Array<ModelMessage[]> = [];
+
+        const result = streamText({
+          model: new MockLanguageModelV4({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                { type: 'text-start', id: '1' },
+                {
+                  type: 'text-delta',
+                  id: '1',
+                  delta: 'Hello, world!',
+                },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: testUsage,
+                },
+              ]),
+            }),
+          }),
+          tools: {
+            tool1: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: () => 'result1',
+            }),
+          },
+          toolApproval: {
+            tool1: 'user-approval',
+          },
+          stopWhen: isStepCount(3),
+          messages: [
+            { role: 'user', content: 'test-input' },
+            {
+              role: 'assistant',
+              content: [
+                {
+                  input: { value: 'value' },
+                  providerExecuted: undefined,
+                  providerOptions: undefined,
+                  toolCallId: 'call-1',
+                  toolName: 'tool1',
+                  type: 'tool-call',
+                },
+                {
+                  approvalId: 'id-1',
+                  toolCallId: 'call-1',
+                  type: 'tool-approval-request',
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  approvalId: 'id-1',
+                  type: 'tool-approval-response',
+                  approved: true,
+                },
+              ],
+            },
+          ],
+          prepareStep: ({ responseMessages }) => {
+            prepareStepResponseMessages.push([...responseMessages]);
+            return undefined;
+          },
+        });
+
+        await result.consumeStream();
+
+        expect(prepareStepResponseMessages).toMatchInlineSnapshot(`
+          [
+            [
+              {
+                "content": [
+                  {
+                    "output": {
+                      "type": "text",
+                      "value": "result1",
+                    },
+                    "toolCallId": "call-1",
+                    "toolName": "tool1",
+                    "type": "tool-result",
+                  },
+                ],
+                "role": "tool",
+              },
+            ],
           ]
         `);
       });

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -783,6 +783,9 @@ class DefaultStreamTextResult<
   private readonly _steps = new DelayedPromise<
     Awaited<StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['steps']>
   >();
+  private readonly _initialResponseMessages = new DelayedPromise<
+    Array<ResponseMessage>
+  >();
 
   private readonly addStream: (
     stream: ReadableStream<TextStreamPart<TOOLS>>,
@@ -939,7 +942,6 @@ class DefaultStreamTextResult<
     let stepFinish!: DelayedPromise<void>;
 
     let recordedContent: Array<ContentPart<TOOLS>> = [];
-    const recordedResponseMessages: Array<ResponseMessage> = [];
     let recordedFinishReason: FinishReason | undefined = undefined;
     let recordedRawFinishReason: string | undefined = undefined;
     let recordedTotalUsage: LanguageModelUsage | undefined = undefined;
@@ -947,6 +949,7 @@ class DefaultStreamTextResult<
     let recordedRequestMessages: Array<ModelMessage> = [];
     let recordedWarnings: Array<CallWarning> = [];
     const recordedSteps: StepResult<TOOLS, RUNTIME_CONTEXT>[] = [];
+    const initialResponseMessages: Array<ResponseMessage> = [];
 
     // Track provider-executed tool calls that support deferred results
     // (e.g., code_execution in programmatic tool calling scenarios).
@@ -1159,10 +1162,7 @@ class DefaultStreamTextResult<
               },
               response: {
                 ...part.response,
-                messages: cloneModelMessages([
-                  ...recordedResponseMessages,
-                  ...stepMessages,
-                ]),
+                messages: cloneModelMessages(stepMessages),
               },
               providerMetadata: part.providerMetadata,
             });
@@ -1179,8 +1179,6 @@ class DefaultStreamTextResult<
           });
 
           recordedSteps.push(currentStepResult);
-
-          recordedResponseMessages.push(...stepMessages);
 
           // resolve the promise to signal that the step has been fully processed
           // by the event processor:
@@ -1207,6 +1205,7 @@ class DefaultStreamTextResult<
             self._rawFinishReason.reject(error);
             self._totalUsage.reject(error);
             self._steps.reject(error);
+            self._initialResponseMessages.reject(error);
 
             return; // no steps recorded (e.g. in error scenario)
           }
@@ -1252,7 +1251,10 @@ class DefaultStreamTextResult<
               dynamicToolResults: finalStep.dynamicToolResults,
               request: finalStep.request,
               response: finalStep.response,
-              responseMessages: finalStep.response.messages,
+              responseMessages: [
+                ...initialResponseMessages,
+                ...recordedSteps.flatMap(step => step.response.messages),
+              ],
               warnings: finalStep.warnings,
               providerMetadata: finalStep.providerMetadata,
               steps: recordedSteps,
@@ -1404,7 +1406,6 @@ class DefaultStreamTextResult<
       });
 
       const initialMessages = initialPrompt.messages;
-      const initialResponseMessages: Array<ResponseMessage> = [];
 
       const { approvedToolApprovals, deniedToolApprovals } =
         collectToolApprovals<TOOLS>({ messages: initialMessages });
@@ -1527,15 +1528,13 @@ class DefaultStreamTextResult<
         }
       }
 
-      recordedResponseMessages.push(...initialResponseMessages);
+      self._initialResponseMessages.resolve(initialResponseMessages);
 
       async function streamStep({
         currentStep,
-        responseMessages,
         usage,
       }: {
         currentStep: number;
-        responseMessages: Array<ResponseMessage>;
         usage: LanguageModelUsage;
       }) {
         // Set up step timeout if configured
@@ -1576,7 +1575,14 @@ class DefaultStreamTextResult<
         try {
           stepFinish = new DelayedPromise<void>();
 
-          const stepInputMessages = [...initialMessages, ...responseMessages];
+          const accumulatedResponseMessages = [
+            ...initialResponseMessages,
+            ...recordedSteps.flatMap(step => step.response.messages),
+          ];
+          const stepInputMessages = [
+            ...initialMessages,
+            ...accumulatedResponseMessages,
+          ];
 
           const prepareStepResult = await prepareStep?.({
             model,
@@ -1584,7 +1590,7 @@ class DefaultStreamTextResult<
             stepNumber: recordedSteps.length,
             messages: stepInputMessages,
             initialMessages,
-            responseMessages,
+            responseMessages: accumulatedResponseMessages,
             toolsContext,
             runtimeContext,
             sandbox,
@@ -1983,20 +1989,9 @@ class DefaultStreamTextResult<
                       steps: recordedSteps,
                     }))
                   ) {
-                    // append to messages for the next step:
-                    responseMessages.push(
-                      ...(await toResponseMessages({
-                        content:
-                          // use transformed content to create the messages for the next step:
-                          recordedSteps[recordedSteps.length - 1].content,
-                        tools,
-                      })),
-                    );
-
                     try {
                       await streamStep({
                         currentStep: currentStep + 1,
-                        responseMessages,
                         usage: combinedUsage,
                       });
                     } catch (error) {
@@ -2030,11 +2025,11 @@ class DefaultStreamTextResult<
       // add the initial stream to the stitchable stream
       await streamStep({
         currentStep: 0,
-        responseMessages: initialResponseMessages,
         usage: createNullLanguageModelUsage(),
       });
     })().catch(async error => {
       await telemetryDispatcher.onError?.({ callId, error });
+      self._initialResponseMessages.reject(error);
 
       // add an error stream part and close the streams:
       self.addStream(
@@ -2132,7 +2127,13 @@ class DefaultStreamTextResult<
   }
 
   get responseMessages() {
-    return this.finalStep.then(step => step.response.messages);
+    return Promise.all([
+      this._initialResponseMessages.promise,
+      this.steps,
+    ]).then(([initialResponseMessages, steps]) => [
+      ...initialResponseMessages,
+      ...steps.flatMap(step => step.response.messages),
+    ]);
   }
 
   get totalUsage() {


### PR DESCRIPTION
## Background

`StepResult.response.messages` contained the messages created in all prior steps of a turn. This can be confusing and makes it impossible to determine which messages were created in a particular step.

## Summary

Limit `response.messages` of `StepResult` to the messages created in that particular step.