### PR TITLE
docs: Improve prepareStep messages documentation

### DIFF
--- a/content/cookbook/00-guides/08-agent-context-compaction.mdx
+++ b/content/cookbook/00-guides/08-agent-context-compaction.mdx
@@ -17,9 +17,9 @@ Agents that call tools can build up large message histories. Each tool call and 
 This example uses a tool that returns long results:
 
 ```ts
-import { openai } from '@ai-sdk/openai';
 import { ToolLoopAgent, isStepCount, tool } from 'ai';
 import { z } from 'zod';
+__PROVIDER_IMPORT__;
 
 const readDocument = tool({
   description: 'Read a document by name',
@@ -35,7 +35,7 @@ const readDocument = tool({
 });
 
 const agent = new ToolLoopAgent({
-  model: openai('gpt-5.5'),
+  model: __MODEL__,
   tools: {
     readDocument,
   },
@@ -74,7 +74,6 @@ Use a real tokenizer or provider usage data if you need tighter accounting. The 
 When you return a new `messages` array, the SDK uses it for the current step and as the base for following steps.
 
 ```ts
-import { openai } from '@ai-sdk/openai';
 import {
   ToolLoopAgent,
   isStepCount,
@@ -83,6 +82,7 @@ import {
   type ModelMessage,
 } from 'ai';
 import { z } from 'zod';
+__PROVIDER_IMPORT__;
 
 const COMPACT_AFTER_TOKENS = 100_000;
 
@@ -104,7 +104,7 @@ const readDocument = tool({
 });
 
 const agent = new ToolLoopAgent({
-  model: openai('gpt-5.5'),
+  model: __MODEL__,
   tools: {
     readDocument,
   },
@@ -154,10 +154,10 @@ The same `prepareStep` behavior works with `generateText` and `streamText`:
 
 ```ts
 import { generateText, isStepCount, pruneMessages } from 'ai';
-import { openai } from '@ai-sdk/openai';
+__PROVIDER_IMPORT__;
 
 const result = await generateText({
-  model: openai('gpt-5.5'),
+  model: __MODEL__,
   prompt: 'Read the project documents and summarize the migration plan.',
   tools: {
     readDocument,

--- a/content/cookbook/00-guides/08-agent-context-compaction.mdx
+++ b/content/cookbook/00-guides/08-agent-context-compaction.mdx
@@ -1,0 +1,185 @@
+---
+title: Compact Agent Context
+description: Learn how to compact agent context by mutating message state between steps with prepareStep.
+tags: ['agent', 'context', 'compaction', 'prepareStep']
+---
+
+# Compact Agent Context
+
+In this guide, you will learn how to compact an agent's context by returning a new `messages` array from `prepareStep`.
+
+The example uses `pruneMessages`, a built-in helper that removes selected messages and message parts. You can use any compaction logic you want. The core behavior is that `prepareStep` can mutate the message state that later steps receive.
+
+## Start With a Growing Agent Loop
+
+Agents that call tools can build up large message histories. Each tool call and tool result becomes part of the context for the next step.
+
+This example uses a tool that returns long results:
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { ToolLoopAgent, isStepCount, tool } from 'ai';
+import { z } from 'zod';
+
+const readDocument = tool({
+  description: 'Read a document by name',
+  inputSchema: z.object({
+    name: z.string(),
+  }),
+  execute: async ({ name }) => {
+    return {
+      name,
+      text: await loadLargeDocument(name),
+    };
+  },
+});
+
+const agent = new ToolLoopAgent({
+  model: openai('gpt-5.5'),
+  tools: {
+    readDocument,
+  },
+  stopWhen: isStepCount(10),
+});
+
+const result = await agent.generate({
+  prompt: 'Read the project documents and summarize the migration plan.',
+});
+```
+
+This works, but the message list grows after each tool call. If the agent reads several large documents, later steps may send old tool results that the model no longer needs in full.
+
+## Add a Compaction Trigger
+
+You decide when compaction should happen.
+
+This example uses a simple token estimate:
+
+```ts
+import type { ModelMessage } from 'ai';
+
+const COMPACT_AFTER_TOKENS = 100_000;
+
+const estimateTokens = (messages: ModelMessage[]) => {
+  return JSON.stringify(messages).length / 4;
+};
+```
+
+Use a real tokenizer or provider usage data if you need tighter accounting. The exact trigger does not matter for the pattern.
+
+## Compact Messages in prepareStep
+
+`prepareStep` runs before each model step. It receives the `messages` that will be sent to the model for that step.
+
+When you return a new `messages` array, the SDK uses it for the current step and as the base for following steps.
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import {
+  ToolLoopAgent,
+  isStepCount,
+  pruneMessages,
+  tool,
+  type ModelMessage,
+} from 'ai';
+import { z } from 'zod';
+
+const COMPACT_AFTER_TOKENS = 100_000;
+
+const estimateTokens = (messages: ModelMessage[]) => {
+  return JSON.stringify(messages).length / 4;
+};
+
+const readDocument = tool({
+  description: 'Read a document by name',
+  inputSchema: z.object({
+    name: z.string(),
+  }),
+  execute: async ({ name }) => {
+    return {
+      name,
+      text: await loadLargeDocument(name),
+    };
+  },
+});
+
+const agent = new ToolLoopAgent({
+  model: openai('gpt-5.5'),
+  tools: {
+    readDocument,
+  },
+  stopWhen: isStepCount(10),
+  prepareStep: ({ messages }) => {
+    if (estimateTokens(messages) > COMPACT_AFTER_TOKENS) {
+      return {
+        messages: pruneMessages({
+          messages,
+          reasoning: 'all',
+          toolCalls: 'before-last-3-messages',
+          emptyMessages: 'remove',
+        }),
+      };
+    }
+  },
+});
+
+const result = await agent.generate({
+  prompt: 'Read the project documents and summarize the migration plan.',
+});
+```
+
+`pruneMessages` is only one way to compact. You can replace it with your own logic when you need a different message shape.
+
+## Understand What Persists
+
+The `messages` parameter is the loop's current message state. If `prepareStep` returns `messages`, that changed list persists into later steps. New assistant and tool response messages are appended as the loop continues.
+
+If you want to build a step from the original input plus the model responses so far, use `initialMessages` and `responseMessages`:
+
+```ts
+prepareStep: ({ initialMessages, responseMessages, stepNumber }) => {
+  if (stepNumber > 0) {
+    return {
+      messages: [...initialMessages, ...responseMessages.slice(-10)],
+    };
+  }
+};
+```
+
+This is useful when you do not want previous `messages` overrides to be the starting point for the next step.
+
+## Use the Same Pattern With Core Functions
+
+The same `prepareStep` behavior works with `generateText` and `streamText`:
+
+```ts
+import { generateText, isStepCount, pruneMessages } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const result = await generateText({
+  model: openai('gpt-5.5'),
+  prompt: 'Read the project documents and summarize the migration plan.',
+  tools: {
+    readDocument,
+  },
+  stopWhen: isStepCount(10),
+  prepareStep: ({ messages }) => {
+    if (estimateTokens(messages) > COMPACT_AFTER_TOKENS) {
+      return {
+        messages: pruneMessages({
+          messages,
+          reasoning: 'all',
+          toolCalls: 'before-last-3-messages',
+          emptyMessages: 'remove',
+        }),
+      };
+    }
+  },
+});
+```
+
+## Learn More
+
+- [Loop Control](/docs/agents/loop-control) for `prepareStep` with agents
+- [Tools and Tool Calling](/docs/ai-sdk-core/tools-and-tool-calling#preparestep-callback) for `prepareStep` with AI SDK Core
+- [`pruneMessages`](/docs/reference/ai-sdk-ui/prune-messages) for built-in message pruning options

--- a/content/cookbook/00-guides/index.mdx
+++ b/content/cookbook/00-guides/index.mdx
@@ -45,6 +45,12 @@ These use-case specific guides are intended to help you build real applications 
       href: '/cookbook/guides/agent-skills',
     },
     {
+      title: 'Compact Agent Context',
+      description:
+        'Compact agent context by mutating message state between steps with prepareStep.',
+      href: '/cookbook/guides/agent-context-compaction',
+    },
+    {
       title: 'Get started with Gemini 2.5',
       description: 'Get started with Gemini 2.5 using the AI SDK.',
       href: '/cookbook/guides/gemini-2-5',

--- a/content/docs/03-agents/04-loop-control.mdx
+++ b/content/docs/03-agents/04-loop-control.mdx
@@ -148,12 +148,7 @@ const budgetExceeded: StopCondition<typeof tools> = ({ steps }) => {
 
 The `prepareStep` callback runs before each step in the loop and defaults to the initial settings if you don't return any changes. Use it to modify settings, manage context, or implement dynamic behavior based on execution history.
 
-It receives `messages` for the current step, plus `initialMessages` and
-`responseMessages` when you need to distinguish the original input from
-assistant/tool messages accumulated in earlier steps. Treat `messages` as the
-loop's current message state: if you return a `messages` override, that override
-persists as the base for later steps, together with the response messages from
-each completed step.
+It receives `messages` for the current step, plus `initialMessages` and `responseMessages` when you need to distinguish the original input from assistant/tool messages accumulated in earlier steps. Treat `messages` as the loop's current message state: if you return a `messages` override, that override persists as the base for later steps, together with the response messages from each completed step.
 
 ### Dynamic Model Selection
 
@@ -187,21 +182,11 @@ const result = await agent.generate({
 
 ### Context Management
 
-Long-running agents can accumulate large tool results, reasoning parts, and
-assistant messages. Use `prepareStep` to mutate the message state that will be
-used by later steps. This is useful for compaction, and you decide when
-compaction should happen.
+Long-running agents can accumulate large tool results, reasoning parts, and assistant messages. Use `prepareStep` to mutate the message state that will be used by later steps. This is useful for compaction, and you decide when compaction should happen.
 
-The `messages` value contains the messages that will be sent for the current
-step. When you return a `messages` override from `prepareStep`, that changed
-list becomes the base for later steps. New assistant and tool response messages
-are appended to it as the loop continues. If you need to rebuild a step from the
-discrete pieces instead of the persisted message state, use `initialMessages`
-for the original input and `responseMessages` for the model/tool response
-messages accumulated so far.
+The `messages` value contains the messages that will be sent for the current step. When you return a `messages` override from `prepareStep`, that changed list becomes the base for later steps. New assistant and tool response messages are appended to it as the loop continues. If you need to rebuild a step from the discrete pieces instead of the persisted message state, use `initialMessages` for the original input and `responseMessages` for the model/tool response messages accumulated so far.
 
-The `pruneMessages` helper provides a built-in way to remove selected messages. You can use it inside `prepareStep` when you want a simple
-compaction strategy.
+The `pruneMessages` helper provides a built-in way to remove selected messages. You can use it inside `prepareStep` when you want a simple compaction strategy.
 
 ```ts
 import { ToolLoopAgent, pruneMessages, type ModelMessage } from 'ai';
@@ -237,10 +222,7 @@ const result = await agent.generate({
 });
 ```
 
-The token estimator above is intentionally simple and only demonstrates one way
-to decide when to compact. The main point is that `prepareStep` can return a new
-`messages` array, and that array becomes the message state for following steps.
-The same pattern also works with `generateText` and `streamText`.
+The token estimator above is intentionally simple and only demonstrates one way to decide when to compact. The main point is that `prepareStep` can return a new `messages` array, and that array becomes the message state for following steps. The same pattern also works with `generateText` and `streamText`.
 
 ### Tool Selection
 

--- a/content/docs/03-agents/04-loop-control.mdx
+++ b/content/docs/03-agents/04-loop-control.mdx
@@ -148,7 +148,12 @@ const budgetExceeded: StopCondition<typeof tools> = ({ steps }) => {
 
 The `prepareStep` callback runs before each step in the loop and defaults to the initial settings if you don't return any changes. Use it to modify settings, manage context, or implement dynamic behavior based on execution history.
 
-It receives `messages` for the current step, plus `initialMessages` and `responseMessages` when you need to distinguish the original input from assistant/tool messages accumulated in earlier steps. If you return a `messages` override, those messages carry forward to later steps together with the response messages from each completed step.
+It receives `messages` for the current step, plus `initialMessages` and
+`responseMessages` when you need to distinguish the original input from
+assistant/tool messages accumulated in earlier steps. Treat `messages` as the
+loop's current message state: if you return a `messages` override, that override
+persists as the base for later steps, together with the response messages from
+each completed step.
 
 ### Dynamic Model Selection
 
@@ -182,28 +187,48 @@ const result = await agent.generate({
 
 ### Context Management
 
-Manage growing conversation history in long-running loops:
+Long-running agents can accumulate large tool results, reasoning parts, and
+assistant messages. Use `prepareStep` to mutate the message state that will be
+used by later steps. This is useful for compaction, and you decide when
+compaction should happen.
+
+The `messages` value contains the messages that will be sent for the current
+step. When you return a `messages` override from `prepareStep`, that changed
+list becomes the base for later steps. New assistant and tool response messages
+are appended to it as the loop continues. If you need to rebuild a step from the
+discrete pieces instead of the persisted message state, use `initialMessages`
+for the original input and `responseMessages` for the model/tool response
+messages accumulated so far.
+
+The `pruneMessages` helper provides a built-in way to remove selected messages. You can use it inside `prepareStep` when you want a simple
+compaction strategy.
 
 ```ts
-import { ToolLoopAgent } from 'ai';
+import { ToolLoopAgent, pruneMessages, type ModelMessage } from 'ai';
 __PROVIDER_IMPORT__;
+
+const COMPACTION_THRESHOLD = 100_000;
+
+const estimateTokens = (messages: ModelMessage[]) => {
+  return JSON.stringify(messages).length / 4;
+};
 
 const agent = new ToolLoopAgent({
   model: __MODEL__,
   tools: {
     // your tools
   },
-  prepareStep: async ({ initialMessages, responseMessages, messages }) => {
-    // Keep only recent messages to stay within context limits
-    if (messages.length > 20) {
+  prepareStep: async ({ messages }) => {
+    if (estimateTokens(messages) > COMPACTION_THRESHOLD) {
       return {
-        messages: [
-          ...initialMessages, // Keep the original user-provided prompt
-          ...responseMessages.slice(-10), // Keep recent assistant/tool messages
-        ],
+        messages: pruneMessages({
+          messages,
+          reasoning: 'all',
+          toolCalls: 'before-last-3-messages',
+          emptyMessages: 'remove',
+        }),
       };
     }
-    return {};
   },
 });
 
@@ -211,6 +236,11 @@ const result = await agent.generate({
   prompt: '...',
 });
 ```
+
+The token estimator above is intentionally simple and only demonstrates one way
+to decide when to compact. The main point is that `prepareStep` can return a new
+`messages` array, and that array becomes the message state for following steps.
+The same pattern also works with `generateText` and `streamText`.
 
 ### Tool Selection
 

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -476,9 +476,14 @@ It is called with the following parameters:
 - `stopWhen`: The stopping condition that was passed into `generateText`.
 - `stepNumber`: The number of the step that is being executed.
 - `steps`: The steps that have been executed so far.
-- `messages`: The messages that will be sent to the model for the current step. If `prepareStep` returns a `messages` override, those messages carry forward to later steps.
-- `initialMessages`: The messages that were passed into `generateText` or `streamText`.
-- `responseMessages`: The accumulated assistant/tool response messages so far, including any tool results generated before the first model step from approved tool calls in the input messages.
+- `messages`: The messages that will be sent to the model for the current step.
+  Treat this as the loop's current message state. If `prepareStep` returns a
+  `messages` override, those messages carry forward as the base for later steps.
+- `initialMessages`: The messages that were passed into `generateText` or
+  `streamText`.
+- `responseMessages`: The accumulated assistant/tool response messages so far,
+  including any tool results generated before the first model step from approved
+  tool calls in the input messages.
 - `runtimeContext`: The runtime context passed via the `runtimeContext` setting.
 - `toolsContext`: The per-tool context map passed via the `toolsContext` setting.
 - `sandbox`: The sandbox passed via the `sandbox` setting.
@@ -509,27 +514,65 @@ const result = await generateText({
 
 #### Message Modification for Longer Agentic Loops
 
-In longer agentic loops, you can use the `messages` parameter to modify the input messages for each step. This is particularly useful for prompt compression.
+In longer agentic loops, you can use the `messages` parameter to mutate the
+message state that will be used by later steps. This is particularly useful for
+context compaction, and you decide when compaction should happen.
 
-The `messages` parameter contains the messages for the current step. By default, this is `initialMessages` followed by the accumulated `responseMessages`. If a previous `prepareStep` returned `messages`, later steps use those messages plus the response messages from the previous step.
-Use `initialMessages` when you need to preserve the original user-provided prompt and `responseMessages` when you only need the accumulated assistant/tool response messages.
+The `messages` parameter contains the messages for the current step. By default,
+this is `initialMessages` followed by the accumulated `responseMessages`. If a
+previous `prepareStep` returned `messages`, later steps use those persisted
+messages plus the response messages from the previous step.
+
+Use `initialMessages` when you need the original input messages and
+`responseMessages` when you need the discrete assistant/tool response messages
+from the model so far.
+
+The `pruneMessages` helper provides a built-in way to remove selected messages
+or message parts. You can use it inside `prepareStep` when you want a simple
+compaction strategy.
 
 ```tsx
-prepareStep: async ({
-  initialMessages,
-  responseMessages,
-  stepNumber,
-  steps,
-  messages,
-}) => {
-  // Compress conversation history for longer loops
-  if (messages.length > 20) {
+import { generateText, pruneMessages, type ModelMessage } from 'ai';
+
+const COMPACTION_THRESHOLD = 100_000;
+
+const estimateTokens = (messages: ModelMessage[]) => {
+  return JSON.stringify(messages).length / 4;
+};
+
+const result = await generateText({
+  // ...
+  prepareStep: ({ messages }) => {
+    if (estimateTokens(messages) > COMPACTION_THRESHOLD) {
+      return {
+        messages: pruneMessages({
+          messages,
+          reasoning: 'all',
+          toolCalls: 'before-last-3-messages',
+          emptyMessages: 'remove',
+        }),
+      };
+    }
+  },
+});
+```
+
+This example uses an estimated token threshold, but that is only one way to
+decide when to compact. The important part is that returning `messages` mutates
+the message state for later steps.
+
+Returned message changes persist across steps. If you want to derive each step's
+messages from the original input plus the discrete response messages instead of
+the persisted message state, rebuild them from `initialMessages` and
+`responseMessages` each time:
+
+```tsx
+prepareStep: ({ initialMessages, responseMessages, stepNumber }) => {
+  if (stepNumber > 0) {
     return {
       messages: [...initialMessages, ...responseMessages.slice(-10)],
     };
   }
-
-  return {};
 },
 ```
 

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -476,14 +476,9 @@ It is called with the following parameters:
 - `stopWhen`: The stopping condition that was passed into `generateText`.
 - `stepNumber`: The number of the step that is being executed.
 - `steps`: The steps that have been executed so far.
-- `messages`: The messages that will be sent to the model for the current step.
-  Treat this as the loop's current message state. If `prepareStep` returns a
-  `messages` override, those messages carry forward as the base for later steps.
-- `initialMessages`: The messages that were passed into `generateText` or
-  `streamText`.
-- `responseMessages`: The accumulated assistant/tool response messages so far,
-  including any tool results generated before the first model step from approved
-  tool calls in the input messages.
+- `messages`: The messages that will be sent to the model for the current step. Treat this as the loop's current message state. If `prepareStep` returns a `messages` override, those messages carry forward as the base for later steps.
+- `initialMessages`: The messages that were passed into `generateText` or `streamText`.
+- `responseMessages`: The accumulated assistant/tool response messages so far, including any tool results generated before the first model step from approved tool calls in the input messages.
 - `runtimeContext`: The runtime context passed via the `runtimeContext` setting.
 - `toolsContext`: The per-tool context map passed via the `toolsContext` setting.
 - `sandbox`: The sandbox passed via the `sandbox` setting.
@@ -514,22 +509,13 @@ const result = await generateText({
 
 #### Message Modification for Longer Agentic Loops
 
-In longer agentic loops, you can use the `messages` parameter to mutate the
-message state that will be used by later steps. This is particularly useful for
-context compaction, and you decide when compaction should happen.
+In longer agentic loops, you can use the `messages` parameter to mutate the message state that will be used by later steps. This is particularly useful for context compaction, and you decide when compaction should happen.
 
-The `messages` parameter contains the messages for the current step. By default,
-this is `initialMessages` followed by the accumulated `responseMessages`. If a
-previous `prepareStep` returned `messages`, later steps use those persisted
-messages plus the response messages from the previous step.
+The `messages` parameter contains the messages for the current step. By default, this is `initialMessages` followed by the accumulated `responseMessages`. If a previous `prepareStep` returned `messages`, later steps use those persisted messages plus the response messages from the previous step.
 
-Use `initialMessages` when you need the original input messages and
-`responseMessages` when you need the discrete assistant/tool response messages
-from the model so far.
+Use `initialMessages` when you need the original input messages and `responseMessages` when you need the discrete assistant/tool response messages from the model so far.
 
-The `pruneMessages` helper provides a built-in way to remove selected messages
-or message parts. You can use it inside `prepareStep` when you want a simple
-compaction strategy.
+The `pruneMessages` helper provides a built-in way to remove selected messages or message parts. You can use it inside `prepareStep` when you want a simple compaction strategy.
 
 ```tsx
 import { generateText, pruneMessages, type ModelMessage } from 'ai';
@@ -557,14 +543,9 @@ const result = await generateText({
 });
 ```
 
-This example uses an estimated token threshold, but that is only one way to
-decide when to compact. The important part is that returning `messages` mutates
-the message state for later steps.
+This example uses an estimated token threshold, but that is only one way to decide when to compact. The important part is that returning `messages` mutates the message state for later steps.
 
-Returned message changes persist across steps. If you want to derive each step's
-messages from the original input plus the discrete response messages instead of
-the persisted message state, rebuild them from `initialMessages` and
-`responseMessages` each time:
+Returned message changes persist across steps. If you want to derive each step's messages from the original input plus the discrete response messages instead of the persisted message state, rebuild them from `initialMessages` and `responseMessages` each time:
 
 ```tsx
 prepareStep: ({ initialMessages, responseMessages, stepNumber }) => {

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -543,7 +543,7 @@ const result = await generateText({
 });
 ```
 
-This example uses an estimated token threshold, but that is only one way to decide when to compact. The important part is that returning `messages` mutates the message state for later steps.
+This example uses an estimated token threshold, but you can use any trigger. The key behavior is that returning `messages` mutates the message state for later steps.
 
 Returned message changes persist across steps. If you want to derive each step's messages from the original input plus the discrete response messages instead of the persisted message state, rebuild them from `initialMessages` and `responseMessages` each time:
 


### PR DESCRIPTION
## Background

We introduced #15093 which changed prepareStep message behaviour. Before `messages` were immutable across steps. Now they are mutable and we have introduced `initialMessages` and `responseMessages` that allow folks to implement the previous behaviour. With this new feature, compaction becomes possible.

## Summary

Update compaction and prepareStep docs sections.