### PR TITLE
fix: Make `generateText` and `streamText` result `usage` report total usage across all steps and deprecate `totalUsage`

### DIFF
--- a/.changeset/curly-timers-usage.md
+++ b/.changeset/curly-timers-usage.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix: Make `generateText` and `streamText` result `usage` report total usage across all steps and deprecate `totalUsage`.

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -56,8 +56,7 @@ The result object of `generateText` contains several promises that resolve when 
 - `result.toolResults`: The results of the tool calls from the last step.
 - `result.finishReason`: The reason the model finished generating text.
 - `result.rawFinishReason`: The raw reason why the generation finished (from the provider).
-- `result.usage`: The usage of the model during the final step of text generation.
-- `result.totalUsage`: The total usage across all steps (for multi-step generations).
+- `result.usage`: The total usage across all steps (for multi-step generations).
 - `result.warnings`: Warnings from the model provider (e.g. unsupported settings).
 - `result.request`: Additional request information, including the messages sent to the model and the request body.
 - `result.response`: Additional response information, including response messages and body.
@@ -235,8 +234,8 @@ It also provides several promises that resolve when the stream is finished:
 - `result.toolResults`: The tool results that have been generated in the last step.
 - `result.finishReason`: The reason the model finished generating text.
 - `result.rawFinishReason`: The raw reason why the generation finished (from the provider).
