### PR TITLE
fix(ai): carry prepareStep message overrides forward across steps

### DIFF
--- a/.changeset/gentle-waves-prepare.md
+++ b/.changeset/gentle-waves-prepare.md
@@ -1,0 +1,5 @@
+---
+"ai": major
+---
+
+fix(ai): carry prepareStep message overrides forward across steps

--- a/content/docs/03-agents/04-loop-control.mdx
+++ b/content/docs/03-agents/04-loop-control.mdx
@@ -148,7 +148,7 @@ const budgetExceeded: StopCondition<typeof tools> = ({ steps }) => {
 
 The `prepareStep` callback runs before each step in the loop and defaults to the initial settings if you don't return any changes. Use it to modify settings, manage context, or implement dynamic behavior based on execution history.
 
-It receives `messages` for the current step, plus `initialMessages` and `responseMessages` when you need to distinguish the original input from assistant/tool messages accumulated in earlier steps.
+It receives `messages` for the current step, plus `initialMessages` and `responseMessages` when you need to distinguish the original input from assistant/tool messages accumulated in earlier steps. If you return a `messages` override, those messages carry forward to later steps together with the response messages from each completed step.
 
 ### Dynamic Model Selection
 
@@ -280,7 +280,7 @@ prepareStep: async ({ stepNumber }) => {
 
 ### Message Modification
 
-Transform messages before sending them to the model:
+Transform messages before sending them to the model. Returned messages carry forward to later steps, so later `messages` values include your transformed messages plus the assistant/tool response messages from completed steps:
 
 ```ts
 import { ToolLoopAgent } from 'ai';

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -476,7 +476,7 @@ It is called with the following parameters:
 - `stopWhen`: The stopping condition that was passed into `generateText`.
 - `stepNumber`: The number of the step that is being executed.
 - `steps`: The steps that have been executed so far.
-- `messages`: The messages that will be sent to the model for the current step.
+- `messages`: The messages that will be sent to the model for the current step. If `prepareStep` returns a `messages` override, those messages carry forward to later steps.
 - `initialMessages`: The messages that were passed into `generateText` or `streamText`.
 - `responseMessages`: The accumulated assistant/tool response messages so far, including any tool results generated before the first model step from approved tool calls in the input messages.
 - `runtimeContext`: The runtime context passed via the `runtimeContext` setting.
@@ -511,15 +511,21 @@ const result = await generateText({
 
 In longer agentic loops, you can use the `messages` parameter to modify the input messages for each step. This is particularly useful for prompt compression.
 
-The `messages` parameter contains `initialMessages` followed by the accumulated `responseMessages`.
+The `messages` parameter contains the messages for the current step. By default, this is `initialMessages` followed by the accumulated `responseMessages`. If a previous `prepareStep` returned `messages`, later steps use those messages plus the response messages from the previous step.
 Use `initialMessages` when you need to preserve the original user-provided prompt and `responseMessages` when you only need the accumulated assistant/tool response messages.
 
 ```tsx
-prepareStep: async ({ stepNumber, steps, messages }) => {
+prepareStep: async ({
+  initialMessages,
+  responseMessages,
+  stepNumber,
+  steps,
+  messages,
+}) => {
   // Compress conversation history for longer loops
   if (messages.length > 20) {
     return {
-      messages: messages.slice(-10),
+      messages: [...initialMessages, ...responseMessages.slice(-10)],
     };
   }
 

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -623,7 +623,7 @@ To see `generateText` in action, check out [these examples](#examples).
                       name: 'messages',
                       type: 'Array<ModelMessage>',
                       description:
-                        'The messages that will be sent to the model for the current step.',
+                        'The messages that will be sent to the model for the current step. If prepareStep returns a messages override, those messages carry forward to later steps.',
                     },
                     {
                       name: 'runtimeContext',
@@ -1148,7 +1148,7 @@ To see `generateText` in action, check out [these examples](#examples).
               name: 'messages',
               type: 'Array<ModelMessage>',
               description:
-                'The messages that will be sent to the model for this step. Uses the user-facing ModelMessage format. May be overridden by prepareStep.',
+                'The messages that will be sent to the model for this step. Uses the user-facing ModelMessage format. May be overridden by prepareStep. If prepareStep returns a messages override, those messages carry forward to later steps.',
             },
             {
               name: 'tools',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -667,7 +667,7 @@ To see `streamText` in action, check out [these examples](#examples).
                       name: 'messages',
                       type: 'Array<ModelMessage>',
                       description:
-                        'The messages that will be sent to the model for the current step.',
+                        'The messages that will be sent to the model for the current step. If prepareStep returns a messages override, those messages carry forward to later steps.',
                     },
                     {
                       name: 'runtimeContext',
@@ -2052,7 +2052,7 @@ To see `streamText` in action, check out [these examples](#examples).
               name: 'messages',
               type: 'Array<ModelMessage>',
               description:
-                'The messages that will be sent to the model for this step. Uses the user-facing ModelMessage format. May be overridden by prepareStep.',
+                'The messages that will be sent to the model for this step. Uses the user-facing ModelMessage format. May be overridden by prepareStep. If prepareStep returns a messages override, those messages carry forward to later steps.',
             },
             {
               name: 'tools',

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -689,6 +689,28 @@ const result = await generateText({
 });
 ```
 
+### Core: `prepareStep` Message Overrides Carry Forward
+
+When `prepareStep` returns `messages`, those messages are now used as the base for subsequent steps. The next step receives those messages plus the response messages from the previous step.
+
+In AI SDK 6, a `messages` override only applied to the current step. To keep that behavior, rebuild the current step's messages from `initialMessages` and `responseMessages` inside `prepareStep`:
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  tools: { weather },
+  prepareStep: ({ initialMessages, responseMessages }) => {
+    return {
+      messages: [
+        ...initialMessages,
+        ...responseMessages,
+        // add any one-step-only message changes here
+      ],
+    };
+  },
+});
+```
+
 ### Tools: Remove Deprecated `ToolCallOptions` Type
 
 The deprecated `ToolCallOptions` type has been removed in AI SDK 7. Replace all remaining usages with `ToolExecutionOptions`.

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -946,6 +946,68 @@ describe('generateText', () => {
       expect(result.request.messages).toStrictEqual(preparedMessages);
       expect(result.steps[0].request.messages).toStrictEqual(preparedMessages);
     });
+
+    it('should carry messages from prepareStep forward to the next step', async () => {
+      const preparedMessages: Array<ModelMessage> = [
+        { role: 'user', content: 'prepared prompt' },
+      ];
+      const prepareStepMessages: Array<Array<ModelMessage>> = [];
+      let responseCount = 0;
+
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            switch (responseCount++) {
+              case 0:
+                return {
+                  ...dummyResponseValues,
+                  content: [
+                    {
+                      type: 'tool-call',
+                      toolCallType: 'function',
+                      toolCallId: 'call-1',
+                      toolName: 'tool1',
+                      input: '{ "value": "test" }',
+                    },
+                  ],
+                  finishReason: { unified: 'tool-calls', raw: undefined },
+                };
+              case 1:
+              default:
+                return {
+                  ...dummyResponseValues,
+                  content: [{ type: 'text', text: 'Done.' }],
+                };
+            }
+          },
+        }),
+        tools: {
+          tool1: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        prompt: 'prompt',
+        stopWhen: isStepCount(3),
+        prepareStep: async ({ messages, stepNumber }) => {
+          prepareStepMessages.push([...messages]);
+
+          if (stepNumber === 0) {
+            return { messages: preparedMessages };
+          }
+        },
+        include: { requestMessages: true },
+      });
+
+      expect(prepareStepMessages[1]).toEqual([
+        ...preparedMessages,
+        ...result.steps[0].response.messages,
+      ]);
+      expect(result.steps[1].request.messages).toEqual([
+        ...preparedMessages,
+        ...result.steps[0].response.messages,
+      ]);
+    });
   });
 
   describe('result.response', () => {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -3999,7 +3999,7 @@ describe('generateText', () => {
               execute: async (args, options) => {
                 expect(args).toStrictEqual({ value: 'value' });
                 expect(options.messages).toStrictEqual([
-                  { role: 'user', content: 'test-input' },
+                  { role: 'user', content: 'new input from prepareStep' },
                 ]);
                 return 'result1';
               },
@@ -4242,7 +4242,7 @@ describe('generateText', () => {
             {
               "messages": [
                 {
-                  "content": "test-input",
+                  "content": "new input from prepareStep",
                   "role": "user",
                 },
                 {
@@ -4500,7 +4500,7 @@ describe('generateText', () => {
                 {
                   "content": [
                     {
-                      "text": "test-input",
+                      "text": "new input from prepareStep",
                       "type": "text",
                     },
                   ],

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -627,6 +627,7 @@ export async function generateText<
       [];
     const steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['steps'] =
       [];
+    let messagesForNextStep = [...initialMessages, ...initialResponseMessages];
 
     // Track provider-executed tool calls that support deferred results
     // (e.g., code_execution in programmatic tool calling scenarios).
@@ -646,10 +647,7 @@ export async function generateText<
           ...initialResponseMessages,
           ...steps.flatMap(step => step.response.messages),
         ];
-        const stepInputMessages = [
-          ...initialMessages,
-          ...accumulatedResponseMessages,
-        ];
+        const stepInputMessages = messagesForNextStep;
 
         const prepareStepResult = await prepareStep?.({
           model,
@@ -783,7 +781,7 @@ export async function generateText<
                 repairToolCall,
                 refineToolInput,
                 system,
-                messages: stepInputMessages,
+                messages: stepMessages,
               }),
             ),
         );
@@ -842,7 +840,7 @@ export async function generateText<
             await tool.onInputAvailable({
               input: toolCall.input,
               toolCallId: toolCall.toolCallId,
-              messages: stepInputMessages,
+              messages: stepMessages,
               abortSignal: mergedAbortSignal,
               context: runtimeContext,
             });
@@ -852,7 +850,7 @@ export async function generateText<
             tools,
             toolApproval,
             toolCall,
-            messages: stepInputMessages,
+            messages: stepMessages,
             toolsContext,
             runtimeContext,
           });
@@ -949,7 +947,7 @@ export async function generateText<
               ),
               tools,
               callId,
-              messages: stepInputMessages,
+              messages: stepMessages,
               abortSignal: mergedAbortSignal,
               timeout,
               sandbox: stepSandbox,
@@ -1067,6 +1065,7 @@ export async function generateText<
         });
 
         steps.push(currentStepResult);
+        messagesForNextStep = [...stepMessages, ...stepResponseMessages];
 
         await notify({
           event: currentStepResult,

--- a/packages/ai/src/generate-text/prepare-step.ts
+++ b/packages/ai/src/generate-text/prepare-step.ts
@@ -19,7 +19,7 @@ import type { StepResult } from './step-result';
  * @param options.steps - The steps that have been executed so far.
  * @param options.stepNumber - The number of the step that is being executed.
  * @param options.model - The model that is being used.
- * @param options.messages - The messages that will be sent to the model for the current step.
+ * @param options.messages - The messages that will be sent to the model for the current step. If you return a `messages` override, those messages carry forward to later steps.
  * @param options.initialMessages - The initial messages that were passed into generateText or streamText.
  * @param options.responseMessages - The response messages that have been accumulated from previous steps.
  * @param options.runtimeContext - The user-defined runtime context.
@@ -48,6 +48,7 @@ export type PrepareStepFunction<
 
   /**
    * The messages that will be sent to the model for the current step.
+   * If you return a `messages` override, those messages carry forward to later steps.
    */
   messages: Array<ModelMessage>;
 
@@ -111,7 +112,7 @@ export type PrepareStepResult<
 
       /**
        * Optionally override the full set of messages sent to the model
-       * for this step.
+       * for this step. The override carries forward to later steps.
        */
       messages?: Array<ModelMessage>;
 

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -5209,6 +5209,84 @@ describe('streamText', () => {
         preparedMessages,
       );
     });
+
+    it('should carry messages from prepareStep forward to the next step', async () => {
+      const preparedMessages: Array<ModelMessage> = [
+        { role: 'user', content: 'prepared prompt' },
+      ];
+      const prepareStepMessages: Array<Array<ModelMessage>> = [];
+      let responseCount = 0;
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream<LanguageModelV4StreamPart>(
+              responseCount++ === 0
+                ? [
+                    {
+                      type: 'stream-start',
+                      warnings: [],
+                    },
+                    {
+                      type: 'tool-call',
+                      toolCallId: 'call-1',
+                      toolName: 'tool1',
+                      input: '{ "value": "test" }',
+                    },
+                    {
+                      type: 'finish',
+                      finishReason: { unified: 'tool-calls', raw: undefined },
+                      usage: testUsage,
+                    },
+                  ]
+                : [
+                    {
+                      type: 'stream-start',
+                      warnings: [],
+                    },
+                    { type: 'text-start', id: '1' },
+                    { type: 'text-delta', id: '1', delta: 'Done.' },
+                    { type: 'text-end', id: '1' },
+                    {
+                      type: 'finish',
+                      finishReason: { unified: 'stop', raw: 'stop' },
+                      usage: testUsage,
+                    },
+                  ],
+            ),
+          }),
+        }),
+        tools: {
+          tool1: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => `${value}-result`,
+          }),
+        },
+        prompt: 'prompt',
+        stopWhen: isStepCount(3),
+        prepareStep: async ({ messages, stepNumber }) => {
+          prepareStepMessages.push([...messages]);
+
+          if (stepNumber === 0) {
+            return { messages: preparedMessages };
+          }
+        },
+        include: { requestMessages: true },
+        onError: () => {},
+      });
+
+      await result.consumeStream();
+
+      const steps = await result.steps;
+      expect(prepareStepMessages[1]).toEqual([
+        ...preparedMessages,
+        ...steps[0].response.messages,
+      ]);
+      expect(steps[1].request.messages).toEqual([
+        ...preparedMessages,
+        ...steps[0].response.messages,
+      ]);
+    });
   });
 
   describe('result.response', () => {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -10821,7 +10821,7 @@ describe('streamText', () => {
                 {
                   "content": [
                     {
-                      "text": "test-input",
+                      "text": "new input from prepareStep",
                       "type": "text",
                     },
                   ],
@@ -11059,7 +11059,7 @@ describe('streamText', () => {
             {
               "messages": [
                 {
-                  "content": "test-input",
+                  "content": "new input from prepareStep",
                   "role": "user",
                 },
                 {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -950,6 +950,8 @@ class DefaultStreamTextResult<
     let recordedWarnings: Array<CallWarning> = [];
     const recordedSteps: StepResult<TOOLS, RUNTIME_CONTEXT>[] = [];
     const initialResponseMessages: Array<ResponseMessage> = [];
+    let stepMessagesForNextStep: Array<ModelMessage> | undefined;
+    let currentStepMessages: Array<ModelMessage> = [];
 
     // Track provider-executed tool calls that support deferred results
     // (e.g., code_execution in programmatic tool calling scenarios).
@@ -1135,7 +1137,7 @@ class DefaultStreamTextResult<
         }
 
         if (part.type === 'finish-step') {
-          const stepMessages = await toResponseMessages({
+          const stepResponseMessages = await toResponseMessages({
             content: recordedContent,
             tools,
           });
@@ -1162,7 +1164,7 @@ class DefaultStreamTextResult<
               },
               response: {
                 ...part.response,
-                messages: cloneModelMessages(stepMessages),
+                messages: cloneModelMessages(stepResponseMessages),
               },
               providerMetadata: part.providerMetadata,
             });
@@ -1179,6 +1181,10 @@ class DefaultStreamTextResult<
           });
 
           recordedSteps.push(currentStepResult);
+          stepMessagesForNextStep = [
+            ...currentStepMessages,
+            ...stepResponseMessages,
+          ];
 
           // resolve the promise to signal that the step has been fully processed
           // by the event processor:
@@ -1575,13 +1581,16 @@ class DefaultStreamTextResult<
         try {
           stepFinish = new DelayedPromise<void>();
 
+          const responseMessagesFromPreviousSteps = recordedSteps.flatMap(
+            step => step.response.messages,
+          );
           const accumulatedResponseMessages = [
             ...initialResponseMessages,
-            ...recordedSteps.flatMap(step => step.response.messages),
+            ...responseMessagesFromPreviousSteps,
           ];
-          const stepInputMessages = [
+          const stepInputMessages = stepMessagesForNextStep ?? [
             ...initialMessages,
-            ...accumulatedResponseMessages,
+            ...initialResponseMessages,
           ];
 
           const prepareStepResult = await prepareStep?.({
@@ -1619,6 +1628,7 @@ class DefaultStreamTextResult<
           toolsContext = prepareStepResult?.toolsContext ?? toolsContext;
 
           const stepMessages = prepareStepResult?.messages ?? stepInputMessages;
+          currentStepMessages = stepMessages;
           const stepSystem = prepareStepResult?.system ?? initialPrompt.system;
 
           const stepProviderOptions = mergeObjects(
@@ -1694,7 +1704,7 @@ class DefaultStreamTextResult<
           const stream2 = invokeToolCallbacksFromStream({
             stream: languageModelStream,
             tools,
-            stepInputMessages,
+            stepInputMessages: stepMessages,
             abortSignal,
             runtimeContext,
           });
@@ -1703,7 +1713,7 @@ class DefaultStreamTextResult<
             createExecuteToolsTransformation({
               tools,
               callId,
-              messages: stepInputMessages,
+              messages: stepMessages,
               abortSignal,
               timeout,
               sandbox: stepSandbox,


### PR DESCRIPTION
## Background

Right now, the `messages` that are returned by `prepareStep` are only used in that particular step. However, this behavior is not very intuitive (see #9631 and #6615 ) and makes compaction unnecessarily difficult.

With the `initialMessages` and `responseMessages` params introduced in #15086 it is possible to preserve the old behavior in `prepareStep` if desired.

## Summary

Use the messages returned by prepareStep as the foundation for subsequent steps, i.e. do not reset it.

## Related Issues
Fixes #9631 and #6615