### PR TITLE
feat: add an optional `workingDirectory` parameter to sandbox command execution

### DIFF
--- a/.changeset/neat-frogs-explain.md
+++ b/.changeset/neat-frogs-explain.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+Add an optional `workingDirectory` parameter to sandbox command execution.

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -146,13 +146,16 @@ const agent = new ToolLoopAgent({
   tools: {
     shell: tool({
       description: 'Execute shell commands in the sandbox.',
-      inputSchema: z.object({ command: z.string() }),
-      execute: async ({ command }, { sandbox }) => {
+      inputSchema: z.object({
+        command: z.string(),
+        workingDirectory: z.string().optional(),
+      }),
+      execute: async ({ command, workingDirectory }, { sandbox }) => {
         if (!sandbox) {
           throw new Error('Sandbox is not available');
         }
 
-        return sandbox.executeCommand({ command });
+        return sandbox.executeCommand({ command, workingDirectory });
       },
     }),
   },

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -859,13 +859,14 @@ const result = await generateText({
     shell: tool({
       inputSchema: z.object({
         command: z.string(),
+        workingDirectory: z.string().optional(),
       }),
-      execute: async ({ command }, { sandbox }) => {
+      execute: async ({ command, workingDirectory }, { sandbox }) => {
         if (!sandbox) {
           throw new Error('Sandbox is not available');
         }
 
-        return sandbox.executeCommand({ command });
+        return sandbox.executeCommand({ command, workingDirectory });
       },
     }),
   },
@@ -878,6 +879,10 @@ The sandbox description is not added to the model prompt automatically. If the
 model should know about details such as the root directory, exposed ports, or
 public hostname, include `sandbox.description` in your system prompt,
 instructions, or user-visible context.
+
+`executeCommand` also accepts an optional `workingDirectory`. Use it when a tool
+needs to run a command from a directory other than the sandbox implementation's
+default working directory.
 
 The AI SDK forwards your sandbox object but does not create or isolate one for
 you.

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -522,12 +522,7 @@ import { OpenTelemetry } from '@ai-sdk/otel';
 
 registerTelemetry(
   new OpenTelemetry({
-    enrichSpan: ({
-      spanType,
-      operationId,
-      callId,
-      runtimeContext,
-    }) => {
+    enrichSpan: ({ spanType, operationId, callId, runtimeContext }) => {
       return {
         ...getCustomAttributes(runtimeContext, spanType),
         'my_app.operation_id': operationId,

--- a/content/docs/07-reference/01-ai-sdk-core/34-sandbox.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/34-sandbox.mdx
@@ -22,7 +22,10 @@ application process unless the tool explicitly delegates work to the sandbox.
 ```ts
 type Sandbox = {
   readonly description: string;
-  readonly executeCommand: (options: { command: string }) => PromiseLike<{
+  readonly executeCommand: (options: {
+    command: string;
+    workingDirectory?: string;
+  }) => PromiseLike<{
     exitCode: number;
     stdout: string;
     stderr: string;
@@ -42,7 +45,7 @@ type Sandbox = {
     },
     {
       name: 'executeCommand',
-      type: '(options: { command: string }) => PromiseLike<{ exitCode: number; stdout: string; stderr: string }>',
+      type: '(options: { command: string; workingDirectory?: string }) => PromiseLike<{ exitCode: number; stdout: string; stderr: string }>',
       description:
         'Executes a command in the sandbox and resolves with the command exit code, standard output, and standard error.',
       properties: [
@@ -53,6 +56,12 @@ type Sandbox = {
               name: 'command',
               type: 'string',
               description: 'The command to execute in the sandbox.',
+            },
+            {
+              name: 'workingDirectory',
+              type: 'string | undefined',
+              description:
+                'Optional working directory to execute the command in. If omitted, the sandbox implementation uses its default working directory.',
             },
           ],
         },
@@ -76,13 +85,16 @@ Inside a tool, read the sandbox from the second `execute` argument:
 
 ```ts
 const shell = tool({
-  inputSchema: z.object({ command: z.string() }),
-  execute: async ({ command }, { sandbox }) => {
+  inputSchema: z.object({
+    command: z.string(),
+    workingDirectory: z.string().optional(),
+  }),
+  execute: async ({ command, workingDirectory }, { sandbox }) => {
     if (!sandbox) {
       throw new Error('Sandbox is not available');
     }
 
-    return sandbox.executeCommand({ command });
+    return sandbox.executeCommand({ command, workingDirectory });
   },
 });
 ```

--- a/examples/ai-e2e-next/sandbox/vercel-sandbox.ts
+++ b/examples/ai-e2e-next/sandbox/vercel-sandbox.ts
@@ -23,10 +23,17 @@ export class VercelSandbox implements AISandbox {
     >,
   ) {}
 
-  async executeCommand({ command }: { command: string }) {
+  async executeCommand({
+    command,
+    workingDirectory,
+  }: {
+    command: string;
+    workingDirectory?: string;
+  }) {
     const result = await this.sandbox.runCommand({
       cmd: 'bash',
-      args: ['-c', `cd "${rootDirectory}" && ${command}`],
+      args: ['-c', command],
+      cwd: workingDirectory ?? rootDirectory,
     });
 
     return {

--- a/examples/ai-e2e-next/tool/sandbox-shell-tool.ts
+++ b/examples/ai-e2e-next/tool/sandbox-shell-tool.ts
@@ -6,14 +6,15 @@ export function sandboxShellTool() {
     description: 'Run a shell command',
     inputSchema: z.object({
       command: z.string(),
+      workingDirectory: z.string().optional(),
     }),
 
-    execute: async ({ command }, { sandbox }) => {
+    execute: async ({ command, workingDirectory }, { sandbox }) => {
       // TODO figure out type inference to turn the runtime error into a type error
       if (!sandbox) {
         throw new Error('Sandbox is not available');
       }
-      return sandbox.executeCommand({ command });
+      return sandbox.executeCommand({ command, workingDirectory });
     },
   });
 }

--- a/examples/ai-functions/src/sandbox/just-bash-sandbox.ts
+++ b/examples/ai-functions/src/sandbox/just-bash-sandbox.ts
@@ -4,8 +4,14 @@ import { type Bash } from 'just-bash';
 export class JustBashSandbox implements Sandbox {
   constructor(private readonly bash: Bash) {}
 
-  async executeCommand({ command }: { command: string }) {
-    const result = await this.bash.exec(command);
+  async executeCommand({
+    command,
+    workingDirectory,
+  }: {
+    command: string;
+    workingDirectory?: string;
+  }) {
+    const result = await this.bash.exec(command, { cwd: workingDirectory });
 
     return {
       exitCode: result.exitCode,

--- a/examples/ai-functions/src/sandbox/local-sandbox.ts
+++ b/examples/ai-functions/src/sandbox/local-sandbox.ts
@@ -24,10 +24,16 @@ export class LocalSandbox implements Sandbox {
     this.rootDirectory = rootDirectory;
   }
 
-  async executeCommand({ command }: { command: string }) {
+  async executeCommand({
+    command,
+    workingDirectory,
+  }: {
+    command: string;
+    workingDirectory?: string;
+  }) {
     try {
       const { stdout, stderr } = await execAsync(command, {
-        cwd: this.rootDirectory,
+        cwd: workingDirectory ?? this.rootDirectory,
         timeout: 60_000,
         maxBuffer: 10 * 1024 * 1024,
       });

--- a/examples/ai-functions/src/sandbox/vercel-sandbox.ts
+++ b/examples/ai-functions/src/sandbox/vercel-sandbox.ts
@@ -10,10 +10,17 @@ export class VercelSandbox implements AISandbox {
     >,
   ) {}
 
-  async executeCommand({ command }: { command: string }) {
+  async executeCommand({
+    command,
+    workingDirectory,
+  }: {
+    command: string;
+    workingDirectory?: string;
+  }) {
     const result = await this.sandbox.runCommand({
       cmd: 'bash',
-      args: ['-c', `cd "${rootDirectory}" && ${command}`],
+      args: ['-c', command],
+      cwd: workingDirectory ?? rootDirectory,
     });
 
     return {

--- a/examples/ai-functions/src/tools/sandbox-shell-tool.ts
+++ b/examples/ai-functions/src/tools/sandbox-shell-tool.ts
@@ -6,14 +6,15 @@ export function sandboxShellTool() {
     description: 'Run a shell command',
     inputSchema: z.object({
       command: z.string(),
+      workingDirectory: z.string().optional(),
     }),
 
-    execute: async ({ command }, { sandbox }) => {
+    execute: async ({ command, workingDirectory }, { sandbox }) => {
       // TODO figure out type inference to turn the runtime error into a type error
       if (!sandbox) {
         throw new Error('Sandbox is not available');
       }
-      return sandbox.executeCommand({ command });
+      return sandbox.executeCommand({ command, workingDirectory });
     },
   });
 }

--- a/packages/provider-utils/src/types/sandbox.ts
+++ b/packages/provider-utils/src/types/sandbox.ts
@@ -17,6 +17,11 @@ export type Sandbox = {
      * Command to execute in the sandbox.
      */
     command: string;
+
+    /**
+     * Working directory to execute the command in.
+     */
+    workingDirectory?: string;
   }) => PromiseLike<{
     /**
      * Exit code returned by the command.


### PR DESCRIPTION
## Background
We introduced a Sandbox abstraction for bash execution in #14949

## Summary
Add `workingDirectory` option to `executeCommand`

## Related Issues
Builds on #14949