### PR TITLE
fix: rename system to instructions

### DIFF
--- a/.changeset/cyan-tips-study.md
+++ b/.changeset/cyan-tips-study.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat(ai): add `instructions` as the primary prompt option and deprecate `system`

--- a/content/docs/02-foundations/03-prompts.mdx
+++ b/content/docs/02-foundations/03-prompts.mdx
@@ -43,21 +43,21 @@ const result = await generateText({
 ## System Prompts
 
 System prompts are the initial set of instructions given to models that help guide and constrain the models' behaviors and responses.
-You can set system prompts using the `system` property.
+You can set system prompts using the `instructions` property.
 System prompts work with both the `prompt` and the `messages` properties.
-System messages in `prompt` or `messages` are rejected by default; use the `system` property for system instructions, or set `allowSystemInMessages: true` when you need to send existing message histories that contain system messages.
+System messages in `prompt` or `messages` are rejected by default; use the `instructions` property for system instructions, or set `allowSystemInMessages: true` when you need to send existing message histories that contain system messages.
 
 <Note type="warning">
   Opting in with `allowSystemInMessages` can create a prompt injection risk
   where users can override or set the system prompt by injecting system
   messages. In most cases, only trusted server-side code should set system
-  instructions via the `system` or `instructions` property.
+  instructions via the `instructions` property.
 </Note>
 
 ```ts highlight="3-6"
 const result = await generateText({
   model: __MODEL__,
-  system:
+  instructions:
     `You help planning travel itineraries. ` +
     `Respond to the users' request with a list ` +
     `of the best stops to make in their destination.`,
@@ -123,7 +123,7 @@ For granular control over applying provider options at the message level, you ca
 ```ts
 const result = await generateText({
   model: __MODEL__,
-  system: {
+  instructions: {
     role: 'system',
     content: 'Cached system message',
     providerOptions: {
@@ -604,7 +604,7 @@ const result = await generateText({
 ### System Messages
 
 System messages are messages that are sent to the model before the user messages to guide the assistant's behavior.
-You can alternatively use the `system` property.
+You can alternatively use the `instructions` property.
 
 ```ts highlight="4"
 const result = await generateText({

--- a/content/docs/03-agents/03-workflows.mdx
+++ b/content/docs/03-agents/03-workflows.mdx
@@ -131,7 +131,7 @@ async function handleCustomerQuery(query: string) {
       classification.complexity === 'simple'
         ? 'openai/gpt-4o-mini'
         : 'openai/o4-mini',
-    system: {
+    instructions: {
       general:
         'You are an expert customer service agent handling general inquiries.',
       refund:
@@ -164,7 +164,7 @@ async function parallelCodeReview(code: string) {
     await Promise.all([
       generateText({
         model,
-        system:
+        instructions:
           'You are an expert in code security. Focus on identifying security vulnerabilities, injection risks, and authentication issues.',
         output: Output.object({
           schema: z.object({
@@ -179,7 +179,7 @@ async function parallelCodeReview(code: string) {
 
       generateText({
         model,
-        system:
+        instructions:
           'You are an expert in code performance. Focus on identifying performance bottlenecks, memory leaks, and optimization opportunities.',
         output: Output.object({
           schema: z.object({
@@ -194,7 +194,7 @@ async function parallelCodeReview(code: string) {
 
       generateText({
         model,
-        system:
+        instructions:
           'You are an expert in code quality. Focus on code structure, readability, and adherence to best practices.',
         output: Output.object({
           schema: z.object({
@@ -217,7 +217,7 @@ async function parallelCodeReview(code: string) {
   // Aggregate results using another model instance
   const { text: summary } = await generateText({
     model,
-    system: 'You are a technical lead summarizing multiple code reviews.',
+    instructions: 'You are a technical lead summarizing multiple code reviews.',
     prompt: `Synthesize these code review results into a concise summary with key actions:
     ${JSON.stringify(reviews, null, 2)}`,
   });
@@ -251,7 +251,7 @@ async function implementFeature(featureRequest: string) {
         estimatedComplexity: z.enum(['low', 'medium', 'high']),
       }),
     }),
-    system:
+    instructions:
       'You are a senior software architect planning feature implementations.',
     prompt: `Analyze this feature request and create an implementation plan:
     ${featureRequest}`,
@@ -278,7 +278,7 @@ async function implementFeature(featureRequest: string) {
             code: z.string(),
           }),
         }),
-        system: workerSystemPrompt,
+        instructions: workerSystemPrompt,
         prompt: `Implement the changes for ${file.filePath} to support:
         ${file.purpose}
 
@@ -317,7 +317,7 @@ async function translateWithFeedback(text: string, targetLanguage: string) {
   // Initial translation
   const { text: translation } = await generateText({
     model: __MODEL__,
-    system: 'You are an expert literary translator.',
+    instructions: 'You are an expert literary translator.',
     prompt: `Translate this text to ${targetLanguage}, preserving tone and cultural nuances:
     ${text}`,
   });
@@ -339,7 +339,7 @@ async function translateWithFeedback(text: string, targetLanguage: string) {
           improvementSuggestions: z.array(z.string()),
         }),
       }),
-      system: 'You are an expert in evaluating literary translations.',
+      instructions: 'You are an expert in evaluating literary translations.',
       prompt: `Evaluate this translation:
 
       Original: ${text}
@@ -365,7 +365,7 @@ async function translateWithFeedback(text: string, targetLanguage: string) {
     // Generate improved translation based on feedback
     const { text: improvedTranslation } = await generateText({
       model: __MODEL__,
-      system: 'You are an expert literary translator.',
+      instructions: 'You are an expert literary translator.',
       prompt: `Improve this translation based on the following feedback:
       ${evaluation.specificIssues.join('\n')}
       ${evaluation.improvementSuggestions.join('\n')}

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -37,7 +37,7 @@ __PROVIDER_IMPORT__;
 
 const { text } = await generateText({
   model: __MODEL__,
-  system:
+  instructions:
     'You are a professional writer. ' +
     'You write simple, clear, and concise content.',
   prompt: `Summarize the following article in 3-5 sentences: ${article}`,

--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -81,7 +81,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: __MODEL__,
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     messages: await convertToModelMessages(messages),
   });
 

--- a/content/docs/04-ai-sdk-ui/04-generative-user-interfaces.mdx
+++ b/content/docs/04-ai-sdk-ui/04-generative-user-interfaces.mdx
@@ -84,7 +84,7 @@ export async function POST(request: Request) {
 
   const result = streamText({
     model: __MODEL__,
-    system: 'You are a friendly assistant!',
+    instructions: 'You are a friendly assistant!',
     messages: await convertToModelMessages(messages),
     stopWhen: isStepCount(5),
   });
@@ -137,7 +137,7 @@ export async function POST(request: Request) {
 
   const result = streamText({
     model: __MODEL__,
-    system: 'You are a friendly assistant!',
+    instructions: 'You are a friendly assistant!',
     messages: await convertToModelMessages(messages),
     stopWhen: isStepCount(5),
     tools,

--- a/content/docs/05-ai-sdk-rsc/04-multistep-interfaces.mdx
+++ b/content/docs/05-ai-sdk-rsc/04-multistep-interfaces.mdx
@@ -83,7 +83,7 @@ export async function submitUserMessage(input: string) {
 
   const ui = await streamUI({
     model: openai('gpt-4o'),
-    system: 'you are a flight booking assistant',
+    instructions: 'you are a flight booking assistant',
     prompt: input,
     text: async ({ content }) => <div>{content}</div>,
     tools: {

--- a/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
+++ b/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
@@ -48,7 +48,7 @@ export async function sendMessage(message: string) {
 
   const { value: stream } = await streamUI({
     model: openai('gpt-4o'),
-    system: 'you are a friendly assistant!',
+    instructions: 'you are a friendly assistant!',
     messages: messages.get(),
     text: async function* ({ content, done }) {
       // process text
@@ -110,7 +110,7 @@ export async function POST(request) {
 
   const result = streamText({
     model: __MODEL__,
-    system: 'you are a friendly assistant!',
+    instructions: 'you are a friendly assistant!',
     messages,
     tools: {
       // tool definitions
@@ -182,7 +182,7 @@ import { Weather } from '@/components/weather';
 
 const { value: stream } = await streamUI({
   model: openai('gpt-4o'),
-  system: 'you are a friendly assistant!',
+  instructions: 'you are a friendly assistant!',
   messages,
   text: async function* ({ content, done }) {
     // process text
@@ -223,7 +223,7 @@ export async function POST(request) {
 
   const result = streamText({
     model: __MODEL__,
-    system: 'you are a friendly assistant!',
+    instructions: 'you are a friendly assistant!',
     messages,
     tools: {
       displayWeather: {
@@ -388,7 +388,7 @@ import { streamUI } from '@ai-sdk/rsc';
 
 const { value: stream } = await streamUI({
   model: openai('gpt-4o'),
-  system: 'you are a friendly assistant!',
+  instructions: 'you are a friendly assistant!',
   messages,
   initial: <div>Loading...</div>,
   text: async function* ({ content, done }) {
@@ -491,7 +491,7 @@ export async function POST(request) {
 
   const result = streamText({
     model: __MODEL__,
-    system: 'you are a friendly assistant!',
+    instructions: 'you are a friendly assistant!',
     messages: coreMessages,
     onFinish: async ({ responseMessages }) => {
       try {
@@ -615,7 +615,7 @@ export async function generateSampleNotifications() {
   (async () => {
     const { partialOutputStream } = streamText({
       model: __MODEL__,
-      system: 'generate sample ios messages for testing',
+      instructions: 'generate sample ios messages for testing',
       prompt: 'messages from a family group chat during diwali, max 4',
       output: Output.object({ schema: notificationsSchema }),
     });

--- a/content/docs/06-advanced/07-rendering-ui-with-language-models.mdx
+++ b/content/docs/06-advanced/07-rendering-ui-with-language-models.mdx
@@ -10,7 +10,7 @@ Language models generate text, so at first it may seem like you would only need 
 ```tsx highlight="16" filename="app/actions.tsx"
 const text = generateText({
   model: __MODEL__,
-  system: 'You are a friendly assistant',
+  instructions: 'You are a friendly assistant',
   prompt: 'What is the weather in SF?',
   tools: {
     getWeather: {
@@ -35,7 +35,7 @@ Above, the language model is passed a [tool](/docs/ai-sdk-core/tools-and-tool-ca
 ```tsx highlight="18-23" filename="app/action.ts"
 const text = generateText({
   model: __MODEL__,
-  system: 'You are a friendly assistant',
+  instructions: 'You are a friendly assistant',
   prompt: 'What is the weather in SF?',
   tools: {
     getWeather: {
@@ -164,7 +164,7 @@ const uiStream = createStreamableUI();
 
 const text = generateText({
   model: __MODEL__,
-  system: 'you are a friendly assistant'
+  instructions: 'you are a friendly assistant'
   prompt: 'what is the weather in SF?'
   tools: {
     getWeather: {

--- a/content/docs/06-advanced/08-model-as-router.mdx
+++ b/content/docs/06-advanced/08-model-as-router.mdx
@@ -24,7 +24,7 @@ When language models are provided with a set of function definitions and instruc
 const sendMessage = (prompt: string) =>
   generateText({
     model: __MODEL__,
-    system: 'you are a friendly weather assistant!',
+    instructions: 'you are a friendly weather assistant!',
     prompt,
     tools: {
       getWeather: {

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -43,10 +43,10 @@ To see `generateText` in action, check out [these examples](#examples).
       description: "The language model to use. Example: openai('gpt-4o')",
     },
     {
-      name: 'system',
+      name: 'instructions',
       type: 'string | SystemModelMessage | SystemModelMessage[]',
       description:
-        'The system prompt to use that specifies the behavior of the model.',
+        'Instructions to use that specify the behavior of the model.'
     },
     {
       name: 'prompt',
@@ -331,7 +331,7 @@ To see `generateText` in action, check out [these examples](#examples).
       type: 'boolean',
       isOptional: true,
       description:
-        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `system` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
+        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `instructions` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
     },
     {
       name: 'tools',
@@ -590,7 +590,7 @@ To see `generateText` in action, check out [these examples](#examples).
       type: '(options: PrepareStepOptions) => PrepareStepResult<TOOLS> | Promise<PrepareStepResult<TOOLS>>',
       isOptional: true,
       description:
-        'Optional function that you can use to provide different settings for a step. You can modify the model, tool choices, active tools, system prompt, input messages, and sandbox for each step.',
+        'Optional function that you can use to provide different settings for a step. You can modify the model, tool choices, active tools, instructions, input messages, and sandbox for each step.',
       properties: [
         {
           type: 'PrepareStepFunction<TOOLS>',
@@ -678,11 +678,11 @@ To see `generateText` in action, check out [these examples](#examples).
                 'If provided, only these tools are enabled/available for this step.',
             },
             {
-              name: 'system',
+              name: 'instructions',
               type: 'string | SystemModelMessage | SystemModelMessage[]',
               isOptional: true,
               description:
-                'Optionally override the system message(s) sent to the model for this step.',
+                'Optionally override the instructions sent to the model for this step.'
             },
             {
               name: 'messages',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -45,10 +45,10 @@ To see `streamText` in action, check out [these examples](#examples).
       description: "The language model to use. Example: openai('gpt-4.1')",
     },
     {
-      name: 'system',
+      name: 'instructions',
       type: 'string | SystemModelMessage | SystemModelMessage[]',
       description:
-        'The system prompt to use that specifies the behavior of the model.',
+        'Instructions to use that specify the behavior of the model.'
     },
     {
       name: 'prompt',
@@ -332,7 +332,7 @@ To see `streamText` in action, check out [these examples](#examples).
       type: 'boolean',
       isOptional: true,
       description:
-        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `system` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
+        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `instructions` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
     },
     {
       name: 'tools',
@@ -634,7 +634,7 @@ To see `streamText` in action, check out [these examples](#examples).
       type: '(options: PrepareStepOptions) => PrepareStepResult<TOOLS> | Promise<PrepareStepResult<TOOLS>>',
       isOptional: true,
       description:
-        'Optional function that you can use to provide different settings for a step. You can modify the model, tool choices, active tools, system prompt, input messages, and sandbox for each step.',
+        'Optional function that you can use to provide different settings for a step. You can modify the model, tool choices, active tools, instructions, input messages, and sandbox for each step.',
       properties: [
         {
           type: 'PrepareStepFunction<TOOLS>',
@@ -722,11 +722,11 @@ To see `streamText` in action, check out [these examples](#examples).
                 'If provided, only these tools are enabled/available for this step.',
             },
             {
-              name: 'system',
+              name: 'instructions',
               type: 'string | SystemModelMessage | SystemModelMessage[]',
               isOptional: true,
               description:
-                'Optionally override the system message(s) sent to the model for this step.',
+                'Optionally override the instructions sent to the model for this step.'
             },
             {
               name: 'messages',

--- a/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/30-model-message.mdx
@@ -26,8 +26,8 @@ type SystemModelMessage = {
 You can access the Zod schema for `SystemModelMessage` with the `systemModelMessageSchema` export.
 
 <Note>
-  Use the top-level `system` property instead of a system message for system
-  instructions. AI SDK functions reject system messages in `prompt` or
+  Use the top-level `instructions` property instead of a system message for
+  system instructions. AI SDK functions reject system messages in `prompt` or
   `messages` by default unless `allowSystemInMessages` is set to `true`.
   Opting in can create a prompt injection risk if users can inject system
   messages.

--- a/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
+++ b/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
@@ -35,10 +35,10 @@ To see `streamUI` in action, check out [these examples](#examples).
       description: 'The initial UI to render.',
     },
     {
-      name: 'system',
+      name: 'instructions',
       type: 'string | SystemModelMessage | SystemModelMessage[]',
       description:
-        'The system prompt to use that specifies the behavior of the model.',
+        'Instructions to use that specify the behavior of the model.'
     },
     {
       name: 'prompt',
@@ -260,7 +260,7 @@ To see `streamUI` in action, check out [these examples](#examples).
       type: 'boolean',
       isOptional: true,
       description:
-        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `system` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
+        'Whether system messages are allowed in the `prompt` or `messages` fields. Defaults to false. System messages in the `instructions` option are always allowed. Enabling this for user-controlled messages can create a prompt injection risk.',
     },
     {
       name: 'maxOutputTokens',

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -69,9 +69,59 @@ export const myProvider = customProvider({
 This is only an import and symbol rename. The `customProvider` options and
 behavior are unchanged.
 
+### Prompt Instructions: `system` Renamed to `instructions`
+
+The top-level prompt option for system instructions has been renamed from
+`system` to `instructions`.
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  system: 'You are a helpful assistant.',
+  prompt: 'Hello!',
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  instructions: 'You are a helpful assistant.',
+  prompt: 'Hello!',
+});
+```
+
+This applies to AI SDK functions that accept `prompt` or `messages`, including
+`generateText`, `streamText`, `generateObject`, `streamObject`, and `streamUI`.
+
+The same rename applies to `prepareStep` results for `generateText` and
+`streamText`:
+
+```tsx filename="AI SDK 6"
+const result = streamText({
+  model: yourModel,
+  prompt: 'Hello!',
+  prepareStep: () => ({
+    system: 'Use concise answers for this step.',
+  }),
+});
+```
+
+```tsx filename="AI SDK 7"
+const result = streamText({
+  model: yourModel,
+  prompt: 'Hello!',
+  prepareStep: () => ({
+    instructions: 'Use concise answers for this step.',
+  }),
+});
+```
+
+The `system` option is still accepted as a deprecated fallback. When both
+`instructions` and `system` are provided, `instructions` takes precedence.
+
 ### Prompt Messages: System Messages in `prompt` or `messages` Are Rejected by Default
 
-AI SDK 7 rejects system messages in the `prompt` or `messages` fields by default. System instructions should usually be passed with the top-level `system` option.
+AI SDK 7 rejects system messages in the `prompt` or `messages` fields by default. System instructions should usually be passed with the top-level `instructions` option.
 
 This can break older persisted chats or custom prompt arrays that include `{ role: 'system' }` messages:
 
@@ -85,12 +135,12 @@ const result = await generateText({
 });
 ```
 
-Move system instructions to the `system` option when possible:
+Move system instructions to the `instructions` option when possible:
 
 ```tsx filename="AI SDK 7"
 const result = await generateText({
   model: yourModel,
-  system: 'You are a helpful assistant.',
+  instructions: 'You are a helpful assistant.',
   messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
@@ -101,7 +151,7 @@ If you need to keep existing chat histories that already contain system messages
   Only use `allowSystemInMessages` for trusted messages. If users can submit or
   edit these messages, they could inject a system message that overrides or sets
   the system prompt. In most cases, system instructions should only be set by
-  trusted server-side code through the `system` or `instructions` property.
+  trusted server-side code through the `instructions` property.
 </Note>
 
 ```tsx filename="AI SDK 7"

--- a/examples/ai-e2e-next/app/api/chat/mcp-elicitation/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/mcp-elicitation/route.ts
@@ -89,7 +89,7 @@ async function processMessages(
           console.log('TOOL RESULTS:', JSON.stringify(toolResults, null, 2));
         }
       },
-      system:
+      instructions:
         'You are a helpful assistant. When asked to register a user, use the register_user tool.',
       messages: await convertToModelMessages(messages),
       onFinish: async () => {

--- a/examples/ai-e2e-next/app/api/chat/mcp-with-auth/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/mcp-with-auth/route.ts
@@ -241,7 +241,7 @@ export async function POST(req: Request) {
             model: openai('gpt-4o-mini'),
             tools,
             stopWhen: isStepCount(10),
-            system:
+            instructions:
               'You are a helpful assistant with access to protected tools.',
             messages: await convertToModelMessages(messages),
           });

--- a/examples/ai-e2e-next/app/api/chat/streaming-tool-calls/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/streaming-tool-calls/route.ts
@@ -32,7 +32,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: openai('gpt-4o'),
     messages: await convertToModelMessages(messages),
-    system:
+    instructions:
       'You are a helpful assistant that answers questions about the weather in a given city.' +
       'You use the showWeatherInformation tool to show the weather information to the user instead of talking about it.',
     tools: {

--- a/examples/ai-e2e-next/app/api/chat/tool-timeout/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/tool-timeout/route.ts
@@ -49,7 +49,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: openai('gpt-5.4'),
     messages: await convertToModelMessages(messages),
-    system:
+    instructions:
       'You are a helpful weather assistant. When a tool times out, explain to the user that the weather service is unavailable and suggest they try again later.',
     tools,
     timeout: {

--- a/examples/ai-e2e-next/app/api/chat/vertex-streaming-tool-calls/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/vertex-streaming-tool-calls/route.ts
@@ -32,7 +32,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: googleVertex('gemini-3.1-pro-preview'),
     messages: await convertToModelMessages(messages),
-    system:
+    instructions:
       'You are a helpful weather assistant. ' +
       'Use getWeatherInformation to fetch weather data, then use showWeatherInformation to display it to the user. ' +
       'Always show the weather using the showWeatherInformation tool.',

--- a/examples/ai-e2e-next/app/api/use-object-expense-tracker/route.ts
+++ b/examples/ai-e2e-next/app/api/use-object-expense-tracker/route.ts
@@ -10,7 +10,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: openai('gpt-4o'),
-    system:
+    instructions:
       'You categorize expenses into one of the following categories: ' +
       'TRAVEL, MEALS, ENTERTAINMENT, OFFICE SUPPLIES, OTHER.' +
       // provide date (including day of week) for reference:

--- a/examples/ai-e2e-next/app/chat/mcp/chat/route.ts
+++ b/examples/ai-e2e-next/app/chat/mcp/chat/route.ts
@@ -26,7 +26,8 @@ export async function POST(req: Request) {
       onStepFinish: async ({ toolResults }) => {
         console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
       },
-      system: 'You are a helpful chatbot capable of basic arithmetic problems',
+      instructions:
+        'You are a helpful chatbot capable of basic arithmetic problems',
       messages: await convertToModelMessages(messages),
       onFinish: async () => {
         await client.close();

--- a/examples/ai-e2e-next/app/stream-ui/actions.tsx
+++ b/examples/ai-e2e-next/app/stream-ui/actions.tsx
@@ -38,7 +38,7 @@ export async function submitUserMessage(content: string) {
   const result = await streamUI({
     model: openai('gpt-5-mini'),
     initial: <Message role="assistant">Working on that...</Message>,
-    system: 'You are a weather assistant.',
+    instructions: 'You are a weather assistant.',
     messages: aiState
       .get()
       .messages.map(({ role, content }) => ({ role, content }) as ModelMessage),

--- a/examples/ai-functions/src/agent/openai/generate-just-bash-sandbox-compaction.ts
+++ b/examples/ai-functions/src/agent/openai/generate-just-bash-sandbox-compaction.ts
@@ -29,7 +29,8 @@ const estimateTokens = (messages: ModelMessage[]) => {
 run(async () => {
   const result = await generateText({
     model: openai('gpt-5.5'),
-    system: 'You have access to a filesystem. Details: ' + sandbox.description,
+    instructions:
+      'You have access to a filesystem. Details: ' + sandbox.description,
     prompt: 'Read every .ts file in this directory',
     sandbox,
     tools: {

--- a/examples/ai-functions/src/complex/math-agent/agent-required-tool-choice.ts
+++ b/examples/ai-functions/src/complex/math-agent/agent-required-tool-choice.ts
@@ -35,7 +35,7 @@ run(async () => {
     onStepFinish: async ({ toolResults }) => {
       console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
     },
-    system:
+    instructions:
       'You are solving math problems. ' +
       'Reason step by step. ' +
       'Use the calculator when necessary. ' +

--- a/examples/ai-functions/src/complex/math-agent/agent.ts
+++ b/examples/ai-functions/src/complex/math-agent/agent.ts
@@ -20,7 +20,7 @@ run(async () => {
     onStepFinish: async ({ toolResults }) => {
       console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
     },
-    system:
+    instructions:
       'You are solving math problems. ' +
       'Reason step by step. ' +
       'Use the calculator when necessary. ' +

--- a/examples/ai-functions/src/e2e/huggingface.test.ts
+++ b/examples/ai-functions/src/e2e/huggingface.test.ts
@@ -87,7 +87,7 @@ describe('HuggingFace Provider', () => {
   it('should handle system messages', async () => {
     const result = await generateText({
       model: huggingFace('meta-llama/Llama-3.1-8B-Instruct'),
-      system:
+      instructions:
         'You are a helpful assistant that responds with exactly one word.',
       prompt: 'Say hello',
     });

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/anthropic-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/anthropic-chatbot.ts
@@ -6,7 +6,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = await generateText({
     model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     messages: [
       { role: 'user', content: 'Hello!' },
       { role: 'assistant', content: 'Hello! How can I help you today?' },

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/chatbot.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/chatbot.ts
@@ -24,7 +24,7 @@ run(async () => {
       await generateText({
         model: amazonBedrock('anthropic.claude-3-haiku-20240307-v1:0'),
         tools: { weatherTool },
-        system: `You are a helpful, respectful and honest assistant. If the weather is requested use the `,
+        instructions: `You are a helpful, respectful and honest assistant. If the weather is requested use the `,
         messages,
       });
 

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/reasoning-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/reasoning-chatbot.ts
@@ -19,7 +19,7 @@ run(async () => {
     const { steps, responseMessages } = await generateText({
       model: amazonBedrock('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
       tools: { weatherTool },
-      system: `You are a helpful, respectful and honest assistant.`,
+      instructions: `You are a helpful, respectful and honest assistant.`,
       messages,
       stopWhen: isStepCount(5),
       reasoning: 'medium',

--- a/examples/ai-functions/src/generate-text/anthropic/chatbot-websearch.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/chatbot-websearch.ts
@@ -34,7 +34,7 @@ run(async () => {
           },
         }),
       },
-      system: `You are a helpful, respectful and honest assistant.`,
+      instructions: `You are a helpful, respectful and honest assistant.`,
       messages,
       stopWhen: isStepCount(3),
     });

--- a/examples/ai-functions/src/generate-text/anthropic/chatbot.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/chatbot.ts
@@ -24,7 +24,7 @@ run(async () => {
       await generateText({
         model: anthropic('claude-3-5-sonnet-20240620'),
         tools: { weatherTool },
-        system: `You are a helpful, respectful and honest assistant.`,
+        instructions: `You are a helpful, respectful and honest assistant.`,
         messages,
       });
 

--- a/examples/ai-functions/src/generate-text/anthropic/reasoning-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/reasoning-chatbot.ts
@@ -31,7 +31,7 @@ run(async () => {
     const { steps, responseMessages } = await generateText({
       model: anthropic('claude-sonnet-4-5-20250929'),
       tools: { weatherTool },
-      system: `You are a helpful, respectful and honest assistant.`,
+      instructions: `You are a helpful, respectful and honest assistant.`,
       messages,
       stopWhen: isStepCount(5),
       reasoning: 'medium',

--- a/examples/ai-functions/src/generate-text/azure/responses-reasoning-summary.ts
+++ b/examples/ai-functions/src/generate-text/azure/responses-reasoning-summary.ts
@@ -6,7 +6,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = await generateText({
     model: azure.responses('gpt-5-mini'), // use your own deployment
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     prompt:
       'Tell me about the debate over Taqueria La Cumbre and El Farolito and who created the San Francisco Mission-style burrito.',
     providerOptions: {

--- a/examples/ai-functions/src/generate-text/cohere/chatbot.ts
+++ b/examples/ai-functions/src/generate-text/cohere/chatbot.ts
@@ -24,7 +24,7 @@ run(async () => {
       await generateText({
         model: cohere('command-r-plus'),
         tools: { weatherTool },
-        system: `You are a helpful, respectful and honest assistant. If the weather is requested use the `,
+        instructions: `You are a helpful, respectful and honest assistant. If the weather is requested use the `,
         messages,
       });
 

--- a/examples/ai-functions/src/generate-text/google/gemini-2-5-flash-lite-multi-step.ts
+++ b/examples/ai-functions/src/generate-text/google/gemini-2-5-flash-lite-multi-step.ts
@@ -7,7 +7,8 @@ run(async () => {
   const result = await generateText({
     model: google('gemini-2.5-flash-lite'),
     // Asking for JSON without specifying `output` is brittle, but still can be useful for model testing.
-    system: 'You are a helpful assistant. Provide the answer in JSON format.',
+    instructions:
+      'You are a helpful assistant. Provide the answer in JSON format.',
     prompt: 'What are the available exams?',
     tools: {
       getExams: tool({

--- a/examples/ai-functions/src/generate-text/google/gemma-system-instructions.ts
+++ b/examples/ai-functions/src/generate-text/google/gemma-system-instructions.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = await generateText({
     model: google('gemma-3-12b-it'),
-    system:
+    instructions:
       'You are a helpful pirate assistant. Always respond like a friendly pirate, using "Arrr" and pirate terminology.',
     prompt: 'What is the meaning of life?',
   });

--- a/examples/ai-functions/src/generate-text/google/vertex-anthropic-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-anthropic-chatbot.ts
@@ -24,7 +24,7 @@ run(async () => {
       await generateText({
         model: vertexAnthropic('claude-3-5-sonnet-v2@20241022'),
         tools: { weatherTool },
-        system: `You are a helpful, respectful and honest assistant.`,
+        instructions: `You are a helpful, respectful and honest assistant.`,
         messages,
       });
 

--- a/examples/ai-functions/src/generate-text/huggingface/system-message.ts
+++ b/examples/ai-functions/src/generate-text/huggingface/system-message.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = await generateText({
     model: huggingFace('meta-llama/Llama-3.1-8B-Instruct'),
-    system:
+    instructions:
       'You are a helpful assistant that always responds in a pirate accent.',
     prompt: 'Tell me about the weather today.',
   });

--- a/examples/ai-functions/src/generate-text/mistral/chatbot.ts
+++ b/examples/ai-functions/src/generate-text/mistral/chatbot.ts
@@ -24,7 +24,7 @@ run(async () => {
       await generateText({
         model: mistral('mistral-large-latest'),
         tools: { weatherTool },
-        system: `You are a helpful, respectful and honest assistant.`,
+        instructions: `You are a helpful, respectful and honest assistant.`,
         messages,
       });
 

--- a/examples/ai-functions/src/generate-text/open-responses/lmstudio-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/open-responses/lmstudio-chatbot.ts
@@ -29,7 +29,7 @@ run(async () => {
       await generateText({
         model: lmstudio('zai-org/glm-4.7-flash'),
         tools: { weatherTool },
-        system: `You are a helpful, respectful and honest assistant. If the weather is requested use the `,
+        instructions: `You are a helpful, respectful and honest assistant. If the weather is requested use the `,
         messages,
       });
 

--- a/examples/ai-functions/src/generate-text/openai/completion-chat.ts
+++ b/examples/ai-functions/src/generate-text/openai/completion-chat.ts
@@ -6,7 +6,7 @@ run(async () => {
   const result = await generateText({
     model: openai('gpt-3.5-turbo-instruct'),
     maxOutputTokens: 1024,
-    system: 'You are a helpful chatbot.',
+    instructions: 'You are a helpful chatbot.',
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/openai/output-json.ts
+++ b/examples/ai-functions/src/generate-text/openai/output-json.ts
@@ -10,7 +10,7 @@ run(async () => {
     tools: { weather: weatherTool },
     stopWhen: isStepCount(5),
     output: Output.json(),
-    system: 'Return JSON only, no other text.',
+    instructions: 'Return JSON only, no other text.',
     prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });
 

--- a/examples/ai-functions/src/generate-text/openai/output-object-multimodal.ts
+++ b/examples/ai-functions/src/generate-text/openai/output-object-multimodal.ts
@@ -16,7 +16,7 @@ run(async () => {
         }),
       }),
     }),
-    system: 'You are an art critic reviewing a piece of art.',
+    instructions: 'You are an art critic reviewing a piece of art.',
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/openai/responses-chatbot.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-chatbot.ts
@@ -24,7 +24,7 @@ run(async () => {
       await generateText({
         model: openai.responses('o3'),
         tools: { weatherTool },
-        system: `You are a helpful, respectful and honest assistant.`,
+        instructions: `You are a helpful, respectful and honest assistant.`,
         messages,
       });
 

--- a/examples/ai-functions/src/generate-text/openai/responses-mcp-tool-approval.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-mcp-tool-approval.ts
@@ -42,7 +42,7 @@ run(async () => {
 
     const result = await generateText({
       model: openai.responses('gpt-5-mini'),
-      system:
+      instructions:
         'You are a helpful assistant that can shorten links. ' +
         'Use the MCP tools available to you to shorten links when needed. ' +
         'When a tool execution is not approved by the user, do not retry it. ' +

--- a/examples/ai-functions/src/generate-text/openai/responses-shell-tool-with-approval.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-shell-tool-with-approval.ts
@@ -47,7 +47,7 @@ run(async () => {
       },
       messages,
       stopWhen: isStepCount(5),
-      system:
+      instructions:
         'You have access to a shell tool that can execute commands on the local filesystem. ' +
         'Use the shell tool when you need to perform file operations or run commands. ' +
         'When a tool execution is not approved by the user, do not retry it. ' +

--- a/examples/ai-functions/src/generate-text/openai/system-message-b.ts
+++ b/examples/ai-functions/src/generate-text/openai/system-message-b.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = await generateText({
     model: openai('gpt-3.5-turbo'),
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     messages: [{ role: 'user', content: 'What is the capital of France?' }],
   });
 

--- a/examples/ai-functions/src/generate-text/openai/tool-approval-generic.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-approval-generic.ts
@@ -43,7 +43,7 @@ run(async () => {
       model: openai('gpt-5.4-mini'),
       // context engineering required to make sure the model does not retry
       // the tool execution if it is not approved for a particular tool call:
-      system:
+      instructions:
         'When a tool call was not approved by the user, ' +
         'do not retry the tool call with the same input.' +
         'Just say that the tool execution was not approved.' +

--- a/examples/ai-functions/src/generate-text/openai/tool-approval.ts
+++ b/examples/ai-functions/src/generate-text/openai/tool-approval.ts
@@ -43,7 +43,7 @@ run(async () => {
       model: openai('gpt-5.4-mini'),
       // context engineering required to make sure the model does not retry
       // the tool execution if it is not approved for a particular tool call:
-      system:
+      instructions:
         'When a tool call was not approved by the user, ' +
         'do not retry the tool call with the same input.' +
         'Just say that the tool execution was not approved.' +

--- a/examples/ai-functions/src/generate-text/xai/grok-3-mini-output-object-reasoning-effort.ts
+++ b/examples/ai-functions/src/generate-text/xai/grok-3-mini-output-object-reasoning-effort.ts
@@ -13,7 +13,7 @@ run(async () => {
         occupation: z.string().optional(),
       }),
     }),
-    system: 'identify the person information from the following text',
+    instructions: 'identify the person information from the following text',
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/generate-text/xai/grok-4-fast-output-object-reasoning.ts
+++ b/examples/ai-functions/src/generate-text/xai/grok-4-fast-output-object-reasoning.ts
@@ -13,7 +13,7 @@ run(async () => {
         occupation: z.string().optional(),
       }),
     }),
-    system: 'identify the person information from the following text',
+    instructions: 'identify the person information from the following text',
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/stream-text/alibaba/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/alibaba/chatbot.ts
@@ -19,7 +19,7 @@ run(async () => {
 
     const result = streamText({
       model: alibaba('qwen-plus'),
-      system: 'You are a helpful, respectful and honest assistant.',
+      instructions: 'You are a helpful, respectful and honest assistant.',
       messages,
       stopWhen: isStepCount(5),
       tools: {

--- a/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/amazon-bedrock/anthropic-chatbot.ts
@@ -6,7 +6,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = streamText({
     model: bedrockAnthropic('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     messages: [
       { role: 'user', content: 'Hello!' },
       { role: 'assistant', content: 'Hello! How can I help you today?' },

--- a/examples/ai-functions/src/stream-text/azure/responses-reasoning-summary.ts
+++ b/examples/ai-functions/src/stream-text/azure/responses-reasoning-summary.ts
@@ -6,7 +6,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = streamText({
     model: azure.responses('gpt-5-mini'), // use your own deployment
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     prompt:
       'Tell me about the debate over Taqueria La Cumbre and El Farolito and who created the San Francisco Mission-style burrito.',
     providerOptions: {

--- a/examples/ai-functions/src/stream-text/google/basic.ts
+++ b/examples/ai-functions/src/stream-text/google/basic.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = streamText({
     model: google('gemini-2.5-pro'),
-    system: 'You are a comedian. Only give funny answers.',
+    instructions: 'You are a comedian. Only give funny answers.',
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/stream-text/google/gemini-2-5-flash-lite-multi-step.ts
+++ b/examples/ai-functions/src/stream-text/google/gemini-2-5-flash-lite-multi-step.ts
@@ -7,7 +7,8 @@ run(async () => {
   const result = streamText({
     model: google('gemini-2.5-flash-lite'),
     // Asking for JSON without specifying `output` is brittle, but still can be useful for model testing.
-    system: 'You are a helpful assistant. Provide the answer in JSON format.',
+    instructions:
+      'You are a helpful assistant. Provide the answer in JSON format.',
     prompt: 'What are the available exams?',
     tools: {
       getExams: tool({

--- a/examples/ai-functions/src/stream-text/google/gemma-system-instructions.ts
+++ b/examples/ai-functions/src/stream-text/google/gemma-system-instructions.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = streamText({
     model: google('gemma-3-12b-it'),
-    system:
+    instructions:
       'You are a helpful pirate assistant. Always respond like a friendly pirate, using "Arrr" and pirate terminology.',
     prompt: 'Tell me a short story about finding treasure.',
   });

--- a/examples/ai-functions/src/stream-text/google/vertex.ts
+++ b/examples/ai-functions/src/stream-text/google/vertex.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = streamText({
     model: googleVertex('gemini-2.5-pro'),
-    system: 'You are a comedian. Only give funny answers.',
+    instructions: 'You are a comedian. Only give funny answers.',
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/stream-text/groq/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/groq/chatbot.ts
@@ -22,7 +22,7 @@ run(async () => {
       onError(error) {
         console.error(error);
       },
-      system: `You are a helpful, respectful and honest assistant.`,
+      instructions: `You are a helpful, respectful and honest assistant.`,
       tools: {
         weather: tool({
           description: 'Get the weather in a location',

--- a/examples/ai-functions/src/stream-text/huggingface/system-message.ts
+++ b/examples/ai-functions/src/stream-text/huggingface/system-message.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 run(async () => {
   const result = streamText({
     model: huggingFace('meta-llama/Llama-3.1-8B-Instruct'),
-    system:
+    instructions:
       'You are a knowledgeable chef who loves to share cooking tips and recipes.',
     prompt: 'How do I make the perfect scrambled eggs?',
   });

--- a/examples/ai-functions/src/stream-text/mistral/chatbot.ts
+++ b/examples/ai-functions/src/stream-text/mistral/chatbot.ts
@@ -22,7 +22,7 @@ run(async () => {
       onError(error) {
         console.error(error);
       },
-      system: `You are a helpful, respectful and honest assistant.`,
+      instructions: `You are a helpful, respectful and honest assistant.`,
       tools: {
         weather: tool({
           description: 'Get the weather in a location',

--- a/examples/ai-functions/src/stream-text/open-responses/lmstudio-chatbot.ts
+++ b/examples/ai-functions/src/stream-text/open-responses/lmstudio-chatbot.ts
@@ -25,7 +25,7 @@ run(async () => {
     const result = streamText({
       model: lmstudio('zai-org/glm-4.7-flash'),
       tools: { weather: weatherTool },
-      system: `You are a helpful, respectful and honest assistant.`,
+      instructions: `You are a helpful, respectful and honest assistant.`,
       stopWhen: isStepCount(5),
       messages,
       onError: ({ error }) => {

--- a/examples/ai-functions/src/stream-text/openai/completion-chat.ts
+++ b/examples/ai-functions/src/stream-text/openai/completion-chat.ts
@@ -6,7 +6,7 @@ run(async () => {
   const result = streamText({
     model: openai('gpt-3.5-turbo-instruct'),
     maxOutputTokens: 1024,
-    system: 'You are a helpful chatbot.',
+    instructions: 'You are a helpful chatbot.',
     messages: [
       {
         role: 'user',

--- a/examples/ai-functions/src/stream-text/openai/output-json.ts
+++ b/examples/ai-functions/src/stream-text/openai/output-json.ts
@@ -9,7 +9,7 @@ run(async () => {
     tools: { weather: weatherTool },
     stopWhen: isStepCount(5),
     output: Output.json(),
-    system: 'Return JSON only, no other text.',
+    instructions: 'Return JSON only, no other text.',
     prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });
 

--- a/examples/ai-functions/src/stream-text/openai/responses-mcp-tool-approval.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-mcp-tool-approval.ts
@@ -42,7 +42,7 @@ run(async () => {
 
     const result = streamText({
       model: openai.responses('gpt-5-mini'),
-      system:
+      instructions:
         'You are a helpful assistant that can shorten links. ' +
         'Use the MCP tools available to you to shorten links when needed. ' +
         'When a tool execution is not approved by the user, do not retry it. ' +

--- a/examples/ai-functions/src/stream-text/openai/responses-reasoning-summary.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-reasoning-summary.ts
@@ -9,7 +9,7 @@ run(async () => {
   const result = streamText({
     // supported: o4-mini, o3, o3-mini and o1
     model: openai.responses('o3-mini'),
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     prompt:
       'Tell me about the debate over Taqueria La Cumbre and El Farolito and who created the San Francisco Mission-style burrito.',
     providerOptions: {

--- a/examples/ai-functions/src/stream-text/openai/responses-reasoning-tool-call.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-reasoning-tool-call.ts
@@ -35,7 +35,7 @@ run(async () => {
         },
       }),
     },
-    system: `If you encounter a function call error, you should retry 3 times before giving up.`,
+    instructions: `If you encounter a function call error, you should retry 3 times before giving up.`,
     prompt: `Generate two texts of 1024 characters each. Count the number of "a" in the first text, and the number of "b" in the second text.`,
     reasoning: 'medium',
     providerOptions: {

--- a/examples/ai-functions/src/stream-text/openai/responses.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses.ts
@@ -6,7 +6,7 @@ run(async () => {
   const result = streamText({
     model: openai.responses('gpt-4o-mini'),
     maxOutputTokens: 100,
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/stream-text/openai/swarm.ts
+++ b/examples/ai-functions/src/stream-text/openai/swarm.ts
@@ -5,12 +5,12 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const agentA = {
-    system: 'You are a helpful agent.',
+    instructions: 'You are a helpful agent.',
     activeTools: ['transferToAgentB'] as 'transferToAgentB'[],
   };
 
   const agentB = {
-    system: 'Only speak in Haikus.',
+    instructions: 'Only speak in Haikus.',
     activeTools: [],
   };
 

--- a/examples/ai-functions/src/stream-text/openai/tool-approval.ts
+++ b/examples/ai-functions/src/stream-text/openai/tool-approval.ts
@@ -43,7 +43,7 @@ run(async () => {
       model: openai('gpt-5.4-mini'),
       // context engineering required to make sure the model does not retry
       // the tool execution if it is not approved for a particular tool call:
-      system:
+      instructions:
         'When a tool call was not approved by the user, ' +
         'do not retry the tool call with the same input.' +
         'Just say that the tool execution was not approved.' +

--- a/examples/mcp/src/http/client.ts
+++ b/examples/mcp/src/http/client.ts
@@ -22,7 +22,7 @@ async function main() {
       onStepFinish: async ({ toolResults }) => {
         console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
       },
-      system: 'You are a helpful chatbot',
+      instructions: 'You are a helpful chatbot',
       prompt: 'Look up information about user with the ID foo_123',
     });
 

--- a/examples/mcp/src/mcp-with-auth/client.ts
+++ b/examples/mcp/src/mcp-with-auth/client.ts
@@ -212,7 +212,7 @@ async function main() {
         });
       }
     },
-    system: 'You are a helpful assistant with access to protected tools.',
+    instructions: 'You are a helpful assistant with access to protected tools.',
     prompt:
       'List the tools available for me to call. Arrange them in alphabetical order.',
   });

--- a/examples/mcp/src/shopify-mcp/client.ts
+++ b/examples/mcp/src/shopify-mcp/client.ts
@@ -24,7 +24,7 @@ async function main() {
     const result = streamText({
       model: openai('gpt-4o-mini'),
       tools,
-      system: 'You are a helpful chatbot',
+      instructions: 'You are a helpful chatbot',
       prompt: 'What tools are available for me to call?',
       onFinish: async () => {
         await mcpClient.close();

--- a/examples/mcp/src/sse/client.ts
+++ b/examples/mcp/src/sse/client.ts
@@ -24,7 +24,7 @@ async function main() {
     onStepFinish: async ({ toolResults }) => {
       console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
     },
-    system: 'You are a helpful chatbot',
+    instructions: 'You are a helpful chatbot',
     prompt: 'List all products, then find availability for Product 1.',
   });
 

--- a/examples/mcp/src/stdio/client.ts
+++ b/examples/mcp/src/stdio/client.ts
@@ -36,7 +36,7 @@ async function main() {
       onStepFinish: async ({ toolResults }) => {
         console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
       },
-      system: 'You are an expert in Pokemon',
+      instructions: 'You are an expert in Pokemon',
       prompt:
         'Which Pokemon could best defeat Feebas? Choose one and share details about it.',
     });

--- a/examples/next-openai-pages/app/api/call-tool/route.ts
+++ b/examples/next-openai-pages/app/api/call-tool/route.ts
@@ -7,7 +7,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: openai('gpt-5'),
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     messages: await convertToModelMessages(messages),
     tools: {
       celsiusToFahrenheit: {

--- a/examples/next-openai-pages/app/api/generate-chat/route.ts
+++ b/examples/next-openai-pages/app/api/generate-chat/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
 
   const { responseMessages } = await generateText({
     model: openai('gpt-5'),
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     messages,
   });
 

--- a/examples/next-openai-pages/app/api/generate-object/route.ts
+++ b/examples/next-openai-pages/app/api/generate-object/route.ts
@@ -7,7 +7,7 @@ export async function POST(req: Request) {
 
   const { output } = await generateText({
     model: openai('gpt-5'),
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     prompt,
     output: Output.object({
       schema: z.object({

--- a/examples/next-openai-pages/app/api/generate-text/route.ts
+++ b/examples/next-openai-pages/app/api/generate-text/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
 
   const { text } = await generateText({
     model: openai('gpt-5'),
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     prompt,
   });
 

--- a/examples/next-openai-pages/app/api/stream-chat/route.ts
+++ b/examples/next-openai-pages/app/api/stream-chat/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: openai('gpt-5'),
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     messages,
   });
 

--- a/examples/next-openai-pages/app/api/stream-text/route.ts
+++ b/examples/next-openai-pages/app/api/stream-text/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: openai('gpt-5'),
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     prompt,
   });
 

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -139,7 +139,7 @@ export class ToolLoopAgent<
     const { instructions, messages, prompt, runtimeContext, ...callArgs } =
       preparedCallArgs;
 
-    const promptArgs = { system: instructions, messages, prompt } as Prompt;
+    const promptArgs = { instructions, messages, prompt } as Prompt;
 
     if (runtimeContext === undefined) {
       return {

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -230,6 +230,7 @@ export async function generateObject<
   const {
     model: modelArg,
     output = 'object',
+    instructions,
     system,
     prompt,
     messages,
@@ -301,7 +302,7 @@ export async function generateObject<
       operationId: 'ai.generateObject' as const,
       provider: model.provider,
       modelId: model.modelId,
-      system,
+      system: instructions ?? system,
       prompt,
       messages,
       maxOutputTokens: callSettings.maxOutputTokens,
@@ -324,6 +325,7 @@ export async function generateObject<
 
   try {
     const standardizedPrompt = await standardizePrompt({
+      instructions,
       system,
       prompt,
       messages,

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -314,6 +314,7 @@ export function streamObject<
   const {
     model,
     output = 'object',
+    instructions,
     system,
     prompt,
     messages,
@@ -372,6 +373,7 @@ export function streamObject<
     maxRetries,
     abortSignal,
     outputStrategy,
+    instructions,
     system,
     prompt,
     messages,
@@ -427,6 +429,7 @@ class DefaultStreamObjectResult<
     maxRetries: maxRetriesArg,
     abortSignal,
     outputStrategy,
+    instructions,
     system,
     prompt,
     messages,
@@ -452,6 +455,7 @@ class DefaultStreamObjectResult<
     maxRetries: number | undefined;
     abortSignal: AbortSignal | undefined;
     outputStrategy: OutputStrategy<PARTIAL, RESULT, ELEMENT_STREAM>;
+    instructions: Prompt['instructions'];
     system: Prompt['system'];
     prompt: Prompt['prompt'];
     messages: Prompt['messages'];
@@ -514,7 +518,7 @@ class DefaultStreamObjectResult<
           operationId: 'ai.streamObject' as const,
           provider: model.provider,
           modelId: model.modelId,
-          system,
+          system: instructions ?? system,
           prompt,
           messages,
           maxOutputTokens: callSettings.maxOutputTokens,
@@ -540,6 +544,7 @@ class DefaultStreamObjectResult<
       });
 
       const standardizedPrompt = await standardizePrompt({
+        instructions,
         system,
         prompt,
         messages,

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1129,7 +1129,7 @@ describe('generateText', () => {
             ...dummyResponseValues,
           }),
         }),
-        system: 'you are a helpful assistant',
+        instructions: 'you are a helpful assistant',
         messages: [{ role: 'user', content: 'test-message' }],
         maxOutputTokens: 100,
         temperature: 0.5,
@@ -2005,7 +2005,7 @@ describe('generateText', () => {
             execute: async ({ value }) => `${value}-result`,
           }),
         },
-        system: 'test-system',
+        instructions: 'test-system',
         prompt: 'test-input',
         maxOutputTokens: 128,
         temperature: 0.7,
@@ -4039,7 +4039,7 @@ describe('generateText', () => {
                   type: 'tool',
                   toolName: 'tool1' as const,
                 },
-                system: 'system-message-0',
+                instructions: 'system-message-0',
                 messages: [
                   {
                     role: 'user',
@@ -4055,7 +4055,7 @@ describe('generateText', () => {
               return {
                 model: trueModel,
                 activeTools: [],
-                system: 'system-message-1',
+                instructions: 'system-message-1',
                 runtimeContext: { context: 'state3' },
               };
             }

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -205,6 +205,7 @@ export async function generateText<
   model: modelArg,
   tools,
   toolChoice,
+  instructions,
   system,
   prompt,
   messages,
@@ -474,6 +475,7 @@ export async function generateText<
   );
 
   const initialPrompt = await standardizePrompt({
+    instructions,
     system,
     prompt,
     messages,
@@ -498,7 +500,7 @@ export async function generateText<
       operationId: 'ai.generateText',
       provider: model.provider,
       modelId: model.modelId,
-      system,
+      system: initialPrompt.system,
       messages: initialPrompt.messages,
       tools,
       toolChoice,

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -669,9 +669,14 @@ export async function generateText<
           prepareStepResult?.model ?? model,
         );
 
+        const stepSystem =
+          prepareStepResult?.instructions ??
+          prepareStepResult?.system ??
+          initialPrompt.system;
+
         const promptMessages = await convertToLanguageModelPrompt({
           prompt: {
-            system: prepareStepResult?.system ?? initialPrompt.system,
+            system: stepSystem,
             messages: prepareStepResult?.messages ?? stepInputMessages,
           },
           supportedUrls: await stepModel.supportedUrls,
@@ -696,8 +701,6 @@ export async function generateText<
         });
 
         const stepMessages = prepareStepResult?.messages ?? stepInputMessages;
-
-        const stepSystem = prepareStepResult?.system ?? initialPrompt.system;
 
         const stepProviderOptions = mergeObjects(
           providerOptions,

--- a/packages/ai/src/generate-text/prepare-step.ts
+++ b/packages/ai/src/generate-text/prepare-step.ts
@@ -106,7 +106,14 @@ export type PrepareStepResult<
       activeTools?: ActiveTools<NoInfer<TOOLS>>;
 
       /**
-       * Optionally override the system message(s) sent to the model for this step.
+       * Optionally override the instructions sent to the model for this step.
+       */
+      instructions?: string | SystemModelMessage | Array<SystemModelMessage>;
+
+      /**
+       * Optionally override the instructions sent to the model for this step.
+       *
+       * @deprecated Use `instructions` instead.
        */
       system?: string | SystemModelMessage | Array<SystemModelMessage>;
 

--- a/packages/ai/src/generate-text/stream-language-model-call.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.ts
@@ -182,6 +182,7 @@ export async function streamLanguageModelCall<
   output,
   toolChoice,
   prompt,
+  instructions,
   system,
   messages,
   allowSystemInMessages,
@@ -252,6 +253,7 @@ export async function streamLanguageModelCall<
   const effectiveCallId = callId ?? generateCallId();
 
   const standardizedPrompt = await standardizePrompt({
+    instructions,
     system,
     prompt,
     messages,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -6223,7 +6223,7 @@ describe('streamText', () => {
 
       const result = streamText({
         model: createTestModel(),
-        system: 'you are a helpful assistant',
+        instructions: 'you are a helpful assistant',
         messages: [{ role: 'user', content: 'test-message' }],
         maxOutputTokens: 100,
         temperature: 0.5,
@@ -10723,7 +10723,7 @@ describe('streamText', () => {
                   type: 'tool',
                   toolName: 'tool1' as const,
                 },
-                system: 'system-message-0',
+                instructions: 'system-message-0',
                 messages: [
                   {
                     role: 'user',
@@ -10737,7 +10737,7 @@ describe('streamText', () => {
             if (stepNumber === 1) {
               return {
                 activeTools: [],
-                system: 'system-message-1',
+                instructions: 'system-message-1',
                 runtimeContext: { context: 'state3' },
               };
             }

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -303,6 +303,7 @@ export function streamText<
   model,
   tools,
   toolChoice,
+  instructions,
   system,
   prompt,
   messages,
@@ -616,6 +617,7 @@ export function streamText<
     stepAbortController,
     chunkTimeoutMs,
     chunkAbortController,
+    instructions,
     system,
     prompt,
     messages,
@@ -812,6 +814,7 @@ class DefaultStreamTextResult<
     stepAbortController,
     chunkTimeoutMs,
     chunkAbortController,
+    instructions,
     system,
     prompt,
     messages,
@@ -860,6 +863,7 @@ class DefaultStreamTextResult<
     chunkAbortController: AbortController | undefined;
     toolsContext: InferToolSetContext<TOOLS>;
     runtimeContext: RUNTIME_CONTEXT;
+    instructions: Prompt['instructions'];
     system: Prompt['system'];
     prompt: Prompt['prompt'];
     messages: Prompt['messages'];
@@ -1374,6 +1378,7 @@ class DefaultStreamTextResult<
 
     (async () => {
       const initialPrompt = await standardizePrompt({
+        instructions,
         system,
         prompt,
         messages,
@@ -1386,7 +1391,7 @@ class DefaultStreamTextResult<
           operationId: 'ai.streamText',
           provider: model.provider,
           modelId: model.modelId,
-          system,
+          system: initialPrompt.system,
           messages: initialPrompt.messages,
           tools,
           toolChoice,

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1634,7 +1634,10 @@ class DefaultStreamTextResult<
 
           const stepMessages = prepareStepResult?.messages ?? stepInputMessages;
           currentStepMessages = stepMessages;
-          const stepSystem = prepareStepResult?.system ?? initialPrompt.system;
+          const stepSystem =
+            prepareStepResult?.instructions ??
+            prepareStepResult?.system ??
+            initialPrompt.system;
 
           const stepProviderOptions = mergeObjects(
             providerOptions,

--- a/packages/ai/src/prompt/prompt.ts
+++ b/packages/ai/src/prompt/prompt.ts
@@ -2,18 +2,26 @@ import type { ModelMessage, SystemModelMessage } from '@ai-sdk/provider-utils';
 
 /**
  * Prompt part of the AI function options.
- * It contains a system message, a simple text prompt, or a list of messages.
+ * It contains instructions, a simple text prompt, or a list of messages.
  */
 export type Prompt = {
   /**
-   * System message to include in the prompt. Can be used with `prompt` or `messages`.
+   * Instructions to include in the prompt. Can be used with `prompt` or `messages`.
+   */
+  instructions?: string | SystemModelMessage | Array<SystemModelMessage>;
+
+  /**
+   * Instructions to include in the prompt. Can be used with `prompt` or `messages`.
+   *
+   * @deprecated Use `instructions` instead.
    */
   system?: string | SystemModelMessage | Array<SystemModelMessage>;
 
   /**
    * Whether system messages are allowed in the `prompt` or `messages` fields.
    *
-   * When disabled, system messages must be provided through the `system` option.
+   * When disabled, system messages must be provided through the `instructions`
+   * option.
    *
    * @default false
    */

--- a/packages/ai/src/prompt/standardize-prompt.test.ts
+++ b/packages/ai/src/prompt/standardize-prompt.test.ts
@@ -115,9 +115,9 @@ describe('standardizePrompt', () => {
     }).rejects.toThrow(InvalidPromptError);
   });
 
-  it('should support SystemModelMessage system message', async () => {
+  it('should support SystemModelMessage instructions', async () => {
     const result = await standardizePrompt({
-      system: {
+      instructions: {
         role: 'system',
         content: 'INSTRUCTIONS',
       },
@@ -140,9 +140,9 @@ describe('standardizePrompt', () => {
     `);
   });
 
-  it('should support array of SystemModelMessage system messages', async () => {
+  it('should support array of SystemModelMessage instructions', async () => {
     const result = await standardizePrompt({
-      system: [
+      instructions: [
         { role: 'system', content: 'INSTRUCTIONS' },
         { role: 'system', content: 'INSTRUCTIONS 2' },
       ],
@@ -167,6 +167,45 @@ describe('standardizePrompt', () => {
             "role": "system",
           },
         ],
+      }
+    `);
+  });
+
+  it('should fall back to system when instructions is not defined', async () => {
+    const result = await standardizePrompt({
+      system: 'SYSTEM',
+      prompt: 'Hello, world!',
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "Hello, world!",
+            "role": "user",
+          },
+        ],
+        "system": "SYSTEM",
+      }
+    `);
+  });
+
+  it('should prefer instructions over system', async () => {
+    const result = await standardizePrompt({
+      instructions: 'INSTRUCTIONS',
+      system: 'SYSTEM',
+      prompt: 'Hello, world!',
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "Hello, world!",
+            "role": "user",
+          },
+        ],
+        "system": "INSTRUCTIONS",
       }
     `);
   });

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -27,17 +27,20 @@ export type StandardizedPrompt = {
  *
  * @param prompt - The prompt definition to standardize.
  * Set `allowSystemInMessages` to true to allow system messages in the
- * `prompt` or `messages` fields. System messages in the `system` option are
- * always allowed.
+ * `prompt` or `messages` fields. System messages in the `instructions`
+ * option are always allowed.
  * @returns The standardized prompt.
  * @throws {InvalidPromptError} When the prompt is invalid.
  */
 export async function standardizePrompt({
   allowSystemInMessages = false,
+  instructions,
   system,
   prompt,
   messages,
 }: Prompt): Promise<StandardizedPrompt> {
+  const resolvedInstructions = instructions ?? system;
+
   if (prompt == null && messages == null) {
     throw new InvalidPromptError({
       prompt,
@@ -52,15 +55,15 @@ export async function standardizePrompt({
     });
   }
 
-  // validate that system is a string or a SystemModelMessage
+  // validate that instructions is a string or a SystemModelMessage
   if (
-    typeof system !== 'string' &&
-    !asArray(system).every(message => message.role === 'system')
+    typeof resolvedInstructions !== 'string' &&
+    !asArray(resolvedInstructions).every(message => message.role === 'system')
   ) {
     throw new InvalidPromptError({
       prompt,
       message:
-        'system must be a string, SystemModelMessage, or array of SystemModelMessage',
+        'instructions must be a string, SystemModelMessage, or array of SystemModelMessage',
     });
   }
 
@@ -89,7 +92,7 @@ export async function standardizePrompt({
     throw new InvalidPromptError({
       prompt,
       message:
-        'System messages are not allowed in the prompt or messages fields. Use the system option instead.',
+        'System messages are not allowed in the prompt or messages fields. Use the instructions option instead.',
     });
   }
 
@@ -106,5 +109,5 @@ export async function standardizePrompt({
     });
   }
 
-  return { messages, system };
+  return { messages, system: resolvedInstructions };
 }

--- a/packages/rsc/src/stream-ui/stream-ui.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.tsx
@@ -101,6 +101,7 @@ export async function streamUI<
   model,
   tools,
   toolChoice,
+  instructions,
   system,
   prompt,
   messages,
@@ -270,6 +271,7 @@ export async function streamUI<
   const { retry } = prepareRetries({ maxRetries, abortSignal });
 
   const validatedPrompt = await standardizePrompt({
+    instructions,
     system,
     prompt,
     messages,

--- a/packages/rsc/src/stream-ui/stream-ui.ui.test.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.ui.test.tsx
@@ -140,6 +140,52 @@ describe('result.value', () => {
     expect(rendered).toMatchSnapshot();
   });
 
+  it('should pass instructions to the model prompt', async () => {
+    let prompt: unknown;
+
+    await streamUI({
+      model: new MockLanguageModelV4({
+        doStream: async options => {
+          prompt = options.prompt;
+
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'text-start', id: '0' },
+              { type: 'text-delta', id: '0', delta: 'Hello' },
+              { type: 'text-end', id: '0' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          };
+        },
+      }),
+      instructions: 'You are a helpful assistant.',
+      prompt: 'Hello!',
+    });
+
+    expect(prompt).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "You are a helpful assistant.",
+          "role": "system",
+        },
+        {
+          "content": [
+            {
+              "text": "Hello!",
+              "type": "text",
+            },
+          ],
+          "providerOptions": undefined,
+          "role": "user",
+        },
+      ]
+    `);
+  });
+
   it('should render tool call results', async () => {
     const result = await streamUI({
       model: mockToolModel,


### PR DESCRIPTION
## Background

With agents, the typical name of what used to be `system` has become `instructions`. `ToolLoopAgent` already uses `instructions`.

## Summary

- Introduce `instructions` property on `generateText` etc that replaces `system`
- Mark `system` as deprecated.