### PR TITLE
feat: expose `finalStep` on text generation results

### DIFF
--- a/.changeset/gorgeous-camels-wash.md
+++ b/.changeset/gorgeous-camels-wash.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+feat: expose `finalStep` on text generation results

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -2126,6 +2126,12 @@ To see `generateText` in action, check out [these examples](#examples).
                 'Response information for every step. You can use this to get information about intermediate steps, such as the tool calls or the response headers.',
             },
             {
+              name: 'finalStep',
+              type: 'StepResult',
+              description:
+                'The final step. This is a shortcut for `steps.at(-1)`.',
+            },
+            {
               name: 'responseMessages',
               type: 'Array<ResponseMessage>',
               description:
@@ -2915,6 +2921,12 @@ To see `generateText` in action, check out [these examples](#examples).
           ],
         },
       ],
+    },
+    {
+      name: 'finalStep',
+      type: 'StepResult<TOOLS>',
+      description:
+        'The final step. This is a shortcut for `steps.at(-1)`.',
     },
   ]}
 />

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1848,6 +1848,12 @@ To see `streamText` in action, check out [these examples](#examples).
                 'Response information for every step. You can use this to get information about intermediate steps, such as the tool calls or the response headers.',
             },
             {
+              name: 'finalStep',
+              type: 'StepResult',
+              description:
+                'The final step. This is a shortcut for `steps.at(-1)`.',
+            },
+            {
               name: 'runtimeContext',
               type: 'CONTEXT',
               description:
@@ -3013,6 +3019,12 @@ To see `streamText` in action, check out [these examples](#examples).
       type: 'AsyncIterableStream<string>',
       description:
         'A text stream that returns only the generated text deltas. You can use it as either an AsyncIterable or a ReadableStream. When an error occurs, the stream will throw the error.',
+    },
+    {
+      name: 'finalStep',
+      type: 'Promise<StepResult>',
+      description:
+        'The final step. This is a shortcut for `steps.at(-1)`. Automatically consumes the stream.',
     },
     {
       name: 'fullStream',

--- a/packages/ai/src/generate-text/generate-text-result.ts
+++ b/packages/ai/src/generate-text/generate-text-result.ts
@@ -152,6 +152,11 @@ export interface GenerateTextResult<
   readonly steps: Array<StepResult<TOOLS, RUNTIME_CONTEXT>>;
 
   /**
+   * The final step. This is a shortcut for `steps.at(-1)`.
+   */
+  readonly finalStep: StepResult<TOOLS, RUNTIME_CONTEXT>;
+
+  /**
    * The generated structured output. It uses the `output` specification.
    *
    */

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -495,6 +495,20 @@ describe('generateText', () => {
 
       expect(result.steps).toMatchSnapshot();
     });
+
+    it('should expose the final step', async () => {
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: 'Hello!' }],
+          }),
+        }),
+        prompt: 'test-input',
+      });
+
+      expect(result.finalStep).toBe(result.steps.at(-1));
+    });
   });
 
   describe('result.toolCalls', () => {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1246,8 +1246,8 @@ class DefaultGenerateTextResult<
 
   private readonly initialResponseMessages: Array<ResponseMessage>;
 
-  private get finalStep() {
-    return this.steps[this.steps.length - 1];
+  get finalStep() {
+    return this.steps.at(-1)!;
   }
 
   get content() {

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -246,6 +246,13 @@ export interface StreamTextResult<
   readonly steps: PromiseLike<Array<StepResult<TOOLS, RUNTIME_CONTEXT>>>;
 
   /**
+   * The final step. This is a shortcut for `steps.at(-1)`.
+   *
+   * Automatically consumes the stream.
+   */
+  readonly finalStep: PromiseLike<StepResult<TOOLS, RUNTIME_CONTEXT>>;
+
+  /**
    * Additional request information from the last step.
    *
    * Automatically consumes the stream.

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -5875,6 +5875,17 @@ describe('streamText', () => {
         ]
       `);
     });
+
+    it('should expose the final step', async () => {
+      const result = streamText({
+        model: createTestModel(),
+        ...defaultSettings(),
+      });
+
+      const steps = await result.steps;
+
+      await expect(result.finalStep).resolves.toBe(steps.at(-1));
+    });
   });
 
   describe('result.toolCalls', () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2064,8 +2064,8 @@ class DefaultStreamTextResult<
     return this._steps.promise;
   }
 
-  private get finalStep() {
-    return this.steps.then(steps => steps[steps.length - 1]);
+  get finalStep() {
+    return this.steps.then(steps => steps.at(-1)!);
   }
 
   get content() {


### PR DESCRIPTION
## Background

We are preparing to rework the properties on `StreamTextResult` and `GenerateTextResult` that currently expose information from the final step. In order to allow for easy migration, we introduce a `finalStep` shorthand.

## Summary

Introduce `finalStep` shorthand (which returns `steps.at(-1)`)

## Future Work

* rework `StreamTextResult` and `GenerateTextResult`