-- `result.usage`: The usage of the model during the final step of text generation.
-- `result.totalUsage`: The total usage across all steps (for multi-step generations).
+- `result.usage`: The total usage across all steps (for multi-step generations).
+- `result.totalUsage`: Deprecated. Use `result.usage` instead.
 - `result.warnings`: Warnings from the model provider (e.g. unsupported settings).
 - `result.steps`: Details for all steps, useful for getting information about intermediate steps.
 - `result.request`: Additional request information from the last step.

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -2346,7 +2346,8 @@ To see `generateText` in action, check out [these examples](#examples).
     {
       name: 'usage',
       type: 'LanguageModelUsage',
-      description: 'The token usage of the last step.',
+      description:
+        'The total token usage of all steps. When there are multiple steps, the usage is the sum of all step usages.',
       properties: [
         {
           type: 'LanguageModelUsage',
@@ -2436,7 +2437,7 @@ To see `generateText` in action, check out [these examples](#examples).
       name: 'totalUsage',
       type: 'LanguageModelUsage',
       description:
-        'The total token usage of all steps. When there are multiple steps, the usage is the sum of all step usages.',
+        'Deprecated. Use usage instead. The total token usage of all steps. When there are multiple steps, the usage is the sum of all step usages.',
       properties: [
         {
           type: 'LanguageModelUsage',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -2350,7 +2350,7 @@ To see `streamText` in action, check out [these examples](#examples).
       name: 'usage',
       type: 'Promise<LanguageModelUsage>',
       description:
-        'The token usage of the last step. Automatically consumes the stream.',
+        'The total token usage of the generated response. When there are multiple steps, the usage is the sum of all step usages. Automatically consumes the stream.',
       properties: [
         {
           type: 'LanguageModelUsage',
@@ -2378,7 +2378,7 @@ To see `streamText` in action, check out [these examples](#examples).
     {
       name: 'totalUsage',
       type: 'Promise<LanguageModelUsage>',
-      description: 'The total token usage of the generated response. When there are multiple steps, the usage is the sum of all step usages. Automatically consumes the stream.',
+      description: 'Deprecated. Use usage instead. The total token usage of the generated response. When there are multiple steps, the usage is the sum of all step usages. Automatically consumes the stream.',
       properties: [
                   {
                   type: 'LanguageModelUsage',

--- a/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
+++ b/content/docs/08-migration-guides/23-migration-guide-7-0.mdx
@@ -866,6 +866,36 @@ If both are present, provider-specific reasoning settings in `providerOptions` t
 
 Both deprecated names remain available in AI SDK 7.
 
+### `generateText` and `streamText` `usage` Now Includes All Steps
+
+The `usage` property on `generateText` and `streamText` results now returns the total token usage across all steps. This matches what `totalUsage` previously represented.
+
+Use `finalStep.usage` to read the previous `usage` behavior, which only returned token usage from the final step:
+
+```tsx filename="AI SDK 6"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Write a haiku, then revise it.',
+  stopWhen: stepCountIs(2),
+});
+
+console.log(result.usage);
+console.log(result.totalUsage);
+```
+
+```tsx filename="AI SDK 7"
+const result = await generateText({
+  model: yourModel,
+  prompt: 'Write a haiku, then revise it.',
+  stopWhen: isStepCount(2),
+});
+
+console.log(result.finalStep.usage); // final step only
+console.log(result.usage); // all steps
+```
+
+`totalUsage` is deprecated. Replace `result.totalUsage` with `result.usage`.
+
 ### Stop Condition Helper Rename: `stepCountIs` -> `isStepCount`
 
 Rename imports and usage in tool-loop stop conditions:

--- a/packages/ai/src/generate-text/generate-text-result.ts
+++ b/packages/ai/src/generate-text/generate-text-result.ts
@@ -107,13 +107,16 @@ export interface GenerateTextResult<
   readonly rawFinishReason: string | undefined;
 
   /**
-   * The token usage of the last step.
+   * The total token usage of all steps.
+   * When there are multiple steps, the usage is the sum of all step usages.
    */
   readonly usage: LanguageModelUsage;
 
   /**
    * The total token usage of all steps.
    * When there are multiple steps, the usage is the sum of all step usages.
+   *
+   * @deprecated Use `usage` instead.
    */
   readonly totalUsage: LanguageModelUsage;
 

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -3895,8 +3895,27 @@ describe('generateText', () => {
         `);
       });
 
-      it('result.usage should contain token usage from final step', async () => {
+      it('result.usage should sum token usage', async () => {
         expect(result.usage).toMatchInlineSnapshot(`
+          {
+            "inputTokenDetails": {
+              "cacheReadTokens": undefined,
+              "cacheWriteTokens": undefined,
+              "noCacheTokens": 13,
+            },
+            "inputTokens": 13,
+            "outputTokenDetails": {
+              "reasoningTokens": undefined,
+              "textTokens": 15,
+            },
+            "outputTokens": 15,
+            "totalTokens": 28,
+          }
+        `);
+      });
+
+      it('result.finalStep.usage should contain token usage from final step', async () => {
+        expect(result.finalStep.usage).toMatchInlineSnapshot(`
           {
             "inputTokenDetails": {
               "cacheReadTokens": undefined,
@@ -4598,8 +4617,27 @@ describe('generateText', () => {
         `);
       });
 
-      it('result.usage should contain token usage from final step', async () => {
+      it('result.usage should sum token usage', async () => {
         expect(result.usage).toMatchInlineSnapshot(`
+          {
+            "inputTokenDetails": {
+              "cacheReadTokens": undefined,
+              "cacheWriteTokens": undefined,
+              "noCacheTokens": 13,
+            },
+            "inputTokens": 13,
+            "outputTokenDetails": {
+              "reasoningTokens": undefined,
+              "textTokens": 15,
+            },
+            "outputTokens": 15,
+            "totalTokens": 28,
+          }
+        `);
+      });
+
+      it('result.finalStep.usage should contain token usage from final step', async () => {
+        expect(result.finalStep.usage).toMatchInlineSnapshot(`
           {
             "inputTokenDetails": {
               "cacheReadTokens": undefined,

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1335,7 +1335,7 @@ class DefaultGenerateTextResult<
   }
 
   get usage() {
-    return this.finalStep.usage;
+    return this.totalUsage;
   }
 
   get output() {

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -215,7 +215,8 @@ export interface StreamTextResult<
   readonly rawFinishReason: PromiseLike<string | undefined>;
 
   /**
-   * The token usage of the last step.
+   * The total token usage of the generated response.
+   * When there are multiple steps, the usage is the sum of all step usages.
    *
    * Automatically consumes the stream.
    */
@@ -226,6 +227,8 @@ export interface StreamTextResult<
    * When there are multiple steps, the usage is the sum of all step usages.
    *
    * Automatically consumes the stream.
+   *
+   * @deprecated Use `usage` instead.
    */
   readonly totalUsage: PromiseLike<LanguageModelUsage>;
 

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -4885,7 +4885,6 @@ describe('streamText', () => {
             "textTokens": 10,
           },
           "outputTokens": 10,
-          "raw": undefined,
           "totalTokens": 13,
         }
       `);
@@ -10307,8 +10306,8 @@ describe('streamText', () => {
           `);
         });
 
-        it('result.usage should contain token usage from final step', async () => {
-          expect(await result.totalUsage).toMatchInlineSnapshot(`
+        it('result.usage should contain total token usage', async () => {
+          expect(await result.usage).toMatchInlineSnapshot(`
             {
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
@@ -10322,6 +10321,26 @@ describe('streamText', () => {
               },
               "outputTokens": 20,
               "totalTokens": 26,
+            }
+          `);
+        });
+
+        it('result.finalStep.usage should contain token usage from final step', async () => {
+          expect((await result.finalStep).usage).toMatchInlineSnapshot(`
+            {
+              "inputTokenDetails": {
+                "cacheReadTokens": 0,
+                "cacheWriteTokens": 0,
+                "noCacheTokens": 3,
+              },
+              "inputTokens": 3,
+              "outputTokenDetails": {
+                "reasoningTokens": 10,
+                "textTokens": 10,
+              },
+              "outputTokens": 10,
+              "raw": undefined,
+              "totalTokens": 13,
             }
           `);
         });
@@ -12044,8 +12063,8 @@ describe('streamText', () => {
           `);
         });
 
-        it('result.usage should contain token usage from final step', async () => {
-          expect(await result.totalUsage).toMatchInlineSnapshot(`
+        it('result.usage should contain total token usage', async () => {
+          expect(await result.usage).toMatchInlineSnapshot(`
             {
               "inputTokenDetails": {
                 "cacheReadTokens": 0,
@@ -12059,6 +12078,26 @@ describe('streamText', () => {
               },
               "outputTokens": 20,
               "totalTokens": 26,
+            }
+          `);
+        });
+
+        it('result.finalStep.usage should contain token usage from final step', async () => {
+          expect((await result.finalStep).usage).toMatchInlineSnapshot(`
+            {
+              "inputTokenDetails": {
+                "cacheReadTokens": 0,
+                "cacheWriteTokens": 0,
+                "noCacheTokens": 3,
+              },
+              "inputTokens": 3,
+              "outputTokenDetails": {
+                "reasoningTokens": 10,
+                "textTokens": 10,
+              },
+              "outputTokens": 10,
+              "raw": undefined,
+              "totalTokens": 13,
             }
           `);
         });

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2135,7 +2135,7 @@ class DefaultStreamTextResult<
   }
 
   get usage() {
-    return this.finalStep.then(step => step.usage);
+    return this.totalUsage;
   }
 
   get request() {


### PR DESCRIPTION
## Background

In #15115 the `finalStep` shorthand was introduced. It is now possible to migrate `StreamTextResult` and `GenerateTextResult` to contain accumulative results instead of the values from the final step.

## Summary

* change `usage` to accumulated usage
* deprecate `totalUsage`

## Related Issues

Builds on #15115 