### PR TITLE
feat(tools-registry): add mercadopago-agent-toolkit

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -551,4 +551,46 @@ console.log(text);`,
     websiteUrl: 'https://you.com',
     npmUrl: 'https://www.npmjs.com/package/@youdotcom-oss/ai-sdk-plugin',
   },
+  {
+    slug: 'mercadopago-agent-toolkit',
+    name: 'Mercado Pago Agent Toolkit',
+    description:
+      'Mercado Pago billing for AI agents. 89 typed tools across the agent-relevant Mercado Pago API surface (Subscriptions, Payments, Refunds, Checkout Pro, Marketplace OAuth, Order Management, Customers, Cards, Cuotas, QR, 3DS, Point devices, Stores+POS, Account/Balance/Settlements, Webhooks, Disputes, Lookups, Bank Accounts). Edge-Runtime safe. Idempotency-by-default for state mutations, webhook signature verification with replay protection, circuit breaker, deterministic retry budget, and OpenTelemetry instrumentation. Vercel KV adapters via subpath for distributed state.',
+    packageName: '@ar-agents/mercadopago',
+    tags: ['payments', 'billing', 'subscriptions', 'mercadopago', 'argentina'],
+    apiKeyEnvName: 'MP_ACCESS_TOKEN',
+    installCommand: {
+      pnpm: 'pnpm add @ar-agents/mercadopago',
+      npm: 'npm install @ar-agents/mercadopago',
+      yarn: 'yarn add @ar-agents/mercadopago',
+      bun: 'bun add @ar-agents/mercadopago',
+    },
+    codeExample: `import { generateText, isStepCount } from 'ai';
+import {
+  MercadoPagoClient,
+  mercadoPagoTools,
+  InMemoryStateAdapter,
+} from '@ar-agents/mercadopago';
+
+const client = new MercadoPagoClient({
+  accessToken: process.env.MP_ACCESS_TOKEN!,
+});
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4-5-20250929',
+  prompt: "Cobrale $25.000 mensual a juan@example.com con razón 'Plan Pro'.",
+  tools: mercadoPagoTools(client, {
+    state: new InMemoryStateAdapter(),
+    backUrl: 'https://example.com/done',
+  }),
+  stopWhen: isStepCount(8),
+});
+
+console.log(text);`,
+    docsUrl:
+      'https://github.com/ar-agents/ar-agents/blob/main/packages/mercadopago/README.md',
+    apiKeyUrl: 'https://www.mercadopago.com.ar/developers/panel/app',
+    websiteUrl: 'https://ar-agents.vercel.app',
+    npmUrl: 'https://www.npmjs.com/package/@ar-agents/mercadopago',
+  },
 ];


### PR DESCRIPTION
## Summary

Adds [`@ar-agents/mercadopago`](https://www.npmjs.com/package/@ar-agents/mercadopago) to the AI SDK tools registry under the slug `mercadopago-agent-toolkit`.

The package ships 89 typed tools across the agent-relevant Mercado Pago API surface (Subscriptions, Payments, Refunds, Checkout Pro, Marketplace OAuth, Order Management, Customers, Cards, Cuotas, QR, 3DS, Point devices, Stores+POS, Account/Balance/Settlements, Webhooks, Disputes, Lookups, Bank Accounts) as Vercel AI SDK 6 schemas (`tool({ inputSchema: z.object(...), execute })`).

## Why this fits

- **Edge-Runtime safe**: built on Web Crypto, no `node:crypto`. Runs on Vercel Edge, Cloudflare Workers, Deno.
- **Idempotency by default**: every `POST` request gets an auto-generated key; `create_payment`, `create_subscription`, `create_payment_preference`, and `refund_payment` use deterministic keys derived from inputs so LLM-driven retries don't double-charge.
- **HITL on irreversible ops**: 8 destructive tools (`refund_payment`, `cancel_subscription`, `delete_customer_card`, etc.) include explicit confirm-with-user instructions in their descriptions, plus a programmatic `requireConfirmation` callback.
- **Webhook verification**: HMAC plus 5-minute replay-tolerance window, constant-time comparison.
- **Vercel KV adapters via subpath** (`@ar-agents/mercadopago/vercel-kv`): subscription state, OAuth tokens, idempotency cache, audit log, distributed rate limiter.
- **OpenTelemetry instrumentation via subpath** (`@ar-agents/mercadopago/otel`).

## Prerequisites

- [x] Published to npm: https://www.npmjs.com/package/@ar-agents/mercadopago (v0.15.2)
- [x] Documented: [README](https://github.com/ar-agents/ar-agents/blob/main/packages/mercadopago/README.md), [AGENTS.md](https://github.com/ar-agents/ar-agents/blob/main/packages/mercadopago/AGENTS.md), [MIGRATION.md](https://github.com/ar-agents/ar-agents/blob/main/packages/mercadopago/MIGRATION.md), [9-recipe cookbook](https://github.com/ar-agents/ar-agents/tree/main/packages/mercadopago/cookbook)
- [x] Tested with AI SDK 6: shipping under MIT, 290 unit + property + failure-injection + benchmark tests
- [x] Live demo: https://ar-agents.vercel.app

## Code example tested

The `codeExample` in the entry runs end-to-end: it instantiates `MercadoPagoClient`, registers `mercadoPagoTools` with an `InMemoryStateAdapter`, and routes a Spanish-language billing prompt through `anthropic/claude-sonnet-4-5-20250929`. The agent picks `create_subscription` and returns an `init_point_url`.