### PR TITLE
fix(mcp): use negotiated protocol version in HTTP transport headers

### DIFF
--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -37,6 +37,7 @@ export class HttpMCPTransport implements MCPTransport {
   private inboundSseConnection?: { close: () => void };
   private redirectMode: RequestRedirect;
   private fetchFn: FetchFunction;
+  private negotiatedProtocolVersion?: string;
 
   // Inbound SSE resumption and reconnection state
   private lastInboundEventId?: string;
@@ -72,13 +73,28 @@ export class HttpMCPTransport implements MCPTransport {
     this.fetchFn = fetchFn ?? globalThis.fetch;
   }
 
+  private captureNegotiatedVersion(msg: JSONRPCMessage): void {
+    if (
+      'result' in msg &&
+      msg.result !== null &&
+      typeof msg.result === 'object' &&
+      'protocolVersion' in msg.result &&
+      typeof (msg.result as Record<string, unknown>).protocolVersion === 'string'
+    ) {
+      this.negotiatedProtocolVersion = (
+        msg.result as Record<string, unknown>
+      ).protocolVersion as string;
+    }
+  }
+
   private async commonHeaders(
     base: Record<string, string>,
   ): Promise<Record<string, string>> {
     const headers: Record<string, string> = {
       ...this.headers,
       ...base,
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version':
+        this.negotiatedProtocolVersion ?? LATEST_PROTOCOL_VERSION,
     };
 
     if (this.sessionId) {
@@ -215,7 +231,10 @@ export class HttpMCPTransport implements MCPTransport {
           const messages: JSONRPCMessage[] = Array.isArray(data)
             ? data.map((m: unknown) => JSONRPCMessageSchema.parse(m))
             : [JSONRPCMessageSchema.parse(data)];
-          for (const m of messages) this.onmessage?.(m);
+          for (const m of messages) {
+            this.captureNegotiatedVersion(m);
+            this.onmessage?.(m);
+          }
           return;
         }
 
@@ -243,6 +262,7 @@ export class HttpMCPTransport implements MCPTransport {
                 if (event === 'message') {
                   try {
                     const msg = await parseJSONRPCMessage(data);
+                    this.captureNegotiatedVersion(msg);
                     this.onmessage?.(msg);
                   } catch (error) {
                     const e = new MCPClientError({
@@ -391,6 +411,7 @@ export class HttpMCPTransport implements MCPTransport {
             if (event === 'message') {
               try {
                 const msg = await parseJSONRPCMessage(data);
+                this.captureNegotiatedVersion(msg);
                 this.onmessage?.(msg);
               } catch (error) {
                 const e = new MCPClientError({


### PR DESCRIPTION
## Problem

After the MCP `initialize` handshake, the server returns the protocol version it actually supports. `HttpMCPTransport` ignores this and always sends `LATEST_PROTOCOL_VERSION` (`2025-11-25`) in the `mcp-protocol-version` header on every subsequent request.

Servers that only support an older version (e.g. Figma Dev Mode MCP supports `2025-06-18`) reject all post-init requests with **HTTP 400**, making the transport completely unusable with those servers.

Fixes #14413.

## Root Cause

`commonHeaders()` hardcodes `LATEST_PROTOCOL_VERSION`:

```ts
// before
'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
```

The negotiated version from the `initialize` result was never stored anywhere on the transport.

## Fix

- Add a private `negotiatedProtocolVersion?: string` field.
- Add a private `captureNegotiatedVersion(msg)` helper that detects an `initialize` result (any JSON-RPC response whose `result` contains a `protocolVersion` string) and stores it.
- Call `captureNegotiatedVersion` before every `onmessage` dispatch — in `send()` (both the direct-JSON and inline-SSE paths) and in `openInboundSse()`.
- Use `this.negotiatedProtocolVersion ?? LATEST_PROTOCOL_VERSION` in `commonHeaders()`.

```ts
// after
'mcp-protocol-version': this.negotiatedProtocolVersion ?? LATEST_PROTOCOL_VERSION,
```

The fix is self-contained in `mcp-http-transport.ts` — no changes to `mcp-client.ts` or the `MCPTransport` interface. Before `initialize` completes the field is `undefined`, so `LATEST_PROTOCOL_VERSION` is used for the handshake itself (correct per spec). After `initialize`, all subsequent requests carry the server's negotiated version.
